### PR TITLE
Reduce allocations and GPU state changes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -2,7 +2,20 @@
   - **Major updates**    
     
   - **Updates**
-    
+    - Alloc reduction: Prevent Observable.notifyObservers allocation ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Prevent per mesh per render closure allocation ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Avoid inadvertent per geometry per render alloc ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Avoid inadvertent per mesh per render alloc ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Avoid Collider root calc allocations ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Reduce mesh rotation allocs ([benaadams](https://github.com/benaadams)) 
+    - Alloc reduction: Allocate less in vector project and unproject ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Improved uniform caching ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Cache program ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Cache vertexAttribPointer ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Reduce buffer binds ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Only bind unbound framebuffers ([benaadams](https://github.com/benaadams)) 
+    - GPU state change reduction: Cache texture changes better ([benaadams](https://github.com/benaadams)) 
+	
   - **Exporters**
     
   - **API doc**

--- a/src/Animations/babylon.animation.ts
+++ b/src/Animations/babylon.animation.ts
@@ -89,7 +89,7 @@
     }
 
     export class Animation {
-        private _keys: Array<any>;
+        private _keys: Array<{frame:number, value: any}>;
         private _offsetsCache = {};
         private _highLimitsCache = {};
         private _stopped = false;
@@ -134,9 +134,7 @@
 
             var animation = new Animation(name, targetProperty, framePerSecond, dataType, loopMode);
 
-            var keys = [];
-            keys.push({ frame: 0, value: from });
-            keys.push({ frame: totalFrame, value: to });
+            var keys: Array<{frame: number, value:any}> = [{ frame: 0, value: from }, { frame: totalFrame, value: to }];
             animation.setKeys(keys);
 
             if (easingFunction !== undefined) {
@@ -256,7 +254,7 @@
             return this._stopped;
         }
 
-        public getKeys(): any[] {
+        public getKeys(): Array<{ frame: number, value: any }> {
             return this._keys;
         }
 
@@ -324,7 +322,7 @@
             return clone;
         }
 
-        public setKeys(values: Array<any>): void {
+        public setKeys(values: Array<{ frame: number, value: any }>): void {
             this._keys = values.slice(0);
             this._offsetsCache = {};
             this._highLimitsCache = {};
@@ -747,7 +745,7 @@
             var animation = new Animation(parsedAnimation.name, parsedAnimation.property, parsedAnimation.framePerSecond, parsedAnimation.dataType, parsedAnimation.loopBehavior);
 
             var dataType = parsedAnimation.dataType;
-            var keys = [];
+            var keys: Array<{ frame: number, value: any }> = [];
             var data;
             var index: number;
 

--- a/src/Collisions/babylon.collider.ts
+++ b/src/Collisions/babylon.collider.ts
@@ -21,37 +21,41 @@
         return true;
     };
 
-    var getLowestRoot = (a: number, b: number, c: number, maxR: number) => {
-        var determinant = b * b - 4.0 * a * c;
-        var result = { root: 0, found: false };
+    var getLowestRoot: (a: number, b: number, c: number, maxR: number) => { root: number, found: boolean } =
+        (function () {
+            var result = { root: 0, found: false };
+            return function (a: number, b: number, c: number, maxR: number) {
+                result.root = 0; result.found = false;
+                var determinant = b * b - 4.0 * a * c;
+                if (determinant < 0)
+                    return result;
 
-        if (determinant < 0)
-            return result;
+                var sqrtD = Math.sqrt(determinant);
+                var r1 = (-b - sqrtD) / (2.0 * a);
+                var r2 = (-b + sqrtD) / (2.0 * a);
 
-        var sqrtD = Math.sqrt(determinant);
-        var r1 = (-b - sqrtD) / (2.0 * a);
-        var r2 = (-b + sqrtD) / (2.0 * a);
+                if (r1 > r2) {
+                    var temp = r2;
+                    r2 = r1;
+                    r1 = temp;
+                }
 
-        if (r1 > r2) {
-            var temp = r2;
-            r2 = r1;
-            r1 = temp;
+                if (r1 > 0 && r1 < maxR) {
+                    result.root = r1;
+                    result.found = true;
+                    return result;
+                }
+
+                if (r2 > 0 && r2 < maxR) {
+                    result.root = r2;
+                    result.found = true;
+                    return result;
+                }
+
+                return result;
+            }
         }
-
-        if (r1 > 0 && r1 < maxR) {
-            result.root = r1;
-            result.found = true;
-            return result;
-        }
-
-        if (r2 > 0 && r2 < maxR) {
-            result.root = r2;
-            result.found = true;
-            return result;
-        }
-
-        return result;
-    };
+    )();
 
     export class Collider {
         public radius = new Vector3(1, 1, 1);

--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -76,7 +76,7 @@
         private _indexParameters: any;
 
         private _program: WebGLProgram;
-        private _valueCache = [];
+        private _valueCache: { [key: string]: any } = {};
 
         constructor(baseName: any, attributesNames: string[], uniformsNames: string[], samplers: string[], engine, defines?: string, fallbacks?: EffectFallbacks, onCompiled?: (effect: Effect) => void, onError?: (effect: Effect, errors: string) => void, indexParameters?: any) {
             this._engine = engine;
@@ -391,103 +391,164 @@
             this._engine.setTextureFromPostProcess(this._samplers.indexOf(channel), postProcess);
         }
 
-        public _cacheMatrix(uniformName, matrix) {
-            if (!this._valueCache[uniformName]) {
-                this._valueCache[uniformName] = new Matrix();
+        public _cacheMatrix(uniformName: string, matrix: Matrix): boolean {
+            var changed = false;
+            var cache: Matrix = this._valueCache[uniformName];
+            if (!cache || !(cache instanceof Matrix)) {
+                changed = true;
+                cache = new Matrix();
             }
 
+            var tm = cache.m;
+            var om = matrix.m;
             for (var index = 0; index < 16; index++) {
-                this._valueCache[uniformName].m[index] = matrix.m[index];
+                if (tm[index] !== om[index]) { 
+                    tm[index] = om[index];
+                    changed = true;
+                }
             }
+
+            this._valueCache[uniformName] = cache;
+            return changed;
         }
 
-        public _cacheFloat2(uniformName: string, x: number, y: number): void {
-            if (!this._valueCache[uniformName]) {
-                this._valueCache[uniformName] = [x, y];
-                return;
+        public _cacheFloat2(uniformName: string, x: number, y: number): boolean {
+            var cache = this._valueCache[uniformName];
+            if (!cache) {
+                cache = [x, y];
+                this._valueCache[uniformName] = cache;
+                return true;
             }
 
-            this._valueCache[uniformName][0] = x;
-            this._valueCache[uniformName][1] = y;
+            var changed = false;
+            if (cache[0] !== x) {
+                cache[0] = x;
+                changed = true;
+            }
+            if (cache[1] !== y) {
+                cache[1] = y;
+                changed = true;
+            }
+
+            this._valueCache[uniformName] = cache;
+            return changed;
         }
 
-        public _cacheFloat3(uniformName: string, x: number, y: number, z: number): void {
-            if (!this._valueCache[uniformName]) {
-                this._valueCache[uniformName] = [x, y, z];
-                return;
+        public _cacheFloat3(uniformName: string, x: number, y: number, z: number): boolean {
+            var cache = this._valueCache[uniformName];
+            if (!cache) {
+                cache = [x, y, z];
+                this._valueCache[uniformName] = cache;
+                return true;
             }
 
-            this._valueCache[uniformName][0] = x;
-            this._valueCache[uniformName][1] = y;
-            this._valueCache[uniformName][2] = z;
+            var changed = false;
+            if (cache[0] !== x) {
+                cache[0] = x;
+                changed = true;
+            }
+            if (cache[1] !== y) {
+                cache[1] = y;
+                changed = true;
+            }
+            if (cache[2] !== y) {
+                cache[2] = y;
+                changed = true;
+            }
+
+            this._valueCache[uniformName] = cache;
+            return changed;
         }
 
-        public _cacheFloat4(uniformName: string, x: number, y: number, z: number, w: number): void {
-            if (!this._valueCache[uniformName]) {
-                this._valueCache[uniformName] = [x, y, z, w];
-                return;
+        public _cacheFloat4(uniformName: string, x: number, y: number, z: number, w: number): boolean {
+            var cache = this._valueCache[uniformName];
+            if (!cache) {
+                cache = [x, y, z, w];
+                this._valueCache[uniformName] = cache;
+                return true;
             }
 
-            this._valueCache[uniformName][0] = x;
-            this._valueCache[uniformName][1] = y;
-            this._valueCache[uniformName][2] = z;
-            this._valueCache[uniformName][3] = w;
+            var changed = false;
+            if (cache[0] !== x) {
+                cache[0] = x;
+                changed = true;
+            }
+            if (cache[1] !== y) {
+                cache[1] = y;
+                changed = true;
+            }
+            if (cache[2] !== y) {
+                cache[2] = y;
+                changed = true;
+            }
+            if (cache[3] !== w) {
+                cache[3] = w;
+                changed = true;
+            }
+
+            this._valueCache[uniformName] = cache;
+            return changed;
         }
 
         public setArray(uniformName: string, array: number[]): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setArray(this.getUniform(uniformName), array);
 
             return this;
         }
 
         public setArray2(uniformName: string, array: number[]): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setArray2(this.getUniform(uniformName), array);
 
             return this;
         }
 
         public setArray3(uniformName: string, array: number[]): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setArray3(this.getUniform(uniformName), array);
 
             return this;
         }
 
         public setArray4(uniformName: string, array: number[]): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setArray4(this.getUniform(uniformName), array);
 
             return this;
         }
 
         public setMatrices(uniformName: string, matrices: Float32Array): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setMatrices(this.getUniform(uniformName), matrices);
 
             return this;
         }
 
         public setMatrix(uniformName: string, matrix: Matrix): Effect {
-            //if (this._valueCache[uniformName] && this._valueCache[uniformName].equals(matrix))
-            //    return this;
-
-           // this._cacheMatrix(uniformName, matrix);
-            this._engine.setMatrix(this.getUniform(uniformName), matrix);
-
+            if (this._cacheMatrix(uniformName, matrix)) {
+                this._engine.setMatrix(this.getUniform(uniformName), matrix);
+            }
             return this;
         }
 
         public setMatrix3x3(uniformName: string, matrix: Float32Array): Effect {
+            this._valueCache[uniformName] = null;
             this._engine.setMatrix3x3(this.getUniform(uniformName), matrix);
 
             return this;
         }
 
-        public setMatrix2x2(uniformname: string, matrix: Float32Array): Effect {
-            this._engine.setMatrix2x2(this.getUniform(uniformname), matrix);
+        public setMatrix2x2(uniformName: string, matrix: Float32Array): Effect {
+            this._valueCache[uniformName] = null;
+            this._engine.setMatrix2x2(this.getUniform(uniformName), matrix);
 
             return this;
         }
 
         public setFloat(uniformName: string, value: number): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName] === value)
+            var cache = this._valueCache[uniformName];
+            if (cache && cache === value)
                 return this;
 
             this._valueCache[uniformName] = value;
@@ -498,7 +559,8 @@
         }
 
         public setBool(uniformName: string, bool: boolean): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName] === bool)
+            var cache = this._valueCache[uniformName];
+            if (cache && cache === bool)
                 return this;
 
             this._valueCache[uniformName] = bool;
@@ -509,84 +571,58 @@
         }
 
         public setVector2(uniformName: string, vector2: Vector2): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === vector2.x && this._valueCache[uniformName][1] === vector2.y)
-                return this;
-
-            this._cacheFloat2(uniformName, vector2.x, vector2.y);
-            this._engine.setFloat2(this.getUniform(uniformName), vector2.x, vector2.y);
-
+            if (this._cacheFloat2(uniformName, vector2.x, vector2.y)) {
+                this._engine.setFloat2(this.getUniform(uniformName), vector2.x, vector2.y);
+            }
             return this;
         }
 
         public setFloat2(uniformName: string, x: number, y: number): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === x && this._valueCache[uniformName][1] === y)
-                return this;
-
-            this._cacheFloat2(uniformName, x, y);
-            this._engine.setFloat2(this.getUniform(uniformName), x, y);
-
+            if (this._cacheFloat2(uniformName, x, y)) {
+                this._engine.setFloat2(this.getUniform(uniformName), x, y);
+            }
             return this;
         }
 
         public setVector3(uniformName: string, vector3: Vector3): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === vector3.x && this._valueCache[uniformName][1] === vector3.y && this._valueCache[uniformName][2] === vector3.z)
-                return this;
-
-            this._cacheFloat3(uniformName, vector3.x, vector3.y, vector3.z);
-
-            this._engine.setFloat3(this.getUniform(uniformName), vector3.x, vector3.y, vector3.z);
-
+            if (this._cacheFloat3(uniformName, vector3.x, vector3.y, vector3.z)) {
+                this._engine.setFloat3(this.getUniform(uniformName), vector3.x, vector3.y, vector3.z);
+            }
             return this;
         }
 
         public setFloat3(uniformName: string, x: number, y: number, z: number): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === x && this._valueCache[uniformName][1] === y && this._valueCache[uniformName][2] === z)
