### PR TITLE
Worker can be in a single file

### DIFF
--- a/Babylon/Collisions/babylon.collisionCoordinator.js
+++ b/Babylon/Collisions/babylon.collisionCoordinator.js
@@ -129,8 +129,8 @@ var BABYLON;
         CollisionCoordinatorWorker.prototype.init = function (scene) {
             this._scene = scene;
             this._scene.registerAfterRender(this._afterRender);
-            var blobURL = URL.createObjectURL(new Blob([BABYLON.CollisionWorker], { type: 'application/javascript' }));
-            this._worker = new Worker(blobURL);
+            var workerUrl = BABYLON.WorkerIncluded ? "./Collisions/babylon.collisionWorker.js" : URL.createObjectURL(new Blob([BABYLON.CollisionWorker], { type: 'application/javascript' }));
+            this._worker = new Worker(workerUrl);
             this._worker.onmessage = this._onMessageFromWorker;
             var message = {
                 payload: {},
@@ -269,4 +269,5 @@ var BABYLON;
     })();
     BABYLON.CollisionCoordinatorLegacy = CollisionCoordinatorLegacy;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.collisionCoordinator.js.map
+
+//# sourceMappingURL=../Collisions/babylon.collisionCoordinator.js.map

--- a/Babylon/Collisions/babylon.collisionCoordinator.ts
+++ b/Babylon/Collisions/babylon.collisionCoordinator.ts
@@ -211,8 +211,8 @@ module BABYLON {
         public init(scene: Scene): void {
             this._scene = scene;
             this._scene.registerAfterRender(this._afterRender);
-            var blobURL = URL.createObjectURL(new Blob([BABYLON.CollisionWorker], { type: 'application/javascript' }));
-            this._worker = new Worker(blobURL);
+            var workerUrl = BABYLON.WorkerIncluded ? "./Collisions/babylon.collisionWorker.js" : URL.createObjectURL(new Blob([BABYLON.CollisionWorker], { type: 'application/javascript' }));
+            this._worker = new Worker(workerUrl);
             this._worker.onmessage = this._onMessageFromWorker;
             var message: BabylonMessage = {
                 payload: {},

--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -141,8 +141,8 @@ var BABYLON;
             this.mainSoundTrack = new BABYLON.SoundTrack(this, { mainTrack: true });
             //simplification queue
             this.simplificationQueue = new BABYLON.SimplificationQueue();
-            //collision coordinator initialization.
-            this.workerCollisions = (!!Worker && !!BABYLON.CollisionWorker);
+            //collision coordinator initialization. For now legacy per default.
+            this.workerCollisions = false; //(!!Worker && (!!BABYLON.CollisionWorker || BABYLON.WorkerIncluded));
         }
         Object.defineProperty(Scene, "FOGMODE_NONE", {
             get: function () {

--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -291,8 +291,8 @@
 
             //simplification queue
             this.simplificationQueue = new SimplificationQueue();
-            //collision coordinator initialization.
-            this.workerCollisions = (!!Worker && !!BABYLON.CollisionWorker);
+            //collision coordinator initialization. For now legacy per default.
+            this.workerCollisions = false; //(!!Worker && (!!BABYLON.CollisionWorker || BABYLON.WorkerIncluded));
         }
 
         // Properties 

--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -153,8 +153,8 @@
         {
             "variable" : "BABYLON.CollisionWorker",
             "files" : [	
-                "../../Babylon/Collisions/babylon.collisionWorker.js",
                 "../../Babylon/Collisions/babylon.collider.js",
+                "../../Babylon/Collisions/babylon.collisionWorker.js",
                 "../../Babylon/Collisions/babylon.collisionCoordinator.js",
                 "../../Babylon/Math/babylon.math.js"
             ]


### PR DESCRIPTION
If single files are loaded, the worked will load the needed scripts.
Worker's location has to be configured in line 214 of
babylon.collisionCoordinator.ts , as the path of the current script's
location is not a standard JS parameter.
The worker's js needs to be included in the main html file as well.
Legacy collision is not the default.
Gulp config was changed to fit the new needs.