### PR TITLE
Webvr parenting

### DIFF
--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -52,7 +52,7 @@ module BABYLON {
 
         private _positionOffset: Vector3 = Vector3.Zero();
 
-        protected _decedents: Array<Node> = [];
+        protected _descendants: Array<Node> = [];
 
         public devicePosition = Vector3.Zero();
         public deviceRotationQuaternion;
@@ -142,13 +142,13 @@ module BABYLON {
              */
             scene.onBeforeCameraRenderObservable.add((camera) => {
                 if (camera.parent === this && this.rigParenting) {
-                    this._decedents = this.getDescendants(true, (n) => {
+                    this._descendants = this.getDescendants(true, (n) => {
                         // don't take the cameras or the controllers!
                         let isController = this.controllers.some(controller => { return controller._mesh === n });
                         let isRigCamera = this._rigCameras.indexOf(<Camera>n) !== -1
                         return !isController && !isRigCamera;
                     });
-                    this._decedents.forEach(node => {
+                    this._descendants.forEach(node => {
                         node.parent = camera;
                     });
                 }
@@ -156,7 +156,7 @@ module BABYLON {
 
             scene.onAfterCameraRenderObservable.add((camera) => {
                 if (camera.parent === this && this.rigParenting) {
-                    this._decedents.forEach(node => {
+                    this._descendants.forEach(node => {
                         node.parent = this;
                     });
                 }

--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -286,11 +286,6 @@
         public update(): void {
             if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
                 this._updateRigCameras();
-            } else if (this._cameraRigParams['parentCamera']) {
-                //WebVR parenting solved. See WebVRFreeCamera's _updateRigCameras function
-                this._cameraRigParams['parentCamera']._decedents.forEach(d => {
-                    d.parent = this;
-                });
             }
             this._checkInputs();
         }
@@ -628,6 +623,7 @@
 
                         //Right eye
                         this._rigCameras[1].viewport = new Viewport(0.5, 0, 0.5, 1.0);
+                        this._rigCameras[0].setCameraRigParameter("left", false);
                         this._rigCameras[1].setCameraRigParameter('eyeParameters', rightEye);
                         this._rigCameras[1].setCameraRigParameter("frameData", rigParams.frameData);
                         this._rigCameras[1].setCameraRigParameter("parentCamera", rigParams.parentCamera);

--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -286,6 +286,11 @@
         public update(): void {
             if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
                 this._updateRigCameras();
+            } else if (this._cameraRigParams['parentCamera']) {
+                //WebVR parenting solved. See WebVRFreeCamera's _updateRigCameras function
+                this._cameraRigParams['parentCamera']._decedents.forEach(d => {
+                    d.parent = this;
+                });
             }
             this._checkInputs();
         }
@@ -618,9 +623,8 @@
                         this._rigCameras[0].setCameraRigParameter("parentCamera", rigParams.parentCamera);
                         this._rigCameras[0]._cameraRigParams.vrWorkMatrix = new Matrix();
                         this._rigCameras[0].getProjectionMatrix = this._getWebVRProjectionMatrix;
+                        this._rigCameras[0].parent = this;
                         this._rigCameras[0]._getViewMatrix = this._getWebVRViewMatrix;
-                        this._rigCameras[0]._isSynchronizedViewMatrix = this._isSynchronizedViewMatrix;
-                        this._rigCameras[0]._updateCameraRotationMatrix = this._updateWebVRCameraRotationMatrix;
 
                         //Right eye
                         this._rigCameras[1].viewport = new Viewport(0.5, 0, 0.5, 1.0);
@@ -629,9 +633,8 @@
                         this._rigCameras[1].setCameraRigParameter("parentCamera", rigParams.parentCamera);
                         this._rigCameras[1]._cameraRigParams.vrWorkMatrix = new Matrix();
                         this._rigCameras[1].getProjectionMatrix = this._getWebVRProjectionMatrix;
+                        this._rigCameras[1].parent = this;
                         this._rigCameras[1]._getViewMatrix = this._getWebVRViewMatrix;
-                        this._rigCameras[1]._isSynchronizedViewMatrix = this._isSynchronizedViewMatrix;
-                        this._rigCameras[1]._updateCameraRotationMatrix = this._updateWebVRCameraRotationMatrix;
                     }
                     break;
 

--- a/src/Cameras/babylon.targetCamera.ts
+++ b/src/Cameras/babylon.targetCamera.ts
@@ -179,7 +179,7 @@ module BABYLON {
 
                 //rotate, if quaternion is set and rotation was used
                 if (this.rotationQuaternion) {
-                    var len = this.rotation.length();
+                    var len = this.rotation.lengthSquared();
                     if (len) {
                         Quaternion.RotationYawPitchRollToRef(this.rotation.y, this.rotation.x, this.rotation.z, this.rotationQuaternion);
                     }
@@ -302,7 +302,6 @@ module BABYLON {
                     break;
 
                 case Camera.RIG_MODE_VR:
-                case Camera.RIG_MODE_WEBVR:
                     if (camLeft.rotationQuaternion) {
                         camLeft.rotationQuaternion.copyFrom(this.rotationQuaternion);
                         camRight.rotationQuaternion.copyFrom(this.rotationQuaternion);


### PR DESCRIPTION
Parenting system of the cameras works correctly.

Each rig camera is a child of the main camera. This is done to avoid changing the view matrix genarated so kindly by the camera.

There is now an option to add meshes as children of the WebVR camra.
The parameter "rigParenting" will decide whether the objects stay attached to the main camera (and thus not being followed when moving the head) ot that they should be attached to the rig cameras and move together with the head rotation.