### PR TITLE
Adding twoSidedLighting property in BabylonStandardMaterial.cs

### DIFF
--- a/Exporters/3ds Max/BabylonExport.Entities/BabylonStandardMaterial.cs
+++ b/Exporters/3ds Max/BabylonExport.Entities/BabylonStandardMaterial.cs
@@ -68,6 +68,9 @@ namespace BabylonExport.Entities
         [DataMember]
         public bool linkEmissiveWithDiffuse { get; set; }
 
+        [DataMember]
+        public bool twoSidedLighting { get; set; }
+
         public BabylonStandardMaterial() : base()
         {
             ambient = new[] {1.0f, 1.0f, 1.0f};


### PR DESCRIPTION
Adding missing support for serialization of twoSidedLighting property in
StandardMaterial