### PR TITLE
Fixed mesh loading when url has a query string

### DIFF
--- a/Babylon/Loading/babylon.sceneLoader.js
+++ b/Babylon/Loading/babylon.sceneLoader.js
@@ -29,7 +29,8 @@
 
         SceneLoader._getPluginForFilename = function (sceneFilename) {
             var dotPosition = sceneFilename.lastIndexOf(".");
-            var extension = sceneFilename.substring(dotPosition).toLowerCase();
+            var queryStringPosition = sceneFilename.indexOf("?");
+            var extension = sceneFilename.substring(dotPosition,queryStringPosition).toLowerCase();
 
             for (var index = 0; index < this._registeredPlugins.length; index++) {
                 var plugin = this._registeredPlugins[index];

--- a/Babylon/Loading/babylon.sceneLoader.ts
+++ b/Babylon/Loading/babylon.sceneLoader.ts
@@ -31,7 +31,8 @@
 
         private static _getPluginForFilename(sceneFilename): ISceneLoaderPlugin {
             var dotPosition = sceneFilename.lastIndexOf(".");
-            var extension = sceneFilename.substring(dotPosition).toLowerCase();
+            var queryStringPosition = sceneFilename.indexOf("?");
+            var extension = sceneFilename.substring(dotPosition,queryStringPosition).toLowerCase();
 
             for (var index = 0; index < this._registeredPlugins.length; index++) {
                 var plugin = this._registeredPlugins[index];


### PR DESCRIPTION
When loading a mesh using SceneLoader.ImportMesh, if the URL had a query string, it was considered as part of the extension, so it was looking for a plugin to load ".babylon?foo&bar" files.

I just changed it to take the extension from between last dot and first question mark.

PS: the gulp build from typescript fails for me, had to do it manually (build from js works) :)
