### PR TITLE
Add specular texture export

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -1365,6 +1365,13 @@ class Material:
                         # Bump
                         BabylonExporter.log('Bump texture found');
                         self.textures.append(Texture('bumpTexture', mtex.normal_factor, mtex, filepath))  
+                    elif mtex.use_map_color_spec:
+                        # Specular
+                        BabylonExporter.log('Specular texture found');
+                        self.textures.append(Texture('specularTexture', mtex.specular_color_factor, mtex, filepath))
+                    else:
+                        BabylonExporter.warn('WARNING image texture type not recognized:  ' + str(mtex) + ', ignored.')
+
                         
             else:
                  BabylonExporter.warn('WARNING texture type not currently supported:  ' + mtex.texture.type + ', ignored.')


### PR DESCRIPTION
importer supports specular textures but blender export seems to be missing. i am not sure what the "level" variable is supposed to do :S i copy pasted from diffuse :O