### PR TITLE
More skinning fixes

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
@@ -218,7 +218,9 @@ module BABYLON.GLTF2 {
 
         // Runtime values
         index?: number;
-        babylonNode?: Node;
+        babylonMesh?: Mesh;
+        babylonSkinToBones?: { [skin: number]: Bone };
+        babylonAnimationTargets?: Node[];
     }
 
     export interface IGLTFSampler extends IGLTFChildRootProperty {
@@ -238,6 +240,7 @@ module BABYLON.GLTF2 {
         joints: number[];
 
         // Runtime values
+        index?: number;
         babylonSkeleton?: Skeleton;
     }
 


### PR DESCRIPTION
Bones are now created for nodes in the hierarchy even when they are not in the glTF skin's joints list so that the hierarchy is complete. Also, multiple animations are now created when skin targets the same node.