### PR TITLE
major fix : billboard mode recomputes now the normals

### DIFF
--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -46,7 +46,6 @@ module BABYLON {
         private _particle: SolidParticle;
         private _fakeCamPos: Vector3 = Vector3.Zero();
         private _rotMatrix: Matrix = new Matrix();
-        private _invertedMatrix: Matrix = new Matrix();
         private _rotated: Vector3 = Vector3.Zero();
         private _quaternion: Quaternion = new Quaternion();
         private _vertex: Vector3 = Vector3.Zero();
@@ -359,11 +358,10 @@ module BABYLON {
                 this._roll = this.mesh.rotation.z;
                 this._quaternionRotationYPR();
                 this._quaternionToRotationMatrix();
-                this._rotMatrix.invertToRef(this._invertedMatrix);
-                Vector3.TransformCoordinatesToRef(this._camera.globalPosition, this._invertedMatrix, this._fakeCamPos);
+                Vector3.TransformCoordinatesToRef(this._camera.globalPosition, this._rotMatrix, this._fakeCamPos);
 
                 // set two orthogonal vectors (_cam_axisX and and _cam_axisY) to the cam-mesh axis (_cam_axisZ)
-                (this.mesh.position).subtractToRef(this._fakeCamPos, this._cam_axisZ);
+                (this._fakeCamPos).subtractToRef(this.mesh.position, this._cam_axisZ);
                 Vector3.CrossToRef(this._cam_axisZ, this._axisX, this._cam_axisY);
                 Vector3.CrossToRef(this._cam_axisZ, this._cam_axisY, this._cam_axisX);
                 this._cam_axisY.normalize();
@@ -437,7 +435,7 @@ module BABYLON {
                     this._positions32[idx + 2] = this._particle.position.z + this._cam_axisX.z * this._rotated.x + this._cam_axisY.z * this._rotated.y + this._cam_axisZ.z * this._rotated.z;
 
                     // normals : if the particles can't be morphed then just rotate the normals
-                    if (!this._computeParticleVertex) {
+                    if (!this._computeParticleVertex && !this.billboard) {
                         this._normal.x = this._fixedNormal32[idx];
                         this._normal.y = this._fixedNormal32[idx + 1];
                         this._normal.z = this._fixedNormal32[idx + 2];
@@ -478,7 +476,7 @@ module BABYLON {
                 }
                 this.mesh.updateVerticesData(VertexBuffer.PositionKind, this._positions32, false, false);
                 if (!this.mesh.areNormalsFrozen) {
-                    if (this._computeParticleVertex) {
+                    if (this._computeParticleVertex || this.billboard) {
                         // recompute the normals only if the particles can be morphed, update then the normal reference array
                         VertexData.ComputeNormals(this._positions32, this._indices, this._normals32);
                         for (var i = 0; i < this._normals32.length; i++) {


### PR DESCRIPTION
The billboard mode had a bug on planar particles, what was hidden by a hemispheric light side effect.

This PR simplify the fakeCam computation (no more inverted rotation) and forces the billboard mode to recompute the particle normals.