### PR TITLE
constantlyUpdateMeshUnderPointer fix

### DIFF
--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -151,9 +151,7 @@
         public forceShowBoundingBoxes = false;
         public clipPlane: Plane;
         public animationsEnabled = true;
-        public 
-	
-	yUpdateMeshUnderPointer = false;
+        public constantlyUpdateMeshUnderPointer = false;
         public useRightHandedSystem = false;
 
         public hoverCursor = "pointer";

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -151,7 +151,9 @@
         public forceShowBoundingBoxes = false;
         public clipPlane: Plane;
         public animationsEnabled = true;
-        public constantlyUpdateMeshUnderPointer = false;
+        public 
+	
+	yUpdateMeshUnderPointer = false;
         public useRightHandedSystem = false;
 
         public hoverCursor = "pointer";
@@ -816,7 +818,7 @@
                 var canvas = this._engine.getRenderingCanvas();
 
                 if (!this.pointerMovePredicate) {
-                    this.pointerMovePredicate = (mesh: AbstractMesh): boolean => mesh.isPickable && mesh.isVisible && mesh.isReady() && (this.constantlyUpdateMeshUnderPointer || mesh.actionManager !== null && mesh.actionManager !== undefined);
+                    this.pointerMovePredicate = (mesh: AbstractMesh): boolean => mesh.isPickable && mesh.isVisible && mesh.isReady() && (this.constantlyUpdateMeshUnderPointer || (mesh.actionManager !== null && mesh.actionManager !== undefined));
                 }
 
                 // Meshes


### PR DESCRIPTION
the constantlyUpdateMeshUnderPointer flag won't work unless the mesh had an action manager. The || should cover both $$'s and not just the first one.