### PR TITLE
Pointer down up

### DIFF
--- a/src/babylon.scene.js
+++ b/src/babylon.scene.js
@@ -137,6 +137,7 @@ var BABYLON;
             this._transformMatrix = BABYLON.Matrix.Zero();
             this._edgesRenderers = new BABYLON.SmartArray(16);
             this._uniqueIdCounter = 0;
+            this._pickedMeshName = null;
             this._engine = engine;
             engine.scenes.push(this);
             this._renderingManager = new BABYLON.RenderingManager(this);
@@ -360,12 +361,13 @@ var BABYLON;
                     return;
                 }
                 _this._updatePointerPosition(evt);
+                _this._pickedMeshName = null;
                 _this._startingPointerPosition.x = _this._pointerX;
                 _this._startingPointerPosition.y = _this._pointerY;
                 _this._startingPointerTime = new Date().getTime();
                 var predicate = null;
                 // Meshes
-                if (!_this.onPointerDown) {
+                if (!_this.onPointerDown && !_this.onPointerDownUp) {
                     predicate = function (mesh) {
                         return mesh.isPickable && mesh.isVisible && mesh.isReady() && mesh.actionManager && mesh.actionManager.hasPointerTriggers;
                     };
@@ -373,6 +375,8 @@ var BABYLON;
                 var pickResult = _this.pick(_this._pointerX, _this._pointerY, predicate, false, _this.cameraToUseForPointers);
                 if (pickResult.hit && pickResult.pickedMesh) {
                     if (pickResult.pickedMesh.actionManager) {
+                        _this._pickedMeshName = pickResult.pickedMesh.name;
+                        console.log(_this._pickedMeshName);
                         if (pickResult.pickedMesh.actionManager.hasPickTriggers) {
                             switch (evt.button) {
                                 case 0:
@@ -433,7 +437,7 @@ var BABYLON;
                 }
                 var predicate = null;
                 _this._updatePointerPosition(evt);
-                if (!_this.onPointerUp) {
+                if (!_this.onPointerUp && !_this.onPointerDownUp) {
                     predicate = function (mesh) {
                         return mesh.isPickable && mesh.isVisible && mesh.isReady() && mesh.actionManager && (mesh.actionManager.hasPickTriggers || mesh.actionManager.hasSpecificTrigger(BABYLON.ActionManager.OnLongPressTrigger));
                     };
@@ -441,6 +445,9 @@ var BABYLON;
                 // Meshes
                 var pickResult = _this.pick(_this._pointerX, _this._pointerY, predicate, false, _this.cameraToUseForPointers);
                 if (pickResult.hit && pickResult.pickedMesh) {
+                    if (_this.onPointerDownUp && _this._pickedMeshName != null && pickResult.pickedMesh.name == _this._pickedMeshName) {
+                        _this.onPointerDownUp(evt, pickResult);
+                    }
                     if (pickResult.pickedMesh.actionManager) {
                         pickResult.pickedMesh.actionManager.processTrigger(BABYLON.ActionManager.OnPickUpTrigger, BABYLON.ActionEvent.CreateNew(pickResult.pickedMesh, evt));
                         if (Math.abs(_this._startingPointerPosition.x - _this._pointerX) < BABYLON.ActionManager.DragMovementThreshold && Math.abs(_this._startingPointerPosition.y - _this._pointerY) < BABYLON.ActionManager.DragMovementThreshold) {

--- a/src/babylon.scene.js
+++ b/src/babylon.scene.js
@@ -374,9 +374,8 @@ var BABYLON;
                 }
                 var pickResult = _this.pick(_this._pointerX, _this._pointerY, predicate, false, _this.cameraToUseForPointers);
                 if (pickResult.hit && pickResult.pickedMesh) {
+                    _this._pickedMeshName = pickResult.pickedMesh.name;
                     if (pickResult.pickedMesh.actionManager) {
-                        _this._pickedMeshName = pickResult.pickedMesh.name;
-                        console.log(_this._pickedMeshName);
                         if (pickResult.pickedMesh.actionManager.hasPickTriggers) {
                             switch (evt.button) {
                                 case 0:


### PR DESCRIPTION
I added a OnPointerUpDown click event to the scene. It saves the Name of the Mesh the user clicked on when the OnPointerDown event is raised. And checks if the Name of the Mesh is still the same on the OnPointerUp event. If yes => fire OnPointerDownUp.

so you can do something like this:
`     
scene.onPointerDownUp = function(evt, pickResult){
	pickResult.pickedMesh.material.diffuseColor = new BABYLON.Color3(0.3, 0.9, 0.3);
	pickResult.pickedMesh.active = true;
}
`

In a scene where the user can move around with the camera and interact with diffrent mesh by clicking on it, it helps that the user doesnt accently raise a click event on a mesh when he actually wants to just rotate the camera. 

Something General:
As you can see at my github account, I am not expirienced with github (or version controll over all). I hope thats how its done.
- fork babylon.js to my github account
- create a branch in of the forked repo where I can add the new feature or do some bug fixing
- when done I test it
- if it works i create a pull request

I only changed the files typescript and javascript file in the source (I created the javascript file with gulp typescript-compile). Is that enough or do I have to also change the files in the dist or the definitely typed file?