### PR TITLE
Animation ranges for Nodes

### DIFF
--- a/src/Bones/babylon.skeleton.ts
+++ b/src/Bones/babylon.skeleton.ts
@@ -80,11 +80,11 @@
                 if (sourceBone){
                     ret = ret && this.bones[i].copyAnimationRange(sourceBone, name, frameOffset, rescaleAsRequired);
                 }else{
-                    BABYLON.Tools.Warn("copyAnimationRange: not same rig, missing source bone " + name);
+                    BABYLON.Tools.Warn("copyAnimationRange: not same rig, missing source bone " + boneName);
                     ret = false;
                 }
             }
-            // do not call createRange(), since it also is done to bones, which was already done
+            // do not call createAnimationRange(), since it also is done to bones, which was already done
             var range = source.getAnimationRange(name);
             this._ranges[name] = new AnimationRange(name, range.from + frameOffset, range.to + frameOffset);
             return ret;

--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -607,6 +607,7 @@
             
             // Animations
             Animation.AppendSerializedAnimations(this, serializationObject);
+            serializationObject.ranges = this.serializeAnimationRanges();
 
             // Layer mask
             serializationObject.layerMask = this.layerMask;
@@ -718,6 +719,7 @@
 
                     camera.animations.push(Animation.Parse(parsedAnimation));
                 }
+                Node.ParseAnimationRanges(camera, parsedCamera, scene);
             }
 
             if (parsedCamera.autoAnimate) {

--- a/src/Lights/babylon.light.ts
+++ b/src/Lights/babylon.light.ts
@@ -186,6 +186,7 @@
 
                     light.animations.push(Animation.Parse(parsedAnimation));
                 }
+                Node.ParseAnimationRanges(light, parsedLight, scene);
             }
 
             if (parsedLight.autoAnimate) {

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1477,6 +1477,7 @@
 
                     mesh.animations.push(Animation.Parse(parsedAnimation));
                 }
+                Node.ParseAnimationRanges(mesh, parsedMesh, scene);
             }
 
             if (parsedMesh.autoAnimate) {
@@ -1516,6 +1517,7 @@
 
                             instance.animations.push(Animation.Parse(parsedAnimation));
                         }
+                        Node.ParseAnimationRanges(instance, parsedMesh, scene);
                     }
                 }
             }

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -145,10 +145,12 @@
 
             // Animations
             Animation.AppendSerializedAnimations(instance, serializationInstance);
+            serializationInstance.ranges = instance.serializeAnimationRanges();
         }
 
         // Animations
         Animation.AppendSerializedAnimations(mesh, serializationObject);
+        serializationObject.ranges = mesh.serializeAnimationRanges();
 
         // Layer mask
         serializationObject.layerMask = mesh.layerMask;


### PR DESCRIPTION
Added methods to allow for AnimationRanges on lights, cameras, & meshes.

These can come from a .babylon & also be serialized. Tested using
Blender exporter.  Need more testing there so, exporter not on this PR.

Also, minor changes for skeleton animation ranges.