### PR TITLE
quaternion inspection

### DIFF
--- a/src/Mesh/babylon.mesh.js
+++ b/src/Mesh/babylon.mesh.js
@@ -795,7 +795,10 @@ var BABYLON;
             this.scaling.copyFromFloats(1, 1, 1);
             this.position.copyFromFloats(0, 0, 0);
             this.rotation.copyFromFloats(0, 0, 0);
-            this.rotationQuaternion = BABYLON.Quaternion.Identity();
+            //only if quaternion is already set
+            if(this.rotationQuaternion) {
+                this.rotationQuaternion = BABYLON.Quaternion.Identity();
+            }
             this._worldMatrix = BABYLON.Matrix.Identity();
         };
         // Cache
@@ -1726,4 +1729,3 @@ var BABYLON;
     })(BABYLON.AbstractMesh);
     BABYLON.Mesh = Mesh;
 })(BABYLON || (BABYLON = {}));
-//# sourceMappingURL=babylon.mesh.js.map

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -921,7 +921,10 @@
             this.scaling.copyFromFloats(1, 1, 1);
             this.position.copyFromFloats(0, 0, 0);
             this.rotation.copyFromFloats(0, 0, 0);
-            this.rotationQuaternion = Quaternion.Identity();
+            //only if quaternion is already set
+            if(this.rotationQuaternion) {
+                this.rotationQuaternion = Quaternion.Identity();
+            }
             this._worldMatrix = Matrix.Identity();
         }
 


### PR DESCRIPTION
Making sure quaternion already exists before initializing it. If it
doesn't the user will continue using the normal rotation object instead.