### PR TITLE
Text2DModelRenderCache now handles correctly the lifetime of the shar…

### DIFF
--- a/src/Canvas2d/babylon.ellipse2d.ts
+++ b/src/Canvas2d/babylon.ellipse2d.ts
@@ -45,7 +45,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectFillInstanced : this.effectFill;
@@ -77,7 +77,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectBorderInstanced : this.effectBorder;
@@ -104,7 +104,7 @@
                 }
             }
 
-            engine.setAlphaMode(curAlphaMode);
+            engine.setAlphaMode(curAlphaMode, true);
 
             if (this.effectFill && this.effectBorder) {
                 engine.setDepthFunction(depthFunction);

--- a/src/Canvas2d/babylon.lines2d.ts
+++ b/src/Canvas2d/babylon.lines2d.ts
@@ -44,7 +44,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectFillInstanced : this.effectFill;
@@ -76,7 +76,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectBorderInstanced : this.effectBorder;
@@ -103,7 +103,7 @@
                 }
             }
 
-            engine.setAlphaMode(curAlphaMode);
+            engine.setAlphaMode(curAlphaMode, true);
 
             if (this.effectFill && this.effectBorder) {
                 engine.setDepthFunction(depthFunction);

--- a/src/Canvas2d/babylon.rectangle2d.ts
+++ b/src/Canvas2d/babylon.rectangle2d.ts
@@ -45,7 +45,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectFillInstanced : this.effectFill;
@@ -77,7 +77,7 @@
                 let pid = context.groupInfoPartData[partIndex];
 
                 if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                    engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                    engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
                 }
 
                 let effect = context.useInstancing ? this.effectBorderInstanced : this.effectBorder;
@@ -104,7 +104,7 @@
                 }
             }
 
-            engine.setAlphaMode(curAlphaMode);
+            engine.setAlphaMode(curAlphaMode, true);
 
             if (this.effectFill && this.effectBorder) {
                 engine.setDepthFunction(depthFunction);

--- a/src/Canvas2d/babylon.sprite2d.ts
+++ b/src/Canvas2d/babylon.sprite2d.ts
@@ -29,7 +29,7 @@
             engine.bindBuffersDirectly(this.vb, this.ib, [1], 4, effect);
 
             if (context.renderMode !== Render2DContext.RenderModeOpaque) {
-                engine.setAlphaMode(Engine.ALPHA_COMBINE);
+                engine.setAlphaMode(Engine.ALPHA_COMBINE, true);
             }
 
             let pid = context.groupInfoPartData[0];
@@ -51,7 +51,7 @@
                 }
             }
 
-            engine.setAlphaMode(cur);
+            engine.setAlphaMode(cur, true);
 
             return true;
         }

--- a/src/Canvas2d/babylon.text2d.ts
+++ b/src/Canvas2d/babylon.text2d.ts
@@ -72,7 +72,7 @@
             }
 
             if (this.fontTexture) {
-                this.fontTexture.dispose();
+                this.fontTexture.decCachedFontTextureCounter();
                 this.fontTexture = null;
             }
 
@@ -354,6 +354,7 @@
             let engine = this.owner.engine;
 
             renderCache.fontTexture = this.fontTexture;
+            renderCache.fontTexture.incCachedFontTextureCounter();
 
             let vb = new Float32Array(4);
             for (let i = 0; i < 4; i++) {

--- a/src/Canvas2d/babylon.text2d.ts
+++ b/src/Canvas2d/babylon.text2d.ts
@@ -51,7 +51,7 @@
                 }
             }
 
-            engine.setAlphaMode(curAlphaMode);
+            engine.setAlphaMode(curAlphaMode, true);
 
             return true;
         }

--- a/src/Shaders/sprite2d.fragment.fx
+++ b/src/Shaders/sprite2d.fragment.fx
@@ -4,7 +4,7 @@ uniform sampler2D diffuseSampler;
 
 void main(void) {
 	vec4 color = texture2D(diffuseSampler, vUV);
-	if (color.a == 0.05) {
+	if (color.a < 0.05) {
 		discard;
 	}
 	color.a *= vOpacity;


### PR DESCRIPTION
…ed FontTexture, making things working after a dispose called on Text2d.

FontTexture has now two new methods: inc/decCachedFontTextureCounter to extend/reduce the lifetime of the shared FontTexture retrieved with GetCachedFontTexture.