### PR TITLE
Feature.options parameter on create xxx methods

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1376,18 +1376,27 @@
         }
 
         // Cylinder and cone
-        public static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: any, scene: Scene, updatable?: any, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
-            // subdivisions is a new parameter, we need to support old signature
-            if (scene === undefined || !(scene instanceof Scene)) {
-                if (scene !== undefined) {
-                    updatable = scene;
+        public static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number, scene: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
+        public static CreateCylinder(name: string, options: {height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, updatable?: boolean}, scene: any): Mesh
+        public static CreateCylinder(name: string, options: any, diameterTopOrScene: any, diameterBottom?: number, tessellation?: number, subdivisions?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
+        
+            if (diameterTopOrScene instanceof Scene ) {
+                scene = diameterTopOrScene;
+                updatable = options.updatable;
+            } else {
+                var height = options;
+                options = {
+                    height: height,
+                    diameterTop: diameterTopOrScene,
+                    diameterBottom: diameterBottom,
+                    tessellation: tessellation,
+                    subdivisions: subdivisions,
+                    sideOrientation: sideOrientation
                 }
-                scene = <Scene>subdivisions;
-                subdivisions = 1;
-            }
 
+            }
             var cylinder = new Mesh(name, scene);
-            var vertexData = VertexData.CreateCylinder(height, diameterTop, diameterBottom, tessellation, subdivisions, sideOrientation);
+            var vertexData = VertexData.CreateCylinder(options);
 
             vertexData.applyToMesh(cylinder, updatable);
 

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1377,7 +1377,7 @@
 
         // Cylinder and cone
         public static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number, scene: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
-        public static CreateCylinder(name: string, options: {height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, updatable?: boolean}, scene: any): Mesh
+        public static CreateCylinder(name: string, options: {height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, updatable?: boolean, sideOrientation?: number}, scene: any): Mesh
         public static CreateCylinder(name: string, options: any, diameterTopOrScene: any, diameterBottom?: number, tessellation?: number, subdivisions?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
         
             if (diameterTopOrScene instanceof Scene ) {

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -787,7 +787,6 @@
         public static CreateCylinder(height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number, sideOrientation?: number): VertexData;
         public static CreateCylinder(options: any, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
             var height = height || options.height || 3;
-            height = options.height || 3;
             diameterTop = diameterTop || options.diameterTop || 1;
             diameterBottom = diameterBottom || options.diameterBottom || 1;
             tessellation = tessellation || options.tessellation || 24;

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -777,8 +777,31 @@
             return vertexData;
         }
 
-        // Cylinder and cone (made using ribbons)
-        public static CreateCylinder(height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number = 1, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
+        // Cylinder and cone 
+        public static CreateCylinder(options: {height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, sideOrientation?: number}): VertexData;
+        public static CreateCylinder(height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number, sideOrientation?: number): VertexData;
+        public static CreateCylinder(options: any, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
+            var height: number;
+            var diameterTop: number;
+            var diameterBottom: number;
+            var tessellation: number;
+            var subdivisions: number;
+
+            if (options.height) {
+                height = options.height;
+                diameterTop = options.diameterTop || 1;
+                diameterBottom = options.diameterBottom || 1;
+                tessellation = options.tessellation || 24;
+                subdivisions = options.subdivisions || 1;
+            } else { // back compat
+                height = options || 3;
+                diameterTop = diameterTop || 1;
+                diameterBottom = diameterBottom || 1;
+                tessellation = tessellation || 24;
+                subdivisions = subdivisions || 1;
+            }
+
+            sideOrientation = sideOrientation || options.sideOrientation || Mesh.DEFAULTSIDE;
 
             var indices = [];
             var positions = [];

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -381,12 +381,17 @@
             return result;
         }
 
-        public static CreateRibbon(pathArray: Vector3[][], closeArray: boolean, closePath: boolean, offset: number, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
-            closeArray = closeArray || false;
-            closePath = closePath || false;
+        public static CreateRibbon(pathArray: Vector3[][], closeArray: boolean, closePath: boolean, offset: number, sideOrientation?: number): VertexData;
+        public static CreateRibbon(options: {pathArray?: Vector3[][], closeArray?: boolean, closePath?: boolean, offset?: number, sideOrientation?: number}): VertexData;
+        public static CreateRibbon(options: any, closeArray?: boolean, closePath?: boolean, offset?: number, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
+
+            var pathArray = pathArray || options.pathArray;
+            closeArray = closeArray || options.closeArray || false;
+            closePath = closePath || options.closePath || false;
             var defaultOffset = Math.floor(pathArray[0].length / 2);
-            offset = offset || defaultOffset;
+            offset = offset || options.offset || defaultOffset;
             offset = offset > defaultOffset ? defaultOffset : Math.floor(offset); // offset max allowed : defaultOffset
+            sideOrientation = sideOrientation || options.sideOrientation || Mesh.DEFAULTSIDE;
 
             var positions: number[] = [];
             var indices: number[] = [];
@@ -781,26 +786,13 @@
         public static CreateCylinder(options: {height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, sideOrientation?: number}): VertexData;
         public static CreateCylinder(height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: number, sideOrientation?: number): VertexData;
         public static CreateCylinder(options: any, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, sideOrientation: number = Mesh.DEFAULTSIDE): VertexData {
-            var height: number;
-            var diameterTop: number;
-            var diameterBottom: number;
-            var tessellation: number;
-            var subdivisions: number;
-
-            if (options.height) {
-                height = options.height || 3;
-                diameterTop = options.diameterTop || 1;
-                diameterBottom = options.diameterBottom || 1;
-                tessellation = options.tessellation || 24;
-                subdivisions = options.subdivisions || 1;
-            } else { // back compat
-                height = options || 3;
-                diameterTop = diameterTop || 1;
-                diameterBottom = diameterBottom || 1;
-                tessellation = tessellation || 24;
-                subdivisions = subdivisions || 1;
-            }
-
+            var height = height || options.height || 3;
+            height = options.height || 3;
+            diameterTop = diameterTop || options.diameterTop || 1;
+            diameterBottom = diameterBottom || options.diameterBottom || 1;
+            tessellation = tessellation || options.tessellation || 24;
+            subdivisions = subdivisions || options.subdivisions || 1;
+                
             sideOrientation = sideOrientation || options.sideOrientation || Mesh.DEFAULTSIDE;
 
             var indices = [];

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -788,7 +788,7 @@
             var subdivisions: number;
 
             if (options.height) {
-                height = options.height;
+                height = options.height || 3;
                 diameterTop = options.diameterTop || 1;
                 diameterBottom = options.diameterBottom || 1;
                 tessellation = options.tessellation || 24;


### PR DESCRIPTION
Added _options_ parameter to _CreateCylinder()_ and _CreateRibbon()_

now these two are equivalent : 
```javascript
BABYLON.Mesh.CreateCylinder(name, height, diamTop, diamBot, tessellation, subdivisions, scene);
BABYLON.MeshCreateCylinder(name, {height: h, diameterTop: dT, diameterBottom: dB, tessellation: tes, subdivisions: sdv}, scene);
```
We can also create a cylinder by default : 
```javascript
BABYLON.MeshCreateCylinder(name, {}, scene);
```
These two are equivalent : 
```javascript
BABYLON.Mesh.CreateRibbon(name, pathArray, closeArray, closePath, offset, scene);
BABYLON.Mesh.CreateRibbon(name, {pathArray: paths, closeArray: cA, closePath: cP, offset: o}, scene);
```
Minimal call : 
```javascript
BABYLON.Mesh.CreateRibbon(name, {pathArray: paths}, scene);
```

The ribbon is still updatable and morphable with : 
```javascript
var ribbon = BABYLON.Mesh.CreateRibbon(name, pathArray, closeArray, closePath, offset, scene, true);
// or
var ribbon = BABYLON.Mesh.CreateRibbon(name, {pathArray: paths, closeArray: cA, closePath: cP, offset: o, updatable: true}, scene);
```
and then
```javascript
var ribbon = BABYLON.Mesh.CreateRibbon(null, pathArray, null, null, null, null, null, ribbon);
// or
var ribbon = BABYLON.Mesh.CreateRibbon(null, {pathArray: paths, instance: ribbon}, scene);
```
any combination will work.