### PR TITLE
Modified export for meshes with parent (Blender exporter)

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -1,7 +1,7 @@
 bl_info = {
     'name': 'Babylon.js',
     'author': 'David Catuhe, Jeff Palmer',
-    'version': (1, 6, 2),
+    'version': (1, 7, 0),
     'blender': (2, 72, 0),
     "location": "File > Export > Babylon.js (.babylon)",
     "description": "Export Babylon.js scenes (.babylon)",

--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -564,7 +564,7 @@ class Mesh(FCurveAnimatable):
         
         world = object.matrix_world
         if object.parent and not hasSkeleton:
-            world *= object.parent.matrix_world.inverted()
+            world = object.matrix_local
             
         # use defaults when not None
         if forcedParent is None:


### PR DESCRIPTION
I've found that using

    world = object.matrix_local

instead of

    world *= object.parent.matrix_world.inverted()

works best for importing meshes with a parent: relative transforms between parent/child are then consistent from Blender to BJS.

Without this change, relative transforms are wrong 95% of time after being exporter in BJS, probably because of the calculation with the parent inverse matrix.

I'm not very confident with Python and Blender scripting so I'll leave you guys to decide whether this modification makes sense, or if I just missed something on my side.