### PR TITLE
Update babylon.meshSimplification.js

### DIFF
--- a/src/Mesh/babylon.meshSimplification.js
+++ b/src/Mesh/babylon.meshSimplification.js
@@ -250,7 +250,7 @@ var BABYLON;
                                 var deleted1 = [];
                                 var v0 = t.vertices[j];
                                 var v1 = t.vertices[(j + 1) % 3];
-                                if (v0.isBorder !== v1.isBorder)
+                                if (v0.isBorder || v1.isBorder)
                                     continue;
                                 var p = BABYLON.Vector3.Zero();
                                 var n = BABYLON.Vector3.Zero();

--- a/src/Mesh/babylon.meshSimplification.ts
+++ b/src/Mesh/babylon.meshSimplification.ts
@@ -320,7 +320,7 @@
                                 var v0 = t.vertices[j];
                                 var v1 = t.vertices[(j + 1) % 3];
 
-                                if (v0.isBorder !== v1.isBorder) continue;
+                                if (v0.isBorder || v1.isBorder) continue;
 
                                 var p = Vector3.Zero();
                                 var n = Vector3.Zero();


### PR DESCRIPTION
Hey,
I noticed a small bug in the porting of this code from C++. It's mentioned and fixed in this blog post - http://voxels.blogspot.co.il/2014/05/quadric-mesh-simplification-with-source.html?_sm_au_=iVVSRHnRQ0SW0JFT.

In case a mesh is not two-manifold, it's possible for both vertices of an edge to be "borders", and this is an edge that should not be collapsed.
Testing for !== instead of || is ignoring this case and so naked edges are collapsed when they shouldn't.