### PR TITLE
fixed reflection texture matrix performance issue

### DIFF
--- a/src/Materials/Textures/babylon.texture.ts
+++ b/src/Materials/Textures/babylon.texture.ts
@@ -255,6 +255,10 @@
                 this._projectionModeMatrix = Matrix.Zero();
             }
 
+            this._cachedUOffset = this.uOffset;
+            this._cachedVOffset = this.vOffset;
+            this._cachedUScale = this.uScale;
+            this._cachedVScale = this.vScale;
             this._cachedCoordinatesMode = this.coordinatesMode;
 
             switch (this.coordinatesMode) {


### PR DESCRIPTION
I found a perfomance issue which happens if many materials are using the same reflection texture.
Here a playground example: http://www.babylonjs-playground.com/#3PYAME  (enable line 20)
This PR fixes this problem.