### PR TITLE
Correcting bug where fur length was not used when determining occlusion

### DIFF
--- a/materialsLibrary/src/fur/fur.fragment.fx
+++ b/materialsLibrary/src/fur/fur.fragment.fx
@@ -6,6 +6,7 @@ uniform vec4 vDiffuseColor;
 
 // Input
 uniform vec4 furColor;
+uniform float furLength;
 varying vec3 vPositionW;
 varying float vfur_length;
 
@@ -111,7 +112,7 @@ void main(void) {
 	#ifdef HIGHLEVEL
 	vec4 color = vec4(finalDiffuse, alpha);
 	#else
-	float r = vfur_length * 0.5;
+	float r = vfur_length / furLength * 0.5;
 	vec4 color = vec4(finalDiffuse * (0.5 + r), alpha);
 	#endif
 	


### PR DESCRIPTION
When furLength was less than 1 you'd end up with a material that was always a bit (or a lot) occluded (in color). Corrected this by dividing the "occlusion strength" by the furLength.