### PR TITLE
fix : changed Path3D first normal discovery to get a more human expected behavior

### DIFF
--- a/Babylon/Math/babylon.math.ts
+++ b/Babylon/Math/babylon.math.ts
@@ -3397,11 +3397,11 @@
             var normal0: Vector3;
             if (va === undefined || va === null) {
                 var point: Vector3;
-                if (vt.x !== 1) {     // search for a point in the plane
-                    point = new Vector3(1, 0, 0);
+                if (vt.y !== 1) {     // search for a point in the plane
+                    point = new Vector3(0, -1, 0);
                 }
-                else if (vt.y !== 1) {
-                    point = new Vector3(0, 1, 0);
+                else if (vt.x !== 1) {
+                    point = new Vector3(1, 0, 0);
                 }
                 else if (vt.z !== 1) {
                     point = new Vector3(0, 0, 1);


### PR DESCRIPTION
To solve this question : http://www.html5gamedevs.com/topic/14475-unexpected-rotation-when-using-extrusion/ in a more human expectation.

If no direction vector given as parameter, the Path3D computes its first normal by itself, searching for intersections with world axis. 
The search order is now changed so it fits the BJS rotation axis order (y, x, z) so the path3D behavior seems more coherent to human head movements.