### PR TITLE
Add ITextureAssetTask

### DIFF
--- a/src/Tools/babylon.assetsManager.ts
+++ b/src/Tools/babylon.assetsManager.ts
@@ -145,9 +145,15 @@
         }
     }
 
-    export class TextureAssetTask implements IAssetTask {
-        public onSuccess: (task: IAssetTask) => void;
-        public onError: (task: IAssetTask) => void;
+    export interface ITextureAssetTask extends IAssetTask {
+        onSuccess: (task: ITextureAssetTask) => void;
+        onError: (task: ITextureAssetTask) => void;
+        texture: Texture;
+    }
+
+    export class TextureAssetTask implements ITextureAssetTask {
+        public onSuccess: (task: ITextureAssetTask) => void;
+        public onError: (task: ITextureAssetTask) => void;
 
         public isCompleted = false;
         public texture: Texture;
@@ -257,7 +263,7 @@
             return task;
         }
 
-        public addTextureTask(taskName: string, url: string, noMipmap?: boolean, invertY?: boolean, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE): IAssetTask {
+        public addTextureTask(taskName: string, url: string, noMipmap?: boolean, invertY?: boolean, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE): ITextureAssetTask {
             var task = new TextureAssetTask(taskName, url, noMipmap, invertY, samplingMode);
             this.tasks.push(task);
 


### PR DESCRIPTION
With the current implementation of the TextureAssetTask, it is necessary to provide a type assertion on the task parameter in the onSuccess handler to get access to the texture property.  This patch removes that requirement.  This PR should result in no changes to the emitted JS - it's just to make TypeScript happy.

For example, this code should now compile without a type error (previously it was required to put a type assertion on the task parameter of the handler to access the texture property (which is not part of IAssetTask).

```typescript
this.shipPartsMaterial = new BABYLON.StandardMaterial("shipPartsMaterial", scene); 
const shipPartsTextureTask = this.assetsManager.addTextureTask("shipParts texture task", "art/ShipParts.png", false)
shipPartsTextureTask.onSuccess = task => {
    this.shipPartsMaterial.diffuseTexture = task.texture;
    this.shipPartsMaterial.diffuseTexture.hasAlpha = true;
};
```

Please note that I didn't update the babylon `index.d.ts` file as part of this patch - is that required or is there a build process that does that?

Thanks!