### PR TITLE
Mesh optimization

### DIFF
--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -878,7 +878,7 @@ var BABYLON;
          * @param settings a collection of simplification settings.
          * @param parallelProcessing should all levels calculate parallel or one after the other.
          * @param type the type of simplification to run.
-         * successCallback optional success callback to be called after the simplification finished processing all settings.
+         * @param successCallback optional success callback to be called after the simplification finished processing all settings.
          */
         Mesh.prototype.simplify = function (settings, parallelProcessing, simplificationType, successCallback) {
             if (parallelProcessing === void 0) { parallelProcessing = true; }
@@ -891,7 +891,12 @@ var BABYLON;
                 successCallback: successCallback
             });
         };
-        //The function doesn't delete unused vertex data, it simply restructure the indices to ignore them.
+        /**
+         * Optimization of the mesh's indices, in case a mesh has duplicated vertices.
+         * The function will only reorder the indices and will not remove unused vertices to avoid problems with submeshes.
+         * This should be used together with the simplification to avoid disappearing triangles.
+         * @param successCallback an optional success callback to be called after the optimization finished.
+         */
         Mesh.prototype.optimize = function (successCallback) {
             var _this = this;
             var indices = this.getIndices();
@@ -923,40 +928,6 @@ var BABYLON;
                     successCallback(_this);
                 }
             });
