### PR TITLE
Render Targets for multi-camera scene

### DIFF
--- a/materialsLibrary/src/water/babylon.waterMaterial.ts
+++ b/materialsLibrary/src/water/babylon.waterMaterial.ts
@@ -466,10 +466,12 @@ module BABYLON {
         private _createRenderTargets(scene: Scene, renderTargetSize: Vector2): void {
             // Render targets
             this._refractionRTT = new RenderTargetTexture(name + "_refraction", { width: renderTargetSize.x, height: renderTargetSize.y }, scene, false, true);
+            this._refractionRTT.sceneLevelRender = false;
             this._refractionRTT.wrapU = BABYLON.Texture.MIRROR_ADDRESSMODE;
             this._refractionRTT.wrapV = BABYLON.Texture.MIRROR_ADDRESSMODE;
 
             this._reflectionRTT = new RenderTargetTexture(name + "_reflection", { width: renderTargetSize.x, height: renderTargetSize.y }, scene, false, true);
+            this._reflectionRTT.sceneLevelRender = false;
             this._reflectionRTT.wrapU = BABYLON.Texture.MIRROR_ADDRESSMODE;
             this._reflectionRTT.wrapV = BABYLON.Texture.MIRROR_ADDRESSMODE;
 
@@ -616,7 +618,7 @@ module BABYLON {
 
         public getClassName(): string {
             return "WaterMaterial";
-        }        
+        }
 
         // Statics
         public static Parse(source: any, scene: Scene, rootUrl: string): WaterMaterial {

--- a/src/Materials/Textures/babylon.mirrorTexture.ts
+++ b/src/Materials/Textures/babylon.mirrorTexture.ts
@@ -30,7 +30,7 @@ module BABYLON {
         public set blurKernel(value: number) {
             this.blurKernelX = value;
             this.blurKernelY = value;
-        }        
+        }
 
         public set blurKernelX(value: number) {
             if (this._blurKernelX === value) {
@@ -43,7 +43,7 @@ module BABYLON {
 
         public get blurKernelX(): number {
             return this._blurKernelX;
-        }        
+        }
 
         public set blurKernelY(value: number) {
             if (this._blurKernelY === value) {
@@ -56,11 +56,11 @@ module BABYLON {
 
         public get blurKernelY(): number {
             return this._blurKernelY;
-        }             
+        }
 
         constructor(name: string, size: any, scene: Scene, generateMipMaps?: boolean, type: number = Engine.TEXTURETYPE_UNSIGNED_INT, samplingMode = Texture.BILINEAR_SAMPLINGMODE, generateDepthBuffer = true) {
             super(name, size, scene, generateMipMaps, true, type, false, samplingMode, generateDepthBuffer);
-
+            this.sceneLevelRender = false;
             this.onBeforeRenderObservable.add(() => {
                 Matrix.ReflectionToRef(this.mirrorPlane, this._mirrorMatrix);
                 this._savedViewMatrix = scene.getViewMatrix();
@@ -83,7 +83,7 @@ module BABYLON {
 
                 delete scene.clipPlane;
             });
-        }     
+        }
 
         private _preparePostProcesses(): void {
             this.clearPostProcesses(true);
@@ -107,9 +107,9 @@ module BABYLON {
                 this._blurY.alwaysForcePOT = this._blurRatio !== 1;
 
                 this.addPostProcess(this._blurX);
-                this.addPostProcess(this._blurY);   
+                this.addPostProcess(this._blurY);
             }
-        }   
+        }
 
         public clone(): MirrorTexture {
             var textureSize = this.getSize();

--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -334,6 +334,7 @@
                 camera = this.activeCamera;
                 engine.setViewport(this.activeCamera.viewport, this._size, this._size);
 
+
                 if (this.activeCamera !== scene.activeCamera) {
                     scene.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix(true));
                 }
@@ -408,7 +409,9 @@
             if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
                 scene.setTransformMatrix(scene.activeCamera.getViewMatrix(), scene.activeCamera.getProjectionMatrix(true));
             }
+
             engine.setViewport(scene.activeCamera.viewport);
+
 
             scene.resetCachedMaterial();
         }
@@ -422,11 +425,7 @@
                 this._postProcessManager._prepareFrame(this._texture, this._postProcesses);
             }
             else if (!useCameraPostProcess || !scene.postProcessManager._prepareFrame(this._texture)) {
-                if (this.isCube) {
-                    engine.bindFramebuffer(this._texture, faceIndex);
-                } else {
-                    engine.bindFramebuffer(this._texture);
-                }
+                engine.bindFramebuffer(this._texture, this.isCube ? faceIndex : undefined, undefined, undefined, !this.sceneLevelRender);
             }
 
             this.onBeforeRenderObservable.notifyObservers(faceIndex);

--- a/src/Materials/Textures/babylon.renderTargetTexture.ts
+++ b/src/Materials/Textures/babylon.renderTargetTexture.ts
@@ -40,7 +40,9 @@
         public activeCamera: Camera;
         public customRenderFunction: (opaqueSubMeshes: SmartArray<SubMesh>, transparentSubMeshes: SmartArray<SubMesh>, alphaTestSubMeshes: SmartArray<SubMesh>, beforeTransparents?: () => void) => void;
         public useCameraPostProcesses: boolean;
-        
+        // should this render target be rendered at scene level or camera level?
+        public sceneLevelRender: boolean;
+
         private _postProcessManager: PostProcessManager;
         private _postProcesses: PostProcess[];
 
@@ -50,7 +52,7 @@
         * An event triggered when the texture is unbind.
         * @type {BABYLON.Observable}
         */
-        public onBeforeBindObservable = new Observable<RenderTargetTexture>();        
+        public onBeforeBindObservable = new Observable<RenderTargetTexture>();
 
         /**
         * An event triggered when the texture is unbind.
@@ -160,6 +162,9 @@
                 this._texture = scene.getEngine().createRenderTargetTexture(size, this._renderTargetOptions);
             }
 
+            //default is true - this will render at scene level
+            this.sceneLevelRender = true;
+
         }
 
         public get samples(): number {
@@ -170,7 +175,7 @@
             if (this._samples === value) {
                 return;
             }
-            
+
             this._samples = this.getScene().getEngine().updateRenderTargetTextureSampleCount(this._texture, value);
         }
 
@@ -320,7 +325,7 @@
                 return;
             }
 
-            this.onBeforeBindObservable.notifyObservers(this);            
+            this.onBeforeBindObservable.notifyObservers(this);
 
             // Set custom projection.
             // Needs to be before binding to prevent changing the aspect ratio.
@@ -329,8 +334,7 @@
                 camera = this.activeCamera;
                 engine.setViewport(this.activeCamera.viewport, this._size, this._size);
 
-                if (this.activeCamera !== scene.activeCamera)
-                {
+                if (this.activeCamera !== scene.activeCamera) {
                     scene.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix(true));
                 }
             }
@@ -356,7 +360,7 @@
                     }
 
                     mesh._preActivateForIntermediateRendering(sceneRenderId);
-                    
+
                     let isMasked;
                     if (!this.renderList) {
                         isMasked = ((mesh.layerMask & camera.layerMask) === 0);
@@ -377,17 +381,17 @@
             }
 
             for (var particleIndex = 0; particleIndex < scene.particleSystems.length; particleIndex++) {
-                    var particleSystem = scene.particleSystems[particleIndex];
+                var particleSystem = scene.particleSystems[particleIndex];
 
-                    let emitter: any = particleSystem.emitter;
-                    if (!particleSystem.isStarted() || !emitter || !emitter.position || !emitter.isEnabled()) {
-                        continue;
-                    }
-
-                    if (currentRenderList.indexOf(emitter) >= 0) {
-                        this._renderingManager.dispatchParticles(particleSystem);
-                    }
+                let emitter: any = particleSystem.emitter;
+                if (!particleSystem.isStarted() || !emitter || !emitter.position || !emitter.isEnabled()) {
+                    continue;
                 }
+
+                if (currentRenderList.indexOf(emitter) >= 0) {
+                    this._renderingManager.dispatchParticles(particleSystem);
+                }
+            }
 
             if (this.isCube) {
                 for (var face = 0; face < 6; face++) {
@@ -409,7 +413,7 @@
             scene.resetCachedMaterial();
         }
 
-        private renderToTarget(faceIndex: number, currentRenderList: AbstractMesh[], currentRenderListLength:number, useCameraPostProcess: boolean, dumpForDebug: boolean): void {
+        private renderToTarget(faceIndex: number, currentRenderList: AbstractMesh[], currentRenderListLength: number, useCameraPostProcess: boolean, dumpForDebug: boolean): void {
             var scene = this.getScene();
             var engine = scene.getEngine();
 
@@ -467,7 +471,7 @@
                 }
 
                 engine.unBindFramebuffer(this._texture, this.isCube, () => {
-                    this.onAfterRenderObservable.notifyObservers(faceIndex);    
+                    this.onAfterRenderObservable.notifyObservers(faceIndex);
                 });
             } else {
                 this.onAfterRenderObservable.notifyObservers(faceIndex);
@@ -487,7 +491,7 @@
             opaqueSortCompareFn: (a: SubMesh, b: SubMesh) => number = null,
             alphaTestSortCompareFn: (a: SubMesh, b: SubMesh) => number = null,
             transparentSortCompareFn: (a: SubMesh, b: SubMesh) => number = null): void {
-            
+
             this._renderingManager.setRenderingOrder(renderingGroupId,
                 opaqueSortCompareFn,
                 alphaTestSortCompareFn,
@@ -500,7 +504,7 @@
          * @param renderingGroupId The rendering group id corresponding to its index
          * @param autoClearDepthStencil Automatically clears depth and stencil between groups if true.
          */
-        public setRenderingAutoClearDepthStencil(renderingGroupId: number, autoClearDepthStencil: boolean): void {            
+        public setRenderingAutoClearDepthStencil(renderingGroupId: number, autoClearDepthStencil: boolean): void {
             this._renderingManager.setRenderingAutoClearDepthStencil(renderingGroupId, autoClearDepthStencil);
         }
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -2711,6 +2711,7 @@
 
             //Camera Custom Render Targets
             let currentActiveCamera = this.activeCamera;
+
             let cameraCustomRenderTargets = this.customRenderTargets.filter(target => !target.sceneLevelRender);
             if (this.renderTargetsEnabled && cameraCustomRenderTargets.length) {
                 Tools.StartPerformanceCounter("Camera Custom render targets", this.customRenderTargets.length > 0);
@@ -2720,8 +2721,6 @@
                         this._renderId++;
 
                         this.activeCamera = renderTarget.activeCamera || this.activeCamera;
-                        // Viewport
-                        engine.setViewport(this.activeCamera.viewport);
                         // Camera
                         this.updateTransformMatrix();
                         renderTarget.render(currentActiveCamera !== this.activeCamera, this.dumpNextRenderTargets);


### PR DESCRIPTION
When using multiple cameras (like in VR) render target textures didn't work correctly.
This solves the issue - there is now an option to render the texture either on the scene level (shadows for example), or camera level (mirror, or water for example).