### PR TITLE
Consolidate render target options into object and fix related bugs

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -1,6 +1,7 @@
 # 2.6.0:
 
 ### Major updates
+ - New Unity 5 Editor Toolkit. Complete pipeline integration [Doc](TODO) - ([MackeyK24](https://github.com/MackeyK24))
  - New DebugLayer. [Doc](TODO) - ([temechon](https://github.com/temechon))
  - New `VideoTexture.CreateFromWebCam` to generate video texture using WebRTC. [Demo](https://www.babylonjs-playground.com#1R77YT#2) - (Sebastien Vandenberghe)(https://github.com/sebavanmicrosoft) / ([deltakosh](https://github.com/deltakosh))
 

--- a/src/Materials/Textures/babylon.mirrorTexture.ts
+++ b/src/Materials/Textures/babylon.mirrorTexture.ts
@@ -6,8 +6,8 @@
         private _mirrorMatrix = Matrix.Zero();
         private _savedViewMatrix: Matrix;
 
-        constructor(name: string, size: number, scene: Scene, generateMipMaps?: boolean) {
-            super(name, size, scene, generateMipMaps, true);
+        constructor(name: string, size: any, scene: Scene, generateMipMaps?: boolean, type: number = Engine.TEXTURETYPE_UNSIGNED_INT, samplingMode = Texture.BILINEAR_SAMPLINGMODE, generateDepthBuffer = true) {
+            super(name, size, scene, generateMipMaps, true, type, false, samplingMode, generateDepthBuffer);
 
             this.onBeforeRenderObservable.add(() => {
                 Matrix.ReflectionToRef(this.mirrorPlane, this._mirrorMatrix);
@@ -35,7 +35,15 @@
 
         public clone(): MirrorTexture {
             var textureSize = this.getSize();
-            var newTexture = new MirrorTexture(this.name, textureSize.width, this.getScene(), this._generateMipMaps);
+            var newTexture = new MirrorTexture(
+                this.name,
+                textureSize.width,
+                this.getScene(),
+                this._renderTargetOptions.generateMipMaps,
+                this._renderTargetOptions.type,
+                this._renderTargetOptions.samplingMode,
+                this._renderTargetOptions.generateDepthBuffer
+            );
 
             // Base texture
             newTexture.hasAlpha = this.hasAlpha;

--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -20,7 +20,7 @@
         * Use this predicate to dynamically define the list of mesh you want to render.
         * If set, the renderList property will be overwritten.
         */
-        public renderListPredicate: (AbstractMesh: AbstractMesh) => boolean;
+        public renderListPredicate: (AbstractMesh) => boolean;
 
         /**
         * Use this list to define the list of mesh you want to render.
@@ -99,9 +99,15 @@
         private _currentRefreshId = -1;
         private _refreshRate = 1;
         private _textureMatrix: Matrix;
+        protected _renderTargetOptions: {
+            generateMipMaps: boolean,
+            type: number,
+            samplingMode: number,
+            generateDepthBuffer: boolean,
+            generateStencilBuffer: boolean
+        };
 
-        constructor(name: string, size: any, scene: Scene, generateMipMaps?: boolean, doNotChangeAspectRatio: boolean = true, type: number = Engine.TEXTURETYPE_UNSIGNED_INT, public isCube = false, samplingMode = Texture.TRILINEAR_SAMPLINGMODE, 
-            generateDepthBuffer = true, generateStencilBuffer = false) {
+        constructor(name: string, size: any, scene: Scene, generateMipMaps?: boolean, doNotChangeAspectRatio: boolean = true, type: number = Engine.TEXTURETYPE_UNSIGNED_INT, public isCube = false, samplingMode = Texture.TRILINEAR_SAMPLINGMODE, generateDepthBuffer = true, generateStencilBuffer = false) {
             super(null, scene, !generateMipMaps);
 
             this.name = name;
@@ -110,28 +116,25 @@
             this._generateMipMaps = generateMipMaps;
             this._doNotChangeAspectRatio = doNotChangeAspectRatio;
 
+            this._renderTargetOptions = {
+                generateMipMaps: generateMipMaps,
+                type: type,
+                samplingMode: samplingMode,
+                generateDepthBuffer: generateDepthBuffer,
+                generateStencilBuffer: generateStencilBuffer
+            };
+
             if (samplingMode === Texture.NEAREST_SAMPLINGMODE) {
                 this.wrapU = Texture.CLAMP_ADDRESSMODE;
                 this.wrapV = Texture.CLAMP_ADDRESSMODE;
             }
 
             if (isCube) {
-                this._texture = scene.getEngine().createRenderTargetCubeTexture(size, { 
-                    generateMipMaps: generateMipMaps, 
-                    samplingMode: samplingMode,
-                    generateDepthBuffer: generateDepthBuffer,
-                    generateStencilBuffer: generateStencilBuffer 
-                });
+                this._texture = scene.getEngine().createRenderTargetCubeTexture(size, this._renderTargetOptions);
                 this.coordinatesMode = Texture.INVCUBIC_MODE;
                 this._textureMatrix = Matrix.Identity();
             } else {
-                this._texture = scene.getEngine().createRenderTargetTexture(size, { 
-                    generateMipMaps: generateMipMaps, 
-                    type: type, 
-                    samplingMode: samplingMode,
-                    generateDepthBuffer: generateDepthBuffer,
-                    generateStencilBuffer: generateStencilBuffer 
-                });
+                this._texture = scene.getEngine().createRenderTargetTexture(size, this._renderTargetOptions);
             }
 
             // Rendering groups
@@ -185,7 +188,7 @@
         public scale(ratio: number): void {
             var newSize = this._size * ratio;
 
-            this.resize(newSize, this._generateMipMaps);
+            this.resize(newSize);
         }
 
         public getReflectionTextureMatrix(): Matrix {
@@ -196,12 +199,12 @@
             return super.getReflectionTextureMatrix();
         }
 
-        public resize(size: any, generateMipMaps?: boolean) {
+        public resize(size: any) {
             this.releaseInternalTexture();
             if (this.isCube) {
-                this._texture = this.getScene().getEngine().createRenderTargetCubeTexture(size);
+                this._texture = this.getScene().getEngine().createRenderTargetCubeTexture(size, this._renderTargetOptions);
             } else {
-                this._texture = this.getScene().getEngine().createRenderTargetTexture(size, generateMipMaps);
+                this._texture = this.getScene().getEngine().createRenderTargetTexture(size, this._renderTargetOptions);
             }
         }
 
@@ -394,7 +397,18 @@
 
         public clone(): RenderTargetTexture {
             var textureSize = this.getSize();
-            var newTexture = new RenderTargetTexture(this.name, textureSize.width, this.getScene(), this._generateMipMaps);
+            var newTexture = new RenderTargetTexture(
+                this.name,
+                textureSize.width,
+                this.getScene(),
+                this._renderTargetOptions.generateMipMaps,
+                this._doNotChangeAspectRatio,
+                this._renderTargetOptions.type,
+                this.isCube,
+                this._renderTargetOptions.samplingMode,
+                this._renderTargetOptions.generateDepthBuffer,
+                this._renderTargetOptions.generateStencilBuffer
+            );
 
             // Base texture
             newTexture.hasAlpha = this.hasAlpha;

--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -20,7 +20,7 @@
         * Use this predicate to dynamically define the list of mesh you want to render.
         * If set, the renderList property will be overwritten.
         */
-        public renderListPredicate: (AbstractMesh) => boolean;
+        public renderListPredicate: (AbstractMesh: AbstractMesh) => boolean;
 
         /**
         * Use this list to define the list of mesh you want to render.


### PR DESCRIPTION
- Fixed bug where resizing would cause critical render target options to be lost
- Fixed bug where cloning would cause critical render target options to be lost
- Corrected types in MirrorTexture parameters
- Added additional render target parameters to MirrorTexture
