### PR TITLE
Fixed screenshot method on Chrome

### DIFF
--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -740,8 +740,6 @@
             var offsetX = Math.max(0, width - newWidth) / 2;
             var offsetY = Math.max(0, height - newHeight) / 2;
 
-            renderContext.fillStyle = camera.getScene().clearColor.toHexString();
-            renderContext.fillRect(0, 0, width, height);
             renderContext.drawImage(engine.getRenderingCanvas(), offsetX, offsetY, newWidth, newHeight);
 
             Tools.EncodeScreenshotCanvasData(successCallback, mimeType);


### PR DESCRIPTION
Filling the screenshot canvas with scene clearColor is 
- useless (the current frame buffer already has the clearColor as background)
- buggy (toHexString() doesn't use clearColor alpha)