### PR TITLE
Fix hierarchy issue for mesh inspector

### DIFF
--- a/inspector/src/tabs/MeshTab.ts
+++ b/inspector/src/tabs/MeshTab.ts
@@ -16,9 +16,9 @@ module INSPECTOR{
             let createNode = (obj : BABYLON.AbstractMesh) => {
                 let descendants = obj.getDescendants(true);
 
+                let node = new TreeItem(this, new MeshAdapter(obj));
+
                 if (descendants.length > 0) {
-                    let node = new TreeItem(this, new MeshAdapter(obj));
-                    alreadyIn.push(obj);
                     for (let child of descendants) {     
                         if (child instanceof BABYLON.AbstractMesh) {
                             if (!Helpers.IsSystemName(child.name)) {  
@@ -28,11 +28,25 @@ module INSPECTOR{
                         }
                     }
                     node.update();
-                    return node;
-                } else {
-                    alreadyIn.push(obj);
-                    return new TreeItem(this, new MeshAdapter(obj));
+                } 
+
+                // Retrieve the root node if the mesh is actually child of another mesh
+                // This can hapen if the child mesh has been created before the parent mesh
+                if(obj.parent != null && alreadyIn.indexOf(obj) != -1){
+                    let i: number = 0;
+                    let notFound: boolean = true;
+                    // Find and delete the root node standing for this mesh
+                    while(i < arr.length && notFound){
+                        if(obj.name === arr[i].id){
+                             arr.splice(i, 1);
+                             notFound = false;
+                        }
+                        i++;
+                    }
                 }
+
+                alreadyIn.push(obj);                
+                return node;
             };
             
             // get all meshes from the first scene

--- a/inspector/src/tabs/PropertyTab.ts
+++ b/inspector/src/tabs/PropertyTab.ts
@@ -121,9 +121,31 @@ module INSPECTOR{
         /** Returns the treeitem corersponding to the given obj, null if not found */
         public getItemFor(_obj:any) : TreeItem{
             let obj = _obj as BABYLON.AbstractMesh;
+            
+            // Search recursively
+            let searchObjectInTree = (object: any, treeItem: TreeItem): TreeItem =>  {
+                if(treeItem.correspondsTo(object)) {
+                    return treeItem;
+                }
+                else{
+                    if(treeItem.children.length > 0){
+                        for (let item of treeItem.children) {
+                            let it = searchObjectInTree(obj, item);
+                            if (it) {
+                                return it;
+                            }
+                        }
+                    }
+                    else{
+                        return null;
+                    }
+                } 
+            }
+
             for (let item of this._treeItems) {
-                if (item.correspondsTo(obj)) {
-                    return item;
+                let it = searchObjectInTree(obj, item);
+                if (it) {
+                    return it;
                 }
             }
             return null;

--- a/inspector/src/tools/PickTool.ts
+++ b/inspector/src/tools/PickTool.ts
@@ -38,7 +38,6 @@ module INSPECTOR {
             let pi = this._inspector.scene.pick(pos.x, pos.y, (mesh:BABYLON.AbstractMesh) => {return true});
             
             if (pi.pickedMesh) {
-                console.log(pi.pickedMesh.name);
                 this._inspector.displayObjectDetails(pi.pickedMesh);
             }
             this._deactivate();

--- a/inspector/test/index.js
+++ b/inspector/test/index.js
@@ -236,6 +236,18 @@ var Test = (function () {
             sphere7.position.x = 40;
         });
 
+        var sphere_1 = BABYLON.Mesh.CreateSphere("_sphere_1", 16, 2, scene);
+
+        var assets_mesh = new BABYLON.AbstractMesh("assets_mesh", scene);
+        var sphere_2 = BABYLON.Mesh.CreateSphere("sphere_2", 3, 2, scene);
+        var sphere_3 = BABYLON.Mesh.CreateSphere("sphere_3", 2, 2, scene);
+        var scene_mesh = new BABYLON.AbstractMesh;
+        scene_mesh.name="scene_mesh";
+    
+        sphere_1.parent = assets_mesh;
+        sphere_2.parent = assets_mesh;
+        sphere_3.parent = assets_mesh;
+
 
         // gui
         var advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("UI");

--- a/inspector/test/index.js
+++ b/inspector/test/index.js
@@ -215,7 +215,7 @@ var Test = (function () {
 
         scene.getMeshByName("Box #6").scaling.x = 2;
 
-        //Other meshes
+        //Other meshes, to contrôl mesh hierarchy
         var box1 = BABYLON.MeshBuilder.CreateBox("box1", {size: 1}, scene);
 
         var box2 = BABYLON.MeshBuilder.CreateBox("box2", {size: 1}, scene);
@@ -239,14 +239,25 @@ var Test = (function () {
         var sphere_1 = BABYLON.Mesh.CreateSphere("_sphere_1", 16, 2, scene);
 
         var assets_mesh = new BABYLON.AbstractMesh("assets_mesh", scene);
-        var sphere_2 = BABYLON.Mesh.CreateSphere("sphere_2", 3, 2, scene);
-        var sphere_3 = BABYLON.Mesh.CreateSphere("sphere_3", 2, 2, scene);
+        var sphere_2 = BABYLON.Mesh.CreateSphere("_sphere_2", 3, 2, scene);
+        var sphere_3 = BABYLON.Mesh.CreateSphere("_sphere_3", 2, 2, scene);
         var scene_mesh = new BABYLON.AbstractMesh;
         scene_mesh.name="scene_mesh";
     
         sphere_1.parent = assets_mesh;
         sphere_2.parent = assets_mesh;
         sphere_3.parent = assets_mesh;
+
+        for (var i=0; i<10 ; i++){
+            var inst = sphere_1.clone("C_" + i + "clone");
+            inst.isVisible = true;
+            inst.setEnabled = true;
+            inst.parent = scene_mesh;
+            inst.position.x = i*2;
+            inst.refreshBoundingInfo();
+            inst.computeWorldMatrix();
+        }
+
 
 
         // gui


### PR DESCRIPTION
Fix hierarchy issue for mesh inspector: prevent meshes names from being displayed twice if the child mesh has been created before the parent mesh.
Search mesh recursively when picked with the inspector; enables to get rid of errors if the picked mesh is child of another.