### PR TITLE
useCameraPostProcess whenever there is a special camera in use

### DIFF
--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -1255,7 +1255,8 @@
                     var renderTarget = this._renderTargets.data[renderIndex];
                     if (renderTarget._shouldRender()) {
                         this._renderId++;
-                        renderTarget.render(false, this.dumpNextRenderTargets);
+                        var hasSpecialRenderTargetCamera = renderTarget.activeCamera && renderTarget.activeCamera !== this.activeCamera;
+                        renderTarget.render(hasSpecialRenderTargetCamera, this.dumpNextRenderTargets);
                     }
                 }
                 Tools.EndPerformanceCounter("Render targets", this._renderTargets.length > 0);
@@ -1457,7 +1458,7 @@
                         // Camera
                         this.updateTransformMatrix();
 
-                        renderTarget.render(false, this.dumpNextRenderTargets);
+                        renderTarget.render(currentActiveCamera !== this.activeCamera, this.dumpNextRenderTargets);
                     }
                 }
                 Tools.EndPerformanceCounter("Custom render targets", this.customRenderTargets.length > 0);


### PR DESCRIPTION
Fixing the postprocessing problem mentioned here:

http://www.html5gamedevs.com/topic/13053-scene-compositing-problems/

I am assuming that the flag was introduced so it won't double apply postprocess effects when using the standard scene camera. Hope my guess is correct.

Should i add the changed javascript files as well?