### PR TITLE
Fix in Geometry.copy()

### DIFF
--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -394,7 +394,8 @@
             var stopChecking = false;
 
             for (var kind in this._vertexBuffers) {
-                vertexData.set(this.getVerticesData(kind), kind);
+                // using slice() to make a copy of the array and not just reference it
+                vertexData.set(this.getVerticesData(kind).slice(0), kind);
 
                 if (!stopChecking) {
                     updatable = this.getVertexBuffer(kind).isUpdatable();


### PR DESCRIPTION
Without this fix, two geometries which have been copied share the same vertex data arrays. This leads to unexpected behaviour, e.g. infinite loop when trying to merge meshes.