### PR TITLE
Using the hardware scaling value when creating a Ray

### DIFF
--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -947,7 +947,7 @@ var BABYLON = BABYLON || {};
             camera = this.activeCamera;
         }
         var viewport = camera.viewport.toGlobal(engine);
-        return BABYLON.Ray.CreateNew(x  * this._engine.getHardwareScalingLevel(), y * this._engine.getHardwareScalingLevel(), viewport.width, viewport.height, world ? world : BABYLON.Matrix.Identity(), camera.getViewMatrix(), camera.getProjectionMatrix());
+        return BABYLON.Ray.CreateNew(x * this._engine.getHardwareScalingLevel(), y * this._engine.getHardwareScalingLevel(), viewport.width, viewport.height, world ? world : BABYLON.Matrix.Identity(), camera.getViewMatrix(), camera.getProjectionMatrix());
     };
 
     BABYLON.Scene.prototype._internalPick = function (rayFunction, predicate, fastCheck) {


### PR DESCRIPTION
This pull request allows you to use picking ray when the hardware scaling is different from 1. Tested and works fine on desktop with a standard resolution and on Android mobile devices (Nexus 4 and 7).
