### PR TITLE
Fix.sps

### DIFF
--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -8,6 +8,7 @@ module BABYLON {
         public counter: number = 0;
         public name: string;
         public mesh: Mesh;
+        public vars: any = {};
         
         // private members
         private _scene: Scene;
@@ -480,6 +481,7 @@ module BABYLON {
         // dispose the SPS
         public dispose(): void {
             this.mesh.dispose();
+            this.vars = null;
             // drop references to internal big arrays for the GC
             this._positions = null;
             this._indices = null;

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -57,6 +57,7 @@ module BABYLON {
         private _cosPitch: number = 0.0;
         private _sinYaw: number = 0.0;
         private _cosYaw: number = 0.0;
+        private _w: number = 0.0;
 
 
         constructor(name: string, scene: Scene, options?: { updatable?: boolean }) {
@@ -398,7 +399,11 @@ module BABYLON {
                     this._vertex.y *= this._particle.scale.y;
                     this._vertex.z *= this._particle.scale.z;
 
-                    Vector3.TransformCoordinatesToRef(this._vertex, this._rotMatrix, this._rotated);
+                    //Vector3.TransformCoordinatesToRef(this._vertex, this._rotMatrix, this._rotated);
+                    this._w = (this._vertex.x * this._rotMatrix.m[3]) + (this._vertex.y * this._rotMatrix.m[7]) + (this._vertex.z * this._rotMatrix.m[11]) + this._rotMatrix.m[15];
+                    this._rotated.x = ( (this._vertex.x * this._rotMatrix.m[0]) + (this._vertex.y * this._rotMatrix.m[4]) + (this._vertex.z * this._rotMatrix.m[8]) + this._rotMatrix.m[12] ) / this._w;
+                    this._rotated.y = ( (this._vertex.x * this._rotMatrix.m[1]) + (this._vertex.y * this._rotMatrix.m[5]) + (this._vertex.z * this._rotMatrix.m[9]) + this._rotMatrix.m[13] ) / this._w;
+                    this._rotated.z = ( (this._vertex.x * this._rotMatrix.m[2]) + (this._vertex.y * this._rotMatrix.m[6]) + (this._vertex.z * this._rotMatrix.m[10]) + this._rotMatrix.m[14] ) / this._w;
 
                     this._positions32[idx] = this._particle.position.x + this._cam_axisX.x * this._rotated.x + this._cam_axisY.x * this._rotated.y + this._cam_axisZ.x * this._rotated.z;
                     this._positions32[idx + 1] = this._particle.position.y + this._cam_axisX.y * this._rotated.x + this._cam_axisY.y * this._rotated.y + this._cam_axisZ.y * this._rotated.z;


### PR DESCRIPTION
* Removed the call to _TransformCoordinates()_ within the render + particle loop and implemented the 3 lines of computation directly with no temp variable : the rotation matrix and coordinate transformation are computed for each vertex of each solid particle at each frame. If we have have thousands of solid particles with dozens of vertices each, it creates dozens of thousands of temp variables each frame that the GC has to manage then. Now, only one SPS object variable (permanent) is used instead, so no more memory allocation/collection. Tested with the profiler. 
* Added a SPS property called _vars_ in order to allow the user to declare SPS level variables and reuse them instead of global variables or instead of using temporary variable in _updateParticle(particle)_ and _updateParticleVertex(particle, vertex, i)_ . These SPS level variables are cleaned up when the SPS is disposed.  
Expected usage :  
```javascript
var SPS = new SolidParticleSystem(name, scene);
//  here add shapes, build mesh, etc ...

SPS.vars.velocityStep = 0.05;
SPS.vars.ageStep = 0.1;

SPS.updateParticle = function(particle) {
  particle.age += SPS.vars.ageStep;
  particle.velocity += SPS.vars.velocityStep;
  particle.position.x += particle.velocity;
}
```
This will be documented