### PR TITLE
Load needed mesh geometry

### DIFF
--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.js
@@ -677,7 +677,6 @@ var BABYLON;
                 }
                 var effectiveTarget = propertyPath.split(".");
                 var values = value.split(",");
-                // Get effective Target
                 for (var i = 0; i < effectiveTarget.length; i++) {
                     target = target[effectiveTarget[i]];
                 }
@@ -780,7 +779,6 @@ var BABYLON;
                 for (var i = 0; i < parsedAction.children.length; i++)
                     traverse(parsedAction.children[i], trigger, condition, newAction, null);
             };
-            // triggers
             for (var i = 0; i < parsedActions.children.length; i++) {
                 var triggerParams;
                 var trigger = parsedActions.children[i];
@@ -801,14 +799,19 @@ var BABYLON;
             var soundName = parsedSound.name;
             var soundUrl = rootUrl + soundName;
             var options = {
-                autoplay: parsedSound.autoplay, loop: parsedSound.loop, volume: parsedSound.volume,
-                spatialSound: parsedSound.spatialSound, maxDistance: parsedSound.maxDistance,
+                autoplay: parsedSound.autoplay,
+                loop: parsedSound.loop,
+                volume: parsedSound.volume,
+                spatialSound: parsedSound.spatialSound,
+                maxDistance: parsedSound.maxDistance,
                 rolloffFactor: parsedSound.rolloffFactor,
                 refDistance: parsedSound.refDistance,
                 distanceModel: parsedSound.distanceModel,
                 playbackRate: parsedSound.playbackRate
             };
-            var newSound = new BABYLON.Sound(soundName, soundUrl, scene, function () { scene._removePendingData(newSound); }, options);
+            var newSound = new BABYLON.Sound(soundName, soundUrl, scene, function () {
+                scene._removePendingData(newSound);
+            }, options);
             scene._addPendingData(newSound);
             if (parsedSound.position) {
                 var soundPosition = BABYLON.Vector3.FromArray(parsedSound.position);
@@ -1011,6 +1014,52 @@ var BABYLON;
                             // Remove found mesh name from list.
                             delete meshesNames[meshesNames.indexOf(parsedMesh.name)];
                         }
+                        //Geometry?
+                        if (parsedMesh.geometryId) {
+                            //does the file contain geometries?
+                            if (parsedData.geometries) {
+                                //find the correct geometry and add it to the scene
+                                var found = false;
+                                ["boxes", "spheres", "cylinders", "toruses", "grounds", "planes", "torusKnots", "vertexData"].forEach(function (geometryType) {
+                                    if (found || !parsedData.geometries[geometryType] || !(parsedData.geometries[geometryType] instanceof Array)) {
+                                        return;
+                                    }
+                                    else {
+                                        parsedData.geometries[geometryType].forEach(function (parsedGeometryData) {
+                                            if (parsedGeometryData.id == parsedMesh.geometryId) {
+                                                switch (geometryType) {
+                                                    case "boxes":
+                                                        parseBox(parsedGeometryData, scene);
+                                                        break;
+                                                    case "spheres":
+                                                        parseSphere(parsedGeometryData, scene);
+                                                        break;
+                                                    case "cylinders":
+                                                        parseCylinder(parsedGeometryData, scene);
+                                                        break;
+                                                    case "toruses":
+                                                        parseTorus(parsedGeometryData, scene);
+                                                        break;
+                                                    case "grounds":
+                                                        parseGround(parsedGeometryData, scene);
+                                                        break;
+                                                    case "planes":
+                                                        parsePlane(parsedGeometryData, scene);
+                                                        break;
+                                                    case "torusKnots":
+                                                        parseTorusKnot(parsedGeometryData, scene);
+                                                        break;
+                                                    case "vertexData":
+                                                        parseVertexData(parsedGeometryData, scene, rootUrl);
+                                                        break;
+                                                }
+                                                found = true;
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+                        }
                         // Material ?
                         if (parsedMesh.materialId) {
                             var materialFound = (loadedMaterialsIds.indexOf(parsedMesh.materialId) !== -1);
@@ -1052,7 +1101,6 @@ var BABYLON;
                         meshes.push(mesh);
                     }
                 }
-                // Connecting parents
                 for (index = 0; index < scene.meshes.length; index++) {
                     var currentMesh = scene.meshes[index];
                     if (currentMesh._waitingParentId) {
@@ -1087,7 +1135,6 @@ var BABYLON;
                     scene.fogEnd = parsedData.fogEnd;
                     scene.fogDensity = parsedData.fogDensity;
                 }
-                // Lights
                 for (var index = 0; index < parsedData.lights.length; index++) {
                     var parsedLight = parsedData.lights[index];
                     parseLight(parsedLight, scene);
@@ -1180,12 +1227,10 @@ var BABYLON;
                         }
                     }
                 }
-                // Meshes
                 for (index = 0; index < parsedData.meshes.length; index++) {
                     var parsedMesh = parsedData.meshes[index];
                     parseMesh(parsedMesh, scene, rootUrl);
                 }
-                // Cameras
                 for (index = 0; index < parsedData.cameras.length; index++) {
                     var parsedCamera = parsedData.cameras[index];
                     parseCamera(parsedCamera, scene);
@@ -1193,7 +1238,6 @@ var BABYLON;
                 if (parsedData.activeCameraID) {
                     scene.setActiveCameraByID(parsedData.activeCameraID);
                 }
-                // Browsing all the graph to connect the dots
                 for (index = 0; index < scene.cameras.length; index++) {
                     var camera = scene.cameras[index];
                     if (camera._waitingParentId) {
@@ -1220,7 +1264,6 @@ var BABYLON;
                         }
                     }
                 }
-                // Connect parents & children and parse actions
                 for (index = 0; index < scene.meshes.length; index++) {
                     var mesh = scene.meshes[index];
                     if (mesh._waitingParentId) {
@@ -1263,4 +1306,3 @@ var BABYLON;
         });
     })(Internals = BABYLON.Internals || (BABYLON.Internals = {}));
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.babylonFileLoader.js.map

--- a/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/Babylon/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -1249,6 +1249,53 @@
                         delete meshesNames[meshesNames.indexOf(parsedMesh.name)];
                     }
 
+                    //Geometry?
+                    if (parsedMesh.geometryId) {
+                        //does the file contain geometries?
+                        if (parsedData.geometries) {
+                            //find the correct geometry and add it to the scene
+                            var found: boolean = false;
+                            ["boxes", "spheres", "cylinders", "toruses", "grounds", "planes", "torusKnots", "vertexData"].forEach((geometryType: string) => {
+                                if (found || !parsedData.geometries[geometryType] || !(parsedData.geometries[geometryType] instanceof Array)) {
+                                    return;
+                                } else {
+                                    parsedData.geometries[geometryType].forEach((parsedGeometryData) => {
+                                        if (parsedGeometryData.id == parsedMesh.geometryId) {
+                                            switch (geometryType) {
+                                                case "boxes":
+                                                    parseBox(parsedGeometryData, scene);
+                                                    break;
+                                                case "spheres":
+                                                    parseSphere(parsedGeometryData, scene);
+                                                    break;
+                                                case "cylinders":
+                                                    parseCylinder(parsedGeometryData, scene);
+                                                    break;
+                                                case "toruses":
+                                                    parseTorus(parsedGeometryData, scene);
+                                                    break;
+                                                case "grounds":
+                                                    parseGround(parsedGeometryData, scene);
+                                                    break;
+                                                case "planes":
+                                                    parsePlane(parsedGeometryData, scene);
+                                                    break;
+                                                case "torusKnots":
+                                                    parseTorusKnot(parsedGeometryData, scene);
+                                                    break;
+                                                case "vertexData":
+                                                    parseVertexData(parsedGeometryData, scene, rootUrl);
+                                                    break;
+                                            }
+                                            found = true;
+                                        }
+                                    });
+                                    
+                                }
+                            });
+                        }
+                    }
+
                     // Material ?
                     if (parsedMesh.materialId) {
                         var materialFound = (loadedMaterialsIds.indexOf(parsedMesh.materialId) !== -1);

--- a/what's new - 2.1 - proposal.md
+++ b/what's new - 2.1 - proposal.md
@@ -57,6 +57,7 @@
  - useCameraPostProcess whenever there is a special camera in use ([m0ppers](https://github.com/m0ppers))
  - delta in BoundingBox's intersectsPoint is now calculated correctly ([raananw](http://www.github.com/raananw)) 
  - textures cache fixed ([deltakosh](http://www.github.com/deltakosh))
+ - ImportMesh not importing referenced geometries ([raananw](http://www.github.com/raananw)) 
  - **Breaking changes**
  - OculusCamera was removed ([deltakosh](http://www.github.com/deltakosh))
  - VRDeviceOrientationCamera was renamed to VRDeviceOrientationFreeCamera ([deltakosh](http://www.github.com/deltakosh))

--- a/what's new - 2.1 - proposal.md
+++ b/what's new - 2.1 - proposal.md
@@ -57,7 +57,7 @@
  - useCameraPostProcess whenever there is a special camera in use ([m0ppers](https://github.com/m0ppers))
  - delta in BoundingBox's intersectsPoint is now calculated correctly ([raananw](http://www.github.com/raananw)) 
  - textures cache fixed ([deltakosh](http://www.github.com/deltakosh))
- - ImportMesh not importing referenced geometries ([raananw](http://www.github.com/raananw)) 
+ - ImportMesh now imports referenced geometries of selected meshes ([raananw](http://www.github.com/raananw)) 
  - **Breaking changes**
  - OculusCamera was removed ([deltakosh](http://www.github.com/deltakosh))
  - VRDeviceOrientationCamera was renamed to VRDeviceOrientationFreeCamera ([deltakosh](http://www.github.com/deltakosh))


### PR DESCRIPTION
ImportMsh did not load external geometries, if they were referenced
using geometryId in the babylon file.
The SceneSerializer actually uses this method (stores geometries and
references the IDs) so it is important to have this implemented in the
ImportMesh as well.
Solves this - http://www.html5gamedevs.com/topic/14764-importing-a-mesh-into-an-existing-scene/