### PR TITLE
Fix for collision worker and gravity

### DIFF
--- a/Babylon/Collisions/babylon.collisionCoordinator.js
+++ b/Babylon/Collisions/babylon.collisionCoordinator.js
@@ -104,8 +104,8 @@ var BABYLON;
         }
         CollisionCoordinatorWorker.prototype.getNewPosition = function (position, velocity, collider, maximumRetry, excludedMesh, onNewPosition, collisionIndex) {
             if (!this._init)
-                ;
-            if (this._collisionsCallbackArray[collisionIndex])
+                return;
+            if (this._collisionsCallbackArray[collisionIndex] || this._collisionsCallbackArray[collisionIndex + 100000])
                 return;
             position.divideToRef(collider.radius, this._scaledPosition);
             velocity.divideToRef(collider.radius, this._scaledVelocity);
@@ -216,7 +216,7 @@ var BABYLON;
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
             this._finalPosition.multiplyInPlace(collider.radius);
             //run the callback
-            onNewPosition(null, this._finalPosition, collider.collidedMesh);
+            onNewPosition(collisionIndex, this._finalPosition, collider.collidedMesh);
         };
         CollisionCoordinatorLegacy.prototype.init = function (scene) {
             this._scene = scene;

--- a/Babylon/Collisions/babylon.collisionCoordinator.ts
+++ b/Babylon/Collisions/babylon.collisionCoordinator.ts
@@ -182,8 +182,8 @@ module BABYLON {
         }
 
         public getNewPosition(position: Vector3, velocity: Vector3, collider: Collider, maximumRetry: number, excludedMesh: AbstractMesh, onNewPosition: (collisionIndex: number, newPosition: BABYLON.Vector3, collidedMesh?: BABYLON.AbstractMesh) => void, collisionIndex: number): void {
-            if (!this._init);
-            if (this._collisionsCallbackArray[collisionIndex]) return;
+            if (!this._init) return;
+            if (this._collisionsCallbackArray[collisionIndex] || this._collisionsCallbackArray[collisionIndex + 100000]) return;
 
             position.divideToRef(collider.radius, this._scaledPosition);
             velocity.divideToRef(collider.radius, this._scaledVelocity);
@@ -353,7 +353,7 @@ module BABYLON {
 
             this._finalPosition.multiplyInPlace(collider.radius);
             //run the callback
-            onNewPosition(null, this._finalPosition, collider.collidedMesh);
+            onNewPosition(collisionIndex, this._finalPosition, collider.collidedMesh);
         }
 
         public init(scene: Scene): void {


### PR DESCRIPTION
There was a problem with parallel processing of gravity-enabled cameras.
The position that was used for normal collision and gravity collision
was the same, and it caused major problems, especially in IE.
This fix make the inspection a bit more "sync" - first the regular
inspection is made, and a temporary position buffer is being used to
inspect the gravity. This actually means that gravity inspection will
take a minimum of 1 frame (probably 2), but the movement will be
correct.