### PR TITLE
Canvas2D bug fix for Sprite2D 

### DIFF
--- a/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
+++ b/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
@@ -1057,7 +1057,20 @@
                         }
                     }
 
-                    modelKey += v.name + ":" + ((propVal != null) ? ((v.typeLevelCompare) ? Tools.getClassName(propVal) : propVal.toString()) : "[null]") + ";";
+                    let value = "[null]";
+                    if (propVal != null) {
+                        if (v.typeLevelCompare) {
+                            value = Tools.getClassName(propVal);
+                        } else {
+                            if (propVal instanceof BaseTexture) {
+                                value = propVal.uid;
+                            } else {
+                                value = propVal.toString();
+                            }
+                        }
+                    }
+
+                    modelKey += v.name + ":" + value + ";";
                 }
             });
 


### PR DESCRIPTION
Only the Texture's URL was used to create the ModelRenderCache which bugs is two textures instances using the same URL were created (and disposed)