### PR TITLE
GUI - Automatically measuring TextBlock size

### DIFF
--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -10,7 +10,7 @@ module BABYLON.GUI {
         public _currentMeasure = Measure.Empty();
         private _fontFamily = "Arial";
         private _fontStyle = "";
-        private _fontSize = new ValueAndUnit(18, ValueAndUnit.UNITMODE_PIXEL, false);
+        protected _fontSize = new ValueAndUnit(18, ValueAndUnit.UNITMODE_PIXEL, false);
         private _font: string;
         public _width = new ValueAndUnit(1, ValueAndUnit.UNITMODE_PERCENTAGE, false);
         public _height = new ValueAndUnit(1, ValueAndUnit.UNITMODE_PERCENTAGE, false);
@@ -864,7 +864,7 @@ module BABYLON.GUI {
             return false;
         }
 
-        private _prepareFont() {
+        protected _prepareFont() {
             if (!this._font && !this._fontSet) {
                 return;
             }

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -10,6 +10,15 @@ module BABYLON.GUI {
 
         private _lines: any[];
         private _totalHeight: number;
+        private _resizeToFit: boolean = false;
+
+        get resizeToFit(): boolean {
+            return this._resizeToFit;
+        }
+
+        set resizeToFit(value: boolean) {
+            this._resizeToFit = value;
+        }
 
         public get textWrapping(): boolean {
             return this._textWrapping;
@@ -175,8 +184,10 @@ module BABYLON.GUI {
                 if (line.width > maxLineWidth) maxLineWidth = line.width;
             }
 
-            this.width = maxLineWidth + 'px';
-            this.height = rootY + this._fontOffset.height + 'px'; //TODO: need to actually measure height
+            if (this._resizeToFit) {
+                this.width = maxLineWidth + 'px';
+                this.height = this._fontOffset.height * this._lines.length + 'px';
+            }
 
             //console.log('width', maxLineWidth);
             //console.log('height', rootY, this._fontOffset.height);

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -126,6 +126,32 @@ module BABYLON.GUI {
             }
         }
 
+        public getRawFontSize(): object {
+            var ignoreAdaptiveScaling: boolean = this._fontSize.ignoreAdaptiveScaling;
+
+            this._fontSize.ignoreAdaptiveScaling = false;
+            
+            var maxLineWidth: number = 0;
+
+            var _lines = this.text.split("\n").forEach(_line => {
+                //can't get context here? if so, have 2 calculations in _additionalProcessing instead? one for with idealWidth and one without
+                var lineWidth: number = this._parseLine(_line, context).width;
+
+                if (lineWidth > maxLineWidth) maxLineWidth = lineWidth;
+            });
+
+            this._prepareFont();
+
+            this._fontSize.ignoreAdaptiveScaling = ignoreAdaptiveScaling;
+
+            this._prepareFont();
+
+            return {
+                width: maxLineWidth,
+                height: this._fontOffset.height * this._lines.length + 'px'
+            }
+        }
+
         protected _parseLine(line: string='', context: CanvasRenderingContext2D): object {
           return {text: line, width: context.measureText(line).width};
         }

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -86,6 +86,7 @@ module BABYLON.GUI {
                     break;
             }
 
+
             context.fillText(text, this._currentMeasure.left + x, y);
         }
 
@@ -165,10 +166,20 @@ module BABYLON.GUI {
 
             rootY += this._currentMeasure.top;
 
+            var maxLineWidth: number = 0;
+
             for (var line of this._lines) {
                 this._drawText(line.text, line.width, rootY, context);
                 rootY += this._fontOffset.height;
+
+                if (line.width > maxLineWidth) maxLineWidth = line.width;
             }
+
+            this.width = maxLineWidth + 'px';
+            this.height = rootY + this._fontOffset.height + 'px'; //TODO: need to actually measure height
+
+            //console.log('width', maxLineWidth);
+            //console.log('height', rootY, this._fontOffset.height);
         }
     }
 }

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -18,6 +18,8 @@ module BABYLON.GUI {
 
         set resizeToFit(value: boolean) {
             this._resizeToFit = value;
+            this._width.ignoreAdaptiveScaling = true;
+            this._height.ignoreAdaptiveScaling = true;
         }
 
         public get textWrapping(): boolean {
@@ -126,7 +128,7 @@ module BABYLON.GUI {
             }
         }
 
-        public getRawFontSize(): object {
+        /*public getRawFontSize(): object {
             var ignoreAdaptiveScaling: boolean = this._fontSize.ignoreAdaptiveScaling;
 
             this._fontSize.ignoreAdaptiveScaling = false;
@@ -152,7 +154,7 @@ module BABYLON.GUI {
                 width: maxLineWidth,
                 height: this._fontOffset.height * _lines.length + 'px'
             }
-        }
+        }*/
 
         protected _parseLine(line: string='', context: CanvasRenderingContext2D): object {
           return {text: line, width: context.measureText(line).width};
@@ -213,12 +215,12 @@ module BABYLON.GUI {
             }
 
             if (this._resizeToFit) {
-                this.width = maxLineWidth + 'px';
+                this.width = 100 + 'px'; //maxLineWidth + 'px';
                 this.height = this._fontOffset.height * this._lines.length + 'px';
             }
 
-            //console.log('width', maxLineWidth);
-            //console.log('height', rootY, this._fontOffset.height);
+            console.log('width', maxLineWidth);
+            console.log('height', this._fontOffset.height * this._lines.length);
         }
     }
 }

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -215,12 +215,15 @@ module BABYLON.GUI {
             }
 
             if (this._resizeToFit) {
-                this.width = 100 + 'px'; //maxLineWidth + 'px';
+                this.width = maxLineWidth + 'px';
                 this.height = this._fontOffset.height * this._lines.length + 'px';
             }
 
-            console.log('width', maxLineWidth);
-            console.log('height', this._fontOffset.height * this._lines.length);
+            console.log('width', this.width);
+            console.log('height', this.height);
+
+            /*console.log('width', maxLineWidth);
+            console.log('height', this._fontOffset.height * this._lines.length);*/
         }
     }
 }

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -131,9 +131,11 @@ module BABYLON.GUI {
 
             this._fontSize.ignoreAdaptiveScaling = false;
             
+            var _lines = this.text.split("\n");
+            
             var maxLineWidth: number = 0;
 
-            var _lines = this.text.split("\n").forEach(_line => {
+            _lines.forEach(_line => {
                 //can't get context here? if so, have 2 calculations in _additionalProcessing instead? one for with idealWidth and one without
                 var lineWidth: number = this._parseLine(_line, context).width;
 
@@ -148,7 +150,7 @@ module BABYLON.GUI {
 
             return {
                 width: maxLineWidth,
-                height: this._fontOffset.height * this._lines.length + 'px'
+                height: this._fontOffset.height * _lines.length + 'px'
             }
         }
 

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -136,7 +136,7 @@ module BABYLON.GUI {
             var maxLineWidth: number = 0;
 
             _lines.forEach(_line => {
-                //can't get context here? if so, have 2 calculations in _additionalProcessing instead? one for with idealWidth and one without
+                //can't get context here? if so, have 2 calculations in _additionalProcessing instead? one with idealWidth and one without
                 var lineWidth: number = this._parseLine(_line, context).width;
 
                 if (lineWidth > maxLineWidth) maxLineWidth = lineWidth;

--- a/gui/src/controls/textBlock.ts
+++ b/gui/src/controls/textBlock.ts
@@ -115,7 +115,7 @@ module BABYLON.GUI {
             this._lines = [];
             var _lines = this.text.split("\n");
 
-            if (this._textWrapping) {
+            if (this._textWrapping && !this._resizeToFit) {
                 for(var _line of _lines) {
                     this._lines.push(this._parseLineWithTextWrapping(_line, context));
                 }


### PR DESCRIPTION
The goal is to have TextBlocks automatically set their own width and height according to their measured text size, instead of having to manually set it for each case - which seems tedious and redundant to me.

It can be optional, but working quite a lot with GUI lately I can say this will make TextBlocks much easier and dynamic.

It's very rough as you can see, but the idea is calculating the width and height of a TextBlock every time it's rendered, and setting it to the control.

Issues:

1) Setting width and height at the moment sets the control as dirty which results in infinitely re-rendering it.
2) Doesn't seem to scale properly with idealWidth.
3) Need to calculate the height, probably something like this?

https://stackoverflow.com/questions/1134586/how-can-you-find-the-height-of-text-on-an-html-canvas

A different way to make it optional is to provide a measureText() function in TextBlock which returns accurately measured width and height, then the user can choose if/how to use this information.

I'm using this code to test the TextBlock's borders:
http://www.babylonjs-playground.com/#JR21MP#2