### PR TITLE
Feature.ground.update coordinate heights

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3705,8 +3705,8 @@
     export class Tmp {
         public static Color3: Color3[] = [Color3.Black(), Color3.Black(), Color3.Black()];
         public static Vector2: Vector2[] = [Vector2.Zero(), Vector2.Zero(), Vector2.Zero()];  // 3 temp Vector2 at once should be enough
-        public static Vector3: Vector3[] = [Vector3.Zero(), Vector3.Zero(), Vector3.Zero()
-            , Vector3.Zero(), Vector3.Zero(), Vector3.Zero()];    // 6 temp Vector3 at once should be enough
+        public static Vector3: Vector3[] = [Vector3.Zero(), Vector3.Zero(), Vector3.Zero(),
+            Vector3.Zero(), Vector3.Zero(), Vector3.Zero(), Vector3.Zero(), Vector3.Zero(), Vector3.Zero()];    // 9 temp Vector3 at once should be enough
         public static Vector4: Vector4[] = [Vector4.Zero(), Vector4.Zero(), Vector4.Zero()];  // 3 temp Vector4 at once should be enough
         public static Quaternion: Quaternion[] = [new Quaternion(0, 0, 0, 0)];                // 1 temp Quaternion at once should be enough
         public static Matrix: Matrix[] = [Matrix.Zero(), Matrix.Zero(),
@@ -3715,5 +3715,3 @@
             Matrix.Zero(), Matrix.Zero()];                      // 6 temp Matrices at once should be enough
     }
 }
-
-

--- a/src/Mesh/babylon.groundMesh.ts
+++ b/src/Mesh/babylon.groundMesh.ts
@@ -194,7 +194,6 @@ module BABYLON {
                     quad.slope.copyFromFloats(cd, h);
                     quad.facet1.copyFromFloats(norm1.x, norm1.y, norm1.z, d1);
                     quad.facet2.copyFromFloats(norm2.x, norm2.y, norm2.z, d2);
-                    this._heightQuads[row * this._subdivisions + col] = quad;
                 }
             }
         }

--- a/src/Mesh/babylon.groundMesh.ts
+++ b/src/Mesh/babylon.groundMesh.ts
@@ -1,4 +1,4 @@
-﻿module BABYLON {
+module BABYLON {
     export class GroundMesh extends Mesh {
         public generateOctree = false;
 
@@ -42,6 +42,7 @@
                 return this.position.y;
             }
             if (!this._heightQuads || this._heightQuads.length == 0) {
+                this._initHeightQuads();
                 this._computeHeightQuads();
             }
             var facet = this._getFacetAt(x, z);
@@ -78,12 +79,25 @@
                 return;
             }
             if (!this._heightQuads || this._heightQuads.length == 0) {
+                this._initHeightQuads();
                 this._computeHeightQuads();
             }
             var facet = this._getFacetAt(x, z);
             ref.x = facet.x;
             ref.y = facet.y;
             ref.z = facet.z;
+        }
+
+        /**
+        * Force the heights to be recomputed for getHeightAtCoordinates() or getNormalAtCoordinates()
+        * if the ground has been updated.
+        * This can be used in the render loop
+        */
+        public updateCoordinateHeights(): void {
+            if (!this._heightQuads || this._heightQuads.length == 0) {
+                this._initHeightQuads();
+            }
+            this._computeHeightQuads();
         }
 
         // Returns the element "facet" from the heightQuads array relative to (x, z) local coordinates
@@ -101,23 +115,36 @@
             return facet;
         }
 
-        // Populates the heightMap array with "facet" elements :
+        //  Creates and populates the heightMap array with "facet" elements :
         // a quad is two triangular facets separated by a slope, so a "facet" element is 1 slope + 2 facets
         // slope : Vector2(c, h) = 2D diagonal line equation setting appart two triangular facets in a quad : z = cx + h
         // facet1 : Vector4(a, b, c, d) = first facet 3D plane equation : ax + by + cz + d = 0
         // facet2 :  Vector4(a, b, c, d) = second facet 3D plane equation : ax + by + cz + d = 0
