### PR TITLE
Update babylon.abstractMesh.ts

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -792,30 +792,26 @@
          * Returns the AbstractMesh.
          * Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
          */
-        public rotateAround(point: BABYLON.Vector3, axis: BABYLON.Vector3, amount: number): BABYLON.AbstractMesh {
+        public rotateAround(point: Vector3, axis: Vector3, amount: number): AbstractMesh {
             axis.normalize();
             if (!this.rotationQuaternion) {
-                this.rotationQuaternion = BABYLON.Quaternion.RotationYawPitchRoll(this.rotation.y, this.rotation.x, this.rotation.z);
-                this.rotation = BABYLON.Vector3.Zero();
+                this.rotationQuaternion = Quaternion.RotationYawPitchRoll(this.rotation.y, this.rotation.x, this.rotation.z);
+                this.rotation.copyFromFloats(0, 0, 0);
             }
-            let translation: BABYLON.Vector3 = point.subtract(this.getAbsolutePosition());
-            let mTranslate: BABYLON.Matrix = BABYLON.Matrix.Translation(translation.x, translation.y, translation.z);
-            let mTranslateInvert: BABYLON.Matrix = mTranslate.clone();
-            mTranslateInvert.invert();
-            let mRotation: BABYLON.Matrix = BABYLON.Matrix.RotationAxis(axis, amount);
-            let transform: BABYLON.Matrix = mTranslateInvert.multiply(mRotation).multiply(mTranslate);
+            point.subtractToRef(this.position, Tmp.Vector3[0]);
+            Matrix.TranslationToRef(Tmp.Vector3[0].x, Tmp.Vector3[0].y, Tmp.Vector3[0].z, Tmp.Matrix[0]);
+            Tmp.Matrix[0].invertToRef(Tmp.Matrix[2]);
+            Matrix.RotationAxisToRef(axis, amount, Tmp.Matrix[1]);
+            Tmp.Matrix[2].multiplyToRef(Tmp.Matrix[1], Tmp.Matrix[2]);
+            Tmp.Matrix[2].multiplyToRef(Tmp.Matrix[0], Tmp.Matrix[2]);
 
-            let t = BABYLON.Vector3.Zero();
-            let r = BABYLON.Quaternion.Identity();
-            let s = BABYLON.Vector3.One();
+            Tmp.Matrix[2].decompose(Tmp.Vector3[0], Tmp.Quaternion[0], Tmp.Vector3[1]);
 
-            transform.decompose(s, r, t);
-
-            this.position.addInPlace(t);
-            this.rotationQuaternion.multiplyInPlace(r);
+            this.position.addInPlace(Tmp.Vector3[1]);
+            this.rotationQuaternion.multiplyInPlace(Tmp.Quaternion[0]);
 
             return this;
-         }
+        }
         
         /**
          * Translates the mesh along the axis vector for the passed distance in the given space.  

--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -784,7 +784,39 @@
             }
             return this;
         }
+        
+        /**
+         * Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in world space.  
+         * Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.  
+         * The passed axis is also normalized.  
+         * Returns the AbstractMesh.
+         * Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
+         */
+        public rotateAround(point: BABYLON.Vector3, axis: BABYLON.Vector3, amount: number): BABYLON.AbstractMesh {
+            axis.normalize();
+            if (!this.rotationQuaternion) {
+                this.rotationQuaternion = BABYLON.Quaternion.RotationYawPitchRoll(this.rotation.y, this.rotation.x, this.rotation.z);
+                this.rotation = BABYLON.Vector3.Zero();
+            }
+            let translation: BABYLON.Vector3 = point.subtract(this.getAbsolutePosition());
+            let mTranslate: BABYLON.Matrix = BABYLON.Matrix.Translation(translation.x, translation.y, translation.z);
+            let mTranslateInvert: BABYLON.Matrix = mTranslate.clone();
+            mTranslateInvert.invert();
+            let mRotation: BABYLON.Matrix = BABYLON.Matrix.RotationAxis(axis, amount);
+            let transform: BABYLON.Matrix = mTranslateInvert.multiply(mRotation).multiply(mTranslate);
 
+            let t = BABYLON.Vector3.Zero();
+            let r = BABYLON.Quaternion.Identity();
+            let s = BABYLON.Vector3.One();
+
+            transform.decompose(s, r, t);
+
+            this.position.addInPlace(t);
+            this.rotationQuaternion.multiplyInPlace(r);
+
+            return this;
+         }
+        
         /**
          * Translates the mesh along the axis vector for the passed distance in the given space.  
          * space (default LOCAL) can be either BABYLON.Space.LOCAL, either BABYLON.Space.WORLD.


### PR DESCRIPTION
Add method "RotateAround", to rotate a mesh around a given point and axis.

We implemented it because it suited our needs, but it might be useful to others.

Not sure the way we compose translation and rotation matrices to then extract their components is the best way to go, but as far as I know their is no "apply transform matrix to mesh" method already implemented. Or is there ?