### PR TITLE
Small fix for normal calculation

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3566,8 +3566,8 @@
             }
             else {
                 normal0 = Vector3.Cross(vt, va);
-                Vector3.CrossToRef(normal0, vt, normal0);
-                //normal0 = Vector3.Cross(normal0, vt);
+                //Vector3.CrossToRef(normal0, vt, normal0);
+                normal0 = Vector3.Cross(normal0, vt);
             }
             normal0.normalize();
             return normal0;


### PR DESCRIPTION
In certain cases, when provided an initial normal, the normal will be
calculated incorrectly. This fixes the issue. @jbousquie