### PR TITLE
fix blender export for empty/null objects

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -894,6 +894,7 @@ class Node:
         self.rotation = scale_vector(rot.to_euler('XYZ'), -1)
         self.scaling = scale
         self.isVisible = False
+        self.isEnabled = True
         self.checkCollisions = False
         self.billboardMode = BILLBOARDMODE_NONE
         self.receiveShadows = False
@@ -911,6 +912,7 @@ class Node:
         write_vector(file_handler, 'rotation', self.rotation)
         write_vector(file_handler, 'scaling', self.scaling)
         write_bool(file_handler, 'isVisible', self.isVisible)
+        write_bool(file_handler, 'isEnabled', self.isEnabled)
         write_bool(file_handler, 'checkCollisions', self.checkCollisions)
         write_int(file_handler, 'billboardMode', self.billboardMode)
         write_bool(file_handler, 'receiveShadows', self.receiveShadows)      


### PR DESCRIPTION
I have a big blender scene where some meshes are grouped using empty objects. When exporting this scene to Babylon, these grouped meshes are not shown. This is because of the empty object being disabled. This PR sets `isEnabled` for empty objects.

However, the `isEnabled` property is set for the whole `Node` class. So I am not sure if this leads to any unwanted side effects?

Since Babylonjs seems to not position child nodes relative to their parent, I had to apply the locations in Blender using `Object` -> `Apply` -> `Location`.