### PR TITLE
Quaternion Init fix at toMesh and FromMesh

### DIFF
--- a/Babylon/Mesh/babylon.csg.js
+++ b/Babylon/Mesh/babylon.csg.js
@@ -259,13 +259,16 @@ var BABYLON;
         // Convert BABYLON.Mesh to BABYLON.CSG
         CSG.FromMesh = function (mesh) {
             var vertex, normal, uv, position, polygon, polygons = [], vertices;
+            var matrix, meshPosition, meshRotation, meshRotationQuaternion, meshScaling;
             if (mesh instanceof BABYLON.Mesh) {
                 mesh.computeWorldMatrix(true);
-                var matrix = mesh.getWorldMatrix();
-                var meshPosition = mesh.position.clone();
-                var meshRotation = mesh.rotation.clone();
-                var meshRotationQuaternion = mesh.rotationQuaternion.clone();
-                var meshScaling = mesh.scaling.clone();
+                matrix = mesh.getWorldMatrix();
+                meshPosition = mesh.position.clone();
+                meshRotation = mesh.rotation.clone();
+                if (mesh.rotationQuaternion) {
+                    meshRotationQuaternion = mesh.rotationQuaternion.clone();
+                }
+                meshScaling = mesh.scaling.clone();
             }
             else {
                 throw 'BABYLON.CSG: Wrong Mesh type, must be BABYLON.Mesh';

--- a/Babylon/Mesh/babylon.csg.js
+++ b/Babylon/Mesh/babylon.csg.js
@@ -492,7 +492,9 @@ var BABYLON;
             mesh.material = material;
             mesh.position.copyFrom(this.position);
             mesh.rotation.copyFrom(this.rotation);
-            mesh.rotationQuaternion.copyFrom(this.rotationQuaternion);
+            if (this.rotationQuaternion) {
+                mesh.rotationQuaternion = this.rotationQuaternion.clone();
+            }
             mesh.scaling.copyFrom(this.scaling);
             mesh.computeWorldMatrix(true);
             return mesh;
@@ -501,4 +503,3 @@ var BABYLON;
     })();
     BABYLON.CSG = CSG;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.csg.js.map

--- a/Babylon/Mesh/babylon.csg.ts
+++ b/Babylon/Mesh/babylon.csg.ts
@@ -589,7 +589,9 @@
 
             mesh.position.copyFrom(this.position);
             mesh.rotation.copyFrom(this.rotation);
-            mesh.rotationQuaternion.copyFrom(this.rotationQuaternion);
+			if(this.rotationQuaternion) {
+				mesh.rotationQuaternion = this.rotationQuaternion.clone();
+			}
             mesh.scaling.copyFrom(this.scaling);
             mesh.computeWorldMatrix(true);
 

--- a/Babylon/Mesh/babylon.csg.ts
+++ b/Babylon/Mesh/babylon.csg.ts
@@ -285,14 +285,21 @@
                 polygon,
                 polygons = [],
                 vertices;
-
+			var matrix, 
+				meshPosition,
+				meshRotation,
+				meshRotationQuaternion,
+				meshScaling;
+				
             if (mesh instanceof BABYLON.Mesh) {
                 mesh.computeWorldMatrix(true);
-                var matrix = mesh.getWorldMatrix();
-                var meshPosition = mesh.position.clone();
-                var meshRotation = mesh.rotation.clone();
-                var meshRotationQuaternion = mesh.rotationQuaternion.clone();
-                var meshScaling = mesh.scaling.clone();
+                matrix = mesh.getWorldMatrix();
+                meshPosition = mesh.position.clone();
+                meshRotation = mesh.rotation.clone();
+				if(mesh.rotationQuaternion) {
+					meshRotationQuaternion = mesh.rotationQuaternion.clone();
+				}
+                meshScaling = mesh.scaling.clone();
             } else {
                 throw 'BABYLON.CSG: Wrong Mesh type, must be BABYLON.Mesh';
             }


### PR DESCRIPTION
Fix for https://github.com/BabylonJS/Babylon.js/issues/542.
Further fixes at FromMesh - if no quaternion was available in the original mesh, an exception would have been thrown, and thus FromMesh would not have functioned correctly.