### PR TITLE
Set measure in px for ideal

### DIFF
--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -768,6 +768,13 @@ module BABYLON.GUI {
         
             this._fontOffset = Control._GetFontOffset(this._font);
         }
+        
+        public measureForIdeal() {
+            this._measure();
+            
+            this.width = this._currentMeasure.width + 'px';
+			this.height = this._currentMeasure.height + 'px';
+        }
 
         // Statics
         private static _HORIZONTAL_ALIGNMENT_LEFT = 0;


### PR DESCRIPTION
It doesn't cover TextBlock and I'm not sure if it's best practice, but it worked for me when measuring containers. I need to dive a little deeper and see how I make it work with all controls.