### PR TITLE
fix : simplify the RotationFromAxis computation, less temp Vector3

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1079,8 +1079,8 @@
             return center;
         }
 
-        /** 
-         * Given three orthogonal left-handed oriented Vector3 axis in space (target system), 
+        /**
+         * Given three orthogonal normalized left-handed oriented Vector3 axis in space (target system),
          * RotationFromAxis() returns the rotation Euler angles (ex : rotation.x, rotation.y, rotation.z) to apply
          * to something in order to rotate it from its local system to the given target system.
          */
@@ -1090,17 +1090,17 @@
             return rotation;
         }
 
-        /** 
+        /**
          * The same than RotationFromAxis but updates the passed ref Vector3 parameter.
          */
         public static RotationFromAxisToRef(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref: Vector3): void {
-            var u = Vector3.Normalize(axis1);
-            var w = Vector3.Normalize(axis3);
+            var u = axis1.normalize();
+            var w = axis3.normalize();
 
             // world axis
             var X = Axis.X;
             var Y = Axis.Y;
-            
+
             // equation unknowns and vars
             var yaw = 0.0;
             var pitch = 0.0;
@@ -1111,14 +1111,13 @@
             var t = 0.0;
             var sign = -1.0;
             var nbRevert = 0;
-            var cross: Vector3;
+            var cross: Vector3 = Vector3.Zero();
             var dot = 0.0;
 
             // step 1  : rotation around w
             // Rv3(u) = u1, and u1 belongs to plane xOz
             // Rv3(w) = w1 = w invariant
             var u1: Vector3;
-            var v1: Vector3;
             if (Tools.WithinEpsilon(w.z, 0, Engine.Epsilon)) {
                 z = 1.0;
             }
@@ -1133,9 +1132,7 @@
 
             u1 = new Vector3(x, y, z);
             u1.normalize();
-            v1 = Vector3.Cross(w, u1);     // v1 image of v through rotation around w
-            v1.normalize();
-            cross = Vector3.Cross(u, u1);  // returns same direction as w (=local z) if positive angle : cross(source, image)
+            Vector3.CrossToRef(u, u1, cross);  // returns same direction as w (=local z) if positive angle : cross(source, image)
             cross.normalize();
             if (Vector3.Dot(w, cross) < 0) {
                 sign = 1.0;
@@ -1148,10 +1145,9 @@
             if (Vector3.Dot(u1, X) < 0) { // checks X orientation
                 roll = Math.PI + roll;
                 u1 = u1.scaleInPlace(-1);
-                v1 = v1.scaleInPlace(-1);
                 nbRevert++;
             }
-            
+
             // step 2 : rotate around u1
             // Ru1(w1) = Ru1(w) = w2, and w2 belongs to plane xOz
             // u1 is yet in xOz and invariant by Ru1, so after this step u1 and w2 will be in xOz
@@ -1160,7 +1156,7 @@
             x = 0.0;
             y = 0.0;
             z = 0.0;
-            sign = -1;
+            sign = -1.0;
             if (Tools.WithinEpsilon(w.z, 0, Engine.Epsilon)) {
                 x = 1.0;
             }
@@ -1174,7 +1170,7 @@
             w2.normalize();
             v2 = Vector3.Cross(w2, u1);   // v2 image of v1 through rotation around u1
             v2.normalize();
-            cross = Vector3.Cross(w, w2); // returns same direction as u1 (=local x) if positive angle : cross(source, image)
+            Vector3.CrossToRef(w, w2, cross); // returns same direction as u1 (=local x) if positive angle : cross(source, image)
             cross.normalize();
             if (Vector3.Dot(u1, cross) < 0) {
                 sign = 1.0;
@@ -1185,15 +1181,13 @@
             pitch = Math.acos(dot) * sign;
             if (Vector3.Dot(v2, Y) < 0) { // checks for Y orientation
                 pitch = Math.PI + pitch;
-                v2 = v2.scaleInPlace(-1);
-                w2 = w2.scaleInPlace(-1);
                 nbRevert++;
             }
-            
+
             // step 3 : rotate around v2
             // Rv2(u1) = X, same as Rv2(w2) = Z, with X=(1,0,0) and Z=(0,0,1)
-            sign = -1;
-            cross = Vector3.Cross(X, u1); // returns same direction as Y if positive angle : cross(source, image)
+            sign = -1.0;
+            Vector3.CrossToRef(X, u1, cross); // returns same direction as Y if positive angle : cross(source, image)
             cross.normalize();
             if (Vector3.Dot(cross, Y) < 0) {
                 sign = 1.0;
@@ -2462,7 +2456,7 @@
             target.subtractToRef(eye, this._zAxis);
             this._zAxis.normalize();
 
-            // X axis            
+            // X axis
             Vector3.CrossToRef(up, this._zAxis, this._xAxis);
 
             if (this._xAxis.lengthSquared() === 0) {
@@ -3053,7 +3047,7 @@
         }
 
         /**
-        * Function will create a new transformed ray starting from origin and ending at the end point. Ray's length will be set, and ray will be 
+        * Function will create a new transformed ray starting from origin and ending at the end point. Ray's length will be set, and ray will be
         * transformed to the given world matrix.
         * @param origin The origin point
         * @param end The end point
@@ -3367,8 +3361,8 @@
         private _binormals = new Array<Vector3>();
         private _raw: boolean;
 
-        /** 
-        * new Path3D(path, normal, raw) 
+        /**
+        * new Path3D(path, normal, raw)
         * path : an array of Vector3, the curve axis of the Path3D
         * normal (optional) : Vector3, the first wanted normal to the curve. Ex (0, 1, 0) for a vertical normal.
         * raw (optional, default false) : boolean, if true the returned Path3D isn't normalized. Useful to depict path acceleration or speed.
@@ -3424,7 +3418,7 @@
             if (!this._raw) {
                 this._tangents[l - 1].normalize();
             }
-            
+
             // normals and binormals at first point : arbitrary vector with _normalVector()
             var tg0 = this._tangents[0];
             var pp0 = this._normalVector(this._curve[0], tg0, firstNormal);
@@ -3453,8 +3447,8 @@
                     this._tangents[i] = prev.add(cur);
                     this._tangents[i].normalize();
                 }
-                this._distances[i] = this._distances[i - 1] + prev.length();   
-                      
+                this._distances[i] = this._distances[i - 1] + prev.length();
+
                 // normals and binormals
                 // http://www.cs.cmu.edu/afs/andrew/scs/cs/15-462/web/old/asst2camera.html
                 curTang = this._tangents[i];
@@ -3502,7 +3496,7 @@
 
             if (va === undefined || va === null) {
                 var point: Vector3;
-                if (!Tools.WithinEpsilon(vt.y, 1, Engine.Epsilon)) {     // search for a point in the plane 
+                if (!Tools.WithinEpsilon(vt.y, 1, Engine.Epsilon)) {     // search for a point in the plane
                     point = new Vector3(0, -1, 0);
                 }
                 else if (!Tools.WithinEpsilon(vt.x, 1, Engine.Epsilon)) {
@@ -3619,6 +3613,3 @@
         }
     }
 }
-
-
-


### PR DESCRIPTION
First optimization : 
The `RotationFromAxis()` has been slightly simplified and some temporary Vector3 were deleted. 
This is better for the GC if the method is called for each solid particle of a SPS for instance.

Some other optimization on this method up to come later.
I wish I can use soon only variables with scalar values inside instead of the current Vector3.