### PR TITLE
fix tiny bugs in SPS and MeshBuilder (2)

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1221,10 +1221,10 @@
         }
 
         public static CreateTiledGround(options: { xmin: number, zmin: number, xmax: number, zmax: number, subdivisions?: { w: number; h: number; }, precision?: { w: number; h: number; } }): VertexData {
-            var xmin = options.xmin;
-            var zmin = options.zmin;
-            var xmax = options.xmax;
-            var zmax = options.zmax;
+            var xmin = options.xmin || -1.0;
+            var zmin = options.zmin || -1.0;
+            var xmax = options.xmax || 1.0;
+            var zmax = options.zmax || 1.0;
             var subdivisions = options.subdivisions || { w: 1, h: 1 };
             var precision = options.precision || { w: 1, h: 1 };
 
@@ -1234,7 +1234,7 @@
             var uvs = [];
             var row: number, col: number, tileRow: number, tileCol: number;
 
-            subdivisions.h = (subdivisions.w < 1) ? 1 : subdivisions.h;
+            subdivisions.h = (subdivisions.h < 1) ? 1 : subdivisions.h;
             subdivisions.w = (subdivisions.w < 1) ? 1 : subdivisions.w;
             precision.w = (precision.w < 1) ? 1 : precision.w;
             precision.h = (precision.h < 1) ? 1 : precision.h;

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -613,11 +613,11 @@
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
          */
         public static CreateGroundFromHeightMap(name: string, url: string, options: { width?: number, height?: number, subdivisions?: number, minHeight?: number, maxHeight?: number, updatable?: boolean, onReady?: (mesh: GroundMesh) => void }, scene: Scene): GroundMesh {
-            var width = options.width || 10;
-            var height = options.height || 10;
-            var subdivisions = options.subdivisions || 1;
-            var minHeight = options.minHeight;
-            var maxHeight = options.maxHeight || 10;
+            var width = options.width || 10.0;
+            var height = options.height || 10.0;
+            var subdivisions = options.subdivisions || 1|0;
+            var minHeight = options.minHeight || 0.0;
+            var maxHeight = options.maxHeight || 10.0;
             var updatable = options.updatable;
             var onReady = options.onReady;
 
@@ -625,8 +625,8 @@
             ground._subdivisions = subdivisions;
             ground._width = width;
             ground._height = height;
-            ground._maxX = ground._width / 2;
-            ground._maxZ = ground._height / 2;
+            ground._maxX = ground._width / 2.0;
+            ground._maxZ = ground._height / 2.0;
             ground._minX = -ground._maxX;
             ground._minZ = -ground._maxZ;
 

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -328,7 +328,7 @@
 
                 if (this._copy.color) {
                     this._color = this._copy.color;
-                } else if (meshCol && meshCol[c]) {
+                } else if (meshCol && meshCol[c] !== undefined) {
                     this._color.r = meshCol[c];
                     this._color.g = meshCol[c + 1];
                     this._color.b = meshCol[c + 2];


### PR DESCRIPTION
fixed following bugs : 
* `CreateGroundFromHeightMap()` : the `minHeight` parameter default value wasn't set
* `CreateTiledGround()` : `xmin`, `zmin`, `xmax`, `zmax` parameter values weren't set
* `SPS` : if a model shape, used with `addShape()`, had initial vertex colors and its red value was 0, the whole vertex color wasn't taken in account (zero is falsy)

This is re-PRed because the former similar PR was accidentally un-merged