### PR TITLE
Mesh optimization in simplification

### DIFF
--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -443,15 +443,13 @@ var BABYLON;
             for (i = 0; i < newTriangles.length; ++i) {
                 var t = newTriangles[i];
                 //now get the new referencing point for each vertex
-                var v0Id = originalIndices[t.originalOffset];
-                var v0Offset = t.vertices[0].originalOffsets.indexOf(v0Id);
-                var v1Id = originalIndices[t.originalOffset + 1];
-                var v1Offset = t.vertices[1].originalOffsets.indexOf(v1Id);
-                var v2Id = originalIndices[t.originalOffset + 2];
-                var v2Offset = t.vertices[2].originalOffsets.indexOf(v2Id);
-                newIndicesArray.push(t.vertices[0].id + v0Offset + startingVertex);
-                newIndicesArray.push(t.vertices[1].id + v1Offset + startingVertex);
-                newIndicesArray.push(t.vertices[2].id + v2Offset + startingVertex);
+                [0, 1, 2].forEach(function (idx) {
+                    var id = originalIndices[t.originalOffset + idx];
+                    var offset = t.vertices[idx].originalOffsets.indexOf(id);
+                    if (offset < 0)
+                        offset = 0;
+                    newIndicesArray.push(t.vertices[idx].id + offset + startingVertex);
+                });
             }
             //overwriting the old vertex buffers and indices.
             this._reconstructedMesh.setIndices(newIndicesArray);

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -189,7 +189,7 @@ var BABYLON;
             this.initDecimatedMesh();
             //iterating through the submeshes array, one after the other.
             BABYLON.AsyncLoop.Run(this._mesh.subMeshes.length, function (loop) {
-                _this.initWithMesh(_this._mesh, loop.index, function () {
+                _this.initWithMesh(loop.index, function () {
                     _this.runDecimation(settings, loop.index, function () {
                         loop.executeNext();
                     });
@@ -319,16 +319,13 @@ var BABYLON;
                 }, 0);
             });
         };
-        QuadraticErrorSimplification.prototype.initWithMesh = function (mesh, submeshIndex, callback) {
+        QuadraticErrorSimplification.prototype.initWithMesh = function (submeshIndex, callback) {
             var _this = this;
-            if (!mesh)
-                return;
             this.vertices = [];
             this.triangles = [];
-            this._mesh = mesh;
             var positionData = this._mesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
-            var indices = mesh.getIndices();
-            var submesh = mesh.subMeshes[submeshIndex];
+            var indices = this._mesh.getIndices();
+            var submesh = this._mesh.subMeshes[submeshIndex];
             var vertexInit = function (i) {
                 var offset = i + submesh.verticesStart;
                 var vertex = new DecimationVertex(BABYLON.Vector3.FromArray(positionData, offset * 3), offset, i);

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -341,7 +341,7 @@ var BABYLON;
             };
             //var totalVertices = mesh.getTotalVertices();
             var totalVertices = submesh.verticesCount;
-            BABYLON.AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations / 2, vertexInit, function () {
+            BABYLON.AsyncLoop.SyncAsyncForLoop(totalVertices, (this.syncIterations / 4) >> 0, vertexInit, function () {
                 var indicesInit = function (i) {
                     var offset = (submesh.indexStart / 3) + i;
                     var pos = (offset * 3);
@@ -420,11 +420,11 @@ var BABYLON;
                         newNormalData.push(normalData[originalOffset * 3]);
                         newNormalData.push(normalData[(originalOffset * 3) + 1]);
                         newNormalData.push(normalData[(originalOffset * 3) + 2]);
-                        if (uvs.length) {
+                        if (uvs && uvs.length) {
                             newUVsData.push(uvs[(originalOffset * 2)]);
                             newUVsData.push(uvs[(originalOffset * 2) + 1]);
                         }
-                        else if (colorsData.length) {
+                        else if (colorsData && colorsData.length) {
                             newColorsData.push(colorsData[(originalOffset * 4)]);
                             newColorsData.push(colorsData[(originalOffset * 4) + 1]);
                             newColorsData.push(colorsData[(originalOffset * 4) + 2]);

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -99,16 +99,22 @@ var BABYLON;
     })();
     BABYLON.DecimationTriangle = DecimationTriangle;
     var DecimationVertex = (function () {
-        function DecimationVertex(position, normal, uv, id) {
+        function DecimationVertex(position, normal, id) {
             this.position = position;
             this.normal = normal;
-            this.uv = uv;
             this.id = id;
             this.isBorder = true;
             this.q = new QuadraticMatrix();
             this.triangleCount = 0;
             this.triangleStart = 0;
+            this.referenceVertices = [];
         }
+        DecimationVertex.prototype.updatePosition = function (newPosition) {
+            this.position.copyFrom(newPosition);
+            this.referenceVertices.forEach(function (vertex) {
+                vertex.position.copyFrom(newPosition);
+            });
+        };
         return DecimationVertex;
     })();
     BABYLON.DecimationVertex = DecimationVertex;
@@ -277,7 +283,7 @@ var BABYLON;
                                 else if (v0.color)
                                     v0.color = color;
                                 v0.q = v1.q.add(v0.q);
-                                v0.position = p;
+                                v0.updatePosition(p);
                                 var tStart = _this.references.length;
                                 deletedTriangles = _this.updateTriangles(v0.id, v0, deleted0, deletedTriangles);
                                 deletedTriangles = _this.updateTriangles(v0.id, v1, deleted1, deletedTriangles);
@@ -334,7 +340,7 @@ var BABYLON;
             var submesh = mesh.subMeshes[submeshIndex];
             var vertexInit = function (i) {
                 var offset = i + submesh.verticesStart;
-                var vertex = new DecimationVertex(BABYLON.Vector3.FromArray(positionData, offset * 3), BABYLON.Vector3.FromArray(normalData, offset * 3), null, i);
+                var vertex = new DecimationVertex(BABYLON.Vector3.FromArray(positionData, offset * 3), BABYLON.Vector3.FromArray(normalData, offset * 3), i);
                 if (_this._mesh.isVerticesDataPresent(BABYLON.VertexBuffer.UVKind)) {
                     vertex.uv = BABYLON.Vector2.FromArray(uvs, offset * 2);
                 }

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -178,7 +178,7 @@ var BABYLON;
     var QuadraticErrorSimplification = (function () {
         function QuadraticErrorSimplification(_mesh) {
             this._mesh = _mesh;
-            this.initialised = false;
+            this.initialized = false;
             this.syncIterations = 5000;
             this.aggressiveness = 7;
             this.decimationIterations = 100;
@@ -326,7 +326,6 @@ var BABYLON;
             this.vertices = [];
             this.triangles = [];
             this._mesh = mesh;
-            //It is assumed that a mesh has positions, normals and either uvs or colors.
             var positionData = this._mesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
             var indices = mesh.getIndices();
             var submesh = mesh.subMeshes[submeshIndex];
@@ -370,7 +369,7 @@ var BABYLON;
                     t.error[3] = Math.min(t.error[0], t.error[1], t.error[2]);
                 };
                 BABYLON.AsyncLoop.SyncAsyncForLoop(_this.triangles.length, _this.syncIterations, triangleInit2, function () {
-                    _this.initialised = true;
+                    _this.initialized = true;
                     callback();
                 });
             });

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -341,7 +341,7 @@ var BABYLON;
             };
             //var totalVertices = mesh.getTotalVertices();
             var totalVertices = submesh.verticesCount;
-            BABYLON.AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations, vertexInit, function () {
+            BABYLON.AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations / 2, vertexInit, function () {
                 var indicesInit = function (i) {
                     var offset = (submesh.indexStart / 3) + i;
                     var pos = (offset * 3);

--- a/Babylon/Mesh/babylon.meshSimplification.js
+++ b/Babylon/Mesh/babylon.meshSimplification.js
@@ -1,9 +1,10 @@
 var BABYLON;
 (function (BABYLON) {
     var SimplificationSettings = (function () {
-        function SimplificationSettings(quality, distance) {
+        function SimplificationSettings(quality, distance, optimizeMesh) {
             this.quality = quality;
             this.distance = distance;
+            this.optimizeMesh = optimizeMesh;
         }
         return SimplificationSettings;
     })();
@@ -189,7 +190,7 @@ var BABYLON;
                     _this.runDecimation(settings, loop.index, function () {
                         loop.executeNext();
                     });
-                });
+                }, settings.optimizeMesh);
             }, function () {
                 setTimeout(function () {
                     successCallback(_this._reconstructedMesh);
@@ -313,7 +314,7 @@ var BABYLON;
                 }, 0);
             });
         };
-        QuadraticErrorSimplification.prototype.initWithMesh = function (submeshIndex, callback) {
+        QuadraticErrorSimplification.prototype.initWithMesh = function (submeshIndex, callback, optimizeMesh) {
             var _this = this;
             this.vertices = [];
             this.triangles = [];
@@ -321,9 +322,11 @@ var BABYLON;
             var indices = this._mesh.getIndices();
             var submesh = this._mesh.subMeshes[submeshIndex];
             var findInVertices = function (positionToSearch) {
-                for (var ii = 0; ii < _this.vertices.length; ++ii) {
-                    if (_this.vertices[ii].position.equals(positionToSearch)) {
-                        return _this.vertices[ii];
+                if (optimizeMesh) {
+                    for (var ii = 0; ii < _this.vertices.length; ++ii) {
+                        if (_this.vertices[ii].position.equals(positionToSearch)) {
+                            return _this.vertices[ii];
+                        }
                     }
                 }
                 return null;
@@ -353,7 +356,6 @@ var BABYLON;
                     var v2 = _this.vertices[vertexReferences[i2 - submesh.verticesStart]];
                     var triangle = new DecimationTriangle([v0, v1, v2]);
                     triangle.originalOffset = pos;
-                    triangle.positionInOffsets = [v0.originalOffsets.indexOf(i0), v1.originalOffsets.indexOf(i1), v2.originalOffsets.indexOf(i2)];
                     _this.triangles.push(triangle);
                 };
                 BABYLON.AsyncLoop.SyncAsyncForLoop(submesh.indexCount / 3, _this.syncIterations, indicesInit, function () {

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -251,7 +251,7 @@
             this.initDecimatedMesh();
             //iterating through the submeshes array, one after the other.
             AsyncLoop.Run(this._mesh.subMeshes.length,(loop: AsyncLoop) => {
-                this.initWithMesh(this._mesh, loop.index,() => {
+                this.initWithMesh(loop.index,() => {
                     this.runDecimation(settings, loop.index,() => {
                         loop.executeNext();
                     });
@@ -398,17 +398,15 @@
                 });
         }
 
-        private initWithMesh(mesh: Mesh, submeshIndex: number, callback: Function) {
-            if (!mesh) return;
+        private initWithMesh(submeshIndex: number, callback: Function) {
 
             this.vertices = [];
             this.triangles = [];
 
-            this._mesh = mesh;
             var positionData = this._mesh.getVerticesData(VertexBuffer.PositionKind);
             
-            var indices = mesh.getIndices();
-            var submesh = mesh.subMeshes[submeshIndex];
+            var indices = this._mesh.getIndices();
+            var submesh = this._mesh.subMeshes[submeshIndex];
 
             var vertexInit = (i) => {
                 var offset = i + submesh.verticesStart;

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -542,16 +542,12 @@
             for (i = 0; i < newTriangles.length; ++i) {
                 var t = newTriangles[i];
                 //now get the new referencing point for each vertex
-                var v0Id = originalIndices[t.originalOffset];
-                var v0Offset = t.vertices[0].originalOffsets.indexOf(v0Id);
-                var v1Id = originalIndices[t.originalOffset + 1];
-                var v1Offset = t.vertices[1].originalOffsets.indexOf(v1Id);
-                var v2Id = originalIndices[t.originalOffset + 2];
-                var v2Offset = t.vertices[2].originalOffsets.indexOf(v2Id);
-
-                newIndicesArray.push(t.vertices[0].id + v0Offset + startingVertex);
-                newIndicesArray.push(t.vertices[1].id + v1Offset + startingVertex);
-                newIndicesArray.push(t.vertices[2].id + v2Offset + startingVertex);
+                [0, 1, 2].forEach(function (idx) {
+                    var id = originalIndices[t.originalOffset + idx]
+                    var offset = t.vertices[idx].originalOffsets.indexOf(id);
+                    if (offset < 0) offset = 0;
+                    newIndicesArray.push(t.vertices[idx].id + offset + startingVertex);
+                });
             }
 
             //overwriting the old vertex buffers and indices.

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -431,7 +431,7 @@
             };
             //var totalVertices = mesh.getTotalVertices();
             var totalVertices = submesh.verticesCount;
-            AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations / 2, vertexInit,() => {
+            AsyncLoop.SyncAsyncForLoop(totalVertices, (this.syncIterations / 4) >> 0, vertexInit,() => {
 
                 var indicesInit = (i) => {
                     var offset = (submesh.indexStart / 3) + i;
@@ -517,10 +517,10 @@
                         newNormalData.push(normalData[originalOffset * 3]);
                         newNormalData.push(normalData[(originalOffset * 3) + 1]);
                         newNormalData.push(normalData[(originalOffset * 3) + 2]);
-                        if (uvs.length) {
+                        if (uvs && uvs.length) {
                             newUVsData.push(uvs[(originalOffset * 2)]);
                             newUVsData.push(uvs[(originalOffset * 2) + 1]);
-                        } else if (colorsData.length) {
+                        } else if (colorsData && colorsData.length) {
                             newColorsData.push(colorsData[(originalOffset * 4)]);
                             newColorsData.push(colorsData[(originalOffset * 4) + 1]);
                             newColorsData.push(colorsData[(originalOffset * 4) + 2]);

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -431,7 +431,7 @@
             };
             //var totalVertices = mesh.getTotalVertices();
             var totalVertices = submesh.verticesCount;
-            AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations, vertexInit,() => {
+            AsyncLoop.SyncAsyncForLoop(totalVertices, this.syncIterations / 2, vertexInit,() => {
 
                 var indicesInit = (i) => {
                     var offset = (submesh.indexStart / 3) + i;

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -144,14 +144,27 @@
         public triangleStart: number;
         public triangleCount: number;
 
+        public uv: Vector2
         //if color is present instead of uvs.
         public color: Color4;
 
-        constructor(public position: Vector3, public normal: Vector3, public uv: Vector2, public id) {
+        public referenceVertices: Array<DecimationVertex>;
+
+        
+
+        constructor(public position: Vector3, public normal: Vector3, public id) {
             this.isBorder = true;
             this.q = new QuadraticMatrix();
             this.triangleCount = 0;
             this.triangleStart = 0;
+            this.referenceVertices = [];
+        }
+
+        public updatePosition(newPosition: Vector3) {
+            this.position.copyFrom(newPosition);
+            this.referenceVertices.forEach(function (vertex) {
+                vertex.position.copyFrom(newPosition);
+            });
         }
     }
 
@@ -352,7 +365,7 @@
                                     v0.color = color;
                                 v0.q = v1.q.add(v0.q);
 
-                                v0.position = p;
+                                v0.updatePosition(p);
 
                                 var tStart = this.references.length;
 
@@ -413,7 +426,7 @@
 
             var vertexInit = (i) => {
                 var offset = i + submesh.verticesStart;
-                var vertex = new DecimationVertex(Vector3.FromArray(positionData, offset * 3), Vector3.FromArray(normalData, offset * 3), null, i);
+                var vertex = new DecimationVertex(Vector3.FromArray(positionData, offset * 3), Vector3.FromArray(normalData, offset * 3), i);
                 if (this._mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                     vertex.uv = Vector2.FromArray(uvs, offset * 2);
                 } else if (this._mesh.isVerticesDataPresent(VertexBuffer.ColorKind)) {

--- a/Babylon/Mesh/babylon.meshSimplification.ts
+++ b/Babylon/Mesh/babylon.meshSimplification.ts
@@ -229,7 +229,7 @@
         private vertices: Array<DecimationVertex>;
         private references: Array<Reference>;
 
-        private initialised: boolean = false;
+        private initialized: boolean = false;
 
         private _reconstructedMesh: Mesh;
 
@@ -405,7 +405,6 @@
             this.triangles = [];
 
             this._mesh = mesh;
-            //It is assumed that a mesh has positions, normals and either uvs or colors.
             var positionData = this._mesh.getVerticesData(VertexBuffer.PositionKind);
             
             var indices = mesh.getIndices();
@@ -453,7 +452,7 @@
                     t.error[3] = Math.min(t.error[0], t.error[1], t.error[2]);
                 };
                 AsyncLoop.SyncAsyncForLoop(this.triangles.length, this.syncIterations, triangleInit2,() => {
-                    this.initialised = true;
+                    this.initialized = true;
                     callback();
                 });
             });


### PR DESCRIPTION
The optimizeIndices method works well for some types of objects but some exporters export vertices with the same position and normals but different uv/color definitions.
This leads to a problem during the reconstruction of the mesh after the simplification process.
This was solved in those commits. An extra optional parameter (optimizeMesh) was added to the simplification settings, thus not breaking the API.
The decimation was cleaned up and simplified as well. It will run better and faster now.

Fully tested with the dude, skull, t-rex from dad72.

SubMeshes are working but have the border-detection problem which cannot be avoided.