### PR TITLE
Strict typing of clear color

### DIFF
--- a/src/Rendering/babylon.renderingManager.ts
+++ b/src/Rendering/babylon.renderingManager.ts
@@ -46,7 +46,7 @@
                 return;
             }
 
-            this._scene.getEngine().clear(0, false, depth, stencil);
+            this._scene.getEngine().clear(null, false, depth, stencil);
             this._depthStencilBufferAlreadyCleaned = true;
         }
 

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -957,12 +957,12 @@
             }
         }
 
-        public clear(color: any, backBuffer: boolean, depth: boolean, stencil: boolean = false): void {
+        public clear(color: Color4, backBuffer: boolean, depth: boolean, stencil: boolean = false): void {
             this.applyStates();
 
             var mode = 0;
-            if (backBuffer) {
-                this._gl.clearColor(color.r, color.g, color.b, color.a !== undefined ? color.a : 1.0);
+            if (backBuffer && color) {
+                this._gl.clearColor(color.r, color.g, color.b, color.a);
                 mode |= this._gl.COLOR_BUFFER_BIT;
             }
             if (depth) {

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -143,7 +143,7 @@
 
         // Members
         public autoClear = true;
-        public clearColor: any = new Color3(0.2, 0.2, 0.3);
+        public clearColor: Color4 = new Color4(0.2, 0.2, 0.3, 1.0);
         public ambientColor = new Color3(0, 0, 0);
 
         public forceWireframe = false;
@@ -2464,7 +2464,7 @@
             if (this.activeCameras.length > 0) {
                 for (var cameraIndex = 0; cameraIndex < this.activeCameras.length; cameraIndex++) {
                     if (cameraIndex > 0) {
-                        this._engine.clear(0, false, true, true);
+                        this._engine.clear(null, false, true, true);
                     }
 
                     this._processSubCameras(this.activeCameras[cameraIndex]);


### PR DESCRIPTION
Scene clearColor was previous typed as `any` and initialized as a `Color3` whereas other uses of clear color use `Color4`. So to simplify and help prevent errors in the future, scene clear color is now typed as `Color4`