### PR TITLE
Making sure parent exists before providing its rendergroup.

### DIFF
--- a/src/Canvas2d/babylon.group2d.ts
+++ b/src/Canvas2d/babylon.group2d.ts
@@ -803,7 +803,7 @@
 
             if (!rd._cacheNode) {
                 // Check if we have to allocate a rendering zone in the global cache texture
-                var res = this.owner._allocateGroupCache(this, this.parent.renderGroup, curWidth ? new Size(curWidth, curHeight) : null, rd._useMipMap, rd._anisotropicLevel);
+                var res = this.owner._allocateGroupCache(this, this.parent && this.parent.renderGroup, curWidth ? new Size(curWidth, curHeight) : null, rd._useMipMap, rd._anisotropicLevel);
                 rd._cacheNode = res.node;
                 rd._cacheTexture = res.texture;
                 rd._cacheRenderSprite = res.sprite;


### PR DESCRIPTION
If no parent is defined, calling the renderGroup will throw an
exception. This simply make sure that the variable exists. If it
doesn't, undefined will be sent, which is a value the function called
can handle.