### PR TITLE
Added setArray2, 3, and 4 for uniform vec arrays.

### DIFF
--- a/Babylon/Materials/babylon.effect.js
+++ b/Babylon/Materials/babylon.effect.js
@@ -248,6 +248,18 @@ var BABYLON;
             this._engine.setArray(this.getUniform(uniformName), array);
             return this;
         };
+        Effect.prototype.setArray2 = function (uniformName, array) {
+            this._engine.setArray2(this.getUniform(uniformName), array);
+            return this;
+        };
+        Effect.prototype.setArray3 = function (uniformName, array) {
+            this._engine.setArray3(this.getUniform(uniformName), array);
+            return this;
+        };
+        Effect.prototype.setArray4 = function (uniformName, array) {
+            this._engine.setArray4(this.getUniform(uniformName), array);
+            return this;
+        };
         Effect.prototype.setMatrices = function (uniformName, matrices) {
             this._engine.setMatrices(this.getUniform(uniformName), matrices);
             return this;

--- a/Babylon/Materials/babylon.effect.ts
+++ b/Babylon/Materials/babylon.effect.ts
@@ -312,6 +312,24 @@
             return this;
         }
 
+        public setArray2(uniformName: string, array: number[]): Effect {
+            this._engine.setArray2(this.getUniform(uniformName), array);
+
+            return this;
+        }
+
+        public setArray3(uniformName: string, array: number[]): Effect {
+            this._engine.setArray3(this.getUniform(uniformName), array);
+
+            return this;
+        }
+
+        public setArray4(uniformName: string, array: number[]): Effect {
+            this._engine.setArray4(this.getUniform(uniformName), array);
+
+            return this;
+        }
+
         public setMatrices(uniformName: string, matrices: Float32Array): Effect {
             this._engine.setMatrices(this.getUniform(uniformName), matrices);
 

--- a/Babylon/babylon.engine.js
+++ b/Babylon/babylon.engine.js
@@ -1047,6 +1047,21 @@ var BABYLON;
                 return;
             this._gl.uniform1fv(uniform, array);
         };
+        Engine.prototype.setArray2 = function (uniform, array) {
+            if (!uniform || array.length % 2 !== 0)
+                return;
+            this._gl.uniform2fv(uniform, array);
+        };
+        Engine.prototype.setArray3 = function (uniform, array) {
+            if (!uniform || array.length % 3 !== 0)
+                return;
+            this._gl.uniform3fv(uniform, array);
+        };
+        Engine.prototype.setArray4 = function (uniform, array) {
+            if (!uniform || array.length % 4 !== 0)
+                return;
+            this._gl.uniform4fv(uniform, array);
+        };
         Engine.prototype.setMatrices = function (uniform, matrices) {
             if (!uniform)
                 return;

--- a/Babylon/babylon.engine.ts
+++ b/Babylon/babylon.engine.ts
@@ -1254,6 +1254,27 @@
             this._gl.uniform1fv(uniform, array);
         }
 
+        public setArray2(uniform: WebGLUniformLocation, array: number[]): void {
+            if (!uniform || array.length % 2 !== 0)
+                return;
+
+            this._gl.uniform2fv(uniform, array);
+        }
+
+        public setArray3(uniform: WebGLUniformLocation, array: number[]): void {
+            if (!uniform || array.length % 3 !== 0)
+                return;
+
+            this._gl.uniform3fv(uniform, array);
+        }
+
+        public setArray4(uniform: WebGLUniformLocation, array: number[]): void {
+            if (!uniform || array.length % 4 !== 0)
+                return;
+
+            this._gl.uniform4fv(uniform, array);
+        }
+
         public setMatrices(uniform: WebGLUniformLocation, matrices: Float32Array): void {
             if (!uniform)
                 return;


### PR DESCRIPTION
Not sure that array length verification is really necessary but I still added

Usage :
GLSL:
uniform vec3 sampleSphere[16];

TS/JS:
var sampleSphere = [
    0.5381, 0.1856, -0.4319,
    0.1379, 0.2486, 0.4430,
    ...
    ...
];

effect.setArray3("sampleSphere", sampleSphere);