### PR TITLE
Run addModuleExports for the generated d.ts file.

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -98,6 +98,7 @@ gulp.task('typescript-compile', function () {
     return merge2([
         tsResult.dts
             .pipe(concat(config.build.declarationFilename))
+            .pipe(addModuleExports("BABYLON"))
             .pipe(gulp.dest(config.build.outputDirectory)),
         tsResult.js
             .pipe(gulp.dest(config.build.srcOutputDirectory))


### PR DESCRIPTION
This apparently used to work, but no longer did. Context here:
http://www.html5gamedevs.com/topic/25425-using-babylonjs-npm-package-from-typescript-with-browserify/#comment-145494