### PR TITLE
Loader updates

### DIFF
--- a/loaders/src/OBJ/babylon.objFileLoader.ts
+++ b/loaders/src/OBJ/babylon.objFileLoader.ts
@@ -867,6 +867,9 @@ module BABYLON {
         }
 
     }
-    //Add this loader into the register plugin
-    BABYLON.SceneLoader.RegisterPlugin(new OBJFileLoader());
+
+    if (BABYLON.SceneLoader) {
+        //Add this loader into the register plugin
+        BABYLON.SceneLoader.RegisterPlugin(new OBJFileLoader());
+    }
 }

--- a/loaders/src/STL/babylon.stlFileLoader.ts
+++ b/loaders/src/STL/babylon.stlFileLoader.ts
@@ -191,5 +191,7 @@ module BABYLON {
         }
     }
 
-    BABYLON.SceneLoader.RegisterPlugin(new STLFileLoader());
+    if (BABYLON.SceneLoader) {
+        BABYLON.SceneLoader.RegisterPlugin(new STLFileLoader());
+    }
 }

--- a/loaders/src/glTF/1.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/1.0/babylon.glTFLoader.ts
@@ -1731,5 +1731,5 @@ module BABYLON.GLTF1 {
         }
     };
 
-    BABYLON.GLTFFileLoader.GLTFLoaderV1 = new GLTFLoader();
+    BABYLON.GLTFFileLoader.CreateGLTFLoaderV1 = () => new GLTFLoader();
 }

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -26,23 +26,27 @@ module BABYLON.GLTF2.Extensions {
 
             loader.createPbrMaterial(material);
             loader.loadMaterialBaseProperties(material);
+            this._loadSpecularGlossinessProperties(loader, material, properties);
+            assign(material.babylonMaterial);
+            return true;
+        }
 
-            material.babylonMaterial.albedoColor = properties.diffuseFactor ? Color3.FromArray(properties.diffuseFactor) : new Color3(1, 1, 1);
-            material.babylonMaterial.reflectivityColor = properties.specularFactor ? Color3.FromArray(properties.specularFactor) : new Color3(1, 1, 1);
-            material.babylonMaterial.microSurface = properties.glossinessFactor === undefined ? 1 : properties.glossinessFactor;
+        private _loadSpecularGlossinessProperties(loader: GLTFLoader, material: IGLTFMaterial, properties: IKHRMaterialsPbrSpecularGlossiness): void {
+            var babylonMaterial = material.babylonMaterial as PBRMaterial;
+
+            babylonMaterial.albedoColor = properties.diffuseFactor ? Color3.FromArray(properties.diffuseFactor) : new Color3(1, 1, 1);
+            babylonMaterial.reflectivityColor = properties.specularFactor ? Color3.FromArray(properties.specularFactor) : new Color3(1, 1, 1);
+            babylonMaterial.microSurface = properties.glossinessFactor === undefined ? 1 : properties.glossinessFactor;
 
             if (properties.diffuseTexture) {
-                material.babylonMaterial.albedoTexture = loader.loadTexture(properties.diffuseTexture);
+                babylonMaterial.albedoTexture = loader.loadTexture(properties.diffuseTexture);
                 loader.loadMaterialAlphaProperties(material);
             }
 
             if (properties.specularGlossinessTexture) {
-                material.babylonMaterial.reflectivityTexture = loader.loadTexture(properties.specularGlossinessTexture);
-                material.babylonMaterial.useMicroSurfaceFromReflectivityMapAlpha = true;
+                babylonMaterial.reflectivityTexture = loader.loadTexture(properties.specularGlossinessTexture);
+                babylonMaterial.useMicroSurfaceFromReflectivityMapAlpha = true;
             }
-
-            assign(material.babylonMaterial);
-            return true;
         }
     }
 

--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -811,29 +811,31 @@ module BABYLON.GLTF2 {
         }
 
         private _loadMaterialMetallicRoughnessProperties(material: IGLTFMaterial): void {
+            var babylonMaterial = material.babylonMaterial as PBRMaterial;
+
             // Ensure metallic workflow
-            material.babylonMaterial.metallic = 1;
-            material.babylonMaterial.roughness = 1;
+            babylonMaterial.metallic = 1;
+            babylonMaterial.roughness = 1;
 
             var properties = material.pbrMetallicRoughness;
             if (!properties) {
                 return;
             }
 
-            material.babylonMaterial.albedoColor = properties.baseColorFactor ? Color3.FromArray(properties.baseColorFactor) : new Color3(1, 1, 1);
-            material.babylonMaterial.metallic = properties.metallicFactor === undefined ? 1 : properties.metallicFactor;
-            material.babylonMaterial.roughness = properties.roughnessFactor === undefined ? 1 : properties.roughnessFactor;
+            babylonMaterial.albedoColor = properties.baseColorFactor ? Color3.FromArray(properties.baseColorFactor) : new Color3(1, 1, 1);
+            babylonMaterial.metallic = properties.metallicFactor === undefined ? 1 : properties.metallicFactor;
+            babylonMaterial.roughness = properties.roughnessFactor === undefined ? 1 : properties.roughnessFactor;
 
             if (properties.baseColorTexture) {
-                material.babylonMaterial.albedoTexture = this.loadTexture(properties.baseColorTexture);
+                babylonMaterial.albedoTexture = this.loadTexture(properties.baseColorTexture);
                 this.loadMaterialAlphaProperties(material);
             }
 
             if (properties.metallicRoughnessTexture) {
-                material.babylonMaterial.metallicTexture = this.loadTexture(properties.metallicRoughnessTexture);
-                material.babylonMaterial.useMetallnessFromMetallicTextureBlue = true;
-                material.babylonMaterial.useRoughnessFromMetallicTextureGreen = true;
-                material.babylonMaterial.useRoughnessFromMetallicTextureAlpha = false;
+                babylonMaterial.metallicTexture = this.loadTexture(properties.metallicRoughnessTexture);
+                babylonMaterial.useMetallnessFromMetallicTextureBlue = true;
+                babylonMaterial.useRoughnessFromMetallicTextureGreen = true;
+                babylonMaterial.useRoughnessFromMetallicTextureAlpha = false;
             }
         }
 
