### PR TITLE
Printing numbered shaders source code when compilation fails

### DIFF
--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -302,13 +302,17 @@
             Tools.LoadFile(fragmentShaderUrl + ".fragment.fx", callback);
         }
 
-        private _dumpShadersSource(vertexCode: string, fragmentCode: string): void {
+        private _dumpShadersSource(vertexCode: string, fragmentCode: string, defines: string): void {
+            // Rebuild shaders source code
+            var shaderVersion = (this._engine.webGLVersion > 1) ? "#version 300 es\n" : "";
+            var prefix = shaderVersion + (defines ? defines + "\n" : "");
+
             // Number lines of shaders source code
             var i = 2;
             var regex = /\n/gm;
-            var formattedVertexCode = "\n1\t" + vertexCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+            var formattedVertexCode = prefix + "\n1\t" + vertexCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
             i = 2;
-            var formattedFragmentCode = "\n1\t" + fragmentCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+            var formattedFragmentCode = prefix + "\n1\t" + fragmentCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
 
             // Dump shaders name and formatted source code
             if (this.name.vertexElement) {
@@ -481,10 +485,7 @@
                 BABYLON.Tools.Error("Attributes: " + attributesNames.map(function(attribute) {
                     return " " + attribute;
                 }));
-                // Rebuild shader source code
-                var shaderVersion = (this._engine.webGLVersion > 1) ? "#version 300 es\n" : "";
-                var prefix = shaderVersion + (defines ? defines + "\n" : "");
-                this._dumpShadersSource(prefix + vertexSourceCode, prefix + fragmentSourceCode);
+                this._dumpShadersSource(vertexSourceCode, fragmentSourceCode, defines);
                 Tools.Error("Error: " + this._compilationError);
 
                 if (fallbacks && fallbacks.isMoreFallbacks) {

--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -306,13 +306,15 @@
             // Rebuild shaders source code
             var shaderVersion = (this._engine.webGLVersion > 1) ? "#version 300 es\n" : "";
             var prefix = shaderVersion + (defines ? defines + "\n" : "");
+            vertexCode = prefix + vertexCode;
+            fragmentCode = prefix + fragmentCode;
 
             // Number lines of shaders source code
             var i = 2;
             var regex = /\n/gm;
-            var formattedVertexCode = prefix + "\n1\t" + vertexCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+            var formattedVertexCode = "\n1\t" + vertexCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
             i = 2;
-            var formattedFragmentCode = prefix + "\n1\t" + fragmentCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+            var formattedFragmentCode = "\n1\t" + fragmentCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
 
             // Dump shaders name and formatted source code
             if (this.name.vertexElement) {

--- a/src/Materials/babylon.effect.ts
+++ b/src/Materials/babylon.effect.ts
@@ -302,18 +302,29 @@
             Tools.LoadFile(fragmentShaderUrl + ".fragment.fx", callback);
         }
 
-        private _dumpShadersName(): void {
+        private _dumpShadersSource(vertexCode: string, fragmentCode: string): void {
+            // Number lines of shaders source code
+            var i = 2;
+            var regex = /\n/gm;
+            var formattedVertexCode = "\n1\t" + vertexCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+            i = 2;
+            var formattedFragmentCode = "\n1\t" + fragmentCode.replace(regex, function() { return "\n" + (i++) + "\t"; });
+
+            // Dump shaders name and formatted source code
             if (this.name.vertexElement) {
-                Tools.Error("Vertex shader:" + this.name.vertexElement);
-                Tools.Error("Fragment shader:" + this.name.fragmentElement);
-            } else if (this.name.vertex) {
-                Tools.Error("Vertex shader:" + this.name.vertex);
-                Tools.Error("Fragment shader:" + this.name.fragment);
-            } else {
-                Tools.Error("Vertex shader:" + this.name);
-                Tools.Error("Fragment shader:" + this.name);
+                BABYLON.Tools.Error("Vertex shader: " + this.name.vertexElement + formattedVertexCode);
+                BABYLON.Tools.Error("Fragment shader: " + this.name.fragmentElement + formattedFragmentCode);
             }
-        }
+            else if (this.name.vertex) {
+                BABYLON.Tools.Error("Vertex shader: " + this.name.vertex + formattedVertexCode);
+                BABYLON.Tools.Error("Fragment shader: " + this.name.fragment + formattedFragmentCode);
+            }
+            else {
+                BABYLON.Tools.Error("Vertex shader: " + this.name + formattedVertexCode);
+                BABYLON.Tools.Error("Fragment shader: " + this.name + formattedFragmentCode);
+            }
+        };
+
         private _processShaderConversion(sourceCode: string, isFragment: boolean, callback: (data: any) => void): void {
 
             var preparedSourceCode = this._processPrecision(sourceCode);
@@ -463,10 +474,18 @@
                 this._compilationError = e.message;
 
                 // Let's go through fallbacks then
-                Tools.Error("Unable to compile effect: ");
-                Tools.Error("Defines: " + defines);
+                Tools.Error("Unable to compile effect:");
+                BABYLON.Tools.Error("Uniforms: " + this._uniformsNames.map(function(uniform) {
+                    return " " + uniform;
+                }));
+                BABYLON.Tools.Error("Attributes: " + attributesNames.map(function(attribute) {
+                    return " " + attribute;
+                }));
+                // Rebuild shader source code
+                var shaderVersion = (this._engine.webGLVersion > 1) ? "#version 300 es\n" : "";
+                var prefix = shaderVersion + (defines ? defines + "\n" : "");
+                this._dumpShadersSource(prefix + vertexSourceCode, prefix + fragmentSourceCode);
                 Tools.Error("Error: " + this._compilationError);
-                this._dumpShadersName();
 
                 if (fallbacks && fallbacks.isMoreFallbacks) {
                     Tools.Error("Trying next fallback.");


### PR DESCRIPTION
Rebuild shaders source code as they were right before compilation, then number lines for debug purpose.
I replaced _dumpShadersName by _dumpShadersSource which does this.
Since defines already are in final source code, I replaced them by uniforms and attributes because issues often happen just because an uniform is missing.