### PR TITLE
Update what's new.md

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -10,4 +10,5 @@
     - Fixed bug with `Mesh.attachToBone` when bone's matrix has a negative determinant ([deltakosh](https://github.com/deltakosh))
     - Fixed a possible but with the active camera while taking a screenshot ([RaananW](https://github.com/RaananW))
   - **Breaking changes**
+    - `Mesh.CreateCylinder()` old signature (without _subdivisions_ parameter) deprecated ([jerome](https://github.com/jbousquie))
 


### PR DESCRIPTION
_Mesh.CreateCylinder()_ old signature (without _subdivisions_) deprecation due to the addition of the new signature (with _options_ parameter) to the current one