### PR TITLE
Fixed use of VRFrameData in non-VR browsers.

### DIFF
--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -113,7 +113,8 @@ module BABYLON {
                 }
             });
 
-            this._frameData = new VRFrameData();
+            if (typeof(VRFrameData) !== "undefined")
+                this._frameData = new VRFrameData();
 
             /**
              * The idea behind the following lines:


### PR DESCRIPTION
Fixed issue introduced by #2835 - creating a WebVRCamera on browsers that have no WebVR support throws an error. 

To reproduce, call scene.createDefaultVRExperience in Chrome.