-            //for (var i = vectorPositions.length - 1; i >= 1; --i) {
-            //    var testedPosition = vectorPositions[i];
-            //    for (var j = 0; j < i; ++j) {
-            //        var againstPosition = vectorPositions[j];
-            //        if (testedPosition.equals(againstPosition)) {
-            //            dupes[i] = j;
-            //            break;
-            //        }
-            //    }
-            //}
-            //optimize each submesh individually.
-            //this.subMeshes.forEach(subMesh => {
-            //    var total = subMesh.indexStart + subMesh.indexCount;
-            //    var i;
-            //    var subMeshPositions: Array<Vector3> = []
-            //    for (i = subMesh.indexStart; i < total; ++i) {
-            //        subMeshPositions[indices[i]] = subMeshPositions[indices[i]] || (BABYLON.Vector3.FromArray(positions, indices[i]));
-            //    }
-            //    var dupes = [];
-            //    //find duplicates
-            //    for (i = subMeshPositions.length - 1; i >= 1; --i) {
-            //        var testedPosition = subMeshPositions[i];
-            //        for (var j = 0; j < i; ++j) {
-            //            var againstPosition = subMeshPositions[j];
-            //            if (testedPosition.equals(againstPosition)) {
-            //                dupes[i] = j;
-            //                break;
-            //            }
-            //        }
-            //    }
-            //    for (i = subMesh.indexStart; i < total; ++i) {
-            //        indices[i] = dupes[indices[i]] || indices[i];
-            //    }
-            //});
         };
         // Statics
         Mesh.CreateRibbon = function (name, pathArray, closeArray, closePath, offset, scene, updatable, sideOrientation) {

--- a/Babylon/Mesh/babylon.mesh.js
+++ b/Babylon/Mesh/babylon.mesh.js
@@ -893,37 +893,70 @@ var BABYLON;
         };
         //The function doesn't delete unused vertex data, it simply restructure the indices to ignore them.
         Mesh.prototype.optimize = function (successCallback) {
+            var _this = this;
             var indices = this.getIndices();
             var positions = this.getVerticesData(BABYLON.VertexBuffer.PositionKind);
-            //optimize each submesh individually.
-            this.subMeshes.forEach(function (subMesh) {
-                var total = subMesh.indexStart + subMesh.indexCount;
-                var i;
-                var subMeshPositions = [];
-                for (i = subMesh.indexStart; i < total; ++i) {
-                    subMeshPositions[indices[i]] = subMeshPositions[indices[i]] || (BABYLON.Vector3.FromArray(positions, indices[i]));
-                }
-                var dupes = [];
-                for (i = subMeshPositions.length - 1; i >= 1; --i) {
-                    var testedPosition = subMeshPositions[i];
-					if(!testedPosition) continue;
-                    for (var j = 0; j < i; ++j) {
-                        var againstPosition = subMeshPositions[j];
-						if(!againstPosition) continue; 
-                        if (testedPosition.equals(againstPosition)) {
-                            dupes[i] = j;
-                            break;
-                        }
+            var vectorPositions = [];
+            for (var pos = 0; pos < positions.length; pos = pos + 3) {
+                vectorPositions.push(BABYLON.Vector3.FromArray(positions, pos));
+            }
+            var dupes = [];
+            BABYLON.AsyncLoop.SyncAsyncForLoop(vectorPositions.length, 40, function (iteration) {
+                var realPos = vectorPositions.length - 1 - iteration;
+                var testedPosition = vectorPositions[realPos];
+                for (var j = 0; j < realPos; ++j) {
+                    var againstPosition = vectorPositions[j];
+                    if (testedPosition.equals(againstPosition)) {
+                        dupes[realPos] = j;
+                        break;
                     }
                 }
-                for (i = subMesh.indexStart; i < total; ++i) {
+            }, function () {
+                for (var i = 0; i < indices.length; ++i) {
                     indices[i] = dupes[indices[i]] || indices[i];
                 }
+                //indices are now reordered
+                var originalSubMeshes = _this.subMeshes.slice(0);
+                _this.setIndices(indices);
+                _this.subMeshes = originalSubMeshes;
+                if (successCallback) {
+                    successCallback(_this);
+                }
             });
-            //indices are now reordered
-            var originalSubMeshes = this.subMeshes.slice(0);
-            this.setIndices(indices);
-            this.subMeshes = originalSubMeshes;
+            //for (var i = vectorPositions.length - 1; i >= 1; --i) {
+            //    var testedPosition = vectorPositions[i];
+            //    for (var j = 0; j < i; ++j) {
+            //        var againstPosition = vectorPositions[j];
+            //        if (testedPosition.equals(againstPosition)) {
+            //            dupes[i] = j;
+            //            break;
+            //        }
+            //    }
+            //}
+            //optimize each submesh individually.
+            //this.subMeshes.forEach(subMesh => {
+            //    var total = subMesh.indexStart + subMesh.indexCount;
+            //    var i;
+            //    var subMeshPositions: Array<Vector3> = []
+            //    for (i = subMesh.indexStart; i < total; ++i) {
+            //        subMeshPositions[indices[i]] = subMeshPositions[indices[i]] || (BABYLON.Vector3.FromArray(positions, indices[i]));
+            //    }
+            //    var dupes = [];
+            //    //find duplicates
+            //    for (i = subMeshPositions.length - 1; i >= 1; --i) {
+            //        var testedPosition = subMeshPositions[i];
+            //        for (var j = 0; j < i; ++j) {
+            //            var againstPosition = subMeshPositions[j];
+            //            if (testedPosition.equals(againstPosition)) {
+            //                dupes[i] = j;
+            //                break;
+            //            }
+            //        }
+            //    }
+            //    for (i = subMesh.indexStart; i < total; ++i) {
+            //        indices[i] = dupes[indices[i]] || indices[i];
+            //    }
+            //});
         };
         // Statics
         Mesh.CreateRibbon = function (name, pathArray, closeArray, closePath, offset, scene, updatable, sideOrientation) {

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1078,7 +1078,7 @@
          * @param settings a collection of simplification settings.
          * @param parallelProcessing should all levels calculate parallel or one after the other.
          * @param type the type of simplification to run.
-         * successCallback optional success callback to be called after the simplification finished processing all settings.
+         * @param successCallback optional success callback to be called after the simplification finished processing all settings.
          */
         public simplify(settings: Array<ISimplificationSettings>, parallelProcessing: boolean = true, simplificationType: SimplificationType = SimplificationType.QUADRATIC, successCallback?: (mesh?: Mesh, submeshIndex?: number) => void) {
             this.getScene().simplificationQueue.addTask({
@@ -1090,7 +1090,12 @@
             });
         }
 
-        //The function doesn't delete unused vertex data, it simply restructure the indices to ignore them.
+        /**
+         * Optimization of the mesh's indices, in case a mesh has duplicated vertices.
+         * The function will only reorder the indices and will not remove unused vertices to avoid problems with submeshes.
+         * This should be used together with the simplification to avoid disappearing triangles.
+         * @param successCallback an optional success callback to be called after the optimization finished.
+         */
         public optimize(successCallback?: (mesh?: Mesh) => void) {
             var indices = this.getIndices();
             var positions = this.getVerticesData(VertexBuffer.PositionKind);
@@ -1123,46 +1128,6 @@
                     successCallback(this);
                 }
             });
-
-            //for (var i = vectorPositions.length - 1; i >= 1; --i) {
-            //    var testedPosition = vectorPositions[i];
-            //    for (var j = 0; j < i; ++j) {
-            //        var againstPosition = vectorPositions[j];
-            //        if (testedPosition.equals(againstPosition)) {
-            //            dupes[i] = j;
-            //            break;
-            //        }
-            //    }
-            //}
-            
-            //optimize each submesh individually.
-            //this.subMeshes.forEach(subMesh => {
-            //    var total = subMesh.indexStart + subMesh.indexCount;
-            //    var i;
-            //    var subMeshPositions: Array<Vector3> = []
-            //    for (i = subMesh.indexStart; i < total; ++i) {
-            //        subMeshPositions[indices[i]] = subMeshPositions[indices[i]] || (BABYLON.Vector3.FromArray(positions, indices[i]));
-            //    }
-            //    var dupes = [];
-            //    //find duplicates
-            //    for (i = subMeshPositions.length - 1; i >= 1; --i) {
-            //        var testedPosition = subMeshPositions[i];
-            //        for (var j = 0; j < i; ++j) {
-            //            var againstPosition = subMeshPositions[j];
-            //            if (testedPosition.equals(againstPosition)) {
-            //                dupes[i] = j;
-            //                break;
-            //            }
-            //        }
-            //    }
-
-                
-            //    for (i = subMesh.indexStart; i < total; ++i) {
-            //        indices[i] = dupes[indices[i]] || indices[i];
-            //    }
-            //});
-
-            
         }
 
         // Statics


### PR DESCRIPTION
There is a problem during decimation, if the mesh has vertices that are duplicated (same position). This is due to the nature of the simplification used (the point references is being moved, but when two points with the exact same properties are referenced in the indices, not all indices will move correctly).
The optimize function will optimize the indices of a mesh. It will not(!) remove unused vertices to avoid problems with submeshes (since they are referencing the vertices start and count), it will only reorder the indices correctly.