### PR TITLE
Make setVerticesData() & updateVerticesData() Float32Array tolerant

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -249,7 +249,7 @@
             return this._geometry.getTotalVertices();
         }
 
-        public getVerticesData(kind: string, copyWhenShared?: boolean): number[] {
+        public getVerticesData(kind: string, copyWhenShared?: boolean): any {
             if (!this._geometry) {
                 return null;
             }
@@ -293,7 +293,7 @@
             return this._geometry.getTotalIndices();
         }
 
-        public getIndices(copyWhenShared?: boolean): number[] {
+        public getIndices(copyWhenShared?: boolean): any {
             if (!this._geometry) {
                 return [];
             }
@@ -440,7 +440,7 @@
             }
         }
 
-        public updateVerticesData(kind: string, data: number[], updateExtends?: boolean, makeItUnique?: boolean): void {
+        public updateVerticesData(kind: string, data: any, updateExtends?: boolean, makeItUnique?: boolean): void {
             if (!this._geometry) {
                 return;
             }
@@ -453,7 +453,13 @@
             }
         }
 
+        private _warned = false;
         public updateVerticesDataDirectly(kind: string, data: Float32Array, offset?: number, makeItUnique?: boolean): void {
+            if (!this._warned){
+                Tools.Warn("Mesh.updateVerticesDataDirectly deprecated since 2.3.");
+                this._warned = true;
+            }
+            
             if (!this._geometry) {
                 return;
             }

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -3,26 +3,26 @@
         isVerticesDataPresent(kind: string): boolean;
         getVerticesData(kind: string, copyWhenShared?: boolean): number[];
         getIndices(copyWhenShared?: boolean): number[];
-        setVerticesData(kind: string, data: number[], updatable?: boolean): void;
-        updateVerticesData(kind: string, data: number[], updateExtends?: boolean, makeItUnique?: boolean): void;
+        setVerticesData(kind: string, data: any, updatable?: boolean): void;
+        updateVerticesData(kind: string, data: any, updateExtends?: boolean, makeItUnique?: boolean): void;
         setIndices(indices: number[]): void;
     }
 
     export class VertexData {
-        public positions: number[];
-        public normals: number[];
-        public uvs: number[];
-        public uvs2: number[];
-        public uvs3: number[];
-        public uvs4: number[];
-        public uvs5: number[];
-        public uvs6: number[];
-        public colors: number[];
-        public matricesIndices: number[];
-        public matricesWeights: number[];
+        public positions: any;
+        public normals: any;
+        public uvs: any;
+        public uvs2: any;
+        public uvs3: any;
+        public uvs4: any;
+        public uvs5: any;
+        public uvs6: any;
+        public colors: any;
+        public matricesIndices: any;
+        public matricesWeights: any;
         public indices: number[];
 
-        public set(data: number[], kind: string) {
+        public set(data: any, kind: string) {
             switch (kind) {
                 case VertexBuffer.PositionKind:
                     this.positions = data;
@@ -1595,7 +1595,7 @@
             }
         }
 
-        private static _ComputeSides(sideOrientation: number, positions: number[], indices: number[], normals: number[], uvs: number[]) {
+        private static _ComputeSides(sideOrientation: number, positions: any, indices: any, normals: any, uvs: any) {
             var li: number = indices.length;
             var ln: number = normals.length;
             var i: number;

--- a/src/Mesh/babylon.vertexBuffer.ts
+++ b/src/Mesh/babylon.vertexBuffer.ts
@@ -3,12 +3,12 @@
         private _mesh: Mesh;
         private _engine: Engine;
         private _buffer: WebGLBuffer;
-        private _data: number[];
+        private _data: any;
         private _updatable: boolean;
         private _kind: string;
         private _strideSize: number;
 
-        constructor(engine: any, data: number[], kind: string, updatable: boolean, postponeInternalCreation?: boolean, stride?: number) {
+        constructor(engine: any, data: any, kind: string, updatable: boolean, postponeInternalCreation?: boolean, stride?: number) {
             if (engine instanceof Mesh) { // old versions of BABYLON.VertexBuffer accepted 'mesh' instead of 'engine'
                 this._engine = engine.getScene().getEngine();
             }
@@ -64,7 +64,7 @@
             return this._updatable;
         }
 
-        public getData(): number[] {
+        public getData(): any {
             return this._data;
         }
 
@@ -77,7 +77,7 @@
         }
 
         // Methods
-        public create(data?: number[]): void {
+        public create(data?: any): void {
             if (!data && this._buffer) {
                 return; // nothing to do
             }
@@ -98,11 +98,11 @@
             }
         }
 
-        public update(data: number[]): void {
+        public update(data: any): void {
             this.create(data);
         }
 
-        public updateDirectly(data: Float32Array, offset: number): void {
+        public updateDirectly(data: Float32Array, offset: number): void {            
             if (!this._buffer) {
                 return;
             }

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -1008,10 +1008,15 @@
             this._cachedVertexBuffers = null;
         }
 
-        public createVertexBuffer(vertices: number[]): WebGLBuffer {
+        public createVertexBuffer(vertices: any): WebGLBuffer {
             var vbo = this._gl.createBuffer();
             this._gl.bindBuffer(this._gl.ARRAY_BUFFER, vbo);
-            this._gl.bufferData(this._gl.ARRAY_BUFFER, new Float32Array(vertices), this._gl.STATIC_DRAW);
+            if (vertices instanceof Float32Array) {
+                this._gl.bufferData(this._gl.ARRAY_BUFFER, vertices, this._gl.STATIC_DRAW);
+            } else {
+                this._gl.bufferData(this._gl.ARRAY_BUFFER, new Float32Array(vertices), this._gl.STATIC_DRAW);
+            }
+
             this._resetVertexBufferBinding();
             vbo.references = 1;
             return vbo;


### PR DESCRIPTION
When Float32Array, no throw away Float32Array created. Saved in format
passed in. 

Mesh.updateVerticesDataDirectly() now deprecated.