### PR TITLE
Changed default value in DepthRenderer to 1.0

### DIFF
--- a/Babylon/Rendering/babylon.depthRenderer.ts
+++ b/Babylon/Rendering/babylon.depthRenderer.ts
@@ -22,6 +22,11 @@
             this._depthMap.refreshRate = 1;
             this._depthMap.renderParticles = false;
             this._depthMap.renderList = null;
+            
+            // set default depth value to 1.0 (far away)
+            this._depthMap.onClear = (engine: Engine) => {
+                engine.clear(new Color4(1.0, 1.0, 1.0, 1.0), true, true);
+            }
 
             // Custom render function
             var renderSubMesh = (subMesh: SubMesh): void => {


### PR DESCRIPTION
Currently the DepthRenderer buffer is cleared with the scene clear color, which is not very practical when using the depth values in shader.