### PR TITLE
Added Parallax Mapping in StandardMaterial

### DIFF
--- a/materialsLibrary/materials/pbr/pbr.fragment.fx
+++ b/materialsLibrary/materials/pbr/pbr.fragment.fx
@@ -797,7 +797,8 @@ void main(void) {
 
 
     #ifdef BUMP
-        normalW = perturbNormal(viewDirectionW);
+		mat3 TBN = cotangent_frame(vNormalW * vBumpInfos.y, -viewDirectionW, vBumpUV);
+		normalW = perturbNormal(viewDirectionW, TBN, vBumpUV);
     #endif
 
     // Ambient color

--- a/src/Materials/babylon.standardMaterial.js
+++ b/src/Materials/babylon.standardMaterial.js
@@ -23,6 +23,8 @@ var BABYLON;
             this.EMISSIVE = false;
             this.SPECULAR = false;
             this.BUMP = false;
+            this.PARALLAX = false;
+            this.PARALLAXOCCLUSION = false;
             this.SPECULAROVERALPHA = false;
             this.CLIPPLANE = false;
             this.ALPHATEST = false;
@@ -119,6 +121,9 @@ var BABYLON;
             this.useSpecularOverAlpha = false;
             this.useReflectionOverAlpha = false;
             this.disableLighting = false;
+            this.useParallax = false;
+            this.useParallaxOcclusion = false;
+            this.parallaxScaleBias = 0.05;
             this.roughness = 0;
             this.indexOfRefraction = 0.98;
             this.invertRefractionY = true;
@@ -308,6 +313,12 @@ var BABYLON;
                     else {
                         needUVs = true;
                         this._defines.BUMP = true;
+                        if (this.useParallax) {
+                            this._defines.PARALLAX = true;
+                            if (this.useParallaxOcclusion) {
+                                this._defines.PARALLAXOCCLUSION = true;
+                            }
+                        }
                     }
                 }
                 if (this.refractionTexture && StandardMaterial.RefractionTextureEnabled) {
@@ -426,6 +437,12 @@ var BABYLON;
                 if (this._defines.BUMP) {
                     fallbacks.addFallback(0, "BUMP");
                 }
+                if (this._defines.PARALLAX) {
+                    fallbacks.addFallback(1, "PARALLAX");
+                }
+                if (this._defines.PARALLAXOCCLUSION) {
+                    fallbacks.addFallback(0, "PARALLAXOCCLUSION");
+                }
                 if (this._defines.SPECULAROVERALPHA) {
                     fallbacks.addFallback(0, "SPECULAROVERALPHA");
                 }
@@ -485,7 +502,7 @@ var BABYLON;
                     "vLightData2", "vLightDiffuse2", "vLightSpecular2", "vLightDirection2", "vLightGround2", "lightMatrix2",
                     "vLightData3", "vLightDiffuse3", "vLightSpecular3", "vLightDirection3", "vLightGround3", "lightMatrix3",
                     "vFogInfos", "vFogColor", "pointSize",
-                    "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vLightmapInfos", "vRefractionInfos",
+                    "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vParallaxScaleBias", "vLightmapInfos", "vRefractionInfos",
                     "mBones",
                     "vClipPlane", "diffuseMatrix", "ambientMatrix", "opacityMatrix", "reflectionMatrix", "emissiveMatrix", "specularMatrix", "bumpMatrix", "lightmapMatrix", "refractionMatrix",
                     "shadowsInfo0", "shadowsInfo1", "shadowsInfo2", "shadowsInfo3", "depthValues",
@@ -596,6 +613,9 @@ var BABYLON;
                         this._effect.setTexture("bumpSampler", this.bumpTexture);
                         this._effect.setFloat2("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level);
                         this._effect.setMatrix("bumpMatrix", this.bumpTexture.getTextureMatrix());
+                        if (this.useParallax) {
+                            this._effect.setFloat("vParallaxScaleBias", this.parallaxScaleBias);
+                        }
                     }
                     if (this.refractionTexture && StandardMaterial.RefractionTextureEnabled) {
                         var depth = 1.0;
@@ -793,6 +813,15 @@ var BABYLON;
         ], StandardMaterial.prototype, "disableLighting", void 0);
         __decorate([
             BABYLON.serialize()
+        ], StandardMaterial.prototype, "useParallax", void 0);
+        __decorate([
+            BABYLON.serialize()
+        ], StandardMaterial.prototype, "useParallaxOcclusion", void 0);
+        __decorate([
+            BABYLON.serialize()
+        ], StandardMaterial.prototype, "parallaxScaleBias", void 0);
+        __decorate([
+            BABYLON.serialize()
         ], StandardMaterial.prototype, "roughness", void 0);
         __decorate([
             BABYLON.serialize()
@@ -828,3 +857,4 @@ var BABYLON;
     })(BABYLON.Material);
     BABYLON.StandardMaterial = StandardMaterial;
 })(BABYLON || (BABYLON = {}));
