### PR TITLE
sprite2D.scaleToSize(size)

### DIFF
--- a/src/Canvas2d/babylon.sprite2d.ts
+++ b/src/Canvas2d/babylon.sprite2d.ts
@@ -229,6 +229,31 @@
         }
 
         /**
+         * Sets the scale of the sprite using a BABYLON.Size(w,h).
+         * Keeps proportion by taking the maximum of the two scale for x and y.
+         * @param {Size} size Size(width,height)
+         */
+        public scaleToSize(size: Size) {
+            var baseSize = this.size;
+            if (baseSize == null || !this.texture.isReady()) {
+                // we're probably at initiation of the scene, size is not set
+                if (this.texture.isReady()) {
+                    baseSize = <Size>this.texture.getBaseSize();
+                }
+                else {
+                    // the texture is not ready, wait for it to load before calling scaleToSize again
+                    var thisObject = <Sprite2D>this;
+                    this.texture.onLoadObservable.add(function () {
+                            thisObject.scaleToSize(size); 
+                        });
+                    return;
+                }
+            }
+            
+            this.scale = Math.max(size.height / baseSize.height, size.width / baseSize.width);
+        }
+
+        /**
          * Get/set if the sprite rendering should be aligned to the target rendering device pixel or not
          */
         public get alignToPixel(): boolean {


### PR DESCRIPTION
Sets the scale of the sprite using a BABYLON.Size(w,h).
Keeps proportion by taking the maximum of the two scale for x and y.

If size is not set it waits for the texture to load.