### PR TITLE
added freezeNormals to createRibbon

### DIFF
--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -67,6 +67,7 @@
         public _shouldGenerateFlatShading: boolean;
         private _preActivateId: number;
         private _sideOrientation: number = Mesh._DEFAULTSIDE;
+        private _areNormalsFrozen: boolean = false;
 
         /**
          * @constructor
@@ -317,7 +318,19 @@
         public set sideOrientation(sideO: number) {
             this._sideOrientation = sideO;
         }
+        
+        public get areNormalsFrozen(): boolean {
+            return this._areNormalsFrozen;
+        }
+        
+        public freezeNormals(): void {
+            this._areNormalsFrozen = true;
+        }
 
+        public unfreezeNormals(): void {
+            this._areNormalsFrozen = false;
+        }
+        
         // Methods  
         public _preActivate(): void {
             var sceneRenderId = this.getScene().getRenderId();
@@ -1214,7 +1227,8 @@
                 };
                 var sideOrientation = ribbonInstance.sideOrientation;
                 var positionFunction = positionsOfRibbon(pathArray, sideOrientation);
-                ribbonInstance.updateMeshPositions(positionFunction, true);
+                var computeNormals = !(ribbonInstance.areNormalsFrozen);
+                ribbonInstance.updateMeshPositions(positionFunction, computeNormals);
 
                 return ribbonInstance;
 


### PR DESCRIPTION
Added _freezeNormals()_/_unfreezeNormals()_ methods.

It concerns only ribbon based meshes : ribbons, tubes, extruded shapes.
It skips/unskips the normals recomputation on mesh update when called with _CreateXXX(..., meshInstance)_ (the case where _CreateXXX()_ is used to update an instance instead of creating a new one).

It improves update performances for meshes that don't need normals (emissiveColor only for instance).
Chromium big ribbon (60K vertices) update test : 
- unfrozen normals = 35 fps
- frozen normals = 60 fps