### PR TITLE
Fixed some bugs in LoadFile

### DIFF
--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -394,7 +394,7 @@
                 request.onprogress = progressCallBack;
 
                 request.onreadystatechange = () => {
-                    if (request.readyState === XMLHttpRequest.DONE) {
+                    if (request.readyState === 4) {
                         request.onreadystatechange = null;//some browsers have issues where onreadystatechange can be called multiple times with the same value
 
                         if (request.status >= 200 && request.status < 300) {

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -397,7 +397,7 @@
                     if (request.readyState === 4) {
                         request.onreadystatechange = null;//some browsers have issues where onreadystatechange can be called multiple times with the same value
 
-                        if (request.status >= 200 && request.status < 300) {
+                        if (request.status >= 200 && request.status < 300 || (navigator.isCocoonJS && (request.status === 0))) {
                             callback(!useArrayBuffer ? request.responseText : request.response);
                         } else { // Failed
                             if (onError) {

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -394,8 +394,10 @@
                 request.onprogress = progressCallBack;
 
                 request.onreadystatechange = () => {
-                    if (request.readyState === 4) {
-                        if (request.status === 200 || Tools.ValidateXHRData(request, !useArrayBuffer ? 1 : 6)) {
+                    if (request.readyState === XMLHttpRequest.DONE) {
+                        request.onreadystatechange = null;//some browsers have issues where onreadystatechange can be called multiple times with the same value
+
+                        if (request.status >= 200 && request.status < 300) {
                             callback(!useArrayBuffer ? request.responseText : request.response);
                         } else { // Failed
                             if (onError) {


### PR DESCRIPTION
Two bugs fixed:

**HTTP errors being considered as a successful response**
Success was conditional on HTTP code 200 *OR* `ValidateXHRData()` returning true. When dataType is 1 (text) ValidateXHRData returns true if the response is a non-empty string. Often when the request fails the response text will be set to some HTTP status error message (like "404 Not found"), causing ValidateXHRData to return true and LoadFile to execute the callback.

I've removed the ValidateXHRData check from LoadFile because more generally we shouldn't want LoadFile to validate the data at all, just load it - then the user of LoadFile can validate the data based on their own criteria (e,g. whether or not it's a valid TGA)

I've also allowed it to accept all HTTP success codes (2XX)

**Callback being called twice in rare cases**
onreadystatechanged may be called multiple times with the value 4 (XMLHttpRequest.DONE), https://bugs.chromium.org/p/chromium/issues/detail?id=162837  nullifying it after it occurs once prevents this