### PR TITLE
Blender Exporter 4.1.0

### DIFF
--- a/src/Bones/babylon.bone.ts
+++ b/src/Bones/babylon.bone.ts
@@ -2,6 +2,7 @@
     export class Bone extends Node {
         public children = new Array<Bone>();
         public animations = new Array<Animation>();
+        public length : number;
 
         private _skeleton: Skeleton;
         private _matrix: Matrix;

--- a/src/Bones/babylon.skeleton.ts
+++ b/src/Bones/babylon.skeleton.ts
@@ -155,6 +155,10 @@
                 };
 
                 serializationObject.bones.push(serializedBone);
+                
+                if (bone.length){
+                    serializedBone.length = bone.length;
+                }
 
                 if (bone.animations && bone.animations.length > 0) {
                     serializedBone.animation = bone.animations[0].serialize();
@@ -175,7 +179,11 @@
                 }
     
                 var bone = new Bone(parsedBone.name, skeleton, parentBone, Matrix.FromArray(parsedBone.matrix));
-    
+                
+                if (parsedBone.length){
+                    bone.length = parsedBone.length;
+                }
+                
                 if (parsedBone.animation) {
                     bone.animations.push(Animation.Parse(parsedBone.animation));
                 }


### PR DESCRIPTION
added:
- support for Bone.length

fixed:
- Error caused when # of influencers exceed 8
- Flawed checking for bone animation optimization