### PR TITLE
fix tiny bugs in SPS and MeshBuilder

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1221,10 +1221,10 @@
         }
 
         public static CreateTiledGround(options: { xmin: number, zmin: number, xmax: number, zmax: number, subdivisions?: { w: number; h: number; }, precision?: { w: number; h: number; } }): VertexData {
-            var xmin = options.xmin;
-            var zmin = options.zmin;
-            var xmax = options.xmax;
-            var zmax = options.zmax;
+            var xmin = options.xmin || -1;
+            var zmin = options.zmin || -1;
+            var xmax = options.xmax || 1;
+            var zmax = options.zmax || 1;
             var subdivisions = options.subdivisions || { w: 1, h: 1 };
             var precision = options.precision || { w: 1, h: 1 };
 
@@ -1234,7 +1234,7 @@
             var uvs = [];
             var row: number, col: number, tileRow: number, tileCol: number;
 
-            subdivisions.h = (subdivisions.w < 1) ? 1 : subdivisions.h;
+            subdivisions.h = (subdivisions.h < 1) ? 1 : subdivisions.h;
             subdivisions.w = (subdivisions.w < 1) ? 1 : subdivisions.w;
             precision.w = (precision.w < 1) ? 1 : precision.w;
             precision.h = (precision.h < 1) ? 1 : precision.h;

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -616,7 +616,7 @@
             var width = options.width || 10;
             var height = options.height || 10;
             var subdivisions = options.subdivisions || 1;
-            var minHeight = options.minHeight;
+            var minHeight = options.minHeight || 0;
             var maxHeight = options.maxHeight || 10;
             var updatable = options.updatable;
             var onReady = options.onReady;

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -328,7 +328,7 @@
 
                 if (this._copy.color) {
                     this._color = this._copy.color;
-                } else if (meshCol && meshCol[c]) {
+                } else if (meshCol && meshCol[c] !== undefined) {
                     this._color.r = meshCol[c];
                     this._color.g = meshCol[c + 1];
                     this._color.b = meshCol[c + 2];


### PR DESCRIPTION
fixed following bugs : 
* `CreateGroundFromHeightMap()` : the `minHeight` parameter default value wasn't set
* `CreateTiledGround()` : `xmin`, `zmin`, `xmax`, `zmax` parameter values weren't set
* `SPS` : if a model shape, used with `addShape()`, had initial vertex colors and its red value was 0, the whole vertex color wasn't taken in account (zero is falsy)