### PR TITLE
Canvas2D: Bug fixes

### DIFF
--- a/canvas2D/src/Engine/babylon.canvas2d.ts
+++ b/canvas2D/src/Engine/babylon.canvas2d.ts
@@ -75,7 +75,6 @@
             isScreenSpace?: boolean,
             cachingStrategy?: number,
             enableInteraction?: boolean,
-            allow3DEventBelowCanvas?: boolean,
             origin?: Vector2,
             isVisible?: boolean,
             backgroundRoundRadius?: number,
@@ -172,8 +171,6 @@
             this._trackedGroups = new Array<Group2D>();
             this._maxAdaptiveWorldSpaceCanvasSize = null;
             this._groupCacheMaps = new StringDictionary<MapTexture[]>();
-
-            this._changeFlags(SmartPropertyPrim.flagAllow3DEventsBelowCanvas, (settings.allow3DEventBelowCanvas != null) && settings.allow3DEventBelowCanvas);
 
             this._patchHierarchy(this);
 
@@ -493,12 +490,6 @@
             }
 
             eventState.skipNextObservers = skip;
-            if (!skip && (this._isFlagSet(SmartPropertyPrim.flagAllow3DEventsBelowCanvas)===false)) {
-                eventState.skipNextObservers = true;
-                if (eventData instanceof PointerInfoPre) {
-                    eventData.skipOnPointerObservable = true;
-                }
-            }
         }
 
         private _updatePointerInfo(eventData: PointerInfoBase, localPosition: Vector2): boolean {
@@ -1077,21 +1068,6 @@
          */
         public get _engineData(): Canvas2DEngineBoundData {
             return this.__engineData;
-        }
-
-        /**
-         * If true is returned, pointerEvent occurring above the Canvas area also sent in 3D scene, if false they are not sent in the 3D Scene
-         */
-        public get allow3DEventBelowCanvas(): boolean {
-            return this._isFlagSet(SmartPropertyPrim.flagAllow3DEventsBelowCanvas);
-        }
-
-        /**
-         * Set true if you want pointerEvent occurring above the Canvas area to also be sent in the 3D scene.
-         * Set false if you don't want the Scene to get the events
-         */
-        public set allow3DEventBelowCanvas(value: boolean) {
-            this._changeFlags(SmartPropertyPrim.flagAllow3DEventsBelowCanvas, value);
         }
 
         public createCanvasProfileInfoCanvas(): Canvas2D {
@@ -1826,7 +1802,7 @@
             this.propertyChanged.add((e, st) => {
                 let mesh = this._worldSpaceNode as AbstractMesh;
                 if (mesh) {
-                    mesh.isVisible = this.isVisible;
+                    mesh.isVisible = e.newValue;
                 }
             }, Prim2DBase.isVisibleProperty.flagId);
         }
@@ -1857,7 +1833,6 @@
          *  - designUseHorizAxis: you can set this member if you use designSize to specify which axis is priority to compute the scale when the ratio of the canvas' size is different from the designSize's one.
          *  - cachingStrategy: either CACHESTRATEGY_TOPLEVELGROUPS, CACHESTRATEGY_ALLGROUPS, CACHESTRATEGY_CANVAS, CACHESTRATEGY_DONTCACHE. Please refer to their respective documentation for more information. Default is Canvas2D.CACHESTRATEGY_DONTCACHE
          *  - enableInteraction: if true the pointer events will be listened and rerouted to the appropriate primitives of the Canvas2D through the Prim2DBase.onPointerEventObservable observable property. Default is true.
-         *  - allow3DEventBelowCanvas: by default pointerEvent occurring above the Canvas will prevent to be also sent in the 3D Scene. If you set this setting to true, events will be sent both for Canvas and 3D Scene
          *  - isVisible: true if the canvas must be visible, false for hidden. Default is true.
          * - backgroundRoundRadius: the round radius of the background, either backgroundFill or backgroundBorder must be specified.
          * - backgroundFill: the brush to use to create a background fill for the canvas. can be a string value (see BABYLON.Canvas2D.GetBrushFromString) or a IBrush2D instance.
@@ -1887,7 +1862,6 @@
             cachingStrategy?: number,
             cacheBehavior?: number,
             enableInteraction?: boolean,
-            allow3DEventBelowCanvas?: boolean,
             isVisible?: boolean,
             backgroundRoundRadius?: number,
             backgroundFill?: IBrush2D | string,

--- a/canvas2D/src/Engine/babylon.canvas2dLayoutEngine.ts
+++ b/canvas2D/src/Engine/babylon.canvas2dLayoutEngine.ts
@@ -62,12 +62,12 @@
         private _doUpdate(prim: Prim2DBase) {
             // Canvas ?
             if (prim instanceof Canvas2D) {
-                prim.layoutArea = prim.actualSize.multiplyByFloats(prim.scaleX, prim.scaleY);
+                prim.layoutArea = prim.actualSize; //.multiplyByFloats(prim.scaleX, prim.scaleY);
             }
 
             // Direct child of Canvas ?
             else if (prim.parent instanceof Canvas2D) {
-                prim.layoutArea = prim.owner.actualSize.multiplyByFloats(prim.owner.scaleX, prim.owner.scaleY);
+                prim.layoutArea = prim.owner.actualSize; //.multiplyByFloats(prim.owner.scaleX, prim.owner.scaleY);
             }
 
             // Indirect child of Canvas

--- a/canvas2D/src/Engine/babylon.group2d.ts
+++ b/canvas2D/src/Engine/babylon.group2d.ts
@@ -829,7 +829,7 @@
                 scale = this.actualScale;
             }
 
-            if (isCanvas && this.owner.cachingStrategy===Canvas2D.CACHESTRATEGY_CANVAS) {
+            if (isCanvas && this.owner.cachingStrategy===Canvas2D.CACHESTRATEGY_CANVAS && this.owner.isScreenSpace) {
                 Group2D._s.width = this.owner.engine.getRenderWidth();
                 Group2D._s.height = this.owner.engine.getRenderHeight();
             } else {

--- a/canvas2D/src/Engine/babylon.prim2dBase.ts
+++ b/canvas2D/src/Engine/babylon.prim2dBase.ts
@@ -2670,7 +2670,7 @@
 
                 this._debugAreaGroup = new Group2D
                     (
-                    {
+                    {   dontInheritParentScale: true,
                         parent: (this.parent!=null) ? this.parent : this, id: "###DEBUG AREA GROUP###", children:
                         [
                             new Group2D({
@@ -2772,9 +2772,10 @@
                 areaInfo[curAreaIndex++] = { off: pos, size: size, min: min, max: max };
             }
 
+            let isCanvas = this instanceof Canvas2D;
             let marginH = this._marginOffset.x + this._marginOffset.z;
             let marginV = this._marginOffset.y + this._marginOffset.w;
-            let actualSize = this.actualSize.multiplyByFloats(this.scaleX, this.scaleY);
+            let actualSize = this.actualSize.multiplyByFloats(isCanvas ? 1 : this.scaleX, isCanvas ? 1 : this.scaleY);
 
             let w = hasLayout ? (this.layoutAreaPos.x + this.layoutArea.width)  : (marginH + actualSize.width);
             let h = hasLayout ? (this.layoutAreaPos.y + this.layoutArea.height) : (marginV + actualSize.height);

--- a/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
+++ b/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
@@ -1279,7 +1279,6 @@
         public static flagDontInheritParentScale  = 0x0080000;    // set if the actualScale must not use its parent's scale to be computed
         public static flagGlobalTransformDirty    = 0x0100000;    // set if the global transform must be recomputed due to a local transform change
         public static flagLayoutBoundingInfoDirty = 0x0200000;    // set if the layout bounding info is dirty
-        public static flagAllow3DEventsBelowCanvas= 0x0400000;    // set if pointer events should be sent to 3D Engine when the pointer is over the Canvas
 
         private   _flags              : number;
         private   _modelKey           : string;

--- a/canvas2D/src/Engine/babylon.sprite2d.ts
+++ b/canvas2D/src/Engine/babylon.sprite2d.ts
@@ -389,20 +389,22 @@
             this.alignToPixel = (settings.alignToPixel == null) ? true : settings.alignToPixel;
             this.useAlphaFromTexture = true;
 
+            // If the user doesn't set a size, we'll use the texture's one, but if the texture is not loading, we HAVE to set a temporary dummy size otherwise the positioning engine will switch the marginAlignement to stretch/stretch, and WE DON'T WANT THAT.
+            // The fucking delayed texture sprite bug is fixed!
+            if (settings.spriteSize == null) {
+                this.size = new Size(10, 10);
+            }
+
             if (settings.spriteSize == null || !texture.isReady()) {
                 if (texture.isReady()) {
-                    //console.log(`Texture of Sprite2D ${this.id} was immediately ready`);
                     let s = texture.getBaseSize();
                     this.size = new Size(s.width, s.height);
                 } else {
-                    //console.log(`Texture of Sprite2D ${this.id} defer loading`);
 
                     texture.onLoadObservable.add(() => {
-                        //console.log(`Texture of Sprite2D ${this.id} loaded`);
-
                         if (settings.spriteSize == null) {
                             let s = texture.getBaseSize();
-                            this.size = new Size(s.width, s.height);
+                        this.size = new Size(s.width, s.height);
                         }
                         this._positioningDirty();
                         this._setLayoutDirty();

--- a/canvas2D/src/Engine/babylon.sprite2d.ts
+++ b/canvas2D/src/Engine/babylon.sprite2d.ts
@@ -391,15 +391,21 @@
 
             if (settings.spriteSize == null || !texture.isReady()) {
                 if (texture.isReady()) {
+                    //console.log(`Texture of Sprite2D ${this.id} was immediately ready`);
                     let s = texture.getBaseSize();
                     this.size = new Size(s.width, s.height);
                 } else {
+                    //console.log(`Texture of Sprite2D ${this.id} defer loading`);
+
                     texture.onLoadObservable.add(() => {
+                        //console.log(`Texture of Sprite2D ${this.id} loaded`);
+
                         if (settings.spriteSize == null) {
                             let s = texture.getBaseSize();
                             this.size = new Size(s.width, s.height);
                         }
                         this._positioningDirty();
+                        this._setLayoutDirty();
                         this._instanceDirtyFlags |= Prim2DBase.originProperty.flagId | Sprite2D.textureProperty.flagId;  // To make sure the sprite is issued again for render
                     });
                 }


### PR DESCRIPTION
Canvas2D: bug fix and allow3DEventBelowCanvas rollbacked
 - allow3DEventBelowCanvas  was removed, not flexible enough
 - WorldSpaceCanvas with custom node wasn't rendering correctly
 - Prim2DBase.actualHeight was returning actualWidth
 - debugDisplayArea support scaling
 - pointerEvent is triggered in Canvas cache strategies other than DONTCACHE
 - Sprite2D delayed texture loading bug FIXED!
 - fix canvasLayoutEngine with designSize