### PR TITLE
Add canDirectLoad to glTFLoader

### DIFF
--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -45,6 +45,10 @@ module BABYLON {
             return loader.loadAsync(scene, loaderData, rootUrl, onSuccess, onError);
         }
 
+        public canDirectLoad(data: string): boolean {
+            return ((data.indexOf("scene") !== -1) && (data.indexOf("node") !== -1));
+        }
+
         private static _parse(data: string | ArrayBuffer): IGLTFLoaderData {
             if (data instanceof ArrayBuffer) {
                 return GLTFFileLoader._parseBinary(data);

--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -168,7 +168,7 @@
             var manifestChecked = success => {
                 scene.database = database;
 
-                var registeredPlugin = directLoad ? SceneLoader._getPluginForDirectLoad(sceneFilename) : SceneLoader._getPluginForFilename(sceneFilename);
+                var registeredPlugin = directLoad ? SceneLoader._getPluginForDirectLoad(directLoad) : SceneLoader._getPluginForFilename(sceneFilename);
                 var plugin = registeredPlugin.plugin;
                 var useArrayBuffer = registeredPlugin.isBinary;
 


### PR DESCRIPTION
Adds `canDirectLoad` to glTFLoader per the [recent change](https://github.com/BabylonJS/Babylon.js/issues/2239) to `ISceneLoaderPlugin` and `ISceneLoaderPluginAsync` so that plugins can determine if they support file content being loaded with the `data:` protocol.

Additionally fixes a bug in the [commit that resolved that issue](https://github.com/BabylonJS/Babylon.js/commit/a458241d78f10f65cf65fa6466ac06e54a28bd7f) that was passing the full protocol (including the `data:`) to the method instead of just the file content.