### PR TITLE
Don't force DynamicTexture height/width to power of two

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -73,6 +73,7 @@
     - Fixed bug with OBJ Loader - All meshes were concatenated with the previous one ([Temechon](https://github.com/Temechon))
     - Fixed the device orientation cameras (both VR and non-VR cameras)  ([RaananW](https://github.com/RaananW))
     - Fixed the WebVR implementation  ([RaananW](https://github.com/RaananW))
+    - `DynamicTexture.clone()` now preserves height in addition to width  ([dahlbyk](https://github.com/dahlbyk))
   - **Breaking changes**
     - `VertexData.CreateLines()` removed as `MeshBuilder.CreateLines()` now calls `MeshBuilder.CreateLineSystem()`
     - `scene.onNewXXXAdded` and `scene.onXXXRemoved` callbacks were removed and replaced by `scene.onNewXXXAddedObservable` and `scene.onXXXRemovedObservable`

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -30,7 +30,7 @@
     - Enabled other post processes to be used when also using a 3D Rig ([jcpalmer](https://github.com/Palmer-JC))
     - Got Skeleton.copyAminationRange scaling better for different bone lengths ([jcpalmer](https://github.com/Palmer-JC))
     - Added skeleton.getBoneIndexByName(boneName: string) ([dad72](https://github.com/dad72))
-    - Added node._children to track children hierarchy ([deltakosh](https://github.com/deltakosh))
+    - Added `node._children` to track children hierarchy ([deltakosh](https://github.com/deltakosh))
     - Added Camera.ForceAttachControlToAlwaysPreventDefault to help embedding Babylon.js in iFrames ([deltakosh](https://github.com/deltakosh))
     - Support for Layer.alphaTest ([deltakosh](https://github.com/deltakosh))
     - New scene.pointerDownPredicate, scene.pointerMovePredicate, scene.pointerUpPredicate to define your own predicates for meshes picking selection ([deltakosh](https://github.com/deltakosh))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -83,3 +83,4 @@
     - `Engine.bindMultiBuffers` is now `Engine.bindBuffers` and strongly typed `{ [key: string]: VertexBuffer; }` of buffers ([benaadams](https://github.com/benaadams))
     - `Engine.createDynamicVertexBuffer` takes vertices rather than capacity, creating and initalizing in one gpu instruction ([benaadams](https://github.com/benaadams)) 
     - Internally new `Engine.bindBuffer` is used rather than `gl.bindBuffer` which only binds when the bound buffer is changing ([benaadams](https://github.com/benaadams)) 
+    - `DynamicTexture` no longer forces height/width to exponents of 2 if MIP maps are disabled and sampling mode is nearest  ([dahlbyk](https://github.com/dahlbyk))

--- a/src/Materials/Textures/babylon.dynamicTexture.js
+++ b/src/Materials/Textures/babylon.dynamicTexture.js
@@ -14,17 +14,18 @@ var BABYLON;
             this.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE;
             this.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
             this._generateMipMaps = generateMipMaps;
+            var forceExponentOfTwo = generateMipMaps || samplingMode !== BABYLON.Texture.NEAREST_SAMPLINGMODE;
             if (options.getContext) {
                 this._canvas = options;
-                this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
+                this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode, forceExponentOfTwo);
             }
             else {
                 this._canvas = document.createElement("canvas");
                 if (options.width) {
-                    this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
+                    this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode, forceExponentOfTwo);
                 }
                 else {
-                    this._texture = scene.getEngine().createDynamicTexture(options, options, generateMipMaps, samplingMode);
+                    this._texture = scene.getEngine().createDynamicTexture(options, options, generateMipMaps, samplingMode, forceExponentOfTwo);
                 }
             }
             var textureSize = this.getSize();

--- a/src/Materials/Textures/babylon.dynamicTexture.js
+++ b/src/Materials/Textures/babylon.dynamicTexture.js
@@ -78,7 +78,7 @@ var BABYLON;
         };
         DynamicTexture.prototype.clone = function () {
             var textureSize = this.getSize();
-            var newTexture = new DynamicTexture(this.name, textureSize.width, this.getScene(), this._generateMipMaps);
+            var newTexture = new DynamicTexture(this.name, textureSize, this.getScene(), this._generateMipMaps);
             // Base texture
             newTexture.hasAlpha = this.hasAlpha;
             newTexture.level = this.level;

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -88,7 +88,7 @@
 
         public clone(): DynamicTexture {
             var textureSize = this.getSize();
-            var newTexture = new DynamicTexture(this.name, textureSize.width, this.getScene(), this._generateMipMaps);
+            var newTexture = new DynamicTexture(this.name, textureSize, this.getScene(), this._generateMipMaps);
 
             // Base texture
             newTexture.hasAlpha = this.hasAlpha;

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -14,16 +14,18 @@
 
             this._generateMipMaps = generateMipMaps;
 
+            var forceExponentOfTwo = generateMipMaps || samplingMode !== Texture.NEAREST_SAMPLINGMODE;
+
             if (options.getContext) {
                 this._canvas = options;
-                this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
+                this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode, forceExponentOfTwo);
             } else {
                 this._canvas = document.createElement("canvas");
 
                 if (options.width) {
-                    this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
+                    this._texture = scene.getEngine().createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode, forceExponentOfTwo);
                 } else {
-                    this._texture = scene.getEngine().createDynamicTexture(options, options, generateMipMaps, samplingMode);
+                    this._texture = scene.getEngine().createDynamicTexture(options, options, generateMipMaps, samplingMode, forceExponentOfTwo);
                 }
             }
 

--- a/src/babylon.engine.js
+++ b/src/babylon.engine.js
@@ -1414,12 +1414,12 @@ var BABYLON;
             this._loadedTexturesCache.push(texture);
             return texture;
         };
-        Engine.prototype.createDynamicTexture = function (width, height, generateMipMaps, samplingMode, forceExponantOfTwo) {
-            if (forceExponantOfTwo === void 0) { forceExponantOfTwo = true; }
+        Engine.prototype.createDynamicTexture = function (width, height, generateMipMaps, samplingMode, forceExponentOfTwo) {
+            if (forceExponentOfTwo === void 0) { forceExponentOfTwo = true; }
             var texture = this._gl.createTexture();
             texture._baseWidth = width;
             texture._baseHeight = height;
-            if (forceExponantOfTwo) {
+            if (forceExponentOfTwo) {
                 width = BABYLON.Tools.GetExponentOfTwo(width, this._caps.maxTextureSize);
                 height = BABYLON.Tools.GetExponentOfTwo(height, this._caps.maxTextureSize);
             }

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -1726,12 +1726,12 @@
             return texture;
         }
 
-        public createDynamicTexture(width: number, height: number, generateMipMaps: boolean, samplingMode: number, forceExponantOfTwo = true): WebGLTexture {
+        public createDynamicTexture(width: number, height: number, generateMipMaps: boolean, samplingMode: number, forceExponentOfTwo = true): WebGLTexture {
             var texture = this._gl.createTexture();
             texture._baseWidth = width;
             texture._baseHeight = height;
 
-            if (forceExponantOfTwo) {
+            if (forceExponentOfTwo) {
                 width = Tools.GetExponentOfTwo(width, this._caps.maxTextureSize);
                 height = Tools.GetExponentOfTwo(height, this._caps.maxTextureSize);
             }


### PR DESCRIPTION
I found this behavior of `DynamicTexture`'s constructor to surprising/frustrating. I think the better approach is to respect the given `height`/`width` by default, with an option to force an exponent of two. If you don't agree with that change in default behavior, I structured the commits such that https://github.com/BabylonJS/Babylon.js/commit/4544934ff785bf18f9ebd1947681cc7603ddba78 can be reverted to remove the breaking change but keep the `forceExponentOfTwo` option.

First PR here, so eager for any feedback. I've tried to update What's New, as well.