### PR TITLE
materials will not repeat when serializing

### DIFF
--- a/src/Tools/babylon.sceneSerializer.js
+++ b/src/Tools/babylon.sceneSerializer.js
@@ -606,11 +606,19 @@ var BABYLON;
             if (mesh.material) {
                 if (mesh.material instanceof BABYLON.StandardMaterial) {
                     serializationObject.materials = serializationObject.materials || [];
-                    serializationObject.materials.push(serializeMaterial(mesh.material));
+                    if (!serializationObject.materials.some(function (mat) {
+                        return mat.id == mesh.material.id;
+                    })) {
+                        serializationObject.materials.push(serializeMaterial(mesh.material));
+                    }
                 }
                 else if (mesh.material instanceof BABYLON.MultiMaterial) {
                     serializationObject.multiMaterials = serializationObject.multiMaterials || [];
-                    serializationObject.multiMaterials.push(serializeMultiMaterial(mesh.material));
+                    if (!serializationObject.multiMaterials.some(function (mat) {
+                        return mat.id == mesh.material.id;
+                    })) {
+                        serializationObject.multiMaterials.push(serializeMultiMaterial(mesh.material));
+                    }
                 }
             }
             //serialize geometry
@@ -745,7 +753,6 @@ var BABYLON;
             var serializationObject = {};
             toSerialize = (toSerialize instanceof Array) ? toSerialize : [toSerialize];
             if (withParents || withChildren) {
-                //deliberate for loop! not for each, appended should be processed as well.
                 for (var i = 0; i < toSerialize.length; ++i) {
                     if (withChildren) {
                         toSerialize[i].getDescendants().forEach(function (node) {

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -748,10 +748,19 @@
             if (mesh.material) {
                 if (mesh.material instanceof StandardMaterial) {
                     serializationObject.materials = serializationObject.materials || [];
-                    serializationObject.materials.push(serializeMaterial(<StandardMaterial>mesh.material));
+                    if (!serializationObject.materials.some(function (mat) {
+                        return mat.id == mesh.material.id;
+                    })) {
+                        serializationObject.materials.push(serializeMaterial(<StandardMaterial>mesh.material));
+                    }
                 } else if (mesh.material instanceof MultiMaterial) {
                     serializationObject.multiMaterials = serializationObject.multiMaterials || [];
-                    serializationObject.multiMaterials.push(serializeMultiMaterial(<MultiMaterial>mesh.material));
+                    if (!serializationObject.multiMaterials.some(function (mat) {
+                        return mat.id == mesh.material.id;
+                    })) {
+                        serializationObject.multiMaterials.push(serializeMultiMaterial(<MultiMaterial>mesh.material));
+                    }
+                    
                 }
             }
             //serialize geometry


### PR DESCRIPTION
When serializing n meshes with the same material using the serialize mesh method, the material was serialized n times instead of 1 time.
This fixes it.