### PR TITLE
Serialize is cube

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -296,7 +296,7 @@
         public movePOV(amountRight: number, amountUp: number, amountForward: number): void {
             this.position.addInPlace(this.calcMovePOV(amountRight, amountUp, amountForward));
         }
-        
+
         /**
          * Calculate relative position change from the point of view of behind the front of the mesh.
          * This is performed taking into account the meshes current rotation, so you do not have to care.
@@ -326,7 +326,7 @@
         public rotatePOV(flipBack: number, twirlClockwise: number, tiltRight: number): void {
             this.rotation.addInPlace(this.calcRotatePOV(flipBack, twirlClockwise, tiltRight));
         }
-        
+
         /**
          * Calculate relative rotation change from the point of view of behind the front of the mesh.
          * Supports definition of mesh facing forward or backward.
@@ -449,12 +449,14 @@
             // Translation
             if (this.infiniteDistance && !this.parent) {
                 var camera = this.getScene().activeCamera;
-                var cameraWorldMatrix = camera.getWorldMatrix();
+                if (camera) {
+                    var cameraWorldMatrix = camera.getWorldMatrix();
 
-                var cameraGlobalPosition = new Vector3(cameraWorldMatrix.m[12], cameraWorldMatrix.m[13], cameraWorldMatrix.m[14]);
+                    var cameraGlobalPosition = new Vector3(cameraWorldMatrix.m[12], cameraWorldMatrix.m[13], cameraWorldMatrix.m[14]);
 
-                Matrix.TranslationToRef(this.position.x + cameraGlobalPosition.x, this.position.y + cameraGlobalPosition.y,
-                    this.position.z + cameraGlobalPosition.z, this._localTranslation);
+                    Matrix.TranslationToRef(this.position.x + cameraGlobalPosition.x, this.position.y + cameraGlobalPosition.y,
+                        this.position.z + cameraGlobalPosition.z, this._localTranslation);
+                }
             } else {
                 Matrix.TranslationToRef(this.position.x, this.position.y, this.position.z, this._localTranslation);
             }
@@ -570,7 +572,7 @@
             /// <param name="rollCor" type="Number">optional roll (z-axis) correction in radians</param>
             /// <returns>Mesh oriented towards targetMesh</returns>
 
-            yawCor = yawCor || 0; // default to zero if undefined 
+            yawCor = yawCor || 0; // default to zero if undefined
             pitchCor = pitchCor || 0;
             rollCor = rollCor || 0;
 

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -104,7 +104,7 @@
             serializationObject.type = "WebVRFreeCamera";
         } else if (camera instanceof VRDeviceOrientationFreeCamera) {
             serializationObject.type = "VRDeviceOrientationFreeCamera";
-        } 
+        }
 
         //special properties of specific cameras
         if (camera instanceof ArcRotateCamera || camera instanceof AnaglyphArcRotateCamera) {
@@ -293,6 +293,7 @@
         if (texture instanceof CubeTexture) {
             serializationObject.name = texture.name;
             serializationObject.hasAlpha = texture.hasAlpha;
+            serializationObject.isCube = true;
             serializationObject.level = texture.level;
             serializationObject.coordinatesMode = texture.coordinatesMode;
 
@@ -861,7 +862,7 @@
 
         public static SerializeMesh(mesh: Mesh): any {
             var serializationObject: any = {};
-			
+
             //only works if the mesh is already loaded
             if (mesh.delayLoadState === Engine.DELAYLOADSTATE_LOADED || mesh.delayLoadState === Engine.DELAYLOADSTATE_NONE) {
                 //serialize material
@@ -895,7 +896,7 @@
                     serializationObject.skeletons = [];
                     serializationObject.skeletons.push(serializeSkeleton(mesh.skeleton));
                 }
-				
+
                 //serialize the actual mesh
                 serializationObject.meshes = [];
                 serializationObject.meshes.push(serializeMesh(mesh, serializationObject));


### PR DESCRIPTION
- the "isCube" property was not serialized for CubeTexture
- in computeWorldMatrix, it's possible for the camera to be null the first time it's computed. This problem happened when the CubeTexture was defined inside the .babylon file.