### PR TITLE
Fix.sps.b box computation

### DIFF
--- a/src/Culling/babylon.boundingBox.ts
+++ b/src/Culling/babylon.boundingBox.ts
@@ -53,11 +53,6 @@
             return this._worldMatrix;
         }
 
-        public setWorldMatrix(matrix: Matrix): BoundingBox {
-            this._worldMatrix.copyFrom(matrix);
-            return this;
-        }
-
         public _update(world: Matrix): void {
             Vector3.FromFloatsToRef(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE, this.minimumWorld);
             Vector3.FromFloatsToRef(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE, this.maximumWorld);

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -669,7 +669,7 @@ module BABYLON {
             }
             if (this._computeBoundingBox) {
                 this.mesh._boundingInfo = new BoundingInfo(this._minimum, this._maximum);
-                this.mesh._boundingInfo.boundingBox.setWorldMatrix(this.mesh._worldMatrix);
+                this.mesh._boundingInfo.update(this.mesh._worldMatrix);
             }
             this.afterUpdateParticles(start, end, update);
         }

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -102,10 +102,8 @@ module BABYLON {
         private _w: number = 0.0;
         private _minimum: Vector3 = Tmp.Vector3[0];
         private _maximum: Vector3 = Tmp.Vector3[1];
-        private _vertexWorld: Vector3 = Tmp.Vector3[2];
 
-
-
+        
         /**
         * Creates a SPS (Solid Particle System) object.
         * @param name the SPS name, this will be the underlying mesh name


### PR DESCRIPTION
Fixed the SPS internal BBox computation : min and max are now computed axis aligned within the loop setting the particles at the mesh vertex positions.
Then only the BBox is generated and updated to the current mesh world matrix as expected.

_documentation in the tuto doc soon_