### PR TITLE
Update babylon.mesh.ts

### DIFF
--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -762,7 +762,9 @@
             var result = new BABYLON.Mesh(name, this.getScene());
 
             // Geometry
-            this._geometry.applyToMesh(result);
+            if (this._geometry) {
+                this._geometry.applyToMesh(result);
+            }
 
             // Deep copy
             BABYLON.Tools.DeepCopy(this, result, ["name", "material", "skeleton"], []);


### PR DESCRIPTION
Fixed bug when cloning a mesh without any geometry (loaded from asset loader for example)
