### PR TITLE
skelDimensionsRatio being passed to Bone.copyAnimationRange

### DIFF
--- a/src/Bones/babylon.skeleton.ts
+++ b/src/Bones/babylon.skeleton.ts
@@ -142,7 +142,7 @@
                 var boneName = this.bones[i].name;
                 var sourceBone = boneDict[boneName];
                 if (sourceBone) {
-                    ret = ret && this.bones[i].copyAnimationRange(sourceBone, name, frameOffset, rescaleAsRequired);
+                    ret = ret && this.bones[i].copyAnimationRange(sourceBone, name, frameOffset, rescaleAsRequired, skelDimensionsRatio);
                 } else {
                     Tools.Warn("copyAnimationRange: not same rig, missing source bone " + boneName);
                     ret = false;


### PR DESCRIPTION
This is an obvious bug.  2.4 ready.  Much better than 2.3.  Further
changes would probably be on the Exporter side.