### PR TITLE
Fix for missing lockTagetId

### DIFF
--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
@@ -373,7 +373,13 @@ var BABYLON;
             }
             // Target
             if (parsedCamera.target) {
-                camera.setTarget(BABYLON.Vector3.FromArray(parsedCamera.target));
+                if (camera.setTarget) {
+                    camera.setTarget(BABYLON.Vector3.FromArray(parsedCamera.target));
+                }
+                else {
+                    //For ArcRotate
+                    camera.target = BABYLON.Vector3.FromArray(parsedCamera.target);
+                }
             }
             else {
                 camera.rotation = BABYLON.Vector3.FromArray(parsedCamera.rotation);

--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -454,7 +454,12 @@
 
         // Target
         if (parsedCamera.target) {
-            camera.setTarget(BABYLON.Vector3.FromArray(parsedCamera.target));
+            if (camera.setTarget) {
+                camera.setTarget(BABYLON.Vector3.FromArray(parsedCamera.target));
+            } else {
+                //For ArcRotate
+                camera.target = BABYLON.Vector3.FromArray(parsedCamera.target);
+            }
         } else {
             camera.rotation = BABYLON.Vector3.FromArray(parsedCamera.rotation);
         }

--- a/Babylon/Tools/babylon.sceneSerializer.js
+++ b/Babylon/Tools/babylon.sceneSerializer.js
@@ -49,7 +49,7 @@ var BABYLON;
     var serializeCamera = function (camera) {
         var serializationObject = {};
         serializationObject.name = camera.name;
-        serializationObject.tags = BABYLON.Tags.GetTags(camera);
+        serializationObject.tags = BABYLON.Tags.GetTags(camera) || [];
         serializationObject.id = camera.id;
         serializationObject.position = camera.position.asArray();
         // Parent
@@ -126,6 +126,9 @@ var BABYLON;
         if (camera['speed'] !== undefined) {
             serializationObject.speed = camera['speed'];
         }
+        if (camera['target'] && camera['target'] instanceof BABYLON.Vector3) {
+            serializationObject.target = camera['target'].asArray();
+        }
         // Target
         if (camera['rotation'] && camera['rotation'] instanceof BABYLON.Vector3) {
             serializationObject.rotation = camera['rotation'].asArray();
@@ -134,12 +137,8 @@ var BABYLON;
         if (camera['lockedTarget'] && camera['lockedTarget'].id) {
             serializationObject.lockedTargetId = camera['lockedTarget'].id;
         }
-        if (camera['checkCollisions'] !== undefined) {
-            serializationObject.checkCollisions = camera['checkCollisions'];
-        }
-        if (camera['applyGravity'] !== undefined) {
-            serializationObject.applyGravity = camera['applyGravity'];
-        }
+        serializationObject.checkCollisions = camera['checkCollisions'] || false;
+        serializationObject.applyGravity = camera['applyGravity'] || false;
         if (camera['ellipsoid']) {
             serializationObject.ellipsoid = camera['ellipsoid'].asArray();
         }

--- a/Babylon/Tools/babylon.sceneSerializer.js
+++ b/Babylon/Tools/babylon.sceneSerializer.js
@@ -106,6 +106,9 @@ var BABYLON;
             serializationObject.alpha = arcCamera.alpha;
             serializationObject.beta = arcCamera.beta;
             serializationObject.radius = arcCamera.radius;
+            if (arcCamera.target && camera.target.id) {
+                serializationObject.lockedTargetId = camera.target.id;
+            }
         }
         else if (camera instanceof BABYLON.FollowCamera) {
             var followCam = camera;

--- a/Babylon/Tools/babylon.sceneSerializer.js
+++ b/Babylon/Tools/babylon.sceneSerializer.js
@@ -106,8 +106,8 @@ var BABYLON;
             serializationObject.alpha = arcCamera.alpha;
             serializationObject.beta = arcCamera.beta;
             serializationObject.radius = arcCamera.radius;
-            if (arcCamera.target && camera.target.id) {
-                serializationObject.lockedTargetId = camera.target.id;
+            if (arcCamera.target && arcCamera.target.id) {
+                serializationObject.lockedTargetId = arcCamera.target.id;
             }
         }
         else if (camera instanceof BABYLON.FollowCamera) {

--- a/Babylon/Tools/babylon.sceneSerializer.ts
+++ b/Babylon/Tools/babylon.sceneSerializer.ts
@@ -55,7 +55,7 @@
     var serializeCamera = (camera: Camera): any => {
         var serializationObject:any = {};
         serializationObject.name = camera.name;
-        serializationObject.tags = Tags.GetTags(camera);
+        serializationObject.tags = Tags.GetTags(camera) || [];
         serializationObject.id = camera.id;
         serializationObject.position = camera.position.asArray();
 
@@ -125,6 +125,10 @@
             serializationObject.speed = camera['speed'];
         }
 
+        if (camera['target'] && camera['target'] instanceof Vector3) {
+            serializationObject.target = camera['target'].asArray();
+        }
+
         // Target
         if (camera['rotation'] && camera['rotation'] instanceof Vector3) {
             serializationObject.rotation = camera['rotation'].asArray();
@@ -135,12 +139,8 @@
             serializationObject.lockedTargetId = camera['lockedTarget'].id;
         }
 
-        if (camera['checkCollisions'] !== undefined) {
-            serializationObject.checkCollisions = camera['checkCollisions'];
-        }
-        if (camera['applyGravity'] !== undefined) {
-            serializationObject.applyGravity = camera['applyGravity'];
-        }
+        serializationObject.checkCollisions = camera['checkCollisions'] || false;
+        serializationObject.applyGravity = camera['applyGravity'] || false;
 
         if (camera['ellipsoid']) {
             serializationObject.ellipsoid = camera['ellipsoid'].asArray();

--- a/Babylon/Tools/babylon.sceneSerializer.ts
+++ b/Babylon/Tools/babylon.sceneSerializer.ts
@@ -105,8 +105,8 @@
             serializationObject.alpha = arcCamera.alpha;
             serializationObject.beta = arcCamera.beta;
             serializationObject.radius = arcCamera.radius;
-            if (arcCamera.target && camera.target.id) {
-                serializationObject.lockedTargetId = camera.target.id;
+            if (arcCamera.target && arcCamera.target.id) {
+                serializationObject.lockedTargetId = arcCamera.target.id;
             }
         } else if (camera instanceof FollowCamera) {
             var followCam = <FollowCamera> camera;

--- a/Babylon/Tools/babylon.sceneSerializer.ts
+++ b/Babylon/Tools/babylon.sceneSerializer.ts
@@ -105,6 +105,9 @@
             serializationObject.alpha = arcCamera.alpha;
             serializationObject.beta = arcCamera.beta;
             serializationObject.radius = arcCamera.radius;
+            if (arcCamera.target && camera.target.id) {
+                serializationObject.lockedTargetId = camera.target.id;
+            }
         } else if (camera instanceof FollowCamera) {
             var followCam = <FollowCamera> camera;
             serializationObject.radius = followCam.radius;


### PR DESCRIPTION
The target property in the Arc cameras is different than the rest.