### PR TITLE
Add toBoundingCenter to ArcRotateCamera.setTarget

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -193,6 +193,8 @@
         private _previousRadius: number;
         //due to async collision inspection
         private _collisionTriggered: boolean;
+        
+        private _targetBoundingCenter: Vector3;
 
         constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene: Scene) {
             super(name, Vector3.Zero(), scene);
@@ -236,7 +238,8 @@
 
         private _getTargetPosition(): Vector3 {
             if ((<any>this.target).getAbsolutePosition) {
-                return (<any>this.target).getAbsolutePosition();
+                var pos : Vector3 = (<any>this.target).getAbsolutePosition();
+                return this._targetBoundingCenter ? pos.add(this._targetBoundingCenter) : pos;
             }
 
             return this.target;
@@ -396,9 +399,15 @@
             this.rebuildAnglesAndRadius();
         }
 
-        public setTarget(target: Vector3): void {
+        public setTarget(target: Vector3, toBoundingCenter = false): void {            
             if (this._getTargetPosition().equals(target)) {
                 return;
+            }
+            
+            if (toBoundingCenter && (<any>target).getBoundingInfo){
+                this._targetBoundingCenter = (<any>target).getBoundingInfo().boundingBox.center.clone();
+            }else{
+                this._targetBoundingCenter = null;
             }
             this.target = target;
             this.rebuildAnglesAndRadius();

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -296,7 +296,7 @@
         }
 
         public static get Version(): string {
-            return "2.5-alpha";
+            return "2.5.-alpha";
         }
 
         // Updatable statics so stick with vars here


### PR DESCRIPTION
- also changed format of Engine.Version.  Need second dot for
TOB version checking code.  Obviously, not permanent.