### PR TITLE
Solve missing inputs with high dpi screens.

### DIFF
--- a/gui/src/advancedDynamicTexture.ts
+++ b/gui/src/advancedDynamicTexture.ts
@@ -351,8 +351,8 @@ module BABYLON.GUI {
                 let camera = scene.cameraToUseForPointers || scene.activeCamera;
                 let engine = scene.getEngine();
                 let viewport = camera.viewport;
-                let x = (scene.pointerX - viewport.x * engine.getRenderWidth()) / viewport.width;
-                let y = (scene.pointerY - viewport.y * engine.getRenderHeight()) / viewport.height;
+                let x = (scene.pointerX / engine.getHardwareScalingLevel() - viewport.x * engine.getRenderWidth()) / viewport.width;
+                let y = (scene.pointerY / engine.getHardwareScalingLevel() - viewport.y * engine.getRenderHeight()) / viewport.height;
 
                 this._shouldBlockPointer = false;
                 this._doPicking(x, y, pi.type);


### PR DESCRIPTION
Makes the computation right when engine is scaled to screen resolution.