### PR TITLE
CreateLines now uses LineSystem

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1131,29 +1131,6 @@
             return vertexData;
         }
 
-        public static CreateLines(options: { points: Vector3[] }): VertexData {
-            var indices = [];
-            var positions = [];
-            var points = options.points;
-
-            for (var index = 0; index < points.length; index++) {
-                positions.push(points[index].x, points[index].y, points[index].z);
-
-                if (index > 0) {
-                    indices.push(index - 1);
-                    indices.push(index);
-                }
-            }
-
-            // Result
-            var vertexData = new VertexData();
-
-            vertexData.indices = indices;
-            vertexData.positions = positions;
-
-            return vertexData;
-        }
-
         public static CreateDashedLines(options: { points: Vector3[], dashSize?: number, gapSize?: number, dashNb?: number }): VertexData {
             var dashSize = options.dashSize || 3;
             var gapSize = options.gapSize || 1;

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -181,27 +181,7 @@
         }
 
         public static CreateLines(name: string, options: { points: Vector3[], updatable?: boolean, instance?: LinesMesh }, scene: Scene): LinesMesh {
-            var instance = options.instance;
-            var points = options.points;
-
-            if (instance) { // lines update
-                var positionFunction = positions => {
-                    var i = 0;
-                    for (var p = 0; p < points.length; p++) {
-                        positions[i] = points[p].x;
-                        positions[i + 1] = points[p].y;
-                        positions[i + 2] = points[p].z;
-                        i += 3;
-                    }
-                };
-                instance.updateMeshPositions(positionFunction, false);
-                return instance;
-            }
-
-            // lines creation
-            var lines = new LinesMesh(name, scene);
-            var vertexData = VertexData.CreateLines(options);
-            vertexData.applyToMesh(lines, options.updatable);
+            var lines = MeshBuilder.CreateLineSystem(name, {lines: [options.points], updatable: options.updatable, instance: options.instance}, scene);
             return lines;
         }
 


### PR DESCRIPTION
* removed `VertexData.CreateLines()`
* changed `MeshBuilder.CreateLines()` : instead of creating its own geometry, it now just calls `MeshBuilder.CreateLineSystem()` with a _lines_ array populated with a single line.