### PR TITLE
Decimation queue and submeshes support

### DIFF
--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -137,6 +137,15 @@ var BABYLON;
             this._sortLODLevels();
             return this;
         };
+        Mesh.prototype.getLODLevelAtDistance = function (distance) {
+            for (var index = 0; index < this._LODLevels.length; index++) {
+                var level = this._LODLevels[index];
+                if (level.distance === distance) {
+                    return level.mesh;
+                }
+            }
+            return null;
+        };
         /**
          * Remove a mesh from the LOD array
          * @param {BABYLON.Mesh} mesh - the mesh to be removed.
@@ -872,18 +881,14 @@ var BABYLON;
          * successCallback optional success callback to be called after the simplification finished processing all settings.
          */
         Mesh.prototype.simplify = function (settings, parallelProcessing, simplificationType, successCallback) {
-            var _this = this;
             if (parallelProcessing === void 0) { parallelProcessing = true; }
             if (simplificationType === void 0) { simplificationType = BABYLON.SimplificationType.QUADRATIC; }
-            this.subMeshes.forEach(function (submesh, index) {
-                _this.getScene().simplificationQueue.addTask({
-                    settings: settings,
-                    parallelProcessing: parallelProcessing,
-                    mesh: _this,
-                    submeshIndex: index,
-                    simplificationType: simplificationType,
-                    successCallback: successCallback
-                });
+            this.getScene().simplificationQueue.addTask({
+                settings: settings,
+                parallelProcessing: parallelProcessing,
+                mesh: this,
+                simplificationType: simplificationType,
+                successCallback: successCallback
             });
         };
         // Statics

--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -872,14 +872,18 @@ var BABYLON;
          * successCallback optional success callback to be called after the simplification finished processing all settings.
          */
         Mesh.prototype.simplify = function (settings, parallelProcessing, simplificationType, successCallback) {
+            var _this = this;
             if (parallelProcessing === void 0) { parallelProcessing = true; }
             if (simplificationType === void 0) { simplificationType = BABYLON.SimplificationType.QUADRATIC; }
-            this.getScene().simplificationQueue.addTask({
-                settings: settings,
-                parallelProcessing: parallelProcessing,
-                mesh: this,
-                simplificationType: simplificationType,
-                successCallback: successCallback
+            this.subMeshes.forEach(function (submesh, index) {
+                _this.getScene().simplificationQueue.addTask({
+                    settings: settings,
+                    parallelProcessing: parallelProcessing,
+                    mesh: _this,
+                    submeshIndex: index,
+                    simplificationType: simplificationType,
+                    successCallback: successCallback
+                });
             });
         };
         // Statics

--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -871,52 +871,16 @@ var BABYLON;
          * @param type the type of simplification to run.
          * successCallback optional success callback to be called after the simplification finished processing all settings.
          */
-        Mesh.prototype.simplify = function (settings, parallelProcessing, type, successCallback) {
-            var _this = this;
+        Mesh.prototype.simplify = function (settings, parallelProcessing, simplificationType, successCallback) {
             if (parallelProcessing === void 0) { parallelProcessing = true; }
-            if (type === void 0) { type = 0 /* QUADRATIC */; }
-            var getSimplifier = function () {
-                switch (type) {
-                    case 0 /* QUADRATIC */:
-                    default:
-                        return new BABYLON.QuadraticErrorSimplification(_this);
-                }
-            };
-            if (parallelProcessing) {
-                //parallel simplifier
-                settings.forEach(function (setting) {
-                    var simplifier = getSimplifier();
-                    simplifier.simplify(setting, function (newMesh) {
-                        _this.addLODLevel(setting.distance, newMesh);
-                        //check if it is the last
-                        if (setting.quality === settings[settings.length - 1].quality && successCallback) {
-                            //all done, run the success callback.
-                            successCallback();
-                        }
-                    });
-                });
-            }
-            else {
-                //single simplifier.
-                var simplifier = getSimplifier();
-                var runDecimation = function (setting, callback) {
-                    simplifier.simplify(setting, function (newMesh) {
-                        _this.addLODLevel(setting.distance, newMesh);
-                        //run the next quality level
-                        callback();
-                    });
-                };
-                BABYLON.AsyncLoop.Run(settings.length, function (loop) {
-                    runDecimation(settings[loop.index], function () {
-                        loop.executeNext();
-                    });
-                }, function () {
-                    //execution ended, run the success callback.
-                    if (successCallback) {
-                        successCallback();
-                    }
-                });
-            }
+            if (simplificationType === void 0) { simplificationType = BABYLON.SimplificationType.QUADRATIC; }
+            this.getScene().simplificationQueue.addTask({
+                settings: settings,
+                parallelProcessing: parallelProcessing,
+                mesh: this,
+                simplificationType: simplificationType,
+                successCallback: successCallback
+            });
         };
         // Statics
         Mesh.CreateRibbon = function (name, pathArray, closeArray, closePath, offset, scene, updatable, sideOrientation) {

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -148,6 +148,17 @@
             return this;
         }
 
+        public getLODLevelAtDistance(distance: number) : Mesh {
+            for (var index = 0; index < this._LODLevels.length; index++) {
+                var level = this._LODLevels[index];
+
+                if (level.distance === distance) {
+                    return level.mesh;
+                }
+            }
+            return null;
+        }
+
         /**
          * Remove a mesh from the LOD array
          * @param {BABYLON.Mesh} mesh - the mesh to be removed.
@@ -1069,17 +1080,14 @@
          * @param type the type of simplification to run.
          * successCallback optional success callback to be called after the simplification finished processing all settings.
          */
-        public simplify(settings: Array<ISimplificationSettings>, parallelProcessing: boolean = true, simplificationType: SimplificationType = SimplificationType.QUADRATIC, successCallback?: () => void) {
-            this.subMeshes.forEach((submesh, index) => {
-                this.getScene().simplificationQueue.addTask({
-                    settings: settings,
-                    parallelProcessing: parallelProcessing,
-                    mesh: this,
-                    submeshIndex:index,
-                    simplificationType: simplificationType,
-                    successCallback: successCallback
-                });  
-            }); 
+        public simplify(settings: Array<ISimplificationSettings>, parallelProcessing: boolean = true, simplificationType: SimplificationType = SimplificationType.QUADRATIC, successCallback?: (mesh?: Mesh, submeshIndex?: number) => void) {
+            this.getScene().simplificationQueue.addTask({
+                settings: settings,
+                parallelProcessing: parallelProcessing,
+                mesh: this,
+                simplificationType: simplificationType,
+                successCallback: successCallback
+            });  
         }
 
         // Statics

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1070,13 +1070,16 @@
          * successCallback optional success callback to be called after the simplification finished processing all settings.
          */
         public simplify(settings: Array<ISimplificationSettings>, parallelProcessing: boolean = true, simplificationType: SimplificationType = SimplificationType.QUADRATIC, successCallback?: () => void) {
-            this.getScene().simplificationQueue.addTask({
-                settings: settings,
-                parallelProcessing: parallelProcessing,
-                mesh: this,
-                simplificationType: simplificationType,
-                successCallback: successCallback
-            });            
+            this.subMeshes.forEach((submesh, index) => {
+                this.getScene().simplificationQueue.addTask({
+                    settings: settings,
+                    parallelProcessing: parallelProcessing,
+                    mesh: this,
+                    submeshIndex:index,
+                    simplificationType: simplificationType,
+                    successCallback: successCallback
+                });  
+            }); 
         }
 
         // Statics

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -443,6 +443,7 @@ var BABYLON;
             }
             var startingVertex = this._reconstructedMesh.getTotalVertices();
             var startingIndex = this._reconstructedMesh.getTotalIndices();
+            //overwriting the old vertex buffers and indices.
             this._reconstructedMesh.setIndices(newIndicesArray);
             this._reconstructedMesh.setVerticesData(BABYLON.VertexBuffer.PositionKind, newPositionData);
             this._reconstructedMesh.setVerticesData(BABYLON.VertexBuffer.NormalKind, newNormalData);
@@ -450,9 +451,6 @@ var BABYLON;
                 this._reconstructedMesh.setVerticesData(BABYLON.VertexBuffer.UVKind, newUVsData);
             if (newColorsData.length > 0)
                 this._reconstructedMesh.setVerticesData(BABYLON.VertexBuffer.ColorKind, newColorsData);
-            //preparing the skeleton support
-            if (this._mesh.skeleton) {
-            }
             //create submesh
             var originalSubmesh = this._mesh.subMeshes[submeshIndex];
             var newSubmesh = new BABYLON.SubMesh(originalSubmesh.materialIndex, startingVertex, newVerticesOrder.length, startingIndex, newTriangles.length, this._reconstructedMesh);

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -13,6 +13,9 @@ var BABYLON;
             this.running = false;
             this._simplificationArray = [];
         }
+        SimplificationQueue.prototype.addTask = function (task) {
+            this._simplificationArray.push(task);
+        };
         SimplificationQueue.prototype.executeNext = function () {
             var task = this._simplificationArray.pop();
             if (task) {

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -47,6 +47,10 @@
             this._simplificationArray = [];
         }
 
+        public addTask(task: ISimplificationTask) {
+            this._simplificationArray.push(task);
+        }
+
         public executeNext() {
             var task = this._simplificationArray.pop();
             if (task) {

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -252,6 +252,7 @@
                 });
             },() => {
                     setTimeout(() => {
+                        this._reconstructedMesh.isVisible = true;
                         successCallback(this._reconstructedMesh);
                     }, 0);
                 });
@@ -405,7 +406,7 @@
             var submesh = mesh.subMeshes[submeshIndex];
 
             var vertexInit = (i) => {
-                var offset = i;// + submesh.verticesStart;
+                var offset = i + submesh.verticesStart;
                 var vertex = new DecimationVertex(Vector3.FromArray(positionData, offset * 3), Vector3.FromArray(normalData, offset * 3), null, i);
                 if (this._mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                     vertex.uv = Vector2.FromArray(uvs, offset * 2);
@@ -420,10 +421,10 @@
 
                 var indicesInit = (i) => {
                     var offset = (submesh.indexStart/3) + i;
-                    var pos = offset * 3;
-                    var i0 = indices[pos + 0];
-                    var i1 = indices[pos + 1];
-                    var i2 = indices[pos + 2];
+                    var pos = (offset * 3);
+                    var i0 = indices[pos + 0] - submesh.verticesStart;
+                    var i1 = indices[pos + 1] - submesh.verticesStart;
+                    var i2 = indices[pos + 2] - submesh.verticesStart;
                     var triangle = new DecimationTriangle([this.vertices[i0].id, this.vertices[i1].id, this.vertices[i2].id]);
                     this.triangles.push(triangle);
                 };
@@ -551,9 +552,9 @@
             if (submeshIndex > 0) {
                 this._reconstructedMesh.subMeshes = [];
                 submeshesArray.forEach(function (submesh) {
-                    new SubMesh(submesh.materialIndex, /*submesh.verticesStart, submesh.verticesCount,*/ 0, newPositionData.length/3, submesh.indexStart, submesh.indexCount, submesh.getMesh());
+                    new SubMesh(submesh.materialIndex, submesh.verticesStart, submesh.verticesCount,/* 0, newPositionData.length/3, */submesh.indexStart, submesh.indexCount, submesh.getMesh());
                 });
-                var newSubmesh = new SubMesh(originalSubmesh.materialIndex, /*startingVertex, newVerticesOrder.length,*/ 0, newPositionData.length / 3, startingIndex, newTriangles.length*3, this._reconstructedMesh);
+                var newSubmesh = new SubMesh(originalSubmesh.materialIndex, startingVertex, newVerticesOrder.length,/* 0, newPositionData.length / 3, */startingIndex, newTriangles.length*3, this._reconstructedMesh);
             }
         }
 
@@ -561,6 +562,7 @@
             this._reconstructedMesh = new Mesh(this._mesh.name + "Decimated", this._mesh.getScene());
             this._reconstructedMesh.material = this._mesh.material;
             this._reconstructedMesh.parent = this._mesh.parent;
+            this._reconstructedMesh.isVisible = false;
         }
 
         private isFlipped(vertex1: DecimationVertex, index2: number, point: Vector3, deletedArray: Array<boolean>, borderFactor: number, delTr: Array<DecimationTriangle>): boolean {

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -530,6 +530,7 @@
             var startingVertex = this._reconstructedMesh.getTotalVertices();
             var startingIndex = this._reconstructedMesh.getTotalIndices();
 
+            //overwriting the old vertex buffers and indices.
             this._reconstructedMesh.setIndices(newIndicesArray);
             this._reconstructedMesh.setVerticesData(VertexBuffer.PositionKind, newPositionData);
             this._reconstructedMesh.setVerticesData(VertexBuffer.NormalKind, newNormalData);
@@ -537,13 +538,7 @@
                 this._reconstructedMesh.setVerticesData(VertexBuffer.UVKind, newUVsData);
             if (newColorsData.length > 0)
                 this._reconstructedMesh.setVerticesData(VertexBuffer.ColorKind, newColorsData);
-
-            //preparing the skeleton support
-            if (this._mesh.skeleton) {
-                //newMesh.skeleton = this._mesh.skeleton.clone("", "");
-                //newMesh.getScene().beginAnimation(newMesh.skeleton, 0, 100, true, 1.0);
-            }
-
+            
             //create submesh
             var originalSubmesh = this._mesh.subMeshes[submeshIndex];
             var newSubmesh = new SubMesh(originalSubmesh.materialIndex, startingVertex, newVerticesOrder.length, startingIndex, newTriangles.length, this._reconstructedMesh);

--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -137,6 +137,8 @@ var BABYLON;
             this.attachControl();
             this._debugLayer = new BABYLON.DebugLayer(this);
             this.mainSoundTrack = new BABYLON.SoundTrack(this, { mainTrack: true });
+            //simplification queue
+            this.simplificationQueue = new BABYLON.SimplificationQueue();
         }
         Object.defineProperty(Scene, "FOGMODE_NONE", {
             get: function () {
@@ -1041,6 +1043,10 @@ var BABYLON;
             // Actions
             if (this.actionManager) {
                 this.actionManager.processTrigger(BABYLON.ActionManager.OnEveryFrameTrigger, null);
+            }
+            //Simplification Queue
+            if (!this.simplificationQueue.running) {
+                this.simplificationQueue.executeNext();
             }
             // Before render
             if (this.beforeRender) {

--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -190,6 +190,9 @@
         public mainSoundTrack: SoundTrack;
         public soundTracks = new Array<SoundTrack>();
 
+        //Simplification Queue
+        public simplificationQueue: SimplificationQueue;
+
         // Private
         private _engine: Engine;
         private _totalVertices = 0;
@@ -271,6 +274,9 @@
 
             this._debugLayer = new DebugLayer(this);
             this.mainSoundTrack = new SoundTrack(this, { mainTrack: true });
+
+            //simplification queue
+            this.simplificationQueue = new SimplificationQueue();
         }
 
         // Properties 
@@ -1336,6 +1342,11 @@
             // Actions
             if (this.actionManager) {
                 this.actionManager.processTrigger(ActionManager.OnEveryFrameTrigger, null);
+            }
+
+            //Simplification Queue
+            if (!this.simplificationQueue.running) {
+                this.simplificationQueue.executeNext();
             }
 
             // Before render


### PR DESCRIPTION
I have extended the decimation functionality.

A Scene has now a decimation queue that is being inspected on every frame for changes. If a new task is added, they are executed async one after the other. Meaning, if someone will now decimate 5 meshes at the same time, they will be decimated one after the other (and not parallel, as it was until now). 
I had to extend the scene class for this. Mesh class was also changed and is now adding a new task to the queue rather than executing it instantly.
Performance will be better when decimating many meshes.

Also added submeshes support. This was rather complex and needed a few changes in the reconstruction code. 

Tested locally on the skull object and self-submeshed meshes.
