### PR TITLE
Fix generated vertex normals

### DIFF
--- a/src/Materials/PBR/babylon.pbrBaseMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrBaseMaterial.ts
@@ -1264,11 +1264,12 @@
                 scene.ambientColor.multiplyToRef(this._ambientColor, this._globalAmbientColor);
 
                 var eyePosition = scene._mirroredCameraPosition ? scene._mirroredCameraPosition : scene.activeCamera.globalPosition;
-                effect.setFloat4("vEyePosition", 
+                var invertNormal = (scene.useRightHandedSystem === (scene._mirroredCameraPosition !== undefined));
+                effect.setFloat4("vEyePosition",
                     eyePosition.x,
                     eyePosition.y,
                     eyePosition.z,
-                    scene._mirroredCameraPosition ? -1 : 1);
+                    invertNormal ? -1 : 1);
                 effect.setColor3("vAmbientColor", this._globalAmbientColor);
             }
 


### PR DESCRIPTION
The generated vertex normals (when normals are not specified) are incorrect when scene.useRightHandedSystem is false. This change makes it work in both right and left handed coordinate systems.