### PR TITLE
Added SPS visibility helpers / bbox, frustum, toussa

### DIFF
--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -46,6 +46,7 @@ module BABYLON {
         private _fakeCamPos: Vector3 = Vector3.Zero();
         private _rotMatrix: Matrix = new Matrix();
         private _invertedMatrix: Matrix = new Matrix();
+        private _scalingMatrix: Matrix = new Matrix();
         private _rotated: Vector3 = Vector3.Zero();
         private _quaternion: Quaternion = new Quaternion();
         private _vertex: Vector3 = Vector3.Zero();
@@ -542,6 +543,17 @@ module BABYLON {
             this._colors32 = null;
             this.pickedParticles = null;
         }
+
+        // refresh the mesh bounding box
+        public refreshVisibleSize(): void {
+            this.mesh.refreshBoundingInfo();
+        }
+
+        // force the mesh to keep active in the render list
+        public forceVisibility(): void {
+            this.mesh.alwaysSelectAsActiveMesh = true;
+        }
+
 
         // Optimizer setters
         public set computeParticleRotation(val: boolean) {

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -363,7 +363,7 @@ module BABYLON {
                 Vector3.TransformCoordinatesToRef(this._camera.globalPosition, this._invertedMatrix, this._fakeCamPos);
 
                 // set two orthogonal vectors (_cam_axisX and and _cam_axisY) to the cam-mesh axis (_cam_axisZ)
-                (this._fakeCamPos).subtractToRef(this.mesh.position, this._cam_axisZ);
+                (this.mesh.position).subtractToRef(this._fakeCamPos, this._cam_axisZ);
                 Vector3.CrossToRef(this._cam_axisZ, this._axisX, this._cam_axisY);
                 Vector3.CrossToRef(this._cam_axisZ, this._cam_axisY, this._cam_axisX);
                 this._cam_axisY.normalize();

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -26,6 +26,7 @@ module BABYLON {
         private _index: number = 0;  // indices index
         private _updatable: boolean = true;
         private _pickable: boolean = false;
+        private _alwaysVisible: boolean = false;
         private _shapeCounter: number = 0;
         private _copy: SolidParticle = new SolidParticle(null, null, null, null, null);
         private _shape: Vector3[];
@@ -46,7 +47,6 @@ module BABYLON {
         private _fakeCamPos: Vector3 = Vector3.Zero();
         private _rotMatrix: Matrix = new Matrix();
         private _invertedMatrix: Matrix = new Matrix();
-        private _scalingMatrix: Matrix = new Matrix();
         private _rotated: Vector3 = Vector3.Zero();
         private _quaternion: Quaternion = new Quaternion();
         private _vertex: Vector3 = Vector3.Zero();
@@ -107,7 +107,8 @@ module BABYLON {
             var mesh = new Mesh(name, this._scene);
             vertexData.applyToMesh(mesh, this._updatable);
             this.mesh = mesh;
-
+            this.mesh.isPickable = this._pickable;
+            
             // free memory
             this._positions = null;
             this._normals = null;
@@ -116,7 +117,6 @@ module BABYLON {
 
             if (!this._updatable) {
                 this.particles.length = 0;
-                this.mesh.isPickable = true;
             }
 
             return mesh;
@@ -544,16 +544,20 @@ module BABYLON {
             this.pickedParticles = null;
         }
 
-        // refresh the mesh bounding box
+        // Visibilty helpers
         public refreshVisibleSize(): void {
             this.mesh.refreshBoundingInfo();
         }
 
-        // force the mesh to keep active in the render list
-        public forceVisibility(): void {
-            this.mesh.alwaysSelectAsActiveMesh = true;
+        // getter and setter
+        public get alwaysVisible(): boolean {
+            return this._alwaysVisible;
         }
 
+        public set alwaysVisible(val: boolean) {
+            this._alwaysVisible = val;
+            this.mesh.alwaysSelectAsActiveMesh = val;
+        }
 
         // Optimizer setters
         public set computeParticleRotation(val: boolean) {

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -70,7 +70,7 @@ module BABYLON {
             this.name = name;
             this._scene = scene;
             this._camera = scene.activeCamera;
-            this._pickable = options ? options.pickable : false;
+            this._pickable = options ? options.isPickable : false;
             if (options && options.updatable) {
                 this._updatable = options.updatable;
             } else {

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -66,7 +66,7 @@ module BABYLON {
         private _w: number = 0.0;
 
 
-        constructor(name: string, scene: Scene, options?: { updatable?: boolean, pickable? :boolean }) {
+        constructor(name: string, scene: Scene, options?: { updatable?: boolean, isPickable? :boolean }) {
             this.name = name;
             this._scene = scene;
             this._camera = scene.activeCamera;
@@ -550,11 +550,11 @@ module BABYLON {
         }
 
         // getter and setter
-        public get alwaysVisible(): boolean {
+        public get isAlwaysVisible(): boolean {
             return this._alwaysVisible;
         }
 
-        public set alwaysVisible(val: boolean) {
+        public set isAlwaysVisible(val: boolean) {
             this._alwaysVisible = val;
             this.mesh.alwaysSelectAsActiveMesh = val;
         }


### PR DESCRIPTION
Added : 
* _SPS.refreshVisibleSize()_ : just refreshes the SPS underlying mesh bounding info
* _SPS.forceVisibility()_ : sets the SPS underlying mesh as always selectable as active

As the SPS may have a variable mesh size, its bounding box may not be updated when needed so the full SPS can disappear from screen because its BBox is no longer in the frustum.
These two helpers will allow the user to update the SPS BBox on demand.

This will be documented