### PR TITLE
onDrawObservable, raw text size, Watcher

### DIFF
--- a/gui/src/controls/container.ts
+++ b/gui/src/controls/container.ts
@@ -144,16 +144,16 @@ module BABYLON.GUI {
                     if (child.isVisible && !child.notRenderable) {
                         child._draw(this._measureForChildren, context);
 
-                        if (child.onDrawObservable.hasObservers()) {
-                            child.onDrawObservable.notifyObservers(child);
+                        if (child.onAfterDrawObservable.hasObservers()) {
+                            child.onAfterDrawObservable.notifyObservers(child);
                         }
                     }
                 }
             }
             context.restore();
 
-            if (this.onDrawObservable.hasObservers()) {
-                this.onDrawObservable.notifyObservers(this);
+            if (this.onAfterDrawObservable.hasObservers()) {
+                this.onAfterDrawObservable.notifyObservers(this);
             }
         }
 

--- a/gui/src/controls/container.ts
+++ b/gui/src/controls/container.ts
@@ -143,10 +143,18 @@ module BABYLON.GUI {
                 for (var child of this._children) {
                     if (child.isVisible && !child.notRenderable) {
                         child._draw(this._measureForChildren, context);
+
+                        if (child.onDrawObservable.hasObservers()) {
+                            child.onDrawObservable.notifyObservers(child);
+                        }
                     }
                 }
             }
             context.restore();
+
+            if (this.onDrawObservable.hasObservers()) {
+                this.onDrawObservable.notifyObservers(this);
+            }
         }
 
         public _processPicking(x: number, y: number, type: number, buttonIndex: number): boolean {

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -96,10 +96,10 @@ module BABYLON.GUI {
         public onDirtyObservable = new Observable<Control>();         
         
          /**
-        * An event triggered when the control is drawn
+        * An event triggered after the control is drawn
         * @type {BABYLON.Observable}
         */
-        public onDrawObservable = new Observable<Control>();    
+        public onAfterDrawObservable = new Observable<Control>();    
 
         public get alpha(): number {
             return this._alpha;

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -93,7 +93,13 @@ module BABYLON.GUI {
         * An event triggered when the control is marked as dirty
         * @type {BABYLON.Observable}
         */
-        public onDirtyObservable = new Observable<Control>();           
+        public onDirtyObservable = new Observable<Control>();         
+        
+         /**
+        * An event triggered when the control is drawn
+        * @type {BABYLON.Observable}
+        */
+        public onDrawObservable = new Observable<Control>();    
 
         public get alpha(): number {
             return this._alpha;


### PR DESCRIPTION
I found myself needing to listen to draw. I notify the observers in container to avoid doing any rewrites. Hopefully you'll be fine with this addition.

New issue I'd like to discuss (can possibly be part of this PR) -

When I'm creating a TextBlock, in many cases its container's size depends on its size, however since that can't be evaluated at the creation time when resizeToFit is set to true, there's a problem.

1) The solution would be to define the size of the container when textBlock.onDrawObservable is notified (probably consistently and not just on the first render, which would be the default behavior when listening to an observable), however it should be possible to evaluate the raw size of the width and height (sort of reverse idealWidth / idealHeight) in order for it to make sense in controls that are using idealWidth and idealHeight and need to depend on that size.

2) Since a container size can depend on more than 1 TextBlock and/or containers that themselves depend on a TextBlock's size, I was thinking of creating a watcher to aggregate observers. It'd be an all purpose watcher rather than just for this specific case of course, I imagine it something like this:

`new Watcher(controls: Control[], observable: string, callback: (control: Control) => void)`

So for instance:

`new Watcher([textBlock1, textBlock2, someContainer], 'onDrawObservable', (control) => console.log('Control Drawn', control);`

I imagine the Watcher being part of bjs rather than gui.

These solutions will of course be useful in many other cases as they're generic.

What do you think?