+//# sourceMappingURL=babylon.standardMaterial.js.map

--- a/src/Materials/babylon.standardMaterial.js
+++ b/src/Materials/babylon.standardMaterial.js
@@ -502,7 +502,7 @@ var BABYLON;
                     "vLightData2", "vLightDiffuse2", "vLightSpecular2", "vLightDirection2", "vLightGround2", "lightMatrix2",
                     "vLightData3", "vLightDiffuse3", "vLightSpecular3", "vLightDirection3", "vLightGround3", "lightMatrix3",
                     "vFogInfos", "vFogColor", "pointSize",
-                    "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vParallaxScaleBias", "vLightmapInfos", "vRefractionInfos",
+                    "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vLightmapInfos", "vRefractionInfos",
                     "mBones",
                     "vClipPlane", "diffuseMatrix", "ambientMatrix", "opacityMatrix", "reflectionMatrix", "emissiveMatrix", "specularMatrix", "bumpMatrix", "lightmapMatrix", "refractionMatrix",
                     "shadowsInfo0", "shadowsInfo1", "shadowsInfo2", "shadowsInfo3", "depthValues",
@@ -611,11 +611,8 @@ var BABYLON;
                     }
                     if (this.bumpTexture && scene.getEngine().getCaps().standardDerivatives && StandardMaterial.BumpTextureEnabled) {
                         this._effect.setTexture("bumpSampler", this.bumpTexture);
-                        this._effect.setFloat2("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level);
+                        this._effect.setFloat3("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level, this.parallaxScaleBias);
                         this._effect.setMatrix("bumpMatrix", this.bumpTexture.getTextureMatrix());
-                        if (this.useParallax) {
-                            this._effect.setFloat("vParallaxScaleBias", this.parallaxScaleBias);
-                        }
                     }
                     if (this.refractionTexture && StandardMaterial.RefractionTextureEnabled) {
                         var depth = 1.0;

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -792,7 +792,7 @@
                     if (this.bumpTexture && scene.getEngine().getCaps().standardDerivatives && StandardMaterial.BumpTextureEnabled) {
                         this._effect.setTexture("bumpSampler", this.bumpTexture);
 
-                        this._effect.setFloat2("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level);
+                        this._effect.setFloat3("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level, this.parallaxScaleBias);
                         this._effect.setMatrix("bumpMatrix", this.bumpTexture.getTextureMatrix());
 
                         if (this.useParallax) {

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -8,6 +8,8 @@
         public EMISSIVE = false;
         public SPECULAR = false;
         public BUMP = false;
+        public PARALLAX = false;
+        public PARALLAXOCCLUSION = false;
         public SPECULAROVERALPHA = false;
         public CLIPPLANE = false;
         public ALPHATEST = false;
@@ -153,6 +155,15 @@
 
         @serialize()
         public disableLighting = false;
+
+        @serialize()
+        public useParallax = false;
+
+        @serialize()
+        public useParallaxOcclusion = false;
+
+        @serialize()
+        public parallaxScaleBias = 0.05;
 
         @serialize()
         public roughness = 0;
@@ -398,6 +409,13 @@
                     } else {
                         needUVs = true;
                         this._defines.BUMP = true;
+
+                        if (this.useParallax) {
+                            this._defines.PARALLAX = true;
+                            if (this.useParallaxOcclusion) {
+                                this._defines.PARALLAXOCCLUSION = true;
+                            }
+                        }
                     }
                 }
 
@@ -544,6 +562,14 @@
                     fallbacks.addFallback(0, "BUMP");
                 }
 
+                if (this._defines.PARALLAX) {
+                    fallbacks.addFallback(1, "PARALLAX");
+                }
+
+                if (this._defines.PARALLAXOCCLUSION) {
+                    fallbacks.addFallback(0, "PARALLAXOCCLUSION");
+                }
+
                 if (this._defines.SPECULAROVERALPHA) {
                     fallbacks.addFallback(0, "SPECULAROVERALPHA");
                 }
@@ -622,7 +648,7 @@
                         "vLightData2", "vLightDiffuse2", "vLightSpecular2", "vLightDirection2", "vLightGround2", "lightMatrix2",
                         "vLightData3", "vLightDiffuse3", "vLightSpecular3", "vLightDirection3", "vLightGround3", "lightMatrix3",
                         "vFogInfos", "vFogColor", "pointSize",
-                        "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vLightmapInfos", "vRefractionInfos",
+                        "vDiffuseInfos", "vAmbientInfos", "vOpacityInfos", "vReflectionInfos", "vEmissiveInfos", "vSpecularInfos", "vBumpInfos", "vParallaxScaleBias", "vLightmapInfos", "vRefractionInfos",
                         "mBones",
                         "vClipPlane", "diffuseMatrix", "ambientMatrix", "opacityMatrix", "reflectionMatrix", "emissiveMatrix", "specularMatrix", "bumpMatrix", "lightmapMatrix", "refractionMatrix",
                         "shadowsInfo0", "shadowsInfo1", "shadowsInfo2", "shadowsInfo3", "depthValues",
@@ -768,6 +794,10 @@
 
                         this._effect.setFloat2("vBumpInfos", this.bumpTexture.coordinatesIndex, 1.0 / this.bumpTexture.level);
                         this._effect.setMatrix("bumpMatrix", this.bumpTexture.getTextureMatrix());
+
+                        if (this.useParallax) {
+                            this._effect.setFloat("vParallaxScaleBias", this.parallaxScaleBias);
+                        }
                     }
 
                     if (this.refractionTexture && StandardMaterial.RefractionTextureEnabled) {

--- a/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -23,11 +23,109 @@
 		return mat3(tangent * invmax, binormal * invmax, normal);
 	}
 
-	vec3 perturbNormal(vec3 viewDir)
+	vec3 perturbNormal(vec3 viewDir, mat3 cotangentFrame, vec2 uv)
 	{
-		vec3 map = texture2D(bumpSampler, vBumpUV).xyz;
+		vec3 map = texture2D(bumpSampler, uv).xyz;
 		map = map * 255. / 127. - 128. / 127.;
-		mat3 TBN = cotangent_frame(vNormalW * vBumpInfos.y, -viewDir, vBumpUV);
-		return normalize(TBN * map);
+		return normalize(cotangentFrame * map);
 	}
+
+#ifdef PARALLAX
+	uniform float vParallaxScaleBias;
+
+	const float minSamples = 4.;
+	const float maxSamples = 15.;
+	const int iMaxSamples = 15;
+
+	// http://www.gamedev.net/page/resources/_/technical/graphics-programming-and-theory/a-closer-look-at-parallax-occlusion-mapping-r3262
+	vec2 parallaxOcclusion(vec3 vViewDirCoT, vec3 vNormalCoT, vec2 texCoord, float parallaxScale) {
+
+		// Calculate the parallax offset vector max length.
+		// This is equivalent to the tangent of the angle between the
+		// viewer position and the fragment location.
+		float parallaxLimit = length(vViewDirCoT.xy) / vViewDirCoT.z;
+
+		// Scale the parallax limit according to heightmap scale.
+		parallaxLimit *= parallaxScale;
+
+		// Calculate the parallax offset vector direction and maximum offset.
+		vec2 vOffsetDir = normalize(vViewDirCoT.xy);
+		vec2 vMaxOffset = vOffsetDir * parallaxLimit;
+
+		// Calculate how many samples should be taken along the view ray
+		// to find the surface intersection.  This is based on the angle
+		// between the surface normal and the view vector.
+		float numSamples = maxSamples + (dot(vViewDirCoT, vNormalCoT) * (minSamples - maxSamples));
+
+		// Specify the view ray step size.  Each sample will shift the current
+		// view ray by this amount.
+		float stepSize = 1.0 / numSamples;
+
+		// Calculate the texture coordinate partial derivatives in screen
+		// space for the tex2Dgrad texture sampling instruction.
+		//vec2 dx = dFdx(vBumpUV);			// Uncomment whevener GL_EXT_shader_texture_lod with texture2DGradEXT will work
+		//vec2 dy = dFdy(vBumpUV);
+
+		// Initialize the starting view ray height and the texture offsets.
+		float currRayHeight = 1.0;
+		vec2 vCurrOffset = vec2(0, 0);
+		vec2 vLastOffset = vec2(0, 0);
+
+		float lastSampledHeight = 1.0;
+		float currSampledHeight = 1.0;
+
+		for (int i = 0; i < iMaxSamples; i++)
+		{
+			// Sample the heightmap at the current texcoord offset.  The heightmap 
+			// is stored in the alpha channel of the height/normal map.
+			currSampledHeight = texture2D(bumpSampler, vBumpUV + vCurrOffset).w;
+
+			// Uncomment whevener GL_EXT_shader_texture_lod with texture2DGradEXT will work
+			//currSampledHeight = texture2DGradEXT(bumpSampler, vBumpUV + vCurrOffset, dx, dy).w;	
+
+			// Test if the view ray has intersected the surface.
+			if (currSampledHeight > currRayHeight)
+			{
+				// Find the relative height delta before and after the intersection.
+				// This provides a measure of how close the intersection is to 
+				// the final sample location.
+				float delta1 = currSampledHeight - currRayHeight;
+				float delta2 = (currRayHeight + stepSize) - lastSampledHeight;
+				float ratio = delta1 / (delta1 + delta2);
+
+				// Interpolate between the final two segments to 
+				// find the true intersection point offset.
+				vCurrOffset = (ratio)* vLastOffset + (1.0 - ratio) * vCurrOffset;
+
+				// Force the exit of the loop
+				break;
+			}
+			else
+			{
+				// take the next view ray height step,
+				currRayHeight -= stepSize;
+
+				// save the current texture coordinate offset and increment
+				// to the next sample location, 
+				vLastOffset = vCurrOffset;
+				vCurrOffset += stepSize * vMaxOffset;
+
+				// and finally save the current heightmap height.
+				lastSampledHeight = currSampledHeight;
+			}
+		}
+
+		return vCurrOffset;
+	}
+
+	vec2 parallaxOffset(vec3 viewDir, float heightScale)
+	{
+		// calculate amount of offset for Parallax Mapping With Offset Limiting
+		float height = texture2D(bumpSampler, vBumpUV).w;
+		vec2 texCoordOffset = heightScale * viewDir.xy * height;
+		return -texCoordOffset;
+	}
+
+#endif
+
 #endif

--- a/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -1,6 +1,6 @@
 ﻿#ifdef BUMP
 	varying vec2 vBumpUV;
-	uniform vec2 vBumpInfos;
+	uniform vec3 vBumpInfos;
 	uniform sampler2D bumpSampler;
 
 	// Thanks to http://www.thetenthplanet.de/archives/1180
@@ -31,8 +31,6 @@
 	}
 
 #ifdef PARALLAX
-	uniform float vParallaxScaleBias;
-
 	const float minSamples = 4.;
 	const float maxSamples = 15.;
 	const int iMaxSamples = 15;
@@ -40,30 +38,15 @@
 	// http://www.gamedev.net/page/resources/_/technical/graphics-programming-and-theory/a-closer-look-at-parallax-occlusion-mapping-r3262
 	vec2 parallaxOcclusion(vec3 vViewDirCoT, vec3 vNormalCoT, vec2 texCoord, float parallaxScale) {
 
-		// Calculate the parallax offset vector max length.
-		// This is equivalent to the tangent of the angle between the
-		// viewer position and the fragment location.
 		float parallaxLimit = length(vViewDirCoT.xy) / vViewDirCoT.z;
-
-		// Scale the parallax limit according to heightmap scale.
 		parallaxLimit *= parallaxScale;
-
-		// Calculate the parallax offset vector direction and maximum offset.
 		vec2 vOffsetDir = normalize(vViewDirCoT.xy);
 		vec2 vMaxOffset = vOffsetDir * parallaxLimit;
-
-		// Calculate how many samples should be taken along the view ray
-		// to find the surface intersection.  This is based on the angle
-		// between the surface normal and the view vector.
 		float numSamples = maxSamples + (dot(vViewDirCoT, vNormalCoT) * (minSamples - maxSamples));
-
-		// Specify the view ray step size.  Each sample will shift the current
-		// view ray by this amount.
 		float stepSize = 1.0 / numSamples;
 
-		// Calculate the texture coordinate partial derivatives in screen
-		// space for the tex2Dgrad texture sampling instruction.
-		//vec2 dx = dFdx(vBumpUV);			// Uncomment whevener GL_EXT_shader_texture_lod with texture2DGradEXT will work
+		// Uncomment whevener GL_EXT_shader_texture_lod with texture2DGradEXT will work
+		//vec2 dx = dFdx(vBumpUV);
 		//vec2 dy = dFdy(vBumpUV);
 
 		// Initialize the starting view ray height and the texture offsets.
@@ -76,25 +59,14 @@
 
 		for (int i = 0; i < iMaxSamples; i++)
 		{
-			// Sample the heightmap at the current texcoord offset.  The heightmap 
-			// is stored in the alpha channel of the height/normal map.
 			currSampledHeight = texture2D(bumpSampler, vBumpUV + vCurrOffset).w;
-
-			// Uncomment whevener GL_EXT_shader_texture_lod with texture2DGradEXT will work
-			//currSampledHeight = texture2DGradEXT(bumpSampler, vBumpUV + vCurrOffset, dx, dy).w;	
 
 			// Test if the view ray has intersected the surface.
 			if (currSampledHeight > currRayHeight)
 			{
-				// Find the relative height delta before and after the intersection.
-				// This provides a measure of how close the intersection is to 
-				// the final sample location.
 				float delta1 = currSampledHeight - currRayHeight;
 				float delta2 = (currRayHeight + stepSize) - lastSampledHeight;
 				float ratio = delta1 / (delta1 + delta2);
-
-				// Interpolate between the final two segments to 
-				// find the true intersection point offset.
 				vCurrOffset = (ratio)* vLastOffset + (1.0 - ratio) * vCurrOffset;
 
 				// Force the exit of the loop
@@ -102,15 +74,10 @@
 			}
 			else
 			{
-				// take the next view ray height step,
 				currRayHeight -= stepSize;
-
-				// save the current texture coordinate offset and increment
-				// to the next sample location, 
 				vLastOffset = vCurrOffset;
 				vCurrOffset += stepSize * vMaxOffset;
 
-				// and finally save the current heightmap height.
 				lastSampledHeight = currSampledHeight;
 			}
 		}

--- a/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -1,0 +1,14 @@
+﻿
+mat3 transposeMat3(mat3 inMatrix) {
+	vec3 i0 = inMatrix[0];
+	vec3 i1 = inMatrix[1];
+	vec3 i2 = inMatrix[2];
+
+	mat3 outMatrix = mat3(
+		vec3(i0.x, i1.x, i2.x),
+		vec3(i0.y, i1.y, i2.y),
+		vec3(i0.z, i1.z, i2.z)
+		);
+
+	return outMatrix;
+}

--- a/src/Shaders/default.fragment.fx
+++ b/src/Shaders/default.fragment.fx
@@ -184,27 +184,22 @@ void main(void) {
 #endif
 
 #if defined(BUMP) || defined(PARALLAX)
-	mat3 TBN = cotangent_frame(vNormalW * vBumpInfos.y, -viewDirectionW, bumpUV);
+	mat3 TBN = cotangent_frame(normalW * vBumpInfos.y, -viewDirectionW, bumpUV);
 #endif
 
 #ifdef PARALLAX
 	mat3 invTBN = transposeMat3(TBN);
 
 #ifdef PARALLAXOCCLUSION
-	vec2 uvOffset = parallaxOcclusion(invTBN * -viewDirectionW, invTBN * normalW, bumpUV, vParallaxScaleBias);
+	vec2 uvOffset = parallaxOcclusion(invTBN * -viewDirectionW, invTBN * normalW, bumpUV, vBumpInfos.z);
 #else
-	vec2 uvOffset = parallaxOffset(invTBN * viewDirectionW, vParallaxScaleBias);
+	vec2 uvOffset = parallaxOffset(invTBN * viewDirectionW, vBumpInfos.z);
 #endif
 
 	diffuseUV += uvOffset;
 	bumpUV += uvOffset;
 
-	// Note by Loic:
-	// Parallax mapping apply an offset on the UV, which may leads to out of bound coordinates
-	// If we use texture wrapping we should NOT doing the following test, otherwise this test
-	//  will discard the pixel if we detect an out of bound coordinate.
-	// It makes senses only with occlusion because the fragment is accurately computed.
-	// I'm quite hesitating about keeping this or not, I think future will tell!
+	// Note by Loic: won't be nice with wrapping textures...
 #ifdef PARALLAXOCCLUSION
 	if (diffuseUV.x > 1.0 || diffuseUV.y > 1.0 || diffuseUV.x < 0.0 || diffuseUV.y < 0.0) {
 		discard;
@@ -218,7 +213,7 @@ void main(void) {
 #endif
 
 #ifdef DIFFUSE
-	baseColor = texture2D(diffuseSampler, vDiffuseUV);
+	baseColor = texture2D(diffuseSampler, diffuseUV);
 
 #ifdef ALPHATEST
 	if (baseColor.a < 0.4)

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -61,7 +61,7 @@ uniform mat4 specularMatrix;
 
 #ifdef BUMP
 varying vec2 vBumpUV;
-uniform vec2 vBumpInfos;
+uniform vec3 vBumpInfos;
 uniform mat4 bumpMatrix;
 #endif
 


### PR DESCRIPTION
Two modes: Parallax Mapping and Parallax Occlusion Mapping.
This feature lies on the top of the Bump's one, requires a Normal Map with the Alpha Channel contain Heightmap information.

A little demo of the effect: https://youtu.be/SEFCZpSjWF8
