### PR TITLE
Update babylon.d.ts

### DIFF
--- a/dist/babylon.d.ts
+++ b/dist/babylon.d.ts
@@ -9169,7 +9169,7 @@ declare module BABYLON {
          * Clones the mesh, used by the class Mesh.
          * Just returns `null` for an AbstractMesh.
          */
-        clone(name: string, newParent: Node, doNotCloneChildren?: boolean): AbstractMesh;
+        clone(name: string, newParent?: Node, doNotCloneChildren?: boolean): AbstractMesh;
         /**
          * Disposes all the mesh submeshes.
          * Returns the AbstractMesh.


### PR DESCRIPTION
BABYLON.AbstractMesh.clone() method's "newParent: Node" argument made optional to match the documentation. Previously it was required, and the TypeScript compiler enforced a Node type be passed when cloning an AbstractMesh.