### PR TITLE
Fixing body position of heightmap object

### DIFF
--- a/src/Physics/Plugins/babylon.cannonJSPlugin.js
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.js
@@ -197,10 +197,9 @@ var BABYLON;
             }
             //If it is a heightfield, if should be centered.
             if (shape.type === CANNON.Shape.types.HEIGHTFIELD) {
-                body.position = body.position.vadd(new CANNON.Vec3(-shape.dim, 0, shape.dim));
+                body.position = new CANNON.Vec3(-shape.dim, 0, shape.dim).vadd(mesh.position);
                 //add it inverted to the delta 
-                deltaPosition.x += shape.dim;
-                deltaPosition.z -= shape.dim;
+                deltaPosition = mesh.position.add(new BABYLON.Vector3(shape.dim, 0, -shape.dim));
             }
             //add the shape
             body.addShape(shape);

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -235,10 +235,9 @@
             
             //If it is a heightfield, if should be centered.
             if (shape.type === CANNON.Shape.types.HEIGHTFIELD) {
-                body.position = body.position.vadd(new CANNON.Vec3(-shape.dim, 0, shape.dim));
+                body.position = new CANNON.Vec3(-shape.dim, 0, shape.dim).vadd(mesh.position);
                 //add it inverted to the delta 
-                deltaPosition.x += shape.dim;
-                deltaPosition.z -= shape.dim;
+                deltaPosition = mesh.position.add(new BABYLON.Vector3(shape.dim, 0, -shape.dim));
             }
             
             //add the shape


### PR DESCRIPTION
Due to the nature of heighfield creation in cannon.js, the heightmap's
position is not the center of the bounding box. Bounding box should be
completely ignored