### PR TITLE
Fixing missing geometry for instances

### DIFF
--- a/dist/preview release - alpha/what's new.md
+++ b/dist/preview release - alpha/what's new.md
@@ -22,4 +22,5 @@
 	- onCollide callback for meshes calling moveWithCollisions. [PR](https://github.com/BabylonJS/Babylon.js/pull/585) [RaananW](https://github.com/RaananW)
   - **Bug fixes**
     - Fixing bug with rig cameras positioning [deltakosh](https://github.com/deltakosh)
+    - Instance meshes' geometry ID is now serialized correctly. [PR](https://github.com/BabylonJS/Babylon.js/pull/607) [RaananW](https://github.com/RaananW)
   - **Breaking changes**

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -154,7 +154,12 @@ module BABYLON {
                 });
             }
 
-            var geometryId = (<Mesh>mesh).geometry ? (<Mesh>mesh).geometry.id : null;
+            var geometryId: string = null;
+            if (mesh instanceof Mesh) {
+                geometryId = (<Mesh>mesh).geometry ? (<Mesh>mesh).geometry.id : null;
+            } else if (mesh instanceof InstancedMesh) {
+                geometryId = (<InstancedMesh>mesh).sourceMesh.geometry ? (<InstancedMesh>mesh).sourceMesh.geometry.id : null;
+            }
 
             return {
                 uniqueId: mesh.uniqueId,


### PR DESCRIPTION
Fix for https://github.com/BabylonJS/Babylon.js/issues/605
Instances don't have the source's geometry, hence the collision was not
triggered when using a worker, which gets only serialized data.
The fix will deliver the source mesh's geometry as geometry id for the
instance.