### PR TITLE
Optimizing mesh simplification

### DIFF
--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -28,14 +28,13 @@ var BABYLON;
         };
         SimplificationQueue.prototype.runSimplification = function (task) {
             var _this = this;
-            function setLODLevel(distance, mesh) {
-            }
             if (task.parallelProcessing) {
                 //parallel simplifier
                 task.settings.forEach(function (setting) {
                     var simplifier = _this.getSimplifier(task);
                     simplifier.simplify(setting, function (newMesh) {
                         task.mesh.addLODLevel(setting.distance, newMesh);
+                        newMesh.isVisible = true;
                         //check if it is the last
                         if (setting.quality === task.settings[task.settings.length - 1].quality && task.successCallback) {
                             //all done, run the success callback.
@@ -51,6 +50,7 @@ var BABYLON;
                 var runDecimation = function (setting, callback) {
                     simplifier.simplify(setting, function (newMesh) {
                         task.mesh.addLODLevel(setting.distance, newMesh);
+                        newMesh.isVisible = true;
                         //run the next quality level
                         callback();
                     });
@@ -190,7 +190,6 @@ var BABYLON;
                 });
             }, function () {
                 setTimeout(function () {
-                    _this._reconstructedMesh.isVisible = true;
                     successCallback(_this._reconstructedMesh);
                 }, 0);
             });

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -92,6 +92,7 @@ var BABYLON;
             this.error = new Array(4);
             this.deleted = false;
             this.isDirty = false;
+            this.deletePending = false;
             this.borderFactor = 0;
         }
         return DecimationTriangle;
@@ -259,7 +260,16 @@ var BABYLON;
                                     continue;
                                 if (_this.isFlipped(v1, i0, p, deleted1, t.borderFactor, delTr))
                                     continue;
-                                if (delTr.length == 2 || delTr[0] === delTr[1]) {
+                                if (deleted0.indexOf(true) < 0 || deleted1.indexOf(true) < 0)
+                                    continue;
+                                var uniqueArray = [];
+                                delTr.forEach(function (deletedT) {
+                                    if (uniqueArray.indexOf(deletedT) === -1) {
+                                        deletedT.deletePending = true;
+                                        uniqueArray.push(deletedT);
+                                    }
+                                });
+                                if (uniqueArray.length % 2 != 0) {
                                     continue;
                                 }
                                 v0.normal = n;
@@ -268,10 +278,6 @@ var BABYLON;
                                 else if (v0.color)
                                     v0.color = color;
                                 v0.q = v1.q.add(v0.q);
-                                if (deleted0.indexOf(true) < 0 || deleted1.indexOf(true) < 0)
-                                    continue;
-                                if (p.equals(v0.position))
-                                    continue;
                                 v0.position = p;
                                 var tStart = _this.references.length;
                                 deletedTriangles = _this.updateTriangles(v0.id, v0, deleted0, deletedTriangles);
@@ -405,7 +411,7 @@ var BABYLON;
                     this.vertices[dst].normal = this.vertices[i].normal;
                     this.vertices[dst].uv = this.vertices[i].uv;
                     this.vertices[dst].color = this.vertices[i].color;
-                    newVerticesOrder.push(i);
+                    newVerticesOrder.push(dst);
                     dst++;
                 }
             }
@@ -505,7 +511,7 @@ var BABYLON;
                 var t = this.triangles[ref.triangleId];
                 if (t.deleted)
                     continue;
-                if (deletedArray[i]) {
+                if (deletedArray[i] && t.deletePending) {
                     t.deleted = true;
                     newDeleted++;
                     continue;

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -129,11 +129,13 @@
         public deleted: boolean;
         public isDirty: boolean;
         public borderFactor: number;
+        public deletePending: boolean;
 
         constructor(public vertices: Array<number>) {
             this.error = new Array<number>(4);
             this.deleted = false;
             this.isDirty = false;
+            this.deletePending = false;
             this.borderFactor = 0;
         }
     }
@@ -332,7 +334,18 @@
                                 if (this.isFlipped(v0, i1, p, deleted0, t.borderFactor, delTr)) continue;
                                 if (this.isFlipped(v1, i0, p, deleted1, t.borderFactor, delTr)) continue;
 
-                                if (delTr.length == 2 || delTr[0] === delTr[1]) {
+                                if (deleted0.indexOf(true) < 0 || deleted1.indexOf(true) < 0)
+                                    continue;
+
+                                var uniqueArray = [];
+                                delTr.forEach(function (deletedT) {
+                                    if (uniqueArray.indexOf(deletedT) === -1) {
+                                        deletedT.deletePending = true;
+                                        uniqueArray.push(deletedT);
+                                    }
+                                });
+
+                                if (uniqueArray.length % 2 != 0) {
                                     continue;
                                 }
 
@@ -343,9 +356,6 @@
                                     v0.color = color;
                                 v0.q = v1.q.add(v0.q);
 
-                                if (deleted0.indexOf(true) < 0 || deleted1.indexOf(true) < 0) continue;
-
-                                if (p.equals(v0.position)) continue;
                                 v0.position = p;
 
                                 var tStart = this.references.length;
@@ -488,7 +498,7 @@
                     this.vertices[dst].normal = this.vertices[i].normal;
                     this.vertices[dst].uv = this.vertices[i].uv;
                     this.vertices[dst].color = this.vertices[i].color;
-                    newVerticesOrder.push(i);
+                    newVerticesOrder.push(dst);
                     dst++;
                 }
             }
@@ -601,7 +611,7 @@
                 var ref = this.references[vertex.triangleStart + i];
                 var t = this.triangles[ref.triangleId];
                 if (t.deleted) continue;
-                if (deletedArray[i]) {
+                if (deletedArray[i] && t.deletePending) {
                     t.deleted = true;
                     newDeleted++;
                     continue;

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -61,17 +61,13 @@
         }
 
         public runSimplification(task: ISimplificationTask) {
-
-            function setLODLevel(distance: number, mesh: Mesh) {
-
-            }
-
             if (task.parallelProcessing) {
                 //parallel simplifier
                 task.settings.forEach((setting) => {
                     var simplifier = this.getSimplifier(task);
                     simplifier.simplify(setting,(newMesh) => {
                         task.mesh.addLODLevel(setting.distance, newMesh);
+                        newMesh.isVisible = true;
                         //check if it is the last
                         if (setting.quality === task.settings[task.settings.length - 1].quality && task.successCallback) {
                             //all done, run the success callback.
@@ -87,6 +83,7 @@
                 var runDecimation = (setting: ISimplificationSettings, callback: () => void) => {
                     simplifier.simplify(setting,(newMesh) => {
                         task.mesh.addLODLevel(setting.distance, newMesh);
+                        newMesh.isVisible = true;
                         //run the next quality level
                         callback();
                     });
@@ -254,7 +251,6 @@
                 });
             },() => {
                     setTimeout(() => {
-                        this._reconstructedMesh.isVisible = true;
                         successCallback(this._reconstructedMesh);
                     }, 0);
                 });


### PR DESCRIPTION
After adding the optimize function, the needed fixes for the
simplification are added here.
This will fix the missing triangles problem (that is mainly caused by
non-optimized meshes).
The simplification will run faster as well, as the checks are not
simplified as well.