### PR TITLE
Array input for SerializeMesh

### DIFF
--- a/dist/preview release - alpha/what's new.md
+++ b/dist/preview release - alpha/what's new.md
@@ -18,7 +18,7 @@
     - Added some utility functions to Vector2/3/4 [PR](https://github.com/BabylonJS/Babylon.js/pull/578) [jahow](https://github.com/jahow)
     - New rawTexture.update function [robgdl](https://github.com/robgdl)
     - Changes to meshes transform baking and added flipFaces [PR](https://github.com/BabylonJS/Babylon.js/pull/579) [jahow](https://github.com/jahow)
-    - SerializeMesh serializes a single mesh to be imported with the loader's ImportMesh. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [RaananW](https://github.com/RaananW)
+    - SerializeMesh serializes a mesh or array of meshes to be imported with the loader's ImportMesh. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [PR2](https://github.com/BabylonJS/Babylon.js/pull/609) [RaananW](https://github.com/RaananW)
 	- onCollide callback for meshes calling moveWithCollisions. [PR](https://github.com/BabylonJS/Babylon.js/pull/585) [RaananW](https://github.com/RaananW)
   - **Bug fixes**
     - Fixing bug with rig cameras positioning [deltakosh](https://github.com/deltakosh)

--- a/src/Tools/babylon.sceneSerializer.js
+++ b/src/Tools/babylon.sceneSerializer.js
@@ -739,9 +739,17 @@ var BABYLON;
             }
             return serializationObject;
         };
-        SceneSerializer.SerializeMesh = function (toSerialize /* Mesh || Mesh[] */) {
+        SceneSerializer.SerializeMesh = function (toSerialize /* Mesh || Mesh[] */, withParents) {
+            if (withParents === void 0) { withParents = false; }
             var serializationObject = {};
             toSerialize = (toSerialize instanceof Array) ? toSerialize : [toSerialize];
+            if (withParents) {
+                for (var i = 0; i < toSerialize.length; ++i) {
+                    if (toSerialize[i].parent) {
+                        toSerialize.push(toSerialize[i].parent);
+                    }
+                }
+            }
             toSerialize.forEach(function (mesh) {
                 finalizeSingleMesh(mesh, serializationObject);
             });

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -903,10 +903,20 @@
             return serializationObject;
         }
 
-        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */): any {
+        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents : boolean = false): any {
             var serializationObject: any = {};
 
             toSerialize = (toSerialize instanceof Array) ? toSerialize : [toSerialize];
+
+            if (withParents) {
+                //deliberate for loop! not for each, appended should be processed as well.
+                for (var i = 0; i < toSerialize.length; ++i) {
+                    if (toSerialize[i].parent) {
+                        toSerialize.push(toSerialize[i].parent);
+                    }
+                }
+            }
+
             toSerialize.forEach(function (mesh: Mesh) {
                 finalizeSingleMesh(mesh, serializationObject);
             });


### PR DESCRIPTION
The (new) SerializeMesh function now accepts either an array of meshes or a single mesh.
There is now an option to also serialize the parents of the meshes to be serialized.