### PR TITLE
Fix for the enum-to-string compile problem

### DIFF
--- a/Babylon/Audio/babylon.sound.js
+++ b/Babylon/Audio/babylon.sound.js
@@ -17,8 +17,8 @@
             this.refDistance = 1;
             this.rolloffFactor = 1;
             this.maxDistance = 100;
-            this.distanceModel = "linear";
-            this.panningModel = "HRTF";
+            this.distanceModel = DistanceModelType.linear;
+            this.panningModel = PanningModelType.HRTF;
             this.startTime = 0;
             this.startOffset = 0;
             this._position = BABYLON.Vector3.Zero();
@@ -116,11 +116,11 @@
 
                 if (this.useCustomAttenuation) {
                     // Tricks to disable in a way embedded Web Audio attenuation
-                    this._soundPanner.distanceModel = "linear";
+                    this._soundPanner.distanceModel = DistanceModelType.linear;
                     this._soundPanner.maxDistance = Number.MAX_VALUE;
                     this._soundPanner.refDistance = 1;
                     this._soundPanner.rolloffFactor = 1;
-                    this._soundPanner.panningModel = "HRTF";
+                    this._soundPanner.panningModel = PanningModelType.HRTF;
                 } else {
                     this._soundPanner.distanceModel = this.distanceModel;
                     this._soundPanner.maxDistance = this.maxDistance;

--- a/Babylon/Audio/babylon.sound.ts
+++ b/Babylon/Audio/babylon.sound.ts
@@ -8,8 +8,8 @@
         public refDistance: number = 1;
         public rolloffFactor: number = 1;
         public maxDistance: number = 100;
-        public distanceModel: string = "linear"; 
-        public panningModel: string = "HRTF";
+        public distanceModel: DistanceModelType = DistanceModelType.linear; 
+        public panningModel: PanningModelType = PanningModelType.HRTF;
         private startTime: number = 0;
         private startOffset: number = 0;
         private _position: Vector3 = Vector3.Zero();
@@ -124,11 +124,11 @@
 
                 if (this.useCustomAttenuation) {
                     // Tricks to disable in a way embedded Web Audio attenuation 
-                    this._soundPanner.distanceModel = "linear";
+                    this._soundPanner.distanceModel = DistanceModelType.linear;
                     this._soundPanner.maxDistance = Number.MAX_VALUE;
                     this._soundPanner.refDistance = 1;
                     this._soundPanner.rolloffFactor = 1;
-                    this._soundPanner.panningModel = "HRTF";
+                    this._soundPanner.panningModel = PanningModelType.HRTF;
                 }
                 else {
                     this._soundPanner.distanceModel = this.distanceModel;


### PR DESCRIPTION
Enums were converted to string, which prevented typescript from
compiling correctly.
This might be connected to the typescript version that was used to
create those files, maybe this should be checked before merging.