### PR TITLE
Physics serialization

### DIFF
--- a/src/Loading/Plugins/babylon.babylonFileLoader.js
+++ b/src/Loading/Plugins/babylon.babylonFileLoader.js
@@ -1269,7 +1269,9 @@ var BABYLON;
                 scene.autoClear = parsedData.autoClear;
                 scene.clearColor = BABYLON.Color3.FromArray(parsedData.clearColor);
                 scene.ambientColor = BABYLON.Color3.FromArray(parsedData.ambientColor);
-                scene.gravity = BABYLON.Vector3.FromArray(parsedData.gravity);
+                if (parsedData.gravity) {
+                    scene.gravity = BABYLON.Vector3.FromArray(parsedData.gravity);
+                }
                 // Fog
                 if (parsedData.fogMode && parsedData.fogMode !== 0) {
                     scene.fogMode = parsedData.fogMode;
@@ -1278,6 +1280,24 @@ var BABYLON;
                     scene.fogEnd = parsedData.fogEnd;
                     scene.fogDensity = parsedData.fogDensity;
                 }
+                //Physics
+                if (parsedData.physicsEnabled) {
+                    var physicsPlugin;
+                    if (parsedData.physicsEngine === "cannon") {
+                        physicsPlugin = new BABYLON.CannonJSPlugin();
+                    }
+                    else if (parsedData.physicsEngine === "oimo") {
+                        physicsPlugin = new BABYLON.OimoJSPlugin();
+                    }
+                    //else - default engine, which is currently oimo
+                    var physicsGravity = parsedData.physicsGravity ? BABYLON.Vector3.FromArray(parsedData.physicsGravity) : null;
+                    scene.enablePhysics(physicsGravity, physicsPlugin);
+                }
+                //collisions, if defined. otherwise, default is true
+                if (parsedData.collisionsEnabled != undefined) {
+                    scene.collisionsEnabled = parsedData.collisionsEnabled;
+                }
+                scene.workerCollisions = !!parsedData.workerCollisions;
                 // Lights
                 for (var index = 0; index < parsedData.lights.length; index++) {
                     var parsedLight = parsedData.lights[index];

--- a/src/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -1551,8 +1551,10 @@
             scene.autoClear = parsedData.autoClear;
             scene.clearColor = BABYLON.Color3.FromArray(parsedData.clearColor);
             scene.ambientColor = BABYLON.Color3.FromArray(parsedData.ambientColor);
-            scene.gravity = BABYLON.Vector3.FromArray(parsedData.gravity);
-
+            if (parsedData.gravity) {
+                scene.gravity = BABYLON.Vector3.FromArray(parsedData.gravity);
+            }
+            
             // Fog
             if (parsedData.fogMode && parsedData.fogMode !== 0) {
                 scene.fogMode = parsedData.fogMode;
@@ -1561,6 +1563,25 @@
                 scene.fogEnd = parsedData.fogEnd;
                 scene.fogDensity = parsedData.fogDensity;
             }
+            
+            //Physics
+            if (parsedData.physicsEnabled) {
+                var physicsPlugin;
+                if (parsedData.physicsEngine === "cannon") {
+                    physicsPlugin = new BABYLON.CannonJSPlugin();
+                } else if(parsedData.physicsEngine === "oimo") {
+                    physicsPlugin = new BABYLON.OimoJSPlugin();
+                }
+                //else - default engine, which is currently oimo
+                var physicsGravity = parsedData.physicsGravity ? BABYLON.Vector3.FromArray(parsedData.physicsGravity) : null;
+                scene.enablePhysics(physicsGravity, physicsPlugin);
+            }
+            
+            //collisions, if defined. otherwise, default is true
+            if(parsedData.collisionsEnabled != undefined) {
+                scene.collisionsEnabled = parsedData.collisionsEnabled;
+            }
+            scene.workerCollisions = !!parsedData.workerCollisions;            
 
             // Lights
             for (var index = 0; index < parsedData.lights.length; index++) {

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.js
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.js
@@ -4,6 +4,7 @@ var BABYLON;
         function CannonJSPlugin() {
             this._registeredMeshes = [];
             this._physicsMaterials = [];
+            this.name = "cannon";
             this.updateBodyPosition = function (mesh) {
                 for (var index = 0; index < this._registeredMeshes.length; index++) {
                     var registeredMesh = this._registeredMeshes[index];
@@ -89,7 +90,11 @@ var BABYLON;
             });
         };
         CannonJSPlugin.prototype.setGravity = function (gravity) {
+            this._gravity = gravity;
             this._world.gravity.set(gravity.x, gravity.y, gravity.z);
+        };
+        CannonJSPlugin.prototype.getGravity = function () {
+            return this._gravity;
         };
         CannonJSPlugin.prototype.registerMesh = function (mesh, impostor, options) {
             this.unregisterMesh(mesh);

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -17,6 +17,8 @@
         private _world: any;
         private _registeredMeshes: Array<IRegisteredMesh> = [];
         private _physicsMaterials = [];
+		
+		public name = "cannon";
 
         public initialize(iterations: number = 10): void {
             this._world = new CANNON.World();

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -17,6 +17,7 @@
         private _world: any;
         private _registeredMeshes: Array<IRegisteredMesh> = [];
         private _physicsMaterials = [];
+		private _gravity: Vector3;
 		
 		public name = "cannon";
 
@@ -72,8 +73,13 @@
         }
 
         public setGravity(gravity: Vector3): void {
+			this._gravity = gravity;
             this._world.gravity.set(gravity.x, gravity.y, gravity.z);
         }
+		
+		public getGravity() : Vector3 {
+			return this._gravity;
+		}
 
         public registerMesh(mesh: AbstractMesh, impostor: number, options?: PhysicsBodyCreationOptions): any {
             this.unregisterMesh(mesh);

--- a/src/Physics/Plugins/babylon.oimoJSPlugin.js
+++ b/src/Physics/Plugins/babylon.oimoJSPlugin.js
@@ -3,6 +3,7 @@ var BABYLON;
     var OimoJSPlugin = (function () {
         function OimoJSPlugin() {
             this._registeredMeshes = [];
+            this.name = "oimo";
             /**
              * Update the body position according to the mesh position
              * @param mesh
@@ -42,7 +43,10 @@ var BABYLON;
             this._world.clear();
         };
         OimoJSPlugin.prototype.setGravity = function (gravity) {
-            this._world.gravity = gravity;
+            this._gravity = this._world.gravity = gravity;
+        };
+        OimoJSPlugin.prototype.getGravity = function () {
+            return this._gravity;
         };
         OimoJSPlugin.prototype.registerMesh = function (mesh, impostor, options) {
             this.unregisterMesh(mesh);

--- a/src/Physics/Plugins/babylon.oimoJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.oimoJSPlugin.ts
@@ -6,6 +6,8 @@ module BABYLON {
         private _registeredMeshes = [];
 		
 		public name = "oimo";
+		
+		private _gravity: Vector3;
 
         private _checkWithEpsilon(value: number): number {
             return value < PhysicsEngine.Epsilon ? PhysicsEngine.Epsilon : value;
@@ -17,8 +19,12 @@ module BABYLON {
         }
 
         public setGravity(gravity: Vector3): void {
-            this._world.gravity = gravity;
+            this._gravity = this._world.gravity = gravity;
         }
+		
+		public getGravity() : Vector3 {
+			return this._gravity;
+		}
 
         public registerMesh(mesh: AbstractMesh, impostor: number, options: PhysicsBodyCreationOptions): any {
             this.unregisterMesh(mesh);

--- a/src/Physics/Plugins/babylon.oimoJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.oimoJSPlugin.ts
@@ -4,6 +4,8 @@ module BABYLON {
     export class OimoJSPlugin implements IPhysicsEnginePlugin {
         private _world;
         private _registeredMeshes = [];
+		
+		public name = "oimo";
 
         private _checkWithEpsilon(value: number): number {
             return value < PhysicsEngine.Epsilon ? PhysicsEngine.Epsilon : value;

--- a/src/Physics/babylon.physicsEngine.js
+++ b/src/Physics/babylon.physicsEngine.js
@@ -21,6 +21,9 @@ var BABYLON;
             this.gravity = gravity || new BABYLON.Vector3(0, -9.807, 0);
             this._currentPlugin.setGravity(this.gravity);
         };
+        PhysicsEngine.prototype._getGravity = function () {
+            return this._currentPlugin.getGravity();
+        };
         PhysicsEngine.prototype._registerMesh = function (mesh, impostor, options) {
             return this._currentPlugin.registerMesh(mesh, impostor, options);
         };
@@ -47,6 +50,9 @@ var BABYLON;
         };
         PhysicsEngine.prototype.getPhysicsBodyOfMesh = function (mesh) {
             return this._currentPlugin.getPhysicsBodyOfMesh(mesh);
+        };
+        PhysicsEngine.prototype.getPhysicsPluginName = function () {
+            return this._currentPlugin.name;
         };
         // Statics
         PhysicsEngine.NoImpostor = 0;

--- a/src/Physics/babylon.physicsEngine.ts
+++ b/src/Physics/babylon.physicsEngine.ts
@@ -1,5 +1,6 @@
 ﻿module BABYLON {
     export interface IPhysicsEnginePlugin {
+		name: string;
         initialize(iterations?: number);
         setGravity(gravity: Vector3): void;
         runOneStep(delta: number): void;
@@ -90,6 +91,10 @@
         public getPhysicsBodyOfMesh(mesh: AbstractMesh) {
             return this._currentPlugin.getPhysicsBodyOfMesh(mesh);
         }
+		
+		public getPhysicsPluginName() : string {
+			return this._currentPlugin.name;
+		}
 
         // Statics
         public static NoImpostor = 0;

--- a/src/Physics/babylon.physicsEngine.ts
+++ b/src/Physics/babylon.physicsEngine.ts
@@ -3,6 +3,7 @@
 		name: string;
         initialize(iterations?: number);
         setGravity(gravity: Vector3): void;
+		getGravity() : Vector3;
         runOneStep(delta: number): void;
         registerMesh(mesh: AbstractMesh, impostor: number, options: PhysicsBodyCreationOptions): any;
         registerMeshesAsCompound(parts: PhysicsCompoundBodyPart[], options: PhysicsBodyCreationOptions): any;
@@ -55,6 +56,10 @@
             this.gravity = gravity || new Vector3(0, -9.807, 0);
             this._currentPlugin.setGravity(this.gravity);
         }
+		
+		public _getGravity() : Vector3 {
+			return this._currentPlugin.getGravity();
+		}
 
         public _registerMesh(mesh: AbstractMesh, impostor: number, options: PhysicsBodyCreationOptions): any {
             return this._currentPlugin.registerMesh(mesh, impostor, options);

--- a/src/Tools/babylon.sceneSerializer.js
+++ b/src/Tools/babylon.sceneSerializer.js
@@ -684,7 +684,7 @@ var BABYLON;
             //Physics
             if (scene.isPhysicsEnabled()) {
                 serializationObject.physicsEnabled = true;
-                serializationObject.physicsGravity = 0;
+                serializationObject.physicsGravity = scene.getPhysicsEngine()._getGravity();
                 serializationObject.physicsEngine = scene.getPhysicsEngine().getPhysicsPluginName();
             }
             // Lights

--- a/src/Tools/babylon.sceneSerializer.js
+++ b/src/Tools/babylon.sceneSerializer.js
@@ -671,6 +671,8 @@ var BABYLON;
             serializationObject.clearColor = scene.clearColor.asArray();
             serializationObject.ambientColor = scene.ambientColor.asArray();
             serializationObject.gravity = scene.gravity.asArray();
+            serializationObject.collisionsEnabled = scene.collisionsEnabled;
+            serializationObject.workerCollisions = scene.workerCollisions;
             // Fog
             if (scene.fogMode && scene.fogMode !== 0) {
                 serializationObject.fogMode = scene.fogMode;
@@ -678,6 +680,12 @@ var BABYLON;
                 serializationObject.fogStart = scene.fogStart;
                 serializationObject.fogEnd = scene.fogEnd;
                 serializationObject.fogDensity = scene.fogDensity;
+            }
+            //Physics
+            if (scene.isPhysicsEnabled()) {
+                serializationObject.physicsEnabled = true;
+                serializationObject.physicsGravity = 0;
+                serializationObject.physicsEngine = scene.getPhysicsEngine().getPhysicsPluginName();
             }
             // Lights
             serializationObject.lights = [];

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -816,7 +816,7 @@
             //Physics
             if (scene.isPhysicsEnabled()) {
                 serializationObject.physicsEnabled = true;
-                serializationObject.physicsGravity = scene.getPhysicsEngine()._getGravity();
+                serializationObject.physicsGravity = scene.getPhysicsEngine()._getGravity().asArray();
                 serializationObject.physicsEngine = scene.getPhysicsEngine().getPhysicsPluginName();
             }
 

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -812,6 +812,13 @@
                 serializationObject.fogEnd = scene.fogEnd;
                 serializationObject.fogDensity = scene.fogDensity;
             }
+            
+            //Physics
+            if(scene.isPhysicsEnabled()) {
+                serializationObject.physicsEnabled = true;
+                serializationObject.physicsGravity = 0;
+                serializationObject.physicsEngine = scene.getPhysicsEngine().getPhysicsPluginName();
+            }
 
             // Lights
             serializationObject.lights = [];

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -814,9 +814,9 @@
             }
             
             //Physics
-            if(scene.isPhysicsEnabled()) {
+            if (scene.isPhysicsEnabled()) {
                 serializationObject.physicsEnabled = true;
-                serializationObject.physicsGravity = 0;
+                serializationObject.physicsGravity = scene.getPhysicsEngine()._getGravity();
                 serializationObject.physicsEngine = scene.getPhysicsEngine().getPhysicsPluginName();
             }
 


### PR DESCRIPTION
The Physics engine can now be defined in the babylon file (optional).
if the physics engine is defined, one can select between the two plugins that BJS has and set the gravity individually.
If it is not defined, but bodies have physics enabled, default values will be used.