### PR TITLE
enable POV at node level

### DIFF
--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -152,8 +152,9 @@
 
         private _globalPosition = Vector3.Zero();
 
-        constructor(name: string, public position: Vector3, scene: Scene) {
+        constructor(name: string, position: Vector3, scene: Scene) {
             super(name, scene);
+            this.position = position;
 
             scene.addCamera(this);
 

--- a/src/Cameras/babylon.targetCamera.ts
+++ b/src/Cameras/babylon.targetCamera.ts
@@ -3,7 +3,6 @@
 
         public cameraDirection = new Vector3(0, 0, 0);
         public cameraRotation = new Vector2(0, 0);
-        public rotation = new Vector3(0, 0, 0);
 
         public speed = 2.0;
         public noRotationConstraint = false;
@@ -27,6 +26,7 @@
 
         constructor(name: string, position: Vector3, scene: Scene) {
             super(name, position, scene);
+            this.rotation = new Vector3(0, 0, 0);
         }
 
         public getFrontPosition(distance: number): Vector3 {

--- a/src/Lights/babylon.directionalLight.ts
+++ b/src/Lights/babylon.directionalLight.ts
@@ -1,6 +1,5 @@
 ﻿module BABYLON {
     export class DirectionalLight extends Light implements IShadowLight {
-        public position: Vector3;
 
         private _transformedDirection: Vector3;
         public transformedPosition: Vector3;
@@ -16,9 +15,10 @@
         private _orthoTop = Number.MIN_VALUE;
         private _orthoBottom = Number.MAX_VALUE;
 
-        constructor(name: string, public direction: Vector3, scene: Scene) {
+        constructor(name: string, direction: Vector3, scene: Scene) {
             super(name, scene);
 
+            this.direction = direction;
             this.position = direction.scale(-1);
         }
 

--- a/src/Lights/babylon.hemisphericLight.ts
+++ b/src/Lights/babylon.hemisphericLight.ts
@@ -4,8 +4,9 @@
 
         private _worldMatrix: Matrix;
 
-        constructor(name: string, public direction: Vector3, scene: Scene) {
+        constructor(name: string, direction: Vector3, scene: Scene) {
             super(name, scene);
+            this.direction = direction;
         }
 
         public setDirectionToTarget(target: Vector3): Vector3 {

--- a/src/Lights/babylon.pointLight.ts
+++ b/src/Lights/babylon.pointLight.ts
@@ -3,8 +3,9 @@
         private _worldMatrix: Matrix;
         public transformedPosition: Vector3;
 
-        constructor(name: string, public position: Vector3, scene: Scene) {
+        constructor(name: string, position: Vector3, scene: Scene) {
             super(name, scene);
+            this.position = position;
         }
 
         public getAbsolutePosition(): Vector3 {

--- a/src/Lights/babylon.spotLight.ts
+++ b/src/Lights/babylon.spotLight.ts
@@ -6,8 +6,10 @@
         private _transformedDirection: Vector3;
         private _worldMatrix: Matrix;
 
-        constructor(name: string, public position: Vector3, public direction: Vector3, public angle: number, public exponent: number, scene: Scene) {
+        constructor(name: string, position: Vector3, direction: Vector3, public angle: number, public exponent: number, scene: Scene) {
             super(name, scene);
+            this.position = position;
+            this.direction = direction;
         }
 
         public getAbsolutePosition(): Vector3 {

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -28,10 +28,6 @@
         }
 
         // Properties
-        public definedFacingForward = true; // orientation for POV movement & rotation
-        public position = new Vector3(0, 0, 0);
-        public rotation = new Vector3(0, 0, 0);
-        public rotationQuaternion: Quaternion;
         public scaling = new Vector3(1, 1, 1);
         public billboardMode = AbstractMesh.BILLBOARDMODE_NONE;
         public visibility = 1.0;
@@ -134,6 +130,8 @@
         constructor(name: string, scene: Scene) {
             super(name, scene);
 
+            this.position = new Vector3(0, 0, 0);
+            this.rotation = new Vector3(0, 0, 0);
             scene.addMesh(this);
         }
 
@@ -306,60 +304,6 @@
                 this.position.y = absolutePositionY;
                 this.position.z = absolutePositionZ;
             }
-        }
-        // ================================== Point of View Movement =================================
-        /**
-         * Perform relative position change from the point of view of behind the front of the mesh.
-         * This is performed taking into account the meshes current rotation, so you do not have to care.
-         * Supports definition of mesh facing forward or backward.
-         * @param {number} amountRight
-         * @param {number} amountUp
-         * @param {number} amountForward
-         */
-        public movePOV(amountRight: number, amountUp: number, amountForward: number): void {
-            this.position.addInPlace(this.calcMovePOV(amountRight, amountUp, amountForward));
-        }
-
-        /**
-         * Calculate relative position change from the point of view of behind the front of the mesh.
-         * This is performed taking into account the meshes current rotation, so you do not have to care.
-         * Supports definition of mesh facing forward or backward.
-         * @param {number} amountRight
-         * @param {number} amountUp
-         * @param {number} amountForward
-         */
-        public calcMovePOV(amountRight: number, amountUp: number, amountForward: number): Vector3 {
-            var rotMatrix = new Matrix();
-            var rotQuaternion = (this.rotationQuaternion) ? this.rotationQuaternion : Quaternion.RotationYawPitchRoll(this.rotation.y, this.rotation.x, this.rotation.z);
-            rotQuaternion.toRotationMatrix(rotMatrix);
-
-            var translationDelta = Vector3.Zero();
-            var defForwardMult = this.definedFacingForward ? -1 : 1;
-            Vector3.TransformCoordinatesFromFloatsToRef(amountRight * defForwardMult, amountUp, amountForward * defForwardMult, rotMatrix, translationDelta);
-            return translationDelta;
-        }
-        // ================================== Point of View Rotation =================================
-        /**
-         * Perform relative rotation change from the point of view of behind the front of the mesh.
-         * Supports definition of mesh facing forward or backward.
-         * @param {number} flipBack
-         * @param {number} twirlClockwise
-         * @param {number} tiltRight
-         */
-        public rotatePOV(flipBack: number, twirlClockwise: number, tiltRight: number): void {
-            this.rotation.addInPlace(this.calcRotatePOV(flipBack, twirlClockwise, tiltRight));
-        }
-
-        /**
-         * Calculate relative rotation change from the point of view of behind the front of the mesh.
-         * Supports definition of mesh facing forward or backward.
-         * @param {number} flipBack
-         * @param {number} twirlClockwise
-         * @param {number} tiltRight
-         */
-        public calcRotatePOV(flipBack: number, twirlClockwise: number, tiltRight: number): Vector3 {
-            var defForwardMult = this.definedFacingForward ? 1 : -1;
-            return new Vector3(flipBack * defForwardMult, twirlClockwise, tiltRight * defForwardMult);
         }
 
         public setPivotMatrix(matrix: Matrix): void {


### PR DESCRIPTION
Allow TargetCamera sub-classes, that have no target, as well as Spolight & DirectionalLight to be positioned & "rotated" in amountRight-amountUp-mountForward & flipBack-twirlClockwise-tiltRight terms.

When integrated into the POV replacement extension, QueuedInterpolation, a scene beforerender will be used instead of a mesh beforerender.