-        private _computeHeightQuads(): void {
+        private _initHeightQuads(): void {
             this._heightQuads = new Array();
+            for (var row = 0; row < this._subdivisions; row++) {
+                for (var col = 0; col < this._subdivisions; col++) {
+                    var quad = { slope: BABYLON.Vector2.Zero(), facet1: new BABYLON.Vector4(0, 0, 0,0), facet2: new BABYLON.Vector4(0, 0, 0,0) };
+                    this._heightQuads[row * this._subdivisions + col] = quad;
+                }
+            }
+        }
+
+        // Compute each quad element values and update the the heightMap array :
+        // slope : Vector2(c, h) = 2D diagonal line equation setting appart two triangular facets in a quad : z = cx + h
+        // facet1 : Vector4(a, b, c, d) = first facet 3D plane equation : ax + by + cz + d = 0
+        // facet2 :  Vector4(a, b, c, d) = second facet 3D plane equation : ax + by + cz + d = 0
+        private _computeHeightQuads(): void {
             var positions = this.getVerticesData(VertexBuffer.PositionKind);
-            var v1 = Vector3.Zero();
-            var v2 = Vector3.Zero();
-            var v3 = Vector3.Zero();
-            var v4 = Vector3.Zero();
-            var v1v2 = Vector3.Zero();
-            var v1v3 = Vector3.Zero();
-            var v1v4 = Vector3.Zero();
-            var norm1 = Vector3.Zero();
-            var norm2 = Vector3.Zero();
+            var v1 = Tmp.Vector3[0];
+            var v2 = Tmp.Vector3[1];
+            var v3 = Tmp.Vector3[2];
+            var v4 = Tmp.Vector3[3];
+            var v1v2 = Tmp.Vector3[4];
+            var v1v3 = Tmp.Vector3[5];
+            var v1v4 = Tmp.Vector3[6];
+            var norm1 = Tmp.Vector3[7];
+            var norm2 = Tmp.Vector3[8];
             var i = 0;
             var j = 0;
             var k = 0;
@@ -147,7 +174,6 @@
                     // 2D slope V1V4
                     cd = (v4.z - v1.z) / (v4.x - v1.x);
                     h = v1.z - cd * v1.x;             // v1 belongs to the slope
-                    var slope = new Vector2(cd, h);
 
                     // facet equations :
                     // we compute each facet normal vector
@@ -163,14 +189,14 @@
                     norm2.normalize();
                     d1 = -(norm1.x * v1.x + norm1.y * v1.y + norm1.z * v1.z);
                     d2 = -(norm2.x * v2.x + norm2.y * v2.y + norm2.z * v2.z);
-                    var facet1 = new BABYLON.Vector4(norm1.x, norm1.y, norm1.z, d1);
-                    var facet2 = new BABYLON.Vector4(norm2.x, norm2.y, norm2.z, d2);
 
-                    var quad = { slope: slope, facet1: facet1, facet2: facet2 };
-                    this._heightQuads.push(quad);
+                    var quad = this._heightQuads[row * this._subdivisions + col];
+                    quad.slope.copyFromFloats(cd, h);
+                    quad.facet1.copyFromFloats(norm1.x, norm1.y, norm1.z, d1);
+                    quad.facet2.copyFromFloats(norm2.x, norm2.y, norm2.z, d2);
+                    this._heightQuads[row * this._subdivisions + col] = quad;
                 }
             }
         }
     }
 }
-


### PR DESCRIPTION
This PR does two things in the Ground class 
* the private method `_computeHeightQuads()` now never reallocates any memory since the _heightQuads_ array is now created and populated once for all by `_initHeightQuads()`
* a new public method is provided : `updateCoordinateHeights()`. The user now can force, on demand,  the _heightQuads_ array recomputation if, for instance, he morphes his ground within the render loop. (PG forthcoming)

In short, this gives to the ground object now the possibility to do natively such a thing (was done with a ribbon and a dedicated function) at better performance than the example : http://www.babylonjs-playground.com/#1QC4YQ#19