### PR TITLE
Disable unused attributes when binding effects

### DIFF
--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -152,6 +152,10 @@
             return this._attributes.length;
         }
 
+        public usesAttributeLocation(location:number){
+            return this._attributes.indexOf(location) !== -1;
+        }
+
         public getUniformIndex(uniformName: string): number {
             return this._uniformsNames.indexOf(uniformName);
         }

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -1648,6 +1648,16 @@
 
             this._currentEffect = effect;
 
+            //disable attributes that we know the effect doesn't require
+            for(let i = 0; i < this._vertexAttribArraysEnabled.length; i++){
+                let attributeEnabled = this._vertexAttribArraysEnabled[i];
+                //check attribute is enabled but not used in this effect
+                if(attributeEnabled && !effect.usesAttributeLocation(i)){
+                    this._gl.disableVertexAttribArray(i);
+                    this._vertexAttribArraysEnabled[i] = false;
+                }
+            } 
+
             if (effect.onBind) {
                 effect.onBind(effect);
             }


### PR DESCRIPTION
In Engine.enableEffect, disable attribute arrays not used by the effect.

When a buffer bound to an attribute array is disposed, the attribute array must be changed to a valid buffer or set to constant for the next draw call, even if the attribute is not used by a shader. Failing this will produce WebGL errors