### PR TITLE
Update what's new - 2.1 - proposal.md

### DIFF
--- a/what's new - 2.1 - proposal.md
+++ b/what's new - 2.1 - proposal.md
@@ -64,4 +64,4 @@
  - OculusCamera was removed ([deltakosh](http://www.github.com/deltakosh))
  - VRDeviceOrientationCamera was renamed to VRDeviceOrientationFreeCamera ([deltakosh](http://www.github.com/deltakosh))
  - WebVRCamera was renamed to WebVRFreeCamera ([deltakosh](http://www.github.com/deltakosh))
- - VideoTexture does not require a size parameter anymore. The new constructor is: ```constructor(name: string, urls: string[], scene: Scene, generateMipMaps = false, invertY = true, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE)```  ([deltakosh](http://www.github.com/deltakosh))
+ - VideoTexture does not require a size parameter anymore. The new constructor is: ```constructor(name: string, urls: string[], scene: Scene, generateMipMaps = false, invertY = false, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE)```  ([deltakosh](http://www.github.com/deltakosh))


### PR DESCRIPTION
Dans "What's new" invertY est spécifier a true, mais il est a false dans le code.

J'avais proposer précédemment ce PR, mais je pense qu'il a été refuser par ce qu'il a déjà été corriger par le code, mais là il s'agit du  "What's new 2.1 proposal" qui indique que invertY est a true, mais dans le code il est a false par défaut.

Je renouvelle donc ce même PR et en français, pour une explication plus claire.