### PR TITLE
Multiple Skeletal Animations Transitions (Crossfade)

### DIFF
--- a/src/Animations/babylon.animatable.ts
+++ b/src/Animations/babylon.animatable.ts
@@ -7,7 +7,7 @@
         private _scene: Scene;
 
         public animationStarted = false;
-
+        public transitionFunction =  null;
         constructor(scene: Scene, public target, public fromFrame: number = 0, public toFrame: number = 100, public loopAnimation: boolean = false, public speedRatio: number = 1.0, public onAnimationEnd?, animations?: any) {
             if (animations) {
                 this.appendAnimations(target, animations);
@@ -27,6 +27,7 @@
                 var animation = animations[index];
 
                 animation._target = target;
+                animation.transitionFunction = this.transitionFunction;
                 this._animations.push(animation);
             }
         }
@@ -136,7 +137,7 @@
 
             this.animationStarted = running;
 
-            if (!running) {
+            if (!running && !this.transitionFunction) {
                 // Remove from active animatables
                 index = this._scene._activeAnimatables.indexOf(this);
                 this._scene._activeAnimatables.splice(index, 1);

--- a/src/Animations/babylon.animation.ts
+++ b/src/Animations/babylon.animation.ts
@@ -27,7 +27,8 @@
 
         public targetPropertyPath: string[];
         public currentFrame: number;
-
+        
+        public transitionFunction = null; 
         public allowMatricesInterpolation = false;
 
         public blendingSpeed = 0.01;
@@ -314,6 +315,10 @@
                             switch (loopMode) {
                                 case Animation.ANIMATIONLOOPMODE_CYCLE:
                                 case Animation.ANIMATIONLOOPMODE_CONSTANT:
+                                    if(this.transitionFunction){
+                                        var TWeight = this.transitionFunction.fadeIn();
+                                        return this.matrixInterpolateFunction(this._target._matrix, startValue, TWeight); //will transite into next animatio.
+                                    }
                                     if (this.allowMatricesInterpolation) {
                                         return this.matrixInterpolateFunction(startValue, endValue, gradient);
                                     }

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3731,6 +3731,33 @@
             Matrix.Zero(), Matrix.Zero(),
             Matrix.Zero(), Matrix.Zero()];                      // 6 temp Matrices at once should be enough
     }
+    ///////////for animation Morphs
+     export class LinearFADE {
+       constructor (transSpeed: number,engine: any) {
+            var Trans = (function() {
+            function Trans(blendTime,engine) {
+  
+                                var inF = 0;
+                                var outF = 1;
+                               /////////linear easeIN
+                                            this.fadeIn = function() {
+                                               var dt = engine.deltaTime/1000;
+                                               inF =  inF + (1 - inF) * (blendTime*dt);
+                                                 return inF;
+                                         };
+                                            this.fadeOut = function() {
+                                               var dt = engine.deltaTime/1000;
+                                               outF = outF + (0 - outF) * (blendTime*dt);
+                                                return outF;
+                                         };  
+                                   
+                                      }
+                      return Trans;
+                  })();
+         var E = new Trans(transSpeed,engine); 
+         return E;  
+        }  
+     }
 }
 
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -856,6 +856,72 @@
             return animatable;
         }
 
+
+        public beginAnimationWithTransition(target: any, from: number, to: number,startAt: number = 0, loop?: boolean, speedRatio: number = 1.0, onAnimationEnd?: () => void,animatable?: Animatable,transitionSpeed: number = 1.0 ): Animatable {
+            
+            var transitionFunction = null;
+            if(!animatable)  {//important !
+                    if(transitionSpeed < 1)  {  transitionFunction = new BABYLON.LinearFADE(transitionSpeed,this._engine); }
+                    animatable = new Animatable(this, target, from, to, loop, speedRatio, onAnimationEnd);
+                    animatable.transitionFunction = transitionFunction;
+               }   
+            
+            // Local animations
+            if (target.animations) {
+                animatable.appendAnimations(target, target.animations);
+                }
+
+            // Children animations
+            if (target.getAnimatables) {
+                var animatables = target.getAnimatables();
+                for (var index = 0; index < animatables.length; index++) {
+                    this.beginAnimationWithTransition(animatables[index], from, to,startAt,loop,speedRatio,onAnimationEnd,animatable,transitionSpeed);
+                }
+            }
+
+              animatable.reset();
+              var animtables; animtables = []; animtables = this.GetAllAnimatablesByTarget(target); 
+              if (animtables.length > 2) {
+                for (var i = 2; i < (animtables.length); i++) {
+                    animtables[i].stop();
+                }
+            }
+      
+          if(startAt != 0 &&  startAt > from && startAt < to) {  animatable.goToFrame(startAt) } 
+            return animatable;
+        }
+
+
+        public GetAllAnimatablesByTarget(target: any): Animatable {
+            var AT; AT = [];
+             
+            for (var index = 0; index < this._activeAnimatables.length; index++) {
+                if (this._activeAnimatables[index].target === target) {
+                    AT.push(this._activeAnimatables[index]);
+                    
+                }
+            }
+            if(AT.length)  { AT.reverse() };
+            return AT;
+           
+        };
+        
+        //////get current/last existing paused or playing  animatable for target
+        public GetCurrentAnimatableByTarget(target: any): Animatable {
+            var AT; AT = [];
+            
+            for (var index = 0; index < this._activeAnimatables.length; index++) {
+                if (this._activeAnimatables[index].target === target) {
+                    AT.push(this._activeAnimatables[index]);
+                    
+                }
+            }
+            
+            if(AT.length){   AT.reverse();return AT[0]   }
+            else { return null  }
+        };
+
+
         public beginDirectAnimation(target: any, animations: Animation[], from: number, to: number, loop?: boolean, speedRatio?: number, onAnimationEnd?: () => void): Animatable {
             if (speedRatio === undefined) {
                 speedRatio = 1.0;


### PR DESCRIPTION
This feature Allow to play two animations on one target simulateosly and transite between them.
for Now it only has Linear Fade in as default ... or use Custom FUNCTION   
var animation = scene.beginAnimationWithTransition(target,from,to,startAt,loop,speed,onAnimationEnd,null,transitionSpeed)

later it can be merged into scene.beginAnimation();
for now i did new prototype for that.

Now if its passed ,, please tell me what to do

watch preview video at https://youtu.be/q1eI6hGYfB0
in this video :  for animations is transitionSpeed set to (0.03)