### PR TITLE
onCollide for meshes

### DIFF
--- a/dist/preview release - alpha/what's new.md
+++ b/dist/preview release - alpha/what's new.md
@@ -13,6 +13,7 @@
     - New rawTexture.update function [robgdl](https://github.com/robgdl)
     - Changes to meshes transform baking and added flipFaces [PR](https://github.com/BabylonJS/Babylon.js/pull/579) [jahow](https://github.com/jahow)
     - SerializeMesh serializes a single mesh to be imported with the loader's ImportMesh. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [RaananW](https://github.com/RaananW)
+	- onCollide callback for meshes calling moveWithCollisions. [PR](https://github.com/BabylonJS/Babylon.js/pull/585) [RaananW](https://github.com/RaananW)
   - **Bug fixes**
     - Fixing bug with rig cameras positioning [deltakosh](https://github.com/deltakosh)
   - **Breaking changes**

--- a/src/Mesh/babylon.abstractMesh.js
+++ b/src/Mesh/babylon.abstractMesh.js
@@ -81,6 +81,10 @@ var BABYLON;
                 if (_this._diffPositionForCollisions.length() > BABYLON.Engine.CollisionsEpsilon) {
                     _this.position.addInPlace(_this._diffPositionForCollisions);
                 }
+				
+				if (_this.onCollide && collidedMesh) {
+					_this.onCollide(collidedMesh);
+				}
             };
             scene.addMesh(this);
         }

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -80,6 +80,7 @@
         private _oldPositionForCollisions = new Vector3(0, 0, 0);
         private _diffPositionForCollisions = new Vector3(0, 0, 0);
         private _newPositionForCollisions = new Vector3(0, 0, 0);
+		public onCollide: (collidedMesh: AbstractMesh) => void;
 
         // Attach to bone
         private _meshToBoneReferal: AbstractMesh;
@@ -766,6 +767,10 @@
             if (this._diffPositionForCollisions.length() > Engine.CollisionsEpsilon) {
                 this.position.addInPlace(this._diffPositionForCollisions);
             }
+			
+			if (this.onCollide && collidedMesh) {
+				this.onCollide(collidedMesh);
+			}
         }
 
         // Submeshes octree


### PR DESCRIPTION
When mesh is using the moveWithCollisions, no callback could be set.
It is now possible to define a callback for mesh collision.