### PR TITLE
Allow CORS on HTML5 audio element

### DIFF
--- a/src/Audio/babylon.sound.js
+++ b/src/Audio/babylon.sound.js
@@ -86,6 +86,7 @@ var BABYLON;
                             this._htmlAudioElement = new Audio();
                             this._htmlAudioElement.src = urlOrArrayBuffer;
                             this._htmlAudioElement.controls = false;
+                            this._htmlAudioElement.crossOrigin = "anonymous";
                             this._htmlAudioElement.loop = this.loop;
                             this._isReadyToPlay = true;
                             document.body.appendChild(this._htmlAudioElement);


### PR DESCRIPTION
This allows the newly added HTML 5 audio element (streaming: true) to access audio files from outside of the local server.