### PR TITLE
Adding features in BABYLON.PostProcess

### DIFF
--- a/Babylon/PostProcess/babylon.postProcess.js
+++ b/Babylon/PostProcess/babylon.postProcess.js
@@ -1,8 +1,9 @@
 var BABYLON;
 (function (BABYLON) {
     var PostProcess = (function () {
-        function PostProcess(name, fragmentUrl, parameters, samplers, ratio, camera, samplingMode, engine, reusable, defines) {
+        function PostProcess(name, fragmentUrl, parameters, samplers, ratio, camera, samplingMode, engine, reusable, defines, textureType) {
             if (samplingMode === void 0) { samplingMode = BABYLON.Texture.NEAREST_SAMPLINGMODE; }
+            if (textureType === void 0) { textureType = BABYLON.Engine.TEXTURETYPE_UNSIGNED_INT; }
             this.name = name;
             this.width = -1;
             this.height = -1;
@@ -21,6 +22,7 @@ var BABYLON;
             this._renderRatio = ratio;
             this.renderTargetSamplingMode = samplingMode ? samplingMode : BABYLON.Texture.NEAREST_SAMPLINGMODE;
             this._reusable = reusable || false;
+            this._textureType = textureType;
             samplers = samplers || [];
             samplers.push("textureSampler");
             this._effect = this._engine.createEffect({ vertex: "postprocess", fragment: fragmentUrl }, ["position"], parameters || [], samplers, defines !== undefined ? defines : "");
@@ -34,8 +36,8 @@ var BABYLON;
             var maxSize = camera.getEngine().getCaps().maxTextureSize;
             var desiredWidth = ((sourceTexture ? sourceTexture._width : this._engine.getRenderingCanvas().width) * this._renderRatio) | 0;
             var desiredHeight = ((sourceTexture ? sourceTexture._height : this._engine.getRenderingCanvas().height) * this._renderRatio) | 0;
-            desiredWidth = BABYLON.Tools.GetExponantOfTwo(desiredWidth, maxSize);
-            desiredHeight = BABYLON.Tools.GetExponantOfTwo(desiredHeight, maxSize);
+            desiredWidth = this._renderRatio.width || BABYLON.Tools.GetExponantOfTwo(desiredWidth, maxSize);
+            desiredHeight = this._renderRatio.height || BABYLON.Tools.GetExponantOfTwo(desiredHeight, maxSize);
             if (this.width !== desiredWidth || this.height !== desiredHeight) {
                 if (this._textures.length > 0) {
                     for (var i = 0; i < this._textures.length; i++) {
@@ -45,9 +47,9 @@ var BABYLON;
                 }
                 this.width = desiredWidth;
                 this.height = desiredHeight;
-                this._textures.push(this._engine.createRenderTargetTexture({ width: this.width, height: this.height }, { generateMipMaps: false, generateDepthBuffer: camera._postProcesses.indexOf(this) === camera._postProcessesTakenIndices[0], samplingMode: this.renderTargetSamplingMode }));
+                this._textures.push(this._engine.createRenderTargetTexture({ width: this.width, height: this.height }, { generateMipMaps: false, generateDepthBuffer: camera._postProcesses.indexOf(this) === camera._postProcessesTakenIndices[0], samplingMode: this.renderTargetSamplingMode, type: this._textureType }));
                 if (this._reusable) {
-                    this._textures.push(this._engine.createRenderTargetTexture({ width: this.width, height: this.height }, { generateMipMaps: false, generateDepthBuffer: camera._postProcesses.indexOf(this) === camera._postProcessesTakenIndices[0], samplingMode: this.renderTargetSamplingMode }));
+                    this._textures.push(this._engine.createRenderTargetTexture({ width: this.width, height: this.height }, { generateMipMaps: false, generateDepthBuffer: camera._postProcesses.indexOf(this) === camera._postProcessesTakenIndices[0], samplingMode: this.renderTargetSamplingMode, type: this._textureType }));
                 }
                 if (this.onSizeChanged) {
                     this.onSizeChanged();

--- a/Babylon/PostProcess/babylon.postProcessManager.js
+++ b/Babylon/PostProcess/babylon.postProcessManager.js
@@ -62,6 +62,9 @@ var BABYLON;
                     engine.bindBuffers(this._vertexBuffer, this._indexBuffer, this._vertexDeclaration, this._vertexStrideSize, effect);
                     // Draw order
                     engine.draw(true, 0, 6);
+                    if (pp.onAfterRender) {
+                        pp.onAfterRender(effect);
+                    }
                 }
             }
             // Restore depth buffer
@@ -101,6 +104,9 @@ var BABYLON;
                     engine.bindBuffers(this._vertexBuffer, this._indexBuffer, this._vertexDeclaration, this._vertexStrideSize, effect);
                     // Draw order
                     engine.draw(true, 0, 6);
+                    if (pp.onAfterRender) {
+                        pp.onAfterRender(effect);
+                    }
                 }
             }
             // Restore depth buffer

--- a/Babylon/PostProcess/babylon.postProcessManager.ts
+++ b/Babylon/PostProcess/babylon.postProcessManager.ts
@@ -78,6 +78,10 @@
 
                     // Draw order
                     engine.draw(true, 0, 6);
+
+                    if (pp.onAfterRender) {
+                        pp.onAfterRender(effect);
+                    }
                 }
             }
 
@@ -123,6 +127,10 @@
 
                     // Draw order
                     engine.draw(true, 0, 6);
+
+                    if (pp.onAfterRender) {
+                        pp.onAfterRender(effect);
+                    }
                 }
             }
 


### PR DESCRIPTION
Adding onAfterRender function in BABYLON.PostProcess: useful to call "engine.readPixels" after rendering the post-process

Make the "ratio" parameter as number or any (PostProcess constructor). Then users can explicitly tell the post-process dimension:
 - ratio = 1.0; // number
 - ratio = {width: 2, height: 2 }; // any, like "size" in engine.createRenderTargetTexture(size: any, ...);

Adding TEXTURE_TYPE support in BABYLON.PostProcess constructor to allow floating point render target textures in post-processes