### PR TITLE
Fixed BABYLON.Mesh.prototype.getPivotMatrix

### DIFF
--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -140,7 +140,7 @@ var BABYLON = BABYLON || {};
     };
 
     BABYLON.Mesh.prototype.getPivotMatrix = function () {
-        return this._localMatrix;
+        return this._pivotMatrix;
     };
 
     BABYLON.Mesh.prototype.isSynchronized = function () {


### PR DESCRIPTION
this._localMatrix was never set and never used. That must have been a typo in 944cfb4.
