### PR TITLE
Feature.dashed lines

### DIFF
--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1350,8 +1350,45 @@
             if (linesInstance) {  //  dashed lines update
                 var positionsOfLines = function(points) {
                     var positionFunction = function(positions) {
-
-                    
+                        var curvect = Vector3.Zero();
+                        var nbSeg = positions.length / 6;
+                        var lg = 0;
+                        var nb = 0;
+                        var shft = 0;
+                        var dashshft = 0;
+                        var curshft = 0;
+                        var p = 0;
+                        var i = 0;
+                        var j = 0;
+                        for (i = 0; i < points.length - 1; i++) {
+                            points[i + 1].subtractToRef(points[i], curvect);
+                            lg += curvect.length();
+                        }
+                        shft = lg / nbSeg;
+                        dashshft = (<any>linesInstance).dashSize * shft / ((<any>linesInstance).dashSize + (<any>linesInstance).gapSize);
+                        for (i = 0; i < points.length - 1; i++) {
+                            points[i + 1].subtractToRef(points[i], curvect);
+                            curvect.normalize();
+                            nb = Math.floor(curvect.length() / shft);
+                            j = 0;
+                            while (j < nb && p < positions.length) {
+                                curshft = shft * j;
+                                positions[p] = points[i].x + curshft * curvect.x;
+                                positions[p + 1] = points[i].y + curshft * curvect.y;
+                                positions[p + 2] = points[i].z + curshft * curvect.z;
+                                positions[p + 3] = points[i].x + (curshft + dashshft)* curvect.x;
+                                positions[p + 4] = points[i].y + (curshft + dashshft) * curvect.y;
+                                positions[p + 5] = points[i].z + (curshft + dashshft) * curvect.z;
+                                p += 6;
+                                j++;
+                            }
+                        }
+                        while (p < positions.length) {
+                            positions[p] = points[i].x;
+                            positions[p + 1] = points[i].y;
+                            positions[p + 2] = points[i].z;
+                            p += 3;
+                        }
                     };
                     return positionFunction;   
                 };
@@ -1363,6 +1400,8 @@
             var dashedLines = new LinesMesh(name, scene, updatable);
             var vertexData = VertexData.CreateDashedLines(points, dashSize, gapSize, dashNb);
             vertexData.applyToMesh(dashedLines, updatable);
+            (<any>dashedLines).dashSize = dashSize;
+            (<any>dashedLines).gapSize = gapSize;
             return dashedLines;
         }
 

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1345,6 +1345,27 @@
             return lines;
         }
 
+        // Dashed Lines
+        public static CreateDashedLines(name: string, points: Vector3[], dashSize:number, gapSize: number, dashNb: number, scene: Scene, updatable?: boolean, linesInstance: LinesMesh = null): LinesMesh {
+            if (linesInstance) {  //  dashed lines update
+                var positionsOfLines = function(points) {
+                    var positionFunction = function(positions) {
+
+                    
+                    };
+                    return positionFunction;   
+                };
+                var positionFunction = positionsOfLines(points);
+                linesInstance.updateMeshPositions(positionFunction, false);
+                return linesInstance;
+            }
+            // dashed lines creation
+            var dashedLines = new LinesMesh(name, scene, updatable);
+            var vertexData = VertexData.CreateDashedLines(points, dashSize, gapSize, dashNb);
+            vertexData.applyToMesh(dashedLines, updatable);
+            return dashedLines;
+        }
+
         // Extrusion
         public static ExtrudeShape(name: string, shape: Vector3[], path: Vector3[], scale: number, rotation: number, cap: number, scene: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, extrudedInstance: Mesh = null): Mesh {
             scale = scale || 1;

--- a/Babylon/Mesh/babylon.mesh.vertexData.ts
+++ b/Babylon/Mesh/babylon.mesh.vertexData.ts
@@ -803,7 +803,6 @@
 
             var curvect = Vector3.Zero();
             var lg = 0;
-            //var unit: Vector3;
             var nb = 0;
             var shft = 0;
             var dashshft = 0;

--- a/Babylon/Mesh/babylon.mesh.vertexData.ts
+++ b/Babylon/Mesh/babylon.mesh.vertexData.ts
@@ -793,6 +793,50 @@
             return vertexData;
         }
 
