### PR TITLE
Fixed a bug in FBX Exporter that prevented SkinnedModels (animated rigs) from working

### DIFF
--- a/Exporters/XNA - OBJ/BabylonExport.Core/Entities/PositionNormalTexturedWeights.cs
+++ b/Exporters/XNA - OBJ/BabylonExport.Core/Entities/PositionNormalTexturedWeights.cs
@@ -6,7 +6,7 @@ namespace BabylonExport.Core
 {
     public struct PositionNormalTexturedWeights : IDumpable, IQueryable
     {
-        public const int Stride = 64;
+        public const int Stride = 52; // Maya returning >=52 for PNTW vertex, not 64
         public Vector3 Position;
         public int Indices;
         public Vector4 Weights;


### PR DESCRIPTION
The FBX Exporter was causing newer rigged & animated models in Autodesk Maya to lose their animations.  Older models and Microsoft's Dude worked fine.  Upon close inspection, I discovered that Maya was consistently returning a vertex stride >=52, not >=64, for skinned models (models w/ vertices that have PositionNormalTexturedWeight).

Thus, changed Vertex Stride from 64 to 52 in Exporters/XNA - OBJ/BabylonExport.Core/Entities/PositionNormalTexturedWeights.cs
