### PR TITLE
Support loading with a module loader.

### DIFF
--- a/Tools/Gulp/gulp-addDtsExport.js
+++ b/Tools/Gulp/gulp-addDtsExport.js
@@ -1,0 +1,31 @@
+var gutil = require('gulp-util');
+var through = require('through2');
+
+module.exports = function (varName) {
+    return through.obj(function (file, enc, cb) {
+
+        var moduleExportsAddition =
+            '\nexport as namespace ' + varName + ';\n' +
+            '\nexport = ' + varName + ';\n';
+
+        if (file.isNull()) {
+            cb(null, file);
+            return;
+        }
+
+        if (file.isStream()) {
+            //streams not supported, no need for now.
+            return;
+        }
+
+        try {
+            file.contents = new Buffer(String(file.contents) + moduleExportsAddition);
+            this.push(file);
+
+        } catch (err) {
+            this.emit('error', new gutil.PluginError('gulp-add-module-exports', err, { fileName: file.path }));
+        }
+        cb();
+    });
+};
+

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -3,6 +3,7 @@ var uglify = require("gulp-uglify");
 var typescript = require("gulp-typescript");
 var sourcemaps = require("gulp-sourcemaps");
 var srcToVariable = require("gulp-content-to-variable");
+var addDtsExport = require("./gulp-addDtsExport");
 var addModuleExports = require("./gulp-addModuleExports");
 var merge2 = require("merge2");
 var concat = require("gulp-concat");
@@ -98,6 +99,7 @@ gulp.task('typescript-compile', function () {
     return merge2([
         tsResult.dts
             .pipe(concat(config.build.declarationFilename))
+            .pipe(addDtsExport("BABYLON"))
             .pipe(gulp.dest(config.build.outputDirectory)),
         tsResult.js
             .pipe(gulp.dest(config.build.srcOutputDirectory))


### PR DESCRIPTION
This is a new attempt of the failed and rolled back #1372.

Babylon.js currently uses namespaces and its types can be pulled in using

    /// <reference path="babylonjs/babylon.d.ts" />

It's generated JavaScript can be loaded using either a script tag, or using a module loader from JavaScript. However, what was not yet supported is loading types and implementation using a module loader from Typescript, because babylon.d.ts was not a module.

This commit adds support for that, following the example here:
https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#support-for-umd-module-definitions

With it, it is additionally possible to load BabylonJS like this from Typescript:

    import * as BABYLON from 'babylonjs/babylon';
    