### PR TITLE
Missing coma in gulpfile

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -168,7 +168,7 @@ gulp.task('scripts', ['shaders'] ,function() {
       '../../Babylon/Audio/babylon.soundtrack.js',
       '../../Babylon/Debug/babylon.debugLayer.js',
       '../../Babylon/Materials/Textures/babylon.rawTexture.js',
-      '../../Babylon/Mesh/babylon.polygonMesh.js'
+      '../../Babylon/Mesh/babylon.polygonMesh.js',
 	  '../../Babylon/Mesh/babylon.meshSimplification.js'
     ])
     .pipe(concat('babylon.js'))


### PR DESCRIPTION
Wrong gulp file was commited, coma was missing.