### PR TITLE
Transformation init in Skeleton

### DIFF
--- a/Babylon/Bones/babylon.skeleton.js
+++ b/Babylon/Bones/babylon.skeleton.js
@@ -10,6 +10,9 @@ var BABYLON;
             this.bones = [];
             this._scene = scene;
             scene.skeletons.push(this);
+            this.prepare():
+            //make sure it will recalculate the matrix next time prepare is called.
+            this._isDirty = true;
         }
         // Members
         Skeleton.prototype.getTransformMatrices = function () {

--- a/Babylon/Bones/babylon.skeleton.ts
+++ b/Babylon/Bones/babylon.skeleton.ts
@@ -14,6 +14,10 @@
             this._scene = scene;
 
             scene.skeletons.push(this);
+            
+            this.prepare();
+            //make sure it will recalculate the matrix next time prepare is called.
+            this._isDirty = true; 
         }
 
         // Members


### PR DESCRIPTION
If prepare is not being called, the _transformMatrices is not initialized, causing this - http://www.html5gamedevs.com/topic/13372-error-if-skeleton-is-out-of-view-when-scene-starts/