### PR TITLE
Restore current frame after append_range() operations

### DIFF
--- a/Exporters/Blender/src/babylon-js/f_curve_animatable.py
+++ b/Exporters/Blender/src/babylon-js/f_curve_animatable.py
@@ -33,6 +33,7 @@ class FCurveAnimatable:
             frameOffset = 0
 
             currentAction = object.animation_data.action
+            currentFrame = bpy.context.scene.frame_current
             for action in bpy.data.actions:
                 # get the range / assigning the action to the object
                 animationRange = AnimationRange.actionPrep(object, action, False, frameOffset)
@@ -54,6 +55,7 @@ class FCurveAnimatable:
                     frameOffset = animationRange.frame_end
 
             object.animation_data.action = currentAction
+            bpy.context.scene.frame_set(currentFrame)
             #Set Animations
             self.animations = []
             if supportsRotation and len(rotAnimation.frames) > 0:


### PR DESCRIPTION
Save and restore current frame after all append_range() operations
have been completed.