### PR TITLE
Making sure toSerialize acts as Set

### DIFF
--- a/dist/preview release - alpha/what's new.md
+++ b/dist/preview release - alpha/what's new.md
@@ -19,7 +19,7 @@
     - Added some utility functions to Vector2/3/4 [PR](https://github.com/BabylonJS/Babylon.js/pull/578) [jahow](https://github.com/jahow)
     - New rawTexture.update function [robgdl](https://github.com/robgdl)
     - Changes to meshes transform baking and added flipFaces [PR](https://github.com/BabylonJS/Babylon.js/pull/579) [jahow](https://github.com/jahow)
-    - SerializeMesh serializes a mesh or array of meshes to be imported with the loader's ImportMesh. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [PR2](https://github.com/BabylonJS/Babylon.js/pull/609) [RaananW](https://github.com/RaananW)
+    - SerializeMesh serializes a mesh or array of meshes to be imported with the loader's ImportMesh optionally including their children and/or parents. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [PR2](https://github.com/BabylonJS/Babylon.js/pull/609) [RaananW](https://github.com/RaananW)
 	- onCollide callback for meshes calling moveWithCollisions. [PR](https://github.com/BabylonJS/Babylon.js/pull/585) [RaananW](https://github.com/RaananW)
 	- Unity Exporter now uses game object name as the Babylon.js mesh name, instead of mesh name which is not unique when dealing with primitive objects (cubes, spheres, planes, etc..) [ozRocker] (https://github.com/punkoffice)	
   - **Bug fixes**

--- a/src/Tools/babylon.sceneSerializer.js
+++ b/src/Tools/babylon.sceneSerializer.js
@@ -739,14 +739,23 @@ var BABYLON;
             }
             return serializationObject;
         };
-        SceneSerializer.SerializeMesh = function (toSerialize /* Mesh || Mesh[] */, withParents) {
+        SceneSerializer.SerializeMesh = function (toSerialize /* Mesh || Mesh[] */, withParents, withChildren) {
             if (withParents === void 0) { withParents = false; }
+            if (withChildren === void 0) { withChildren = false; }
             var serializationObject = {};
             toSerialize = (toSerialize instanceof Array) ? toSerialize : [toSerialize];
-            if (withParents) {
+            if (withParents || withChildren) {
                 //deliberate for loop! not for each, appended should be processed as well.
                 for (var i = 0; i < toSerialize.length; ++i) {
-                    if (toSerialize[i].parent) {
+                    if (withChildren) {
+                        toSerialize[i].getDescendants().forEach(function (node) {
+                            if (node instanceof BABYLON.Mesh && (toSerialize.indexOf(node) < 0)) {
+                                toSerialize.push(node);
+                            }
+                        });
+                    }
+                    //make sure the array doesn't contain the object already
+                    if (withParents && toSerialize[i].parent && (toSerialize.indexOf(toSerialize[i].parent) < 0)) {
                         toSerialize.push(toSerialize[i].parent);
                     }
                 }

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -903,15 +903,23 @@
             return serializationObject;
         }
 
-        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false): any {
+        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false, withChildren: boolean = false): any {
             var serializationObject: any = {};
 
             toSerialize = (toSerialize instanceof Array) ? toSerialize : [toSerialize];
 
-            if (withParents) {
+			if (withParents || withChildren) {
                 //deliberate for loop! not for each, appended should be processed as well.
                 for (var i = 0; i < toSerialize.length; ++i) {
-                    if (toSerialize[i].parent) {
+					if(withChildren) {
+						toSerialize[i].getDescendants().forEach((node) => {
+							if(node instanceof Mesh && (toSerialize.indexOf(node) < 0)) {
+								toSerialize.push(node);
+							}
+						});
+					}
+					//make sure the array doesn't contain the object already
+                    if (withParents && toSerialize[i].parent && (toSerialize.indexOf(toSerialize[i].parent) < 0)) {
                         toSerialize.push(toSerialize[i].parent);
                     }
                 }


### PR DESCRIPTION
When adding N meshes with the same parent, the parent would be added N
times. Now fixed.
Also added the withChildren flag to allow to serialize a parent together
with all of its children.