### PR TITLE
Setting default target for ArcRotate target

### DIFF
--- a/Babylon/Cameras/babylon.arcRotateCamera.ts
+++ b/Babylon/Cameras/babylon.arcRotateCamera.ts
@@ -54,6 +54,10 @@
         constructor(name: string, public alpha: number, public beta: number, public radius: number, public target: any, scene: Scene) {
             super(name, BABYLON.Vector3.Zero(), scene);
 
+	    if(!this.target) {
+            	this.target = Vector3.Zero();
+            }
+
             this.getViewMatrix();
         }
 


### PR DESCRIPTION
The loader is setting the target after the view matrix is being generated. target is needed at this time already.
Will fix the loader problem.