### PR TITLE
Optimization default submesh creation

### DIFF
--- a/src/Mesh/babylon.subMesh.ts
+++ b/src/Mesh/babylon.subMesh.ts
@@ -67,10 +67,12 @@
             }
 
             var indices = this._renderingMesh.getIndices();
-            var extend;
+            var extend: { minimum: Vector3, maximum: Vector3 };
 
+            //is this the only submesh?
             if (this.indexStart === 0 && this.indexCount === indices.length) {
-                extend = Tools.ExtractMinAndMax(data, this.verticesStart, this.verticesCount);
+                //the rendering mesh's bounding info can be used, it is the standard submesh for all indices.
+                extend = { minimum: this._renderingMesh.getBoundingInfo().minimum.clone(), maximum: this._renderingMesh.getBoundingInfo().maximum.clone() };
             } else {
                 extend = Tools.ExtractMinAndMaxIndexed(data, indices, this.indexStart, this.indexCount);
             }


### PR DESCRIPTION
Minimum and maximum can be reused from the mesh's bounding info object,
as it is the same. This removes one more call to
Tools.ExtractMinAndMaxIndexed , a very expensive calculation.