### PR TITLE
added excludeWithLayerMask to lights

### DIFF
--- a/Babylon/Lights/babylon.light.ts
+++ b/Babylon/Lights/babylon.light.ts
@@ -25,6 +25,7 @@
         public includeOnlyWithLayerMask = 0;
         public includedOnlyMeshes = new Array<AbstractMesh>();
         public excludedMeshes = new Array<AbstractMesh>();
+        public excludeWithLayerMask = 0;
 
         public _shadowGenerator: ShadowGenerator;
         private _parentedWorldMatrix: Matrix;
@@ -66,6 +67,11 @@
             }
 
             if (this.includeOnlyWithLayerMask !== 0 && this.includeOnlyWithLayerMask !== mesh.layerMask) {
+                return false;
+            }
+
+
+            if (this.excludeWithLayerMask !== 0 && this.excludeWithLayerMask === mesh.layerMask) {
                 return false;
             }
 

--- a/Babylon/Lights/babylon.light.ts
+++ b/Babylon/Lights/babylon.light.ts
@@ -71,7 +71,7 @@
             }
 
 
-            if (this.excludeWithLayerMask !== 0 && this.excludeWithLayerMask === mesh.layerMask) {
+            if (this.excludeWithLayerMask !== 0 && this.excludeWithLayerMask & mesh.layerMask) {
                 return false;
             }
 


### PR DESCRIPTION
Just tested includeWithLayerMask  (will document this with includeWithLayerMask as well), and scene meshes are not affected by 2nd camera's light.

LayerMask'ed meshes for the 2nd camera ARE affected by the scene lights though.  Usage, first iterate through scene lights, & set excludeWithLayerMask to the mask being used by the 2nd camera.