### PR TITLE
Transfer sampling mode to new texture when cloning an existing one

### DIFF
--- a/Babylon/Materials/Textures/babylon.texture.ts
+++ b/Babylon/Materials/Textures/babylon.texture.ts
@@ -205,7 +205,7 @@
         }
 
         public clone(): Texture {
-            var newTexture = new BABYLON.Texture(this._texture.url, this.getScene(), this._noMipmap, this._invertY);
+            var newTexture = new BABYLON.Texture(this._texture.url, this.getScene(), this._noMipmap, this._invertY, this._samplingMode);
 
             // Base texture
             newTexture.hasAlpha = this.hasAlpha;


### PR DESCRIPTION
A small detail that can cause a lot of headache, since texture cloning happens when a material is cloned.