### PR TITLE
Allow ComputeNormals to work with Typed Arrays & the Typescript Level.

### DIFF
--- a/Babylon/Mesh/babylon.mesh.vertexData.js
+++ b/Babylon/Mesh/babylon.mesh.vertexData.js
@@ -884,6 +884,11 @@ var BABYLON;
             return vertexData;
         };
         // Tools
+        /**
+         * @param {any} - positions (number[] or Float32Array)
+         * @param {any} - indices   (number[] or Uint16Array)
+         * @param {any} - normals   (number[] or Float32Array)
+         */
         VertexData.ComputeNormals = function (positions, indices, normals) {
             var positionVectors = [];
             var facesOfVertices = [];
@@ -968,4 +973,5 @@ var BABYLON;
     })();
     BABYLON.VertexData = VertexData;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.mesh.vertexData.js.map
+
+//# sourceMappingURL=../Mesh/babylon.mesh.vertexData.js.map

--- a/Babylon/Mesh/babylon.mesh.vertexData.ts
+++ b/Babylon/Mesh/babylon.mesh.vertexData.ts
@@ -1113,13 +1113,18 @@
         }
 
         // Tools
-        public static ComputeNormals(positions: number[], indices: number[], normals: number[]) {
+        /**
+         * @param {any} - positions (number[] or Float32Array)
+         * @param {any} - indices   (number[] or Uint16Array)
+         * @param {any} - normals   (number[] or Float32Array)
+         */
+        public static ComputeNormals(positions: any, indices: any, normals: any) {
             var positionVectors = [];
             var facesOfVertices = [];
             var index;
 
             for (index = 0; index < positions.length; index += 3) {
-                var vector3 = new Vector3(positions[index], positions[index + 1], positions[index + 2]);
+                var vector3 = new Vector3(<number> positions[index], <number> positions[index + 1], <number> positions[index + 2]);
                 positionVectors.push(vector3);
                 facesOfVertices.push([]);
             }


### PR DESCRIPTION
No logic changes, only are types switched to 'any' & casting inside.