### PR TITLE
XMLHttpRequest is looking first in the cache

### DIFF
--- a/Babylon/Tools/babylon.database.js
+++ b/Babylon/Tools/babylon.database.js
@@ -468,7 +468,8 @@ var BABYLON = BABYLON || {};
             var xhr = new XMLHttpRequest(), sceneText;
             var that = this;
 
-            xhr.open("GET", url, true);
+            var urlTimeStamped = url + (url.match(/\?/) == null ? "?" : "&") + (new Date()).getTime();
+            xhr.open("GET", urlTimeStamped, true);
 
             xhr.onprogress = progressCallback;
             


### PR DESCRIPTION
Fixing an issue described here : http://www.html5gamedevs.com/topic/6906-problem-with-manifest-cache-new-file-version-not-downloaded/

The last version of a scene cannot be retrieved because of the browser cache.
