### PR TITLE
Source conform to typescript 1.4

### DIFF
--- a/Babylon/Materials/Textures/babylon.videoTexture.js
+++ b/Babylon/Materials/Textures/babylon.videoTexture.js
@@ -31,6 +31,7 @@ var BABYLON;
                 }
             });
             urls.forEach(function (url) {
+                //Backwards-compatibility for typescript 1. from 1.3 it should say "SOURCE". see here - https://github.com/Microsoft/TypeScript/issues/1850
                 var source = document.createElement("source");
                 source.src = url;
                 _this.video.appendChild(source);

--- a/Babylon/Materials/Textures/babylon.videoTexture.ts
+++ b/Babylon/Materials/Textures/babylon.videoTexture.ts
@@ -32,7 +32,8 @@
             });
 
             urls.forEach(url => {
-                var source = document.createElement("source");
+                //Backwards-compatibility for typescript 1. from 1.3 it should say "SOURCE". see here - https://github.com/Microsoft/TypeScript/issues/1850
+                var source = <HTMLSourceElement> document.createElement("source");
                 source.src = url;
                 this.video.appendChild(source);
             });

--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -714,6 +714,7 @@ var BABYLON;
                 canvas.height = heightMapHeight;
                 context.drawImage(img, 0, 0);
                 // Create VertexData from map data
+                //Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949
                 var buffer = context.getImageData(0, 0, heightMapWidth, heightMapHeight).data;
                 _this.applyDisplacementMapFromBuffer(buffer, heightMapWidth, heightMapHeight, minHeight, maxHeight);
                 //execute success callback, if set
@@ -973,6 +974,7 @@ var BABYLON;
                 canvas.height = heightMapHeight;
                 context.drawImage(img, 0, 0);
                 // Create VertexData from map data
+                //Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949 
                 var buffer = context.getImageData(0, 0, heightMapWidth, heightMapHeight).data;
                 var vertexData = BABYLON.VertexData.CreateGroundFromHeightMap(width, height, subdivisions, minHeight, maxHeight, buffer, heightMapWidth, heightMapHeight);
                 vertexData.applyToMesh(ground, updatable);

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -879,7 +879,8 @@
                 context.drawImage(img, 0, 0);
 
                 // Create VertexData from map data
-                var buffer = context.getImageData(0, 0, heightMapWidth, heightMapHeight).data;
+                //Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949
+                var buffer = <Uint8Array> (<any>context.getImageData(0, 0, heightMapWidth, heightMapHeight).data);
 
                 this.applyDisplacementMapFromBuffer(buffer, heightMapWidth, heightMapHeight, minHeight, maxHeight);
                 //execute success callback, if set
@@ -1213,7 +1214,8 @@
                 context.drawImage(img, 0, 0);
 
                 // Create VertexData from map data
-                var buffer = context.getImageData(0, 0, heightMapWidth, heightMapHeight).data;
+                //Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949 
+                var buffer = <Uint8Array> (<any>context.getImageData(0, 0, heightMapWidth, heightMapHeight).data);
                 var vertexData = VertexData.CreateGroundFromHeightMap(width, height, subdivisions, minHeight, maxHeight, buffer, heightMapWidth, heightMapHeight);
 
                 vertexData.applyToMesh(ground, updatable);

