### PR TITLE
Fix to the parseURL function so it works when using hash based paths.

### DIFF
--- a/Babylon/Tools/babylon.database.ts
+++ b/Babylon/Tools/babylon.database.ts
@@ -30,7 +30,8 @@ module BABYLON {
         static parseURL = function(url: string) {
             var a = document.createElement('a');
             a.href = url;
-            var fileName = url.substring(url.lastIndexOf("/") + 1, url.length);
+            var urlWithoutHash = url.substring(0, url.lastIndexOf("#"));
+            var fileName = url.substring(urlWithoutHash.lastIndexOf("/") + 1, url.length);
             var absLocation = url.substring(0, url.indexOf(fileName, 0));
             return absLocation;
         }


### PR DESCRIPTION
Had a problem with angularjs and babylon, when using the route functions of angular you get urls like this:

http://localhost:8000/index.html#/something

The parseURL function whould then return "http://localhost:8000/index.html#/" as the "abslocation" which meant that it couldn't load the manifest file.
