### PR TITLE
Scaling root bone animation on copy part 1

### DIFF
--- a/Exporters/Blender/io_export_babylon.py
+++ b/Exporters/Blender/io_export_babylon.py
@@ -1,7 +1,7 @@
 bl_info = {
     'name': 'Babylon.js',
     'author': 'David Catuhe, Jeff Palmer',
-    'version': (4, 5, 1),
+    'version': (4, 6, 0),
     'blender': (2, 75, 0),
     'location': 'File > Export > Babylon.js (.babylon)',
     'description': 'Export Babylon.js scenes (.babylon)',
@@ -1427,6 +1427,9 @@ class Skeleton:
         scene.objects.active = skeleton
         bpy.ops.object.mode_set(mode='EDIT')
 
+        # dimensions when in edit mode, are those at rest
+        self.dimensions = skeleton.dimensions
+
         # you need to access edit_bones from skeleton.data not skeleton.pose when in edit mode
         for editBone in skeleton.data.edit_bones:
             for myBoneObj in self.bones:
@@ -1449,6 +1452,7 @@ class Skeleton:
         file_handler.write('{')
         write_string(file_handler, 'name', self.name, True)
         write_int(file_handler, 'id', self.id)  # keep int for legacy of original exporter
+        write_vector(file_handler, 'dimensionsAtRest', self.dimensions)
 
         file_handler.write(',"bones":[')
         first = True

--- a/src/Bones/babylon.skeleton.ts
+++ b/src/Bones/babylon.skeleton.ts
@@ -1,7 +1,7 @@
 ﻿module BABYLON {
     export class Skeleton {
         public bones = new Array<Bone>();
-
+        public dimensionsAtRest : Vector3;
         public needInitialSkinMatrix = false;
 
         private _scene: Scene;
@@ -325,6 +325,7 @@
 
             serializationObject.name = this.name;
             serializationObject.id = this.id;
+            serializationObject.dimensionsAtRest = this.dimensionsAtRest;
 
             serializationObject.bones = [];
 
@@ -364,6 +365,9 @@
 
         public static Parse(parsedSkeleton: any, scene: Scene): Skeleton {
             var skeleton = new Skeleton(parsedSkeleton.name, parsedSkeleton.id, scene);
+            if (parsedSkeleton.dimensionsAtRest){
+                skeleton.dimensionsAtRest = Vector3.FromArray(parsedSkeleton.dimensionsAtRest);
+            }
 
             skeleton.needInitialSkinMatrix = parsedSkeleton.needInitialSkinMatrix;
 

--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -295,6 +295,9 @@
                     }               
                     cam._postProcesses = this._postProcesses.slice(0).concat(rigPostProcess);
                     rigPostProcess.markTextureDirty();
+                    
+                }else{
+                    cam._postProcesses = this._postProcesses.slice(0);
                 }
             }
         }


### PR DESCRIPTION
- Blender 4.6.0 exporting skeleton.dimensionsAtRest
- Skeleton.parse loads it

Once PRed, can work on bone.copyAnimationRange in playground.

Minor fix for Camera post processes.