### PR TITLE
Separate pipe for npm module d.ts file

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -5,6 +5,7 @@
     "minNoWorkerFilename": "babylon.noworker.js",
     "minCoreFilename": "babylon.core.js",
     "declarationFilename": "babylon.d.ts",
+    "declarationModuleFilename": "babylon.module.d.ts",
     "outputDirectory": "../../dist/preview release",
     "srcOutputDirectory": "../../src/"
   },

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -214,7 +214,10 @@ gulp.task('typescript-compile', function () {
     return merge2([
         tsResult.dts
             .pipe(concat(config.build.declarationFilename))
-            //.pipe(addDtsExport("BABYLON"))
+            .pipe(gulp.dest(config.build.outputDirectory)),
+        tsResult.dts
+            .pipe(concat(config.build.declarationModuleFilename))
+            .pipe(addDtsExport("BABYLON"))
             .pipe(gulp.dest(config.build.outputDirectory)),
         tsResult.js
             .pipe(sourcemaps.write("./", 

--- a/Tools/Npm/getfiles.bat
+++ b/Tools/Npm/getfiles.bat
@@ -1,4 +1,5 @@
 xcopy /Y /F "../../dist/preview release/babylon.d.ts" .
+xcopy /Y /F "../../dist/preview release/babylon.module.d.ts" .
 xcopy /Y /F "../../dist/preview release/babylon.js" .
 xcopy /Y /F "../../dist/preview release/babylon.max.js"  .
 xcopy /Y /F "../../dist/preview release/babylon.noworker.js" . 

--- a/Tools/Npm/package.json
+++ b/Tools/Npm/package.json
@@ -15,6 +15,7 @@
   "main": "babylon.js",
   "files": [
     "babylon.d.ts",
+    "babylon.module.d.ts",
     "babylon.js",
     "babylon.max.js",
     "babylon.noworker.js",
@@ -23,7 +24,7 @@
     "Oimo.js",
     "package.json"
   ],
-  "typings": "babylon.d.ts",
+  "typings": "babylon.module.d.ts",
   "keywords": [
     "3D",
     "javascript",


### PR DESCRIPTION
This is a continuation of https://github.com/BabylonJS/Babylon.js/pull/1380

https://github.com/Microsoft/TypeScript/issues/8335#issuecomment-215194561 also seems to corroborate with this method for node modules.

This commit gets around the compile errors by creating a separate babylon.module.d.ts file that should be included in the npm package. I made a change in the Tools/Npm/package.json but I don't think it'll be sufficient since it doesn't seem like it does all the packaging.

The original babylon.d.ts file is still produced so running `gulp loaders` shouldn't produce new errors for files that have
```///.<reference.path="../../../dist/preview.release/babylon.d.ts"/>``` 

If this is no longer the correct approach, please let me know! thanks!