### PR TITLE
Fixed matrix decomposition with negative scaling

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -3283,13 +3283,13 @@
             translation.y = this.m[13];
             translation.z = this.m[14];
 
-            var xs = MathTools.Sign(this.m[0] * this.m[1] * this.m[2] * this.m[3]) < 0 ? -1 : 1;
-            var ys = MathTools.Sign(this.m[4] * this.m[5] * this.m[6] * this.m[7]) < 0 ? -1 : 1;
-            var zs = MathTools.Sign(this.m[8] * this.m[9] * this.m[10] * this.m[11]) < 0 ? -1 : 1;
+            scale.x = Math.sqrt(this.m[0] * this.m[0] + this.m[1] * this.m[1] + this.m[2] * this.m[2]);
+            scale.y = Math.sqrt(this.m[4] * this.m[4] + this.m[5] * this.m[5] + this.m[6] * this.m[6]);
+            scale.z = Math.sqrt(this.m[8] * this.m[8] + this.m[9] * this.m[9] + this.m[10] * this.m[10]);
 
-            scale.x = xs * Math.sqrt(this.m[0] * this.m[0] + this.m[1] * this.m[1] + this.m[2] * this.m[2]);
-            scale.y = ys * Math.sqrt(this.m[4] * this.m[4] + this.m[5] * this.m[5] + this.m[6] * this.m[6]);
-            scale.z = zs * Math.sqrt(this.m[8] * this.m[8] + this.m[9] * this.m[9] + this.m[10] * this.m[10]);
+            if (this.determinant() <= 0) {
+                scale.y *= -1;
+            }
 
             if (scale.x === 0 || scale.y === 0 || scale.z === 0) {
                 rotation.x = 0;


### PR DESCRIPTION
This intends to fix an issue encountered when using `Matrix.decompose()`:
- http://www.html5gamedevs.com/topic/25222-decomposing-negative-scaling-matrices/

Fact is decomposing a matrix that invert one axis (scaling) gave wrong results.

The following fix, checking the matrix determinant, is based on this post (vagran_zulu last comment):
- http://answers.unity3d.com/questions/402280/how-to-decompose-a-trs-matrix.html