### PR TITLE
Fix error on rotationQuaternion combination.

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -865,7 +865,7 @@
             Tmp.Matrix[2].decompose(Tmp.Vector3[0], Tmp.Quaternion[0], Tmp.Vector3[1]);
 
             this.position.addInPlace(Tmp.Vector3[1]);
-            this.rotationQuaternion.multiplyInPlace(Tmp.Quaternion[0]);
+            Tmp.Quaternion[0].multiplyToRef(this.rotationQuaternion, this.rotationQuaternion);
 
             return this;
         }


### PR DESCRIPTION
I think I mistakenly inverted the quaternion multiplication, so it only worked in particular cases (rotation = 0, rotate around X, Y or Z axis...) -the cases I tested-.

It should be more general with this commit !