### PR TITLE
Make disposal detectable

### DIFF
--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -12,6 +12,7 @@
         private _totalVertices = 0;
         private _indices = [];
         private _vertexBuffers;
+        public _isDisposed = false;
         public _delayInfo; //ANY
         private _indexBuffer;
         public _boundingInfo: BoundingInfo;
@@ -384,6 +385,7 @@
             if (index > -1) {
                 geometries.splice(index, 1);
             }
+            this._isDisposed = true;
         }
 
         public copy(id: string): Geometry {


### PR DESCRIPTION
Added a way to detect when Geometry no longer has any meshes.  Did this though a _isDisposed member. 
 
Now that I have it up on Github, noticed the '_'.  I only saw the public, which is needed since defined in AbstractMesh, but referenced in Mesh.

Can add this additional stolen code on next commit:
        public isDisposed(): boolean {
            return this._isDisposed;
        }
