### PR TITLE
gui(controls) remove redundant DOMImage declarations

### DIFF
--- a/gui/src/controls/checkbox.ts
+++ b/gui/src/controls/checkbox.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../dist/preview release/babylon.d.ts"/>
 
-var DOMImage = Image;
-
 module BABYLON.GUI {
     export class Checkbox extends Control {
         private _isChecked = false;

--- a/gui/src/controls/colorpicker.ts
+++ b/gui/src/controls/colorpicker.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../dist/preview release/babylon.d.ts"/>
 
-var DOMImage = Image;
-
 module BABYLON.GUI {
     export class ColorPicker extends Control {
         private _colorWheelCanvas: HTMLCanvasElement;

--- a/gui/src/controls/line.ts
+++ b/gui/src/controls/line.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../dist/preview release/babylon.d.ts"/>
 
-var DOMImage = Image;
-
 module BABYLON.GUI {
     export class Line extends Control {
         private _lineWidth = 1;

--- a/gui/src/controls/radioButton.ts
+++ b/gui/src/controls/radioButton.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../dist/preview release/babylon.d.ts"/>
 
-var DOMImage = Image;
-
 module BABYLON.GUI {
     export class RadioButton extends Control {
         private _isChecked = false;

--- a/gui/src/controls/slider.ts
+++ b/gui/src/controls/slider.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../dist/preview release/babylon.d.ts"/>
 
-var DOMImage = Image;
-
 module BABYLON.GUI {
     export class Slider extends Control {
         private _thumbWidth = new ValueAndUnit(30, ValueAndUnit.UNITMODE_PIXEL, false);


### PR DESCRIPTION
Good afternoon,

I found a few redundant declarations of the `DOMImage` variable, so I decided to omit them.

I tested everything in the `http://localhost:1338/playground/index-local.html` playground and as expected I experienced no changes in behavior.

I hope this helps.