### PR TITLE
Init BoundingInfo after resetting.

### DIFF
--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -293,6 +293,8 @@
                     mesh._boundingInfo = new BABYLON.BoundingInfo(extend.minimum, extend.maximum);
 
                     mesh._createGlobalSubMesh();
+                    //bounding info was just created again, world matrix should be applied again.
+                    mesh._updateBoundingInfo();
                 }
             }
 


### PR DESCRIPTION
After resetting BoundingInfo, world matrix should be reapplied
This should solve the problem presented here: http://www.html5gamedevs.com/topic/11598-visibility-problems-loading-groundmesh-on-demand/