### PR TITLE
check that to and from keys are not the same

### DIFF
--- a/src/Animations/babylon.animation.ts
+++ b/src/Animations/babylon.animation.ts
@@ -455,6 +455,7 @@
             if (this.targetPropertyPath.length > 1) {
                 var property = this._target[this.targetPropertyPath[0]];
 
+
                 for (var index = 1; index < this.targetPropertyPath.length - 1; index++) {
                     property = property[this.targetPropertyPath[index]];
                 }
@@ -532,6 +533,11 @@
                 to = this._keys[this._keys.length - 1].frame;
             }
 
+            //to and from cannot be the same key
+            if(from === to) {
+                from++;
+            }
+            
             // Compute ratio
             var range = to - from;
             var offsetValue;


### PR DESCRIPTION
adding in check to make sure to and from are not the same key, if so they error when used to set range as it will be 0 and then get an error when dividing by it later.

I noticed when I was animating small segments of time (a few key frames) the execution time would cause the "to" and "from" to be the same value.  This would then cause an error later due to it setting the range to 0, and trying to divide by it.  Let me know if there is a better way of doing this.