### PR TITLE
Tags Serialization correction

### DIFF
--- a/src/Tools/babylon.tags.js
+++ b/src/Tools/babylon.tags.js
@@ -31,11 +31,23 @@ var BABYLON;
             }
             return !BABYLON.Tools.IsEmpty(obj._tags);
         };
-        Tags.GetTags = function (obj) {
+        Tags.GetTags = function (obj, asString) {
+            if (asString === void 0) { asString = true; }
             if (!obj._tags) {
                 return null;
             }
-            return obj._tags;
+            if (asString) {
+                var tagsArray = [];
+                for (var tag in obj._tags) {
+                    if (obj._tags.hasOwnProperty(tag) && obj._tags[tag] === true) {
+                        tagsArray.push(tag);
+                    }
+                }
+                return tagsArray.join(" ");
+            }
+            else {
+                return obj._tags;
+            }
         };
         // the tags 'true' and 'false' are reserved and cannot be used as tags
         // a tag cannot start with '||', '&&', and '!'

--- a/src/Tools/babylon.tags.ts
+++ b/src/Tools/babylon.tags.ts
@@ -35,11 +35,22 @@
             return !Tools.IsEmpty(obj._tags);
         }
 
-        public static GetTags(obj: any): any {
+        public static GetTags(obj: any, asString: boolean = true): any {
             if (!obj._tags) {
                 return null;
             }
-            return obj._tags;
+            if(asString) {
+                var tagsArray = []
+                for(var tag in obj._tags) {
+                    if(obj._tags.hasOwnProperty(tag) && obj._tags[tag]===true) {
+                        tagsArray.push(tag);
+                    }
+                }
+                return tagsArray.join(" ");
+            } else {
+                return obj._tags;
+            }
+            
         }
 
         // the tags 'true' and 'false' are reserved and cannot be used as tags


### PR DESCRIPTION
Tags should be serialized as a string with SPACE as delimiter. GetTags
function was extended to support this.