### PR TITLE
fixed Path3D : no more wrong normal/binormal computation due to normalization approximation

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3619,16 +3619,17 @@
         // returns an arbitrary point in the plane defined by the point v0 and the vector vt orthogonal to this plane
         // if va is passed, it returns the va projection on the plane orthogonal to vt at the point v0
         private _normalVector(v0: Vector3, vt: Vector3, va: Vector3): Vector3 {
+            var epsilon = 0.001;
             var normal0: Vector3;
             if (va === undefined || va === null) {
                 var point: Vector3;
-                if (vt.y !== 1) {     // search for a point in the plane
+                if (!Tools.WithinEpsilon(vt.y, 1, epsilon)) {     // search for a point in the plane
                     point = new Vector3(0, -1, 0);
                 }
-                else if (vt.x !== 1) {
+                else if (!Tools.WithinEpsilon(vt.x, 1, epsilon)) {
                     point = new Vector3(1, 0, 0);
                 }
-                else if (vt.z !== 1) {
+                else if (!Tools.WithinEpsilon(vt.z, 1, epsilon)) {
                     point = new Vector3(0, 0, 1);
                 }
                 normal0 = Vector3.Cross(vt, point);
@@ -3636,7 +3637,6 @@
             else {
                 normal0 = Vector3.Cross(vt, va);
                 Vector3.CrossToRef(normal0, vt, normal0);
-                //normal0 = Vector3.Cross(normal0, vt);
             }
             normal0.normalize();
             return normal0;


### PR DESCRIPTION
The Path3D normals and binormals are computed in a point of the curve path from the tangent in this point and from an arbitrary vector chosen as non-collinear to this tangent.
If the tangent normalization is approximated, the choice of the arbitrary vector gave in in some limit cases something collinear with the tangent.

This PR fixes this problem with the use of  _WithinEpsilon()_