### PR TITLE
Feature.curve3

### DIFF
--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3420,6 +3420,7 @@
 
     export class Curve3 {
         private _points: Vector3[];
+        private _length:number = 0;
 
         // QuadraticBezier(origin_V3, control_V3, destination_V3 )
         public static CreateQuadraticBezier(v0: Vector3, v1: Vector3, v2: Vector3, nbPoints: number): Curve3 {
@@ -3451,10 +3452,15 @@
 
         constructor(points: Vector3[]) {
             this._points = points;
+            this._length = this._computeLength(points);
         }
 
         public getPoints() {
             return this._points;
+        }
+
+        public length() {
+            return this._length;
         }
 
         public continue(curve: Curve3): Curve3 {
@@ -3464,7 +3470,16 @@
             for (var i = 1; i < curvePoints.length; i++) {
                 continuedPoints.push(curvePoints[i].subtract(curvePoints[0]).add(lastPoint));
             }
-            return new Curve3(continuedPoints);
+            var continuedCurve = new Curve3(continuedPoints);
+            return continuedCurve;
+        }
+
+        private _computeLength(path: Vector3[]): number {
+            var l = 0;
+            for (var i = 1; i < path.length; i++) {
+                l += (path[i].subtract(path[i - 1])).length();
+            }
+            return l;
         }
     }
 

--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3422,7 +3422,7 @@
         private _points: Vector3[];
         private _length:number = 0;
 
-        // QuadraticBezier(origin_V3, control_V3, destination_V3 )
+        // QuadraticBezier(origin_V3, control_V3, destination_V3, nbPoints)
         public static CreateQuadraticBezier(v0: Vector3, v1: Vector3, v2: Vector3, nbPoints: number): Curve3 {
             nbPoints = nbPoints > 2 ? nbPoints : 3;
             var bez = new Array<Vector3>();
@@ -3436,7 +3436,7 @@
             return new Curve3(bez);
         }
 
-        // CubicBezier(origin_V3, control1_V3, control2_V3, destination_V3)
+        // CubicBezier(origin_V3, control1_V3, control2_V3, destination_V3, nbPoints)
         public static CreateCubicBezier(v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3, nbPoints: number): Curve3 {
             nbPoints = nbPoints > 3 ? nbPoints : 4;
             var bez = new Array<Vector3>();
@@ -3448,6 +3448,16 @@
                 bez.push(new Vector3(equation(i / nbPoints, v0.x, v1.x, v2.x, v3.x), equation(i / nbPoints, v0.y, v1.y, v2.y, v3.y), equation(i / nbPoints, v0.z, v1.z, v2.z, v3.z)));
             }
             return new Curve3(bez);
+        }
+
+        // HermiteSpline(origin_V3, originTangent_V3, destination_V3, destinationTangent_V3, nbPoints)
+        public static CreateHermiteSpline(p1: Vector3, t1: Vector3, p2: Vector3, t2: Vector3, nbPoints: number): Curve3 {
+            var hermite = new Array<Vector3>();
+            var step = 1 / nbPoints;
+            for(var i = 0; i <= nbPoints; i++) {
+                hermite.push(BABYLON.Vector3.Hermite(p1, t1, p2, t2, i * step));
+            }
+            return new Curve3(hermite);
         }
 
         constructor(points: Vector3[]) {


### PR DESCRIPTION
Added methog _length()_ to curve3 : returns the total length of the curve
Added the Hermite Spline curve to the curve3 collection.
```javascript
var hermite = BABYLON.Curve3.CreateHermiteSpline(p1, t1, p2, t2, nbPoints);
```
This curve is based on the internal BJS Vector3.Hermite.
It is very useful to smoothly continue or close other curves by using their first and last segments as Hermite tangents.

example : smoothly closing two concatened cubic bezier curves
```javascript
var cubicA = BABYLON.Curve3.CreateCubicBezier(vA0, vA1, vA2, vA3, 50);
var cubicB = BABYLON.Curve3.CreateCubicBezier(vB0, vB1, vB2, vB3, 50);
var continued = cubicA.continue(cubicB);

var t = continued.length() / 2;                // tangent scale factor
var points = continued.getPoints();
var p1 = points[points.length - 1];            // last continued point = first hermite point
var t1 = (p1.subtract(points[points.length - 2])).scale(t); // last segment scaled = hermite tangent t1
var p2 = points[0];                            // first continued point = last hermite point
var t2 = (points[1].subtract(p2)).scale(t);    // first segment scaled = hermite tangent t2

var hermite = BABYLON.Curve3.CreateHermiteSpline(p1, t1, p2, t2, 50);
continued = continued.continue(hermite);

var closedCurve = BABYLON.Mesh.CreateLines("closed", continued.getPoints(), scene);
```


