### PR TITLE
Fix a bug on intersection Enter/Exit triggers

### DIFF
--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -1113,6 +1113,9 @@
                             if (indexOfOther > -1) {
                                 sourceMesh._intersectionsInProgress.splice(indexOfOther, 1);
                             }
+                        } else if (areIntersecting && currentIntersectionInProgress === -1 && action.trigger === ActionManager.OnIntersectionExitTrigger) {
+
+                            sourceMesh._intersectionsInProgress.push(otherMesh);
                         }
                     }
                 }


### PR DESCRIPTION
The action is not launched if a mesh has only a trigger OnIntersectionExitTrigger (and no OnIntersectionEnterTrigger), as shown in the following example : http://www.babylonjs-playground.com/#1UKEF (check line 130).