### PR TITLE
Update bower.json for 2.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "babylonjs",
   "description": "Babylon.js is a complete JavaScript framework for building 3D games with HTML 5 and WebGL",
-  "main": "./dist/babylon.2.3.js",
+  "main": "./dist/babylon.2.4.js",
   "homepage": "https://www.babylonjs.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Bower change not being included in the 2.4.0 tag means a typical `"babylonjs": "^2.4.0"` dependency often won't work correctly. This PR is branched directly from [v2.4.0](https://github.com/BabylonJS/Babylon.js/commits/v2.4.0) — rather than merge into `master`, you might simply tag this commit as 2.4.1 for Bower users' benefit, without also bringing in changes since 2.4.0.