### PR TITLE
Enables to display all render target texture properly in inspector

### DIFF
--- a/inspector/src/tabs/TextureTab.ts
+++ b/inspector/src/tabs/TextureTab.ts
@@ -95,58 +95,51 @@ module INSPECTOR {
             }
             else if (texture instanceof BABYLON.RenderTargetTexture) {
                 // RenderTarget textures
-                if(texture.activeCamera){
-                    BABYLON.Tools.CreateScreenshotUsingRenderTarget(this._inspector.scene.getEngine(), texture.activeCamera, { precision: 1 }, (data) => img.src = data);
-                }
-                else{
-                    let scene = this._inspector.scene;
-                    let engine = scene.getEngine();
-                    let size = texture.getSize();
+                let scene = this._inspector.scene;
+                let engine = scene.getEngine();
+                let size = texture.getSize();
                     
-                    // Clone the texture
-                    let screenShotTexture = texture.clone();
-                    screenShotTexture.activeCamera = texture.activeCamera;
-                    screenShotTexture.onBeforeRender = texture.onBeforeRender;
-                    screenShotTexture.onAfterRender = texture.onAfterRender;
-                    screenShotTexture.onBeforeRenderObservable = texture.onBeforeRenderObservable;
-                    screenShotTexture.onAfterUnbindObservable = texture.onAfterUnbindObservable;
+                // Clone the texture
+                let screenShotTexture = texture.clone();
+                screenShotTexture.activeCamera = texture.activeCamera;
+                screenShotTexture.onBeforeRender = texture.onBeforeRender;
+                screenShotTexture.onAfterRender = texture.onAfterRender;
+                screenShotTexture.onBeforeRenderObservable = texture.onBeforeRenderObservable;
+                
+                // To display the texture after rendering
+                screenShotTexture.onAfterRenderObservable.add((faceIndex: number) => {
+                    let targetImg: HTMLImageElement;
+                    switch(faceIndex){
+                        case 0:
+                            targetImg = img;
+                            break;
+                        case 1:
+                            targetImg = img1;
+                            break;
+                        case 2:
+                            targetImg = img2;
+                            break;
+                        case 3:
+                            targetImg = img3;
+                            break;
+                        case 4:
+                            targetImg = img4;
+                            break;
+                        case 5:
+                            targetImg = img5;
+                            break;
+                        default:
+                            targetImg = img;
+                            break;
+                    }
+                    BABYLON.Tools.DumpFramebuffer(size.width, size.height, engine,  (data) => targetImg.src = data, "image/png");
+                });
 
-                    // To display the texture after rendering
-                    screenShotTexture.onAfterRenderObservable.add((faceIndex: number) => {
-                        let targetImg: HTMLImageElement;
-                        switch(faceIndex){
-                            case 0:
-                                targetImg = img;
-                                break;
-                            case 1:
-                                targetImg = img1;
-                                break;
-                            case 2:
-                                targetImg = img2;
-                                break;
-                            case 3:
-                                targetImg = img3;
-                                break;
-                            case 4:
-                                targetImg = img4;
-                                break;
-                            case 5:
-                                targetImg = img5;
-                                break;
-                            default:
-                                targetImg = img;
-                                break;
-
-                        }
-                        BABYLON.Tools.DumpFramebuffer(size.width, size.height, engine,  (data) => targetImg.src = data, "image/png");
-                    });
-
-                    // Render the texture
-                    scene.incrementRenderId();
-                    scene.resetCachedMaterial();
-                    screenShotTexture.render(true);
-                    screenShotTexture.dispose();
-                }
+                // Render the texture
+                scene.incrementRenderId();
+                scene.resetCachedMaterial();
+                screenShotTexture.render();
+                screenShotTexture.dispose();
             } else if (texture.url) {
                 // If an url is present, the texture is an image
                 img.src = texture.url;

--- a/inspector/test/index.js
+++ b/inspector/test/index.js
@@ -260,9 +260,7 @@ var Test = (function () {
 
         // to test reflection prob texture handling
         var probe = new BABYLON.ReflectionProbe("probe", 512, scene);
-        for(let mesh of scene.meshes){
-            probe.renderList.push(mesh);
-        }
+        probe.renderList.push(sphere1);
 
         // gui
         var advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("UI");


### PR DESCRIPTION
Display six textures in case the render target texture is cube.
Take renderList into account if the render target texture doesn't render all meshes.