### PR TITLE
calling orientationChanged on attachControl.

### DIFF
--- a/src/Cameras/Inputs/babylon.freecamera.input.deviceorientation.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.deviceorientation.ts
@@ -28,6 +28,9 @@ module BABYLON {
         attachControl(element: HTMLElement, noPreventDefault?: boolean) {
             window.addEventListener("orientationchange", this._orientationChanged);
             window.addEventListener("deviceorientation", this._deviceOrientation);
+            //In certain cases, the attach control is called AFTER orientation was changed,
+            //So this is needed.
+            this._orientationChanged();
         }
 
         private _orientationChanged = () => {


### PR DESCRIPTION
When attachControl is called after the device changed its orientation,
the rotation is wrong.
This solve the issue.