### PR TITLE
Fix materialDefines

### DIFF
--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -579,7 +579,7 @@
                     }
 
                     if (!subMesh._materialDefines) {
-                        return;
+                        continue;
                     }
 
                     func(subMesh._materialDefines);

--- a/src/Mesh/babylon.subMesh.ts
+++ b/src/Mesh/babylon.subMesh.ts
@@ -9,6 +9,9 @@
 
         public setEffect(effect: Effect, defines?: MaterialDefines) {
             if (this._materialEffect === effect) {
+                if (!effect) {
+                    this._materialDefines = undefined;
+                }
                 return;
             }
             this._materialDefines = defines;
@@ -100,9 +103,7 @@
 
                 if (this._currentMaterial !== effectiveMaterial) {
                     this._currentMaterial = effectiveMaterial;
-                    if (this._materialDefines) {
-                        this._materialDefines.markAllAsDirty();
-                    }
+                    this._materialDefines = undefined;
                 }
 
                 return effectiveMaterial;


### PR DESCRIPTION
Reset materialDefines if a new Material is assigned to a Mesh and subMeshes._materialEffect is already null.
Reset materialDefines if a new subMaterial is assigned to a subMesh.
When marking subMeshes as dirty, don't return if a subMesh doesn't have defines.