+        public static CreateDashedLines(points: Vector3[], dashSize: number, gapSize: number, dashNb: number): VertexData {
+            dashSize = dashSize || 3;
+            gapSize = gapSize || 1;
+            dashNb = dashNb || 200;
+
+            var positions = [];
+            var indices = [];
+
+            var curvect = Vector3.Zero();
+            var lg = 0;
+            //var unit: Vector3;
+            var nb = 0;
+            var shft = 0;
+            var dashshft = 0;
+            var curshft = 0;
+            var idx = 0;
+            var i = 0;
+            for (i = 0; i < points.length - 1; i++) {
+                points[i + 1].subtractToRef(points[i], curvect);
+                lg += curvect.length();
+            }
+            shft = lg / dashNb;
+            dashshft = dashSize * shft / (dashSize + gapSize);
+            for (i = 0; i < points.length - 1; i++) {
+                points[i + 1].subtractToRef(points[i], curvect);
+                curvect.normalize();
+                nb = Math.floor(curvect.length() / shft);
+                for (var j = 0; j < nb; j++) {
+                      curshft = shft * j;
+                      positions.push(points[i].x + curshft * curvect.x , points[i].y + curshft * curvect.y, points[i].z + curshft * curvect.z);
+                      positions.push(points[i].x + (curshft + dashshft)* curvect.x, points[i].y + (curshft + dashshft) * curvect.y, points[i].z + (curshft + dashshft) * curvect.z);
+                      indices.push(idx, idx + 1);
+                      idx += 2;
+                }
+            }
+
+            // Result
+            var vertexData = new VertexData();
+            vertexData.positions = positions;
+            vertexData.indices = indices;
+
+            return vertexData;
+        }
+
         public static CreateGround(width: number, height: number, subdivisions: number): VertexData {
             var indices = [];
             var positions = [];

--- a/Babylon/Mesh/babylon.mesh.vertexData.ts
+++ b/Babylon/Mesh/babylon.mesh.vertexData.ts
@@ -820,11 +820,11 @@
                 curvect.normalize();
                 nb = Math.floor(curvect.length() / shft);
                 for (var j = 0; j < nb; j++) {
-                      curshft = shft * j;
-                      positions.push(points[i].x + curshft * curvect.x , points[i].y + curshft * curvect.y, points[i].z + curshft * curvect.z);
-                      positions.push(points[i].x + (curshft + dashshft)* curvect.x, points[i].y + (curshft + dashshft) * curvect.y, points[i].z + (curshft + dashshft) * curvect.z);
-                      indices.push(idx, idx + 1);
-                      idx += 2;
+                    curshft = shft * j;
+                    positions.push(points[i].x + curshft * curvect.x , points[i].y + curshft * curvect.y, points[i].z + curshft * curvect.z);
+                    positions.push(points[i].x + (curshft + dashshft)* curvect.x, points[i].y + (curshft + dashshft) * curvect.y, points[i].z + (curshft + dashshft) * curvect.z);
+                    indices.push(idx, idx + 1);
+                    idx += 2;
                 }
             }
 


### PR DESCRIPTION
Added new mesh type : Dashed Lines
Creation : 
```javascript
var dashed = BABYLON.Mesh.CreateDashedLines("dl", points, dashSize, gapSize, dashNb, scene, true);
```
* **points** : array of Vector3
* **dashNb** : (default 200) the number of dashes wanted, equivalent to some scale (it will try to reach this number according to the _points_ array number of segments)
* **dashSize** and **gapSize** : (default 3 / 1) relative dash and gap size within each stroke along the curve. exemple : with 3 and 1, the dash will be three times bigger than the gap.

Update/morphing : 
```javascript
var points = [Vectors3];  // an filled with Vectors3
updatePoints(points);     // some function to change each Vector3 coordinates
dashed = BABYLON.Mesh.CreateDashedLines(null, points, null, null, null, null, null, dashed);
```