### PR TITLE
Added FOV mode setting to engine

### DIFF
--- a/Babylon/Cameras/babylon.camera.ts
+++ b/Babylon/Cameras/babylon.camera.ts
@@ -291,7 +291,7 @@
                     this.minZ = 0.1;
                 }
 
-                Matrix.PerspectiveFovLHToRef(this.fov, engine.getAspectRatio(this), this.minZ, this.maxZ, this._projectionMatrix);
+                Matrix.PerspectiveFovLHToRef(this.fov, engine.getAspectRatio(this), this.minZ, this.maxZ, this._projectionMatrix, engine.fovMode);
                 return this._projectionMatrix;
             }
 

--- a/Babylon/Cameras/babylon.camera.ts
+++ b/Babylon/Cameras/babylon.camera.ts
@@ -4,6 +4,9 @@
         public static PERSPECTIVE_CAMERA = 0;
         public static ORTHOGRAPHIC_CAMERA = 1;
 
+        private static FOVMODE_VERTICAL_FIXED = 0;
+        private static FOVMODE_HORIZONTAL_FIXED = 1;
+
         // Members
         public upVector = Vector3.Up();
         public orthoLeft = null;
@@ -19,6 +22,7 @@
         public viewport = new Viewport(0, 0, 1.0, 1.0);
         public subCameras = [];
         public layerMask: number = 0xFFFFFFFF;
+        public fovMode: number = Camera.FOVMODE_VERTICAL_FIXED;
 
         private _computedViewMatrix = Matrix.Identity();
         public _projectionMatrix = new Matrix();
@@ -291,7 +295,7 @@
                     this.minZ = 0.1;
                 }
 
-                Matrix.PerspectiveFovLHToRef(this.fov, engine.getAspectRatio(this), this.minZ, this.maxZ, this._projectionMatrix, engine.fovMode);
+                Matrix.PerspectiveFovLHToRef(this.fov, engine.getAspectRatio(this), this.minZ, this.maxZ, this._projectionMatrix, this.fovMode);
                 return this._projectionMatrix;
             }
 

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -2089,9 +2089,6 @@
             if(v_fixed) { result.m[5] = tan; }
             else if(h_fixed) { result.m[5] = tan * aspect; }
 
-            result.m[0] = tan / aspect;
-            result.m[1] = result.m[2] = result.m[3] = 0.0;
-            result.m[5] = tan;
             result.m[4] = result.m[6] = result.m[7] = 0.0;
             result.m[8] = result.m[9] = 0.0;
             result.m[10] = -zfar / (znear - zfar);

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -2078,8 +2078,8 @@
         public static PerspectiveFovLHToRef(fov: number, aspect: number, znear: number, zfar: number, result: Matrix, fovMode?: number): void {
             var tan = 1.0 / (Math.tan(fov * 0.5));
 
-            var v_fixed = !fovMode || (fovMode == BABYLON.Camera.FOVMODE_VERTICAL_FIXED);
-            var h_fixed = (fovMode == BABYLON.Camera.FOVMODE_HORIZONTAL_FIXED);
+            var v_fixed = !fovMode || (fovMode == Camera.FOVMODE_VERTICAL_FIXED);
+            var h_fixed = (fovMode == Camera.FOVMODE_HORIZONTAL_FIXED);
 
             if(v_fixed) { result.m[0] = tan / aspect; }
             else if(h_fixed) { result.m[0] = tan; }  

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -2075,8 +2075,19 @@
             return matrix;
         }
 
