### PR TITLE
force ribbon vertex data to be float32arrays

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -715,11 +715,14 @@
 
             // Result
             var vertexData = new VertexData();
-
+            var positions32 = new Float32Array(positions);
+            var normals32 = new Float32Array(normals);
+            var uvs32 = new Float32Array(uvs);
+            
             vertexData.indices = indices;
-            vertexData.positions = positions;
-            vertexData.normals = normals;
-            vertexData.uvs = uvs;
+            vertexData.positions = positions32;
+            vertexData.normals = normals32;
+            vertexData.uvs = uvs32;
             if (customColors) {
                 vertexData.set(colors, VertexBuffer.ColorKind);
             }

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -122,7 +122,7 @@
          * You can also set the mesh side orientation with the values : BABYLON.Mesh.FRONTSIDE (default), BABYLON.Mesh.BACKSIDE or BABYLON.Mesh.DOUBLESIDE  
          * Detail here : http://doc.babylonjs.com/tutorials/02._Discover_Basic_Elements#side-orientation    
          * The optional parameter `invertUV` (boolean, default false) swaps in the geometry the U and V coordinates to apply a texture.  
-         * The parameter `uvs` is an optional flat array of `Vector4` to update/set each ribbon vertex with its own custom UV values instead of the computed ones.  
+         * The parameter `uvs` is an optional flat array of `Vector2` to update/set each ribbon vertex with its own custom UV values instead of the computed ones.  
          * The parameters `colors` is an optional flat array of `Color4` to set/update each ribbon vertex with its own custom color values.  
          * Note that if you use the parameters `uvs` or `colors`, the passed arrays must be populated with the right number of elements, it is to say the number of ribbon vertices. Remember that 
          * if you set `closePath` to `true`, there's one extra vertex per path in the geometry.  


### PR DESCRIPTION
This fix forces each ribbon float vertex data to be stored in Float32arrays only at construction time.
As the ribbon is the basic brick for many updatable/morphable parametric shapes (tubes, extrusions, terrains, etc), this optimizes the underlying usage of `updateDynamicVertexBuffer()` by not creating a new float32array each call.

Now the js optimizer and GC won't complain any longer on  each frame updates (checked). 