### PR TITLE
use the inverse of the normal factor

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -1475,7 +1475,7 @@ class Material:
                     if mtex.use_map_normal:
                         # Bump
                         BabylonExporter.log('Bump texture found');
-                        self.textures.append(Texture('bumpTexture', mtex.normal_factor, mtex, filepath))
+                        self.textures.append(Texture('bumpTexture', 1.0/mtex.normal_factor, mtex, filepath))
                     elif mtex.use_map_color_spec:
                         # Specular
                         BabylonExporter.log('Specular texture found');


### PR DESCRIPTION
To properly match the bump level in Blender, it needs to be inverted when exported because the Babylon.js loader use the inverse of the level (*as mentioned here: https://github.com/BabylonJS/Babylon.js/blob/master/src/Materials/babylon.standardMaterial.ts#L696*).