### PR TITLE
fix Blender export

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -1,7 +1,7 @@
 bl_info = {
     'name': 'Babylon.js',
     'author': 'David Catuhe, Jeff Palmer',
-    'version': (1, 6, 1),
+    'version': (1, 6, 2),
     'blender': (2, 72, 0),
     "location": "File > Export > Babylon.js (.babylon)",
     "description": "Export Babylon.js scenes (.babylon)",
@@ -901,6 +901,7 @@ class Node:
         self.isEnabled = True
         self.checkCollisions = False
         self.billboardMode = BILLBOARDMODE_NONE
+        self.castShadows = False
         self.receiveShadows = False
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     def get_proper_name(self):


### PR DESCRIPTION
I got the following Blender export error:

```
========= An error was encountered =========
  File "/Applications/blender.app/Contents/Resources/2.73/scripts/addons/io_export_babylon.py", line 268, in execute
    self.shadowGenerators.append(ShadowGenerator(object, self.meshesAndNodes, scene))
  File "/Applications/blender.app/Contents/Resources/2.73/scripts/addons/io_export_babylon.py", line 1206, in __init__
    for mesh in meshesAndNodes:
ERROR:  'Node' object has no attribute 'castShadows'
========= end of processing =========
```

This PR fixes this issue (seems to be introduced in 6628dc3b6644c295456fe3b4edf9fb032f78421f) by adding the `castShadows` attribute to the `Node` class.