### PR TITLE
Added missing Vector2.copyFromFloats method

### DIFF
--- a/Babylon/Math/babylon.math.js
+++ b/Babylon/Math/babylon.math.js
@@ -266,6 +266,11 @@
             this.x = source.x;
             this.y = source.y;
         };
+		
+		Vector2.prototype.copyFromFloats = function (x, y) {
+            this.x = x;
+            this.y = y;
+        };
 
         Vector2.prototype.add = function (otherVector) {
             return new Vector2(this.x + otherVector.x, this.y + otherVector.y);

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -233,6 +233,11 @@
             this.x = source.x;
             this.y = source.y;
         }
+		
+		public copyFromFloats(x: number, y: number): void {
+			this.x = x;
+			this.y = y;
+		}
 
         public add(otherVector: Vector2): Vector2 {
             return new Vector2(this.x + otherVector.x, this.y + otherVector.y);


### PR DESCRIPTION
This PR adds the missing Vector2.copyFromFloats method which is already implemented in Vector3.
