### PR TITLE
Set defaults for texture wrap mode and sampling mode for glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoaderUtils.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderUtils.ts
@@ -36,6 +36,9 @@ module BABYLON.GLTF2 {
         }
 
         public static GetTextureWrapMode(mode: ETextureWrapMode): number {
+            // Set defaults if undefined
+            mode = mode === undefined ? ETextureWrapMode.CLAMP_TO_EDGE : mode;
+
             switch (mode) {
                 case ETextureWrapMode.CLAMP_TO_EDGE: Texture.CLAMP_ADDRESSMODE;
                 case ETextureWrapMode.MIRRORED_REPEAT: return Texture.MIRROR_ADDRESSMODE;
@@ -66,6 +69,10 @@ module BABYLON.GLTF2 {
         }
 
         public static GetTextureSamplingMode(magFilter: ETextureMagFilter, minFilter: ETextureMinFilter): number {
+            // Set defaults if undefined
+            magFilter = magFilter === undefined ? ETextureMagFilter.NEAREST : magFilter;
+            minFilter = minFilter === undefined ? ETextureMinFilter.NEAREST_MIPMAP_NEAREST : minFilter;
+
             if (magFilter === ETextureMagFilter.LINEAR) {
                 switch (minFilter) {
                     case ETextureMinFilter.NEAREST: return Texture.LINEAR_NEAREST;


### PR DESCRIPTION
This removes the Tools.Warn output spew