### PR TITLE
BABYLON.Mesh.prototype.{s,g}etLocalTranslation

### DIFF
--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -303,7 +303,10 @@ var BABYLON = BABYLON || {};
         if (this.parent && this.parent.getWorldMatrix && this.billboardMode === BABYLON.Mesh.BILLBOARDMODE_NONE) {
             this._localWorld.multiplyToRef(this.parent.getWorldMatrix(), this._worldMatrix);
         } else {
-            this._worldMatrix = this._localWorld;
+            // multiplyToRef instead of this._worldMatrix = this._localWorld;
+            // to be sure not to have a bug with a call to this._localWorld.multiplyToRef(this.parent.getWorldMatrix(), this._worldMatrix);
+            // Moreover multiplyToRef is more efficient than clone
+            this._localPivotScalingRotation.multiplyToRef(this._localTranslation, this._worldMatrix);
         }
 
         // Bounding info
@@ -533,6 +536,27 @@ var BABYLON = BABYLON || {};
     };
 
     // Geometry
+    // deprecated: use setPositionWithLocalVector instead. It fixes setLocalTranslation.
+    BABYLON.Mesh.prototype.setLocalTranslation = function(vector3) {
+        console.warn("deprecated: use setPositionWithLocalVector instead");
+        this.computeWorldMatrix();
+        var worldMatrix = this._worldMatrix.clone();
+        worldMatrix.setTranslation(BABYLON.Vector3.Zero());
+
+        this.position = BABYLON.Vector3.TransformCoordinates(vector3, worldMatrix);
+    };
+    
+    // deprecated: use getPositionExpressedInLocalSpace instead. It fixes getLocalTranslation.
+    BABYLON.Mesh.prototype.getLocalTranslation = function () {
+        console.warn("deprecated: use getPositionExpressedInLocalSpace instead");
+        this.computeWorldMatrix();
+        var invWorldMatrix = this._worldMatrix.clone();
+        invWorldMatrix.setTranslation(BABYLON.Vector3.Zero());
+        invWorldMatrix.invert();
+
+        return BABYLON.Vector3.TransformCoordinates(this.position, invWorldMatrix);
+    };
+    
     BABYLON.Mesh.prototype.setPositionWithLocalVector = function(vector3) {
         this.computeWorldMatrix();
         


### PR DESCRIPTION
Fixed BABYLON.Mesh.prototype.{s,g}etLocalTranslation to take into account the parent.
Renamed BABYLON.Mesh.prototype.{s,g}etLocalTranslation respectively by BABYLON.Mesh.prototype.setPositionWithLocalVector and BABYLON.Mesh.prototype.getPositionExpressedInLocalSpace
Added BABYLON.Mesh.prototype.locallyTranslate

BABYLON.Mesh.prototype.locallyTranslate adds the passed vector3 (expressed in local space; the origin of vector3 is the origin of the local space) after conversion to the parent space to the position (expressed in parent space)
whereas BABYLON.Mesh.prototype.setPositionWithLocalVector sets the position (expressed in parent space) to the passed vector3 (expressed in local space but which the origin is the origin of the parent space) once it has been converted.

The following code for BABYLON.Mesh.prototype.setPositionWithLocalVector could also be used. It explains itself the relation between setPositionWithLocalVector and locallyTranslate.

``` javascript
BABYLON.Mesh.prototype.setPositionWithLocalVector = function(vector3) {
    this.position = BABYLON.Vector3.Zero();
    this.locallyTranslate(vector3);
};
```

And here is a jsfiddle to illustrate it: http://jsfiddle.net/gwenaelhagenmuller/35uFf/12/
