### PR TITLE
renderingGroupId fix for auto-lod

### DIFF
--- a/src/Mesh/babylon.meshSimplification.ts
+++ b/src/Mesh/babylon.meshSimplification.ts
@@ -574,6 +574,7 @@
             this._reconstructedMesh.material = this._mesh.material;
             this._reconstructedMesh.parent = this._mesh.parent;
             this._reconstructedMesh.isVisible = false;
+            this._reconstructedMesh.renderingGroupId = this._mesh.renderingGroupId;
         }
 
         private isFlipped(vertex1: DecimationVertex, vertex2: DecimationVertex, point: Vector3, deletedArray: Array<boolean>, borderFactor: number, delTr: Array<DecimationTriangle>): boolean {


### PR DESCRIPTION
keeping the original renderingGroupId for the LOD level