### PR TITLE
Update UV mapping on icosphere

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.js
+++ b/src/Mesh/babylon.mesh.vertexData.js
@@ -441,7 +441,7 @@ var BABYLON;
                     vTotalDistance[i] = dist;
                 }
             }
-            // uvs            
+            // uvs
             var u;
             var v;
             for (p = 0; p < pathArray.length; p++) {
@@ -457,7 +457,7 @@ var BABYLON;
             var l1 = lg[p] - 1; // path1 length
             var l2 = lg[p + 1] - 1; // path2 length
             var min = (l1 < l2) ? l1 : l2; // current path stop index
-            var shft = idx[1] - idx[0]; // shift 
+            var shft = idx[1] - idx[0]; // shift
             var path1nb = closeArray ? lg.length : lg.length - 1; // number of path1 to iterate	on
             while (pi <= min && p < path1nb) {
                 // draw two triangles between path1 (p1) and path2 (p2) : (p1.pi, p2.pi, p1.pi+1) and (p2.pi+1, p1.pi+1, p2.pi) clockwise
@@ -655,7 +655,7 @@ var BABYLON;
             vertexData.uvs = uvs;
             return vertexData;
         };
-        // Cylinder and cone 
+        // Cylinder and cone
         VertexData.CreateCylinder = function (options) {
             var height = options.height || 2;
             var diameterTop = (options.diameterTop === 0) ? 0 : options.diameterTop || options.diameter || 1;
@@ -1149,31 +1149,99 @@ var BABYLON;
             ];
             // index of 3 vertex makes a face of icopshere
             var ico_indices = [
-                0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11,
-                1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
-                3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9,
-                4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1
+                0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 12, 22, 23,
+                1, 5, 20, 5, 11, 4, 23, 22, 13, 22, 18, 6, 7, 1, 8,
+                14, 21, 4, 14, 4, 2, 16, 13, 6, 15, 6, 19, 3, 8, 9,
+                4, 21, 5, 13, 17, 23, 6, 13, 22, 19, 6, 18, 9, 8, 1
+            ];
+            // vertex for uv have aliased position, not for UV
+            var vertices_unalias_id = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                // vertex alias
+                0,
+                2,
+                3,
+                3,
+                3,
+                4,
+                7,
+                8,
+                9,
+                9,
+                10,
+                11 // 23: B + 12
             ];
             // uv as integer step (not pixels !)
             var ico_vertexuv = [
-                4, 1, 2, 1, 6, 3, 5, 4,
-                4, 3, 3, 2, 7, 4, 3, 0,
-                1, 0, 0, 1, 5, 0, 5, 2 // v8-11
+                5, 1, 3, 1, 6, 4, 0, 0,
+                5, 3, 4, 2, 2, 2, 4, 0,
+                2, 0, 1, 1, 6, 0, 6, 2,
+                // vertex alias (for same vertex on different faces)
+                0, 4,
+                3, 3,
+                4, 4,
+                3, 1,
+                4, 2,
+                4, 4,
+                0, 2,
+                1, 1,
+                2, 2,
+                3, 3,
+                1, 3,
+                2, 4 // 23: B + 12
             ];
