### PR TITLE
Improve FontTexture quality + some fixes

### DIFF
--- a/src/Canvas2d/babylon.prim2dBase.ts
+++ b/src/Canvas2d/babylon.prim2dBase.ts
@@ -1307,7 +1307,7 @@
                         throw new Error(`Parent ${parent.id} of ${settings.id} doesn't have a valid owner!`);
                     }
 
-                    if (!(this instanceof Group2D) && !(this instanceof Sprite2D && settings.id !== null && settings.id.indexOf("__cachedSpriteOfGroup__") === 0) && (owner.cachingStrategy === Canvas2D.CACHESTRATEGY_TOPLEVELGROUPS) && (parent === owner)) {
+                    if (!(this instanceof Group2D) && !(this instanceof Sprite2D && settings.id != null && settings.id.indexOf("__cachedSpriteOfGroup__") === 0) && (owner.cachingStrategy === Canvas2D.CACHESTRATEGY_TOPLEVELGROUPS) && (parent === owner)) {
                         throw new Error("Can't create a primitive with the canvas as direct parent when the caching strategy is TOPLEVELGROUPS. You need to create a Group below the canvas and use it as the parent for the primitive");
                     }
                 }

--- a/src/Canvas2d/babylon.sprite2d.ts
+++ b/src/Canvas2d/babylon.sprite2d.ts
@@ -296,14 +296,14 @@
             this.texture = texture;
             this.texture.wrapU = Texture.CLAMP_ADDRESSMODE;
             this.texture.wrapV = Texture.CLAMP_ADDRESSMODE;
-            this.size = settings.spriteSize || null;
+            this.size = settings.spriteSize;
             this.spriteLocation = settings.spriteLocation || new Vector2(0, 0);
             this.spriteFrame = 0;
             this.invertY = (settings.invertY == null) ? false : settings.invertY;
             this.alignToPixel = (settings.alignToPixel == null) ? true : settings.alignToPixel;
             this._isTransparent = true;
 
-            if (!this.size) {
+            if (settings.spriteSize==null) {
                 var s = texture.getSize();
                 this.size = new Size(s.width, s.height);
             }

--- a/src/Materials/Textures/babylon.fontTexture.ts
+++ b/src/Materials/Textures/babylon.fontTexture.ts
@@ -158,7 +158,7 @@
             // we reached the end of the current line?
             var xMargin = 2;
             var yMargin = 2;
-            let width = measure.width;
+            let width = Math.round(measure.width);
             if (this._currentFreePosition.x + width + xMargin > textureSize.width) {
                 this._currentFreePosition.x = 0;
                 this._currentFreePosition.y += this._lineHeight + yMargin;      // +2 for safety margin
@@ -170,11 +170,11 @@
             }
 
             // Draw the character in the texture
-            this._context.fillText(char, this._currentFreePosition.x - 0.5, this._currentFreePosition.y - this._offset - 0.5);
+            this._context.fillText(char, this._currentFreePosition.x, this._currentFreePosition.y - this._offset);
 
             // Fill the CharInfo object
             info.topLeftUV = new Vector2(this._currentFreePosition.x / textureSize.width, this._currentFreePosition.y / textureSize.height);
-            info.bottomRightUV = new Vector2(info.topLeftUV.x + (width / textureSize.width), info.topLeftUV.y + ((this._lineHeight + 2) / textureSize.height));
+            info.bottomRightUV = new Vector2((this._currentFreePosition.x + width) / textureSize.width, info.topLeftUV.y + ((this._lineHeight + 2) / textureSize.height));
             info.charWidth = width;
 
             // Add the info structure

--- a/src/Materials/Textures/babylon.fontTexture.ts
+++ b/src/Materials/Textures/babylon.fontTexture.ts
@@ -156,12 +156,12 @@
             var textureSize = this.getSize();
 
             // we reached the end of the current line?
-            var xMargin = 2;
-            var yMargin = 2;
             let width = Math.round(measure.width);
+            var xMargin = Math.ceil(this._lineHeight/20);
+            var yMargin = xMargin;
             if (this._currentFreePosition.x + width + xMargin > textureSize.width) {
                 this._currentFreePosition.x = 0;
-                this._currentFreePosition.y += this._lineHeight + yMargin;      // +2 for safety margin
+                this._currentFreePosition.y += this._lineHeight + yMargin;
 
                 // No more room?
                 if (this._currentFreePosition.y > textureSize.height) {
@@ -258,7 +258,7 @@
                     }
                 }
             }
-            return { height: end - start, offset: start-1}
+            return { height: (end - start)+1, offset: start-1}
         }
 
         public get canRescale(): boolean {


### PR DESCRIPTION
FontChar are now rounded to ensure a proper storage in the FontTexture (issues with Chrome)

Canvas2D:
 - check fail when a Sprite2D is created without ID
 - Sprite2D default size wasn't set to the texture one during init.