### PR TITLE
Geometry disposal detection

### DIFF
--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -12,7 +12,7 @@
         private _totalVertices = 0;
         private _indices = [];
         private _vertexBuffers;
-        public _isDisposed = false;
+        private _isDisposed = false;
         public _delayInfo; //ANY
         private _indexBuffer;
         public _boundingInfo: BoundingInfo;

--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -12,6 +12,7 @@
         private _totalVertices = 0;
         private _indices = [];
         private _vertexBuffers;
+        public _isDisposed = false;
         public _delayInfo; //ANY
         private _indexBuffer;
         public _boundingInfo: BoundingInfo;
@@ -384,6 +385,7 @@
             if (index > -1) {
                 geometries.splice(index, 1);
             }
+            this._isDisposed = true;
         }
 
         public copy(id: string): Geometry {

--- a/Babylon/Mesh/babylon.geometry.ts
+++ b/Babylon/Mesh/babylon.geometry.ts
@@ -351,6 +351,10 @@
             }, () => { }, scene.database);
         }
 
+        public isDisposed(): boolean {
+            return this._isDisposed;
+        }
+
         public dispose(): void {
             var meshes = this._meshes;
             var numOfMeshes = meshes.length;


### PR DESCRIPTION
Added a way to detect when Geometry no longer has any meshes. Did this though a _isDisposed member.

This is accessed via isDisposed()