### PR TITLE
Features/ncoder/references

### DIFF
--- a/src/Bones/babylon.bone.ts
+++ b/src/Bones/babylon.bone.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="..\babylon.node.ts" />
+
+module BABYLON {
     export class Bone extends Node {
         public children = new Array<Bone>();
         public animations = new Array<Animation>();

--- a/src/Cameras/babylon.arcRotateCameraInputsManager.ts
+++ b/src/Cameras/babylon.arcRotateCameraInputsManager.ts
@@ -1,3 +1,5 @@
+/// <reference path="..\Cameras\babylon.cameraInputsManager.ts" />
+
 module BABYLON {
     export class ArcRotateCameraInputsManager extends CameraInputsManager<ArcRotateCamera> {
         constructor(camera: ArcRotateCamera) {

--- a/src/Cameras/babylon.deviceOrientationCamera.ts
+++ b/src/Cameras/babylon.deviceOrientationCamera.ts
@@ -1,3 +1,5 @@
+/// <reference path="babylon.freeCamera.ts" />
+
 module BABYLON {
     // We're mainly based on the logic defined into the FreeCamera code
     export class DeviceOrientationCamera extends FreeCamera {

--- a/src/Cameras/babylon.followCamera.ts
+++ b/src/Cameras/babylon.followCamera.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.targetCamera.ts" />
+
+module BABYLON {
     export class FollowCamera extends TargetCamera {
         @serialize()
         public radius: number = 12;

--- a/src/Cameras/babylon.gamepadCamera.ts
+++ b/src/Cameras/babylon.gamepadCamera.ts
@@ -1,3 +1,5 @@
+/// <reference path="babylon.universalCamera.ts" />
+
 module BABYLON {
     // We're mainly based on the logic defined into the FreeCamera code
     export class GamepadCamera extends UniversalCamera {

--- a/src/Cameras/babylon.stereoscopicCameras.ts
+++ b/src/Cameras/babylon.stereoscopicCameras.ts
@@ -1,4 +1,9 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.freeCamera.ts" />
+/// <reference path="babylon.arcRotateCamera.ts" />
+/// <reference path="babylon.gamepadCamera.ts" />
+/// <reference path="babylon.universalCamera.ts" />
+
+module BABYLON {
     export class AnaglyphFreeCamera extends FreeCamera {
         constructor(name: string, position: Vector3, interaxialDistance: number, scene: Scene) {
             super(name, position, scene);

--- a/src/Cameras/babylon.targetCamera.ts
+++ b/src/Cameras/babylon.targetCamera.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.camera.ts" />
+
+module BABYLON {
     export class TargetCamera extends Camera {
 
         public cameraDirection = new Vector3(0, 0, 0);

--- a/src/Cameras/babylon.touchCamera.ts
+++ b/src/Cameras/babylon.touchCamera.ts
@@ -1,3 +1,5 @@
+/// <reference path="babylon.freeCamera.ts" />
+
 module BABYLON {
     // We're mainly based on the logic defined into the FreeCamera code
     export class TouchCamera extends FreeCamera {

--- a/src/Cameras/babylon.universalCamera.ts
+++ b/src/Cameras/babylon.universalCamera.ts
@@ -1,3 +1,5 @@
+/// <reference path="babylon.touchCamera.ts" />
+
 module BABYLON {
     // We're mainly based on the logic defined into the FreeCamera code
     export class UniversalCamera extends TouchCamera {

--- a/src/Layer/babylon.highlightlayer.ts
+++ b/src/Layer/babylon.highlightlayer.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="..\PostProcess\babylon.postProcess.ts" />
+
+module BABYLON {
     /**
      * Special Glow Blur post process only blurring the alpha channel
      * It enforces keeping the most luminous color in the color channel.

--- a/src/Lights/babylon.directionalLight.ts
+++ b/src/Lights/babylon.directionalLight.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.light.ts" />
+
+module BABYLON {
     export class DirectionalLight extends Light implements IShadowLight {
         @serializeAsVector3()
         public position: Vector3;

--- a/src/Materials/Textures/Procedurals/babylon.customProceduralTexture.ts
+++ b/src/Materials/Textures/Procedurals/babylon.customProceduralTexture.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.proceduralTexture.ts" />
+
+module BABYLON {
     export class CustomProceduralTexture extends ProceduralTexture {
         private _animate: boolean = true;
         private _time: number = 0;

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.texture.ts" />
+
+module BABYLON {
     export class DynamicTexture extends Texture {
         private _generateMipMaps: boolean;
         private _canvas: HTMLCanvasElement;

--- a/src/Materials/Textures/babylon.mirrorTexture.ts
+++ b/src/Materials/Textures/babylon.mirrorTexture.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.renderTargetTexture.ts" />
+
+module BABYLON {
     export class MirrorTexture extends RenderTargetTexture {
         public mirrorPlane = new Plane(0, 1, 0, 1);
 

--- a/src/Materials/Textures/babylon.refractionTexture.ts
+++ b/src/Materials/Textures/babylon.refractionTexture.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.renderTargetTexture.ts" />
+
+module BABYLON {
     /**
     * Creates a refraction texture used by refraction channel of the standard material.
     * @param name the texture name

--- a/src/Mesh/babylon.groundMesh.ts
+++ b/src/Mesh/babylon.groundMesh.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.mesh.ts" />
+
+module BABYLON {
     export class GroundMesh extends Mesh {
         public generateOctree = false;
 

--- a/src/Mesh/babylon.linesMesh.ts
+++ b/src/Mesh/babylon.linesMesh.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="babylon.mesh.ts" />
+
+module BABYLON {
     export class LinesMesh extends Mesh {
         public color = new Color3(1, 1, 1);
         public alpha = 1;

--- a/src/Mesh/babylon.polygonMesh.ts
+++ b/src/Mesh/babylon.polygonMesh.ts
@@ -1,3 +1,5 @@
+/// <reference path="..\Math\babylon.math.ts" />
+
 module BABYLON {
     class IndexedVector2 extends Vector2 {
         constructor(original: Vector2, public index: number) {

--- a/src/PostProcess/babylon.hdrRenderingPipeline.ts
+++ b/src/PostProcess/babylon.hdrRenderingPipeline.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="RenderPipeline\babylon.postProcessRenderPipeline.ts" />
+
+module BABYLON {
     export class HDRRenderingPipeline extends PostProcessRenderPipeline implements IDisposable {
 
         /**

--- a/src/PostProcess/babylon.standardRenderingPipeline.ts
+++ b/src/PostProcess/babylon.standardRenderingPipeline.ts
@@ -1,4 +1,6 @@
-﻿module BABYLON {
+﻿/// <reference path="RenderPipeline\babylon.postProcessRenderPipeline.ts" />
+
+module BABYLON {
     export class StandardRenderingPipeline extends PostProcessRenderPipeline implements IDisposable, IAnimatable {
         /**
         * Public members


### PR DESCRIPTION
I was reading https://doc.babylonjs.com/generals/setup_visualstudio and I knew a simpler way to get sourcemaps up and running for debugging.

Right now I've got a nice standalone project setup to build babylon with very minimal changes, and I get:

![map files](https://cloud.githubusercontent.com/assets/1332278/22995650/8665ce48-f380-11e6-9f1a-f80290358f59.png)

All I had to do was set "Combine Javascript Output file" to dist/babylon.2.5.js (probably should have been babylon.2.5.max.js, but a small detail)
and "Generate declaration files"

That gives a nice concatenated output built by the typescript compiler instead of grunt/gulp, with proper source mappings.

Details:

All these reference nodes do is tell the typescript compiler that this file needs to be concatenated before another one. I've noticed that some errors may happen at runtime if the order is wrong. As such, a few reference paths may still be missing for some features of the engine I havn't used.