--- a/Babylon/Tools/babylon.database.js
+++ b/Babylon/Tools/babylon.database.js
@@ -197,7 +197,8 @@ var BABYLON;
                             // the transaction could abort because of a QuotaExceededError error
                             transaction.onabort = function (event) {
                                 try {
-                                    if (event.srcElement.error.name === "QuotaExceededError") {
+                                    //backwards compatibility with ts 1.0, srcElement doesn't have an "error" according to ts 1.3
+                                    if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                         this.hasReachedQuota = true;
                                     }
                                 }
@@ -306,7 +307,7 @@ var BABYLON;
                     // the transaction could abort because of a QuotaExceededError error
                     transaction.onabort = function (event) {
                         try {
-                            if (event.srcElement.error.name === "QuotaExceededError") {
+                            if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                 _this.hasReachedQuota = true;
                             }
                         }
@@ -420,7 +421,8 @@ var BABYLON;
                             // the transaction could abort because of a QuotaExceededError error
                             transaction.onabort = function (event) {
                                 try {
-                                    if (event.srcElement.error.name === "QuotaExceededError") {
+                                    //backwards compatibility with ts 1.0, srcElement doesn't have an "error" according to ts 1.3
+                                    if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                         this.hasReachedQuota = true;
                                     }
                                 }

--- a/Babylon/Tools/babylon.database.ts
+++ b/Babylon/Tools/babylon.database.ts
@@ -257,7 +257,8 @@ module BABYLON {
                             // the transaction could abort because of a QuotaExceededError error
                             transaction.onabort = function (event) {
                                 try {
-                                    if (event.srcElement.error.name === "QuotaExceededError") {
+                                    //backwards compatibility with ts 1.0, srcElement doesn't have an "error" according to ts 1.3
+                                    if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                         this.hasReachedQuota = true;
                                     }
                                 }
@@ -375,8 +376,8 @@ module BABYLON {
 
                     // the transaction could abort because of a QuotaExceededError error
                     transaction.onabort = event => {
-                        try {
-                            if (event.srcElement.error.name === "QuotaExceededError") {
+                        try {//backwards compatibility with ts 1.0, srcElement doesn't have an "error" according to ts 1.3
+                            if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                 this.hasReachedQuota = true;
                             }
                         }
@@ -494,7 +495,7 @@ module BABYLON {
 
                 xhr.onprogress = progressCallback;
 
-                xhr.addEventListener("load", () => {
+                xhr.addEventListener("load", () => { 
                     if (xhr.status === 200 || BABYLON.Tools.ValidateXHRData(xhr, !useArrayBuffer ? 1 : 6)) {
                         // Blob as response (XHR2)
                         //fileData = xhr.responseText;
@@ -507,7 +508,8 @@ module BABYLON {
                             // the transaction could abort because of a QuotaExceededError error
                             transaction.onabort = function (event) {
                                 try {
-                                    if (event.srcElement.error.name === "QuotaExceededError") {
+                                    //backwards compatibility with ts 1.0, srcElement doesn't have an "error" according to ts 1.3
+                                    if (event.srcElement['error'] && event.srcElement['error'].name === "QuotaExceededError") {
                                         this.hasReachedQuota = true;
                                     }
                                 }

--- a/Babylon/Tools/babylon.tools.js
+++ b/Babylon/Tools/babylon.tools.js
@@ -220,7 +220,8 @@ var BABYLON;
         Tools.ReadFileAsDataURL = function (fileToLoad, callback, progressCallback) {
             var reader = new FileReader();
             reader.onload = function (e) {
-                callback(e.target.result);
+                //target doesn't have result from ts 1.3
+                callback(e.target['result']);
             };
             reader.onprogress = progressCallback;
             reader.readAsDataURL(fileToLoad);
@@ -228,7 +229,8 @@ var BABYLON;
         Tools.ReadFile = function (fileToLoad, callback, progressCallBack, useArrayBuffer) {
             var reader = new FileReader();
             reader.onload = function (e) {
-                callback(e.target.result);
+                //target doesn't have result from ts 1.3
+                callback(e.target['result']);
             };
             reader.onprogress = progressCallBack;
             if (!useArrayBuffer) {
@@ -412,7 +414,9 @@ var BABYLON;
                 var context = screenshotCanvas.getContext('2d');
                 // Copy the pixels to a 2D canvas
                 var imageData = context.createImageData(width, height);
-                imageData.data.set(data);
+                //cast is due to ts error in lib.d.ts, see here - https://github.com/Microsoft/TypeScript/issues/949
+                var data = imageData.data;
+                data.set(data);
                 context.putImageData(imageData, 0, 0);
                 var base64Image = screenshotCanvas.toDataURL();
                 //Creating a link if the browser have the download attribute on the a tag, to automatically start download generated image.

--- a/Babylon/Tools/babylon.tools.ts
+++ b/Babylon/Tools/babylon.tools.ts
@@ -285,7 +285,8 @@
         public static ReadFileAsDataURL(fileToLoad, callback, progressCallback): void {
             var reader = new FileReader();
             reader.onload = e => {
-                callback(e.target.result);
+                //target doesn't have result from ts 1.3
+                callback(e.target['result']);
             };
             reader.onprogress = progressCallback;
             reader.readAsDataURL(fileToLoad);
@@ -294,7 +295,8 @@
         public static ReadFile(fileToLoad, callback, progressCallBack, useArrayBuffer?: boolean): void {
             var reader = new FileReader();
             reader.onload = e => {
-                callback(e.target.result);
+                //target doesn't have result from ts 1.3
+                callback(e.target['result']);
             };
             reader.onprogress = progressCallBack;
             if (!useArrayBuffer) {
@@ -506,7 +508,9 @@
 
                 // Copy the pixels to a 2D canvas
                 var imageData = context.createImageData(width, height);
-                imageData.data.set(data);
+                //cast is due to ts error in lib.d.ts, see here - https://github.com/Microsoft/TypeScript/issues/949
+                var data = <Uint8Array> (<any> imageData.data);
+                data.set(data);
                 context.putImageData(imageData, 0, 0);
 
                 var base64Image = screenshotCanvas.toDataURL();

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -24,16 +24,20 @@ gulp.task('shaders', function() {
  */
 gulp.task('typescript-to-js', function() {
   //Compile all ts file into their respective js file.
-  return gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
-	.pipe(sourcemaps.init())
-    .pipe(typescript({ noExternalResolve: true, target: 'ES5'}))
-    .pipe(gulp.dest('../../Babylon/'));
+  
+  var tsResult = gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
+                       .pipe(sourcemaps.init()) // This means sourcemaps will be generated
+                       .pipe(typescript({ noExternalResolve: true, target: 'ES5'}));
+  
+   return tsResult.js
+                .pipe(sourcemaps.write('.')) // Now the sourcemaps are added to the .js file
+                .pipe(gulp.dest('../../Babylon/'));
 });
 
 /**
  * Compile the declaration file babylon.d.ts
  */
-gulp.task('typescript-declaration', function() {
+gulp.task('typescript-declaration', ['typescript-to-js'], function() {
 	
 	var tsResult = gulp.src(['../../Babylon/**/*.ts','../../References/**/*.d.ts'])
                        .pipe(typescript({
@@ -209,7 +213,7 @@ gulp.task('default', function() {
 /**
  * The defaut typescript task, call the tasks: shaders, scripts, clean AFTER the task typescript-to-js
  */
-gulp.task('typescript', ['typescript-to-js', 'typescript-declaration'], function() {
+gulp.task('typescript', ['typescript-declaration'], function() {
     gulp.start('shaders','scripts', 'clean');
 });
 

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -9,7 +9,7 @@
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
-	"gulp-typescript" : "2.0.0",
+	"gulp-typescript" : "2.4.0",
 	"gulp-sourcemaps" : "1.3.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",


### PR DESCRIPTION
There are some problems in the main lib.d.ts from typescript 1.3 and up.
The JS files are untouched, those are just casts to make typescript play
nice.
To make bjs compile on compilers from 1 and up those edits are required.

Error example can be found here -
http://www.html5gamedevs.com/topic/12229-starting-bjs-ts-sublime-text/page-2