### PR TITLE
Canvas2D: bug fix on boundingInfo update

### DIFF
--- a/canvas2D/src/Engine/babylon.ellipse2d.ts
+++ b/canvas2D/src/Engine/babylon.ellipse2d.ts
@@ -203,8 +203,9 @@
             return ((x * x) / (w * w) + (y * y) / (h * h)) <= 1;
         }
 
-        protected updateLevelBoundingInfo() {
+        protected updateLevelBoundingInfo(): boolean {
             BoundingInfo2D.CreateFromSizeToRef(this.actualSize, this._levelBoundingInfo);
+            return true;
         }
 
         /**

--- a/canvas2D/src/Engine/babylon.group2d.ts
+++ b/canvas2D/src/Engine/babylon.group2d.ts
@@ -340,7 +340,7 @@
             return true;
         }
 
-        protected updateLevelBoundingInfo() {
+        protected updateLevelBoundingInfo(): boolean {
             let size: Size;
 
             // If the size is set by the user, the boundingInfo is computed from this value
@@ -353,6 +353,7 @@
             }
 
             BoundingInfo2D.CreateFromSizeToRef(size, this._levelBoundingInfo);
+            return true;
         }
 
         // Method called only on renderable groups to prepare the rendering

--- a/canvas2D/src/Engine/babylon.lines2d.ts
+++ b/canvas2D/src/Engine/babylon.lines2d.ts
@@ -369,11 +369,12 @@
             return res;
         }
 
-        protected updateLevelBoundingInfo() {
+        protected updateLevelBoundingInfo(): boolean {
             if (!this._boundingMin) {
                 this._computeLines2D();
             }
             BoundingInfo2D.CreateFromMinMaxToRef(this._boundingMin.x, this._boundingMax.x, this._boundingMin.y, this._boundingMax.y, this._levelBoundingInfo);
+            return true;
         }
 
         /**

--- a/canvas2D/src/Engine/babylon.prim2dBase.ts
+++ b/canvas2D/src/Engine/babylon.prim2dBase.ts
@@ -2565,6 +2565,9 @@
                     this._boundingInfo.clear();
                 } else {
                     this._boundingInfo.copyFrom(this.levelBoundingInfo);
+                    if (this._isFlagSet(SmartPropertyPrim.flagLevelBoundingInfoDirty)) {
+                        return this._boundingInfo;
+                    }
                 }
                 let bi = this._boundingInfo;
 

--- a/canvas2D/src/Engine/babylon.rectangle2d.ts
+++ b/canvas2D/src/Engine/babylon.rectangle2d.ts
@@ -288,8 +288,9 @@
             return true;
         }
 
-        protected updateLevelBoundingInfo() {
+        protected updateLevelBoundingInfo(): boolean {
             BoundingInfo2D.CreateFromSizeToRef(this.actualSize, this._levelBoundingInfo);
+            return true;
         }
 
         /**

--- a/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
+++ b/canvas2D/src/Engine/babylon.smartPropertyPrim.ts
@@ -1178,8 +1178,11 @@
          */
         public get levelBoundingInfo(): BoundingInfo2D {
             if (this._isFlagSet(SmartPropertyPrim.flagLevelBoundingInfoDirty)) {
-                this.updateLevelBoundingInfo();
-                this._clearFlags(SmartPropertyPrim.flagLevelBoundingInfoDirty);
+                if (this.updateLevelBoundingInfo()) {
+                    this._clearFlags(SmartPropertyPrim.flagLevelBoundingInfoDirty);
+                } else {
+                    this._levelBoundingInfo.clear();
+                }
             }
             return this._levelBoundingInfo;
         }
@@ -1187,8 +1190,8 @@
         /**
          * This method must be overridden by a given Primitive implementation to compute its boundingInfo
          */
-        protected updateLevelBoundingInfo() {
-
+        protected updateLevelBoundingInfo(): boolean {
+            return false;
         }
 
         /**

--- a/canvas2D/src/Engine/babylon.sprite2d.ts
+++ b/canvas2D/src/Engine/babylon.sprite2d.ts
@@ -241,8 +241,9 @@
             this._alignToPixel = value;
         }
 
-        protected updateLevelBoundingInfo() {
+        protected updateLevelBoundingInfo(): boolean {
             BoundingInfo2D.CreateFromSizeToRef(this.size, this._levelBoundingInfo);
+            return true;
         }
 
         /**

--- a/canvas2D/src/Engine/babylon.text2d.ts
+++ b/canvas2D/src/Engine/babylon.text2d.ts
@@ -296,7 +296,11 @@
         }
 
         protected updateLevelBoundingInfo() {
+            if (!this.owner || !this._text) {
+                return false;
+            }
             BoundingInfo2D.CreateFromSizeToRef(this.actualSize, this._levelBoundingInfo);
+            return true;
         }
 
         /**


### PR DESCRIPTION
SmartPropertyPrim.updateLevelBoundingInfo can now return a boolean to notify of the success or failure of the update.  In case of failure another attempt to compute it will be made at the next get on the object.