### PR TITLE
Changes to support binary file formats for vertex data

### DIFF
--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -607,6 +607,10 @@
             mesh.delayLoadingFile = rootUrl + parsedMesh.delayLoadingFile;
             mesh._boundingInfo = new BABYLON.BoundingInfo(BABYLON.Vector3.FromArray(parsedMesh.boundingBoxMinimum), BABYLON.Vector3.FromArray(parsedMesh.boundingBoxMaximum));
 
+            if (parsedMesh._binaryInfo) {
+                mesh._binaryInfo = parsedMesh._binaryInfo;
+            }
+
             mesh._delayInfo = [];
             if (parsedMesh.hasUVs) {
                 mesh._delayInfo.push(BABYLON.VertexBuffer.UVKind);
@@ -794,6 +798,67 @@
             if (geometry) {
                 geometry.applyToMesh(mesh);
             }
+        } else if (parsedGeometry instanceof ArrayBuffer) {
+
+            var binaryInfo = mesh._binaryInfo;
+
+            if (binaryInfo.positionsAttrDesc && binaryInfo.positionsAttrDesc.count > 0) {
+                var positionsData = new Float32Array(parsedGeometry, binaryInfo.positionsAttrDesc.offset, binaryInfo.positionsAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.PositionKind, positionsData, false);
+            }
+
+            if (binaryInfo.normalsAttrDesc && binaryInfo.normalsAttrDesc.count > 0) {
+                var normalsData = new Float32Array(parsedGeometry, binaryInfo.normalsAttrDesc.offset, binaryInfo.normalsAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.NormalKind, normalsData, false);
+            }
+
+            if (binaryInfo.uvsAttrDesc && binaryInfo.uvsAttrDesc.count > 0) {
+                var uvsData = new Float32Array(parsedGeometry, binaryInfo.uvsAttrDesc.offset, binaryInfo.uvsAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.UVKind, uvsData, false);
+            }
+
+            if (binaryInfo.uvs2AttrDesc && binaryInfo.uvs2AttrDesc.count > 0) {
+                var uvs2Data = new Float32Array(parsedGeometry, binaryInfo.uvs2AttrDesc.offset, binaryInfo.uvs2AttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.UV2Kind, uvs2Data, false);
+            }
+
+            if (binaryInfo.colorsAttrDesc && binaryInfo.colorsAttrDesc.count > 0) {
+                var colorsData = new Float32Array(parsedGeometry, binaryInfo.colorsAttrDesc.offset, binaryInfo.colorsAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.ColorKind, colorsData, false);
+            }
+
+            if (binaryInfo.matricesIndicesAttrDesc && binaryInfo.matricesIndicesAttrDesc.count > 0) {
+                var matricesIndicesData = new Int32Array(parsedGeometry, binaryInfo.matricesIndicesAttrDesc.offset, binaryInfo.matricesIndicesAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.MatricesIndicesKind, matricesIndicesData, false);
+            }
+
+            if (binaryInfo.matricesWeightsAttrDesc && binaryInfo.matricesWeightsAttrDesc.count > 0) {
+                var matricesWeightsData = new Float32Array(parsedGeometry, binaryInfo.matricesWeightsAttrDesc.offset, binaryInfo.matricesWeightsAttrDesc.count);
+                mesh.setVerticesData(BABYLON.VertexBuffer.MatricesWeightsKind, matricesWeightsData, false);
+            }
+
+            if (binaryInfo.indicesAttrDesc && binaryInfo.indicesAttrDesc.count > 0) {
+                var indicesData = new Int32Array(parsedGeometry, binaryInfo.indicesAttrDesc.offset, binaryInfo.indicesAttrDesc.count);
+                mesh.setIndices(indicesData);
+            }
+
+            if (binaryInfo.subMeshesAttrDesc && binaryInfo.subMeshesAttrDesc.count > 0) {
+                var subMeshesData = new Int32Array(parsedGeometry, binaryInfo.subMeshesAttrDesc.offset, binaryInfo.subMeshesAttrDesc.count * 5);
+
+                mesh.subMeshes = [];
+                for (var i = 0; i < binaryInfo.subMeshesAttrDesc.count; i++) {
+                    var materialIndex = subMeshesData[(i * 5) + 0];
+                    var verticesStart = subMeshesData[(i * 5) + 1];
+                    var verticesCount = subMeshesData[(i * 5) + 2];
+                    var indexStart = subMeshesData[(i * 5) + 3];
+                    var indexCount = subMeshesData[(i * 5) + 4];
+
+                    var subMesh = new BABYLON.SubMesh(materialIndex, verticesStart, verticesCount, indexStart, indexCount, mesh);
+                }
+            }
+
+            return;
+
         } else if (parsedGeometry.positions && parsedGeometry.normals && parsedGeometry.indices) {
             mesh.setVerticesData(BABYLON.VertexBuffer.PositionKind, parsedGeometry.positions, false);
             mesh.setVerticesData(BABYLON.VertexBuffer.NormalKind, parsedGeometry.normals, false);

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -10,6 +10,7 @@
         public delayLoadState = BABYLON.Engine.DELAYLOADSTATE_NONE;
         public instances = new Array<InstancedMesh>();
         public delayLoadingFile: string;
+        public _binaryInfo : BinaryAttrData;
 
         // Private
         public _geometry: Geometry;
@@ -518,11 +519,20 @@
 
                 scene._addPendingData(that);
 
+                var getBinaryData = (this.delayLoadingFile.indexOf(".babylonbinarymeshdata") !== -1) ? true : false;
+
                 BABYLON.Tools.LoadFile(this.delayLoadingFile, data => {
-                    this._delayLoadingFunction(JSON.parse(data), this);
+
+                    if (data instanceof ArrayBuffer) {
+                        this._delayLoadingFunction(data, this);
+                    }
+                    else {
+                        this._delayLoadingFunction(JSON.parse(data), this);
+                    }
+
                     this.delayLoadState = BABYLON.Engine.DELAYLOADSTATE_LOADED;
                     scene._removePendingData(this);
-                }, () => { }, scene.database);
+                }, () => { }, scene.database, getBinaryData);
             }
         }
 

--- a/Exporters/BinaryConverter/BabylonLodScene.cs
+++ b/Exporters/BinaryConverter/BabylonLodScene.cs
@@ -12,6 +12,9 @@ namespace BabylonBinaryConverter
         [DataMember]
         public new BabylonLodMesh[] meshes { get; set; }
 
+        [DataMember]
+        public bool useDelayedTextureLoading { get; set; }
+
 
         public BabylonLodScene(string outputPath) : base(outputPath)
         {

--- a/Exporters/BinaryConverter/Program.cs
+++ b/Exporters/BinaryConverter/Program.cs
@@ -96,7 +96,9 @@ namespace BabylonBinaryConverter
             try
             {
                 BabylonLodScene scene = JsonConvert.DeserializeObject<BabylonLodScene>(File.ReadAllText(WebUtility.UrlDecode(srcFilename)));
-                
+                scene.autoClear = true;
+                scene.useDelayedTextureLoading = true;
+
                 scene.Convert(srcPath, dstPath);
 
                 File.WriteAllText(WebUtility.UrlDecode(dstFilename), JsonConvert.SerializeObject(scene, (formatted ? Formatting.Indented : Formatting.None)));


### PR DESCRIPTION
These changes should not interfere with existing file formats, and should allow the use of binary vertex data generated with a new Tool\ConvertToBinary
