### PR TITLE
Change screenshot file naming format

### DIFF
--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -505,8 +505,8 @@
                 var a = window.document.createElement("a");
                 a.href = base64Image;
                 var date = new Date();
-                var stringDate = date.getFullYear() + "/" + date.getMonth() + "/" + date.getDate() + "-" + date.getHours() + ":" + date.getMinutes();
-                a.setAttribute("download", "screenshot-" + stringDate + ".png");
+                var stringDate = date.getFullYear() + "-" + date.getMonth() + "-" + date.getDate() + "_" + date.getHours() + "-" + ('0'+date.getMinutes()).slice(-2);
+                a.setAttribute("download", "screenshot_" + stringDate + ".png");
 
                 window.document.body.appendChild(a);
 


### PR DESCRIPTION
On many systems, we can't have "/" in filenames.
Also better to have minutes from 0 to 9 with 2 digits