### PR TITLE
Fixed operators priority issue

### DIFF
--- a/Babylon/babylon.engine.js
+++ b/Babylon/babylon.engine.js
@@ -27,7 +27,7 @@
         this._workingContext = this._workingCanvas.getContext("2d");
 
         // Viewport
-        this._hardwareScalingLevel = 1.0 / window.devicePixelRatio || 1.0;
+        this._hardwareScalingLevel = 1.0 / (window.devicePixelRatio || 1.0);
         this.resize();
 
         // Caps


### PR DESCRIPTION
Not sure of what you expect if window.devicePixelRatio is undefined, null or 0 but I guess in this case _hardwareScalingLevel should be 1.0, that's why I added brackets.

Here are the tests: http://jsfiddle.net/gwenaelhagenmuller/27Y5T/
