### PR TITLE
new mesh type : LineSystem

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1106,7 +1106,31 @@
 
             return vertexData;
         }
-
+        
+        public static CreateLineSystem(options: {lines: Vector3[][]}): VertexData {
+            var indices = [];
+            var positions = [];
+            var lines = options.lines;
+            var idx = 0;
+            
+            for (var l = 0; l < lines.length; l++) {
+                var points = lines[l];
+                for (var index = 0; index < points.length; index++) {
+                    positions.push(points[index].x, points[index].y, points[index].z);
+                    
+                    if (index > 0) {
+                        indices.push(idx - 1);
+                        indices.push(idx);
+                    }
+                    idx ++;
+                }               
+            }
+            var vertexData = new VertexData();
+            vertexData.indices = indices;
+            vertexData.positions = positions;
+            return vertexData;
+        }
+        
         public static CreateLines(options: { points: Vector3[] }): VertexData {
             var indices = [];
             var positions = [];

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -151,6 +151,34 @@
 
             return torusKnot;
         }
+        
+        public static CreateLineSystem(name: string, options: {lines: Vector3[][], updatable: boolean, instance?: LinesMesh}, scene: Scene): LinesMesh {
+            var instance = options.instance;
+            var lines = options.lines;
+            
+            if (instance) { // lines update
+                var positionFunction = positions => {
+                    var i = 0;
+                    for (var l = 0; l < lines.length; l++) {
+                        var points = lines[l];
+                        for (var p = 0; p < points.length; p++) {
+                            positions[i] = points[p].x;
+                            positions[i + 1] = points[p].y;
+                            positions[i + 2] = points[p].z;
+                            i += 3;
+                        }
+                    }
+                };
+                instance.updateMeshPositions(positionFunction, false);
+                return instance;
+            }
+            
+            // line system creation
+            var lineSystem = new LinesMesh(name, scene);
+            var vertexData = VertexData.CreateLineSystem(options);
+            vertexData.applyToMesh(lineSystem, options.updatable);
+            return lineSystem;
+        }
 
         public static CreateLines(name: string, options: { points: Vector3[], updatable?: boolean, instance?: LinesMesh }, scene: Scene): LinesMesh {
             var instance = options.instance;


### PR DESCRIPTION
new mesh type : LineSystem.
This low level mesh type allows to design several different and independent lines within a single mesh. It is passed an array of lines, each line being an array of successive Vector3.  
It is obviously also updatable with the same method.
```javascript
var ls = BABYLON.MeshBuilder.CreateLineSystem('ls', {lines: lineArray, updatable: true}, scene);
myMorphFunction(lineArray);
ls = BABYLON.MeshBuilder.CreateLineSystem(null, {lines: lineArray, instance: ls});
```
Demo in PG and doc as soon it is pushed in the PG engine.
online example : http://jerome.bousquie.fr/BJS/test/linesystem.html

Once it is merged (if it is), I will be able to refactor (to remove LOC) the current LinesMesh and related VertexData because they are just a case of a LineSystem : a line system with only one line actually.

Then, some light basic helpers could be easily coded on top of the LineSystem: CreateGrid() for instance