### PR TITLE
ShaderMaterial Base64 Encoded Vertex And Fragment Programs

### DIFF
--- a/src/Materials/babylon.effect.js
+++ b/src/Materials/babylon.effect.js
@@ -133,6 +133,12 @@ var BABYLON;
                 callback(vertexCode);
                 return;
             }
+            // Base64 encoded ?
+            if (vertex.startsWith("base64:")) {
+            	var vertexBinary = window.atob(vertex.substr(7));
+            	callback(vertexBinary);
+            	return;
+            }
             // Is in local store ?
             if (Effect.ShadersStore[vertex + "VertexShader"]) {
                 callback(Effect.ShadersStore[vertex + "VertexShader"]);
@@ -154,6 +160,12 @@ var BABYLON;
                 var fragmentCode = BABYLON.Tools.GetDOMTextContent(fragment);
                 callback(fragmentCode);
                 return;
+            }
+            // Base64 encoded ?
+            if (fragment.startsWith("base64:")) {
+            	var fragmentBinary = window.atob(fragment.substr(7));
+            	callback(fragmentBinary);
+            	return;
             }
             // Is in local store ?
             if (Effect.ShadersStore[fragment + "PixelShader"]) {

--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -177,6 +177,13 @@
                 return;
             }
 
+            // Base64 encoded ?
+            if (vertex.startsWith("base64:")) {
+            	var vertexBinary = window.atob(vertex.substr(7));
+            	callback(vertexBinary);
+            	return;
+            }
+
             // Is in local store ?
             if (Effect.ShadersStore[vertex + "VertexShader"]) {
                 callback(Effect.ShadersStore[vertex + "VertexShader"]);
@@ -201,6 +208,13 @@
                 var fragmentCode = Tools.GetDOMTextContent(fragment);
                 callback(fragmentCode);
                 return;
+            }
+
+            // Base64 encoded ?
+            if (fragment.startsWith("base64:")) {
+            	var fragmentBinary = window.atob(fragment.substr(7));
+            	callback(fragmentBinary);
+            	return;
             }
 
             // Is in local store ?


### PR DESCRIPTION
Added support for ShaderMaterial Base64 Encoded Vertex And Fragment
Programs:
{
   vertextElement: “base64:xxxxxxxx”,
   fragmentElement: “base64:xxxxxxxx”
}