### PR TITLE
Check alpha texture exist before setting it in OutlineRenderer render…

### DIFF
--- a/src/Rendering/babylon.outlineRenderer.ts
+++ b/src/Rendering/babylon.outlineRenderer.ts
@@ -38,14 +38,16 @@
             // Alpha test
             if (material && material.needAlphaTesting()) {
                 var alphaTexture = material.getAlphaTestTexture();
-                this._effect.setTexture("diffuseSampler", alphaTexture);
-                this._effect.setMatrix("diffuseMatrix", alphaTexture.getTextureMatrix());
+                if (alphaTexture) {
+                    this._effect.setTexture("diffuseSampler", alphaTexture);
+                    this._effect.setMatrix("diffuseMatrix", alphaTexture.getTextureMatrix());
+                }
             }
 
             engine.setZOffset(-this.zOffset);
 
             mesh._processRendering(subMesh, this._effect, Material.TriangleFillMode, batch, hardwareInstancedRendering,
-                (isInstance, world) => { this._effect.setMatrix("world", world)});
+                (isInstance, world) => { this._effect.setMatrix("world", world) });
 
             engine.setZOffset(0);
         }


### PR DESCRIPTION
Babylon inspector crashes when hovering meshes that have fire material. This pull request checks if alphaTexture exists before using it.

Same problem as here : [PR](https://github.com/BabylonJS/Babylon.js/commit/93fa8d3f58e8afe69e45ef512309f5d75a4f99fc)
but crashing in inspector.