### PR TITLE
Remove redundant highp fallback that can trigger infinite loop

### DIFF
--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -346,16 +346,7 @@
                     this.onCompiled(this);
                 }
             } catch (e) {
-                // Is it a problem with precision?
-                if (e.message.indexOf("highp") !== -1) {
-                    vertexSourceCode = vertexSourceCode.replace("precision highp float", "precision mediump float");
-                    fragmentSourceCode = fragmentSourceCode.replace("precision highp float", "precision mediump float");
-
-                    this._prepareEffect(vertexSourceCode, fragmentSourceCode, attributesNames, defines, fallbacks);
-
-                    return;
-                }
-                // Let's go through fallbacks then
+                // Let's go through fallbacks
                 if (fallbacks && fallbacks.isMoreFallbacks) {
                     Tools.Error("Unable to compile effect with current defines. Trying next fallback.");
                     this._dumpShadersName();


### PR DESCRIPTION
Say your shader error was something like `Error: ERROR: 0:16: '=' :  cannot convert from 'highp 4-component vector of float' to 'highp 3-component vector of float'(…)` (which is emitted by Chrome when setting a vec3 with a vec4)
 
Since the error contains 'highp' it tries to replace the precision statement and then runs _prepareEffect again, which doesn't resolve the issue, triggering the infinite loop.
 
I think the best fix immediately is to remove the check completely. Babylon is already trying to resolve highp support issues in '_processPrecision', so this fix shouldn't actually be needed.
 
In a broader discussion, I think the approach of string searching for complete precision statements isn't the best one, the current approach doesn't account for the variations in whitespace, we could regex search of course but it's arguable this is still fragile
 
Some other ideas:
- If highp isn't supported, prepend `#define highp mediump` (ensuring it's placed after the `#version` directive if one exists)
We don't even need to check for highp precision support in js, this would do it:

 ```glsl
#ifndef GL_FRAGMENT_PRECISION_HIGH
#define highp mediump
#endif
 ```

- We could store desired precision as an option in js, this way Babylon can prepend the correct precision statement itself
 
In any case I think it's important Babylon emits a warning for the developers when it forces a change to the shaders.