### PR TITLE
Fix.sps.improvement

### DIFF
--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -18,6 +18,7 @@ module BABYLON {
         public _modelBoundingInfo: BoundingInfo;        // reference to the shape model BoundingInfo object
         public _boundingInfo: BoundingInfo;             // particle BoundingInfo
         public _sps: SolidParticleSystem;               // reference to the SPS what the particle belongs to
+        public _stillInvisible: boolean = false;         // still set as invisible in order to skip useless computations
 
         /**
          * Creates a Solid Particle object.

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -657,8 +657,9 @@
 
                 // call to custom user function to update the particle properties
                 this.updateParticle(this._particle);
-                
-                if (!this._particle.alive) {
+
+                // skip the computations for inactive or already invisible particles
+                if (!this._particle.alive || (this._particle._stillInvisible && !this._particle.isVisible)) {
                     // increment indexes for the next particle
                     pt = this._shape.length;
                     index += pt * 3;
@@ -668,6 +669,7 @@
                 }
 
                 if (this._particle.isVisible) {
+                    this._particle._stillInvisible = false; // un-mark permanent invisibility
 
                     // particle rotation matrix
                     if (this.billboard) {
@@ -763,15 +765,17 @@
                         }
                     } 
                 } 
-                // particle not visible : scaled to zero and positioned to the camera position
+                // particle just set invisible : scaled to zero and positioned at the origin
                 else {
+                    this._particle._stillInvisible = true;      // mark the particle as invisible
                     for (pt = 0; pt < this._shape.length; pt++) {
                         idx = index + pt * 3;
                         colidx = colorIndex + pt * 4;
                         uvidx = uvIndex + pt * 2;
-                        this._positions32[idx] = this._camera.globalPosition.x;
-                        this._positions32[idx + 1] = this._camera.globalPosition.y;
-                        this._positions32[idx + 2] = this._camera.globalPosition.z;
+
+                        this._positions32[idx] = 0.0;
+                        this._positions32[idx + 1] = 0.0;
+                        this._positions32[idx + 2] = 0.0; 
                         this._normals32[idx] = 0.0;
                         this._normals32[idx + 1] = 0.0;
                         this._normals32[idx + 2] = 0.0;

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -658,6 +658,15 @@
                 // call to custom user function to update the particle properties
                 this.updateParticle(this._particle);
                 
+                if (!this._particle.alive) {
+                    // increment indexes for the next particle
+                    pt = this._shape.length;
+                    index += pt * 3;
+                    colorIndex += pt * 4;
+                    uvIndex += pt * 2;
+                    continue;
+                }
+
                 if (this._particle.isVisible) {
 
                     // particle rotation matrix


### PR DESCRIPTION
SPS perf improvement : the inactive particles ( _.alive = false_ ) and the invisible ones ( _.isVisible = false_ ) are now skipped from the heavy computation iterations : positions, rotation, bbox, normals, etc.

* the inactive/dead particles just keep their current status, including visibility, until reactivated
* the invisible ones are scaled to zero and set to the origin at the first pass, then they aren't computed any longer until reset as visible

Both invisible and dead particles aren't then pickable.