### PR TITLE
Solving a problem when initializing two textures using the same WebGL texture

### DIFF
--- a/src/Materials/Textures/babylon.texture.ts
+++ b/src/Materials/Textures/babylon.texture.ts
@@ -111,7 +111,11 @@
                     this._delayedOnError = onError;
                 }
             } else {
-                Tools.SetImmediate(() => load());
+                if (this._texture.isReady) {
+                    Tools.SetImmediate(() => load());
+                } else {
+                    this._texture.onLoadedCallbacks.push(load);
+                }
             }
         }
 
@@ -274,9 +278,9 @@
 
             var texture = SerializationHelper.Parse(() => {
                 if (parsedTexture.customType) {
-                     var customTexture = Tools.Instantiate(parsedTexture.customType);
-                     return customTexture.Parse(parsedTexture, scene, rootUrl);
-                 } else if (parsedTexture.mirrorPlane) {
+                    var customTexture = Tools.Instantiate(parsedTexture.customType);
+                    return customTexture.Parse(parsedTexture, scene, rootUrl);
+                } else if (parsedTexture.mirrorPlane) {
                     var mirrorTexture = new MirrorTexture(parsedTexture.name, parsedTexture.renderTargetSize, scene);
                     mirrorTexture._waitingRenderList = parsedTexture.renderList;
                     mirrorTexture.mirrorPlane = Plane.FromArray(parsedTexture.mirrorPlane);

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -58,7 +58,7 @@
     }
 
     var prepareWebGLTexture = (texture: WebGLTexture, gl: WebGLRenderingContext, scene: Scene, width: number, height: number, invertY: boolean, noMipmap: boolean, isCompressed: boolean,
-        processFunction: (width: number, height: number) => void, onLoad: () => void, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE) => {
+        processFunction: (width: number, height: number) => void, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE) => {
         var engine = scene.getEngine();
         var potWidth = Tools.GetExponentOfTwo(width, engine.getCaps().maxTextureSize);
         var potHeight = Tools.GetExponentOfTwo(height, engine.getCaps().maxTextureSize);
@@ -88,9 +88,9 @@
         engine.resetTextureCache();
         scene._removePendingData(texture);
 
-        if (onLoad) {
-            onLoad();
-        }
+        texture.onLoadedCallbacks.forEach(function (callback) {
+            callback();
+        });
     };
 
     var partialLoad = (url: string, index: number, loadedImages: any, scene,
@@ -1853,6 +1853,7 @@
             texture.noMipmap = noMipmap;
             texture.references = 1;
             texture.samplingMode = samplingMode;
+            texture.onLoadedCallbacks = [onLoad];
             this._loadedTexturesCache.push(texture);
 
             var onerror = () => {
@@ -1871,7 +1872,7 @@
 
                     prepareWebGLTexture(texture, this._gl, scene, header.width, header.height, invertY, noMipmap, false, () => {
                         Internals.TGATools.UploadContent(this._gl, data);
-                    }, onLoad, samplingMode);
+                    }, samplingMode);
                 };
                 if (!(fromData instanceof Array))
                     Tools.LoadFile(url, arrayBuffer => {
@@ -1888,7 +1889,7 @@
                     prepareWebGLTexture(texture, this._gl, scene, info.width, info.height, invertY, !loadMipmap, info.isFourCC, () => {
 
                         Internals.DDSTools.UploadDDSLevels(this._gl, this.getCaps().s3tc, data, info, loadMipmap, 1);
-                    }, onLoad, samplingMode);
+                    }, samplingMode);
                 };
 
                 if (!(fromData instanceof Array))
@@ -1927,7 +1928,7 @@
                         }
 
                         this._gl.texImage2D(this._gl.TEXTURE_2D, 0, this._gl.RGBA, this._gl.RGBA, this._gl.UNSIGNED_BYTE, isPot ? img : this._workingCanvas);
-                    }, onLoad, samplingMode);
+                    }, samplingMode);
                 };
 
 

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -91,6 +91,7 @@
         texture.onLoadedCallbacks.forEach(function (callback) {
             callback();
         });
+        texture.onLoadedCallbacks = [];
     };
 
     var partialLoad = (url: string, index: number, loadedImages: any, scene,

--- a/src/babylon.mixins.ts
+++ b/src/babylon.mixins.ts
@@ -61,6 +61,7 @@ interface WebGLTexture {
     references: number;
     generateMipMaps: boolean;
     type: number;
+    onLoadedCallbacks: Array<Function>;
     _size: number;
     _baseWidth: number;
     _baseHeight: number;


### PR DESCRIPTION
if the webgl teture is not yet ready, but exists in the cache, the
onLoad function  will be called when the texture is not yet ready.

The signature of an internal function in the engine was changed, but it cannot be externally used. It is fully backwards compatible.