-            // Vertices [0, 1, ...9, A, B] : position on UV plane (7,8,9,10=A have duplicate position)
-            // v=5h          9+  8+  7+
-            // v=4h        9+  3   6   A+
-            // v=3h      9+  4   2   A+
-            // v=2h    9+  5   B   A+
-            // v=1h  9   1   0   A+
-            // v=0h    8   7   A
-            //     u=0 1 2 3 4 5 6 7 8 9   *a
-            //
+            // Vertices[0, 1, ...9, A, B] : position on UV plane
+            // '+' indicate duplicate position to be fixed (3,9:0,2,3,4,7,8,A,B)
+            // First island of uv mapping
+            // v = 4h          3+  2
+            // v = 3h        9+  4
+            // v = 2h      9+  5   B
+            // v = 1h    9   1   0
+            // v = 0h  3   8   7   A
+            //     u = 0 1 2 3 4 5 6  *a
+            // Second island of uv mapping
+            // v = 4h  0+  B+  4+
+            // v = 3h    A+  2+
+            // v = 2h  7+  6   3+
+            // v = 1h    8+  3+
+            // v = 0h
+            //     u = 0 1 2 3 4 5 6  *a
+            // Face layout on texture UV mapping
+            // ============
+            // \ 4  /\ 16 /   ======
+            //  \  /  \  /   /\ 11 /
+            //   \/ 7  \/   /  \  /
+            //    =======  / 10 \/
+            //   /\ 17 /\  =======
+            //  /  \  /  \ \ 15 /\
+            // / 8  \/ 12 \ \  /  \
+            // ============  \/ 6  \
+            // \ 18 /\  ============
+            //  \  /  \ \ 5  /\ 0  /
+            //   \/ 13 \ \  /  \  /
+            //   =======  \/ 1  \/
+            //       =============
+            //      /\ 19 /\  2 /\
+            //     /  \  /  \  /  \
+            //    / 14 \/ 9  \/  3 \
+            //   ===================
             // uv step is u:1 or 0.5, v:cos(30)=sqrt(3)/2, ratio approx is 84/97
-            var ustep = 97 / 1024;
-            var vstep = 168 / 1024;
-            var uoffset = 50 / 1024;
-            var voffset = 51 / 1024;
+            var ustep = 138 / 1024;
+            var vstep = 239 / 1024;
+            var uoffset = 60 / 1024;
+            var voffset = 26 / 1024;
+            // Second island should have margin, not to touch the first island
+            // avoid any borderline artefact in pixel rounding
+            var island_u_offset = -40 / 1024;
+            var island_v_offset = +20 / 1024;
+            // face is either island 0 or 1 :
+            // second island is for faces : [4, 7, 8, 12, 13, 16, 17, 18]
+            var island = [
+                0, 0, 0, 0, 1,
+                0, 0, 1, 1, 0,
+                0, 0, 1, 1, 0,
+                0, 1, 1, 1, 0,
+            ];
             var indices = [];
             var positions = [];
             var normals = [];
@@ -1190,60 +1258,14 @@ var BABYLON;
             for (var face = 0; face < 20; face++) {
                 // 3 vertex per face
                 for (var v012 = 0; v012 < 3; v012++) {
-                    // look up vertex 0,1,2 to its index in 0 to 11
+                    // look up vertex 0,1,2 to its index in 0 to 11 (or 23 including alias)
                     var v_id = ico_indices[3 * face + v012];
                     // vertex have 3D position (x,y,z)
-                    face_vertex_pos[v012].copyFromFloats(ico_vertices[3 * v_id], ico_vertices[3 * v_id + 1], ico_vertices[3 * v_id + 2]);
+                    face_vertex_pos[v012].copyFromFloats(ico_vertices[3 * vertices_unalias_id[v_id]], ico_vertices[3 * vertices_unalias_id[v_id] + 1], ico_vertices[3 * vertices_unalias_id[v_id] + 2]);
                     // Normalize to get normal, then scale to radius
                     face_vertex_pos[v012].normalize().scaleInPlace(radius);
-                    // uv from vertex ID (may need fix due to unwrap on texture plan, unalias needed)
-                    // vertex may get to different UV according to belonging face (see fix below)
-                    var fix = 0;
-                    // Vertice 9 UV to be fixed
-                    if (face === 5 && v012 === 2) {
-                        fix = 1;
-                    }
-                    if (face === 15 && v012 === 1) {
-                        fix = 2;
-                    }
-                    if (face === 10 && v012 === 1) {
-                        fix = 3;
-                    }
-                    if (face === 14 && v012 === 2) {
-                        fix = 4;
-                    }
-                    // vertice 10 UV to be fixed
-                    if (face === 4 && v012 === 1) {
-                        fix = 1;
-                    }
-                    if (face === 7 && v012 === 1) {
-                        fix = 2;
-                    }
-                    if (face === 17 && v012 === 2) {
-                        fix = 3;
-                    }
-                    if (face === 8 && v012 === 0) {
-                        fix = 4;
-                    }
-                    // vertice 7 UV to be fixed
-                    if (face === 8 && v012 === 1) {
-                        fix = 5;
-                    }
-                    if (face === 18 && v012 === 0) {
-                        fix = 5;
-                    }
-                    // vertice 8 UV to be fixed
-                    if (face === 13 && v012 === 2) {
-                        fix = 5;
-                    }
-                    if (face === 14 && v012 === 1) {
-                        fix = 5;
-                    }
-                    if (face === 18 && v012 === 2) {
-                        fix = 5;
-                    }
-                    //
-                    face_vertex_uv[v012].copyFromFloats((ico_vertexuv[2 * v_id] + fix) * ustep + uoffset, (ico_vertexuv[2 * v_id + 1] + fix) * vstep + voffset);
+                    // uv Coordinates from vertex ID
+                    face_vertex_uv[v012].copyFromFloats(ico_vertexuv[2 * v_id] * ustep + uoffset + island[face] * island_u_offset, ico_vertexuv[2 * v_id + 1] * vstep + voffset + island[face] * island_v_offset);
                 }
                 // Subdivide the face (interpolate pos, norm, uv)
                 // - pos is linear interpolation, then projected to sphere (converge polyhedron to sphere)
@@ -1612,7 +1634,7 @@ var BABYLON;
                     }
                     break;
                 case BABYLON.Mesh.DOUBLESIDE:
