### PR TITLE
NPM now points to non-minimized version

### DIFF
--- a/Tools/Npm/package.json
+++ b/Tools/Npm/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/BabylonJS/Babylon.js.git"
   },
-  "main": "babylon.js",
+  "main": "babylon.max.js",
   "files": [
     "babylon.d.ts",
     "babylon.module.d.ts",


### PR DESCRIPTION
This change is proposed to follow other NPM packages rules.

The fact is that people will minify their global project,
often with source-mapping, and therefore always need the non-minified version.