### PR TITLE
changed intersection / isVisible for consistency + API doc comments

### DIFF
--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -18,6 +18,16 @@ module BABYLON {
         public _modelBoundingInfo: BoundingInfo;        // reference to the shape model BoundingInfo object
         public _boundingInfo: BoundingInfo;             // particle BoundingInfo
 
+        /**
+         * Creates a Solid Particle object.
+         * Don't create particles manually, use instead the Solid Particle System internal tools like _addParticle()
+         * `particleIndex` (integer) is the particle index in the Solid Particle System pool. It's also the particle identifier.  
+         * `positionIndex` (integer) is the starting index of the particle vertices in the SPS "positions" array.
+         *  `model` (ModelShape) is a reference to the model shape on what the particle is designed.  
+         * `shapeId` (integer) is the model shape identifier in the SPS.
+         * `idxInShape` (integer) is the index of the particle in the current model (ex: the 10th box of addShape(box, 30))
+         * `modelBoundingInfo` is the reference to the model BoundingInfo used for intersection computations.
+         */
         constructor(particleIndex: number, positionIndex: number, model: ModelShape, shapeId: number, idxInShape: number, modelBoundingInfo?: BoundingInfo) {
             this.idx = particleIndex;
             this._pos = positionIndex;
@@ -30,7 +40,9 @@ module BABYLON {
             }
         }
 
-        //legacy support, changed scale to scaling
+        /**
+         * legacy support, changed scale to scaling
+         */
         public get scale(): Vector3 {
             return this.scaling;
         }
@@ -39,7 +51,9 @@ module BABYLON {
             this.scaling = scale;
         }
 
-        //legacy support, changed quaternion to rotationQuaternion
+        /**
+         * legacy support, changed quaternion to rotationQuaternion
+         */ 
         public get quaternion(): Quaternion {
             return this.rotationQuaternion;
         }
@@ -48,10 +62,12 @@ module BABYLON {
             this.rotationQuaternion = q;
         }
 
+        /**
+         * Returns a boolean. True if the particle intersects another particle or another mesh, else false.
+         * The intersection is computed on the particle bounding sphere and Axis Aligned Bounding Box (AABB)
+         * `target` is the object (solid particle or mesh) what the intersection is computed against.
+         */
         public intersectsMesh(target: Mesh | SolidParticle): boolean {
-            if (!(this.isVisible && target.isVisible)) {
-                return false;       // only visible particle and target can intersect
-            }
             if (!this._boundingInfo || !target._boundingInfo) {
                 return false;
             }
@@ -66,6 +82,10 @@ module BABYLON {
         public _positionFunction: (particle: SolidParticle, i: number, s: number) => void;
         public _vertexFunction: (particle: SolidParticle, vertex: Vector3, i: number) => void;
 
+        /**
+         * Creates a ModelShape object. This is an internal simplified reference to a mesh used as for a model to replicate particles from by the SPS.
+         * SPS internal tool, don't use it manually.  
+         */
         constructor(id: number, shape: Vector3[], shapeUV: number[], posFunction: (particle: SolidParticle, i: number, s: number) => void, vtxFunction: (particle: SolidParticle, vertex: Vector3, i: number) => void) {
             this.shapeID = id;
             this._shape = shape;


### PR DESCRIPTION
* Reverted solid particle intersection about isVisible for consistency reasons with the standard mesh intersection behavior (now invisible particles can still intersect, up to the user to manage this according to his need)
* Added missing doc comments in the SolidParticle class for API doc.