### PR TITLE
Feature.sps.b box.internal.computation

### DIFF
--- a/src/Culling/babylon.boundingBox.ts
+++ b/src/Culling/babylon.boundingBox.ts
@@ -11,7 +11,7 @@
         private _worldMatrix: Matrix;
 
         constructor(public minimum: Vector3, public maximum: Vector3) {
-            // Bounding vectors            
+            // Bounding vectors
             this.vectors.push(this.minimum.clone());
             this.vectors.push(this.maximum.clone());
 
@@ -32,7 +32,7 @@
 
             this.vectors.push(this.maximum.clone());
             this.vectors[7].y = this.minimum.y;
-            
+
             // OBB
             this.center = this.maximum.add(this.minimum).scale(0.5);
             this.extendSize = this.maximum.subtract(this.minimum).scale(0.5);
@@ -51,6 +51,11 @@
         // Methods
         public getWorldMatrix(): Matrix {
             return this._worldMatrix;
+        }
+
+        public setWorldMatrix(matrix: Matrix): BoundingBox {
+            this._worldMatrix.copyFrom(matrix);
+            return this;
         }
 
         public _update(world: Matrix): void {
@@ -175,4 +180,4 @@
             return true;
         }
     }
-} 
+}


### PR DESCRIPTION
Added a SPS feature : property  `sps.computeBoundingBox`
If set to true (false by default for perf reasons), the Bounding Box is internally computed within the loop computing each vertex position, so no extra re-iteration as a SPS can be huge in term of vertex number.

This property is taken in account only by `setParticles()`
So it's different from `refreshVisibility()` that can be called at any time and recomputes from scratch the BBox.