### PR TITLE
Test shadowMap before push in renderTargets

### DIFF
--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -760,7 +760,7 @@ var BABYLON = BABYLON || {};
             var light = this.lights[lightIndex];
             var shadowGenerator = light.getShadowGenerator();
 
-            if (light.isEnabled() && shadowGenerator) {
+            if (light.isEnabled() && shadowGenerator && shadowGenerator.getShadowMap()._scene.textures.indexOf(shadowGenerator.getShadowMap()) !== -1) {
                 this._renderTargets.push(shadowGenerator.getShadowMap());
             }
         }


### PR DESCRIPTION
Error when the shadowGenerator is dispose, the renderTargets doesn't have to push the shadow map.
The shadow map has to be test before push in the renderTargets list.
