### PR TITLE
fix for manual bone rotation issue affecting all cloned animated skel…

### DIFF
--- a/src/Bones/babylon.bone.ts
+++ b/src/Bones/babylon.bone.ts
@@ -5,7 +5,7 @@
         public length: number;
 
         private _skeleton: Skeleton;
-        public _matrix: Matrix;
+        private _localMatrix: Matrix;
         private _restPose: Matrix;
         private _baseMatrix: Matrix;
         private _worldTransform = new Matrix();
@@ -17,11 +17,23 @@
         private _scaleVector = new Vector3(1, 1, 1);
         private _negateScaleChildren = new Vector3(1, 1, 1);
         private _scalingDeterminant = 1;
+
+        get _matrix():Matrix{
+            return this._localMatrix;
+        }
+
+        set _matrix(val:Matrix){
+            if(this._localMatrix){
+                this._localMatrix.copyFrom(val);
+            }else{
+                this._localMatrix = val;
+            }
+        }
         
         constructor(public name: string, skeleton: Skeleton, parentBone: Bone, matrix: Matrix, restPose?: Matrix) {
             super(name, skeleton.getScene());
             this._skeleton = skeleton;
-            this._matrix = matrix;
+            this._localMatrix = matrix;
             this._baseMatrix = matrix;
             this._restPose = restPose ? restPose : matrix.clone();
 
@@ -47,7 +59,7 @@
         }
 
         public getLocalMatrix(): Matrix {
-            return this._matrix;
+            return this._localMatrix;
         }
 
         public getBaseMatrix(): Matrix {
@@ -77,7 +89,7 @@
         // Methods
         public updateMatrix(matrix: Matrix, updateDifferenceMatrix = true): void {
             this._baseMatrix = matrix.clone();
-            this._matrix = matrix.clone();
+            this._localMatrix = matrix.clone();
 
             this._skeleton._markAsDirty();
 
@@ -559,9 +571,9 @@
         public computeAbsoluteTransforms (): void {
 
             if (this._parent) {
-                this._matrix.multiplyToRef(this._parent._absoluteTransform, this._absoluteTransform);
+                this._localMatrix.multiplyToRef(this._parent._absoluteTransform, this._absoluteTransform);
             } else {
-                this._absoluteTransform.copyFrom(this._matrix);
+                this._absoluteTransform.copyFrom(this._localMatrix);
 
                 var poseMatrix = this._skeleton.getPoseMatrix();
 


### PR DESCRIPTION
…etons that

Fix for this issue:
http://www.html5gamedevs.com/topic/28257-cloning-bones/

When an animation is played on a bone, the matrix from the animation key frame replaces the _matrix (localMatrix) of the bone.
When a skeleton is cloned, the animations of each of the bones are copied, but they still share keyframes.   Since the animations share the same keyframes and the keyframe matrix replace the bone's localMatrix, the bones of a cloned skeleton end up sharing the same localMatrix when they play the same animation.

This PG compares bones of two cloned skeletons before and after animations are run:
http://www.babylonjs-playground.com/#1ZBQR3#5

This fix uses a setter to force the _matrix to copy the values to the localMatrix of the bone.  As a result, the bone retains the original unique localMatrix.
