### PR TITLE
Bug fixed on clone() method

### DIFF
--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -836,7 +836,7 @@ var BABYLON = BABYLON || {};
         // Buffers
         result._vertexBuffers = this._vertexBuffers;
         for (var kind in result._vertexBuffers) {
-            result._vertexBuffers[kind].references++;
+            result._vertexBuffers[kind]._buffer.references++;
         }
 
         result._indexBuffer = this._indexBuffer;


### PR DESCRIPTION
VertexBuffer.references is not defined. VertexBuffer._buffer.references should be used instead.

This fixes a graphical issues when the cloned mesh is being disposed.
