### PR TITLE
Fix moveWithCollisions when no worker is used

### DIFF
--- a/Babylon/Mesh/babylon.abstractMesh.js
+++ b/Babylon/Mesh/babylon.abstractMesh.js
@@ -75,7 +75,7 @@ var BABYLON;
             this._onCollisionPositionChange = function (collisionId, newPosition, collidedMesh) {
                 if (collidedMesh === void 0) { collidedMesh = null; }
                 //TODO move this to the collision coordinator!
-                if (collisionId != null || collisionId != undefined)
+                if (_this.getScene().workerCollisions)
                     newPosition.multiplyInPlace(_this._collider.radius);
                 newPosition.subtractToRef(_this._oldPositionForCollisions, _this._diffPositionForCollisions);
                 if (_this._diffPositionForCollisions.length() > BABYLON.Engine.CollisionsEpsilon) {
@@ -501,10 +501,7 @@ var BABYLON;
             this.rotationQuaternion = BABYLON.Quaternion.RotationYawPitchRoll(yaw + yawCor, pitch + pitchCor, rollCor);
         };
         AbstractMesh.prototype.isInFrustum = function (frustumPlanes) {
-            if (!this._boundingInfo.isInFrustum(frustumPlanes)) {
-                return false;
-            }
-            return true;
+            return this._boundingInfo.isInFrustum(frustumPlanes);
         };
         AbstractMesh.prototype.isCompletelyInFrustum = function (camera) {
             if (!camera) {
@@ -824,4 +821,3 @@ var BABYLON;
     })(BABYLON.Node);
     BABYLON.AbstractMesh = AbstractMesh;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.abstractMesh.js.map

--- a/Babylon/Mesh/babylon.abstractMesh.ts
+++ b/Babylon/Mesh/babylon.abstractMesh.ts
@@ -564,11 +564,7 @@
         }
 
         public isInFrustum(frustumPlanes: Plane[]): boolean {
-            if (!this._boundingInfo.isInFrustum(frustumPlanes)) {
-                return false;
-            }
-
-            return true;
+            return this._boundingInfo.isInFrustum(frustumPlanes);
         }
 
         public isCompletelyInFrustum(camera?: Camera): boolean {
@@ -724,7 +720,7 @@
 
         private _onCollisionPositionChange = (collisionId: number, newPosition: Vector3, collidedMesh: AbstractMesh = null) => {
             //TODO move this to the collision coordinator!
-            if (collisionId != null || collisionId != undefined)
+            if (this.getScene().workerCollisions)
                 newPosition.multiplyInPlace(this._collider.radius);
 
             newPosition.subtractToRef(this._oldPositionForCollisions, this._diffPositionForCollisions);


### PR DESCRIPTION
When the worker is not used for collisions, there is no need to
recalculate the new position (using the collider's radius).