### PR TITLE
Fix for wrong intersection result

### DIFF
--- a/Babylon/Mesh/babylon.subMesh.js
+++ b/Babylon/Mesh/babylon.subMesh.js
@@ -114,6 +114,7 @@
                 var currentIntersectInfo = ray.intersectsTriangle(p0, p1, p2);
 
                 if (currentIntersectInfo) {
+                    if(currentIntersectInfo.distance < 0 ) continue;
                     if (fastCheck || !intersectInfo || currentIntersectInfo.distance < intersectInfo.distance) {
                         intersectInfo = currentIntersectInfo;
                         intersectInfo.faceId = index / 3;

--- a/Babylon/Mesh/babylon.subMesh.ts
+++ b/Babylon/Mesh/babylon.subMesh.ts
@@ -125,6 +125,7 @@
                 var currentIntersectInfo = ray.intersectsTriangle(p0, p1, p2);
 
                 if (currentIntersectInfo) {
+                    if(currentIntersectInfo.distance < 0 ) continue;
                     if (fastCheck || !intersectInfo || currentIntersectInfo.distance < intersectInfo.distance) {
                         intersectInfo = currentIntersectInfo;
                         intersectInfo.faceId = index / 3;


### PR DESCRIPTION
Preventing selection of a face that is behind the ray's origin position.
The problem is that if the origin point is INSIDE a mesh, the faces behind the point will be selected as well. The Distance received from the PickingInfo will still be positive, due to the new initialization in the scene pick function, so it cannot be detected at the scene. This is the best location to inspect this.