### PR TITLE
added Lathe mesh type

### DIFF
--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1484,6 +1484,38 @@
             return extrudedGeneric;
         }
 
+        // Lathe
+        public static CreateLathe(name: string, shape: Vector3[], radius: number, tessellation: number, scene: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
+            radius = radius || 1;
+            tessellation = tessellation || radius * 60;
+            var pi2 = Math.PI * 2;
+            var Y = BABYLON.Axis.Y;
+            var shapeLathe = new Array<Vector3>();
+            // first rotatable point
+            var  i = 0;
+            while (shape[i].x == 0) {
+                i++;
+            }
+            var pt = shape[i];        
+            for (i = 0; i < shape.length; i++) {
+                shapeLathe.push(shape[i].subtract(pt));
+            }
+            // circle path
+            var step = pi2 / tessellation;
+            var rotated;
+            var path = new Array<Vector3>();;
+            for (i = 0; i < tessellation; i++) {
+                rotated = new Vector3(Math.cos(i * step) * radius, 0, Math.sin(i * step) * radius);
+                path.push(rotated);
+            }
+            path.push(path[0]);
+            // extusion
+            var scaleFunction = function() { return 1; };
+            var rotateFunction = function() { return 0; };
+            var lathe = Mesh.ExtrudeShapeCustom(name, shapeLathe, path, scaleFunction, rotateFunction, true, false, Mesh.NO_CAP, scene, updatable, sideOrientation);
+            return lathe;
+        }
+
         // Plane & ground
         public static CreatePlane(name: string, size: number, scene: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
             var plane = new Mesh(name, scene);


### PR DESCRIPTION
new mesh type : Lathe
```javascript
var shape = [Vectors3 ...];
var lathe = BABYLON.Mesh.CreateLathe("lathe", shape, radius, tessellation, scene);
```
* shape : an array of successive Vectors3 designing a shape in the xOy plane. This shape will be rotated around the Y world axis.
* radius (default = 1) : lathe radius
* tessellation (default = 60 * radius) : lathe tessellation

This mesh type is really straight forward and easy to use for beginners who want to start coding parametric shapes.
I don't implement caps or update/morphing because they can be done with extruded shapes or tubes for advanced users and because there would be too many parameters for this kind of easy-access mesh.
_(and maybe because I'm lazy too)_