### PR TITLE
Legacy Collision Detection Event Support

### DIFF
--- a/Exporters/3ds Max/BabylonExport.Entities/BabylonParticleSystem.cs
+++ b/Exporters/3ds Max/BabylonExport.Entities/BabylonParticleSystem.cs
@@ -12,6 +12,9 @@ namespace BabylonExport.Entities
         public bool preventAutoStart { get; set; }
 
         [DataMember]
+        public bool autoAnimate { get; set; }
+
+        [DataMember]
         public string emitterId { get; set; }
 
         [DataMember]
@@ -39,16 +42,13 @@ namespace BabylonExport.Entities
         public float[] colorDead { get; set; }
 
         [DataMember]
-        public float deadAlpha { get; set; }
-
-        [DataMember]
         public float emitRate { get; set; }
 
         [DataMember]
         public float updateSpeed { get; set; }
 
         [DataMember]
-        public int targetStopFrame { get; set; }
+        public float targetStopDuration { get; set; }
 
         [DataMember]
         public float minEmitPower { get; set; }
@@ -88,5 +88,19 @@ namespace BabylonExport.Entities
 
         [DataMember]
         public bool linkToEmitter { get; set; }
+
+        [DataMember]
+        public object[] animations { get; set; }
+
+        [DataMember]
+        public object customShader { get; set; }
+
+        public BabylonParticleSystem()
+        {
+            this.preventAutoStart = true;
+            this.autoAnimate = false;
+            this.animations = null;
+            this.customShader = null;
+        }
     }
 }

--- a/src/Physics/babylon.physicsImpostor.ts
+++ b/src/Physics/babylon.physicsImpostor.ts
@@ -337,13 +337,13 @@ module BABYLON {
 
         //event and body object due to cannon's event-based architecture.
         public onCollide = (e: { body: any }) => {
+            if (!this._onPhysicsCollideCallbacks.length && !this.onCollideEvent) return;
             var otherImpostor = this._physicsEngine.getImpostorWithPhysicsBody(e.body);
             if (otherImpostor) {
                 // Legacy collision detection event support
                 if (this.onCollideEvent) {
                     this.onCollideEvent(this, otherImpostor);
                 }
-                if (!this._onPhysicsCollideCallbacks.length) return;
                 this._onPhysicsCollideCallbacks.filter((obj) => {
                     return obj.otherImpostors.indexOf(otherImpostor) !== -1
                 }).forEach((obj) => {

--- a/src/Physics/babylon.physicsImpostor.ts
+++ b/src/Physics/babylon.physicsImpostor.ts
@@ -330,13 +330,22 @@ module BABYLON {
             }
         }
 
+        /**
+         * Legacy collision detection event support
+         */
+        public onCollideEvent: (collider:BABYLON.PhysicsImpostor, collidedWith:BABYLON.PhysicsImpostor) => void = null;
+
         //event and body object due to cannon's event-based architecture.
         public onCollide = (e: { body: any }) => {
-            if (!this._onPhysicsCollideCallbacks.length) return;
             var otherImpostor = this._physicsEngine.getImpostorWithPhysicsBody(e.body);
             if (otherImpostor) {
+                // Legacy collision detection event support
+                if (this.onCollideEvent) {
+                    this.onCollideEvent(this, otherImpostor);
+                }
+                if (!this._onPhysicsCollideCallbacks.length) return;
                 this._onPhysicsCollideCallbacks.filter((obj) => {
-                    return (obj.otherImpostors.length === 0 || obj.otherImpostors.indexOf(otherImpostor) !== -1)
+                    return obj.otherImpostors.indexOf(otherImpostor) !== -1
                 }).forEach((obj) => {
                     obj.callback(this, otherImpostor);
                 })


### PR DESCRIPTION
Allow for basic collision detection support without specific imposters.
Fixes otherImporters.length === 0 issue.