### PR TITLE
Fixed getActiveMeshes name in babylon.scene.js

### DIFF
--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -134,7 +134,7 @@ var BABYLON = BABYLON || {};
         return this._evaluateActiveMeshesDuration;
     };
 
-    BABYLON.Scene.prototype.geActiveMeshes = function () {
+    BABYLON.Scene.prototype.getActiveMeshes = function () {
         return this._activeMeshes;
     };
 


### PR DESCRIPTION
Fixed getActiveMeshes name in babylon.scene.js
