### PR TITLE
Engine texture fixes

### DIFF
--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -2349,6 +2349,10 @@
             }
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
 
+            if (generateMipMaps) {
+                this._gl.generateMipmap(this._gl.TEXTURE_2D);
+            }
+
             // Unbind
             this._bindTextureDirectly(gl.TEXTURE_2D, null);
             gl.bindRenderbuffer(gl.RENDERBUFFER, null);

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -2146,6 +2146,11 @@
 
             this._gl.texParameteri(this._gl.TEXTURE_2D, this._gl.TEXTURE_MAG_FILTER, filters.mag);
             this._gl.texParameteri(this._gl.TEXTURE_2D, this._gl.TEXTURE_MIN_FILTER, filters.min);
+
+            if (generateMipMaps) {
+                this._gl.generateMipmap(this._gl.TEXTURE_2D);
+            }
+
             this._bindTextureDirectly(this._gl.TEXTURE_2D, null);
 
             texture.samplingMode = samplingMode;

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -2349,10 +2349,6 @@
             }
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
 
-            if (generateMipMaps) {
-                this._gl.generateMipmap(this._gl.TEXTURE_2D);
-            }
-
             // Unbind
             this._bindTextureDirectly(gl.TEXTURE_2D, null);
             gl.bindRenderbuffer(gl.RENDERBUFFER, null);


### PR DESCRIPTION
- Added missing gl.generateMipmaps to Engine createRawTexture
- Removed gl.generateMipmaps from createRenderTargetTexture since it's generating mipmaps of blank texture (and mipmaps are generated for the framebuffer color attachment elsewhere)