### PR TITLE
Allow Engine to run for CocoonJS with standard html

### DIFF
--- a/Babylon/babylon.engine.js
+++ b/Babylon/babylon.engine.js
@@ -747,8 +747,8 @@ var BABYLON;
          * @param {number} [requiredHeight] - the height required for rendering. If not provided the rendering canvas' height is used.
          */
         Engine.prototype.setViewport = function (viewport, requiredWidth, requiredHeight) {
-            var width = requiredWidth || this._renderingCanvas.width;
-            var height = requiredHeight || this._renderingCanvas.height;
+            var width = requiredWidth || (navigator.isCocoonJS ? window.innerWidth : this._renderingCanvas.width);
+            var height = requiredHeight || (navigator.isCocoonJS ? window.innerHeight : this._renderingCanvas.height);
             var x = viewport.x || 0;
             var y = viewport.y || 0;
             this._cachedViewport = viewport;
@@ -772,7 +772,9 @@ var BABYLON;
          *   });
          */
         Engine.prototype.resize = function () {
-            this.setSize(this._renderingCanvas.clientWidth / this._hardwareScalingLevel, this._renderingCanvas.clientHeight / this._hardwareScalingLevel);
+            var width = navigator.isCocoonJS ? window.innerWidth : this._renderingCanvas.clientWidth;
+            var height = navigator.isCocoonJS ? window.innerHeight : this._renderingCanvas.clientHeight;
+            this.setSize(width / this._hardwareScalingLevel, height / this._hardwareScalingLevel);
         };
         /**
          * force a specific size of the canvas
@@ -1895,4 +1897,5 @@ var BABYLON;
     })();
     BABYLON.Engine = Engine;
 })(BABYLON || (BABYLON = {}));
+
 //# sourceMappingURL=babylon.engine.js.map

--- a/Babylon/babylon.engine.ts
+++ b/Babylon/babylon.engine.ts
@@ -866,8 +866,8 @@
          * @param {number} [requiredHeight] - the height required for rendering. If not provided the rendering canvas' height is used.
          */
         public setViewport(viewport: Viewport, requiredWidth?: number, requiredHeight?: number): void {
-            var width = requiredWidth || this._renderingCanvas.width;
-            var height = requiredHeight || this._renderingCanvas.height;
+            var width = requiredWidth   || (navigator.isCocoonJS ? window.innerWidth  : this._renderingCanvas.width);
+            var height = requiredHeight || (navigator.isCocoonJS ? window.innerHeight : this._renderingCanvas.height);
             var x = viewport.x || 0;
             var y = viewport.y || 0;
 
@@ -898,7 +898,10 @@
          *   });
          */
         public resize(): void {
-            this.setSize(this._renderingCanvas.clientWidth / this._hardwareScalingLevel, this._renderingCanvas.clientHeight / this._hardwareScalingLevel);
+            var width  = navigator.isCocoonJS ? window.innerWidth  : this._renderingCanvas.clientWidth;
+            var height = navigator.isCocoonJS ? window.innerHeight : this._renderingCanvas.clientHeight;
+            
+            this.setSize(width / this._hardwareScalingLevel, height / this._hardwareScalingLevel);
         }
 
         /**


### PR DESCRIPTION
, including devices where the hardware scaling != 1.

By standard, no viewport meta setting in header, making a presized,throw
away webgl context, or calling setSize().