### PR TITLE
 Dispose meshes in LOD levels

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1484,6 +1484,15 @@
                     highlightLayer.removeExcludedMesh(this);
                 }
             }
+		
+            // Dispose meshes in LOD levels
+            for (let i = 0; i < this._LODLevels.length; i++) {
+                let mesh = this._LODLevels[i].mesh;
+                if (mesh) {
+                    mesh.dispose(doNotRecurse);
+                }
+            }
+            
             super.dispose(doNotRecurse);
         }
 


### PR DESCRIPTION
I found in my scene, that meshes I added as LOD level not disposing on masterMesh disposing. 

Maybe I am wrong. Otherwise there is no public method to get all meshes from LOD levels.