### PR TITLE
Fix missing code in glTF loader to load alpha factor

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -903,6 +903,7 @@ module BABYLON.GLTF2 {
             }
 
             babylonMaterial.albedoColor = properties.baseColorFactor ? Color3.FromArray(properties.baseColorFactor) : new Color3(1, 1, 1);
+            babylonMaterial.alpha = properties.baseColorFactor ? properties.baseColorFactor[3] : 1.0;
             babylonMaterial.metallic = properties.metallicFactor === undefined ? 1 : properties.metallicFactor;
             babylonMaterial.roughness = properties.roughnessFactor === undefined ? 1 : properties.roughnessFactor;
 


### PR DESCRIPTION
Fix bug reported here: http://www.html5gamedevs.com/topic/31740-gltf-2-loader-doesnt-handle-alpha-properly-when-only-supplied-as-a-factor/