### PR TITLE
gulp fix

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -50,7 +50,10 @@ gulp.task('typescript-compile', function() {
                     target: 'ES5', 
                     declarationFiles: true,
                     typescript: require('typescript')
-                }));
+                })).on('error', function(error) {
+                    console.log('Typescript compile failed');
+                    process.exit(1);
+                });
     return merge2([
         tsResult.dts
             .pipe(concat(config.build.declarationFilename))


### PR DESCRIPTION
gulp will quit with error code 1 if typescript didn't compile correctly.
Until now travis builds succeeded even when the typescript compile
failed.