### PR TITLE
add animations attibute on sprites

### DIFF
--- a/Babylon/Sprites/babylon.sprite.js
+++ b/Babylon/Sprites/babylon.sprite.js
@@ -13,6 +13,9 @@ var BABYLON = BABYLON || {};
         this.color = new BABYLON.Color4(1.0, 1.0, 1.0, 1.0);
 
         this._frameCount = 0;
+
+        // Animations
+        this.animations = [];
     };
 
     // Members


### PR DESCRIPTION
Hello,

I wish to use animation on a sprite node.

By animation I mean the property interpolation. Something like

```
var animation = new BABYLON.Animation(
   ...
 );

animation.setKeys( 
   ...
);

mySprite.animations.push( animation );

```

The points is the animations array does not exist on a sprite node. Not a big deal, I instanciate it and it works fine. But I think it will be better to have a homogene API so I add the field.
