### PR TITLE
CreatePolygon before applyToMesh dispose of existing polygon and crea…

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1646,15 +1646,15 @@
             var face: number = 0;
             for (var index = 0; index < normals.length; index += 3) { 
                 //Edge Face  no. 1
-                if(Math.abs(normals[index + 1]) == 0) {
+                if(Math.abs(normals[index + 1]) < 0.001) {
                    face = 1; 
                 }
                 //Top Face  no. 0
-                if(normals[index + 1] == 1) {
+                if(Math.abs(normals[index + 1] - 1) < 0.001 ) {
                    face = 0; 
                 }
                 //Bottom Face  no. 2
-                if(normals[index + 1] == -1) {
+                if(Math.abs(normals[index + 1] + 1) < 0.001 ) {
                    face = 2; 
                 }
                 idx = index / 3;

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -817,6 +817,8 @@
 			var polygon = polygonTriangulation.build(options.updatable, depth);
             polygon.sideOrientation = options.sideOrientation;
 			var vertexData = VertexData.CreatePolygon(polygon, options.sideOrientation, options.faceUV, options.faceColors, options.frontUVs, options.backUVs);
+            polygon.dispose();
+            var polygon = new Mesh(name, scene);
             vertexData.applyToMesh(polygon, options.updatable);			
 			
             return polygon;


### PR DESCRIPTION
From the stable version 3.0 BABYLON.Mesh.DOUBLESIDE no longer worked with CreatePolygon. This appears to be because vertexData.applyToMesh no longer changes an existing mesh. Hence the change which deletes the existing mesh polygon and creates a new mesh to apply new vertexData to. Also following Jerome's suggestion the equality checks ==0, ==1, == -1 have been changed to allow for possible floating point errors.