### PR TITLE
Canvas2D: allow3DEventsBelowCanvas setting added

### DIFF
--- a/canvas2D/src/Engine/babylon.canvas2d.ts
+++ b/canvas2D/src/Engine/babylon.canvas2d.ts
@@ -76,6 +76,7 @@
             isScreenSpace?: boolean,
             cachingStrategy?: number,
             enableInteraction?: boolean,
+            allow3DEventBelowCanvas?: boolean,
             origin?: Vector2,
             isVisible?: boolean,
             backgroundRoundRadius?: number,
@@ -168,6 +169,8 @@
             this._trackedGroups = new Array<Group2D>();
             this._maxAdaptiveWorldSpaceCanvasSize = null;
             this._groupCacheMaps = new StringDictionary<MapTexture[]>();
+
+            this._changeFlags(SmartPropertyPrim.flagAllow3DEventsBelowCanvas, (settings.allow3DEventBelowCanvas != null) && settings.allow3DEventBelowCanvas);
 
             this._patchHierarchy(this);
 
@@ -487,6 +490,12 @@
             }
 
             eventState.skipNextObservers = skip;
+            if (!skip && (this._isFlagSet(SmartPropertyPrim.flagAllow3DEventsBelowCanvas)===false)) {
+                eventState.skipNextObservers = true;
+                if (eventData instanceof PointerInfoPre) {
+                    eventData.skipOnPointerObservable = true;
+                }
+            }
         }
 
         private _updatePointerInfo(eventData: PointerInfoBase, localPosition: Vector2): boolean {
@@ -1060,6 +1069,21 @@
          */
         public get _engineData(): Canvas2DEngineBoundData {
             return this.__engineData;
+        }
+
+        /**
+         * If true is returned, pointerEvent occurring above the Canvas area also sent in 3D scene, if false they are not sent in the 3D Scene
+         */
+        public get allow3DEventBelowCanvas(): boolean {
+            return this._isFlagSet(SmartPropertyPrim.flagAllow3DEventsBelowCanvas);
+        }
+
+        /**
+         * Set true if you want pointerEvent occurring above the Canvas area to also be sent in the 3D scene.
+         * Set false if you don't want the Scene to get the events
+         */
+        public set allow3DEventBelowCanvas(value: boolean) {
+            this._changeFlags(SmartPropertyPrim.flagAllow3DEventsBelowCanvas, value);
         }
 
         public createCanvasProfileInfoCanvas(): Canvas2D {
@@ -1817,6 +1841,7 @@
          *  - designUseHorizAxis: you can set this member if you use designSize to specify which axis is priority to compute the scale when the ratio of the canvas' size is different from the designSize's one.
          *  - cachingStrategy: either CACHESTRATEGY_TOPLEVELGROUPS, CACHESTRATEGY_ALLGROUPS, CACHESTRATEGY_CANVAS, CACHESTRATEGY_DONTCACHE. Please refer to their respective documentation for more information. Default is Canvas2D.CACHESTRATEGY_DONTCACHE
          *  - enableInteraction: if true the pointer events will be listened and rerouted to the appropriate primitives of the Canvas2D through the Prim2DBase.onPointerEventObservable observable property. Default is true.
+         *  - allow3DEventBelowCanvas: by default pointerEvent occurring above the Canvas will prevent to be also sent in the 3D Scene. If you set this setting to true, events will be sent both for Canvas and 3D Scene
          *  - isVisible: true if the canvas must be visible, false for hidden. Default is true.
          * - backgroundRoundRadius: the round radius of the background, either backgroundFill or backgroundBorder must be specified.
          * - backgroundFill: the brush to use to create a background fill for the canvas. can be a string value (see BABYLON.Canvas2D.GetBrushFromString) or a IBrush2D instance.
@@ -1846,6 +1871,7 @@
             cachingStrategy?: number,
             cacheBehavior?: number,
             enableInteraction?: boolean,
+            allow3DEventBelowCanvas?: boolean,
             isVisible?: boolean,
             backgroundRoundRadius?: number,
             backgroundFill?: IBrush2D | string,

--- a/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
+++ b/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
@@ -1265,8 +1265,8 @@
         public static flagActualScaleDirty        = 0x0040000;    // set if the actualScale property needs to be recomputed
         public static flagDontInheritParentScale  = 0x0080000;    // set if the actualScale must not use its parent's scale to be computed
         public static flagGlobalTransformDirty    = 0x0100000;    // set if the global transform must be recomputed due to a local transform change
-        public static flagLayoutBoundingInfoDirty = 0x0100000;    // set if the layout bounding info is dirty
-        public static flagAllow3DEventsBelowCanvas= 0x0200000;    // set if pointer events should be sent to 3D Engine when the pointer is over the Canvas
+        public static flagLayoutBoundingInfoDirty = 0x0200000;    // set if the layout bounding info is dirty
+        public static flagAllow3DEventsBelowCanvas= 0x0400000;    // set if pointer events should be sent to 3D Engine when the pointer is over the Canvas
 
         private   _flags              : number;
         private   _modelKey           : string;

--- a/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
+++ b/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
@@ -1266,6 +1266,7 @@
         public static flagDontInheritParentScale  = 0x0080000;    // set if the actualScale must not use its parent's scale to be computed
         public static flagGlobalTransformDirty    = 0x0100000;    // set if the global transform must be recomputed due to a local transform change
         public static flagLayoutBoundingInfoDirty = 0x0100000;    // set if the layout bounding info is dirty
+        public static flagAllow3DEventsBelowCanvas= 0x0200000;    // set if pointer events should be sent to 3D Engine when the pointer is over the Canvas
 
         private   _flags              : number;
         private   _modelKey           : string;


### PR DESCRIPTION
allow3DEventBelowCanvas: by default pointerEvent occurring above the Canvas will prevent to be also sent in the 3D Scene. If you set this setting to true, events will be sent both for Canvas and 3D Scene