### PR TITLE
add function getFrontPosition

### DIFF
--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -450,6 +450,13 @@
             Matrix.OrthoOffCenterLHToRef(this.orthoLeft || -halfWidth, this.orthoRight || halfWidth, this.orthoBottom || -halfHeight, this.orthoTop || halfHeight, this.minZ, this.maxZ, this._projectionMatrix);
             return this._projectionMatrix;
         }
+        
+        public getFrontPosition(num: num): void {
+	        var dir = this.getTarget().subtract(this.position);
+	        dir.normalize();
+	        dir.scaleInPlace(num);		
+	        return this.position.add(dir);
+        }
 
         public dispose(): void {
             // Remove from scene


### PR DESCRIPTION
Used to retrieve a position in front of the camera.
for example:

Place an object in front of the camera of 10 unit.
box.position = camera.getFrontPosition(10);