### PR TITLE
Fix camera dispose() for cameras with no inputs.

### DIFF
--- a/src/Cameras/babylon.camera.ts
+++ b/src/Cameras/babylon.camera.ts
@@ -553,7 +553,9 @@
             this.onAfterCheckInputsObservable.clear();
 
             // Inputs
-            this.inputs.clear();
+            if (this.inputs) {
+                this.inputs.clear();
+            }
 
             // Animations
             this.getScene().stopAnimation(this);


### PR DESCRIPTION
TargetCamera leaves this.inputs as undefined.