### PR TITLE
Add better handling of scene loader plugin errors and progress

### DIFF
--- a/loaders/src/glTF/1.0/babylon.glTFBinaryExtension.ts
+++ b/loaders/src/glTF/1.0/babylon.glTFBinaryExtension.ts
@@ -25,7 +25,7 @@ module BABYLON.GLTF1 {
             super("KHR_binary_glTF");
         }
 
-        public loadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: () => void): boolean {
+        public loadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: (message: string) => void): boolean {
             var extensionsUsed = (<any>data.json).extensionsUsed;
             if (!extensionsUsed || extensionsUsed.indexOf(this.name) === -1) {
                 return false;
@@ -36,7 +36,7 @@ module BABYLON.GLTF1 {
             return true;
         }
 
-        public loadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: () => void): boolean {
+        public loadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: (message: string) => void): boolean {
             if (gltfRuntime.extensionsUsed.indexOf(this.name) === -1) {
                 return false;
             }
@@ -49,7 +49,7 @@ module BABYLON.GLTF1 {
             return true;
         }
 
-        public loadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: () => void): boolean {
+        public loadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: (message: string) => void): boolean {
             var texture: IGLTFTexture = gltfRuntime.textures[id];
             var source: IGLTFImage = gltfRuntime.images[texture.source];
             if (!source.extensions || !(this.name in source.extensions)) {
@@ -63,7 +63,7 @@ module BABYLON.GLTF1 {
             return true;
         }
 
-        public loadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderString: string) => void, onError: () => void): boolean {
+        public loadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderString: string) => void, onError: (message: string) => void): boolean {
             var shader: IGLTFShader = gltfRuntime.shaders[id];
             if (!shader.extensions || !(this.name in shader.extensions)) {
                 return false;

--- a/loaders/src/glTF/1.0/babylon.glTFLoaderExtension.ts
+++ b/loaders/src/glTF/1.0/babylon.glTFLoaderExtension.ts
@@ -16,7 +16,7 @@ module BABYLON.GLTF1 {
         * Defines an override for loading the runtime
         * Return true to stop further extensions from loading the runtime
         */
-        public loadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: () => void): boolean {
+        public loadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -24,7 +24,7 @@ module BABYLON.GLTF1 {
          * Defines an onverride for creating gltf runtime
          * Return true to stop further extensions from creating the runtime
          */
-        public loadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: () => void): boolean {
+        public loadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -32,7 +32,7 @@ module BABYLON.GLTF1 {
         * Defines an override for loading buffers
         * Return true to stop further extensions from loading this buffer
         */
-        public loadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: () => void, onProgress?: () => void): boolean {
+        public loadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: (message: string) => void, onProgress?: () => void): boolean {
             return false;
         }
 
@@ -40,7 +40,7 @@ module BABYLON.GLTF1 {
         * Defines an override for loading texture buffers
         * Return true to stop further extensions from loading this texture data
         */
-        public loadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: () => void): boolean {
+        public loadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -48,7 +48,7 @@ module BABYLON.GLTF1 {
         * Defines an override for creating textures
         * Return true to stop further extensions from loading this texture
         */
-        public createTextureAsync(gltfRuntime: IGLTFRuntime, id: string, buffer: ArrayBufferView, onSuccess: (texture: Texture) => void, onError: () => void): boolean {
+        public createTextureAsync(gltfRuntime: IGLTFRuntime, id: string, buffer: ArrayBufferView, onSuccess: (texture: Texture) => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -56,7 +56,7 @@ module BABYLON.GLTF1 {
         * Defines an override for loading shader strings
         * Return true to stop further extensions from loading this shader data
         */
-        public loadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderString: string) => void, onError: () => void): boolean {
+        public loadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderString: string) => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -64,7 +64,7 @@ module BABYLON.GLTF1 {
         * Defines an override for loading materials
         * Return true to stop further extensions from loading this material
         */
-        public loadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: () => void): boolean {
+        public loadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: (message: string) => void): boolean {
             return false;
         }
 
@@ -72,7 +72,7 @@ module BABYLON.GLTF1 {
         // Utilities
         // ---------
 
-        public static LoadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: () => void): void {
+        public static LoadRuntimeAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onSuccess: (gltfRuntime: IGLTFRuntime) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadRuntimeAsync(scene, data, rootUrl, onSuccess, onError);
             }, () => {
@@ -82,7 +82,7 @@ module BABYLON.GLTF1 {
             });
         }
 
-        public static LoadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: () => void): void {
+        public static LoadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadRuntimeExtensionsAsync(gltfRuntime, onSuccess, onError);
             }, () => {
@@ -92,7 +92,7 @@ module BABYLON.GLTF1 {
             });
         }
 
-        public static LoadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (bufferView: ArrayBufferView) => void, onError: () => void, onProgress?: () => void): void {
+        public static LoadBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (bufferView: ArrayBufferView) => void, onError: (message: string) => void, onProgress?: () => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadBufferAsync(gltfRuntime, id, onSuccess, onError, onProgress);
             }, () => {
@@ -100,13 +100,13 @@ module BABYLON.GLTF1 {
             });
         }
 
-        public static LoadTextureAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (texture: Texture) => void, onError: () => void): void {
+        public static LoadTextureAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (texture: Texture) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.LoadTextureBufferAsync(gltfRuntime, id,
                 buffer => GLTFLoaderExtension.CreateTextureAsync(gltfRuntime, id, buffer, onSuccess, onError),
                 onError);
         }
 
-        public static LoadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderData: string) => void, onError: () => void): void {
+        public static LoadShaderStringAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (shaderData: string) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadShaderStringAsync(gltfRuntime, id, onSuccess, onError);
             }, () => {
@@ -114,7 +114,7 @@ module BABYLON.GLTF1 {
             });
         }
 
