### PR TITLE
Fixed bug on 'onPointerPick'

### DIFF
--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -898,8 +898,8 @@
                 var pickResult = this.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, this.pointerDownPredicate, false, this.cameraToUseForPointers);
 
                 if (pickResult.hit && pickResult.pickedMesh) {
+                    this._pickedDownMesh = pickResult.pickedMesh;
                     if (pickResult.pickedMesh.actionManager) {
-                        this._pickedDownMesh = pickResult.pickedMesh;
                         if (pickResult.pickedMesh.actionManager.hasPickTriggers) {
                             switch (evt.button) {
                                 case 0:


### PR DESCRIPTION
If the selected mesh has no actionManager, the attribute _pickedMesh is never set, thus the 'onPointerPick' is never called.