### PR TITLE
Bug fix

### DIFF
--- a/Babylon/Mesh/babylon.abstractMesh.ts
+++ b/Babylon/Mesh/babylon.abstractMesh.ts
@@ -743,7 +743,10 @@
 
             // Remove from scene
             var index = this.getScene().meshes.indexOf(this);
-            this.getScene().meshes.splice(index, 1);
+            if (index != -1){
+                // Remove from the scene if mesh found
+                this.getScene().meshes.splice(index, 1);
+            }
 
             if (!doNotRecurse) {
                 // Particles


### PR DESCRIPTION
Fixed a bug removing the last mesh of the scene graph if this mesh is already disposed.
This bug can be reproduced here : http://www.babylonjs.com/playground/#20DP3L
