### PR TITLE
Allows y === null in drawText.

### DIFF
--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -75,11 +75,11 @@ module BABYLON {
             }
 
             this._context.font = font;
-            if (x === null  || typeof x === "undefined") {
+            if (x === null  || x === undefined) {
                 var textSize = this._context.measureText(text);
                 x = (size.width - textSize.width) / 2;
             }
-            if (y === null || typeof y === "undefined") {
+            if (y === null || y === undefined) {
                 var fontSize = parseInt((font.replace(/\D/g,'')));;
                 y = (size.height /2) + (fontSize/3.65);
             }

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -75,11 +75,11 @@ module BABYLON {
             }
 
             this._context.font = font;
-            if (x === null) {
+            if (x === null  || typeof x === "undefined") {
                 var textSize = this._context.measureText(text);
                 x = (size.width - textSize.width) / 2;
             }
-            if (y === null) {
+            if (y === null || typeof y === "undefined") {
                 var fontSize = parseInt((font.replace(/\D/g,'')));;
                 y = (size.height /2) + (fontSize/3.65);
             }

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -81,7 +81,7 @@ module BABYLON {
             }
             if (y === null) {
                 var fontSize = parseInt((font.replace(/\D/g,'')));;
-                y = (size.height /2) + (fontSize/4);
+                y = (size.height /2) + (fontSize/3.65);
             }
             
             this._context.fillStyle = color;

--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -79,7 +79,11 @@ module BABYLON {
                 var textSize = this._context.measureText(text);
                 x = (size.width - textSize.width) / 2;
             }
-
+            if (y === null) {
+                var fontSize = parseInt((font.replace(/\D/g,'')));;
+                y = (size.height /2) + (fontSize/4);
+            }
+            
             this._context.fillStyle = color;
             this._context.fillText(text, x, y);
 


### PR DESCRIPTION
Allows leaving Y as null in the dynamicTexture.drawText function and centers the text vertically instead.

PG; http://www.babylonjs-playground.com/#1023O#47

_Side-note;_
As working with font sizes is rather difficult due to the many measuring types, it's orbviously not perfect, but it works very well for standard-use cases and with the use of PX, as is used in the turtorial, adding further support for pt, em, vw & vh, etc would be too much of a complication( in my mind), for such a simple feature.