-        public static PerspectiveFovLHToRef(fov: number, aspect: number, znear: number, zfar: number, result: Matrix): void {
+        public static PerspectiveFovLHToRef(fov: number, aspect: number, znear: number, zfar: number, result: Matrix, fovMode?: number): void {
             var tan = 1.0 / (Math.tan(fov * 0.5));
+
+            var v_fixed = !fovMode || (fovMode == BABYLON.Engine.FOVMODE_VERTICAL_FIXED);
+            var h_fixed = (fovMode == BABYLON.Engine.FOVMODE_HORIZONTAL_FIXED);
+
+            if(v_fixed) { result.m[0] = tan / aspect; }
+            else if(h_fixed) { result.m[0] = tan; }  
+
+            result.m[1] = result.m[2] = result.m[3] = 0.0;
+
+            if(v_fixed) { result.m[5] = tan; }
+            else if(h_fixed) { result.m[5] = tan * aspect; }
 
             result.m[0] = tan / aspect;
             result.m[1] = result.m[2] = result.m[3] = 0.0;

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -2078,8 +2078,8 @@
         public static PerspectiveFovLHToRef(fov: number, aspect: number, znear: number, zfar: number, result: Matrix, fovMode?: number): void {
             var tan = 1.0 / (Math.tan(fov * 0.5));
 
-            var v_fixed = !fovMode || (fovMode == BABYLON.Engine.FOVMODE_VERTICAL_FIXED);
-            var h_fixed = (fovMode == BABYLON.Engine.FOVMODE_HORIZONTAL_FIXED);
+            var v_fixed = !fovMode || (fovMode == BABYLON.Camera.FOVMODE_VERTICAL_FIXED);
+            var h_fixed = (fovMode == BABYLON.Camera.FOVMODE_HORIZONTAL_FIXED);
 
             if(v_fixed) { result.m[0] = tan / aspect; }
             else if(h_fixed) { result.m[0] = tan; }  

--- a/Babylon/babylon.engine.ts
+++ b/Babylon/babylon.engine.ts
@@ -365,6 +365,9 @@
         private static _DELAYLOADSTATE_LOADING = 2;
         private static _DELAYLOADSTATE_NOTLOADED = 4;
 
+        private static _FOVMODE_VERTICAL_FIXED = 0;
+        private static _FOVMODE_HORIZONTAL_FIXED = 1;
+
         private static _TEXTUREFORMAT_ALPHA = 0;
         private static _TEXTUREFORMAT_LUMINANCE = 1;
         private static _TEXTUREFORMAT_LUMINANCE_ALPHA = 2;
@@ -445,6 +448,7 @@
         public cullBackFaces = true;
         public renderEvenInBackground = true;
         public scenes = new Array<Scene>();
+        public fovMode = Engine.FOVMODE_VERTICAL_FIXED;
 
         // Private Members
         public _gl: WebGLRenderingContext;

--- a/Babylon/babylon.engine.ts
+++ b/Babylon/babylon.engine.ts
@@ -365,9 +365,6 @@
         private static _DELAYLOADSTATE_LOADING = 2;
         private static _DELAYLOADSTATE_NOTLOADED = 4;
 
-        private static _FOVMODE_VERTICAL_FIXED = 0;
-        private static _FOVMODE_HORIZONTAL_FIXED = 1;
-
         private static _TEXTUREFORMAT_ALPHA = 0;
         private static _TEXTUREFORMAT_LUMINANCE = 1;
         private static _TEXTUREFORMAT_LUMINANCE_ALPHA = 2;
@@ -448,7 +445,6 @@
         public cullBackFaces = true;
         public renderEvenInBackground = true;
         public scenes = new Array<Scene>();
-        public fovMode = Engine.FOVMODE_VERTICAL_FIXED;
 
         // Private Members
         public _gl: WebGLRenderingContext;


### PR DESCRIPTION
- a new 'fovMode' public property has been added on the engine
- two new static constants have been added to the Engine class:
  FOVMODE_VERTICAL_FIXED (default)
  FOVMODE_HORIZONTAL_FIXED
- a new optional parameter has been added to the PerspectiveFovLHToRef
  function of the Matrix class, allowing to change the FOV mode
- the Camera class has been modified, so that when it calls
  PerspectiveFovLHToRef to create its projection matrix, it will pass the
  current engine fovMode property to it
- FOV mode can be effectively changed at runtime, since the camera's
  projection matrix will be recreated with the newest FOV mode at each resize
- since the property can take different values, it is possible to add new
  FOV modes, for example: anamorphic, stretch, etc.

More info: http://en.wikipedia.org/wiki/Field_of_view_in_video_games