### PR TITLE
Better regex for endsolid

### DIFF
--- a/Loaders/STL/babylon.stlFileLoader.js
+++ b/Loaders/STL/babylon.stlFileLoader.js
@@ -2,7 +2,7 @@ var BABYLON;
 (function (BABYLON) {
     var STLFileLoader = (function () {
         function STLFileLoader() {
-            this.solidPattern = /solid (\S*)([\S\s]*)endsolid (\S*)/g;
+            this.solidPattern = /solid (\S*)([\S\s]*)endsolid[ ]*(\S*)/g;
             this.facetsPattern = /facet([\s\S]*?)endfacet/g;
             this.normalPattern = /normal[\s]+([\-+]?[0-9]+\.?[0-9]*([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+/g;
             this.vertexPattern = /vertex[\s]+([\-+]?[0-9]+\.?[0-9]*([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+/g;

--- a/Loaders/STL/babylon.stlFileLoader.ts
+++ b/Loaders/STL/babylon.stlFileLoader.ts
@@ -2,7 +2,7 @@
 
     export class STLFileLoader implements ISceneLoaderPlugin {
 
-        public solidPattern = /solid (\S*)([\S\s]*)endsolid (\S*)/g;
+        public solidPattern = /solid (\S*)([\S\s]*)endsolid[ ]*(\S*)/g;
         public facetsPattern = /facet([\s\S]*?)endfacet/g;
         public normalPattern = /normal[\s]+([\-+]?[0-9]+\.?[0-9]*([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+/g;
         public vertexPattern = /vertex[\s]+([\-+]?[0-9]+\.?[0-9]*([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+[\s]+([\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?)+/g;


### PR DESCRIPTION
Sometimes endsolid ends with a space and without a name-string, which
will prevent the old regex from detecting the solid correctly.