### PR TITLE
Do not clone mesh parent

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -141,9 +141,12 @@
                 }
 
                 // Deep copy
-                Tools.DeepCopy(source, this, ["name", "material", "skeleton", "instances"], ["_poseMatrix"]);
+                Tools.DeepCopy(source, this, ["name", "material", "skeleton", "instances", "parent"], ["_poseMatrix"]);
 
-                // Pivot                
+                // Parent
+                this.parent = source.parent;
+
+                // Pivot
                 this.setPivotMatrix(source.getPivotMatrix());
 
                 this.id = name + "." + source.id;


### PR DESCRIPTION
Hi!

A parent is a Node or extends a Node.
A parent being:

- a Mesh was not an issue since Mesh are ignored when cloning (Tools.cloneValue)
- a Node was not an issue since Node does not have clone method.
- a **class that both extends a Node and has a clone method was an issue**: the parent was cloned.

By itself, cloning the parent is odd to me but not an error.
It's an error if children are cloned too, since parent's children will be cloned, resulting in an infinite loop.

Rather than preventing the error, i changed the odd behavior of even attempting to clone parent.

So, **i added parent to the ignore list while cloning a mesh.**