### PR TITLE
Disposing the skeleton when disposing the mesh

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -1010,6 +1010,10 @@
                 this._edgesRenderer.dispose();
                 this._edgesRenderer = null;
             }
+            
+            if(this.skeleton) {
+                this.skeleton.dispose();
+            }
 
             // SubMeshes
             this.releaseSubMeshes();


### PR DESCRIPTION
I am not sure if skeletons are reusable, but if not - it makes sense to actually dispose them when disposing the mesh to prevent from disposing two objects one after the other.