### PR TITLE
XBOX gamepad is now prioritized

### DIFF
--- a/src/Cameras/Inputs/babylon.arcrotatecamera.input.gamepad.ts
+++ b/src/Cameras/Inputs/babylon.arcrotatecamera.input.gamepad.ts
@@ -53,9 +53,11 @@ module BABYLON {
         }
 
         private _onNewGameConnected(gamepad: Gamepad) {
-            // Only the first gamepad can control the camera
-            if (!this.gamepad && gamepad.type !== Gamepad.POSE_ENABLED) {
-                this.gamepad = gamepad;
+            if (gamepad.type !== Gamepad.POSE_ENABLED) {
+                // prioritize XBOX gamepads.
+                if (!this.gamepad || gamepad.type === Gamepad.XBOX) {
+                    this.gamepad = gamepad;
+                }
             }
         }
 

--- a/src/Cameras/Inputs/babylon.freecamera.input.gamepad.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.gamepad.ts
@@ -61,8 +61,11 @@ module BABYLON {
 
         private _onNewGameConnected(gamepad: Gamepad) {
             // Only the first gamepad found can control the camera
-            if (!this.gamepad && gamepad.type !== Gamepad.POSE_ENABLED) {
-                this.gamepad = gamepad;
+            if (gamepad.type !== Gamepad.POSE_ENABLED) {
+                // prioritize XBOX gamepads.
+                if (!this.gamepad || gamepad.type === Gamepad.XBOX) {
+                    this.gamepad = gamepad;
+                }
             }
         }
 


### PR DESCRIPTION
Problem with the oculus is that it has the oculus remote which is a
gamepad as well. So we prioritize XBOX gamepads per default.