### PR TITLE
Fix.create xxx.with.options

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1628,15 +1628,59 @@
         }
 
         // Extrusion
-        public static ExtrudeShape(name: string, shape: Vector3[], path: Vector3[], scale: number, rotation: number, cap: number, scene: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, extrudedInstance: Mesh = null): Mesh {
-            scale = scale || 1;
-            rotation = rotation || 0;
-            var extruded = Mesh._ExtrudeShapeGeneric(name, shape, path, scale, rotation, null, null, false, false, cap, false, scene, updatable, sideOrientation, extrudedInstance);
+        public static ExtrudeShape(name: string, shape: Vector3[], path: Vector3[], scale: number, rotation: number, cap: number, scene: Scene, updatable?: boolean, sideOrientation?: number, instance?: Mesh): Mesh;
+        public static ExtrudeShape(name: string, options: {shape: Vector3[], path: Vector3[], scale?: number, rotation?: number, cap?: number, updatable?: boolean, sideOrientation?: number, instance?: Mesh}, scene: Scene): Mesh;
+        public static ExtrudeShape(name: string, options: any, pathOrScene?: any, scale?: number, rotation?: number, cap?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, instance: Mesh = null): Mesh {
+            var path: Vector3[];
+            var shape: Vector3[];
+            if (Array.isArray(options)) {
+                shape = options;
+                path = pathOrScene;
+                scale = scale || 1;
+                rotation = rotation || 0;
+                cap = (cap === 0) ? 0 : cap || Mesh.NO_CAP;
+            } else {
+                scene = pathOrScene;
+                path = options.path;
+                shape = options.shape;
+                scale = options.scale || 1;
+                rotation = options.rotation || 0;
+                cap = (options.cap === 0) ? 0 : options.cap || Mesh.NO_CAP;
+                updatable = options.updatable;
+                sideOrientation = (options.sideOrientation === 0) ? 0 : options.sideOrientation || Mesh.DEFAULTSIDE;
+                instance = options.instance
+            }
+
+
+            var extruded = Mesh._ExtrudeShapeGeneric(name, shape, path, scale, rotation, null, null, false, false, cap, false, scene, updatable, sideOrientation, instance);
             return extruded;
         }
 
-        public static ExtrudeShapeCustom(name: string, shape: Vector3[], path: Vector3[], scaleFunction, rotationFunction, ribbonCloseArray: boolean, ribbonClosePath: boolean, cap: number, scene: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, extrudedInstance: Mesh = null): Mesh {
-            var extrudedCustom = Mesh._ExtrudeShapeGeneric(name, shape, path, null, null, scaleFunction, rotationFunction, ribbonCloseArray, ribbonClosePath, cap, true, scene, updatable, sideOrientation, extrudedInstance);
+        public static ExtrudeShapeCustom(name: string, shape: Vector3[], path: Vector3[], scaleFunction, rotationFunction, ribbonCloseArray: boolean, ribbonClosePath: boolean, cap: number, scene: Scene, updatable?: boolean, sideOrientation?: number, instance?: Mesh): Mesh;
+        public static ExtrudeShapeCustom(name: string, options: {shape: Vector3[], path: Vector3[], scaleFunction?, rotationFunction?, ribbonCloseArray?: boolean, ribbonClosePath?: boolean, cap?: number, updatable?: boolean, sideOrientation?: number, instance?: Mesh}, scene: Scene): Mesh;
+        public static ExtrudeShapeCustom(name: string, options: any, pathOrScene?: any, scaleFunction?, rotationFunction?, ribbonCloseArray?: boolean, ribbonClosePath?: boolean, cap?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, instance: Mesh = null): Mesh {
+            var path: Vector3[];
+            var shape: Vector3[];
+            if (Array.isArray(options)) {
+                shape = options;
+                path = pathOrScene;
+                ribbonCloseArray = ribbonCloseArray || false;
+                ribbonClosePath = ribbonClosePath || false;
+                cap = (cap === 0) ? 0 : cap || Mesh.NO_CAP;
+            } else {
+                scene = pathOrScene;
+                path = options.path;
+                shape = options.shape;
+                scaleFunction = options.scaleFunction;
+                rotationFunction = options.rotationFunction;
+                ribbonCloseArray = options.ribbonCloseArray || false;
+                ribbonClosePath = options.ribbonClosePath || false;
+                cap = (options.cap === 0) ? 0 : options.cap || Mesh.NO_CAP;
+                updatable = options.updatable;
+                sideOrientation = (options.sideOrientation === 0) ? 0 : options.sideOrientation || Mesh.DEFAULTSIDE;
+                instance = options.instance;
+            }
+            var extrudedCustom = Mesh._ExtrudeShapeGeneric(name, shape, path, null, null, scaleFunction, rotationFunction, ribbonCloseArray, ribbonClosePath, cap, true, scene, updatable, sideOrientation, instance);
             return extrudedCustom;
         }
 
@@ -1691,11 +1735,11 @@
                         shapePaths[0] = capPath(shapePaths[1]);
                         break;
                     case Mesh.CAP_END:
-                        shapePaths[index] = capPath(shapePaths[shapePaths.length - 2]);
+                        shapePaths[index] = capPath(shapePaths[index - 1]);
                         break;
                     case Mesh.CAP_ALL:
                         shapePaths[0] = capPath(shapePaths[1]);
-                        shapePaths[index] = capPath(shapePaths[shapePaths.length - 2]);
+                        shapePaths[index] = capPath(shapePaths[index - 1]);
                         break;
                     default:
                         break;

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1890,7 +1890,7 @@
                 var normal: Vector3;
                 var rotated: Vector3;
                 var rotationMatrix: Matrix;
-                var index = 0;
+                var index = (cap === Mesh._NO_CAP || cap === Mesh.CAP_END) ? 0 : 1;
                 for (var i = 0; i < path.length; i++) {
                     rad = radiusFunctionFinal(i, distances[i]); // current radius
                     circlePath = Array<Vector3>();              // current circle array
@@ -1915,14 +1915,14 @@
                     case Mesh.NO_CAP:
                         break;
                     case Mesh.CAP_START:
-                        circlePaths.unshift(capPath(tessellation + 1, 0));
+                        circlePaths[0] = capPath(tessellation, 0);
                         break;
                     case Mesh.CAP_END:
-                        circlePaths.push(capPath(tessellation + 1, path.length - 1));
+                        circlePaths[index]= capPath(tessellation, path.length - 1);
                         break;
                     case Mesh.CAP_ALL:
-                        circlePaths.unshift(capPath(tessellation + 1, 0));
-                        circlePaths.push(capPath(tessellation + 1, path.length - 1));
+                        circlePaths[0] = capPath(tessellation, 0);
+                        circlePaths[index] = capPath(tessellation, path.length - 1);
                         break;
                     default:
                         break;

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1671,8 +1671,8 @@
                 scene = pathOrScene;
                 path = options.path;
                 shape = options.shape;
-                scaleFunction = options.scaleFunction;
-                rotationFunction = options.rotationFunction;
+                scaleFunction = options.scaleFunction || ((i, distance) => { return 1; });
+                rotationFunction = options.rotationFunction || ((i, distance) => { return 0; });
                 ribbonCloseArray = options.ribbonCloseArray || false;
                 ribbonClosePath = options.ribbonClosePath || false;
                 cap = (options.cap === 0) ? 0 : options.cap || Mesh.NO_CAP;

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1654,7 +1654,7 @@
                 var returnRotation: { (i: number, distance: number): number; } = (i, distance) => { return rotation; };
                 var rotate: { (i: number, distance: number): number; } = custom ? rotateFunction : returnRotation;
                 var scl: { (i: number, distance: number): number; } = custom ? scaleFunction : returnScale;
-                var index = 0;
+                var index = (cap === Mesh.NO_CAP || cap === Mesh.CAP_END) ? 0 : 1;
 
                 for (var i = 0; i < curve.length; i++) {
                     var shapePath = new Array<Vector3>();
@@ -1688,14 +1688,14 @@
                     case Mesh.NO_CAP:
                         break;
                     case Mesh.CAP_START:
-                        shapePaths.unshift(capPath(shapePaths[0]));
+                        shapePaths[0] = capPath(shapePaths[1]);
                         break;
                     case Mesh.CAP_END:
-                        shapePaths.push(capPath(shapePaths[shapePaths.length - 1]));
+                        shapePaths[index] = capPath(shapePaths[shapePaths.length - 2]);
                         break;
                     case Mesh.CAP_ALL:
-                        shapePaths.unshift(capPath(shapePaths[0]));
-                        shapePaths.push(capPath(shapePaths[shapePaths.length - 1]));
+                        shapePaths[0] = capPath(shapePaths[1]);
+                        shapePaths[index] = capPath(shapePaths[shapePaths.length - 2]);
                         break;
                     default:
                         break;

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -485,7 +485,10 @@
                 if (closeArray) {
                     path1 = pathArray[p];
                     path2 = pathArray[0];
-                    vectlg = path2[i].subtract(path1[i]).length();
+                    if (i === minlg) {   // closePath
+                        vertex2 = path2[0];
+                    }
+                    vectlg = vertex2.subtract(vertex1).length();
                     dist = vectlg + vTotalDistance[i];
                     vTotalDistance[i] = dist;
                 }


### PR DESCRIPTION
fixed three bugs : 
* since the smooth seam was implemented on Ribbon _closePath_, the ribbon couldn't be built with _closePath_ and _closeArray_ set to true together => works now
* capped tube wasn't morphable => fixed
* capped extruded shape wasn't morphable => fixed

updated : 
* _Mesh.ExtrudeShape()_ and _Mesh.ExtrudeShapeCustom()_ both support now the new _options_ parameter in addition to their current signature

documentation up to come