### PR TITLE
Adding the option to prevent the creation of a SceneNode for the WorldSpaceCanvas.

### DIFF
--- a/src/Canvas2d/babylon.canvas2d.ts
+++ b/src/Canvas2d/babylon.canvas2d.ts
@@ -96,8 +96,9 @@
          * - sideOrientation: Unexpected behavior occur if the value is different from Mesh.DEFAULTSIDE right now, so please use this one, which is the default.
          * - cachingStrategy Must be CACHESTRATEGY_CANVAS for now, which is the default.
          * - isVisible: true if the canvas must be visible, false for hidden. Default is true.
+         * - noWorldSpaceNode: if true there won't be a WorldSpaceNode created for this canvas, you'll be responsible of rendering the canvas texture in the scene.
          */
-        static CreateWorldSpace(scene: Scene, size: Size, options: { id?: string, position?: Vector3, rotation?: Quaternion, renderScaleFactor?: number, sideOrientation?: number, cachingStrategy?: number, enableInteraction?: boolean, isVisible?: boolean}): Canvas2D {
+        static CreateWorldSpace(scene: Scene, size: Size, options: { id?: string, position?: Vector3, rotation?: Quaternion, renderScaleFactor?: number, sideOrientation?: number, cachingStrategy?: number, enableInteraction?: boolean, isVisible?: boolean, noWorldSpaceNode?: boolean}): Canvas2D {
 
             let cs = options && options.cachingStrategy || Canvas2D.CACHESTRATEGY_CANVAS;
 
@@ -114,20 +115,26 @@
             let c = new Canvas2D();
             c.setupCanvas(scene, id, new Size(size.width * rsf, size.height * rsf), false, cs, options && options.enableInteraction || true, Vector2.Zero(), options && options.isVisible || true, null, null, null, null, null, null);
 
-            let plane = new WorldSpaceCanvas2D(id, scene, c);
-            let vertexData = VertexData.CreatePlane({ width: size.width / 2, height: size.height / 2, sideOrientation: options && options.sideOrientation || Mesh.DEFAULTSIDE });
-            let mtl = new StandardMaterial(id + "_Material", scene);
+            if (!options || !options.noWorldSpaceNode) {
+                let plane = new WorldSpaceCanvas2D(id, scene, c);
+                let vertexData = VertexData.CreatePlane({
+                    width: size.width / 2,
+                    height: size.height / 2,
+                    sideOrientation: options && options.sideOrientation || Mesh.DEFAULTSIDE
+                });
+                let mtl = new StandardMaterial(id + "_Material", scene);
 
-            c.applyCachedTexture(vertexData, mtl);
-            vertexData.applyToMesh(plane, false);
+                c.applyCachedTexture(vertexData, mtl);
+                vertexData.applyToMesh(plane, false);
 
-            mtl.specularColor = new Color3(0, 0, 0);
-            mtl.disableLighting =true;
-            mtl.useAlphaFromDiffuseTexture = true;
-            plane.position = options && options.position || Vector3.Zero();
-            plane.rotationQuaternion = options && options.rotation || Quaternion.Identity();
-            plane.material = mtl;
-            c._worldSpaceNode = plane;
+                mtl.specularColor = new Color3(0, 0, 0);
+                mtl.disableLighting = true;
+                mtl.useAlphaFromDiffuseTexture = true;
+                plane.position = options && options.position || Vector3.Zero();
+                plane.rotationQuaternion = options && options.rotation || Quaternion.Identity();
+                plane.material = mtl;
+                c._worldSpaceNode = plane;
+            }
 
             return c;
         }

--- a/src/Canvas2d/babylon.group2d.ts
+++ b/src/Canvas2d/babylon.group2d.ts
@@ -86,6 +86,28 @@
         }
 
         /**
+         * Allow you to access the information regarding the cached rectangle of the Group2D into the MapTexture.
+         * If the `noWorldSpaceNode` options was used at the creation of a WorldSpaceCanvas, the rendering of the canvas must be made by the caller, so typically you want to bind the cacheTexture property to some material/mesh and you must use the cachedRect.UVs property to get the UV coordinates to use for your quad that will display the Canvas.
+         */
+        public get cachedRect(): PackedRect {
+            if (!this._renderableData) {
+                return null;
+            }
+            return this._renderableData._cacheNode;
+        }
+
+        /**
+         * Access the texture that maintains a cached version of the Group2D.
+         * This is useful only if you're not using a WorldSpaceNode for your WorldSpace Canvas and therefore need to perform the rendering yourself.
+         */
+        public get cacheTexture(): MapTexture {
+            if (!this._renderableData) {
+                return null;
+            }
+            return this._renderableData._cacheTexture;
+        }
+
+        /**
          * Call this method to remove this Group and its children from the Canvas
          */
         public dispose(): boolean {


### PR DESCRIPTION
Adding two properties in Group2D to have access to the MapTexture and the PackedRect of the bitmap that contain the cached version (to use for rendering).