### PR TITLE
removed direction.normalize in Ray.Transform and Ray.TransformToRef, …

### DIFF
--- a/src/Culling/babylon.ray.ts
+++ b/src/Culling/babylon.ray.ts
@@ -389,9 +389,7 @@
         public static Transform(ray: Ray, matrix: Matrix): Ray {
             var newOrigin = Vector3.TransformCoordinates(ray.origin, matrix);
             var newDirection = Vector3.TransformNormal(ray.direction, matrix);
-
-            newDirection.normalize();
-
+            
             return new Ray(newOrigin, newDirection, ray.length);
         }
 
@@ -399,8 +397,7 @@
             
             Vector3.TransformCoordinatesToRef(ray.origin, matrix, result.origin);
             Vector3.TransformNormalToRef(ray.direction, matrix, result.direction);
-
-            result.direction.normalize();            
+            
         }
     }
 }


### PR DESCRIPTION
…since it breaks transformation of ray

This fixes:
http://www.html5gamedevs.com/topic/28465-rayintersectsmesh-doesnt-hit-mesh-if-scaled/