### PR TITLE
StandMaterial._TextureDirtyFlag of 0 was not correctly marking textur…

### DIFF
--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -170,11 +170,11 @@
             return Material._CounterClockWiseSideOrientation;
         }
 
-        private static _TextureDirtyFlag = 0;
-        private static _LightDirtyFlag = 1;
-        private static _FresnelDirtyFlag = 2;
-        private static _AttributesDirtyFlag = 4;
-        private static _MiscDirtyFlag = 8;
+        private static _TextureDirtyFlag = 1;
+        private static _LightDirtyFlag = 2;
+        private static _FresnelDirtyFlag = 4;
+        private static _AttributesDirtyFlag = 8;
+        private static _MiscDirtyFlag = 16;
 
         public static get TextureDirtyFlag(): number {
             return Material._TextureDirtyFlag;


### PR DESCRIPTION
…es as dirty due to bitwise comparison of 0&0 always being false

another fix for this:
http://www.html5gamedevs.com/topic/30655-disabling-reflection-texture-has-no-fps-win/