### PR TITLE
Changed cylinder path computation

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -741,7 +741,7 @@
 
                 for (var j = 0; j < tessellation; j++) {
                     angle = j * angle_step;
-                    ringVertex = Vector3.TransformCoordinates(normals[i], Matrix.RotationAxis(tangents[i], angle));
+                    ringVertex = new BABYLON.Vector3(Math.cos(-angle), 0, Math.sin(-angle));
                     ringVertex.scaleInPlace(radiusFunction(i, distances[i])).addInPlace(path[i]);
                     pathArray[i].push(ringVertex);
                 }
@@ -763,7 +763,7 @@
                 var circleVector;
                 for (var i = 0; i < tessellation; i++) {
                     angle = Math.PI * 2 * i / tessellation;
-                    circleVector = Vector3.TransformCoordinates(normals[0], Matrix.RotationAxis(tangents[0], angle));
+                    circleVector = new BABYLON.Vector3(Math.cos(-angle), 0, Math.sin(-angle));
                     var position = circleVector.scale(radius).add(offset);
                     var textureCoordinate = new Vector2(circleVector.x * textureScale.x + 0.5, circleVector.z * textureScale.y + 0.5);
                     vertexdata.positions.push(position.x, position.y, position.z);


### PR DESCRIPTION
This should fix this issue: http://www.html5gamedevs.com/topic/16166-csg-cylinder-issue/
Example of the fix in PG (with normals display): http://www.babylonjs-playground.com/#TDUK0#4

Note: normals are a bit skewed along the cylinder's length... :/