### PR TITLE
renamed setVector3Array to setArray3 in ShaderMaterial

### DIFF
--- a/src/Materials/babylon.shaderMaterial.ts
+++ b/src/Materials/babylon.shaderMaterial.ts
@@ -137,7 +137,7 @@
             return this;
         }
 
-        public setVector3Array(name: string, value: number[]): ShaderMaterial {
+        public setArray3(name: string, value: number[]): ShaderMaterial {
             this._checkUniform(name);
             this._vectors3Arrays[name] = value;
 
@@ -503,7 +503,7 @@
 
             // Vector3Array
             for (name in source.vectors3Arrays) {
-                material.setVector3Array(name, source.vectors3Arrays[name]);
+                material.setArray3(name, source.vectors3Arrays[name]);
             }
             
             return material;


### PR DESCRIPTION
renamed setVector3Array to setArray3 for better name consistency (compared to Engine and Effect methods)
Not a breaking change because setVector3Array was introduced only 2 days ago, by myself, so I'm pretty sure no one is already using it...