### PR TITLE
GLTF: Correct initialization of node rotation from quaternion.

### DIFF
--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -934,7 +934,7 @@ module BABYLON {
                 var translation = node.translation || [0, 0, 0];
                 var rotation = node.rotation || [0, 0, 0, 1];
                 var scale = node.scale || [1, 1, 1];
-                configureNode(lastNode, Vector3.FromArray(translation), Quaternion.RotationAxis(Vector3.FromArray(rotation).normalize(), rotation[3]), Vector3.FromArray(scale));
+                configureNode(lastNode, Vector3.FromArray(translation), Quaternion.FromArray(rotation), Vector3.FromArray(scale));
             }
 
             lastNode.updateCache(true);


### PR DESCRIPTION
In the GLTF loader, the initialization of a node's rotation from a specified quaternion is wrong. This commit replaces the Quaternion.RotationAxis computation with a Quaternion.FromArray.