### PR TITLE
partitioning auto-adjustment + fix division by zero

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1915,10 +1915,24 @@
          */
         public getFacetsAtLocalCoordinates(x: number, y: number, z: number): number[] {
             var bInfo = this.getBoundingInfo();
-            var subRatio = this._partitioningSubdivisions * this._partitioningBBoxRatio;
-            var ox = Math.floor((x - bInfo.minimum.x * this._partitioningBBoxRatio) / (bInfo.maximum.x - bInfo.minimum.x) * subRatio);
-            var oy = Math.floor((y - bInfo.minimum.y * this._partitioningBBoxRatio) / (bInfo.maximum.y - bInfo.minimum.y) * subRatio);
-            var oz = Math.floor((z - bInfo.minimum.z * this._partitioningBBoxRatio) / (bInfo.maximum.z - bInfo.minimum.z) * subRatio);
+            var bbSizeX = (bInfo.maximum.x - bInfo.minimum.x > Epsilon) ? bInfo.maximum.x - bInfo.minimum.x : Epsilon;
+            var bbSizeY = (bInfo.maximum.y - bInfo.minimum.y > Epsilon) ? bInfo.maximum.y - bInfo.minimum.y : Epsilon;
+            var bbSizeZ = (bInfo.maximum.z - bInfo.minimum.z > Epsilon) ? bInfo.maximum.z - bInfo.minimum.z : Epsilon;
+            var bbSizeMax =  bbSizeX;
+            bbSizeMax = (bbSizeX > bbSizeY) ? bbSizeX : bbSizeY;
+            bbSizeMax = (bbSizeMax > bbSizeZ) ? bbSizeMax : bbSizeZ;
+            var subDivX = Math.floor(this._partitioningSubdivisions * bbSizeX / bbSizeMax);   // adjust the number of subdivisions per axis
+            var subDivY = Math.floor(this._partitioningSubdivisions * bbSizeY / bbSizeMax);   // according to each bbox size per axis
+            var subDivZ = Math.floor(this._partitioningSubdivisions * bbSizeZ / bbSizeMax);
+            subDivX = subDivX < 1 ? 1 : subDivX;                                               // at least one subdivision
+            subDivY = subDivY < 1 ? 1 : subDivY;
+            subDivZ = subDivZ < 1 ? 1 : subDivZ;
+            var xSubRatio = subDivX * this._partitioningBBoxRatio / bbSizeX;
+            var ySubRatio = subDivY * this._partitioningBBoxRatio / bbSizeY;
+            var zSubRatio = subDivZ * this._partitioningBBoxRatio / bbSizeZ;
+            var ox = Math.floor((x - bInfo.minimum.x * this._partitioningBBoxRatio) * xSubRatio);
+            var oy = Math.floor((y - bInfo.minimum.y * this._partitioningBBoxRatio) * ySubRatio);
+            var oz = Math.floor((z - bInfo.minimum.z * this._partitioningBBoxRatio) * zSubRatio);
             if (ox < 0 || ox > this._partitioningSubdivisions || oy < 0 || oy > this._partitioningSubdivisions || oz < 0 || oz > this._partitioningSubdivisions) {
                 return null;
             }

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -128,8 +128,14 @@
         private _partitioningSubdivisions: number = 10; // number of subdivisions per axis in the partioning space  
         private _partitioningBBoxRatio: number = 1.01;  // the partioning array space is by default 1% bigger than the bounding box
         private _facetDataEnabled: boolean = false;     // is the facet data feature enabled on this mesh ?
-        private _facetParameters: any;                  // keep a reference to the object parameters to avoid memory re-allocation
-
+        private _facetParameters: any = {};                  // keep a reference to the object parameters to avoid memory re-allocation
+        private _bbSize: Vector3 = Vector3.Zero();      // bbox size approximated for facet data
+        private _subDiv = {                         // actual number of subdivisions per axis for ComputeNormals()
+            max: 1,
+            X: 1,
+            Y: 1,
+            Z: 1
+        };
         /**
          * Read-only : the number of facets in the mesh
          */
@@ -1418,6 +1424,11 @@
                 }
             }
 
+            // facet data
+            if (this._facetDataEnabled) {
+                this.disableFacetData();
+            }
+
             super.dispose(doNotRecurse);
         }
 
