### PR TITLE
Added SPS parameter : bSphereRadiusFactor

### DIFF
--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -112,22 +112,27 @@
         private _maxBbox: Vector3 = Tmp.Vector3[5];
         private _particlesIntersect: boolean = false;
         public _bSphereOnly: boolean = false;
+        public _bSphereRadiusFactor: number = 1.0;
 
         /**
         * Creates a SPS (Solid Particle System) object.
         * `name` (String) is the SPS name, this will be the underlying mesh name.  
         * `scene` (Scene) is the scene in which the SPS is added.  
-        * `updatable` (default true) : if the SPS must be updatable or immutable.  
-        * `isPickable` (default false) : if the solid particles must be pickable.  
-        * `particleIntersection` (default false) : if the solid particle intersections must be computed
+        * `updatable` (optional boolean, default true) : if the SPS must be updatable or immutable.  
+        * `isPickable` (optional boolean, default false) : if the solid particles must be pickable.  
+        * `particleIntersection` (optional boolean, default false) : if the solid particle intersections must be computed.    
+        * `boundingSphereOnly` (optional boolean, default false) : if the particle intersection must be computed only with the bounding sphere (no bounding box computation, so faster).  
+        * `bSphereRadiusFactor` (optional float, default 1.0) : a number to multiply the boundind sphere radius by in order to reduce it for instance. 
+        *  Example : bSphereRadiusFactor = 1.0 / Math.sqrt(3.0) => the bounding sphere exactly matches a spherical mesh.  
         */
-        constructor(name: string, scene: Scene, options?: { updatable?: boolean; isPickable?: boolean; particleIntersection?: boolean; boundingSphereOnly?: boolean }) {
+        constructor(name: string, scene: Scene, options?: { updatable?: boolean; isPickable?: boolean; particleIntersection?: boolean; boundingSphereOnly?: boolean; bSphereRadiusFactor?: number }) {
             this.name = name;
             this._scene = scene;
             this._camera = <TargetCamera>scene.activeCamera;
             this._pickable = options ? options.isPickable : false;
             this._particlesIntersect = options ? options.particleIntersection : false;
             this._bSphereOnly= options ? options.boundingSphereOnly : false;
+            this._bSphereRadiusFactor = (options && options.bSphereRadiusFactor) ? options.bSphereRadiusFactor : 1.0;
             if (options && options.updatable) {
                 this._updatable = options.updatable;
             } else {
@@ -733,7 +738,7 @@
                     bSphere.center.x = this._particle.position.x + (this._minBbox.x + this._maxBbox.x) * 0.5;
                     bSphere.center.y = this._particle.position.y + (this._minBbox.y + this._maxBbox.y) * 0.5;
                     bSphere.center.z = this._particle.position.z + (this._minBbox.z + this._maxBbox.z) * 0.5;
-                    bSphere.radius = 0.5 * Math.sqrt((this._maxBbox.x - this._minBbox.x) * (this._maxBbox.x - this._minBbox.x) + (this._maxBbox.y - this._minBbox.y) * (this._maxBbox.y - this._minBbox.y) + (this._maxBbox.z - this._minBbox.z) * (this._maxBbox.z - this._minBbox.z));
+                    bSphere.radius = this._bSphereRadiusFactor * 0.5 * Math.sqrt((this._maxBbox.x - this._minBbox.x) * (this._maxBbox.x - this._minBbox.x) + (this._maxBbox.y - this._minBbox.y) * (this._maxBbox.y - this._minBbox.y) + (this._maxBbox.z - this._minBbox.z) * (this._maxBbox.z - this._minBbox.z));
                     bSphere._update(this.mesh._worldMatrix);
                 }
 


### PR DESCRIPTION
```javascript
var sps = new BABYLON.SolidParticleSystem("sps", scene, {particleIntersection: true, boundingSphereOnly: true, bSphereRadiusFactor : 1.0 / Math.sqrt(3.0)};
```
The new paramater `bSphereRadiusFactor` allows to modify the bounding sphere radius : the bounding sphere radius is multiplied by this parameter.  

Example : with the factor 1 / SQRT(3), a spherical particle will exactly match its bounding sphere.
As sometimes tiny animated objects (solid particles) can be approximated by little spheres, this is really useful to set their bounding spheres close to their own shape and then just use the fast bounding sphere intersection only.