### PR TITLE
Feature.single face polyhedron

### DIFF
--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -478,7 +478,7 @@
             return tube;
         }
 
-        public static CreatePolyhedron(name: string, options: { type?: number, size?: number, sizeX?: number, sizeY?: number, sizeZ?: number, custom?: any, faceUV?: Vector4[], faceColors?: Color4[], updatable?: boolean, sideOrientation?: number }, scene: Scene): Mesh {
+        public static CreatePolyhedron(name: string, options: { type?: number, size?: number, sizeX?: number, sizeY?: number, sizeZ?: number, custom?: any, faceUV?: Vector4[], faceColors?: Color4[], singleFace?: boolean, updatable?: boolean, sideOrientation?: number }, scene: Scene): Mesh {
             var polyhedron = new Mesh(name, scene);
 
             var vertexData = VertexData.CreatePolyhedron(options);


### PR DESCRIPTION
Added the parameter _singleFace_ to _CreatePolyhedron()_
false by default
```javascript
BABYLON.MeshBuilder.CreatePolyhedron("p",{singleFace: true}, scene);
```
The polyhedron is then created with a single face folded around it and not with x independant faces.
It is useful if we want to morph the polyhedron because all its faces stay then linked to each other (vertex re-use under the hood instead vertex per faces)