### PR TITLE
Addition of layerMask to BABYLON.Layer

### DIFF
--- a/src/Layer/babylon.layer.ts
+++ b/src/Layer/babylon.layer.ts
@@ -7,7 +7,8 @@
         public offset = new Vector2(0, 0);
         public alphaBlendingMode = Engine.ALPHA_COMBINE;
         public alphaTest: boolean;
-
+        public layerMask: number = 0x0FFFFFFF;
+        
         private _scene: Scene;
         private _vertexBuffers: { [key: string]: VertexBuffer } = {};
         private _indexBuffer: WebGLBuffer;
@@ -63,7 +64,7 @@
             this.texture = imgUrl ? new Texture(imgUrl, scene, true) : null;
             this.isBackground = isBackground === undefined ? true : isBackground;
             this.color = color === undefined ? new Color4(1, 1, 1, 1) : color;
-
+            
             this._scene = scene || Engine.LastCreatedScene;
             this._scene.layers.push(this);
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -2674,7 +2674,7 @@
                 engine.setDepthBuffer(false);
                 for (layerIndex = 0; layerIndex < this.layers.length; layerIndex++) {
                     layer = this.layers[layerIndex];
-                    if (layer.isBackground) {
+                    if (layer.isBackground && ((layer.layerMask & this.activeCamera.layerMask) !== 0)) {
                         layer.render();
                     }
                 }
@@ -2726,7 +2726,7 @@
                 engine.setDepthBuffer(false);
                 for (layerIndex = 0; layerIndex < this.layers.length; layerIndex++) {
                     layer = this.layers[layerIndex];
-                    if (!layer.isBackground) {
+                    if (!layer.isBackground && ((layer.layerMask & this.activeCamera.layerMask) !== 0)) {
                         layer.render();
                     }
                 }


### PR DESCRIPTION
Added a layerMask property to the BABYLON.Layer class to allow temporary stops of rendering a layer without having to dispose or use other "hacks".

Neat when using multiple layers and having to display each in a different setting / scene level, avoiding constant dispose & (re)-load events.