### PR TITLE
Update babylon.arcRotateCamera.ts ; boolean AllowSamePosition for camera.setTarget.

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -406,8 +406,8 @@
             this.rebuildAnglesAndRadius();
         }
 
-        public setTarget(target: Vector3, toBoundingCenter = false): void {            
-            if (this._getTargetPosition().equals(target)) {
+        public setTarget(target: Vector3, toBoundingCenter = false, allowSamePosition = false): void {            
+            if (!allowSamePosition && this._getTargetPosition().equals(target)) {
                 return;
             }
             


### PR DESCRIPTION
Added a boolean to allow camera.setTarget on same position,

If you setTarget( mesh ); to lock on to a mesh that doesn't move, unlocking it at the same position to allow camera panning, etc, e.g; setTarget( mesh.position.clone() ); will be ignored and you'll continue to be locked to the mesh.

use example; camera.setTarget( mesh.position.clone(), false, **true**);

Forum; http://www.html5gamedevs.com/topic/28151-arcrotatecamera-unable-to-undo-settargetmesh-without-moving-mesh-first/