### PR TITLE
Fix gulp errors

### DIFF
--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -9,10 +9,12 @@
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
-	"gulp-typescript" : "2.4.0",
+	
+	"gulp-typescript" : "2.4.2",
 	"gulp-sourcemaps" : "1.3.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",
-    "through": "^2.3.4"
+    "through": "^2.3.4",
+	"gulp-param": "0.6.3"
   }
 }

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -9,12 +9,11 @@
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
-	
-	"gulp-typescript" : "2.4.2",
-	"gulp-sourcemaps" : "1.3.0",
+    "gulp-typescript" : "2.4.2",
+    "gulp-sourcemaps" : "1.3.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",
     "through": "^2.3.4",
-	"gulp-param": "0.6.3"
+    "gulp-param": "0.6.3"
   }
 }


### PR DESCRIPTION
Missing gulp-param dependency and updating gulp-typescript to use tsc
1.4 and not .5 alpha.