### PR TITLE
Fix.tmp vars insertion

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -472,8 +472,8 @@
 
             var num = 1.0 / len;
 
-            this.x *= len;
-            this.y *= len;
+            this.x *= num;
+            this.y *= num;
 
             return this;
         }
@@ -786,7 +786,7 @@
                 return this;
 
             var num = 1.0 / len;
-            
+
             this.x *= num;
             this.y *= num;
             this.z *= num;

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -467,7 +467,7 @@
         public normalize(): Vector2 {
             var len = this.length();
 
-            if (len  === 0)
+            if (len === 0)
                 return this;
 
             var num = 1.0 / len;

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -467,13 +467,13 @@
         public normalize(): Vector2 {
             var len = this.length();
 
-            if (len === 0)
+            if (len  === 0)
                 return this;
 
             var num = 1.0 / len;
 
-            this.x *= num;
-            this.y *= num;
+            this.x *= len;
+            this.y *= len;
 
             return this;
         }
@@ -786,7 +786,7 @@
                 return this;
 
             var num = 1.0 / len;
-
+            
             this.x *= num;
             this.y *= num;
             this.z *= num;
@@ -1111,13 +1111,13 @@
             var t = 0.0;
             var sign = -1.0;
             var nbRevert = 0;
-            var cross: Vector3 = Vector3.Zero();
+            var cross: Vector3 = Tmp.Vector3[0];
             var dot = 0.0;
 
             // step 1  : rotation around w
             // Rv3(u) = u1, and u1 belongs to plane xOz
             // Rv3(w) = w1 = w invariant
-            var u1: Vector3;
+            var u1: Vector3 = Tmp.Vector3[1];
             if (Tools.WithinEpsilon(w.z, 0, Engine.Epsilon)) {
                 z = 1.0;
             }
@@ -1130,7 +1130,9 @@
                 z = Math.sqrt(1 / (1 + t * t));
             }
 
-            u1 = new Vector3(x, y, z);
+            u1.x = x;
+            u1.y = y;
+            u1.z = z;
             u1.normalize();
             Vector3.CrossToRef(u, u1, cross);  // returns same direction as w (=local z) if positive angle : cross(source, image)
             cross.normalize();
@@ -1151,8 +1153,8 @@
             // step 2 : rotate around u1
             // Ru1(w1) = Ru1(w) = w2, and w2 belongs to plane xOz
             // u1 is yet in xOz and invariant by Ru1, so after this step u1 and w2 will be in xOz
-            var w2: Vector3;
-            var v2: Vector3;
+            var w2: Vector3 = Tmp.Vector3[2];
+            var v2: Vector3 = Tmp.Vector3[3];
             x = 0.0;
             y = 0.0;
             z = 0.0;
@@ -1166,9 +1168,11 @@
                 z = Math.sqrt(1 / (1 + t * t));
             }
 
-            w2 = new Vector3(x, y, z);
+            w2.x = x;
+            w2.y = y;
+            w2.z = z;
             w2.normalize();
-            v2 = Vector3.Cross(w2, u1);   // v2 image of v1 through rotation around u1
+            Vector3.CrossToRef(w2, u1, v2);   // v2 image of v1 through rotation around u1
             v2.normalize();
             Vector3.CrossToRef(w, w2, cross); // returns same direction as u1 (=local x) if positive angle : cross(source, image)
             cross.normalize();
@@ -3621,7 +3625,8 @@
         public static Int: number[] = [0, 0, 0, 0, 0, 0];                                     // 6 temp integers at once should be enough
         public static Float: number[] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0];                       // 6 temp floats at once should be enough
         public static Vector2: Vector2[] = [Vector2.Zero(), Vector2.Zero(), Vector2.Zero()];  // 3 temp Vector2 at once should be enough
-        public static Vector3: Vector3[] = [Vector3.Zero(), Vector3.Zero(), Vector3.Zero()];  // 3 temp Vector3 at once should be enough
+        public static Vector3: Vector3[] = [Vector3.Zero(), Vector3.Zero(), Vector3.Zero()
+                                        , Vector3.Zero(), Vector3.Zero(), Vector3.Zero()];    // 6 temp Vector3 at once should be enough
         public static Vector4: Vector4[] = [Vector4.Zero(), Vector4.Zero(), Vector4.Zero()];  // 3 temp Vector4 at once should be enough
         public static Quaternion: Quaternion[] = [new Quaternion(0, 0, 0, 0)];                // 1 temp Quaternion at once should be enough
         public static Matrix: Matrix[] = [Matrix.Zero(), Matrix.Zero(),
@@ -3630,4 +3635,3 @@
                                           Matrix.Zero(), Matrix.Zero()];                      // 6 temp Matrices at once should be enough
     }
 }
-


### PR DESCRIPTION
first use for me of the Tmp class.
The math method `RotationFromAxis()` doesn't use any longer any temporary internal Vector3.