### PR TITLE
Physics extendsizeWorld fix

### DIFF
--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -338,7 +338,6 @@
             object.computeWorldMatrix && object.computeWorldMatrix(true);
             // The delta between the mesh position and the mesh bounding box center
             var center = impostor.getObjectCenter();
-            var extendSize = impostor.getObjectExtendSize();
             this._tmpDeltaPosition.copyFrom(object.position.subtract(center));
             this._tmpPosition.copyFrom(center);
             var quaternion = object.rotationQuaternion;

--- a/src/Physics/babylon.physicsImpostor.ts
+++ b/src/Physics/babylon.physicsImpostor.ts
@@ -15,6 +15,7 @@ module BABYLON {
         parent?: any;
         getBoundingInfo?(): BoundingInfo;
         computeWorldMatrix?(force: boolean): void;
+        getWorldMatrix?(): Matrix;
         getChildMeshes?(): Array<AbstractMesh>;
         getVerticesData?(kind: string): Array<number> | Float32Array;
         getIndices?(): IndicesArray;
@@ -24,6 +25,8 @@ module BABYLON {
     export class PhysicsImpostor {
 
         public static DEFAULT_OBJECT_SIZE: Vector3 = new BABYLON.Vector3(1, 1, 1);
+
+        public static IDENTITY_QUATERNION = Quaternion.Identity();
 
         private _physicsEngine: PhysicsEngine;
         //The native cannon/oimo/energy physics body object.
@@ -168,8 +171,18 @@ module BABYLON {
 
         public getObjectExtendSize(): Vector3 {
             if (this.object.getBoundingInfo) {
+                let q = this.object.rotationQuaternion;
+                //reset rotation
+                this.object.rotationQuaternion = PhysicsImpostor.IDENTITY_QUATERNION;
+                //calculate the world matrix with no rotation
                 this.object.computeWorldMatrix && this.object.computeWorldMatrix(true);
-                return this.object.getBoundingInfo().boundingBox.extendSizeWorld.scale(2);
+                let size = this.object.getBoundingInfo().boundingBox.extendSizeWorld.scale(2)
+                //bring back the rotation
+                this.object.rotationQuaternion = q;
+                //calculate the world matrix with the new rotation
+                this.object.computeWorldMatrix && this.object.computeWorldMatrix(true);
+
+                return size;
             } else {
                 return PhysicsImpostor.DEFAULT_OBJECT_SIZE;
             }

--- a/src/Physics/babylon.physicsImpostor.ts
+++ b/src/Physics/babylon.physicsImpostor.ts
@@ -169,7 +169,7 @@ module BABYLON {
         public getObjectExtendSize(): Vector3 {
             if (this.object.getBoundingInfo) {
                 this.object.computeWorldMatrix && this.object.computeWorldMatrix(true);
-                return this.object.getBoundingInfo().boundingBox.extendSizeWorld.scale(2).multiply(this.object.scaling)
+                return this.object.getBoundingInfo().boundingBox.extendSizeWorld.scale(2);
             } else {
                 return PhysicsImpostor.DEFAULT_OBJECT_SIZE;
             }


### PR DESCRIPTION
Resetting the rotation and calculating the extendSizeWorld allows the physics engine to have the right size, and then apply the rotation afterwards.