### PR TITLE
changing subdivisionsY to subdivisionsZ

### DIFF
--- a/src/Mesh/babylon.groundMesh.ts
+++ b/src/Mesh/babylon.groundMesh.ts
@@ -6,7 +6,7 @@
         private _heightQuads: { slope: Vector2; facet1: Vector4; facet2: Vector4 }[];
         
         public _subdivisionsX: number;
-        public _subdivisionsY: number;
+        public _subdivisionsZ: number;
         public _width: number;
         public _height: number;
         public _minX: number;
@@ -19,20 +19,20 @@
         }
 
         public get subdivisions(): number {
-            return Math.min(this._subdivisionsX, this._subdivisionsY);
+            return Math.min(this._subdivisionsX, this._subdivisionsZ);
         }
 
         public get subdivisionsX(): number {
             return this._subdivisionsX;
         }
 
-        public get subdivisionsY(): number {
-            return this._subdivisionsY;
+        public get subdivisionsZ(): number {
+            return this._subdivisionsZ;
         }
 
         public optimize(chunksCount: number, octreeBlocksSize = 32): void {
             this._subdivisionsX = chunksCount;
-            this._subdivisionsY = chunksCount;
+            this._subdivisionsZ = chunksCount;
             this.subdivide(chunksCount);
             this.createOrUpdateSubmeshesOctree(octreeBlocksSize);
         }
@@ -115,9 +115,9 @@
         private _getFacetAt(x: number, z: number): Vector4 {
             // retrieve col and row from x, z coordinates in the ground local system
             var subdivisionsX = this._subdivisionsX;
-            var subdivisionsY = this._subdivisionsY;
+            var subdivisionsZ = this._subdivisionsZ;
             var col = Math.floor((x + this._maxX) * this._subdivisionsX / this._width);
-            var row = Math.floor(-(z + this._maxZ) * this._subdivisionsY / this._height + this._subdivisionsY);
+            var row = Math.floor(-(z + this._maxZ) * this._subdivisionsZ / this._height + this._subdivisionsZ);
             var quad = this._heightQuads[row * this._subdivisionsX + col];
             var facet;
             if (z < quad.slope.x * x + quad.slope.y) {
@@ -135,9 +135,9 @@
         // facet2 :  Vector4(a, b, c, d) = second facet 3D plane equation : ax + by + cz + d = 0
         private _initHeightQuads(): void {
             var subdivisionsX = this._subdivisionsX;
-            var subdivisionsY = this._subdivisionsY;
+            var subdivisionsZ = this._subdivisionsZ;
             this._heightQuads = new Array();
-            for (var row = 0; row < subdivisionsY; row++) {
+            for (var row = 0; row < subdivisionsZ; row++) {
                 for (var col = 0; col < subdivisionsX; col++) {
                     var quad = { slope: BABYLON.Vector2.Zero(), facet1: new BABYLON.Vector4(0, 0, 0, 0), facet2: new BABYLON.Vector4(0, 0, 0, 0) };
                     this._heightQuads[row * subdivisionsX + col] = quad;
@@ -169,9 +169,9 @@
             var d2 = 0;
 
             var subdivisionsX = this._subdivisionsX;
-            var subdivisionsY = this._subdivisionsY;
+            var subdivisionsZ = this._subdivisionsZ;
 
-            for (var row = 0; row < subdivisionsY; row++) {
+            for (var row = 0; row < subdivisionsZ; row++) {
                 for (var col = 0; col < subdivisionsX; col++) {
                     i = col * 3;
                     j = row * (subdivisionsX + 1) * 3;

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1180,7 +1180,7 @@
             return vertexData;
         }
 
-        public static CreateGround(options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsY?: number }): VertexData {
+        public static CreateGround(options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsZ?: number }): VertexData {
             var indices = [];
             var positions = [];
             var normals = [];
@@ -1190,11 +1190,11 @@
             var width: number = options.width || 1;
             var height: number = options.height || 1;
             var subdivisionsX: number = options.subdivisionsX || options.subdivisions || 1;
-            var subdivisionsY: number = options.subdivisionsY || options.subdivisions || 1;
+            var subdivisionsZ: number = options.subdivisionsZ || options.subdivisions || 1;
 
-            for (row = 0; row <= subdivisionsY; row++) {
+            for (row = 0; row <= subdivisionsZ; row++) {
                 for (col = 0; col <= subdivisionsX; col++) {
-                    var position = new Vector3((col * width) / subdivisionsX - (width / 2.0), 0, ((subdivisionsY - row) * height) / subdivisionsY - (height / 2.0));
+                    var position = new Vector3((col * width) / subdivisionsX - (width / 2.0), 0, ((subdivisionsZ - row) * height) / subdivisionsZ - (height / 2.0));
                     var normal = new Vector3(0, 1.0, 0);
 
                     positions.push(position.x, position.y, position.z);
@@ -1203,7 +1203,7 @@
                 }
             }
 
-            for (row = 0; row < subdivisionsY; row++) {
+            for (row = 0; row < subdivisionsZ; row++) {
                 for (col = 0; col < subdivisionsX; col++) {
                     indices.push(col + 1 + (row + 1) * (subdivisionsX + 1));
                     indices.push(col + 1 + row * (subdivisionsX + 1));

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -638,11 +638,11 @@
          * The parameter `subdivisions` (positive integer) sets the number of subdivisions per side.       
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
          */
-        public static CreateGround(name: string, options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsY?: number, updatable?: boolean }, scene: any): Mesh {
+        public static CreateGround(name: string, options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsZ?: number, updatable?: boolean }, scene: any): Mesh {
             var ground = new GroundMesh(name, scene);
             ground._setReady(false);
             ground._subdivisionsX = options.subdivisionsX || options.subdivisions || 1;
-            ground._subdivisionsY = options.subdivisionsY || options.subdivisions || 1;
+            ground._subdivisionsZ = options.subdivisionsZ || options.subdivisions || 1;
             ground._width = options.width || 1;
             ground._height = options.height || 1;
             ground._maxX = ground._width / 2;
@@ -708,7 +708,7 @@
 
             var ground = new GroundMesh(name, scene);
             ground._subdivisionsX = subdivisions;
-            ground._subdivisionsY = subdivisions;
+            ground._subdivisionsZ = subdivisions;
             ground._width = width;
             ground._height = height;
             ground._maxX = ground._width / 2.0;


### PR DESCRIPTION
When I first added subdivisionsY to the groundMesh I was looking at how you would subdivide a grid/plane in Blender.  It makes more sense to call it subdivisionsZ though, because the z axis in BJS is where the y axis is in Blender.