@@ -1832,8 +1843,28 @@
             var positions = this.getVerticesData(VertexBuffer.PositionKind);
             var indices = this.getIndices();
             var normals = this.getVerticesData(VertexBuffer.NormalKind);
-            var options = this.getFacetDataParameters();
-            VertexData.ComputeNormals(positions, indices, normals, options);
+            var bInfo = this.getBoundingInfo();
+            this._bbSize.x = (bInfo.maximum.x - bInfo.minimum.x > Epsilon) ? bInfo.maximum.x - bInfo.minimum.x : Epsilon;
+            this._bbSize.y = (bInfo.maximum.y - bInfo.minimum.y > Epsilon) ? bInfo.maximum.y - bInfo.minimum.y : Epsilon;
+            this._bbSize.z = (bInfo.maximum.z - bInfo.minimum.z > Epsilon) ? bInfo.maximum.z - bInfo.minimum.z : Epsilon;
+            var bbSizeMax = (this._bbSize.x > this._bbSize.y) ? this._bbSize.x : this._bbSize.y;
+            bbSizeMax = (bbSizeMax > this._bbSize.z) ? bbSizeMax : this._bbSize.z;
+            this._subDiv.max = this._partitioningSubdivisions;
+            this._subDiv.X = Math.floor(this._subDiv.max * this._bbSize.x / bbSizeMax);   // adjust the number of subdivisions per axis
+            this._subDiv.Y = Math.floor(this._subDiv.max * this._bbSize.y / bbSizeMax);   // according to each bbox size per axis
+            this._subDiv.Z = Math.floor(this._subDiv.max * this._bbSize.z / bbSizeMax);
+            this._subDiv.X = this._subDiv.X < 1 ? 1 : this._subDiv.X;                     // at least one subdivision
+            this._subDiv.Y = this._subDiv.Y < 1 ? 1 : this._subDiv.Y;
+            this._subDiv.Z = this._subDiv.Z < 1 ? 1 : this._subDiv.Z;
+            // set the parameters for ComputeNormals()
+            this._facetParameters.facetNormals = this.getFacetLocalNormals(); 
+            this._facetParameters.facetPositions = this.getFacetLocalPositions();
+            this._facetParameters.facetPartitioning = this.getFacetLocalPartitioning();
+            this._facetParameters.bInfo = bInfo;
+            this._facetParameters.bbSize = this._bbSize;
+            this._facetParameters.subDiv = this._subDiv;
+            this._facetParameters.ratio = this.partitioningBBoxRatio;
+            VertexData.ComputeNormals(positions, indices, normals, this._facetParameters);
             return this;
         }
         /**
@@ -1915,28 +1946,13 @@
          */
         public getFacetsAtLocalCoordinates(x: number, y: number, z: number): number[] {
             var bInfo = this.getBoundingInfo();
-            var bbSizeX = (bInfo.maximum.x - bInfo.minimum.x > Epsilon) ? bInfo.maximum.x - bInfo.minimum.x : Epsilon;
-            var bbSizeY = (bInfo.maximum.y - bInfo.minimum.y > Epsilon) ? bInfo.maximum.y - bInfo.minimum.y : Epsilon;
-            var bbSizeZ = (bInfo.maximum.z - bInfo.minimum.z > Epsilon) ? bInfo.maximum.z - bInfo.minimum.z : Epsilon;
-            var bbSizeMax =  bbSizeX;
-            bbSizeMax = (bbSizeX > bbSizeY) ? bbSizeX : bbSizeY;
-            bbSizeMax = (bbSizeMax > bbSizeZ) ? bbSizeMax : bbSizeZ;
-            var subDivX = Math.floor(this._partitioningSubdivisions * bbSizeX / bbSizeMax);   // adjust the number of subdivisions per axis
-            var subDivY = Math.floor(this._partitioningSubdivisions * bbSizeY / bbSizeMax);   // according to each bbox size per axis
-            var subDivZ = Math.floor(this._partitioningSubdivisions * bbSizeZ / bbSizeMax);
-            subDivX = subDivX < 1 ? 1 : subDivX;                                               // at least one subdivision
-            subDivY = subDivY < 1 ? 1 : subDivY;
-            subDivZ = subDivZ < 1 ? 1 : subDivZ;
-            var xSubRatio = subDivX * this._partitioningBBoxRatio / bbSizeX;
-            var ySubRatio = subDivY * this._partitioningBBoxRatio / bbSizeY;
-            var zSubRatio = subDivZ * this._partitioningBBoxRatio / bbSizeZ;
-            var ox = Math.floor((x - bInfo.minimum.x * this._partitioningBBoxRatio) * xSubRatio);
-            var oy = Math.floor((y - bInfo.minimum.y * this._partitioningBBoxRatio) * ySubRatio);
-            var oz = Math.floor((z - bInfo.minimum.z * this._partitioningBBoxRatio) * zSubRatio);
-            if (ox < 0 || ox > this._partitioningSubdivisions || oy < 0 || oy > this._partitioningSubdivisions || oz < 0 || oz > this._partitioningSubdivisions) {
+            var ox = Math.floor((x - bInfo.minimum.x * this._partitioningBBoxRatio) * this._subDiv.X * this._partitioningBBoxRatio / this._bbSize.x);
+            var oy = Math.floor((y - bInfo.minimum.y * this._partitioningBBoxRatio) * this._subDiv.Y * this._partitioningBBoxRatio / this._bbSize.y);
+            var oz = Math.floor((z - bInfo.minimum.z * this._partitioningBBoxRatio) * this._subDiv.Z * this._partitioningBBoxRatio / this._bbSize.z);
+            if (ox < 0 || ox > this._subDiv.max || oy < 0 || oy > this._subDiv.max || oz < 0 || oz > this._subDiv.max) {
                 return null;
             }
-            return this._facetPartitioning[ox + this._partitioningSubdivisions * oy + this._partitioningSubdivisions * this._partitioningSubdivisions * oz];
+            return this._facetPartitioning[ox + this._subDiv.max * oy + this._subDiv.max * this._subDiv.max * oz];
         }
         /** 
          * Returns the closest mesh facet index at (x,y,z) World coordinates, null if not found.  
@@ -2021,16 +2037,6 @@
          * Returns the object "parameter" set with all the expected parameters for facetData computation by ComputeNormals()  
          */
         public getFacetDataParameters(): any {
-            if (!this._facetParameters) {
-                this._facetParameters = {
-                    facetNormals: this.getFacetLocalNormals(), 
-                    facetPositions: this.getFacetLocalPositions(),
-                    facetPartitioning: this.getFacetLocalPartitioning(),
-                    bInfo: this.getBoundingInfo(),
-                    partitioningSubdivisions: this.partitioningSubdivisions,
-                    ratio: this.partitioningBBoxRatio
-                };
-            }
             return this._facetParameters;
         }
         /** 
@@ -2038,11 +2044,13 @@
          * Returns the mesh.  
          */
         public disableFacetData(): Mesh {
-            this._facetDataEnabled = false;
-            this._facetPositions = null;
-            this._facetNormals = null;
-            this._facetPartitioning = null;
-            this._facetParameters = null;
+            if (this._facetDataEnabled) {
+                this._facetDataEnabled = false;
+                this._facetPositions = null;
+                this._facetNormals = null;
+                this._facetPartitioning = null;
+                this._facetParameters = null;
+            }
             return this;
         }
 

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -2020,9 +2020,21 @@
                 var block_idx_v1 = 0;       // v1 vertex block index
                 var block_idx_v2 = 0;       // v2 vertex block index
                 var block_idx_v3 = 0;       // v3 vertex block index  
-                var xSubRatio = 0.0;        // tmp x divider
-                var ySubRatio = 0.0;        // tmp x divider
-                var zSubRatio = 0.0;        // tmp x divider  
+                var bbSizeX = (options.bInfo.maximum.x - options.bInfo.minimum.x > Epsilon) ? options.bInfo.maximum.x - options.bInfo.minimum.x : Epsilon;
+                var bbSizeY = (options.bInfo.maximum.y - options.bInfo.minimum.y > Epsilon) ? options.bInfo.maximum.y - options.bInfo.minimum.y : Epsilon;
+                var bbSizeZ = (options.bInfo.maximum.z - options.bInfo.minimum.z > Epsilon) ? options.bInfo.maximum.z - options.bInfo.minimum.z : Epsilon;
+                var bbSizeMax =  bbSizeX;
+                bbSizeMax = (bbSizeX > bbSizeY) ? bbSizeX : bbSizeY;
+                bbSizeMax = (bbSizeMax > bbSizeZ) ? bbSizeMax : bbSizeZ;
+                var subDivX = Math.floor(options.partitioningSubdivisions * bbSizeX / bbSizeMax);   // adjust the number of subdivisions per axis
+                var subDivY = Math.floor(options.partitioningSubdivisions * bbSizeY / bbSizeMax);   // according to each bbox size per axis
+                var subDivZ = Math.floor(options.partitioningSubdivisions * bbSizeZ / bbSizeMax);
+                subDivX = subDivX < 1 ? 1 : subDivX;                                                // at least one subdivision
+                subDivY = subDivY < 1 ? 1 : subDivY;
+                subDivZ = subDivZ < 1 ? 1 : subDivZ;
+                var xSubRatio = subDivX * options.ratio / bbSizeX;
+                var ySubRatio = subDivY * options.ratio / bbSizeY;
+                var zSubRatio = subDivZ * options.ratio / bbSizeZ;
                 var subSq = options.partitioningSubdivisions * options.partitioningSubdivisions;
                 options.facetPartitioning.length = 0;
             }
