### PR TITLE
Added 'buttons[]' for the Arc and Free cameras to customize which pointer buttons rotate them

### DIFF
--- a/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
+++ b/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
@@ -42,7 +42,7 @@ module BABYLON {
             this._pointerInput = (p, s) => {
                 var evt = <PointerEvent>p.event;
 
-                if (this.buttons.indexOf(evt.button) === -1) {
+                if (p.type !== PointerEventTypes.POINTERMOVE && this.buttons.indexOf(evt.button) === -1) {
                     return;
                 }
 

--- a/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
+++ b/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
@@ -5,7 +5,7 @@ module BABYLON {
         camera: ArcRotateCamera;
 
         @serialize()
-        public pointerButtons = [0, 1, 2];
+        public buttons = [0, 1, 2];
 
         @serialize()
         public angularSensibilityX = 1000.0;
@@ -42,7 +42,7 @@ module BABYLON {
             this._pointerInput = (p, s) => {
                 var evt = <PointerEvent>p.event;
 
-                if (this.pointerButtons.indexOf(evt.button) === -1) {
+                if (this.buttons.indexOf(evt.button) === -1) {
                     return;
                 }
 

--- a/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
+++ b/src/Cameras/Inputs/babylon.arcrotatecamera.input.pointers.ts
@@ -5,6 +5,9 @@ module BABYLON {
         camera: ArcRotateCamera;
 
         @serialize()
+        public pointerButtons = [0, 1, 2];
+
+        @serialize()
         public angularSensibilityX = 1000.0;
 
         @serialize()
@@ -38,6 +41,11 @@ module BABYLON {
 
             this._pointerInput = (p, s) => {
                 var evt = <PointerEvent>p.event;
+
+                if (this.pointerButtons.indexOf(evt.button) === -1) {
+                    return;
+                }
+
                 if (p.type === PointerEventTypes.POINTERDOWN) {
                     try {
                         evt.srcElement.setPointerCapture(evt.pointerId);

--- a/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
@@ -28,7 +28,7 @@ module BABYLON {
                         return;
                     }
 
-                    if(this.buttons.indexOf(evt.button) === -1){
+                    if(p.type !== PointerEventTypes.POINTERMOVE && this.buttons.indexOf(evt.button) === -1){
                         return;
                     }
 

--- a/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
@@ -3,6 +3,9 @@ module BABYLON {
         camera: FreeCamera;
 
         @serialize()
+        public pointerButtons = [0, 1, 2];
+
+        @serialize()
         public angularSensibility = 2000.0;
 
         private _pointerInput: (p: PointerInfo, s: EventState) => void;
@@ -22,6 +25,10 @@ module BABYLON {
                     var evt = <PointerEvent>p.event;
 
                     if (!this.touchEnabled && evt.pointerType === "touch") {
+                        return;
+                    }
+
+                    if(this.pointerButtons.indexOf(evt.button) === -1){
                         return;
                     }
 

--- a/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.mouse.ts
@@ -3,7 +3,7 @@ module BABYLON {
         camera: FreeCamera;
 
         @serialize()
-        public pointerButtons = [0, 1, 2];
+        public buttons = [0, 1, 2];
 
         @serialize()
         public angularSensibility = 2000.0;
@@ -28,7 +28,7 @@ module BABYLON {
                         return;
                     }
 
-                    if(this.pointerButtons.indexOf(evt.button) === -1){
+                    if(this.buttons.indexOf(evt.button) === -1){
                         return;
                     }
 


### PR DESCRIPTION
In commit 1/2 they were named 'pointerButtons', but since accessing input properties directly from the camera instead of from the input class turned out to only be kept for backward compatibility, I renamed them to 'buttons'.

What do you think?