### PR TITLE
Upgrade.maths.path3d and rotation from axis

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1060,6 +1060,15 @@
          * to something in order to rotate it from its local system to the given target system.
          */
         public static RotationFromAxis(axis1: Vector3, axis2: Vector3, axis3: Vector3): Vector3 {
+            var rotation = Vector3.Zero();
+            Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
+            return rotation;
+        }
+
+        /** 
+         * The same than RotationFromAxis but update the passed ref Vector3 parameter.
+         */
+        public static RotationFromAxisToRef(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref: Vector3): void {
             var u = Vector3.Normalize(axis1);
             var w = Vector3.Normalize(axis3);
 
@@ -1171,7 +1180,9 @@
                 yaw = Math.PI + yaw;
             }
 
-            return new Vector3(pitch, yaw, roll);
+            ref.x = pitch;
+            ref.y = yaw;
+            ref.z = roll;
         }
     }
 

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3515,6 +3515,12 @@
         private _binormals = new Array<Vector3>();
         private _raw: boolean;
 
+        /** 
+        * new Path3D(path, normal, raw) 
+        * path : an array of Vector3, the axis curve of the path3d
+        * normal (optional) : Vector3, the first desired normal to the curve. Ex (0, 1, 0) for vertical normal.
+        * raw (optional, default false) : boolean, if true the returned path3d is not normalized. Useful to depict path acceleration or speed.
+        */
         constructor(public path: Vector3[], firstNormal?: Vector3, raw?: boolean) {
             for (var p = 0; p < path.length; p++) {
                 this._curve[p] = path[p].clone(); // hard copy

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1066,7 +1066,7 @@
         }
 
         /** 
-         * The same than RotationFromAxis but update the passed ref Vector3 parameter.
+         * The same than RotationFromAxis but updates the passed ref Vector3 parameter.
          */
         public static RotationFromAxisToRef(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref: Vector3): void {
             var u = Vector3.Normalize(axis1);
@@ -3528,9 +3528,9 @@
 
         /** 
         * new Path3D(path, normal, raw) 
-        * path : an array of Vector3, the axis curve of the path3d
-        * normal (optional) : Vector3, the first desired normal to the curve. Ex (0, 1, 0) for vertical normal.
-        * raw (optional, default false) : boolean, if true the returned path3d is not normalized. Useful to depict path acceleration or speed.
+        * path : an array of Vector3, the curve axis of the Path3D
+        * normal (optional) : Vector3, the first wanted normal to the curve. Ex (0, 1, 0) for a vertical normal.
+        * raw (optional, default false) : boolean, if true the returned Path3D isn't normalized. Useful to depict path acceleration or speed.
         */
         constructor(public path: Vector3[], firstNormal?: Vector3, raw?: boolean) {
             for (var p = 0; p < path.length; p++) {

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3513,11 +3513,13 @@
         private _tangents = new Array<Vector3>();
         private _normals = new Array<Vector3>();
         private _binormals = new Array<Vector3>();
+        private _raw: boolean;
 
-        constructor(public path: Vector3[], firstNormal?: Vector3) {
+        constructor(public path: Vector3[], firstNormal?: Vector3, raw?: boolean) {
             for (var p = 0; p < path.length; p++) {
                 this._curve[p] = path[p].clone(); // hard copy
             }
+            this._raw = raw || false;
             this._compute(firstNormal);
         }
 
@@ -3557,17 +3559,25 @@
 
             // first and last tangents
             this._tangents[0] = this._getFirstNonNullVector(0);
-            this._tangents[0].normalize();
+            if (!this._raw) {
+                this._tangents[0].normalize();
+            }
             this._tangents[l - 1] = this._curve[l - 1].subtract(this._curve[l - 2]);
-            this._tangents[l - 1].normalize();
+            if (!this._raw) {
+                this._tangents[l - 1].normalize();
+            }
             
             // normals and binormals at first point : arbitrary vector with _normalVector()
             var tg0 = this._tangents[0];
             var pp0 = this._normalVector(this._curve[0], tg0, firstNormal);
             this._normals[0] = pp0;
-            this._normals[0].normalize();
+            if (!this._raw) {
+                this._normals[0].normalize();
+            }
             this._binormals[0] = Vector3.Cross(tg0, this._normals[0]);
-            this._binormals[0].normalize();
+            if (!this._raw) {
+                this._binormals[0].normalize();
+            }
             this._distances[0] = 0;
 
             // normals and binormals : next points
@@ -3592,9 +3602,13 @@
                 curTang = this._tangents[i];
                 prevBinor = this._binormals[i - 1];
                 this._normals[i] = Vector3.Cross(prevBinor, curTang);
-                this._normals[i].normalize();
+                if (!this._raw) {
+                    this._normals[i].normalize();
+                }
                 this._binormals[i] = Vector3.Cross(curTang, this._normals[i]);
-                this._binormals[i].normalize();
+                if (!this._raw) {
+                    this._binormals[i].normalize();
+                }
             }
         }
 


### PR DESCRIPTION
Upgrade of Path3D constructor : new _raw_ boolean parameter. If _true_ the returned Path3D isn't normalized. It may be convenient to depict speed or acceleration related to the path (slope, bend, etc)

Added RotationFromAxisToRef : the same as RotationFromAxis but assigning to a reference instead of returning a new Vector3