### PR TITLE
fix for ArcRotateCamera not detecting out of sync when target moves

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -267,7 +267,7 @@ module BABYLON {
             if (!super._isSynchronizedViewMatrix())
                 return false;
 
-            return this._cache._target.equals(this._target)
+            return this._cache._target.equals(this._getTargetPosition())
                 && this._cache.alpha === this.alpha
                 && this._cache.beta === this.beta
                 && this._cache.radius === this.radius


### PR DESCRIPTION
fix for this:
http://www.html5gamedevs.com/topic/31106-arcrotatecamera-target-animation-after-tab-switch/#comment-178547

and this:
http://www.html5gamedevs.com/topic/30760-mesh-as-camera-target/