@@ -857,52 +859,57 @@ module BABYLON.GLTF2 {
         }
 
         public createPbrMaterial(material: IGLTFMaterial): void {
-            material.babylonMaterial = new PBRMaterial(material.name || "mat" + material.index, this._babylonScene);
-            material.babylonMaterial.sideOrientation = Material.CounterClockWiseSideOrientation;
-            material.babylonMaterial.useScalarInLinearSpace = true;
+            var babylonMaterial = new PBRMaterial(material.name || "mat" + material.index, this._babylonScene);
+            babylonMaterial.sideOrientation = Material.CounterClockWiseSideOrientation;
+            babylonMaterial.useScalarInLinearSpace = true;
+            material.babylonMaterial = babylonMaterial;
         }
 
         public loadMaterialBaseProperties(material: IGLTFMaterial): void {
-            material.babylonMaterial.useEmissiveAsIllumination = (material.emissiveFactor || material.emissiveTexture) ? true : false;
-            material.babylonMaterial.emissiveColor = material.emissiveFactor ? Color3.FromArray(material.emissiveFactor) : new Color3(0, 0, 0);
+            var babylonMaterial = material.babylonMaterial as PBRMaterial;
+
+            babylonMaterial.useEmissiveAsIllumination = (material.emissiveFactor || material.emissiveTexture) ? true : false;
+            babylonMaterial.emissiveColor = material.emissiveFactor ? Color3.FromArray(material.emissiveFactor) : new Color3(0, 0, 0);
             if (material.doubleSided) {
-                material.babylonMaterial.backFaceCulling = false;
-                material.babylonMaterial.twoSidedLighting = true;
+                babylonMaterial.backFaceCulling = false;
+                babylonMaterial.twoSidedLighting = true;
             }
 
             if (material.normalTexture) {
-                material.babylonMaterial.bumpTexture = this.loadTexture(material.normalTexture);
+                babylonMaterial.bumpTexture = this.loadTexture(material.normalTexture);
                 if (material.normalTexture.scale !== undefined) {
-                    material.babylonMaterial.bumpTexture.level = material.normalTexture.scale;
+                    babylonMaterial.bumpTexture.level = material.normalTexture.scale;
                 }
             }
 
             if (material.occlusionTexture) {
-                material.babylonMaterial.ambientTexture = this.loadTexture(material.occlusionTexture);
-                material.babylonMaterial.useAmbientInGrayScale = true;
+                babylonMaterial.ambientTexture = this.loadTexture(material.occlusionTexture);
+                babylonMaterial.useAmbientInGrayScale = true;
                 if (material.occlusionTexture.strength !== undefined) {
-                    material.babylonMaterial.ambientTextureStrength = material.occlusionTexture.strength;
+                    babylonMaterial.ambientTextureStrength = material.occlusionTexture.strength;
                 }
             }
 
             if (material.emissiveTexture) {
-                material.babylonMaterial.emissiveTexture = this.loadTexture(material.emissiveTexture);
+                babylonMaterial.emissiveTexture = this.loadTexture(material.emissiveTexture);
             }
         }
 
         public loadMaterialAlphaProperties(material: IGLTFMaterial): void {
+            var babylonMaterial = material.babylonMaterial as PBRMaterial;
+
             var alphaMode = material.alphaMode || "OPAQUE";
             switch (alphaMode) {
                 case "OPAQUE":
                     // default is opaque
                     break;
                 case "MASK":
-                    material.babylonMaterial.albedoTexture.hasAlpha = true;
-                    material.babylonMaterial.useAlphaFromAlbedoTexture = false;
+                    babylonMaterial.albedoTexture.hasAlpha = true;
+                    babylonMaterial.useAlphaFromAlbedoTexture = false;
                     break;
                 case "BLEND":
-                    material.babylonMaterial.albedoTexture.hasAlpha = true;
-                    material.babylonMaterial.useAlphaFromAlbedoTexture = true;
+                    babylonMaterial.albedoTexture.hasAlpha = true;
+                    babylonMaterial.useAlphaFromAlbedoTexture = true;
                     break;
                 default:
                     Tools.Warn("Invalid alpha mode '" + material.alphaMode + "'");

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
@@ -185,7 +185,7 @@ module BABYLON.GLTF2 {
 
         // Runtime values
         index?: number;
-        babylonMaterial?: PBRMaterial;
+        babylonMaterial?: Material;
     }
 
     export interface IGLTFMeshPrimitive extends IGLTFProperty {


### PR DESCRIPTION
- OBJ, STL, glTF loaders now can stand alone without requiring SceneLoader.
- glTF loader now caches Material instead of PBRMaterial and has additional callback for material, texture, and completion.