### PR TITLE
SPS intersectsMesh() added for digested meshes

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -794,7 +794,7 @@
             return this._boundingInfo.isCompletelyInFrustum(frustumPlanes);;
         }
 
-        public intersectsMesh(mesh: AbstractMesh, precise?: boolean): boolean {
+        public intersectsMesh(mesh: AbstractMesh | SolidParticle, precise?: boolean): boolean {
             if (!this._boundingInfo || !mesh._boundingInfo) {
                 return false;
             }

--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -49,6 +49,9 @@ module BABYLON {
         }
 
         public intersectsMesh(target: Mesh | SolidParticle): boolean {
+            if (!(this.isVisible && target.isVisible)) {
+                return false;       // only visible particle and target can intersect
+            }
             if (!this._boundingInfo || !target._boundingInfo) {
                 return false;
             }


### PR DESCRIPTION
* Added support for solid particle intersections to SPS digested meshes
* Added SolidParticle type declaration to AbstractMesh.intersectsMesh() : can compute intersection either against standard mesh, either against solid particles now
* small optimization to reduce the calls to this.mesh.getWorldMatrix within the SPS process