### PR TITLE
Fix "No plane" error by making sure all polygons have planes.

### DIFF
--- a/src/Mesh/babylon.csg.ts
+++ b/src/Mesh/babylon.csg.ts
@@ -159,7 +159,7 @@
         }
 
         public clone(): Polygon {
-            var vertices = this.vertices.map(v => v.clone());
+            var vertices = this.vertices.map(v => v.clone()).filter(v => v.plane);
             return new Polygon(vertices, this.shared);
         }
 


### PR DESCRIPTION
In certain situations when CSG subtracting you will get an error that says you cannot access `normal` of `null`. It is at [this line](https://github.com/BabylonJS/Babylon.js/blob/dea49de07ac07a2bf7896aaa0e13c26e0f674c9e/src/Mesh/babylon.csg.ts#L99)

The reason is because the `plane` of that polygon is `null` in certain situations. I made sure this doesn't happen by going back to the clone method that `CSG.subtract` calls and filtering out polygons without planes. I fixed it in JS. I honestly have no experience with TS so I don't know if this solves the problem properly in TS. But I can tell you it did solve the problem for me in JS. 

This fixes the problem I had reported [here on the forums](http://www.html5gamedevs.com/topic/27404-cannot-read-property-normal-of-null/#comment-157275).