### PR TITLE
Oimo quaternion fix

### DIFF
--- a/src/Physics/Plugins/babylon.oimoJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.oimoJSPlugin.ts
@@ -307,6 +307,7 @@ module BABYLON {
 
                 }
                 impostor.object.rotationQuaternion.copyFrom(impostor.physicsBody.getQuaternion());
+                impostor.object.rotationQuaternion.normalize();
             }
         }
 


### PR DESCRIPTION
Normalizing the quaternion coming back from Oimo, as it can be returned
unnormalized when constantly updated from Babylon.js.
This extra call can also be called when sending the quaternion TO oimo,
but this is an extra call per frame, which might not be needed.