### PR TITLE
Add "layerMask" property for meshes and cameras

### DIFF
--- a/Babylon/Cameras/babylon.camera.ts
+++ b/Babylon/Cameras/babylon.camera.ts
@@ -17,6 +17,7 @@
         public mode = Camera.PERSPECTIVE_CAMERA;
         public isIntermediate = false;
         public viewport = new Viewport(0, 0, 1.0, 1.0);
+        public layerMask: number = 0xFFFFFFFF;
         public subCameras = [];
 
         private _computedViewMatrix = BABYLON.Matrix.Identity();

--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
@@ -303,7 +303,7 @@ var BABYLON = BABYLON || {};
     var parseCamera = function (parsedCamera, scene) {
         var camera = new BABYLON.FreeCamera(parsedCamera.name, BABYLON.Vector3.FromArray(parsedCamera.position), scene);
         camera.id = parsedCamera.id;
-
+        
         BABYLON.Tags.AddTagsTo(camera, parsedCamera.tags);
 
         // Parent
@@ -349,6 +349,14 @@ var BABYLON = BABYLON || {};
             scene.beginAnimation(camera, parsedCamera.autoAnimateFrom, parsedCamera.autoAnimateTo, parsedCamera.autoAnimateLoop, 1.0);
         }
 
+        
+        // Layer Mask
+        if (parsedCamera.layerMask && (parseInt(parsedCamera.layerMask) != NaN)) {
+          camera.layerMask = Math.abs(parseInt(parsedCamera.layerMask));
+        } else {
+          camera.layerMask = 0xFFFFFFFF;
+        }
+        
         return camera;
     };
 
@@ -496,7 +504,7 @@ var BABYLON = BABYLON || {};
     var parseMesh = function (parsedMesh, scene, rootUrl) {
         var mesh = new BABYLON.Mesh(parsedMesh.name, scene);
         mesh.id = parsedMesh.id;
-
+        
         BABYLON.Tags.AddTagsTo(mesh, parsedMesh.tags);
 
         mesh.position = BABYLON.Vector3.FromArray(parsedMesh.position);
@@ -536,7 +544,7 @@ var BABYLON = BABYLON || {};
         if (parsedMesh.parentId) {
             mesh.parent = scene.getLastEntryByID(parsedMesh.parentId);
         }
-
+        
         // Geometry
         if (parsedMesh.delayLoadingFile) {
             mesh.delayLoadState = BABYLON.Engine.DELAYLOADSTATE_NOTLOADED;
@@ -613,6 +621,13 @@ var BABYLON = BABYLON || {};
 
         if (parsedMesh.autoAnimate) {
             scene.beginAnimation(mesh, parsedMesh.autoAnimateFrom, parsedMesh.autoAnimateTo, parsedMesh.autoAnimateLoop, 1.0);
+        }
+
+        // Layer Mask
+        if (parsedMesh.layerMask && (parseInt(parsedMesh.layerMask) != NaN)) {
+          mesh.layerMask = Math.abs(parseInt(parsedMesh.layerMask));
+        } else {
+          mesh.layerMask = 0xFFFFFFFF;
         }
 
         return mesh;

--- a/Babylon/Mesh/babylon.abstractMesh.ts
+++ b/Babylon/Mesh/babylon.abstractMesh.ts
@@ -45,6 +45,7 @@
         public material: Material;
         public receiveShadows = false;
         public actionManager: ActionManager;
+        public layerMask: number = 0xFFFFFFFF;
 
         // Physics
         public _physicImpostor = PhysicsEngine.NoImpostor;

--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -750,7 +750,7 @@
                     mesh.computeWorldMatrix();
                     mesh._preActivate();
 
-                    if (mesh.isEnabled() && mesh.isVisible && mesh.visibility > 0 && mesh.isInFrustum(this._frustumPlanes)) {
+                    if (mesh.isEnabled() && ((mesh.layerMask & this.activeCamera.layerMask) != 0) && mesh.isVisible && mesh.visibility > 0 && mesh.isInFrustum(this._frustumPlanes)) {
                         this._activeMeshes.push(mesh);
                         mesh._activate(this._renderId);
 


### PR DESCRIPTION
## Added "layerMask" property to meshes and cameras.

Implementation of Layers from Unity or 3DSMax. Each camera has 32bit mask of layers which it renders ( 1 bit for each layer ) and each mesh has bit-mask of layers, in which it should be rendered. 

> There is possible fail if numbers in Javascript interpreter are represented as floats instead of doubles. Float is not precise enough to hold all uint_32 values without deformation.

Default values for both are _0xFFFFFFFF_ (max 32-bit unsigned int), so in default configuration all meshes are rendered in all cameras.

Property is also implemented in .babylon-file parser, so there can be defined meshes connected to various cameras.

Maybe needs some check in condition added into _babylon.scene.ts_

[Related forum post here](http://www.html5gamedevs.com/topic/3865-what-do-you-want-in-babylonjs/?p=40350)
