### PR TITLE
added Curve3 continue() method

### DIFF
--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3412,6 +3412,16 @@
         public getPoints() {
             return this._points;
         }
+
+        public continue(curve: Curve3) {
+            var lastPoint = this._points[this._points.length - 1];
+            var continuedPoints = this._points.slice();
+            var curvePoints = curve.getPoints();
+            for (var i = 1; i < curvePoints.length; i++) {
+                continuedPoints.push(curvePoints[i].add(lastPoint));
+            }
+            return new Curve3(continuedPoints);
+        }
     }
 
     // SIMD


### PR DESCRIPTION
Added _continue()_ method to _Curve3_ class.
Usage : 
```javascript
var continuedCurve3 = firstCurve3.continue(secondCurve3).continue(thirdCurve3);
```
Given A and B, two Curve3 objects, _A.continue(B)_ returns a new Curve3 object which is the curve built from the A curve continued in space by the B curve : the last point of curve A is the first point of curve B then translated to this new origin.
This method is useful for developers who want to "concatenate" complex curves (ex : many consecutive cubicBezier, instead of computing by themselves 5th or 6th degrees bezier curves) and then to handle them as a single curve.

example : http://localhost/BJS/test/curves.html
The violet curve is twice the orange curve and once the yellow one, all _continued_ 
```javascript
var continued = cubicBezierVectors.continue(cubicBezierVectors).continue(quadraticBezierVectors);
var continuedCurve = BABYLON.Mesh.CreateLines("continued", continued.getPoints(), scene);
```