### PR TITLE
Adding support to Babylon.JS for morph targets

### DIFF
--- a/serializers/src/OBJ/babylon.objSerializer.ts
+++ b/serializers/src/OBJ/babylon.objSerializer.ts
@@ -28,7 +28,7 @@ module BABYLON {
                 if (materials) {
                     output.push("usemtl " + mesh[j].material.id);
                 }
-                var g = mesh[j].Geometry;
+                var g = mesh[j].geometry;
                 var trunkVerts = g.getVerticesData('position');
                 var trunkNormals = g.getVerticesData('normal');
                 var trunkUV = g.getVerticesData('uv');

--- a/src/Materials/babylon.materialHelper.ts
+++ b/src/Materials/babylon.materialHelper.ts
@@ -72,10 +72,12 @@
             if (useMorphTargets) {
                 if ((<any>mesh).morphTargetManager) {
                     var manager = (<Mesh>mesh).morphTargetManager;
+                    defines["MORPHTARGETS_TANGENT"] = manager.supportsTangents && defines["TANGENT"];
                     defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"] ;
                     defines["MORPHTARGETS"] = (manager.numInfluencers > 0);
                     defines["NUM_MORPH_INFLUENCERS"] = manager.numInfluencers;
                 } else {
+                    defines["MORPHTARGETS_TANGENT"] = false;
                     defines["MORPHTARGETS_NORMAL"] = false;
                     defines["MORPHTARGETS"] = false;
                     defines["NUM_MORPH_INFLUENCERS"] = 0;
@@ -266,11 +268,16 @@
                 var maxAttributesCount = Engine.LastCreatedEngine.getCaps().maxVertexAttribs;
                 var manager = (<Mesh>mesh).morphTargetManager;
                 var normal = manager.supportsNormals && defines["NORMAL"];
+                var tangent = manager.supportsTangents && defines["TANGENT"];
                 for (var index = 0; index < influencers; index++) {
                     attribs.push(VertexBuffer.PositionKind + index);
 
                     if (normal) {
                         attribs.push(VertexBuffer.NormalKind + index);
+                    }
+
+                    if (tangent) {
+                        attribs.push(VertexBuffer.TangentKind + index);
                     }
 
                     if (attribs.length > maxAttributesCount) {

--- a/src/Materials/babylon.pbrMaterial.ts
+++ b/src/Materials/babylon.pbrMaterial.ts
@@ -79,6 +79,7 @@
 
         public MORPHTARGETS = false;
         public MORPHTARGETS_NORMAL = false;
+        public MORPHTARGETS_TANGENT = false;
         public NUM_MORPH_INFLUENCERS = 0;
 
         constructor() {
@@ -1033,6 +1034,7 @@
 
                if ((<any>mesh).morphTargetManager) {
                     var manager = (<Mesh>mesh).morphTargetManager;
+                    this._defines.MORPHTARGETS_TANGENT = manager.supportsTangents && this._defines.TANGENT;
                     this._defines.MORPHTARGETS_NORMAL = manager.supportsNormals && this._defines.NORMAL;
                     this._defines.MORPHTARGETS = (manager.numInfluencers > 0);
                     this._defines.NUM_MORPH_INFLUENCERS = manager.numInfluencers;

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -61,6 +61,7 @@ module BABYLON {
         public CAMERACOLORCURVES = false;
         public MORPHTARGETS = false;
         public MORPHTARGETS_NORMAL = false;
+        public MORPHTARGETS_TANGENT = false;
         public NUM_MORPH_INFLUENCERS = 0;
 
         constructor() {

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -2021,6 +2021,9 @@
                     if (morphTarget.hasNormals) {
                         this.geometry.setVerticesData(VertexBuffer.NormalKind + index, morphTarget.getNormals(), false, 3);
                     }
+                    if (morphTarget.hasTangents) {
+                        this.geometry.setVerticesData(VertexBuffer.TangentKind + index, morphTarget.getTangents(), false, 3);
+                    }
                 }
             } else {
                 var index = 0;
@@ -2033,6 +2036,10 @@
                     if (this.geometry.isVerticesDataPresent(VertexBuffer.NormalKind + index))
                     {
                         this.geometry.removeVerticesData(VertexBuffer.NormalKind + index);
+                    }
+                    if (this.geometry.isVerticesDataPresent(VertexBuffer.TangentKind + index))
+                    {
+                        this.geometry.removeVerticesData(VertexBuffer.TangentKind + index);
                     }
                     index++;
                 }    

--- a/src/Morph/babylon.morphTarget.ts
+++ b/src/Morph/babylon.morphTarget.ts
@@ -2,6 +2,7 @@ module BABYLON {
     export class MorphTarget {
         private _positions: Float32Array;
         private _normals: Float32Array;
+        private _tangents: Float32Array;
         private _influence: number;
 
         public onInfluenceChanged = new Observable<boolean>();
@@ -31,6 +32,10 @@ module BABYLON {
             return this._normals !== undefined;
         }
 
+        public get hasTangents(): boolean {
+            return this._tangents !== undefined;
+        }
+
         public setPositions(data: Float32Array | number[]) {
             this._positions = new Float32Array(data);
         }
@@ -47,6 +52,14 @@ module BABYLON {
             return this._normals;
         }
 
+        public setTangents(data: Float32Array | number[]) {
+            this._tangents = new Float32Array(data);
+        }
+
+        public getTangents(): Float32Array {
+            return this._tangents;
+        }
+
         /**
          * Serializes the current target into a Serialization object.  
          * Returns the serialized object.  
@@ -61,6 +74,9 @@ module BABYLON {
             if (this.hasNormals) {
                 serializationObject.normals = Array.prototype.slice.call(this.getNormals());
             }
+            if (this.hasTangents) {
+                serializationObject.tangents = Array.prototype.slice.call(this.getTangents());
+            }
 
             return serializationObject;
         }
@@ -73,6 +89,9 @@ module BABYLON {
 
             if (serializationObject.normals) {
                 result.setNormals(serializationObject.normals);
+            }
+            if (serializationObject.tangents) {
+                result.setTangents(serializationObject.tangents);
             }
 
             return result;
@@ -89,6 +108,9 @@ module BABYLON {
 
             if (mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                 result.setNormals(mesh.getVerticesData(VertexBuffer.NormalKind));
+            }
+            if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
+                result.setTangents(mesh.getVerticesData(VertexBuffer.TangentKind));
             }
 
             return result;

--- a/src/Morph/babylon.morphTargetManager.ts
+++ b/src/Morph/babylon.morphTargetManager.ts
@@ -6,6 +6,7 @@ module BABYLON {
         private _scene: Scene;
         private _influences: Float32Array;
         private _supportsNormals = false;
+        private _supportsTangents = false;
         private _vertexCount = 0;
         private _uniqueId = 0;
 
@@ -31,6 +32,10 @@ module BABYLON {
 
         public get supportsNormals(): boolean {
             return this._supportsNormals;
+        }
+
+        public get supportsTangents(): boolean {
+            return this._supportsTangents;
         }
 
         public get numInfluencers(): number {
@@ -96,12 +101,14 @@ module BABYLON {
             this._activeTargets.reset();
             var tempInfluences = [];
             this._supportsNormals = true;
+            this._supportsTangents = true;
             for (var target of this._targets) {
                 if (target.influence > 0) {
                     this._activeTargets.push(target);
                     tempInfluences.push(target.influence);
 
                     this._supportsNormals = this._supportsNormals && target.hasNormals;
+                    this._supportsTangents = this._supportsTangents && target.hasTangents;
 
                     if (this._vertexCount === 0) {
                         this._vertexCount = target.getPositions().length / 3;

--- a/src/Shaders/ShadersInclude/bumpVertex.fx
+++ b/src/Shaders/ShadersInclude/bumpVertex.fx
@@ -1,8 +1,8 @@
 #if defined(BUMP) || defined(PARALLAX)
 	#if defined(TANGENT) && defined(NORMAL)
-		vec3 normalW = normalize(vec3(finalWorld * vec4(normal, 0.0)));
-		vec3 tangentW = normalize(vec3(finalWorld * vec4(tangent.xyz, 0.0)));
-		vec3 bitangentW = cross(normalW, tangentW) * tangent.w;
+		vec3 normalW = normalize(vec3(finalWorld * vec4(normalUpdated, 0.0)));
+		vec3 tangentW = normalize(vec3(finalWorld * vec4(tangentUpdated.xyz, 0.0)));
+		vec3 bitangentW = cross(normalW, tangentW) * tangentUpdated.w;
 		vTBN = mat3(tangentW, bitangentW, normalW);
 	#endif
 #endif

--- a/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -3,5 +3,10 @@
 	
 	#ifdef MORPHTARGETS_NORMAL
 	normalUpdated += (normal{X} - normal) * morphTargetInfluences[{X}];
-	#endif	
+	#endif
+
+	#ifdef MORPHTARGETS_TANGENT
+	tangentTemp = tangentUpdated.xyz + ((tangent{X} - tangent.xyz) * morphTargetInfluences[{X}]);
+	tangentUpdated = vec4(tangentTemp, tangentUpdated.w);
+	#endif
 #endif

--- a/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -6,7 +6,6 @@
 	#endif
 
 	#ifdef MORPHTARGETS_TANGENT
-	tangentTemp = tangentUpdated.xyz + ((tangent{X} - tangent.xyz) * morphTargetInfluences[{X}]);
-	tangentUpdated = vec4(tangentTemp, tangentUpdated.w);
+	tangentUpdated.xyz += (tangent{X} - tangent.xyz) * morphTargetInfluences[{X}];
 	#endif
 #endif

--- a/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -4,4 +4,8 @@
 	#ifdef MORPHTARGETS_NORMAL
 	attribute vec3 normal{X};
 	#endif
+
+	#ifdef MORPHTARGETS_TANGENT
+	attribute vec3 tangent{X};
+	#endif
 #endif

--- a/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
+++ b/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
@@ -1,7 +1,3 @@
 ﻿#ifdef MORPHTARGETS
 	uniform float morphTargetInfluences[NUM_MORPH_INFLUENCERS];
-
-	#ifdef MORPHTARGETS_TANGENT
-	vec3 tangentTemp;
-	#endif
 #endif

--- a/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
+++ b/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
@@ -1,3 +1,7 @@
 ﻿#ifdef MORPHTARGETS
 	uniform float morphTargetInfluences[NUM_MORPH_INFLUENCERS];
+
+	#ifdef MORPHTARGETS_TANGENT
+	vec3 tangentTemp;
+	#endif
 #endif

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -86,6 +86,9 @@ void main(void) {
 #ifdef NORMAL	
 	vec3 normalUpdated = normal;
 #endif
+#ifdef TANGENT
+	vec4 tangentUpdated = tangent;
+#endif
 
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]
 

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -87,8 +87,11 @@ varying vec3 vDirectionW;
 
 void main(void) {
 	vec3 positionUpdated = position;
-#ifdef NORMAL	
+#ifdef NORMAL
 	vec3 normalUpdated = normal;
+#endif
+#ifdef TANGENT
+    vec4 tangentUpdated = tangent;
 #endif
 
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]


### PR DESCRIPTION
1) Fixes a compiler error in serializers (capitalization of a memeber)
2) Adds support to morph targets to have tangent data