### PR TITLE
Update babylon.oimoJSPlugin.ts

### DIFF
--- a/Babylon/Physics/Plugins/babylon.oimoJSPlugin.ts
+++ b/Babylon/Physics/Plugins/babylon.oimoJSPlugin.ts
@@ -167,6 +167,8 @@ module BABYLON {
         private _createBodyAsCompound(part: PhysicsCompoundBodyPart, options: PhysicsBodyCreationOptions, initialMesh: AbstractMesh): any {
             var bodyParameters = null;
             var mesh = part.mesh;
+            // We need the bounding box/sphere info to compute the physics body
+            mesh.computeWorldMatrix();
 
             switch (part.impostor) {
                 case BABYLON.PhysicsEngine.SphereImpostor:


### PR DESCRIPTION
The mesh world matrix is now computed if needed, to avoid weird bounding info.