### PR TITLE
Changes to meshes transform baking and added flipFaces

### DIFF
--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -901,21 +901,15 @@
             this.setVerticesData(VertexBuffer.PositionKind, temp, this.getVertexBuffer(VertexBuffer.PositionKind).isUpdatable());
 
             // Normals
-            if (!this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
+            if (!this.isVerticesDataPresent(BABYLON.VertexBuffer.NormalKind)) {
                 return;
             }
-            data = this.getVerticesData(VertexBuffer.NormalKind);
+            data = this.getVerticesData(BABYLON.VertexBuffer.NormalKind);
             temp = [];
-            var temp_normal = new Vector3(0, 0, 0);    // this vector is used to normalize the newly transformed normal
             for (index = 0; index < data.length; index += 3) {
-                Vector3.TransformNormal(Vector3.FromArray(data, index), transform).toArray(temp, index);
-                temp_normal.copyFromFloats(temp[index], temp[index + 1], temp[index + 2]);
-                temp_normal.normalize();
-                temp[index] = temp_normal.x;
-                temp[index+1] = temp_normal.y;
-                temp[index+2] = temp_normal.z;
+                BABYLON.Vector3.TransformNormal(BABYLON.Vector3.FromArray(data, index), transform).normalize().toArray(temp, index);
             }
-            this.setVerticesData(VertexBuffer.NormalKind, temp, this.getVertexBuffer(VertexBuffer.NormalKind).isUpdatable());
+            this.setVerticesData(BABYLON.VertexBuffer.NormalKind, temp, this.getVertexBuffer(BABYLON.VertexBuffer.NormalKind).isUpdatable());
             
             // flip faces?
             if (transform.m[0] * transform.m[5] * transform.m[10] < 0) { this.flipFaces(); }

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -908,7 +908,7 @@
             temp = [];
             var temp_normal = new Vector3(0, 0, 0);    // this vector is used to normalize the newly transformed normal
             for (index = 0; index < data.length; index += 3) {
-                Vector3.TransformNormal(BABYLON.Vector3.FromArray(data, index), transform).toArray(temp, index);
+                Vector3.TransformNormal(Vector3.FromArray(data, index), transform).toArray(temp, index);
                 temp_normal.copyFromFloats(temp[index], temp[index + 1], temp[index + 2]);
                 temp_normal.normalize();
                 temp[index] = temp_normal.x;

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -904,17 +904,32 @@
             if (!this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                 return;
             }
-
             data = this.getVerticesData(VertexBuffer.NormalKind);
             temp = [];
+            var temp_normal = new Vector3(0, 0, 0);    // this vector is used to normalize the newly transformed normal
             for (index = 0; index < data.length; index += 3) {
-                Vector3.TransformNormal(Vector3.FromArray(data, index), transform).toArray(temp, index);
+                Vector3.TransformNormal(BABYLON.Vector3.FromArray(data, index), transform).toArray(temp, index);
+                temp_normal.copyFromFloats(temp[index], temp[index + 1], temp[index + 2]);
+                temp_normal.normalize();
+                temp[index] = temp_normal.x;
+                temp[index+1] = temp_normal.y;
+                temp[index+2] = temp_normal.z;
             }
-
             this.setVerticesData(VertexBuffer.NormalKind, temp, this.getVertexBuffer(VertexBuffer.NormalKind).isUpdatable());
+            
+            // flip faces?
+            if (transform.m[0] * transform.m[5] * transform.m[10] < 0) { this.flipFaces(); }
         }
 
-
+        // Will apply current transform to mesh and reset world matrix
+        public bakeCurrentTransformIntoVertices(): void {
+            this.bakeTransformIntoVertices(this.computeWorldMatrix(true));
+            this.scaling.copyFromFloats(1, 1, 1);
+            this.position.copyFromFloats(0, 0, 0);
+            this.rotation.copyFromFloats(0, 0, 0);
+            this.rotationQuaternion = Quaternion.Identity();
+            this._worldMatrix = Matrix.Identity();
+        }
 
         // Cache
         public _resetPointsArrayCache(): void {
@@ -1125,6 +1140,27 @@
             }
 
             this.synchronizeInstances();
+        }
+
+        // will inverse faces orientations, and invert normals too if specified
+        public flipFaces(flipNormals: boolean = false): void {
+            var vertex_data = VertexData.ExtractFromMesh(this);
+            
+            if (flipNormals) {
+                for (var i = 0; i < vertex_data.normals.length; i++) {
+                    vertex_data.normals[i] *= -1;
+                }
+            }
+            
+            var temp;
+            for (var i = 0; i < vertex_data.indices.length; i += 3) {
+                // reassign indices
+                temp = vertex_data.indices[i + 1];
+                vertex_data.indices[i + 1] = vertex_data.indices[i + 2];
+                vertex_data.indices[i + 2] = temp;
+            }
+
+            vertex_data.applyToMesh(this);
         }
 
         // Instances

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -1140,7 +1140,7 @@
         public flipFaces(flipNormals: boolean = false): void {
             var vertex_data = VertexData.ExtractFromMesh(this);
             
-            if (flipNormals) {
+            if (flipNormals && this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                 for (var i = 0; i < vertex_data.normals.length; i++) {
                     vertex_data.normals[i] *= -1;
                 }

--- a/Babylon/Mesh/babylon.mesh.ts
+++ b/Babylon/Mesh/babylon.mesh.ts
@@ -901,15 +901,15 @@
             this.setVerticesData(VertexBuffer.PositionKind, temp, this.getVertexBuffer(VertexBuffer.PositionKind).isUpdatable());
 
             // Normals
-            if (!this.isVerticesDataPresent(BABYLON.VertexBuffer.NormalKind)) {
+            if (!this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                 return;
             }
-            data = this.getVerticesData(BABYLON.VertexBuffer.NormalKind);
+            data = this.getVerticesData(VertexBuffer.NormalKind);
             temp = [];
             for (index = 0; index < data.length; index += 3) {
-                BABYLON.Vector3.TransformNormal(BABYLON.Vector3.FromArray(data, index), transform).normalize().toArray(temp, index);
+                Vector3.TransformNormal(Vector3.FromArray(data, index), transform).normalize().toArray(temp, index);
             }
-            this.setVerticesData(BABYLON.VertexBuffer.NormalKind, temp, this.getVertexBuffer(BABYLON.VertexBuffer.NormalKind).isUpdatable());
+            this.setVerticesData(VertexBuffer.NormalKind, temp, this.getVertexBuffer(VertexBuffer.NormalKind).isUpdatable());
             
             // flip faces?
             if (transform.m[0] * transform.m[5] * transform.m[10] < 0) { this.flipFaces(); }


### PR DESCRIPTION
Added the following functions to the Mesh class:
- `bakeCurrentTransformIntoVertices()`: computes the world matrix of the mesh, bake it in its vertices and then clears all transform
- `flipFaces(flipNormals: boolean)`: inverse all the faces of the mesh, and optionally scales all the normals by -1

Modified the following function:
- `bakeTransformIntoVertices(...)`: this function now makes sure that transformed normals are kept normalized, and flip the faces of the mesh if necessary

Should make mirroring meshes much easier!