### PR TITLE
Webvr new api changes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -21,6 +21,7 @@
  - Text2D super sampling to enhance quality in World Space Canvas
  - World Space Canvas is now rendering in an adaptive way for its resolution to fit the on screen projected one to achieve a good rendering quality
  - Transparent Primitives are now drawn with Instanced Array when supported
+- WebVR Camera was updated to be conform with the current specs. ([RaananW](https://github.com/RaananW)) 
 
 ### Exporters
     

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -107,8 +107,8 @@ module BABYLON {
 
         public requestVRFullscreen(requestPointerlock: boolean) {
             //Backwards comp.
-            Tools.Warn("requestVRFullscreen is deprecated. Use engine.switchFullscreen() instead")
-            this.getEngine().switchFullscreen(requestPointerlock);
+            Tools.Warn("requestVRFullscreen is deprecated. call attachControl() to start sending frames to the VR display.")
+            //this.getEngine().switchFullscreen(requestPointerlock);
         }
 
         public getTypeName(): string {

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -19,11 +19,8 @@ module BABYLON {
 
         private _quaternionCache: Quaternion;
 
-        constructor(name: string, position: Vector3, scene: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault(), private webVROptions: WebVROptions = {}) {
+        constructor(name: string, position: Vector3, scene: Scene, compensateDistortion = false, private webVROptions: WebVROptions = {}) {
             super(name, position, scene);
-
-            vrCameraMetrics.compensateDistortion = compensateDistortion;
-            this.setCameraRigMode(Camera.RIG_MODE_VR, { vrCameraMetrics: vrCameraMetrics });
 
             //enable VR
             this.getEngine().initWebVR();
@@ -53,6 +50,9 @@ module BABYLON {
                             //choose the first one
                             this._vrDevice = devices[0];
                         }
+
+                        //reset the rig parameters.
+                        this.setCameraRigMode(Camera.RIG_MODE_WEBVR, { vrDisplay: this._vrDevice });
                     } else {
                         Tools.Error("No WebVR devices found!");
                     }

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -17,7 +17,6 @@ module BABYLON {
         private _oldSize: BABYLON.Size;
         private _oldHardwareScaleFactor: number;
 
-        private _initialQuaternion: Quaternion;
         private _quaternionCache: Quaternion;
 
         constructor(name: string, position: Vector3, scene: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault(), private webVROptions: WebVROptions = {}) {
@@ -78,10 +77,6 @@ module BABYLON {
                     //Flip in XY plane
                     this.rotationQuaternion.z *= -1;
                     this.rotationQuaternion.w *= -1;
-                    if (this._initialQuaternion) {
-                        this._quaternionCache.copyFrom(this.rotationQuaternion);
-                        this._initialQuaternion.multiplyToRef(this.rotationQuaternion, this.rotationQuaternion);
-                    }
                 }
 
             }
@@ -115,24 +110,10 @@ module BABYLON {
             return "WebVRFreeCamera";
         }
 
-        public resetToCurrentRotation(axis: BABYLON.Axis = BABYLON.Axis.Y) {
-            //can only work if this camera has a rotation quaternion already.
-            if (!this.rotationQuaternion) return;
-
-            if (!this._initialQuaternion) {
-                this._initialQuaternion = new BABYLON.Quaternion();
-            }
-
-            this._initialQuaternion.copyFrom(this._quaternionCache || this.rotationQuaternion);
-
-            ['x', 'y', 'z'].forEach((axisName) => {
-                if (!axis[axisName]) {
-                    this._initialQuaternion[axisName] = 0;
-                } else {
-                    this._initialQuaternion[axisName] *= -1;
-                }
-            });
-            this._initialQuaternion.normalize();
+        public resetToCurrentRotation() {
+            //uses the vrDisplay's "resetPose()".
+            //pitch and roll won't be affected.
+            this._vrDevice.resetPose();
         }
     }
 }

--- a/src/Cameras/babylon.targetCamera.ts
+++ b/src/Cameras/babylon.targetCamera.ts
@@ -238,7 +238,7 @@
         public createRigCamera(name: string, cameraIndex: number): Camera {
             if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
                 var rigCamera = new TargetCamera(name, this.position.clone(), this.getScene());
-                if (this.cameraRigMode === Camera.RIG_MODE_VR) {
+                if (this.cameraRigMode === Camera.RIG_MODE_VR || this.cameraRigMode === Camera.RIG_MODE_WEBVR) {
                     if (!this.rotationQuaternion) {
                         this.rotationQuaternion = new Quaternion();
                     }
@@ -274,6 +274,7 @@
                     break;
 
                 case Camera.RIG_MODE_VR:
+                case Camera.RIG_MODE_WEBVR:
                     camLeft.rotationQuaternion.copyFrom(this.rotationQuaternion);
                     camRight.rotationQuaternion.copyFrom(this.rotationQuaternion);
                     camLeft.position.copyFrom(this.position);

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1731,7 +1731,7 @@
         }
 
         public copyFrom(src: Size) {
-            this.width  = src.width;
+            this.width = src.width;
             this.height = src.height;
         }
 
@@ -2917,6 +2917,27 @@
             result.m[10] = -zfar / (znear - zfar);
             result.m[11] = 1.0;
             result.m[12] = result.m[13] = result.m[15] = 0.0;
+            result.m[14] = (znear * zfar) / (znear - zfar);
+        }
+
+        public static PerspectiveFovWebVRToRef(fov, znear: number, zfar: number, result: Matrix, isVerticalFovFixed = true) {
+            var upTan = Math.tan(fov.upDegrees * Math.PI / 180.0);
+            var downTan = Math.tan(fov.downDegrees * Math.PI / 180.0);
+            var leftTan = Math.tan(fov.leftDegrees * Math.PI / 180.0);
+            var rightTan = Math.tan(fov.rightDegrees * Math.PI / 180.0);
+            var xScale = 2.0 / (leftTan + rightTan);
+            var yScale = 2.0 / (upTan + downTan);
+            result.m[0] = xScale;
+            result.m[1] = result.m[2] = result.m[3] = result.m[4] = 0.0;
+            result.m[5] = yScale;
+            result.m[6] = result.m[7] =  0.0;
+            result.m[8] = ((leftTan - rightTan) * xScale * 0.5);
+            result.m[9] = -((upTan - downTan) * yScale * 0.5);
+            //result.m[10] = -(znear + zfar) / (zfar - znear);
+            result.m[10] = -zfar / (znear - zfar);
+            result.m[11] = 1.0;
+            result.m[12] = result.m[13] = result.m[15] = 0.0;
+            //result.m[14] = -(2.0 * zfar * znear) / (zfar - znear);
             result.m[14] = (znear * zfar) / (znear - zfar);
         }
 

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -256,7 +256,10 @@
          * @param requester - the object that will request the next frame. Falls back to window.
          */
         public static QueueNewFrame(func, requester: any = window): void {
-            if (requester.requestAnimationFrame)
+            //if WebVR is enabled AND presenting, requestAnimationFrame is triggered when enabled.
+            if(requester.isPresenting) {
+                return;
+            } else if (requester.requestAnimationFrame)
                 requester.requestAnimationFrame(func);
             else if (requester.msRequestAnimationFrame)
                 requester.msRequestAnimationFrame(func);

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -257,9 +257,9 @@
          */
         public static QueueNewFrame(func, requester: any = window): void {
             //if WebVR is enabled AND presenting, requestAnimationFrame is triggered when enabled.
-            if(requester.isPresenting) {
+            /*if(requester.isPresenting) {
                 return;
-            } else if (requester.requestAnimationFrame)
+            } else*/ if (requester.requestAnimationFrame)
                 requester.requestAnimationFrame(func);
             else if (requester.msRequestAnimationFrame)
                 requester.msRequestAnimationFrame(func);

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -566,7 +566,7 @@
             this._loadingScreen = new DefaultLoadingScreen(this._renderingCanvas);
 
             //Load WebVR Devices
-            if(options.autoEnableWebVR) {
+            if (options.autoEnableWebVR) {
                 this.initWebVR();
             }
 
@@ -985,7 +985,8 @@
                 this._oldHardwareScaleFactor = this.getHardwareScalingLevel();
 
                 //according to the WebVR specs, requestAnimationFrame should be triggered only once.
-                this._vrAnimationFrameHandler = this._vrDisplayEnabled.requestAnimationFrame(this._bindedRenderFunction);
+                //But actually, no browser follow the specs...
+                //this._vrAnimationFrameHandler = this._vrDisplayEnabled.requestAnimationFrame(this._bindedRenderFunction);
 
                 //get the width and height, change the render size
                 var leftEye = this._vrDisplayEnabled.getEyeParameters('left');
@@ -993,10 +994,11 @@
                 this.setHardwareScalingLevel(1);
                 this.setSize(leftEye.renderWidth * 2, leftEye.renderHeight);
             } else {
-                this._vrDisplayEnabled.cancelAnimationFrame(this._vrAnimationFrameHandler);
-                this._vrDisplayEnabled = null;
+                //When the specs are implemented, need to uncomment this.
+                //this._vrDisplayEnabled.cancelAnimationFrame(this._vrAnimationFrameHandler);
                 this.setHardwareScalingLevel(this._oldHardwareScaleFactor);
                 this.setSize(this._oldSize.width, this._oldSize.height);
+                this._vrDisplayEnabled = undefined;
             }
         }
 


### PR DESCRIPTION
Now setting projection matrix from the WebVR parameters, thus elimnating
the need for distortion compensation.
Also added the possibility of auto-enabling WebVR, while not being
initialized automatically.  This was done because when WebVR is
initializing it starts the native VR software, which might not be
desired.
The WebVR camera forces WebVR init.
resetPose is now used to reset the camera's rotation.