### PR TITLE
Default Values for CreateDashedLines Added

### DIFF
--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -422,9 +422,8 @@
         public static CreateDashedLines(name: string, options: { points: Vector3[], dashSize?: number, gapSize?: number, dashNb?: number, updatable?: boolean, instance?: LinesMesh }, scene: Scene): LinesMesh {
             var points = options.points;
             var instance = options.instance;
-            var gapSize = options.gapSize;
-            var dashNb = options.dashNb;
-            var dashSize = options.dashSize;
+            var gapSize = options.gapSize || 1;
+            var dashSize = options.dashSize || 3;
 
             if (instance) {  //  dashed lines update
                 var positionFunction = (positions: number[]): void => {


### PR DESCRIPTION
If  options not set for gapSize and dashSize then variables on lines 425, and 426 are undefined and so undefined is stored in the mesh properties of gapSize and dashSize for dashedLines object on lines 477 and 478. This means that when an instance is used dashshft on line 445 is calculated using undefined variables resulting in NaN for positions[p + 3], positions[p + 4], positions[p + 5] on lines 456 to 458.

dashNb is not used for an instance and default is dealt with in VertexData.CreateDashedLines(options).

The method used only allows the option points to be changed, will need to update documentation to state this.