### PR TITLE
fix "for...in" array iteration 

### DIFF
--- a/Babylon/Rendering/babylon.renderingManager.ts
+++ b/Babylon/Rendering/babylon.renderingManager.ts
@@ -90,9 +90,11 @@
         }
 
         public reset(): void {
-            for (var index in this._renderingGroups) {
+            for (var index = 0; index < RenderingManager.MAX_RENDERINGGROUPS; index++) {
                 var renderingGroup = this._renderingGroups[index];
-                renderingGroup.prepare();
+                if (renderingGroup) {
+                    renderingGroup.prepare();
+                }
             }
         }
 


### PR DESCRIPTION
Bad practice to iterate array with a "for...in", because if other script redefine array prototype, those new elements will be listed in the "for...in". Modifying prototypes is also a bad thing to do, but many complex framework still do it (they often add some "each", "last", etc method for arrays) and that will make BJS unusable.

I'm not sure if the "for loop" I set is the best one for performance (not as intersting as the original "for...in" of course). Here I simply copied the one in render function of the same file. 
Better to check that before merging.