### PR TITLE
Update babylon.2.2.d.ts

### DIFF
--- a/dist/babylon.2.2.d.ts
+++ b/dist/babylon.2.2.d.ts
@@ -5849,6 +5849,8 @@ declare module BABYLON {
         coordinatesMode: number;
         wrapU: number;
         wrapV: number;
+        uScale: number;
+        vScale: number;
         anisotropicFilteringLevel: number;
         _cachedAnisotropicFilteringLevel: number;
         private _scene;


### PR DESCRIPTION
I'm not sure how you're generating the distribution babylon.2.2.d.ts so this may need to also be edited elsewhere, but it resolves the following error: `error TS2339: Property 'uScale' does not exist on type 'BaseTexture'` when it is indeed a valid property.