### PR TITLE
Loopmode defined twice

### DIFF
--- a/Babylon/Animations/babylon.animation.js
+++ b/Babylon/Animations/babylon.animation.js
@@ -6,7 +6,6 @@
             this.targetProperty = targetProperty;
             this.framePerSecond = framePerSecond;
             this.dataType = dataType;
-            this.loopMode = loopMode;
             this._offsetsCache = {};
             this._highLimitsCache = {};
             this._stopped = false;


### PR DESCRIPTION
The first definition has been removed, as it is redondant with the second definition, more precise.
I cannot find the mistake in the typescript file :(