-                return this;
-
-            this._cacheFloat3(uniformName, x, y, z);
-            this._engine.setFloat3(this.getUniform(uniformName), x, y, z);
-
+            if (this._cacheFloat3(uniformName, x, y, z)) {
+                this._engine.setFloat3(this.getUniform(uniformName), x, y, z);
+            }
             return this;
         }
 
         public setVector4(uniformName: string, vector4: Vector4): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === vector4.x && this._valueCache[uniformName][1] === vector4.y && this._valueCache[uniformName][2] === vector4.z && this._valueCache[uniformName][3] === vector4.w)
-                return this;
-
-            this._cacheFloat4(uniformName, vector4.x, vector4.y, vector4.z, vector4.w);
-
-            this._engine.setFloat4(this.getUniform(uniformName), vector4.x, vector4.y, vector4.z, vector4.w);
-
+            if (this._cacheFloat4(uniformName, vector4.x, vector4.y, vector4.z, vector4.w)) {
+                this._engine.setFloat4(this.getUniform(uniformName), vector4.x, vector4.y, vector4.z, vector4.w);
+            }
             return this;
         }
 
         public setFloat4(uniformName: string, x: number, y: number, z: number, w: number): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === x && this._valueCache[uniformName][1] === y && this._valueCache[uniformName][2] === z && this._valueCache[uniformName][3] === w)
