### PR TITLE
SPS billboard doesn't use ComputeNormals() any longer

### DIFF
--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -78,9 +78,9 @@
         private _axisX: Vector3 = Axis.X;
         private _axisY: Vector3 = Axis.Y;
         private _axisZ: Vector3 = Axis.Z;
-        private _camera: Camera;
+        private _camera: TargetCamera;
         private _particle: SolidParticle;
-        private _fakeCamPos: Vector3 = Vector3.Zero();
+        private _camDir: Vector3 = Vector3.Zero();
         private _rotMatrix: Matrix = new Matrix();
         private _invertMatrix: Matrix = new Matrix();
         private _rotated: Vector3 = Vector3.Zero();
@@ -114,7 +114,7 @@
         constructor(name: string, scene: Scene, options?: { updatable?: boolean; isPickable?: boolean }) {
             this.name = name;
             this._scene = scene;
-            this._camera = scene.activeCamera;
+            this._camera = <TargetCamera>scene.activeCamera;
             this._pickable = options ? options.isPickable : false;
             if (options && options.updatable) {
                 this._updatable = options.updatable;
@@ -507,17 +507,17 @@
 
             // if the particles will always face the camera
             if (this.billboard) {
-                // compute a fake camera position : un-rotate the camera position by the current mesh rotation
+                // compute the camera position and un-rotate it by the current mesh rotation
                 this._yaw = this.mesh.rotation.y;
                 this._pitch = this.mesh.rotation.x;
                 this._roll = this.mesh.rotation.z;
                 this._quaternionRotationYPR();
                 this._quaternionToRotationMatrix();
                 this._rotMatrix.invertToRef(this._invertMatrix);
-                Vector3.TransformCoordinatesToRef(this._camera.globalPosition, this._invertMatrix, this._fakeCamPos);
+                this._camera._currentTarget.subtractToRef(this._camera.globalPosition, this._camDir);
+                Vector3.TransformCoordinatesToRef(this._camDir, this._invertMatrix, this._cam_axisZ);
 
-                // set two orthogonal vectors (_cam_axisX and and _cam_axisY) to the cam-mesh axis (_cam_axisZ)
-                (this.mesh.position).subtractToRef(this._fakeCamPos, this._cam_axisZ);
+                // set two orthogonal vectors (_cam_axisX and and _cam_axisY) to the rotated camDir axis (_cam_axisZ)
                 Vector3.CrossToRef(this._cam_axisZ, this._axisX, this._cam_axisY);
                 Vector3.CrossToRef(this._cam_axisZ, this._cam_axisY, this._cam_axisX);
                 this._cam_axisY.normalize();

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -493,17 +493,17 @@
             // custom beforeUpdate
             this.beforeUpdateParticles(start, end, update);
 
-            this._cam_axisX.x = 1;
-            this._cam_axisX.y = 0;
-            this._cam_axisX.z = 0;
+            this._cam_axisX.x = 1.0;
+            this._cam_axisX.y = 0.0;
+            this._cam_axisX.z = 0.0;
 
-            this._cam_axisY.x = 0;
-            this._cam_axisY.y = 1;
-            this._cam_axisY.z = 0;
+            this._cam_axisY.x = 0.0;
+            this._cam_axisY.y = 1.0;
+            this._cam_axisY.z = 0.0;
 
-            this._cam_axisZ.x = 0;
-            this._cam_axisZ.y = 0;
-            this._cam_axisZ.z = 1;
+            this._cam_axisZ.x = 0.0;
+            this._cam_axisZ.y = 0.0;
+            this._cam_axisZ.z = 1.0;
 
             // if the particles will always face the camera
             if (this.billboard) {
@@ -517,7 +517,7 @@
                 Vector3.TransformCoordinatesToRef(this._camera.globalPosition, this._invertMatrix, this._fakeCamPos);
 
                 // set two orthogonal vectors (_cam_axisX and and _cam_axisY) to the cam-mesh axis (_cam_axisZ)
-                (this._fakeCamPos).subtractToRef(this.mesh.position, this._cam_axisZ);
+                (this.mesh.position).subtractToRef(this._fakeCamPos, this._cam_axisZ);
                 Vector3.CrossToRef(this._cam_axisZ, this._axisX, this._cam_axisY);
                 Vector3.CrossToRef(this._cam_axisZ, this._cam_axisY, this._cam_axisX);
                 this._cam_axisY.normalize();
@@ -556,7 +556,7 @@
                         this._particle.rotation.x = 0.0;
                         this._particle.rotation.y = 0.0;
                     }
-                    if (this._computeParticleRotation) {
+                    if (this._computeParticleRotation || this.billboard) {
                         if (this._particle.rotationQuaternion) {
                             this._quaternion.copyFrom(this._particle.rotationQuaternion);
                         } else {
@@ -618,7 +618,7 @@
                         }
 
                         // normals : if the particles can't be morphed then just rotate the normals, what if much more faster than ComputeNormals()
-                        if (!this._computeParticleVertex && !this.billboard) {
+                        if (!this._computeParticleVertex) {
                             this._normal.x = this._fixedNormal32[idx];
                             this._normal.y = this._fixedNormal32[idx + 1];
                             this._normal.z = this._fixedNormal32[idx + 2];
@@ -688,7 +688,7 @@
                 }
                 this.mesh.updateVerticesData(VertexBuffer.PositionKind, this._positions32, false, false);
                 if (!this.mesh.areNormalsFrozen) {
-                    if (this._computeParticleVertex || this.billboard) {
+                    if (this._computeParticleVertex) {
                         // recompute the normals only if the particles can be morphed, update then also the normal reference array _fixedNormal32[]
                         VertexData.ComputeNormals(this._positions32, this._indices, this._normals32);
                         for (var i = 0; i < this._normals32.length; i++) {


### PR DESCRIPTION
SPS billboard now correctly rotates the normals in the same time than the particle positions.
This means the billboard mode doesn't use `ComputeNormals()` any longer and thus doesn't need to re-iterate over the huge number of vertices/indices/normals.

In other terms, the SPS billboard mode is now as fast as the standard SPS mode.
This makes the SPS a good option for planar billboarded particles what would need the light reflection compared to the BJS standard particle system.