-                    // positions 
+                    // positions
                     var lp = positions.length;
                     var l = lp / 3;
                     for (var p = 0; p < lp; p++) {

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -545,7 +545,7 @@
             }
 
 
-            // uvs            
+            // uvs
             var u: number;
             var v: number;
             for (p = 0; p < pathArray.length; p++) {
@@ -562,7 +562,7 @@
             var l1: number = lg[p] - 1;           		// path1 length
             var l2: number = lg[p + 1] - 1;         	// path2 length
             var min: number = (l1 < l2) ? l1 : l2;   	// current path stop index
-            var shft: number = idx[1] - idx[0];         // shift 
+            var shft: number = idx[1] - idx[0];         // shift
             var path1nb: number = closeArray ? lg.length : lg.length - 1;     // number of path1 to iterate	on
 
             while (pi <= min && p < path1nb) {       	//  stay under min and don't go over next to last path
@@ -610,7 +610,7 @@
                     normals[indexLast + 2] = normals[indexFirst + 2];
                 }
             }
-            
+
             // sides
             VertexData._ComputeSides(sideOrientation, positions, indices, normals, uvs);
 
@@ -804,7 +804,7 @@
             return vertexData;
         }
 
-        // Cylinder and cone 
+        // Cylinder and cone
         public static CreateCylinder(options: { height?: number, diameterTop?: number, diameterBottom?: number, diameter?: number, tessellation?: number, subdivisions?: number, arc?: number, faceColors?: Color4[], faceUV?: Vector4[], sideOrientation?: number }): VertexData {
             var height: number = options.height || 2;
             var diameterTop: number = (options.diameterTop === 0) ? 0 : options.diameterTop || options.diameter || 1;
@@ -938,7 +938,7 @@
                     }
                 }
             };
-            
+
             // add caps to geometry
             createCylinderCap(false);
             createCylinderCap(true);
@@ -1405,33 +1405,105 @@
 
             // index of 3 vertex makes a face of icopshere
             var ico_indices = [
-                0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11,
-                1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
-                3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9,
-                4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1
+                0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 12, 22, 23,
+                1, 5, 20, 5, 11, 4, 23, 22, 13, 22, 18, 6, 7, 1, 8,
+                14, 21, 4, 14, 4, 2, 16, 13, 6, 15, 6, 19, 3, 8, 9,
+                4, 21, 5, 13, 17, 23, 6, 13, 22, 19, 6, 18, 9, 8, 1
             ];
