### PR TITLE
Feature.cylinder.diameter

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1426,7 +1426,7 @@
 
         // Cylinder and cone
         public static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: any, scene: Scene, updatable?: any, sideOrientation?: number): Mesh;
-        public static CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, arc: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, sideOrientation?: number }, scene: any): Mesh;
+        public static CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, diameter?: number, tessellation?: number, subdivisions?: number, arc: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, sideOrientation?: number }, scene: any): Mesh;
         public static CreateCylinder(name: string, options: any, diameterTopOrScene: any, diameterBottom?: number, tessellation?: number, subdivisions?: any, scene?: Scene, updatable?: any, sideOrientation: number = Mesh.DEFAULTSIDE): Mesh {
 
             if (diameterTopOrScene instanceof Scene) {

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -755,10 +755,10 @@
         }
 
         // Cylinder and cone 
-        public static CreateCylinder(options: { height?: number, diameterTop?: number, diameterBottom?: number, tessellation?: number, subdivisions?: number, arc?: number, faceColors?: Color4[], faceUV?: Vector4[], sideOrientation?: number }): VertexData {
+        public static CreateCylinder(options: { height?: number, diameterTop?: number, diameterBottom?: number, diameter?: number, tessellation?: number, subdivisions?: number, arc?: number, faceColors?: Color4[], faceUV?: Vector4[], sideOrientation?: number }): VertexData {
             var height: number = options.height || 2;
-            var diameterTop: number = (options.diameterTop === 0) ? 0 : options.diameterTop || 1;
-            var diameterBottom: number = options.diameterBottom || 1;
+            var diameterTop: number = (options.diameterTop === 0) ? 0 : options.diameterTop || options.diameter || 1;
+            var diameterBottom: number = options.diameterBottom || options.diameter || 1;
             var tessellation: number = options.tessellation || 24;
             var subdivisions: number = options.subdivisions || 1;
             var arc = (options.arc <= 0) ? 1.0 : options.arc || 1.0;


### PR DESCRIPTION
Added the parameter `diameter` to _CreateCylinder()_ to simplify the call if `diameterTop` and `diameterBottom` are similar : 
```javascript
var cyl = BABYLON.Mesh.CreateCylinder("cyl", {diameter: 6}, scene);
```

