### PR TITLE
fixed arcRotateCamera target position - using absolute position now

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.js
+++ b/src/Cameras/babylon.arcRotateCamera.js
@@ -102,7 +102,7 @@ var BABYLON;
             configurable: true
         });
         ArcRotateCamera.prototype._getTargetPosition = function () {
-            return this.target.getAbsolutePosition() || this.target;
+            return this.target.getAbsolutePosition ? this.target.getAbsolutePosition() : this.target;
         };
         // Cache
         ArcRotateCamera.prototype._initCache = function () {

--- a/src/Cameras/babylon.arcRotateCamera.js
+++ b/src/Cameras/babylon.arcRotateCamera.js
@@ -102,7 +102,7 @@ var BABYLON;
             configurable: true
         });
         ArcRotateCamera.prototype._getTargetPosition = function () {
-            return this.target.position || this.target;
+            return this.target.getAbsolutePosition() || this.target;
         };
         // Cache
         ArcRotateCamera.prototype._initCache = function () {

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -89,7 +89,7 @@
         }
 
         public _getTargetPosition(): Vector3 {
-            return this.target.position || this.target;
+            return this.target.getAbsolutePosition() || this.target;
         }
 
         // Cache

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -89,7 +89,7 @@
         }
 
         public _getTargetPosition(): Vector3 {
-            return this.target.getAbsolutePosition() || this.target;
+			return this.target.getAbsolutePosition ? this.target.getAbsolutePosition() : this.target;
         }
 
         // Cache


### PR DESCRIPTION
ArcRotateCamera looks at the position relativ to its targets parent mesh... 
That, of course, causes unexpected behaviour. 

Example:

    window.addEventListener('DOMContentLoaded', function(){
    var canvas = <HTMLCanvasElement>document.getElementById('renderCanvas');
    
    var engine: Engine = new Engine(canvas);
    var scene = new Scene(engine);
    
    Mesh.CreateGround("ground", 1000, 1000, 10, scene, true);
    new PointLight("omni", new Vector3(0, 50, 0), scene);



    var box = Mesh.CreateBox("box", 50, scene);
    var parentBox = Mesh.CreateBox("boxParent", 50, scene);

    box.parent = parentBox;
    box.position.y = -75;

    var arCam= new ArcRotateCamera("Camera", 45, 0.5, 500, box, scene);
    arCam.attachControl(engine.getRenderingCanvas());
    
    
    arCam.target = box;
    
    scene.registerBeforeRender(function(){
        parentBox.position.y++;
        box.position.x += 0.5;        
    })
    box.getAbsolutePosition();
    
    engine.runRenderLoop(() => {
            scene.render();
    });
    });