+            // vertex for uv have aliased position, not for UV
+            var vertices_unalias_id = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                // vertex alias
+                0,  // 12: 0 + 12
+                2,  // 13: 2 + 11
+                3,  // 14: 3 + 11
+                3,  // 15: 3 + 12
+                3,  // 16: 3 + 13
+                4,  // 17: 4 + 13
+                7,  // 18: 7 + 11
+                8,  // 19: 8 + 11
+                9,  // 20: 9 + 11
+                9,  // 21: 9 + 12
+                10, // 22: A + 12
+                11 // 23: B + 12
+            ];
+
 
             // uv as integer step (not pixels !)
             var ico_vertexuv = [
-                4, 1, 2, 1, 6, 3, 5, 4,  // v0-3
-                4, 3, 3, 2, 7, 4, 3, 0,  // v4-7
-                1, 0, 0, 1, 5, 0, 5, 2   // v8-11
+                5, 1, 3, 1, 6, 4, 0, 0,  // v0-3
+                5, 3, 4, 2, 2, 2, 4, 0,  // v4-7
+                2, 0, 1, 1, 6, 0, 6, 2,  // v8-11
+                // vertex alias (for same vertex on different faces)
+                0, 4, // 12: 0 + 12
+                3, 3, // 13: 2 + 11
+                4, 4, // 14: 3 + 11
+                3, 1, // 15: 3 + 12
+                4, 2, // 16: 3 + 13
+                4, 4, // 17: 4 + 13
+                0, 2, // 18: 7 + 11
+                1, 1, // 19: 8 + 11
+                2, 2, // 20: 9 + 11
+                3, 3, // 21: 9 + 12
+                1, 3, // 22: A + 12
+                2, 4  // 23: B + 12
             ];
-            // Vertices [0, 1, ...9, A, B] : position on UV plane (7,8,9,10=A have duplicate position)
-            // v=5h          9+  8+  7+
-            // v=4h        9+  3   6   A+
-            // v=3h      9+  4   2   A+
-            // v=2h    9+  5   B   A+
-            // v=1h  9   1   0   A+
-            // v=0h    8   7   A
-            //     u=0 1 2 3 4 5 6 7 8 9   *a
-            //
+
+            // Vertices[0, 1, ...9, A, B] : position on UV plane
+            // '+' indicate duplicate position to be fixed (3,9:0,2,3,4,7,8,A,B)
+            // First island of uv mapping
+            // v = 4h          3+  2
+            // v = 3h        9+  4
+            // v = 2h      9+  5   B
+            // v = 1h    9   1   0
+            // v = 0h  3   8   7   A
+            //     u = 0 1 2 3 4 5 6  *a
+
+            // Second island of uv mapping
+            // v = 4h  0+  B+  4+
+            // v = 3h    A+  2+
+            // v = 2h  7+  6   3+
+            // v = 1h    8+  3+
+            // v = 0h
+            //     u = 0 1 2 3 4 5 6  *a
+
+            // Face layout on texture UV mapping
+            // ============
+            // \ 4  /\ 16 /   ======
+            //  \  /  \  /   /\ 11 /
+            //   \/ 7  \/   /  \  /
+            //    =======  / 10 \/
+            //   /\ 17 /\  =======
+            //  /  \  /  \ \ 15 /\
+            // / 8  \/ 12 \ \  /  \
+            // ============  \/ 6  \
+            // \ 18 /\  ============
+            //  \  /  \ \ 5  /\ 0  /
+            //   \/ 13 \ \  /  \  /
+            //   =======  \/ 1  \/
+            //       =============
+            //      /\ 19 /\  2 /\
+            //     /  \  /  \  /  \
+            //    / 14 \/ 9  \/  3 \
+            //   ===================
 
             // uv step is u:1 or 0.5, v:cos(30)=sqrt(3)/2, ratio approx is 84/97
-            var ustep = 97 / 1024;
-            var vstep = 168 / 1024;
-            var uoffset = 50 / 1024;
-            var voffset = 51 / 1024;
+            var ustep = 138 / 1024;
+            var vstep = 239 / 1024;
+            var uoffset = 60 / 1024;
+            var voffset = 26 / 1024;
+            // Second island should have margin, not to touch the first island
+            // avoid any borderline artefact in pixel rounding
+            var island_u_offset = -40 / 1024;
+            var island_v_offset = +20 / 1024;
+            // face is either island 0 or 1 :
+            // second island is for faces : [4, 7, 8, 12, 13, 16, 17, 18]
+            var island = [
+                0, 0, 0, 0, 1, //  0 - 4
+                0, 0, 1, 1, 0, //  5 - 9
+                0, 0, 1, 1, 0, //  10 - 14
+                0, 1, 1, 1, 0, //  15 - 19
+            ];
 
             var indices = [];
             var positions = [];
