### PR TITLE
Update babylon.renderTargetTexture.ts

### DIFF
--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -126,6 +126,10 @@
 
         public render(useCameraPostProcess?: boolean, dumpForDebug?: boolean) {
             var scene = this.getScene();
+            
+            if (this.activeCamera !== scene.activeCamera) {
+        		scene.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix(true));
+        	}
 
             if (this._waitingRenderList) {
                 this.renderList = [];
@@ -179,6 +183,10 @@
             if (this.onAfterUnbind) {
                 this.onAfterUnbind();
             }
+            
+            if (this.activeCamera !== scene.activeCamera) {
+        		scene.setTransformMatrix(scene.activeCamera.getViewMatrix(), scene.activeCamera.getProjectionMatrix(true));
+        	}
 
             scene.resetCachedMaterial();
         }


### PR DESCRIPTION
RenderTargetTexture can now renders the activeCamera's view and not the scene's active camera.