### PR TITLE
Material onBind callback improvement

### DIFF
--- a/Babylon/Materials/babylon.material.ts
+++ b/Babylon/Materials/babylon.material.ts
@@ -25,7 +25,7 @@
         public onCompiled: (effect: Effect) => void;
         public onError: (effect: Effect, errors: string) => void;
         public onDispose: () => void;
-        public onBind: (material: Material) => void;
+        public onBind: (material: Material, mesh: Mesh) => void;
         public getRenderTargetTextures: () => SmartArray<RenderTargetTexture>;
 
         public _effect: Effect;
@@ -109,7 +109,7 @@
             this._scene._cachedMaterial = this;
 
             if (this.onBind) {
-                this.onBind(this);
+                this.onBind(this, mesh);
             }
         }
 

--- a/Babylon/Materials/babylon.shaderMaterial.ts
+++ b/Babylon/Materials/babylon.shaderMaterial.ts
@@ -231,7 +231,7 @@
                 }
             }
 
-            super.bind(world, null);
+            super.bind(world, mesh);
         }
 
         public dispose(forceDisposeEffect?: boolean): void {


### PR DESCRIPTION
A minor modification that allows this callback to be much more useful.

By passing the current mesh as an argument, it is possible to change material/shader parameters according to custom properties.

I've also changed the ShaderMaterial bind() function since I've noticed it wasn't passing the current mesh as an argument to its parent function.