### PR TITLE
added per ring + per quad section if enclosed to VertexData.CreateCylinder

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -857,12 +857,19 @@
             var j: number;
             var r: number;
             var ringIdx: number = 1;
+            var c: number = 1;
 
             for (i = 0; i <= subdivisions; i++) {
                 h = i / subdivisions;
                 radius = (h * (diameterTop - diameterBottom) + diameterBottom) / 2;
                 ringIdx = (hasRings && i !== 0 && i !== subdivisions) ? 2 : 1;
                 for (r = 0; r < ringIdx; r++) {
+                    if (hasRings) {
+                        c += r;
+                    }
+                    if (enclose) {
+                        c += 2 * r;
+                    }
                     for (j = 0; j <= tessellation; j++) {
                         angle = j * angle_step;
 
@@ -885,7 +892,7 @@
                             ringNormal.normalize();
                         }
 
-                        // keep first values for enclose
+                        // keep first ring vertex values for enclose
                         if (j === 0) {
                             ringFirstVertex.copyFrom(ringVertex);
                             ringFirstNormal.copyFrom(ringNormal);
@@ -895,7 +902,7 @@
                         normals.push(ringNormal.x, ringNormal.y, ringNormal.z);
                         uvs.push(faceUV[1].x + (faceUV[1].z - faceUV[1].x) * j / tessellation, faceUV[1].y + (faceUV[1].w - faceUV[1].y) * h);
                         if (faceColors) {
-                            colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
+                            colors.push(faceColors[c].r, faceColors[c].g, faceColors[c].b, faceColors[c].a);
                         }
                     }
 
@@ -915,14 +922,13 @@
                         uvs.push(faceUV[1].x + (faceUV[1].z - faceUV[1].x), faceUV[1].y + (faceUV[1].w - faceUV[1].y));
                         uvs.push(faceUV[1].x + (faceUV[1].z - faceUV[1].x), faceUV[1].y + (faceUV[1].w - faceUV[1].y));
                         uvs.push(faceUV[1].x + (faceUV[1].z - faceUV[1].x), faceUV[1].y + (faceUV[1].w - faceUV[1].y));
-                        if (faceColors) {
-                            colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
-                            colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
-                            colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
-                            colors.push(faceColors[1].r, faceColors[1].g, faceColors[1].b, faceColors[1].a);
-                        }
+                        colors.push(faceColors[c + 1].r, faceColors[c + 1].g, faceColors[c + 1].b, faceColors[c + 1].a);
+                        colors.push(faceColors[c + 1].r, faceColors[c + 1].g, faceColors[c + 1].b, faceColors[c + 1].a);
+                        colors.push(faceColors[c + 2].r, faceColors[c + 2].g, faceColors[c + 2].b, faceColors[c + 2].a);
+                        colors.push(faceColors[c + 2].r, faceColors[c + 2].g, faceColors[c + 2].b, faceColors[c + 2].a);
                     }
                 }
+
             }
 
             // indices


### PR DESCRIPTION
```javascript
MeshBuilder.CreateCylinder('c', {subdivisions: 3, hasRings: true, arc: 0.6, enclose: true, faceColors: colors}, scene);
```
If colors is an array of `Color4`, we can now define a color per : 
* subdivision if `hasRings` if set to true
* even per section quad if the cylinder is sliced with an `arc`

_faceColors_ is an array of `Color4` per cylinder surface.
first surface : bottom cap
last surface : top cap

Each other surface if a tubular ring surface (so as many as subdivisions if `hasRings` is true, one else), so one color4 element in the _faceColor_ array. 
If the cylinder is sliced with `arc`, whatever the value of `arc` to keep consistent, there are 2 more quad surfaces per ring, so 3 color4 elements in this case (1 tubular surface + 2 quads).