@@ -2082,9 +2094,6 @@
                 if (computeFacetPartitioning) {
                     // store the facet indexes in arrays in the main facetPartitioning array :
                     // compute each facet vertex (+ facet barycenter) index in the partiniong array
-                    xSubRatio = options.partitioningSubdivisions * options.ratio / (options.bInfo.maximum.x - options.bInfo.minimum.x);
-                    ySubRatio = options.partitioningSubdivisions * options.ratio / (options.bInfo.maximum.y - options.bInfo.minimum.y);
-                    zSubRatio = options.partitioningSubdivisions * options.ratio / (options.bInfo.maximum.z - options.bInfo.minimum.z);
                     ox = Math.floor((options.facetPositions[index].x - options.bInfo.minimum.x * options.ratio) * xSubRatio);
                     oy = Math.floor((options.facetPositions[index].y - options.bInfo.minimum.y * options.ratio) * ySubRatio);
                     oz = Math.floor((options.facetPositions[index].z - options.bInfo.minimum.z * options.ratio) * zSubRatio);

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1965,12 +1965,13 @@
          * facetPositions : optional array of facet positions (vector3)
          * facetNormals : optional array of facet normals (vector3)
          * facetPartitioning : optional partitioning array. facetPositions is required for facetPartitioning computation
-         * partitioningSubdivisions : optional partitioning number of subdivsions on  each axis (int), required for facetPartitioning computation
+         * subDiv : optional partitioning data about subdivsions on  each axis (int), required for facetPartitioning computation
          * ratio : optional partitioning ratio / bounding box, required for facetPartitioning computation
-         * bInfo : optional bounding box info, required for facetPartitioning computation
+         * bbSize : optional bounding box size data, required for facetPartitioning computation
+         * bInfo : optional bounding info, required for facetPartitioning computation
          */
         public static ComputeNormals(positions: any, indices: any, normals: any, 
-            options?: { facetNormals?: any, facetPositions?: any, facetPartitioning?: any, ratio?: number, bInfo?: any, partitioningSubdivisions?: number}): void {
+            options?: { facetNormals?: any, facetPositions?: any, facetPartitioning?: any, ratio?: number, bInfo?: any, bbSize?: Vector3, subDiv?: any}): void {
 
             // temporary scalar variables
             var index = 0;                      // facet index     
@@ -2020,22 +2021,13 @@
                 var block_idx_v1 = 0;       // v1 vertex block index
                 var block_idx_v2 = 0;       // v2 vertex block index
                 var block_idx_v3 = 0;       // v3 vertex block index  
-                var bbSizeX = (options.bInfo.maximum.x - options.bInfo.minimum.x > Epsilon) ? options.bInfo.maximum.x - options.bInfo.minimum.x : Epsilon;
-                var bbSizeY = (options.bInfo.maximum.y - options.bInfo.minimum.y > Epsilon) ? options.bInfo.maximum.y - options.bInfo.minimum.y : Epsilon;
-                var bbSizeZ = (options.bInfo.maximum.z - options.bInfo.minimum.z > Epsilon) ? options.bInfo.maximum.z - options.bInfo.minimum.z : Epsilon;
-                var bbSizeMax =  bbSizeX;
-                bbSizeMax = (bbSizeX > bbSizeY) ? bbSizeX : bbSizeY;
-                bbSizeMax = (bbSizeMax > bbSizeZ) ? bbSizeMax : bbSizeZ;
-                var subDivX = Math.floor(options.partitioningSubdivisions * bbSizeX / bbSizeMax);   // adjust the number of subdivisions per axis
-                var subDivY = Math.floor(options.partitioningSubdivisions * bbSizeY / bbSizeMax);   // according to each bbox size per axis
-                var subDivZ = Math.floor(options.partitioningSubdivisions * bbSizeZ / bbSizeMax);
-                subDivX = subDivX < 1 ? 1 : subDivX;                                                // at least one subdivision
-                subDivY = subDivY < 1 ? 1 : subDivY;
-                subDivZ = subDivZ < 1 ? 1 : subDivZ;
-                var xSubRatio = subDivX * options.ratio / bbSizeX;
-                var ySubRatio = subDivY * options.ratio / bbSizeY;
-                var zSubRatio = subDivZ * options.ratio / bbSizeZ;
-                var subSq = options.partitioningSubdivisions * options.partitioningSubdivisions;
+
+                var bbSizeMax = (options.bbSize.x > options.bbSize.y) ? options.bbSize.x : options.bbSize.y;
+                bbSizeMax = (bbSizeMax > options.bbSize.z) ? bbSizeMax : options.bbSize.z;
+                var xSubRatio = options.subDiv.X * options.ratio / options.bbSize.x;
+                var ySubRatio = options.subDiv.Y * options.ratio / options.bbSize.y;
+                var zSubRatio = options.subDiv.Z * options.ratio / options.bbSize.z;
+                var subSq = options.subDiv.max * options.subDiv.max;
                 options.facetPartitioning.length = 0;
             }
         
@@ -2107,10 +2099,10 @@
                     b3y = Math.floor((positions[v3y] - options.bInfo.minimum.y * options.ratio) * ySubRatio);
                     b3z = Math.floor((positions[v3z] - options.bInfo.minimum.z * options.ratio) * zSubRatio);
                     
-                    block_idx_v1 = b1x + options.partitioningSubdivisions * b1y + subSq * b1z;
-                    block_idx_v2 = b2x + options.partitioningSubdivisions * b2y + subSq * b2z;
-                    block_idx_v3 = b3x + options.partitioningSubdivisions * b3y + subSq * b3z;
-                    block_idx_o = ox + options.partitioningSubdivisions * oy + subSq * oz;
+                    block_idx_v1 = b1x + options.subDiv.max * b1y + subSq * b1z;
+                    block_idx_v2 = b2x + options.subDiv.max * b2y + subSq * b2z;
+                    block_idx_v3 = b3x + options.subDiv.max * b3y + subSq * b3z;
+                    block_idx_o = ox + options.subDiv.max * oy + subSq * oz;
 
                     options.facetPartitioning[block_idx_o] = options.facetPartitioning[block_idx_o] ? options.facetPartitioning[block_idx_o] :new Array();
                     options.facetPartitioning[block_idx_v1] = options.facetPartitioning[block_idx_v1] ? options.facetPartitioning[block_idx_v1] :new Array();

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -658,7 +658,6 @@
                         }
 
                         // normals : if the particles can't be morphed then just rotate the normals, what is much more faster than ComputeNormals()
-                        // the same for the facet data
                         if (!this._computeParticleVertex) {
                             this._normal.x = this._fixedNormal32[idx];
                             this._normal.y = this._fixedNormal32[idx + 1];


### PR DESCRIPTION
* Internal mesh partitioning improvement : 
Now the number of subdivisions is auto-adjusted per axis. 
Example : if the mesh is sized 150 x 3  x 200 and if we want 20 subdivisions, the z axis will be divided in 20 subdivisions, the x axis will be divided in only 15 (instead of 20) and the y axis in only 1.

* fixed some possible divisions by zero : if the mesh bbox is sized of zero on an axis (in case of a dynamic morphing), it's considered as sized of Epsilon instead.