### PR TITLE
Change handjs link to https://github.com/deltakosh/handjs repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ In no event and under no legal theory, whether in tort (including negligence), c
 While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
 
 ## External dependencies
-- hand.js: http://handjs.codeplex.com
+- hand.js: https://github.com/deltakosh/handjs
 
 
 


### PR DESCRIPTION
The http://handjs.codeplex.com indicates the project has moved to github
so updating the link.

Note: that https://github.com/deltakosh/handjs is discontinued and
suggests using https://github.com/jquery/PEP until native support is
pervasive.

The PE W3C spec https://www.w3.org/TR/pointerevents/ was approved as a
recommendation 24 Feburary 2015. There are currently are three native
implementations IE v11, Edge v14 and Chrome v55 according to
https://www.w3.org/TR/pointerevents/.