### PR TITLE
debug layer : better layout and events management

### DIFF
--- a/Babylon/Debug/babylon.debugLayer.ts
+++ b/Babylon/Debug/babylon.debugLayer.ts
@@ -419,6 +419,8 @@
 
             var boundingBoxesCheckbox = document.createElement("input");
             boundingBoxesCheckbox.type = "checkbox";
+            boundingBoxesCheckbox.style.pointerEvents = "auto";
+            boundingBoxesCheckbox.style.setProperty ("width", "25px", "important");
             boundingBoxesCheckbox.checked = initialState;
 
             boundingBoxesCheckbox.addEventListener("change", (evt: Event) => {

--- a/Babylon/Debug/babylon.debugLayer.ts
+++ b/Babylon/Debug/babylon.debugLayer.ts
@@ -450,6 +450,8 @@
 
             var boundingBoxesCheckbox = document.createElement("input");
             boundingBoxesCheckbox.type = "checkbox";
+            boundingBoxesCheckbox.style.pointerEvents = "auto";
+            boundingBoxesCheckbox.style.setProperty ("width", "25px", "important");
             boundingBoxesCheckbox.checked = initialState;
 
             boundingBoxesCheckbox.addEventListener("change", (evt: Event) => {
@@ -467,6 +469,8 @@
 
             var boundingBoxesRadio = document.createElement("input");
             boundingBoxesRadio.type = "radio";
+            boundingBoxesRadio.style.pointerEvents = "auto";
+            boundingBoxesRadio.style.setProperty ("width", "25px", "important");  
             boundingBoxesRadio.name = name;
             boundingBoxesRadio.checked = initialState;
 
@@ -487,7 +491,8 @@
             this._globalDiv.style.fontFamily = "Segoe UI, Arial";
             this._globalDiv.style.fontSize = "14px";
             this._globalDiv.style.color = "white";
-
+            this._globalDiv.style.pointerEvents = "none"; 
+            
             // Drawing canvas
             this._drawingCanvas = document.createElement("canvas");
             this._drawingCanvas.id = "DebugLayerDrawingCanvas";
@@ -539,6 +544,7 @@
                 this._logDiv.style.background = background;
                 this._logDiv.style.padding = "0px 0px 0px 5px";
                 this._logDiv.style.display = "none";
+                this._logDiv.style.pointerEvents = "auto";
                 this._generateheader(this._logDiv, "LOGS");
                 this._logSubsetDiv = document.createElement("div");
                 this._logSubsetDiv.style.height = "127px";


### PR DESCRIPTION
With thoses changes, the debug layer doesn't take events so it's possible to manipulate the scene (camera, etc) even under the debug layer's area (checkboxes, radio buttons are still clickable and text in the log window can be copied). 
Also the size of some elements is better adapted to all kind of screens (on little screens layout was a mess).