-                return this;
-
-            this._cacheFloat4(uniformName, x, y, z, w);
-            this._engine.setFloat4(this.getUniform(uniformName), x, y, z, w);
-
+            if (this._cacheFloat4(uniformName, x, y, z, w)) {
+                this._engine.setFloat4(this.getUniform(uniformName), x, y, z, w);
+            }
             return this;
         }
 
         public setColor3(uniformName: string, color3: Color3): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === color3.r && this._valueCache[uniformName][1] === color3.g && this._valueCache[uniformName][2] === color3.b)
-                return this;
-
-            this._cacheFloat3(uniformName, color3.r, color3.g, color3.b);
-            this._engine.setColor3(this.getUniform(uniformName), color3);
-
+            if (this._cacheFloat3(uniformName, color3.r, color3.g, color3.b)) {
+                this._engine.setColor3(this.getUniform(uniformName), color3);
+            }
             return this;
         }
 
         public setColor4(uniformName: string, color3: Color3, alpha: number): Effect {
-            if (this._valueCache[uniformName] && this._valueCache[uniformName][0] === color3.r && this._valueCache[uniformName][1] === color3.g && this._valueCache[uniformName][2] === color3.b && this._valueCache[uniformName][3] === alpha)
-                return this;
-
-            this._cacheFloat4(uniformName, color3.r, color3.g, color3.b, alpha);
-            this._engine.setColor4(this.getUniform(uniformName), color3, alpha);
-
+            if (this._cacheFloat4(uniformName, color3.r, color3.g, color3.b, alpha)) {
+                this._engine.setColor4(this.getUniform(uniformName), color3, alpha);
+            }
             return this;
         }
 