@@ -1450,41 +1522,20 @@
             for (var face = 0; face < 20; face++) {
                 // 3 vertex per face
                 for (var v012 = 0; v012 < 3; v012++) {
-                    // look up vertex 0,1,2 to its index in 0 to 11
+                    // look up vertex 0,1,2 to its index in 0 to 11 (or 23 including alias)
                     var v_id = ico_indices[3 * face + v012];
                     // vertex have 3D position (x,y,z)
                     face_vertex_pos[v012].copyFromFloats(
-                        ico_vertices[3 * v_id],
-                        ico_vertices[3 * v_id + 1],
-                        ico_vertices[3 * v_id + 2]);
+                        ico_vertices[3 * vertices_unalias_id[v_id]],
+                        ico_vertices[3 * vertices_unalias_id[v_id] + 1],
+                        ico_vertices[3 * vertices_unalias_id[v_id] + 2]);
                     // Normalize to get normal, then scale to radius
                     face_vertex_pos[v012].normalize().scaleInPlace(radius);
 
-                    // uv from vertex ID (may need fix due to unwrap on texture plan, unalias needed)
-                    // vertex may get to different UV according to belonging face (see fix below)
-                    var fix = 0;
-                    // Vertice 9 UV to be fixed
-                    if (face === 5 && v012 === 2) { fix = 1; }
-                    if (face === 15 && v012 === 1) { fix = 2; }
-                    if (face === 10 && v012 === 1) { fix = 3; }
-                    if (face === 14 && v012 === 2) { fix = 4; }
-                    // vertice 10 UV to be fixed
-                    if (face === 4 && v012 === 1) { fix = 1; }
-                    if (face === 7 && v012 === 1) { fix = 2; }
-                    if (face === 17 && v012 === 2) { fix = 3; }
-                    if (face === 8 && v012 === 0) { fix = 4; }
-                    // vertice 7 UV to be fixed
-                    if (face === 8 && v012 === 1) { fix = 5; }
-                    if (face === 18 && v012 === 0) { fix = 5; }
-                    // vertice 8 UV to be fixed
-                    if (face === 13 && v012 === 2) { fix = 5; }
-                    if (face === 14 && v012 === 1) { fix = 5; }
-                    if (face === 18 && v012 === 2) { fix = 5; }
-                    //
+                    // uv Coordinates from vertex ID
                     face_vertex_uv[v012].copyFromFloats(
-                        (ico_vertexuv[2 * v_id] + fix) * ustep + uoffset,
-                        (ico_vertexuv[2 * v_id + 1] + fix) * vstep + voffset);
-
+                        ico_vertexuv[2 * v_id] * ustep + uoffset + island[face] * island_u_offset,
+                        ico_vertexuv[2 * v_id + 1] * vstep + voffset + island[face] * island_v_offset);
                 }
 
                 // Subdivide the face (interpolate pos, norm, uv)
@@ -1824,7 +1875,7 @@
          */
         public static ComputeNormals(positions: any, indices: any, normals: any) {
             var index = 0;
-            
+
             // temp Vector3
             var p1p2 = Vector3.Zero();
             var p3p2 = Vector3.Zero();
@@ -1864,7 +1915,7 @@
                 normals[i3 * 3 + 1] += faceNormal.y;
                 normals[i3 * 3 + 2] += faceNormal.z;
             }
-            
+
             // last normalization
             for (index = 0; index < normals.length / 3; index++) {
                 Vector3.FromFloatsToRef(normals[index * 3], normals[index * 3 + 1], normals[index * 3 + 2], vertexNormali1);
@@ -1903,7 +1954,7 @@
                     break;
 
                 case Mesh.DOUBLESIDE:
-                    // positions 
+                    // positions
                     var lp: number = positions.length;
                     var l: number = lp / 3;
                     for (var p = 0; p < lp; p++) {


### PR DESCRIPTION
- better use of texture surface compare to previous map
  Use 2 islands of triangle to cover about 61 % of the square bitmap
- create alias vertex (case of same 3D position with different UV)