### PR TITLE
Added 'panningMouseButton' parameter in ArcRotateCamera class

### DIFF
--- a/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
+++ b/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
@@ -16,7 +16,7 @@ module BABYLON {
         @serialize()
         public panningSensibility: number = 50.0;
 
-        private _isRightClick: boolean = false;
+        private _isPanClick: boolean = false;
         private _isCtrlPushed: boolean = false;
         public pinchInwards = true;
 
@@ -47,8 +47,8 @@ module BABYLON {
                     }
 
 
-                    // Manage panning with right click
-                    this._isRightClick = evt.button === 2;
+                    // Manage panning with pan button click
+                    this._isPanClick = evt.button === this.camera._panningMouseButton;
 
                     // manage pointers
                     cacheSoloPointer = { x: evt.clientX, y: evt.clientY, pointerId: evt.pointerId, type: evt.pointerType };
@@ -90,7 +90,7 @@ module BABYLON {
                     if (pointA && pointB === undefined) {
                         if (this.panningSensibility !== 0 &&
                             ((this._isCtrlPushed && this.camera._useCtrlForPanning) ||
-                                (!this.camera._useCtrlForPanning && this._isRightClick))) {
+                                (!this.camera._useCtrlForPanning && this._isPanClick))) {
                             this.camera
                                 .inertialPanningX += -(evt.clientX - cacheSoloPointer.x) / this.panningSensibility;
                             this.camera
@@ -223,7 +223,7 @@ module BABYLON {
                 element.removeEventListener("keydown", this._onKeyDown);
                 element.removeEventListener("keyup", this._onKeyUp);
 
-                this._isRightClick = false;
+                this._isPanClick = false;
                 this._isCtrlPushed = false;
                 this.pinchInwards = true;
 

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -170,6 +170,7 @@
 
         public _viewMatrix = new Matrix();
         public _useCtrlForPanning: boolean;
+        public _panningMouseButton: number;
         public inputs: ArcRotateCameraInputsManager;
 
         public _reset: () => void;
@@ -254,8 +255,9 @@
         }
 
         // Methods
-        public attachControl(element: HTMLElement, noPreventDefault?: boolean, useCtrlForPanning: boolean = true): void {
+        public attachControl(element: HTMLElement, noPreventDefault?: boolean, useCtrlForPanning: boolean = true, panningMouseButton: number = 2): void {
             this._useCtrlForPanning = useCtrlForPanning;
+            this._panningMouseButton = panningMouseButton;
 
             this.inputs.attachElement(element, noPreventDefault);
 


### PR DESCRIPTION
I would like to use the middle mouse button to drag the camera (pan feature).

So I added an optional parameter named 'panningMouseButton' to the 'attachControl' method in 'ArcRotateCamera' class.