### PR TITLE
Fixed depth calculation for DepthRenderer

### DIFF
--- a/Babylon/Shaders/depth.fragment.fx
+++ b/Babylon/Shaders/depth.fragment.fx
@@ -16,6 +16,6 @@ void main(void)
 		discard;
 #endif
 
-	float depth = gl_FragCoord.z / far;
+	float depth = gl_FragCoord.z / gl_FragCoord.w / far;
 	gl_FragColor = vec4(depth, depth * depth, 0.0, 1.0);
 }


### PR DESCRIPTION
Very small fix, large consequences! Also the SSAO render pipeline works better now.
Depth value varies between 0 (viewer) and 1 (far plane).
References:
http://www.html5gamedevs.com/topic/9549-getting-a-depth-texture/
http://www.html5gamedevs.com/topic/12153-depth-only-pass/