-        public static LoadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: () => void): void {
+        public static LoadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadMaterialAsync(gltfRuntime, id, onSuccess, onError);
             }, () => {
@@ -122,7 +122,7 @@ module BABYLON.GLTF1 {
             });
         }
 
-        private static LoadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: () => void): void {
+        private static LoadTextureBufferAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (buffer: ArrayBufferView) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.loadTextureBufferAsync(gltfRuntime, id, onSuccess, onError);
             }, () => {
@@ -130,7 +130,7 @@ module BABYLON.GLTF1 {
             });
         }
 
-        private static CreateTextureAsync(gltfRuntime: IGLTFRuntime, id: string, buffer: ArrayBufferView, onSuccess: (texture: Texture) => void, onError: () => void): void {
+        private static CreateTextureAsync(gltfRuntime: IGLTFRuntime, id: string, buffer: ArrayBufferView, onSuccess: (texture: Texture) => void, onError: (message: string) => void): void {
             GLTFLoaderExtension.ApplyExtensions(loaderExtension => {
                 return loaderExtension.createTextureAsync(gltfRuntime, id, buffer, onSuccess, onError);
             }, () => {

--- a/loaders/src/glTF/1.0/babylon.glTFMaterialsCommonExtension.ts
+++ b/loaders/src/glTF/1.0/babylon.glTFMaterialsCommonExtension.ts
@@ -61,7 +61,7 @@ module BABYLON.GLTF1 {
             super("KHR_materials_common");
         }
 
-        public loadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: () => void): boolean {
+        public loadRuntimeExtensionsAsync(gltfRuntime: IGLTFRuntime, onSuccess: () => void, onError: (message: string) => void): boolean {
             if (!gltfRuntime.extensions) return false;
 
             var extension = gltfRuntime.extensions[this.name];
@@ -105,7 +105,7 @@ module BABYLON.GLTF1 {
             return false;
         }
 
-        public loadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: () => void): boolean {
+        public loadMaterialAsync(gltfRuntime: IGLTFRuntime, id: string, onSuccess: (material: Material) => void, onError: (message: string) => void): boolean {
             var material: IGLTFMaterial = gltfRuntime.materials[id];
             if (!material || !material.extensions) return false;
 
@@ -158,7 +158,7 @@ module BABYLON.GLTF1 {
             return true;
         }
 
-        private _loadTexture(gltfRuntime: IGLTFRuntime, id: string, material: StandardMaterial, propertyPath: string, onError: () => void): void {
+        private _loadTexture(gltfRuntime: IGLTFRuntime, id: string, material: StandardMaterial, propertyPath: string, onError: (message: string) => void): void {
             // Create buffer from texture url
             GLTFLoaderBase.LoadTextureBufferAsync(gltfRuntime, id, (buffer) => {
                 // Create texture from buffer

--- a/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -43,13 +43,9 @@ module BABYLON.GLTF2.Extensions {
                     return;
                 }
 
-                // Load the next LOD once the loader has succeeded.
-                loader.executeWhenRenderReady(succeeded => {
-                    if (!succeeded) {
-                        return;
-                    }
-
-                    // Load the next LOD when all of the textures are loaded.
+                // Load the next LOD when the loader is ready to render and
+                // all active material textures of the current LOD are loaded.
+                loader.executeWhenRenderReady(() => {
                     BaseTexture.WhenAllReady(babylonMaterial.getActiveTextures(), () => {
                         this.loadMaterialLOD(loader, material, materialLODs, lod - 1, assign);
                     });

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
@@ -247,7 +247,6 @@ module BABYLON.GLTF2 {
 
         // Runtime values (one per coordinate index)
         babylonTextures?: Texture[];
-        blobURL?: string;
     }
 
     export interface IGLTFTextureInfo {

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderUtils.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderUtils.ts
@@ -46,25 +46,6 @@ module BABYLON.GLTF2 {
             }
         }
 
-        /**
-         * Returns the byte stride giving an accessor
-         * @param accessor: the GLTF accessor objet
-         */
-        public static GetByteStrideFromType(accessor: IGLTFAccessor): number {
-            // Needs this function since "byteStride" isn't requiered in glTF format
-            var type = accessor.type;
-
-            switch (type) {
-                case "VEC2": return 2;
-                case "VEC3": return 3;
-                case "VEC4": return 4;
-                case "MAT2": return 4;
-                case "MAT3": return 9;
-                case "MAT4": return 16;
-                default: return 1;
-            }
-        }
-
         public static GetTextureSamplingMode(magFilter: ETextureMagFilter, minFilter: ETextureMinFilter): number {
             if (magFilter === ETextureMagFilter.LINEAR) {
                 switch (minFilter) {


### PR DESCRIPTION
Before this change, loader plugin error messages and progress are not piped all the way to the scene loader. With this change, the error message and progress are now piped from the loader plugin all the way to the scene loader public functions which already have errors and progress callbacks. The public SceneLoader functions (ImportMesh, Load, Append) now all have a message in the error callback and a progress event in the progress callback.

The SceneLoader public functions ImportMesh and Append are also factored to remove duplication and increase consistency.

Finally, some issues in the glTF loader error handling, especially regarding version checks, are fixed.