### PR TITLE
API doc : precision on createInstance for Lines

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1591,6 +1591,7 @@
          * - setPivotMatrix
          * - scaling
          * tuto : http://doc.babylonjs.com/tutorials/How_to_use_Instances
+         * Warning : this method is not supported for `Line` mesh and `LineSystem`
          */
         public createInstance(name: string): InstancedMesh {
             return new InstancedMesh(name, this);


### PR DESCRIPTION
Added a useful precision on createInstance() that is not supported on Lines and LineSystem