### PR TITLE
Add isPickable property to BABYLON.Sprite

### DIFF
--- a/dist/babylon.2.2.d.ts
+++ b/dist/babylon.2.2.d.ts
@@ -5013,6 +5013,7 @@ declare module BABYLON {
         cellIndex: number;
         invertU: number;
         invertV: number;
+        isPickable: boolean;
         disposeWhenFinishedAnimating: boolean;
         animations: Animation[];
         private _animationStarted;


### PR DESCRIPTION
According to the wiki, https://github.com/BabylonJS/Babylon.js/wiki/08-Sprites, isPickable is a property of Sprite.