### PR TITLE
Changed to use game object name instead of mesh name

### DIFF
--- a/Exporters/Unity 5/Unity3D2Babylon/SceneBuilder.Meshes.cs
+++ b/Exporters/Unity 5/Unity3D2Babylon/SceneBuilder.Meshes.cs
@@ -39,9 +39,9 @@ namespace Unity3D2Babylon
             BabylonMesh babylonMesh = new BabylonMesh();
             var renderer = gameObject.GetComponent<Renderer>();
 
-            ExporterWindow.ReportProgress(progress, "Exporting mesh: " + mesh.name);
+            ExporterWindow.ReportProgress(progress, "Exporting mesh: " + gameObject.name);
 
-            babylonMesh.name = mesh.name;
+            babylonMesh.name = gameObject.name;
             babylonMesh.id = GetID(transform.gameObject);
             babylonMesh.receiveShadows = renderer.receiveShadows;
 


### PR DESCRIPTION
When creating a game object based off a primitive object (cube,
cylinder, plane, etc...) you would end up with the name of the primitive
object (mesh name) in the resulting .babylon file.  This presented
problems when trying to refer to an object.  For example, you would have
cubes all called "Cube" instead of the actual game object name.