### PR TITLE
Enable High DPI display support.

### DIFF
--- a/Babylon/babylon.engine.js
+++ b/Babylon/babylon.engine.js
@@ -27,7 +27,7 @@
         this._workingContext = this._workingCanvas.getContext("2d");
 
         // Viewport
-        this._hardwareScalingLevel = 1.0;
+        this._hardwareScalingLevel = 1.0 / window.devicePixelRatio || 1.0;
         this.resize();
 
         // Caps


### PR DESCRIPTION
These changes make the webGL context render at the native resolution
for high DPI displays like on the retina MacBook Pro and Chromebook
Pixel.

Low DPI:
![lowdpi](https://f.cloud.github.com/assets/327081/821734/786f1b16-efe0-11e2-8092-97dfaa648fe6.png)

High DPI:
![hidpi](https://f.cloud.github.com/assets/327081/821736/7ccd99da-efe0-11e2-971a-3e4124874e8c.png)