--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -451,8 +451,8 @@
                 cache[1] = y;
                 changed = true;
             }
-            if (cache[2] !== y) {
-                cache[2] = y;
+            if (cache[2] !== z) {
+                cache[2] = z;
                 changed = true;
             }
 
@@ -477,8 +477,8 @@
                 cache[1] = y;
                 changed = true;
             }
-            if (cache[2] !== y) {
-                cache[2] = y;
+            if (cache[2] !== z) {
+                cache[2] = z;
                 changed = true;
             }
             if (cache[3] !== w) {

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -2011,7 +2011,10 @@
         }
 
         public static RotationAxis(axis: Vector3, angle: number): Quaternion {
-            var result = new Quaternion();
+            return Quaternion.RotationAxisToRef(axis, angle, new Quaternion());
+        }
+
+        public static RotationAxisToRef(axis: Vector3, angle: number, result: Quaternion): Quaternion {
             var sin = Math.sin(angle / 2);
 
             axis.normalize();
@@ -2033,14 +2036,10 @@
         }
 
         public static RotationYawPitchRoll(yaw: number, pitch: number, roll: number): Quaternion {
-            var result = new Quaternion();
-
-            Quaternion.RotationYawPitchRollToRef(yaw, pitch, roll, result);
-
-            return result;
+            return Quaternion.RotationYawPitchRollToRef(yaw, pitch, roll, new Quaternion());
         }
 
-        public static RotationYawPitchRollToRef(yaw: number, pitch: number, roll: number, result: Quaternion): void {
+        public static RotationYawPitchRollToRef(yaw: number, pitch: number, roll: number, result: Quaternion): Quaternion {
             // Produces a quaternion from Euler angles in the z-y-x orientation (Tait-Bryan angles)
             var halfRoll = roll * 0.5;
             var halfPitch = pitch * 0.5;
@@ -2057,6 +2056,8 @@
             result.y = (sinYaw * cosPitch * cosRoll) - (cosYaw * sinPitch * sinRoll);
             result.z = (cosYaw * cosPitch * sinRoll) - (sinYaw * sinPitch * cosRoll);
             result.w = (cosYaw * cosPitch * cosRoll) + (sinYaw * sinPitch * sinRoll);
+
+            return result;
         }
 
         public static RotationAlphaBetaGamma(alpha: number, beta: number, gamma: number): Quaternion {

--- a/src/Mesh/babylon.geometry.ts
+++ b/src/Mesh/babylon.geometry.ts
@@ -415,6 +415,10 @@
 
             this.delayLoadState = Engine.DELAYLOADSTATE_LOADING;
 
+            this._queueLoad(scene, onLoaded);
+        }
+
+        private _queueLoad(scene: Scene, onLoaded?: () => void): void {
             scene._addPendingData(this);
             Tools.LoadFile(this.delayLoadingFile, data => {
                 this._delayLoadingFunction(JSON.parse(data), this);

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -973,7 +973,7 @@
         }
 
         public _processRendering(subMesh: SubMesh, effect: Effect, fillMode: number, batch: _InstancesBatch, hardwareInstancedRendering: boolean,
-            onBeforeDraw: (isInstance: boolean, world: Matrix) => void) {
+            onBeforeDraw: (isInstance: boolean, world: Matrix, effectiveMaterial?: Material) => void, effectiveMaterial?: Material) {
             var scene = this.getScene();
             var engine = scene.getEngine();
 
@@ -983,7 +983,7 @@
                 if (batch.renderSelf[subMesh._id]) {
                     // Draw
                     if (onBeforeDraw) {
-                        onBeforeDraw(false, this.getWorldMatrix());
+                        onBeforeDraw(false, this.getWorldMatrix(), effectiveMaterial);
                     }
 
                     this._draw(subMesh, fillMode, this._overridenInstanceCount);
@@ -996,7 +996,7 @@
                         // World
                         var world = instance.getWorldMatrix();
                         if (onBeforeDraw) {
-                            onBeforeDraw(true, world);
+                            onBeforeDraw(true, world, effectiveMaterial);
                         }
 
                         // Draw
@@ -1063,12 +1063,7 @@
             }
 
             // Draw
-            this._processRendering(subMesh, effect, fillMode, batch, hardwareInstancedRendering,
-                (isInstance, world) => {
-                    if (isInstance) {
-                        effectiveMaterial.bindOnlyWorldMatrix(world);
-                    }
-                });
+            this._processRendering(subMesh, effect, fillMode, batch, hardwareInstancedRendering, this._onBeforeDraw);
 
             // Unbind
             effectiveMaterial.unbind();
@@ -1090,6 +1085,12 @@
             }
 
             this.onAfterRenderObservable.notifyObservers(this);
+        }
+
+        private _onBeforeDraw(isInstance: boolean, world: Matrix, effectiveMaterial: Material): void {
+            if (isInstance) {
+                effectiveMaterial.bindOnlyWorldMatrix(world);
+            }
         }
 
         /**

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1127,32 +1127,35 @@
         }
 
         public _checkDelayState(): void {
-            var that = this;
             var scene = this.getScene();
 
             if (this._geometry) {
                 this._geometry.load(scene);
             }
-            else if (that.delayLoadState === Engine.DELAYLOADSTATE_NOTLOADED) {
-                that.delayLoadState = Engine.DELAYLOADSTATE_LOADING;
+            else if (this.delayLoadState === Engine.DELAYLOADSTATE_NOTLOADED) {
+                this.delayLoadState = Engine.DELAYLOADSTATE_LOADING;
 
-                scene._addPendingData(that);
-
-                var getBinaryData = (this.delayLoadingFile.indexOf(".babylonbinarymeshdata") !== -1);
-
-                Tools.LoadFile(this.delayLoadingFile, data => {
-
-                    if (data instanceof ArrayBuffer) {
-                        this._delayLoadingFunction(data, this);
-                    }
-                    else {
-                        this._delayLoadingFunction(JSON.parse(data), this);
-                    }
-
-                    this.delayLoadState = Engine.DELAYLOADSTATE_LOADED;
-                    scene._removePendingData(this);
-                }, () => { }, scene.database, getBinaryData);
+                this._queueLoad(this, scene);
             }
+        }
+
+        private _queueLoad(mesh: Mesh, scene: Scene): void {
+            scene._addPendingData(mesh);
+
+            var getBinaryData = (this.delayLoadingFile.indexOf(".babylonbinarymeshdata") !== -1);
+
+            Tools.LoadFile(this.delayLoadingFile, data => {
+
+                if (data instanceof ArrayBuffer) {
+                    this._delayLoadingFunction(data, this);
+                }
+                else {
+                    this._delayLoadingFunction(JSON.parse(data), this);
+                }
+
+                this.delayLoadState = Engine.DELAYLOADSTATE_LOADED;
+                scene._removePendingData(this);
+            }, () => { }, scene.database, getBinaryData);
         }
 
         /**

--- a/src/Tools/babylon.observable.ts
+++ b/src/Tools/babylon.observable.ts
@@ -9,8 +9,13 @@
         * If the callback of a given Observer set skipNextObservers to true the following observers will be ignored
         */
         constructor(mask: number, skipNextObservers = false) {
+            this.initalize(mask, skipNextObservers);
+        }
+
+        public initalize(mask: number, skipNextObservers = false): EventState {
             this.mask = mask;
             this.skipNextObservers = skipNextObservers;
+            return this;
         }
 
         /**
@@ -40,6 +45,8 @@
      * A given observer can register itself with only Move and Stop (mask = 0x03), then it will only be notified when one of these two occurs and will never be for Turn Left/Right.
      */
     export class Observable<T> {
+        private static _pooledEventState: EventState = null;
+
         _observers = new Array<Observer<T>>();
 
         /**
@@ -103,7 +110,8 @@
          * @param mask
          */
         public notifyObservers(eventData: T, mask: number = -1): void {
-            var state = new EventState(mask);
+            var state = Observable._pooledEventState ? Observable._pooledEventState.initalize(mask) : new EventState(mask);
+            Observable._pooledEventState = null;
 
             for (var obs of this._observers) {
                 if (obs.mask & mask) {
@@ -113,6 +121,8 @@
                     break;
                 }
             }
+
+            Observable._pooledEventState = state;
         }
 
         /**

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -1305,11 +1305,7 @@
             this._vertexAttribArraysEnabled = this._vertexAttribArraysEnabled || [];
 
             // Use program
-            var program = effect.getProgram();
-            if (this._currentProgram !== program) {
-                this._gl.useProgram(program);
-                this._currentProgram = program;
-            }
+            this.setProgram(effect.getProgram());
 
             var i, ul;
             for (i = 0, ul = this._vertexAttribArraysToUse.length; i < ul; i++) {
@@ -2280,12 +2276,16 @@
             }
         }
 
-        public bindSamplers(effect: Effect): void {
-            var program = effect.getProgram();
+        private setProgram(program: WebGLProgram): void {
             if (this._currentProgram !== program) {
                 this._gl.useProgram(program);
                 this._currentProgram = program;
             }
+        }
+
+        public bindSamplers(effect: Effect): void {
+            this.setProgram(effect.getProgram());
+
             var samplers = effect.getSamplers();
             for (var index = 0; index < samplers.length; index++) {
                 var uniform = effect.getUniform(samplers[index]);

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -339,6 +339,7 @@
         private _maxTextureChannels = 16;
         private _activeTexturesCache = new Array<BaseTexture>(this._maxTextureChannels);
         private _currentEffect: Effect;
+        private _currentProgram: WebGLProgram;
         private _compiledEffects = {};
         private _vertexAttribArraysEnabled: boolean[];
         private _vertexAttribArraysToUse: boolean[];
@@ -1271,7 +1272,11 @@
             this._vertexAttribArraysEnabled = this._vertexAttribArraysEnabled || [];
 
             // Use program
-            this._gl.useProgram(effect.getProgram());
+            var program = effect.getProgram();
+            if (this._currentProgram !== program) {
+                this._gl.useProgram(program);
+                this._currentProgram = program;
+            }
 
             var i, ul;
             for (i = 0, ul = this._vertexAttribArraysToUse.length; i < ul; i++) {
@@ -2243,7 +2248,11 @@
         }
 
         public bindSamplers(effect: Effect): void {
-            this._gl.useProgram(effect.getProgram());
+            var program = effect.getProgram();
+            if (this._currentProgram !== program) {
+                this._gl.useProgram(program);
+                this._currentProgram = program;
+            }
             var samplers = effect.getSamplers();
             for (var index = 0; index < samplers.length; index++) {
                 var uniform = effect.getUniform(samplers[index]);

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -987,9 +987,17 @@
         }
 
         public bindArrayBuffer(buffer: WebGLBuffer): void {
-            if (this._currentBoundBuffer[this._gl.ARRAY_BUFFER] !== buffer) {
-                this._gl.bindBuffer(this._gl.ARRAY_BUFFER, buffer);
-                this._currentBoundBuffer[this._gl.ARRAY_BUFFER] = buffer;
+            this.bindBuffer(buffer, this._gl.ARRAY_BUFFER);
+        }
+
+        private bindIndexBuffer(buffer: WebGLBuffer): void {
+            this.bindBuffer(buffer, this._gl.ELEMENT_ARRAY_BUFFER);
+        }
+
+        private bindBuffer(buffer: WebGLBuffer, target: number): void {
+            if (this._currentBoundBuffer[target] !== buffer) {
+                this._gl.bindBuffer(target, buffer);
+                this._currentBoundBuffer[target] = buffer;
             }
         }
 
@@ -1014,18 +1022,8 @@
             }
 
             if (changed) {
-                if (this._currentBoundBuffer[this._gl.ARRAY_BUFFER] !== buffer) {
-                    this._gl.bindBuffer(this._gl.ARRAY_BUFFER, buffer);
-                    this._currentBoundBuffer[this._gl.ARRAY_BUFFER] = buffer;
-                }
+                this.bindArrayBuffer(buffer);
                 this._gl.vertexAttribPointer(indx, size, type, normalized, stride, offset);
-            }
-        }
-
-        private bindIndexBuffer(buffer: WebGLBuffer): void {
-            if (this._currentBoundBuffer[this._gl.ELEMENT_ARRAY_BUFFER] !== buffer) {
-                this._gl.bindBuffer(this._gl.ELEMENT_ARRAY_BUFFER, buffer);
-                this._currentBoundBuffer[this._gl.ELEMENT_ARRAY_BUFFER] = buffer;
             }
         }
 


### PR DESCRIPTION
Non SIMD/asm changes from #1180 

With the tweak to the sample https://github.com/BabylonJS/Samples/commit/b21a56c51044db967bad7544b7b246f939f3a7c0 and these changes I gain about 20 dancers in the non-SIMD path

Allocations (reduced to just rAF callback allocation per frame)
* Prevent Observable.notifyObservers allocation
* Prevent per mesh per render closure allocation
* Avoid inadvertent per geometry per render alloc
* Avoid inadvertent per mesh per render alloc
* Avoid Collider root calc allocations
* Reduce mesh rotation allocs
* Allocate less in vector project and unproject

Decrease GPU state changes and redundant calls
* Improved uniform caching
* Cache program
* Cache vertexAttribPointer
* Reduce buffer binds	
* Only bind unbound framebuffers
* Cache texture changes better