### PR TITLE
LookAt now works in global space as well

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -746,7 +746,7 @@
         }
 
         private static _lookAtVectorCache = new Vector3(0,0,0);
-        public lookAt(targetPoint: Vector3, yawCor: number, pitchCor: number, rollCor: number): void {
+        public lookAt(targetPoint: Vector3, yawCor: number = 0, pitchCor: number = 0, rollCor: number = 0, space: Space = Space.LOCAL): void {
             /// <summary>Orients a mesh towards a target point. Mesh must be drawn facing user.</summary>
             /// <param name="targetPoint" type="Vector3">The position (must be in same space as current mesh) to look at</param>
             /// <param name="yawCor" type="Number">optional yaw (y-axis) correction in radians</param>
@@ -754,12 +754,9 @@
             /// <param name="rollCor" type="Number">optional roll (z-axis) correction in radians</param>
             /// <returns>Mesh oriented towards targetMesh</returns>
 
-            yawCor = yawCor || 0; // default to zero if undefined
-            pitchCor = pitchCor || 0;
-            rollCor = rollCor || 0;
-
             var dv = AbstractMesh._lookAtVectorCache;
-            targetPoint.subtractToRef(this.position, dv);
+            var pos = space === Space.LOCAL ? this.position : this.getAbsolutePosition();
+            targetPoint.subtractToRef(pos, dv);
             var yaw = -Math.atan2(dv.z, dv.x) - Math.PI / 2;
             var len = Math.sqrt(dv.x * dv.x + dv.z * dv.z);
             var pitch = Math.atan2(dv.y, len);


### PR DESCRIPTION
The target point should be in the same space as the current object, but
sometimes it is not possible (for example, when you want to look at a
mesh that is a child of a different node).
If space is local (default) the position of the mesh is used, but if
space is world, the absolute position of the mesh is used, and then it
is expected that the targetPoint will also be in world space.
Also - made optional parameters really optional :smile: