### PR TITLE
Update babylon.camera.ts

### DIFF
--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -646,7 +646,10 @@
             this._cameraRigParams.vrWorkMatrix.multiplyToRef(this._cameraRigParams.vrHMatrix, this._projectionMatrix);
             return this._projectionMatrix;
         }
-
+        
+        protected _updateCameraRotationMatrix() {
+           // only here for webvr
+        }
         /**
          * This function MUST be overwritten by the different WebVR cameras available.
          * The context in which it is running is the RIG camera. So 'this' is the TargetCamera, left or right.


### PR DESCRIPTION
Fixing TypeScript error
The function is taken from the WebVR camera, but TypeScript takes "this" as the camera class.