### PR TITLE
Feature Arc and Slice on Spheres, Tubes, Cylinders, Lathes

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1974,7 +1974,7 @@
         public static CreateTube(name: string, options: any, radiusOrScene: any, tessellation?: number, radiusFunction?: { (i: number, distance: number): number; }, cap?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE, instance: Mesh = null): Mesh {
             var path: Vector3[];
             var radius: number;
-            var arc: number;
+            var arc: number = (options.arc <= 0) ? 1.0 : options.arc || 1.0;;
             if (Array.isArray(options)) {
                 path = options;
                 radius = radiusOrScene;
@@ -2062,7 +2062,6 @@
 
             }
             // tube creation
-            arc = (options.arc <= 0) ? 1.0 : options.arc || 1.0
             path3D = <any>new Path3D(path);
             var newPathArray = new Array<Array<Vector3>>();
             cap = (cap < 0 || cap > 3) ? 0 : cap;

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1426,7 +1426,7 @@
 
         // Cylinder and cone
         public static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: any, scene: Scene, updatable?: any, sideOrientation?: number): Mesh;
-        public static CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, sideOrientation?: number }, scene: any): Mesh;
+        public static CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, arc: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, sideOrientation?: number }, scene: any): Mesh;
         public static CreateCylinder(name: string, options: any, diameterTopOrScene: any, diameterBottom?: number, tessellation?: number, subdivisions?: any, scene?: Scene, updatable?: any, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
 
             if (diameterTopOrScene instanceof Scene) {

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1775,10 +1775,13 @@
 
         // Lathe
         public static CreateLathe(name: string, shape: Vector3[], radius: number, tessellation: number, scene: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
-        public static CreateLathe(name: string, options: { shape: Vector3[], radius?: number, tessellation?: number, updatable?: boolean, sideOrientation?: number }, scene: Scene): Mesh;
+        public static CreateLathe(name: string, options: { shape: Vector3[], radius?: number, tessellation?: number, arc?: number, closed: boolean, updatable?: boolean, sideOrientation?: number }, scene: Scene): Mesh;
         public static CreateLathe(name: string, options: any, radiusOrScene: any, tessellation?: number, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
             var shape: Vector3[];
             var radius: number;
+            var arc: number = (options.arc <= 0) ? 1.0 : options.arc || 1.0;
+            var closed: boolean = (options.closed === undefined) ? true : options.closed;
+
             if (Array.isArray(options)) {
                 shape = options;
                 radius = radiusOrScene || 1;
@@ -1806,19 +1809,21 @@
             }
 
             // circle path
-            var step = pi2 / tessellation;
+            var step = pi2 / tessellation * arc;
             var rotated;
             var path = new Array<Vector3>();;
-            for (i = 0; i < tessellation; i++) {
+            for (i = 0; i <= tessellation; i++) {
                 rotated = new Vector3(Math.cos(i * step) * radius, 0, Math.sin(i * step) * radius);
                 path.push(rotated);
             }
-            path.push(path[0]);
+            if (closed) {
+                path.push(path[0]);
+            }
 
             // extrusion
             var scaleFunction = () => { return 1; };
             var rotateFunction = () => { return 0; };
-            var lathe = Mesh.ExtrudeShapeCustom(name, shapeLathe, path, scaleFunction, rotateFunction, true, false, Mesh.NO_CAP, scene, updatable, sideOrientation);
+            var lathe = Mesh.ExtrudeShapeCustom(name, shapeLathe, path, scaleFunction, rotateFunction, closed, false, Mesh.NO_CAP, scene, updatable, sideOrientation);
             return lathe;
         }
 

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1399,7 +1399,7 @@
         }
 
         public static CreateSphere(name: string, segments: number, diameter: number, scene?: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
-        public static CreateSphere(name: string, options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, sideOrientation?: number, updatable?: boolean }, scene: any): Mesh;
+        public static CreateSphere(name: string, options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, arc?: number, slice?: number, sideOrientation?: number, updatable?: boolean }, scene: any): Mesh;
         public static CreateSphere(name: string, options: any, diameterOrScene: any, scene?: Scene, updatable?: boolean, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
             if (diameterOrScene instanceof Scene) {
                 scene = diameterOrScene;

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -813,9 +813,9 @@
                     }
                     positions.push(ringVertex.x, ringVertex.y, ringVertex.z);
                     normals.push(ringNormal.x, ringNormal.y, ringNormal.z);
-                    uvs.push(faceUV[0].x + (faceUV[0].z - faceUV[0].x) * j / tessellation, faceUV[0].y + (faceUV[0].w - faceUV[0].y) * h);
+                    uvs.push(faceUV[1].x + (faceUV[1].z - faceUV[1].x) * j / tessellation, faceUV[1].y + (faceUV[1].w - faceUV[1].y) * h);
                     if (faceColors) {
-                        colors.push(faceColors[0].r, faceColors[0].g, faceColors[0].b, faceColors[0].a);
+                        colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
                     }
                 }
             }
@@ -845,10 +845,10 @@
                 var angle;
                 var circleVector;
                 var i: number;
-                var u: Vector4 = (isTop) ? faceUV[1] : faceUV[2];
+                var u: Vector4 = (isTop) ? faceUV[2] : faceUV[0];
                 var c: Color4;
                 if (faceColors) {
-                    c = (isTop) ? faceColors[1] : faceColors[2];
+                    c = (isTop) ? faceColors[2] : faceColors[0];
                 }
                 for (i = 0; i < tessellation; i++) {
                     angle = Math.PI * 2 * i / tessellation;

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -685,11 +685,13 @@
             return vertexData;
         }
 
-        public static CreateSphere(options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, sideOrientation?: number }): VertexData {
+        public static CreateSphere(options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, arc?: number, slice?: number, sideOrientation?: number }): VertexData {
             var segments: number = options.segments || 32;
             var diameterX: number = options.diameterX || options.diameter || 1;
             var diameterY: number = options.diameterY || options.diameter || 1;
             var diameterZ: number = options.diameterZ || options.diameter || 1;
+            var arc: number = (options.arc <= 0) ? 1.0 : options.arc || 1.0;
+            var slice: number = (options.slice <= 0) ? 1.0 : options.slice || 1.0;
             var sideOrientation = (options.sideOrientation === 0) ? 0 : options.sideOrientation || Mesh.DEFAULTSIDE;
 
             var radius = new Vector3(diameterX / 2, diameterY / 2, diameterZ / 2);
@@ -704,12 +706,12 @@
 
             for (var zRotationStep = 0; zRotationStep <= totalZRotationSteps; zRotationStep++) {
                 var normalizedZ = zRotationStep / totalZRotationSteps;
-                var angleZ = (normalizedZ * Math.PI);
+                var angleZ = normalizedZ * Math.PI * slice;
 
                 for (var yRotationStep = 0; yRotationStep <= totalYRotationSteps; yRotationStep++) {
                     var normalizedY = yRotationStep / totalYRotationSteps;
 
-                    var angleY = normalizedY * Math.PI * 2;
+                    var angleY = normalizedY * Math.PI * 2 * arc;
 
                     var rotationZ = Matrix.RotationZ(-angleZ);
                     var rotationY = Matrix.RotationY(angleY);


### PR DESCRIPTION
Added the features arc and/or slice to spheres, tubes, cylinders and lathes.
These are percentage of 2 * PI rotation angles in the range ]0, 1]
```javascript
var hemi = BABYLON.Mesh.CreateSphere("h", {slice: 0.5}, scene); // hemisphere

var lune = BABYLON.Mesh.CreateSphere("h", {arc: 0.2}, scene);   // spherical lune

var touque = BABYLON.Mesh.CreateCylinder("bbq", {arc: 0.5}, scene); // half cylinder

var tube = BABYLON.Mesh.CreateTube("t", {path: myPath, arc: 0.5}, scene); // half tube
BABYLON.Mesh.CreateTube(null, {path: myPath, arc: 0.2, instance: tube});  // note it's updatable !

var lathe =  BABYLON.Mesh.CreateLathe("l", {shape : mySh, arc: 0.2, closed: false}, scene);
// new "closed" parameter : keeps the lathe open
```