### PR TITLE
Added panningSensibility check to be able to deactivate panning

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.js
+++ b/src/Cameras/babylon.arcRotateCamera.js
@@ -177,7 +177,7 @@ var BABYLON;
                     }
                     switch (pointers.count) {
                         case 1:
-                            if ((_this._isCtrlPushed && useCtrlForPanning) || (!useCtrlForPanning && _this._isRightClick)) {
+                            if (this.panningSensibility !== 0 && ((_this._isCtrlPushed && useCtrlForPanning) || (!useCtrlForPanning && _this._isRightClick))) {
                                 _this.inertialPanningX += -(evt.clientX - cacheSoloPointer.x) / _this.panningSensibility;
                                 _this.inertialPanningY += (evt.clientY - cacheSoloPointer.y) / _this.panningSensibility;
                             }

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -179,7 +179,7 @@
                     switch (pointers.count) {
 
                         case 1: //normal camera rotation
-                            if ((this._isCtrlPushed && useCtrlForPanning) || (!useCtrlForPanning && this._isRightClick)) {
+                            if (this.panningSensibility !== 0 && ((this._isCtrlPushed && useCtrlForPanning) || (!useCtrlForPanning && this._isRightClick))) {
                                 this.inertialPanningX += -(evt.clientX - cacheSoloPointer.x) / this.panningSensibility;
                                 this.inertialPanningY += (evt.clientY - cacheSoloPointer.y) / this.panningSensibility;
                             } else {


### PR DESCRIPTION
ArcRotateCamera panning is activated by default (via CTRL + left clic), it's also possible to choose to activate it on right clic (via attachControl param) but it wasn't possible to deactivate it. 
Now we can, just by setting the panningSensibility to 0.