### PR TITLE
Fix a bug when the scene is a data stream (starting with 'data:')

### DIFF
--- a/src/Loading/babylon.sceneLoader.js
+++ b/src/Loading/babylon.sceneLoader.js
@@ -97,11 +97,12 @@ var BABYLON;
                     importMeshFromData(data);
                 }, progressCallBack, database);
             };
-            if (scene.getEngine().enableOfflineSupport) {
+            if (scene.getEngine().enableOfflineSupport && !(sceneFilename.substr && sceneFilename.substr(0, 5) === "data:")) {
                 // Checking if a manifest file has been set for this scene and if offline mode has been requested
                 var database = new BABYLON.Database(rootUrl + sceneFilename, manifestChecked);
             }
             else {
+                // If the scene is a data stream or offline support is not enabled, it's a direct load
                 manifestChecked(true);
             }
         };

--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -123,11 +123,12 @@
                 }, progressCallBack, database);
             };
 
-            if (scene.getEngine().enableOfflineSupport) {
+            if (scene.getEngine().enableOfflineSupport && !(sceneFilename.substr && sceneFilename.substr(0, 5) === "data:")) {
                 // Checking if a manifest file has been set for this scene and if offline mode has been requested
                 var database = new Database(rootUrl + sceneFilename, manifestChecked);
             }
             else {
+                // If the scene is a data stream or offline support is not enabled, it's a direct load
                 manifestChecked(true);
             }
         }


### PR DESCRIPTION
The manifest call is done with a very looooooong URL, and thus never called : the model never loads.