### PR TITLE
BugFix SubMesh with CreateFromIndices

### DIFF
--- a/Babylon/Mesh/babylon.subMesh.ts
+++ b/Babylon/Mesh/babylon.subMesh.ts
@@ -172,7 +172,7 @@
 
                 if (vertexIndex < minVertexIndex)
                     minVertexIndex = vertexIndex;
-                else if (vertexIndex > maxVertexIndex)
+                if (vertexIndex > maxVertexIndex)
                     maxVertexIndex = vertexIndex;
             }
 


### PR DESCRIPTION
If the indexes decrease, the maxVertexIndex is never set and stay -Number.MAX_VALUE which is obviously not the good value
