### PR TITLE
Ground getHeightAtCoordinates debug

### DIFF
--- a/src/Math/babylon.math.js
+++ b/src/Math/babylon.math.js
@@ -899,10 +899,10 @@ var BABYLON;
             return result;
         };
         Vector3.CrossToRef = function (left, right, result) {
-            Tmp.Vector3[0].x = left.y * right.z - left.z * right.y;
-            Tmp.Vector3[0].y = left.z * right.x - left.x * right.z;
-            Tmp.Vector3[0].z = left.x * right.y - left.y * right.x;
-            result.copyFrom(Tmp.Vector3[0]);
+            var x = left.y * right.z - left.z * right.y;
+            var y = left.z * right.x - left.x * right.z;
+            var z = left.x * right.y - left.y * right.x;
+            result.copyFromFloats(x, y, z);
         };
         Vector3.Normalize = function (vector) {
             var result = Vector3.Zero();

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1132,10 +1132,10 @@
         }
 
         public static CrossToRef(left: Vector3, right: Vector3, result: Vector3): void {
-            Tmp.Vector3[0].x = left.y * right.z - left.z * right.y;
-            Tmp.Vector3[0].y = left.z * right.x - left.x * right.z;
-            Tmp.Vector3[0].z = left.x * right.y - left.y * right.x;
-            result.copyFrom(Tmp.Vector3[0]);
+            var x = left.y * right.z - left.z * right.y;
+            var y = left.z * right.x - left.x * right.z;
+            var z = left.x * right.y - left.y * right.x;
+            result.copyFromFloats(x, y, z);
         }
 
         public static Normalize(vector: Vector3): Vector3 {


### PR DESCRIPTION
Vector3.CrossToRef function was modifying Tmp.Vector3[0]'s value to store its result. But GroundMesh.prototype._computeHeightQuads was both using Tmp.Vector3[0]'s value, and calling Vector3.CrossToRef, resulting in an undesired value in Tmp.Vector3[0] and a bug.