### PR TITLE
Added Color4 support in CloudProceduralTexture

### DIFF
--- a/src/Materials/Textures/Procedurals/babylon.standardProceduralTexture.ts
+++ b/src/Materials/Textures/Procedurals/babylon.standardProceduralTexture.ts
@@ -149,8 +149,8 @@
     }
 
     export class CloudProceduralTexture extends ProceduralTexture {
-        private _skyColor = new Color3(0.15, 0.68, 1.0);
-        private _cloudColor = new Color3(1, 1, 1);
+        private _skyColor = new Color4(0.15, 0.68, 1.0, 1.0);
+        private _cloudColor = new Color4(1, 1, 1, 1.0);
 
         constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
             super(name, size, "cloud", scene, fallbackTexture, generateMipMaps);
@@ -159,24 +159,24 @@
         }
 
         public updateShaderUniforms() {
-            this.setColor3("skyColor", this._skyColor);
-            this.setColor3("cloudColor", this._cloudColor);
+            this.setColor4("skyColor", this._skyColor);
+            this.setColor4("cloudColor", this._cloudColor);
         }
 
-        public get skyColor(): Color3 {
+        public get skyColor(): Color4 {
             return this._skyColor;
         }
 
-        public set skyColor(value: Color3) {
+        public set skyColor(value: Color4) {
             this._skyColor = value;
             this.updateShaderUniforms();
         }
 
-        public get cloudColor(): Color3 {
+        public get cloudColor(): Color4 {
             return this._cloudColor;
         }
 
-        public set cloudColor(value: Color3) {
+        public set cloudColor(value: Color4) {
             this._cloudColor = value;
             this.updateShaderUniforms();
         }

--- a/src/Shaders/cloud.fragment.fx
+++ b/src/Shaders/cloud.fragment.fx
@@ -4,8 +4,8 @@ precision highp float;
 
 varying vec2 vUV;
 
-uniform vec3 skyColor;
-uniform vec3 cloudColor;
+uniform vec4 skyColor;
+uniform vec4 cloudColor;
 
 float rand(vec2 n) {
 	return fract(cos(dot(n, vec2(12.9898, 4.1414))) * 43758.5453);
@@ -30,7 +30,7 @@ float fbm(vec2 n) {
 void main() {
 
 	vec2 p = vUV * 12.0;
-	vec3 c = mix(skyColor, cloudColor, fbm(p));
-	gl_FragColor = vec4(c, 1);
+	vec4 c = mix(skyColor, cloudColor, fbm(p));
+	gl_FragColor = c;
 
 }


### PR DESCRIPTION
Making it consistent with documentation (also transparent skies look nice).

Fix in action here: http://www.babylonjs-playground.com/#24C4KC#16