### PR TITLE
Fix issue with loadAsync never finishing

### DIFF
--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -283,6 +283,8 @@
                         if (onsuccess) {
                             onsuccess(scene);
                         }
+
+                        scene._removePendingData(loadingToken);
                     }, () => {
                         if (onerror) {
                             onerror(scene);


### PR DESCRIPTION
loadAsync never finishes because the pending data is never removed and thus isReady() is never true