### PR TITLE
Added Clean-JS-MAP task

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -398,6 +398,6 @@ gulp.task("zip-blender" , function() {
 
 gulp.task('clean-JS-MAP', function () {
 	  return del([
-		  '../../src/**/*.js.map','../../src/**.js'
+		  '../../src/**/*.js.map','../../src/**/*.js'
 	  ], {force: true});
 	});

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -26,6 +26,8 @@ var zip = require('gulp-zip');
 var config = require("./config.json");
 var customConfig = require("./custom.config.json");
 
+var del = require('del');
+
 var debug = require('gulp-debug');
 var includeShadersStream;
 var shadersStream;
@@ -393,3 +395,9 @@ gulp.task("zip-blender" , function() {
     .pipe(zip('Blender2Babylon-5.2.zip'))
     .pipe(gulp.dest('../../Exporters/Blender'));
 });
+
+gulp.task('clean-JS-MAP', function () {
+	  return del([
+		  '../../src/**/*.js.map','../../src/**.js'
+	  ], {force: true});
+	});

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -32,7 +32,8 @@
     "style-loader": "^0.13.1",
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.7.0",
-    "gulp-zip": "~3.2.0"
+    "gulp-zip": "~3.2.0",
+    "del": "2.2.2"
   },
   "scripts": {
     "install": "npm --prefix ../../Playground/ install ../../Playground/ && gulp typescript-compile && gulp typescript-libraries && gulp deployLocalDev"

--- a/Tools/Gulp/profiling.html
+++ b/Tools/Gulp/profiling.html
@@ -75,7 +75,7 @@ On this page:
                         	var name = fileNames[i].match(reg)[0].substring(8);  // remove the babylon.
                         	files[i] = [false, fileNames[i], name];
                         }
-						appendSecondarySearches("math.js", "mathtools|color3|color4|vector2|vector3|vector4|size|quaternion|matrix|plane|viewport|frustum|bezierCurve"); // got tired
+						appendSecondarySearches("math.js", "mathtools|color3|color4|vector2|vector3|vector4|size|quaternion|matrix|plane|viewport|frustum|space|axis|bezierCurve|orientation|angle|arc2|path2|path3d|curve3|sphericalHarmonics|mathTmp");
 
 						// force stuff to always be added
 						appendSecondarySearches("decorators.js", "engine"); //needed for Serialize


### PR DESCRIPTION
Got tired of looking at all the tmp .js & .map files in repo after a
building session.  Not automatically part of the build process.

Finally no more triple vision.