### PR TITLE
Bugfix : Do not add a loading screen if there is already one

### DIFF
--- a/src/Tools/babylon.loadingScreen.ts
+++ b/src/Tools/babylon.loadingScreen.ts
@@ -19,6 +19,10 @@ module BABYLON {
 		}
 		
 		public displayLoadingUI(): void {
+            if (this._loadingDiv) {
+                // Do not add a loading screen if there is already one
+                return;
+            }
 			this._loadingDiv = document.createElement("div");
 
 		    this._loadingDiv.id = "babylonjsLoadingDiv";


### PR DESCRIPTION
This bug can easily be reproduced when loading several assets with several way (Load, ImportMesh, AssetManager)