### PR TITLE
WebVR improvements

### DIFF
--- a/Playground/scripts/scripts.txt
+++ b/Playground/scripts/scripts.txt
@@ -28,3 +28,4 @@ refraction and Reflection
 pbr
 instanced bones
 pointer events handling
+webvr

--- a/Playground/scripts/webvr.js
+++ b/Playground/scripts/webvr.js
@@ -1,0 +1,35 @@
+var createScene = function () {
+
+    // This creates a basic Babylon Scene object (non-mesh)
+    var scene = new BABYLON.Scene(engine);
+    scene.createDefaultVRExperience();
+
+    // This creates a light, aiming 0,1,0 - to the sky (non-mesh)
+    var light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);
+
+    // Default intensity is 1. Let's dim the light a small amount
+    light.intensity = 0.7;
+
+    // Create some spheres at the default eye level (2m)
+    createSphereBox(scene, 2, 2);
+    createSphereBox(scene, 3, 2);
+        
+    // Our built-in 'ground' shape. Params: name, width, depth, subdivs, scene
+    var ground = BABYLON.Mesh.CreateGround("ground1", 6, 6, 2, scene);
+
+    return scene;
+};
+
+function createSphereBox(scene, distance, height) {    
+    createSphere(scene,  distance, height,  distance);
+    createSphere(scene,  distance, height, -distance);
+    createSphere(scene, -distance, height,  distance);
+    createSphere(scene, -distance, height, -distance);    
+}
+function createSphere(scene, x, y, z) {
+    // Our built-in 'sphere' shape. Params: name, subdivs, size, scene
+    var sphere = BABYLON.Mesh.CreateSphere("sphere1", 4, 0.4, scene);
+    sphere.position.x = x;
+    sphere.position.y = y;
+    sphere.position.z = z;
+}

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -3,12 +3,18 @@ module BABYLON {
         private _scene: BABYLON.Scene;
         private _position;
         private _btnVR: HTMLButtonElement;
-        private _webVRsupportedAndReady = false;
+        private _webVRsupported = false;
         private _canvas: HTMLCanvasElement;
         private _isInVRMode = false;
         private _webVRCamera: WebVRFreeCamera;
+        private _vrDisplay = null;
         private _vrDeviceOrientationCamera: VRDeviceOrientationFreeCamera;
         private _deviceOrientationCamera: DeviceOrientationCamera;
+        
+        private onVrDisplayConnectDelegate: any;
+        private onVrDisplayDisconnectDelegate: any;
+        private onVrDisplayPresentChangeDelegate: any;
+        private onFullScreenChangeDelegate: any;
         
         constructor(scene: Scene, private webVROptions: WebVROptions = {}) {
             this._scene = scene;
@@ -34,18 +40,24 @@ module BABYLON {
             this._btnVR.id = "babylonVRiconbtn";
             this._btnVR.title = "Click to switch to VR";
             var css = ".babylonVRicon { position: absolute; right: 20px; height: 50px; width: 80px; background-color: rgba(51,51,51,0.7); background-image: url(data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%222048%22%20height%3D%221152%22%20viewBox%3D%220%200%202048%201152%22%20version%3D%221.1%22%3E%3Cpath%20transform%3D%22rotate%28180%201024%2C576.0000000000001%29%22%20d%3D%22m1109%2C896q17%2C0%2030%2C-12t13%2C-30t-12.5%2C-30.5t-30.5%2C-12.5l-170%2C0q-18%2C0%20-30.5%2C12.5t-12.5%2C30.5t13%2C30t30%2C12l170%2C0zm-85%2C256q59%2C0%20132.5%2C-1.5t154.5%2C-5.5t164.5%2C-11.5t163%2C-20t150%2C-30t124.5%2C-41.5q23%2C-11%2042%2C-24t38%2C-30q27%2C-25%2041%2C-61.5t14%2C-72.5l0%2C-257q0%2C-123%20-47%2C-232t-128%2C-190t-190%2C-128t-232%2C-47l-81%2C0q-37%2C0%20-68.5%2C14t-60.5%2C34.5t-55.5%2C45t-53%2C45t-53%2C34.5t-55.5%2C14t-55.5%2C-14t-53%2C-34.5t-53%2C-45t-55.5%2C-45t-60.5%2C-34.5t-68.5%2C-14l-81%2C0q-123%2C0%20-232%2C47t-190%2C128t-128%2C190t-47%2C232l0%2C257q0%2C68%2038%2C115t97%2C73q54%2C24%20124.5%2C41.5t150%2C30t163%2C20t164.5%2C11.5t154.5%2C5.5t132.5%2C1.5zm939%2C-298q0%2C39%20-24.5%2C67t-58.5%2C42q-54%2C23%20-122%2C39.5t-143.5%2C28t-155.5%2C19t-157%2C11t-148.5%2C5t-129.5%2C1.5q-59%2C0%20-130%2C-1.5t-148%2C-5t-157%2C-11t-155.5%2C-19t-143.5%2C-28t-122%2C-39.5q-34%2C-14%20-58.5%2C-42t-24.5%2C-67l0%2C-257q0%2C-106%2040.5%2C-199t110%2C-162.5t162.5%2C-109.5t199%2C-40l81%2C0q27%2C0%2052%2C14t50%2C34.5t51%2C44.5t55.5%2C44.5t63.5%2C34.5t74%2C14t74%2C-14t63.5%2C-34.5t55.5%2C-44.5t51%2C-44.5t50%2C-34.5t52%2C-14l14%2C0q37%2C0%2070%2C0.5t64.5%2C4.5t63.5%2C12t68%2C23q71%2C30%20128.5%2C78.5t98.5%2C110t63.5%2C133.5t22.5%2C149l0%2C257z%22%20fill%3D%22white%22%20/%3E%3C/svg%3E%0A); background-size: 80%; background-repeat:no-repeat; background-position: center; border: none; outline: none; transition: transform 0.125s ease-out } .babylonVRicon:hover { transform: scale(1.05) } .babylonVRicon:active {background-color: rgba(51,51,51,1) } .babylonVRicon:focus {background-color: rgba(51,51,51,1) }";
-            
+            css += ".babylonVRicon.vrdisplayconnected { border: 4px solid #0F0; }";
+
             var style = document.createElement('style');
             style.appendChild(document.createTextNode(css));
             document.getElementsByTagName('head')[0].appendChild(style);  
 
             this._btnVR.style.top = this._canvas.offsetTop + this._canvas.offsetHeight - 70 + "px";
             this._btnVR.style.left = this._canvas.offsetLeft + this._canvas.offsetWidth - 100 + "px";
+            this._btnVR.addEventListener("click", () => {
+                this.enterVR();
+            });
 
             window.addEventListener("resize", () => {
                 this._btnVR.style.top = this._canvas.offsetTop + this._canvas.offsetHeight - 70 + "px";
                 this._btnVR.style.left = this._canvas.offsetLeft + this._canvas.offsetWidth - 100 + "px";
             });
+            
+            document.body.appendChild(this._btnVR);
 
             // Exiting VR mode using 'ESC' key on desktop
             document.addEventListener("keydown", (event) => {
@@ -60,48 +72,103 @@ module BABYLON {
                     this.exitVR();
                 }
             }, BABYLON.PointerEventTypes.POINTERDOUBLETAP, false);
+            
+            this._vrDeviceOrientationCamera = new BABYLON.VRDeviceOrientationFreeCamera("VRDeviceOrientationVRHelper", this._position, this._scene);
+            this._webVRCamera = null;
 
+            this.onVrDisplayConnectDelegate = (display) => { this.gotVRDisplays([display]); };
+            this.onVrDisplayDisconnectDelegate = () => { this.gotVRDisplays([]); };
+            this.onVrDisplayPresentChangeDelegate = () => { this.onVrDisplayPresentChange(); };
+            this.onFullScreenChangeDelegate = () => { this.onFullScreenChange(); };
+            window.addEventListener('vrdisplayconnect', this.onVrDisplayConnectDelegate);
+            window.addEventListener('vrdisplaydisconnect', this.onVrDisplayDisconnectDelegate);
+            window.addEventListener('vrdisplaypresentchange', this.onVrDisplayPresentChangeDelegate);
+            document.addEventListener('fullscreenchange', this.onFullScreenChangeDelegate);
+            this.detectVR();
+        }
+
+        private onVrDisplayPresentChange() {
+            if (this._vrDisplay) {
+                // A VR display is connected
+                this._isInVRMode = this._vrDisplay.isPresenting;
+            } else {
+                Tools.Warn('Detected VRDisplayPresentChange on an unknown VRDisplay. Did you can enterVR on the vrExperienceHelper?');
+            }
+        }
+
+        private onFullScreenChange() {            
+            this._isInVRMode = document.fullscreen;
+        }
+
+        private gotVRDisplays(displays) {
+            this._webVRsupported = true;
+            if (displays.length > 0) {
+                this._webVRCamera = this._webVRCamera || new BABYLON.WebVRFreeCamera("WebVRHelper", this._position, this._scene);
+                this._vrDisplay = displays[0];
+            }
+            else if (this._webVRCamera) {
+                this._webVRCamera.dispose();
+                this._webVRCamera = null;                           
+                this._vrDisplay = null;
+            }                    
+            this.updateButtonVisibility();
+        }
+
+        private detectVR() {
+            
             if (navigator.getVRDisplays) {
-                navigator.getVRDisplays().then((headsets) => {
-                    if (headsets.length > 0) {
-                        this._webVRCamera = new BABYLON.WebVRFreeCamera("WebVRHelper", this._position, this._scene);
-                        this._webVRsupportedAndReady = true;
-                    }
-                    else 
-                    {
-                        this._vrDeviceOrientationCamera = new BABYLON.VRDeviceOrientationFreeCamera("VRDeviceOrientationVRHelper", this._position, this._scene);
-                    }
-                    document.body.appendChild(this._btnVR); 
+                var gotVRDisplays = (displays) => this.gotVRDisplays(displays);
+                navigator.getVRDisplays().then(gotVRDisplays).catch((error) => {
+                    this._webVRsupported = false;
+                    Tools.Warn(error || 'getVRDisplays rejected; system not capable of WebVR.');
+
+                    this.updateButtonVisibility();
                 });
             }
             else {
+                this._webVRsupported = false;
                 this._vrDeviceOrientationCamera = new BABYLON.VRDeviceOrientationFreeCamera("VRDeviceOrientationVRHelper", this._position, this._scene);
                 document.body.appendChild(this._btnVR); 
-            }
 
-            this._btnVR.addEventListener("click", () => {
-                this.enterVR();
-            });
+                this.updateButtonVisibility();
+            }
         }
 
+        private updateButtonVisibility() {            
+            if (!this._btnVR) {
+                return;
+            }
+            if (this._isInVRMode) {
+                this._btnVR.style.display = "none";
+            } else {
+                this._btnVR.style.display = "";
+                this._btnVR.className = "babylonVRicon" + (this._vrDisplay ? " vrdisplayconnected" : "");
+            }
+        }
+
+        /**
+         * Attempt to enter VR. If a headset is connected and ready, will request present on that.
+         * Otherwise, will use the fullscreen API.
+         */
         public enterVR() {
             // If WebVR is supported and a headset is connected
-            if (this._webVRsupportedAndReady) {
+            if (this._webVRsupported && this._webVRCamera) {
                 this._webVRCamera.position = this._position;
                 this._scene.activeCamera = this._webVRCamera;
             }
             else {
                 this._vrDeviceOrientationCamera.position = this._position;
                 this._scene.activeCamera = this._vrDeviceOrientationCamera;
-                this._scene.getEngine().switchFullscreen(true); 
+                this._scene.getEngine().switchFullscreen(true);
             }
             this._scene.activeCamera.attachControl(this._canvas);
-            this._isInVRMode = true;
-            this._btnVR.style.display = "none";
         }
 
+        /**
+         * Attempt to exit VR, or fullscreen.
+         */
         public exitVR() {
-            if (this._webVRsupportedAndReady) {
+            if (this._webVRsupported) {
                 this._scene.getEngine().disableVR();
             }
             if (this._scene.activeCamera) {
@@ -111,7 +178,6 @@ module BABYLON {
             this._scene.activeCamera = this._deviceOrientationCamera;
             this._scene.activeCamera.attachControl(this._canvas);
             this._isInVRMode = false;
-            this._btnVR.style.display = ""; 
         }
 
         public get position(): Vector3 {
@@ -135,6 +201,13 @@ module BABYLON {
                 this._vrDeviceOrientationCamera.dispose();
             }
             document.body.removeChild(this._btnVR);
+
+            window.removeEventListener('vrdisplayconnect', this.onVrDisplayConnectDelegate);
+            window.removeEventListener('vrdisplaydisconnect', this.onVrDisplayDisconnectDelegate);
+            window.removeEventListener('vrdisplaypresentchange', this.onVrDisplayPresentChangeDelegate);
+            document.removeEventListener('fullscreenchange', this.onFullScreenChangeDelegate);
+
+            // TODO: Remove other event listeners on window and document.
         }
 
         public getClassName(): string {

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -95,7 +95,23 @@ module BABYLON {
             }
 
             //enable VR
-            this.getEngine().initWebVR();
+            var engine = this.getEngine();
+            engine.initWebVR().add(() => {
+                
+                this._vrDevice = engine.getVRDevice(this.webVROptions.displayName);
+                this._vrEnabled = !!this._vrDevice;
+
+                if (!this._vrEnabled) {
+                    return;
+                }
+
+                //reset the rig parameters.
+                this.setCameraRigMode(Camera.RIG_MODE_WEBVR, { parentCamera: this, vrDisplay: this._vrDevice, frameData: this._frameData, specs: this._specsVersion });
+
+                if (this._attached) {
+                    this.getEngine().enableVR(this._vrDevice)
+                }
+            });
 
             //check specs version
             if (!window.VRFrameData) {
@@ -105,22 +121,6 @@ module BABYLON {
             } else {
                 this._frameData = new VRFrameData();
             }
-
-            this.getEngine().getVRDevice(this.webVROptions.displayName, device => {
-                if (!device) {
-                    return;
-                }
-
-                this._vrEnabled = true;               
-                this._vrDevice = device;
-
-                //reset the rig parameters.
-                this.setCameraRigMode(Camera.RIG_MODE_WEBVR, { parentCamera: this, vrDisplay: this._vrDevice, frameData: this._frameData, specs: this._specsVersion });
-
-                if (this._attached) {
-                    this.getEngine().enableVR(this._vrDevice)
-                }
-            });                
 
             /**
              * The idea behind the following lines:

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -40,7 +40,7 @@ module BABYLON {
     export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
         public _vrDevice = null;
         public rawPose: DevicePose = null;
-        private _vrEnabled = false;
+        private _onVREnabled: (success: boolean) => void;
         private _specsVersion: number = 1.1;
         private _attached: boolean = false;
 
@@ -96,20 +96,17 @@ module BABYLON {
 
             //enable VR
             var engine = this.getEngine();
-            engine.initWebVR().add(() => {
+            this._onVREnabled = (success:boolean) => { if (success) { this.initControllers(); } };
+            engine.onVRRequestPresentComplete.add(this._onVREnabled);
+            engine.initWebVR().add((event:IDisplayChangedEventArgs) => {
                 
-                this._vrDevice = engine.getVRDevice(this.webVROptions.displayName);
-                this._vrEnabled = !!this._vrDevice;
-
-                if (!this._vrEnabled) {
-                    return;
-                }
+                this._vrDevice = event.vrDisplay;
 
                 //reset the rig parameters.
                 this.setCameraRigMode(Camera.RIG_MODE_WEBVR, { parentCamera: this, vrDisplay: this._vrDevice, frameData: this._frameData, specs: this._specsVersion });
 
-                if (this._attached) {
-                    this.getEngine().enableVR(this._vrDevice)
+                if (this._attached && this._vrDevice) {
+                    this.getEngine().enableVR();
                 }
             });
 
@@ -155,6 +152,11 @@ module BABYLON {
                 }
             });
         }
+        
+        public dispose(): void {
+            this.getEngine().onVRRequestPresentComplete.removeCallback(this._onVREnabled);
+            super.dispose();
+        }
 
         public getControllerByName(name: string): WebVRController {
             for (var gp of this.controllers) {
@@ -194,11 +196,11 @@ module BABYLON {
         } 
 
         public _checkInputs(): void {
-            if (this._vrEnabled) {
+            if (this._vrDevice && this._vrDevice.isPresenting) {
                 if (this._specsVersion === 1.1) {
                     this._vrDevice.getFrameData(this._frameData);
                 } else {
-                    //backwards comp
+                    // TODO: Does backwards comp need to be here any more? The Engine class doesn't support it any more.
                     let pose = this._vrDevice.getPose();
                     this._frameData.pose = pose;
                 }
@@ -244,12 +246,9 @@ module BABYLON {
 
             noPreventDefault = Camera.ForceAttachControlToAlwaysPreventDefault ? false : noPreventDefault;
 
-            if (this._vrEnabled) {
-                this.getEngine().enableVR(this._vrDevice);
+            if (this._vrDevice) {
+                this.getEngine().enableVR();
             }
-
-            // try to attach the controllers, if found.
-            this.initControllers();
         }
 
         public detachControl(element: HTMLElement): void {
@@ -257,7 +256,6 @@ module BABYLON {
             this.getScene().gamepadManager.onGamepadDisconnectedObservable.remove(this._onGamepadDisconnectedObserver);
             
             super.detachControl(element);
-            this._vrEnabled = false;
             this._attached = false;
             this.getEngine().disableVR();
         }

--- a/src/babylon.engine.ts
+++ b/src/babylon.engine.ts
@@ -254,6 +254,11 @@
         doNotHandleContextLost?: boolean;
     }
 
+    export interface IDisplayChangedEventArgs {
+        vrDisplay: any;
+        vrSupported: boolean;
+    }
+
     /**
      * The engine class is responsible for interfacing with all lower-level APIs such as WebGL and Audio.
      */
@@ -556,8 +561,8 @@
 
         //WebVR
 
-        private _vrDisplays: any[];
-        private _vrDisplayEnabled;
+        private _vrDisplay: any = undefined;
+        private _vrSupported: boolean = false;
         private _oldSize: BABYLON.Size;
         private _oldHardwareScaleFactor: number;
         private _vrExclusivePointerMode = false;
@@ -611,8 +616,11 @@
 
         // VRDisplay connection
         private _onVrDisplayConnect: (display: any) => void;
-        private _onVrDisplayDisconnect: () => void;        
-        public onVRDisplayChangedObservable = new Observable<any>();
+        private _onVrDisplayDisconnect: () => void;
+        private _onVrDisplayPresentChange: () => void;
+        public onVRDisplayChangedObservable = new Observable<IDisplayChangedEventArgs>();
+        public onVRRequestPresentComplete = new Observable<boolean>();
+        public onVRRequestPresentStart = new Observable<Engine>();
 
         private _hardwareScalingLevel: number;
         private _caps: EngineCapabilities;
@@ -947,12 +955,10 @@
                 document.addEventListener("webkitpointerlockchange", this._onPointerLockChange, false);
 
                 this._onVRDisplayPointerRestricted = () => {
-                    this._vrExclusivePointerMode = true;
                     canvas.requestPointerLock();
                 }
 
                 this._onVRDisplayPointerUnrestricted = () => {
-                    this._vrExclusivePointerMode = false;
                     document.exitPointerLock();
                 }
 
@@ -1402,7 +1408,10 @@
 
             if (this._activeRenderLoops.length > 0) {
                 // Register new frame
-                this._frameHandler = Tools.QueueNewFrame(this._bindedRenderFunction, this._vrDisplayEnabled);
+                var requester = window;
+                if (this._vrDisplay && this._vrDisplay.isPresenting)
+                    requester = this._vrDisplay;
+                this._frameHandler = Tools.QueueNewFrame(this._bindedRenderFunction, requester);
             } else {
                 this._renderingQueueLaunched = false;
             }
@@ -1529,8 +1538,9 @@
             }
 
             //submit frame to the vr device, if enabled
-            if (this._vrDisplayEnabled && this._vrDisplayEnabled.isPresenting) {
-                this._vrDisplayEnabled.submitFrame()
+            if (this._vrDisplay && this._vrDisplay.isPresenting) {
+                // TODO: We should only submit the frame if we read frameData successfully.
+                this._vrDisplay.submitFrame();
             }
         }
 
@@ -1543,7 +1553,7 @@
          */
         public resize(): void {
             // We're not resizing the size of the canvas while in VR mode & presenting
-            if (!(this._vrDisplayEnabled && this._vrDisplayEnabled.isPresenting)) {
+            if (!(this._vrDisplay && this._vrDisplay.isPresenting)) {
                 var width = navigator.isCocoonJS ? window.innerWidth : this._renderingCanvas.clientWidth;
                 var height = navigator.isCocoonJS ? window.innerHeight : this._renderingCanvas.clientHeight;
 
@@ -1579,83 +1589,106 @@
             }
         }
 
-        //WebVR functions
+        // WebVR functions
         public isVRDevicePresent() : boolean {
-            return this._vrDisplays != null && this._vrDisplays.length > 0);
+            return !!this._vrDisplay;
         }
 
         public getVRDevice() : any {
-            var devices = this._vrDisplays || [];
-
-            if (devices.length > 0) {
-                return devices[0];
-            } else {
-                Tools.Error("No WebVR devices found!");
-                return null;
-            }
+            return this._vrDisplay;
         }
 
         public initWebVR(): Observable<any> {
-            this.onVRDisplayChangedObservable = new Observable<any>();
+            var notifyObservers = () => {
+                var eventArgs = {
+                    vrDisplay: this._vrDisplay,
+                    vrSupported: this._vrSupported
+                };
+                this.onVRDisplayChangedObservable.notifyObservers(eventArgs);
+            }
 
             if (!this._onVrDisplayConnect) {
-                this._onVrDisplayConnect = (display) => {
-                    this._vrDisplays = [display];
-                    // TODO: Notify observable
+                this._onVrDisplayConnect = (event) => {
+                    this._vrDisplay = event.display;
+                    notifyObservers();
                 };
                 this._onVrDisplayDisconnect = () => {
-                    this._vrDisplays = [];
-                    // TODO: Notify observable
+                    this._vrDisplay.cancelAnimationFrame(this._frameHandler);
+                    this._vrDisplay = undefined;
+                    this._frameHandler = Tools.QueueNewFrame(this._bindedRenderFunction);
+                    notifyObservers();
                 };
+                this._onVrDisplayPresentChange = () => {                    
+                    this._vrExclusivePointerMode = this._vrDisplay && this._vrDisplay.isPresenting;
+                }
+                window.addEventListener('vrdisplayconnect', this._onVrDisplayConnect);
+                window.addEventListener('vrdisplaydisconnect', this._onVrDisplayDisconnect);
+                window.addEventListener('vrdisplaypresentchange', this._onVrDisplayPresentChange);
             }
             
-            this._getVRDisplays();
+            this._getVRDisplays(notifyObservers);
 
             return this.onVRDisplayChangedObservable;
         }
 
-        public enableVR(vrDevice) {
-            this._vrDisplayEnabled = vrDevice;
-            this._vrDisplayEnabled.requestPresent([{ source: this.getRenderingCanvas() }]).then(this._onVRFullScreenTriggered);
+        public enableVR() {
+            if (this._vrDisplay && !this._vrDisplay.isPresenting) {
+                var onResolved = () => {
+                    this.onVRRequestPresentComplete.notifyObservers(true);
+                    this._onVRFullScreenTriggered();
+                };
+                var onRejected = () => {
+                    this.onVRRequestPresentComplete.notifyObservers(false);
+                };
+                
+                this.onVRRequestPresentStart.notifyObservers(this);
+                this._vrDisplay.requestPresent([{ source: this.getRenderingCanvas() }]).then(onResolved).catch(onRejected);
+            }
         }
 
         public disableVR() {
-            if (this._vrDisplayEnabled) {
-                this._vrDisplayEnabled.exitPresent().then(this._onVRFullScreenTriggered);
+            if (this._vrDisplay && this._vrDisplay.isPresenting) {
+                this._vrDisplay.exitPresent().then(this._onVRFullScreenTriggered).catch(this._onVRFullScreenTriggered);
             }
         }
 
         private _onVRFullScreenTriggered = () => {
-            if (this._vrDisplayEnabled && this._vrDisplayEnabled.isPresenting) {
+            if (this._vrDisplay && this._vrDisplay.isPresenting) {
                 //get the old size before we change
                 this._oldSize = new BABYLON.Size(this.getRenderWidth(), this.getRenderHeight());
                 this._oldHardwareScaleFactor = this.getHardwareScalingLevel();
 
                 //get the width and height, change the render size
-                var leftEye = this._vrDisplayEnabled.getEyeParameters('left');
+                var leftEye = this._vrDisplay.getEyeParameters('left');
                 var width, height;
                 this.setHardwareScalingLevel(1);
                 this.setSize(leftEye.renderWidth * 2, leftEye.renderHeight);
             } else {
-                //When the specs are implemented, need to uncomment this.
                 this.setHardwareScalingLevel(this._oldHardwareScaleFactor);
                 this.setSize(this._oldSize.width, this._oldSize.height);
-                this._vrDisplayEnabled = undefined;
             }
         }
 
-        private _getVRDisplays() {
+        private _getVRDisplays(callback) {
             var getWebVRDevices = (devices: Array<any>) => {
-                return this._vrDisplays = devices;
+                this._vrSupported = true;
+                // note that devices may actually be an empty array. This is fine;
+                // we expect this._vrDisplay to be undefined in this case.
+                return this._vrDisplay = devices[0];
             }
 
             if (navigator.getVRDisplays) {
-                navigator.getVRDisplays().then(getWebVRDevices).catch((error) => {
+                // TODO: Backwards compatible for 1.0?
+                navigator.getVRDisplays().then(getWebVRDevices).then(callback).catch((error) => {
                     // TODO: System CANNOT support WebVR, despite API presence.
+                    this._vrSupported = false;
+                    callback();
                 });
             } else {
                 // TODO: Browser does not support WebVR
-                this._vrDisplays = [];
+                this._vrDisplay = undefined;
+                this._vrSupported = false;
+                callback();
             }
         }
 
@@ -4406,6 +4439,14 @@
             document.removeEventListener("mspointerlockchange", this._onPointerLockChange);
             document.removeEventListener("mozpointerlockchange", this._onPointerLockChange);
             document.removeEventListener("webkitpointerlockchange", this._onPointerLockChange);
+            
+            if (this._onVrDisplayConnect) {
+                window.removeEventListener('vrdisplayconnect', this._onVrDisplayConnect);
+                window.removeEventListener('vrdisplaydisconnect', this._onVrDisplayDisconnect);
+                window.removeEventListener('vrdisplaypresentchange', this._onVrDisplayPresentChange);
+                this._onVrDisplayConnect = undefined;
+                this._onVrDisplayDisconnect = undefined;                
+            }
 
             // Remove from Instances
             var index = Engine.Instances.indexOf(this);


### PR DESCRIPTION
- Now handles headset connection/disconnection events
- Switches back to window render loop when headset is disconnected
- Bugfixes to allow you to enter VR more than once
- Added Observables so apps can handle cases where requestPresent doesn't return instantaneously 
- Remove support for finding headset by id (which is an anti-pattern)
- Added WebVR sample (used as reference for WebVR supprot checklist)
- Fixed camera mouse drag disabled when in VR (should be when in VR at all, not simply when the headset has pointer restriction)

Note that this has yet to be tested on Vive & Oculus. I will test on Vive tomorrow in the office, but will need someone to assist with Oculus testing.