### PR TITLE
Make private HTMLCanvasElement compatible with the one in lib.d.ts

### DIFF
--- a/src/babylon.mixins.ts
+++ b/src/babylon.mixins.ts
@@ -48,9 +48,9 @@ interface Document {
 
 interface HTMLCanvasElement {
     requestPointerLock(): void;
-    msRequestPointerLock(): void;
-    mozRequestPointerLock(): void;
-    webkitRequestPointerLock(): void;
+    msRequestPointerLock?(): void;
+    mozRequestPointerLock?(): void;
+    webkitRequestPointerLock?(): void;
 }
 
 interface CanvasRenderingContext2D {


### PR DESCRIPTION
Babylon.js has a mixin for HTMLCanvasElement to add vendor-prefixed requestPointerLock methods. The problem is that it does not expose this mixin, so it is not possible from Typescript to provide this except by either using any, or by created the same mixin one self and keeping the definitions in sync. This Typescript code:

    const canvas = document.getElementById("main-canvas") as HTMLCanvasElement;
    const engine = new BABYLON.Engine(canvas, true);

Will currently fail with:

    error TS2345: Argument of type 'HTMLCanvasElement' is not assignable to parameter of type 'HTMLCanvasElement'.
    Property 'msRequestPointerLock' is missing in type 'HTMLCanvasElement'.

This is because the HTMLCanvasElement in the first line is the one provided by lib.d.ts which does not have the vendor-prefixed methods, but the one expected in the second line is the private mixin BABYLON uses.

The solution implemented in this commit is to mark the vendor-prefixed methods optional, which is appropriate because indeed it will depend on the browser implementation if they are there, and indeed [Babylon.js already checks](https://github.com/BabylonJS/Babylon.js/search?utf8=%E2%9C%93&q=msRequestPointerLock) if they are set.

This has the pleasant side-effect that it makes the private HTMLCanvasElement mixin compatible with the one from lib.d.ts, and as a result, the code above compiles.