### PR TITLE
collisionMask, allows filtering of which meshes should collide.

### DIFF
--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -103,10 +103,10 @@
             this.cameraRotation = new Vector2(0, 0);
         }
 	
-	 // Collision
+	 // Collisions
 	private _collisionMask = -1;
 	public set setCollisionMask(mask: number) {
-	    this._collisionMask = !isNaN(mask) ? mask : -1;
+	    this._collisionMask = mask && !isNaN(mask) ? mask : -1;
 	}
 	 
         public _collideWithWorld(velocity: Vector3): void {

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -8,7 +8,7 @@
 
         @serialize()
         public applyGravity = false;
-
+                
         public inputs : FreeCameraInputsManager;
         
         //-- begin properties for backward compatibility for inputs

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -125,7 +125,7 @@
 
             globalPosition.subtractFromFloatsToRef(0, this.ellipsoid.y, 0, this._oldPosition);
             this._collider.radius = this.ellipsoid;
-	    this._collider._collisionMask = !isNaN(this._collisionMask) ? this._collisionMask : -1;
+	    this._collider._collisionMask = (!isNaN(this._collisionMask) ? this._collisionMask : -1);
 		
             //no need for clone, as long as gravity is not on.
             var actualVelocity = velocity;

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -115,7 +115,7 @@
             globalPosition.subtractFromFloatsToRef(0, this.ellipsoid.y, 0, this._oldPosition);
             this._collider.radius = this.ellipsoid;
 
-            if(!this._collider.collisionFilter) this._collider.collisionFilter = this.collisionFilter ? this.collisionFilter : 1;
+	    this._collider._collisionMask = this._collisionMask ? this._collisionMask : -1;
 		
             //no need for clone, as long as gravity is not on.
             var actualVelocity = velocity;

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -8,7 +8,7 @@
 
         @serialize()
         public applyGravity = false;
-                
+	    
         public inputs : FreeCameraInputsManager;
         
         //-- begin properties for backward compatibility for inputs
@@ -102,7 +102,13 @@
             this.cameraDirection = new Vector3(0, 0, 0);
             this.cameraRotation = new Vector2(0, 0);
         }
-
+	
+	 // CollisionMask
+	public _collisionMask = -1;
+	public setCollisionMask(mask: number): void {
+	    this._collisionMask = !isNaN(mask) ? mask : -1;
+	}
+	 
         public _collideWithWorld(velocity: Vector3): void {
             var globalPosition: Vector3;
 
@@ -114,7 +120,6 @@
 
             globalPosition.subtractFromFloatsToRef(0, this.ellipsoid.y, 0, this._oldPosition);
             this._collider.radius = this.ellipsoid;
-
 	    this._collider._collisionMask = this._collisionMask ? this._collisionMask : -1;
 		
             //no need for clone, as long as gravity is not on.

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -102,7 +102,7 @@
             this.cameraDirection = new Vector3(0, 0, 0);
             this.cameraRotation = new Vector2(0, 0);
         }
-	
+
 	 // Collisions
 	private _collisionMask = -1;
 	 

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -106,7 +106,7 @@
 	 // Collisions
 	private _collisionMask = -1;
 	 
-	public get collisionMask() {
+	public get collisionMask(): number {
 	    return this._collisionMask;
 	}
 	 

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -125,7 +125,7 @@
 
             globalPosition.subtractFromFloatsToRef(0, this.ellipsoid.y, 0, this._oldPosition);
             this._collider.radius = this.ellipsoid;
-	    this._collider._collisionMask = this._collisionMask ? this._collisionMask : -1;
+	    this._collider._collisionMask = !isNaN(this._collisionMask) ? this._collisionMask : -1;
 		
             //no need for clone, as long as gravity is not on.
             var actualVelocity = velocity;

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -8,7 +8,7 @@
 
         @serialize()
         public applyGravity = false;
-	    
+
         public inputs : FreeCameraInputsManager;
         
         //-- begin properties for backward compatibility for inputs
@@ -103,9 +103,9 @@
             this.cameraRotation = new Vector2(0, 0);
         }
 	
