### PR TITLE
Check new camera to prevent null exception. Assigned null during dispose

### DIFF
--- a/src/Cameras/Inputs/babylon.freeCameraDeviceOrientationInput.ts
+++ b/src/Cameras/Inputs/babylon.freeCameraDeviceOrientationInput.ts
@@ -22,7 +22,9 @@ module BABYLON {
 
         public set camera(camera: FreeCamera) {
             this._camera = camera;
-            if (!this._camera.rotationQuaternion) this._camera.rotationQuaternion = new Quaternion();
+            if (this._camera != null && !this._camera.rotationQuaternion) {
+                this._camera.rotationQuaternion = new Quaternion();
+            }
         }
 
         attachControl(element: HTMLElement, noPreventDefault?: boolean) {


### PR DESCRIPTION
As discussed in bugs forum: http://www.html5gamedevs.com/topic/32467-vr-helper/