### PR TITLE
created RenderableGroupData.resetPrimDirtyList and reset the prim dir…

### DIFF
--- a/canvas2D/src/Engine/babylon.group2d.ts
+++ b/canvas2D/src/Engine/babylon.group2d.ts
@@ -558,7 +558,7 @@
                     }
                 }
 
-                this._renderableData._primDirtyList.length = 0;
+                this._renderableData.resetPrimDirtyList();
                 
                 // Restore saved states
                 engine.setAlphaTesting(curAlphaTest);
@@ -1135,6 +1135,19 @@
         transparentPrimitiveZChanged(tpi: TransparentPrimitiveInfo) {
             this._transparentListChanged = true;
             //this.updateSmallestZChangedPrim(tpi);
+        }
+
+        resetPrimDirtyList(){
+            let dirtyList = this._primDirtyList;
+            let numDirty = dirtyList.length;
+
+            for(let i = 0; i < numDirty; i++){
+                if(dirtyList[i]._isFlagSet(SmartPropertyPrim.flagPrimInDirtyList)){
+                    dirtyList[i]._resetPropertiesDirty();
+                }
+            }
+            
+            dirtyList.length = 0;
         }
 
         _primDirtyList: Array<Prim2DBase>;


### PR DESCRIPTION
…ty flags before removing from the list.

This fixes sprites from not displaying until the screen is resized.
http://www.babylonjs-playground.com/#22PLQU#2