### PR TITLE
Improve error if canvas is null or undefined

### DIFF
--- a/src/babylon.engine.js
+++ b/src/babylon.engine.js
@@ -214,6 +214,9 @@ var BABYLON;
             //    // Do nothing
             //}
             if (!this._gl) {
+                if (!canvas) {
+                    throw new Error("The provided canvas is null or undefined.");
+                }
                 try {
                     this._gl = (canvas.getContext("webgl", options) || canvas.getContext("experimental-webgl", options));
                 }

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -518,6 +518,9 @@
             //}
 
             if (!this._gl) {
+                if (!canvas) {
+                    throw new Error("The provided canvas is null or undefined.");
+                }
                 try {
                     this._gl = <WebGLRenderingContext>(canvas.getContext("webgl", options) || canvas.getContext("experimental-webgl", options));
                 } catch (e) {


### PR DESCRIPTION
Greetings.  With the current version of Babylon.js, if the user passes in a null or undefined canvas, the error is "WebGL is not supported".  This is misleading.  This PR includes a better error.

I ran Gulp and it seems fine.  There was a bunch of other stuff that changed when I built, but I didn't include them - I am assuming this is OK and someone will do a full build before a release, right?