### PR TITLE
Check during workerCollision set

### DIFF
--- a/Babylon/babylon.scene.js
+++ b/Babylon/babylon.scene.js
@@ -185,6 +185,7 @@ var BABYLON;
                 return this._workerCollisions;
             },
             set: function (enabled) {
+                enabled = (enabled && !!Worker);
                 this._workerCollisions = enabled;
                 if (this.collisionCoordinator) {
                     this.collisionCoordinator.destroy();
@@ -1731,4 +1732,3 @@ var BABYLON;
     })();
     BABYLON.Scene = Scene;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.scene.js.map

--- a/Babylon/babylon.scene.ts
+++ b/Babylon/babylon.scene.ts
@@ -302,6 +302,9 @@
         }
 
         public set workerCollisions(enabled: boolean) {
+        
+            enabled = (enabled && !!Worker)
+        
             this._workerCollisions = enabled;
             if (this.collisionCoordinator) {
                 this.collisionCoordinator.destroy();


### PR DESCRIPTION
Setting workerCollisions to true will also check if Worker support
exists in the browser and will set legacy (and false) if not.