### PR TITLE
Fix arc rotate panning

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.js
+++ b/src/Cameras/babylon.arcRotateCamera.js
@@ -405,9 +405,9 @@ var BABYLON;
                 if (Math.abs(this.inertialPanningY) < BABYLON.Engine.Epsilon)
                     this.inertialPanningY = 0;
                 this._localDirection.copyFromFloats(this.inertialPanningX, this.inertialPanningY, this.inertialPanningY);
+                this._localDirection.multiplyInPlace(this.panningAxis);
                 this._viewMatrix.invertToRef(this._cameraTransformMatrix);
                 BABYLON.Vector3.TransformNormalToRef(this._localDirection, this._cameraTransformMatrix, this._transformedDirection);
-                this._transformedDirection.multiplyInPlace(this.panningAxis);
                 this.target.addInPlace(this._transformedDirection);
             }
             // Limits

--- a/src/Cameras/babylon.arcRotateCamera.js
+++ b/src/Cameras/babylon.arcRotateCamera.js
@@ -42,7 +42,7 @@ var BABYLON;
             this._keys = [];
             this._viewMatrix = new BABYLON.Matrix();
             // Panning
-            this.panningAxis = new BABYLON.Vector3(1, 0, 1);
+            this.panningAxis = new BABYLON.Vector3(1, 1, 0);
             this._isRightClick = false;
             this._isCtrlPushed = false;
             this.checkCollisions = false;
@@ -408,6 +408,10 @@ var BABYLON;
                 this._localDirection.multiplyInPlace(this.panningAxis);
                 this._viewMatrix.invertToRef(this._cameraTransformMatrix);
                 BABYLON.Vector3.TransformNormalToRef(this._localDirection, this._cameraTransformMatrix, this._transformedDirection);
+                //Eliminate y if map panning is enabled (panningAxis == 1,0,1)
+                if (!this.panningAxis.y) {
+                    this._transformedDirection.y = 0;
+                }
                 this.target.addInPlace(this._transformedDirection);
             }
             // Limits

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -443,6 +443,10 @@
                 this._localDirection.multiplyInPlace(this.panningAxis);
                 this._viewMatrix.invertToRef(this._cameraTransformMatrix);
                 Vector3.TransformNormalToRef(this._localDirection, this._cameraTransformMatrix, this._transformedDirection);
+                //Eliminate y if map panning is enabled (panningAxis == 1,0,1)
+                if (!this.panningAxis.y) {
+					this._transformedDirection.y = 0;
+				}
                 this.target.addInPlace(this._transformedDirection);
             }
 

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -440,9 +440,9 @@
                     this.inertialPanningY = 0;
 
                 this._localDirection.copyFromFloats(this.inertialPanningX, this.inertialPanningY, this.inertialPanningY);
+                this._localDirection.multiplyInPlace(this.panningAxis);
                 this._viewMatrix.invertToRef(this._cameraTransformMatrix);
                 Vector3.TransformNormalToRef(this._localDirection, this._cameraTransformMatrix, this._transformedDirection);
-                this._transformedDirection.multiplyInPlace(this.panningAxis);
                 this.target.addInPlace(this._transformedDirection);
             }
 

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -46,7 +46,7 @@
         private _MSGestureHandler: MSGesture;
 
         // Panning
-        public panningAxis: Vector3 = new Vector3(1, 0, 1);
+        public panningAxis: Vector3 = new Vector3(1, 1, 0);
         private _localDirection: Vector3;
         private _transformedDirection: Vector3;
         private _isRightClick: boolean = false;


### PR DESCRIPTION
Fixing the Arc Rotate panning problem.
Up-down was only working under specific terms of transformation (silly, sorry).
It now works correctly.
Also - returned the original values for the panning axis so that the default panning is left right up down 