### PR TITLE
make a clear distinction between ambient light and clear color

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -468,9 +468,11 @@ class World:
         self.autoClear = True
         world = scene.world
         if world:
-            self.world_ambient = world.ambient_color
+            self.ambient_color = world.ambient_color
+            self.clear_color   = world.horizon_color
         else:
-            self.world_ambient = mathutils.Color((0.2, 0.2, 0.3))
+            self.ambient_color = mathutils.Color((0.2, 0.2, 0.3))
+            self.clear_color   = mathutils.Color((0.0, 0.0, 0.0))
 
         self.gravity = scene.gravity
 
@@ -485,8 +487,8 @@ class World:
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     def to_scene_file(self, file_handler):
         write_bool(file_handler, 'autoClear', self.autoClear, True)
-        write_color(file_handler, 'clearColor', self.world_ambient)
-        write_color(file_handler, 'ambientColor', self.world_ambient)
+        write_color(file_handler, 'clearColor', self.clear_color)
+        write_color(file_handler, 'ambientColor', self.ambient_color)
         write_vector(file_handler, 'gravity', self.gravity)
 
         if hasattr(self, 'fogMode'):


### PR DESCRIPTION
The only problem here, and it's a design problem from Blender, is that the horizon_color is also used for the color of the fog, if there's any. But that exception is better than using the ambient light also for the clear color. Makes the scene looks closer to the one in Blender.