### PR TITLE
Bug fix - when the gamepad is disconnected

### DIFF
--- a/src/Cameras/Inputs/babylon.freecamera.input.gamepad.ts
+++ b/src/Cameras/Inputs/babylon.freecamera.input.gamepad.ts
@@ -29,7 +29,7 @@ module BABYLON {
         }
 
         checkInputs() {
-            if (this.gamepad) {
+            if (this.gamepad && this.gamepad.leftStick) {
                 var camera = this.camera;
                 var LSValues = this.gamepad.leftStick;
                 var normalizedLX = LSValues.x / this.gamepadMoveSensibility;


### PR DESCRIPTION
When the actual gamepad is disconnected, the gamepad object will still
exist. Now the leftStick value is being tested, which ensures that the
values are provided.
checking for browserGamepad might also be valid, but the browser might
leave the object as well.