### PR TITLE
Update babylon.scene.ts

### DIFF
--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -760,6 +760,16 @@
                 // Remove from the scene if mesh found 
                 this.cameras.splice(index, 1);
             }
+            // Remove from activeCameras
+            var index2 = this.activeCameras.indexOf(toRemove);
+            if (index2 !== -1) {
+                // Remove from the scene if mesh found
+                this.activeCameras.splice(index2, 1);
+            }
+            // Reset the activeCamera
+            if (this.activeCamera === toRemove) {
+                this.activeCamera = null;
+            }
             if (this.onCameraRemoved) {
                 this.onCameraRemoved(toRemove);
             }


### PR DESCRIPTION
When disposing a camera, its reference was still in activeCamera and activeCameras