### PR TITLE
Gulp fix

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -24,16 +24,20 @@ gulp.task('shaders', function() {
  */
 gulp.task('typescript-to-js', function() {
   //Compile all ts file into their respective js file.
-  return gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
-	.pipe(sourcemaps.init())
-    .pipe(typescript({ noExternalResolve: true, target: 'ES5'}))
-    .pipe(gulp.dest('../../Babylon/'));
+  
+  var tsResult = gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
+                       .pipe(sourcemaps.init()) // This means sourcemaps will be generated
+                       .pipe(typescript({ noExternalResolve: true, target: 'ES5'}));
+  
+   return tsResult.js
+                .pipe(sourcemaps.write('.')) // Now the sourcemaps are added to the .js file
+                .pipe(gulp.dest('../../Babylon/'));
 });
 
 /**
  * Compile the declaration file babylon.d.ts
  */
-gulp.task('typescript-declaration', function() {
+gulp.task('typescript-declaration', ['typescript-to-js'], function() {
 	
 	var tsResult = gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
                        .pipe(typescript({
@@ -209,7 +213,7 @@ gulp.task('default', function() {
 /**
  * The defaut typescript task, call the tasks: shaders, scripts, clean AFTER the task typescript-to-js
  */
-gulp.task('typescript', ['typescript-to-js', 'typescript-declaration'], function() {
+gulp.task('typescript', ['typescript-declaration'], function() {
     gulp.start('shaders','scripts', 'clean');
 });
 

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -3,8 +3,10 @@ var gulp = require('gulp'),
     rename = require('gulp-rename'),
     concat = require('gulp-concat'),
     clean = require('gulp-clean'),
-    typescript = require('gulp-tsc'),
-    shaders = require('./gulp-shaders')
+    typescript = require('gulp-typescript'),
+	sourcemaps = require('gulp-sourcemaps'),
+	merge = require('merge2'),
+    shaders = require('./gulp-shaders'),
     gulpFilter = require('gulp-filter');
 
 /**
@@ -23,7 +25,8 @@ gulp.task('shaders', function() {
 gulp.task('typescript-to-js', function() {
   //Compile all ts file into their respective js file.
   return gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
-    .pipe(typescript({ target: 'ES5', sourcemap: true }))
+	.pipe(sourcemaps.init())
+    .pipe(typescript({ noExternalResolve: true, target: 'ES5'}))
     .pipe(gulp.dest('../../Babylon/'));
 });
 
@@ -31,13 +34,16 @@ gulp.task('typescript-to-js', function() {
  * Compile the declaration file babylon.d.ts
  */
 gulp.task('typescript-declaration', function() {
-  var declarationFilter = gulpFilter('**/*.d.ts');
+	
+	var tsResult = gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
+                       .pipe(typescript({
+                           declarationFiles: true,
+                           noExternalResolve: true,
+						   target: 'ES5'
+                       }));
 
-  return gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
-    .pipe(typescript({ target: 'ES5', declaration: true, out: 'tmp.js' }))
-    .pipe(declarationFilter)
-    .pipe(rename('babylon.d.ts'))
-    .pipe(gulp.dest('build/'));
+    return tsResult.dts.pipe(concat('babylon.d.ts'))
+	.pipe(gulp.dest('build/'));
 });
 
 /**

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -5,11 +5,13 @@
   "main": "",
   "devDependencies": {
     "gulp": "^3.6.2",
+	"typescript": "1.3.0",
     "gulp-clean": "^0.3.0",
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
-    "gulp-tsc": "^0.9.2",
+	"gulp-typescript" : "2.0.0",
+	"gulp-sourcemaps" : "",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",
     "through": "^2.3.4"

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -5,13 +5,12 @@
   "main": "",
   "devDependencies": {
     "gulp": "^3.6.2",
-	"typescript": "1.3.0",
     "gulp-clean": "^0.3.0",
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
 	"gulp-typescript" : "2.0.0",
-	"gulp-sourcemaps" : "",
+	"gulp-sourcemaps" : "1.3.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",
     "through": "^2.3.4"


### PR DESCRIPTION
gulp tsc is not defining which typescript version to use.
At the moment babylon only supports version 1.0.1 due to small changes in the lib.d.ts in newer ts versions.

Checked on a windows machine, this fixes also the problem with "command line too long" that windows had.

Another fix would be to check the problems with typescript 1.4 and see how they can be fixed.