-	 // CollisionMask
-	public _collisionMask = -1;
-	public setCollisionMask(mask: number): void {
+	 // Collision
+	private _collisionMask = -1;
+	public set setCollisionMask(mask: number) {
 	    this._collisionMask = !isNaN(mask) ? mask : -1;
 	}
 	 

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -115,7 +115,6 @@
             globalPosition.subtractFromFloatsToRef(0, this.ellipsoid.y, 0, this._oldPosition);
             this._collider.radius = this.ellipsoid;
 
-            // CollisionFilter @ http://www.html5gamedevs.com/topic/28193-exclude-mesh-for-collision/
             if(!this._collider.collisionFilter) this._collider.collisionFilter = this.collisionFilter ? this.collisionFilter : 1;
 		
             //no need for clone, as long as gravity is not on.

--- a/src/Cameras/babylon.freeCamera.ts
+++ b/src/Cameras/babylon.freeCamera.ts
@@ -105,8 +105,13 @@
 	
 	 // Collisions
 	private _collisionMask = -1;
-	public set setCollisionMask(mask: number) {
-	    this._collisionMask = mask && !isNaN(mask) ? mask : -1;
+	 
+	public get collisionMask() {
+	    return this._collisionMask;
+	}
+	 
+	public set collisionMask(mask: number) {
+	    this._collisionMask = !isNaN(mask) ? mask : -1;
 	}
 	 
         public _collideWithWorld(velocity: Vector3): void {

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -354,6 +354,9 @@ module BABYLON {
             collider.retry = 0;
             collider.initialVelocity = this._scaledVelocity;
             collider.initialPosition = this._scaledPosition;
+            
+            if(!collider.collisionFilter || collider.collisionFilter === 1) collider.collisionFilter = excludedMesh && excludedMesh.collisionFilter ? excludedMesh.collisionFilter  : 1;
+            
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
 
             this._finalPosition.multiplyInPlace(collider.radius);
@@ -390,7 +393,9 @@ module BABYLON {
             // Check all meshes
             for (var index = 0; index < this._scene.meshes.length; index++) {
                 var mesh = this._scene.meshes[index];
-                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh) {
+                
+                mesh.collisionFilter = mesh.collisionFilter ? mesh.collisionFilter : 1;
+                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh && ((collider.collisionFilter === 1 && mesh.collisionFilter === 1)  || collider.collisionFilter > mesh.collisionFilter)) {
                     mesh._checkCollision(collider);
                 }
             }

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -354,8 +354,7 @@ module BABYLON {
             collider.retry = 0;
             collider.initialVelocity = this._scaledVelocity;
             collider.initialPosition = this._scaledPosition;
-            collider._collisionMask = excludedMesh && excludedMesh._collisionMask ? excludedMesh._collisionMask : collider._collisionMask;
-            
+                        
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
 
             this._finalPosition.multiplyInPlace(collider.radius);
@@ -387,13 +386,17 @@ module BABYLON {
                 return;
             }
 
+            // Check if this is a camera else -1
+            collider._collisionMask = (!isNaN(collider._collisionMask) ? collider._collisionMask : -1)
+            // Check if this is a mesh else camera or -1
+            var collisionMask = (excludedMesh ? excludedMesh._collisionMask : collider._collisionMask);
+
             collider._initialize(position, velocity, closeDistance);
 
             // Check all meshes
             for (var index = 0; index < this._scene.meshes.length; index++) {
                 var mesh = this._scene.meshes[index];
-                if(!mesh._collisionGroup) mesh._collisionGroup = -1;
-                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh &&  ((collider._collisionMask & mesh._collisionGroup) !== 0)) {
+                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh &&  ((collisionMask & mesh._collisionMask) !== 0)) {
                     mesh._checkCollision(collider);
                 }
             }

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -354,7 +354,7 @@ module BABYLON {
             collider.retry = 0;
             collider.initialVelocity = this._scaledVelocity;
             collider.initialPosition = this._scaledPosition;
-                        
+
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
 
             this._finalPosition.multiplyInPlace(collider.radius);

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -354,7 +354,6 @@ module BABYLON {
             collider.retry = 0;
             collider.initialVelocity = this._scaledVelocity;
             collider.initialPosition = this._scaledPosition;
-
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
 
             this._finalPosition.multiplyInPlace(collider.radius);

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -354,8 +354,7 @@ module BABYLON {
             collider.retry = 0;
             collider.initialVelocity = this._scaledVelocity;
             collider.initialPosition = this._scaledPosition;
-            
-            if(!collider.collisionFilter || collider.collisionFilter === 1) collider.collisionFilter = excludedMesh && excludedMesh.collisionFilter ? excludedMesh.collisionFilter  : 1;
+            collider._collisionMask = excludedMesh && excludedMesh._collisionMask ? excludedMesh._collisionMask : collider._collisionMask;
             
             this._collideWithWorld(this._scaledPosition, this._scaledVelocity, collider, maximumRetry, this._finalPosition, excludedMesh);
 
@@ -393,9 +392,8 @@ module BABYLON {
             // Check all meshes
             for (var index = 0; index < this._scene.meshes.length; index++) {
                 var mesh = this._scene.meshes[index];
-                
-                mesh.collisionFilter = mesh.collisionFilter ? mesh.collisionFilter : 1;
-                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh && ((collider.collisionFilter === 1 && mesh.collisionFilter === 1)  || collider.collisionFilter > mesh.collisionFilter)) {
+                if(!mesh._collisionGroup) mesh._collisionGroup = -1;
+                if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh &&  ((collider._collisionMask & mesh._collisionGroup) !== 0)) {
                     mesh._checkCollision(collider);
                 }
             }

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -174,7 +174,7 @@
         
         private _collisionMask = -1;
         
-        public get collisionMask() {
+        public get collisionMask(): number {
             return this._collisionMask;
         }
         

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -164,12 +164,22 @@
 
         // Collisions
         private _checkCollisions = false;
+        private _collisionGroup = -1;
+        private _collisionMask = -1;
         public ellipsoid = new Vector3(0.5, 1, 0.5);
         public ellipsoidOffset = new Vector3(0, 0, 0);
         private _collider = new Collider();
         private _oldPositionForCollisions = new Vector3(0, 0, 0);
         private _diffPositionForCollisions = new Vector3(0, 0, 0);
         private _newPositionForCollisions = new Vector3(0, 0, 0);
+        
+        public set setCollisionGroup(mask: number) {
+            this._collisionGroup = !isNaN(mask) ? mask : -1;
+        }
+        
+        public set setCollisionMask(mask: number) {
+            this._collisionMask = !isNaN(mask) ? mask : -1;
+        }
 
         // Attach to bone
         private _meshToBoneReferal: AbstractMesh;

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -164,7 +164,6 @@
 
         // Collisions
         private _checkCollisions = false;
-        private _collisionGroup = -1;
         private _collisionMask = -1;
         public ellipsoid = new Vector3(0.5, 1, 0.5);
         public ellipsoidOffset = new Vector3(0, 0, 0);
@@ -173,12 +172,14 @@
         private _diffPositionForCollisions = new Vector3(0, 0, 0);
         private _newPositionForCollisions = new Vector3(0, 0, 0);
         
-        public set setCollisionGroup(mask: number) {
-            this._collisionGroup = mask && !isNaN(mask) ? mask : -1;
+        private _collisionMask = -1;
+        
+        public get collisionMask() {
+            return this._collisionMask;
         }
         
-        public set setCollisionMask(mask: number) {
-            this._collisionMask = mask && !isNaN(mask) ? mask : -1;
+        public set collisionMask(mask: number) {
+            this._collisionMask = !isNaN(mask) ? mask : -1;
         }
 
         // Attach to bone

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -174,11 +174,11 @@
         private _newPositionForCollisions = new Vector3(0, 0, 0);
         
         public set setCollisionGroup(mask: number) {
-            this._collisionGroup = !isNaN(mask) ? mask : -1;
+            this._collisionGroup = mask && !isNaN(mask) ? mask : -1;
         }
         
         public set setCollisionMask(mask: number) {
-            this._collisionMask = !isNaN(mask) ? mask : -1;
+            this._collisionMask = mask && !isNaN(mask) ? mask : -1;
         }
 
         // Attach to bone


### PR DESCRIPTION
@ http://www.html5gamedevs.com/topic/28193-exclude-mesh-for-collision/
@ http://www.babylonjs-playground.com/#20PQBI#17

Allows the option to add collisionMask to abstractMeshes & freeCameras

Example & in-depth explaination can be found in the PG linked above.

To-Do's; 
Integrate into webworker..