### PR TITLE
added some missing type annotations

### DIFF
--- a/src/Materials/Textures/babylon.hdrCubeTexture.ts
+++ b/src/Materials/Textures/babylon.hdrCubeTexture.ts
@@ -452,7 +452,7 @@ module BABYLON {
          * @param onError Method called if any error happens during download.
          * @return The packed binary data.
          */
-        public static generateBabylonHDR(url: string, size: number, callback: ((ArrayBuffer) => void), onError: (() => void) = null): void {
+        public static generateBabylonHDR(url: string, size: number, callback: ((ArrayBuffer: ArrayBuffer) => void), onError: (() => void) = null): void {
             // Needs the url tho create the texture.
             if (!url) {
                 return null;

--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -20,7 +20,7 @@
         * Use this predicate to dynamically define the list of mesh you want to render.
         * If set, the renderList property will be overwritten.
         */
-        public renderListPredicate: (AbstractMesh) => boolean;
+        public renderListPredicate: (AbstractMesh: AbstractMesh) => boolean;
 
         /**
         * Use this list to define the list of mesh you want to render.

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -188,7 +188,7 @@
             };
         }
 
-        public static Vector2ArrayFeeder(array: Array<Vector2> | Float32Array): (i) => Vector2 {
+        public static Vector2ArrayFeeder(array: Array<Vector2> | Float32Array): (i: number) => Vector2 {
             return (index: number) => {
                 let isFloatArray = ((<Float32Array>array).BYTES_PER_ELEMENT !== undefined);
                 let length = isFloatArray ? array.length / 2 : array.length;
@@ -1065,7 +1065,7 @@
             return name;
         }
 
-        public static first<T>(array: Array<T>, predicate: (item) => boolean) {
+        public static first<T>(array: Array<T>, predicate: (item: T) => boolean) {
             for (let el of array) {
                 if (predicate(el)) {
                     return el;
@@ -1107,7 +1107,7 @@
          * This method can be used with hashCodeFromStream when your input is an array of values that are either: number, string, boolean or custom type implementing the getHashCode():number method.
          * @param array
          */
-        public static arrayOrStringFeeder(array: any): (i) => number {
+        public static arrayOrStringFeeder(array: any): (i: number) => number {
             return (index: number) => {
                 if (index >= array.length) {
                     return null;

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -2584,7 +2584,7 @@
         }
 
         public createRawCubeTexture(url: string, scene: Scene, size: number, format: number, type: number, noMipmap: boolean,
-            callback: (ArrayBuffer) => ArrayBufferView[],
+            callback: (ArrayBuffer: ArrayBuffer) => ArrayBufferView[],
             mipmmapGenerator: ((faces: ArrayBufferView[]) => ArrayBufferView[][])): WebGLTexture {
             var gl = this._gl;
             var texture = gl.createTexture();


### PR DESCRIPTION
Currently you get some errors if you refernce the babylon.d.ts in a project where the "noImplicitAny" typescript option is enabled. I added the missing type annotations. 