### PR TITLE
Update babylon.abstractMesh.ts

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -644,19 +644,19 @@
          * @param {number} z
          * @param {number} maxHeight (default 200)
          */
-        public getHeightMeshAtCoordinates(x: number, z: number, maxHeight = 200): AbstractMesh {		
-		    var ray = new BABYLON.Ray(new BABYLON.Vector3(x, maxHeight, z), new BABYLON.Vector3(0, -1, 0), 2*maxHeight);
-		    var res = this.intersects(ray, true);
-		    return res.pickedPoint.y;
-	    }
+        public getHeightMeshAtCoordinates(x: number, z: number, maxHeight = 200): Vector3 {		
+            var ray = new BABYLON.Ray(new BABYLON.Vector3(x, maxHeight, z), new BABYLON.Vector3(0, -1, 0), 2*maxHeight);
+            var res = this.intersects(ray, true);
+            return res.pickedPoint.y;
+        }
          
         /**
          * Redefine updatable on a mesh
          */
-        public setUpdatable(updatable?: boolean): AbstractMesh {		
-		    this.setVerticesData(BABYLON.VertexBuffer.PositionKind, this.getVerticesData(BABYLON.VertexBuffer.PositionKind), updatable);
-		    this.setVerticesData(BABYLON.VertexBuffer.NormalKind, this.getVerticesData(BABYLON.VertexBuffer.NormalKind), updatable);		
-	    }
+        public setUpdatable(updatable?: boolean): void {		
+            this.setVerticesData(BABYLON.VertexBuffer.PositionKind, this.getVerticesData(BABYLON.VertexBuffer.PositionKind), updatable);
+            this.setVerticesData(BABYLON.VertexBuffer.NormalKind, this.getVerticesData(BABYLON.VertexBuffer.NormalKind), updatable);		
+        }
 
         // ================================== Point of View Movement =================================
         /**

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -637,6 +637,26 @@
             }
             return this;
         }
+        
+        /**
+         * Return the point Y of a coordinate on a mesh 
+         * @param {number} x
+         * @param {number} z
+         * @param {number} maxHeight (default 200)
+         */
+        public getHeightMeshAtCoordinates(x: number, z: number, maxHeight = 200): AbstractMesh {		
+		    var ray = new BABYLON.Ray(new BABYLON.Vector3(x, maxHeight, z), new BABYLON.Vector3(0, -1, 0), 2*maxHeight);
+		    var res = this.intersects(ray, true);
+		    return res.pickedPoint.y;
+	    }
+         
+        /**
+         * Redefine updatable on a mesh
+         */
+        public setUpdatable(updatable?: boolean): AbstractMesh {		
+		    this.setVerticesData(BABYLON.VertexBuffer.PositionKind, this.getVerticesData(BABYLON.VertexBuffer.PositionKind), updatable);
+		    this.setVerticesData(BABYLON.VertexBuffer.NormalKind, this.getVerticesData(BABYLON.VertexBuffer.NormalKind), updatable);		
+	    }
 
         // ================================== Point of View Movement =================================
         /**


### PR DESCRIPTION
I add a function getHeightMeshAtCoordinates, because when a terrain is serialize and reload with ImportMesh, getHeightAtCoordinates that is made for when creating a field with CreatGround, no longer works.
In this case, we can use this function which will return the point Y of a coordinate.

I also add setUpdatable on the mesh, because you can only put an object updatable to the creation of the object, but once serialize and reload with ImportMesh, it is no longer updatable. With this function you can redefine updatable.