### PR TITLE
Fix.path3 d.same position points

### DIFF
--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3281,9 +3281,9 @@
         private _normals = new Array<Vector3>();
         private _binormals = new Array<Vector3>();
 
-        constructor(public path: Vector3[]) {
+        constructor(public path: Vector3[], firstNormal?: Vector3) {
             this._copyPath(path);
-            this._compute();
+            this._compute(firstNormal);
         }
 
         public getCurve(): Vector3[] {
@@ -3306,9 +3306,9 @@
             return this._distances;
         }
 
-        public update(path: Vector3[]): Path3D {
+        public update(path: Vector3[], firstNormal?: Vector3): Path3D {
             this._copyPath(path);
-            this._compute();
+            this._compute(firstNormal);
             return this;
         }
 
@@ -3319,7 +3319,7 @@
         }
 
         // private function compute() : computes tangents, normals and binormals
-        private _compute() {
+        private _compute(firstNormal) {
             var l = this._curve.length;
 
             // first and last tangents
@@ -3330,7 +3330,7 @@
             
             // normals and binormals at first point : arbitrary vector with _normalVector()
             var tg0 = this._tangents[0];
-            var pp0 = this._normalVector(this._curve[0], tg0);
+            var pp0 = this._normalVector(this._curve[0], tg0, firstNormal);
             this._normals[0] = pp0;
             this._normals[0].normalize();
             this._binormals[0] = Vector3.Cross(tg0, this._normals[0]);
@@ -3390,22 +3390,30 @@
             return nLVector;
         }
 
-        // private function normalVector(v0, vt) :
+        // private function normalVector(v0, vt, va) :
         // returns an arbitrary point in the plane defined by the point v0 and the vector vt orthogonal to this plane
-        private _normalVector(v0: Vector3, vt: Vector3): Vector3 {
-            var point: Vector3;
-
-            if (vt.x !== 1) {     // search for a point in the plane
-                point = new Vector3(1, 0, 0);
+        // if va is passed, it returns the va projection on the plane orthogonal to vt at the point v0
+        private _normalVector(v0: Vector3, vt: Vector3, va: Vector3): Vector3 {
+            var normal0: Vector3;
+            if (va === undefined || va === null) {
+                var point: Vector3;
+                if (vt.x !== 1) {     // search for a point in the plane
+                    point = new Vector3(1, 0, 0);
+                }
+                else if (vt.y !== 1) {
+                    point = new Vector3(0, 1, 0);
+                }
+                else if (vt.z !== 1) {
+                    point = new Vector3(0, 0, 1);
+                }
+                normal0 = Vector3.Cross(vt, point);
             }
-            else if (vt.y !== 1) {
-                point = new Vector3(0, 1, 0);
+            else {
+                normal0 = Vector3.Cross(vt, va);
+                Vector3.CrossToRef(normal0, vt, normal0);
+                //normal0 = Vector3.Cross(normal0, vt);
             }
-            else if (vt.z !== 1) {
-                point = new Vector3(0, 0, 1);
-            }
-            var normal0: Vector3 = Vector3.Cross(vt, point);
-            normal0.normalize();
+            normal0.normalize();       
             return normal0;
         }
     }

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3282,7 +3282,9 @@
         private _binormals = new Array<Vector3>();
 
         constructor(public path: Vector3[], firstNormal?: Vector3) {
-            this._copyPath(path);
+            for (var p = 0; p < path.length; p++) {
+                this._curve[p] = path[p].clone(); // hard copy
+            }  
             this._compute(firstNormal);
         }
 
@@ -3307,15 +3309,13 @@
         }
 
         public update(path: Vector3[], firstNormal?: Vector3): Path3D {
-            this._copyPath(path);
+            for (var p = 0; p < path.length; p++) {
+                this._curve[p].x = path[p].x;
+                this._curve[p].y = path[p].y;
+                this._curve[p].z = path[p].z;
+            }  
             this._compute(firstNormal);
             return this;
-        }
-
-        private _copyPath(path: Vector3[]) {
-            for (var p = 0; p < path.length; p++) {
-                this._curve[p] = path[p].clone(); // hard copy
-            }            
         }
 
         // private function compute() : computes tangents, normals and binormals

--- a/Babylon/Mesh/babylon.mesh.vertexData.ts
+++ b/Babylon/Mesh/babylon.mesh.vertexData.ts
@@ -1161,48 +1161,76 @@
          * @param {any} - normals   (number[] or Float32Array)
          */
         public static ComputeNormals(positions: any, indices: any, normals: any) {
-            var positionVectors = [];
-            var facesOfVertices = [];
-            var index;
-
-            for (index = 0; index < positions.length; index += 3) {
-                var vector3 = new Vector3(<number> positions[index], <number> positions[index + 1], <number> positions[index + 2]);
-                positionVectors.push(vector3);
-                facesOfVertices.push([]);
-            }
-            // Compute normals
-            var facesNormals = [];
-            for (index = 0; index < indices.length / 3; index++) {
+            var index = 0;
+            
+            // temp Vector3
+            var p1 = BABYLON.Vector3.Zero();
+            var p2 = BABYLON.Vector3.Zero();
+            var p3 = BABYLON.Vector3.Zero();
+            var p1p2 = BABYLON.Vector3.Zero();
+            var p3p2 = BABYLON.Vector3.Zero();
+            var faceNormal = BABYLON.Vector3.Zero();
+            
+            var vertexNormali1 = BABYLON.Vector3.Zero();
+            var vertexNormali2 = BABYLON.Vector3.Zero();
+            var vertexNormali3 = BABYLON.Vector3.Zero();
+            
+            // indice triplet = 1 face
+            var nbFaces = indices.length / 3;
+            for (index = 0; index < nbFaces; index++) {
                 var i1 = indices[index * 3];
                 var i2 = indices[index * 3 + 1];
                 var i3 = indices[index * 3 + 2];
-
-                var p1 = positionVectors[i1];
-                var p2 = positionVectors[i2];
-                var p3 = positionVectors[i3];
-
-                var p1p2 = p1.subtract(p2);
-                var p3p2 = p3.subtract(p2);
-
-                facesNormals[index] = Vector3.Normalize(Vector3.Cross(p1p2, p3p2));
-                facesOfVertices[i1].push(index);
-                facesOfVertices[i2].push(index);
-                facesOfVertices[i3].push(index);
+                
+                // setting the temp V3
+                BABYLON.Vector3.FromFloatsToRef(positions[i1 * 3], positions[i1 * 3 + 1], positions[i1 * 3 + 2] , p1);
+                BABYLON.Vector3.FromFloatsToRef(positions[i2 * 3], positions[i2 * 3 + 1], positions[i2 * 3 + 2] , p2);
+                BABYLON.Vector3.FromFloatsToRef(positions[i3 * 3], positions[i3 * 3 + 1], positions[i3 * 3 + 2] , p3);
+                
+                p1.subtractToRef(p2, p1p2);
+                p3.subtractToRef(p2, p3p2);
+                
+                BABYLON.Vector3.CrossToRef(p1p2, p3p2, faceNormal);
+                faceNormal.normalize();
+    
+                // All intermediate results are stored in the normals array :
+                // get the normals at i1, i2 and i3 indexes
+                normals[i1 * 3]     = normals[i1 * 3]     || 0.0;
+                normals[i1 * 3 + 1] = normals[i1 * 3 + 1] || 0.0;
+                normals[i1 * 3 + 2] = normals[i1 * 3 + 2] || 0.0;
+                normals[i2 * 3]     = normals[i2 * 3]     || 0.0;
+                normals[i2 * 3 + 1] = normals[i2 * 3 + 1] || 0.0;
+                normals[i2 * 3 + 2] = normals[i2 * 3 + 2] || 0.0; 
+                normals[i3 * 3]     = normals[i3 * 3]     || 0.0;
+                normals[i3 * 3 + 1] = normals[i3 * 3 + 1] || 0.0;
+                normals[i3 * 3 + 2] = normals[i3 * 3 + 2] || 0.0;
+                // make intermediate vectors3 from normals values
+                BABYLON.Vector3.FromFloatsToRef(normals[i1 * 3], normals[i1 * 3 + 1], normals[i1 * 3 + 2] , vertexNormali1);
+                BABYLON.Vector3.FromFloatsToRef(normals[i2 * 3], normals[i2 * 3 + 1], normals[i2 * 3 + 2] , vertexNormali2);
+                BABYLON.Vector3.FromFloatsToRef(normals[i3 * 3], normals[i3 * 3 + 1], normals[i3 * 3 + 2] , vertexNormali3);
+                // add the current face normals to these intermediate vectors3
+                vertexNormali1 = vertexNormali1.addInPlace(faceNormal);
+                vertexNormali2 = vertexNormali2.addInPlace(faceNormal);
+                vertexNormali3 = vertexNormali3.addInPlace(faceNormal);
+                // store back intermediate vectors3 into the normals array
+                normals[i1 * 3]     = vertexNormali1.x;
+                normals[i1 * 3 + 1] = vertexNormali1.y;
+                normals[i1 * 3 + 2] = vertexNormali1.z;
+                normals[i2 * 3]     = vertexNormali2.x;
+                normals[i2 * 3 + 1] = vertexNormali2.y;
+                normals[i2 * 3 + 2] = vertexNormali2.z;
+                normals[i3 * 3]     = vertexNormali3.x;
+                normals[i3 * 3 + 1] = vertexNormali3.y;
+                normals[i3 * 3 + 2] = vertexNormali3.z;
             }
-
-            for (index = 0; index < positionVectors.length; index++) {
-                var faces = facesOfVertices[index];
-
-                var normal = Vector3.Zero();
-                for (var faceIndex = 0; faceIndex < faces.length; faceIndex++) {
-                    normal.addInPlace(facesNormals[faces[faceIndex]]);
-                }
-
-                normal = Vector3.Normalize(normal.scale(1.0 / faces.length));
-
-                normals[index * 3] = normal.x;
-                normals[index * 3 + 1] = normal.y;
-                normals[index * 3 + 2] = normal.z;
+            
+            // last normalization
+            for (index = 0; index < normals.length / 3; index++) {
+                BABYLON.Vector3.FromFloatsToRef(normals[index * 3], normals[index * 3 + 1], normals[index * 3 + 2] , vertexNormali1);
+                vertexNormali1.normalize();
+                normals[index * 3]     = vertexNormali1.x;
+                normals[index * 3 + 1] = vertexNormali1.y;
+                normals[index * 3 + 2] = vertexNormali1.z;    
             }
         }
 


### PR DESCRIPTION
This commit adds the ability to pass an optional Vector3 to path3D in order to give some wanted orientation to the first normal (normal on the first path point).

May help users needing to build their Path3D with a given starting local system without to deal then with complex rotations.