### PR TITLE
Fixing instanced meshes and worker collisions

### DIFF
--- a/src/Collisions/babylon.collisionCoordinator.js
+++ b/src/Collisions/babylon.collisionCoordinator.js
@@ -180,7 +180,7 @@ var BABYLON;
                 geometryId = mesh.geometry ? mesh.geometry.id : null;
             }
             else if (mesh instanceof BABYLON.InstancedMesh) {
-                geometryId = mesh.sourceMesh.geometry ? mesh.sourceMesh.geometry.id : null;
+                geometryId = (mesh.sourceMesh && mesh.sourceMesh.geometry) ? mesh.sourceMesh.geometry.id : null;
             }
             return {
                 uniqueId: mesh.uniqueId,

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -158,7 +158,7 @@ module BABYLON {
             if (mesh instanceof Mesh) {
                 geometryId = (<Mesh>mesh).geometry ? (<Mesh>mesh).geometry.id : null;
             } else if (mesh instanceof InstancedMesh) {
-                geometryId = (<InstancedMesh>mesh).sourceMesh.geometry ? (<InstancedMesh>mesh).sourceMesh.geometry.id : null;
+                geometryId = ((<InstancedMesh>mesh).sourceMesh && (<InstancedMesh>mesh).sourceMesh.geometry) ? (<InstancedMesh>mesh).sourceMesh.geometry.id : null;
             }
 
             return {


### PR DESCRIPTION
The mesh is added to the scene before the source mesh was even set (and
is updated later). Without checking if the sourceMesh exists it would
throw an exception at the first call of the constructor and will prevent
worker collisions to work with instances.