### PR TITLE
Adding Contact Data to physics collisions

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -74,7 +74,7 @@
         public _physicsMass: number;
         public _physicsFriction: number;
         public _physicRestitution: number;
-        public onPhysicsCollide: (collidedMesh: AbstractMesh) => void; 
+        public onPhysicsCollide: (collidedMesh: AbstractMesh, contact: any) => void; 
 
         // Collisions
         private _checkCollisions = false;

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -57,7 +57,7 @@
                             //find the mesh that collided with the registered mesh
                             for (var idx = 0; idx < this._registeredMeshes.length; idx++) {
                                 if (this._registeredMeshes[idx].body == e.body) {
-                                    registeredMesh.mesh.onPhysicsCollide(this._registeredMeshes[idx].mesh);
+                                    registeredMesh.mesh.onPhysicsCollide(this._registeredMeshes[idx].mesh, e.contact);
                                 }
                             }
                         }

--- a/src/Physics/Plugins/babylon.oimoJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.oimoJSPlugin.ts
@@ -402,7 +402,7 @@ module BABYLON {
                             //get the mesh and execute the callback
                             var otherMesh = mesh.getScene().getMeshByUniqueID(otherUniqueId);
                             if (otherMesh)
-                                mesh.onPhysicsCollide(otherMesh);
+                                mesh.onPhysicsCollide(otherMesh, contact);
                         }
                         contact = contact.next;
                     }


### PR DESCRIPTION
When the physics engines find collision they create a contact object
that includes information that might be useful for the game developers.
This small change sends the contact objects ob both engines to the
onPhysicsCollide function.