### PR TITLE
added additional check to see if WebGL is supported

### DIFF
--- a/Babylon/babylon.engine.js
+++ b/Babylon/babylon.engine.js
@@ -11,7 +11,7 @@
             throw new Error("WebGL not supported");
         }
 
-        if (this._gl === undefined) {
+        if (this._gl === undefined || this._gl === null) {
             throw new Error("WebGL not supported");
         }
 


### PR DESCRIPTION
I ran into this issue on Chrome for Linux -- if WebGL is supported but not _fully_ supported with OpenGL, it would return "null" on `canvas.getContext("webgl")` instead of "undefined". The original check in the Babylon.js code would pass and Chrome would throw an error about `MAX_TEXTURE_IMAGE_UNITS` not being defined and wouldn't render anything. This simple additional if clause fixes that issue.
