### PR TITLE
fix for bone.getPositionToRef in world space bug

### DIFF
--- a/src/Bones/babylon.bone.ts
+++ b/src/Bones/babylon.bone.ts
@@ -626,13 +626,20 @@ module BABYLON {
 
             }else{
                 
+                var wm;
+                
+                //mesh.getWorldMatrix() needs to be called before skeleton.computeAbsoluteTransforms()
+                if(mesh){
+                    wm = mesh.getWorldMatrix();
+                }
+                
                 this._skeleton.computeAbsoluteTransforms();
                 
                 var tmat = Tmp.Matrix[0];
 
                 if (mesh) {
                     tmat.copyFrom(this.getAbsoluteTransform());
-                    tmat.multiplyToRef(mesh.getWorldMatrix(), tmat);
+                    tmat.multiplyToRef(wm, tmat);
                 }else{
                     tmat = this.getAbsoluteTransform();
                 }


### PR DESCRIPTION
another fix for this bug:

http://www.html5gamedevs.com/topic/28650-using-animation-move-mesh-cause-the-first-bone-controller-stop-working/