### PR TITLE
Update babylon.sceneSerializer.ts

### DIFF
--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -131,13 +131,16 @@
         serializationObject.instances = [];
         for (var index = 0; index < mesh.instances.length; index++) {
             var instance = mesh.instances[index];
-            var serializationInstance = {
+            var serializationInstance : any = {
                 name: instance.name,
                 position: instance.position.asArray(),
-                rotation: instance.rotation.asArray(),
-                rotationQuaternion: instance.rotationQuaternion.asArray(),
                 scaling: instance.scaling.asArray()
             };
+            if (instance.rotationQuaternion) {
+                serializationInstance.rotationQuaternion = instance.rotationQuaternion.asArray();
+            } else if (instance.rotation) {
+                serializationInstance.rotation = instance.rotation.asArray();
+            }
             serializationObject.instances.push(serializationInstance);
 
             // Animations


### PR DESCRIPTION
Fixing instance serialization when no quaternion exists.