### PR TITLE
Change Default for maxHeight for CreateGroundFromHeightMap

### DIFF
--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -728,7 +728,7 @@
             var height = options.height || 10.0;
             var subdivisions = options.subdivisions || 1|0;
             var minHeight = options.minHeight || 0.0;
-            var maxHeight = options.maxHeight || 10.0;
+            var maxHeight = options.maxHeight || 1.0;
             var filter = options.colorFilter || new Color3(0.3, 0.59, 0.11);
             var updatable = options.updatable;
             var onReady = options.onReady;


### PR DESCRIPTION
(change line 731 - 10.0 to 1.0) In documentation default value is given as 1, in code it is 10. For default ground size of 10 x 10 I think the default size of 1 makes more sense than 10. Having done a search in Playground for MeshBuilder.CreateGroundFRomHeightMap all the PG where this appears set their own maxHeight so probably not a problem to change. However if you think this change might cause issues for users then just change default in documentation 10 instead.