### PR TITLE
Make tasks and waitingTasksCount protected

### DIFF
--- a/src/Tools/babylon.assetsManager.ts
+++ b/src/Tools/babylon.assetsManager.ts
@@ -180,10 +180,10 @@
     }
 
     export class AssetsManager {
-        private _tasks = new Array<IAssetTask>();
         private _scene: Scene;
 
-        private _waitingTasksCount = 0;
+        protected tasks = new Array<IAssetTask>();
+        protected waitingTasksCount = 0;
 
         public onFinish: (tasks: IAssetTask[]) => void;
         public onTaskSuccess: (task: IAssetTask) => void;
@@ -197,45 +197,45 @@
 
         public addMeshTask(taskName: string, meshesNames: any, rootUrl: string, sceneFilename: string): IAssetTask {
             var task = new MeshAssetTask(taskName, meshesNames, rootUrl, sceneFilename);
-            this._tasks.push(task);
+            this.tasks.push(task);
 
             return task;
         }
 
         public addTextFileTask(taskName: string, url: string): IAssetTask {
             var task = new TextFileAssetTask(taskName, url);
-            this._tasks.push(task);
+            this.tasks.push(task);
 
             return task;
         }
 
         public addBinaryFileTask(taskName: string, url: string): IAssetTask {
             var task = new BinaryFileAssetTask(taskName, url);
-            this._tasks.push(task);
+            this.tasks.push(task);
 
             return task;
         }
 
         public addImageTask(taskName: string, url: string): IAssetTask {
             var task = new ImageAssetTask(taskName, url);
-            this._tasks.push(task);
+            this.tasks.push(task);
 
             return task;
         }
 
         public addTextureTask(taskName: string, url: string, noMipmap?: boolean, invertY?: boolean, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE): IAssetTask {
             var task = new TextureAssetTask(taskName, url, noMipmap, invertY, samplingMode);
-            this._tasks.push(task);
+            this.tasks.push(task);
 
             return task;
         }
 
         private _decreaseWaitingTasksCount(): void {
-            this._waitingTasksCount--;
+            this.waitingTasksCount--;
 
-            if (this._waitingTasksCount === 0) {
+            if (this.waitingTasksCount === 0) {
                 if (this.onFinish) {
-                    this.onFinish(this._tasks);
+                    this.onFinish(this.tasks);
                 }
 
                 this._scene.getEngine().hideLoadingUI();
@@ -257,16 +257,16 @@
         }
 
         public reset(): AssetsManager {
-            this._tasks = new Array<IAssetTask>();
+            this.tasks = new Array<IAssetTask>();
             return this;
         }
 
         public load(): AssetsManager {
-            this._waitingTasksCount = this._tasks.length;
+            this.waitingTasksCount = this.tasks.length;
 
-            if (this._waitingTasksCount === 0) {
+            if (this.waitingTasksCount === 0) {
                 if (this.onFinish) {
-                    this.onFinish(this._tasks);
+                    this.onFinish(this.tasks);
                 }
                 return this;
             }
@@ -275,8 +275,8 @@
                 this._scene.getEngine().displayLoadingUI();
             }
 
-            for (var index = 0; index < this._tasks.length; index++) {
-                var task = this._tasks[index];
+            for (var index = 0; index < this.tasks.length; index++) {
+                var task = this.tasks[index];
                 this._runTask(task);
             }
 


### PR DESCRIPTION
Making tasks array and waitingTasksCount protected would allow developers to extend the AssetsManager and add custom tasks, such as a FontFileAssetTask. This would be useful for situations like http://www.html5gamedevs.com/topic/23989-custom-fonts-in-canvas2d/ where a third party library is used to load font faces before Text2D renders. BabylonJS might not want to add a FontFileAssetTask due to the overhead, but it would be helpful for developers that want to maintain the AssetsManager pattern without duplicating the entire code.