### PR TITLE
GUI Event Bubbling

### DIFF
--- a/gui/src/advancedDynamicTexture.ts
+++ b/gui/src/advancedDynamicTexture.ts
@@ -323,7 +323,7 @@ module BABYLON.GUI {
 
                 if (type === BABYLON.PointerEventTypes.POINTERMOVE) {
                     if (this._lastControlOver) {
-                        this._lastControlOver._onPointerOut();
+                        this._lastControlOver._onPointerOut(this._lastControlOver);
                     }
                     
                     this._lastControlOver = null;
@@ -379,7 +379,7 @@ module BABYLON.GUI {
                     this.focusedControl = null;
                 } else if (pi.type === BABYLON.PointerEventTypes.POINTERMOVE) {
                     if (this._lastControlOver) {
-                        this._lastControlOver._onPointerOut();
+                        this._lastControlOver._onPointerOut(this._lastControlOver);
                     }              
                     this._lastControlOver = null;
                 }
@@ -417,7 +417,7 @@ module BABYLON.GUI {
         private _attachToOnPointerOut(scene: Scene): void {
             this._canvasPointerOutObserver = scene.getEngine().onCanvasPointerOutObservable.add(() => {
                 if (this._lastControlOver) {
-                    this._lastControlOver._onPointerOut();
+                    this._lastControlOver._onPointerOut(this._lastControlOver);
                 }            
                 this._lastControlOver = null;
 

--- a/gui/src/controls/button.ts
+++ b/gui/src/controls/button.ts
@@ -51,8 +51,8 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerEnter(): boolean {
-            if (!super._onPointerEnter()) {
+        public _onPointerEnter(target: Control): boolean {
+            if (!super._onPointerEnter(target)) {
                 return false;
             }
 
@@ -63,16 +63,16 @@ module BABYLON.GUI {
             return true;
         }
 
-        public _onPointerOut(): void {
+        public _onPointerOut(target: Control): void {
             if (this.pointerOutAnimation) {
                 this.pointerOutAnimation();
             }
 
-            super._onPointerOut();
+            super._onPointerOut(target);
         }
 
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }
 
@@ -84,12 +84,12 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerUp(coordinates: Vector2, buttonIndex: number): void {
+        public _onPointerUp(target: Control, coordinates: Vector2, buttonIndex: number): void {
             if (this.pointerUpAnimation) {
                 this.pointerUpAnimation();
             }
 
-            super._onPointerUp(coordinates, buttonIndex);
+            super._onPointerUp(target, coordinates, buttonIndex);
         }        
 
         // Statics

--- a/gui/src/controls/checkbox.ts
+++ b/gui/src/controls/checkbox.ts
@@ -102,8 +102,8 @@ module BABYLON.GUI {
         }
 
         // Events
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }
 

--- a/gui/src/controls/colorpicker.ts
+++ b/gui/src/controls/colorpicker.ts
@@ -362,8 +362,8 @@ module BABYLON.GUI {
             return false;
         }
 
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }            
 
@@ -384,19 +384,19 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerMove(coordinates: Vector2): void {
+        public _onPointerMove(target: Control, coordinates: Vector2): void {
             if (this._pointerIsDown) {
                 this._updateValueFromPointer(coordinates.x, coordinates.y);
             }
 
-            super._onPointerMove(coordinates);
+            super._onPointerMove(target, coordinates);
         }
 
-        protected _onPointerUp (coordinates: Vector2, buttonIndex: number): void {
+        public _onPointerUp (target: Control, coordinates: Vector2, buttonIndex: number): void {
             this._pointerIsDown = false;
             
             this._host._capturingControl = null;
-            super._onPointerUp(coordinates, buttonIndex);
+            super._onPointerUp(target, coordinates, buttonIndex);
         }     
     }    
 }

--- a/gui/src/controls/container.ts
+++ b/gui/src/controls/container.ts
@@ -76,6 +76,8 @@ module BABYLON.GUI {
 
             if (index !== -1) {
                 this._children.splice(index, 1);
+
+                control.parent = null;
             }
 
             this._markAsDirty();
@@ -93,6 +95,8 @@ module BABYLON.GUI {
             }
 
             this._children.push(control);
+
+            control.parent = this;
 
             this._markAsDirty();
         }

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -839,10 +839,6 @@ module BABYLON.GUI {
         }
 
         public _onPointerMove(target: Control, coordinates: Vector2): void {
-            /*if (this.onPointerMoveObservable.hasObservers()) {
-                this.onPointerMoveObservable.notifyObservers(coordinates);
-            }*/
-
             var canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerMove(target, coordinates);
@@ -854,9 +850,6 @@ module BABYLON.GUI {
             }
 
             this._enterCount++;
-            /*if (this.onPointerEnterObservable.hasObservers()) {
-                this.onPointerEnterObservable.notifyObservers(this);
-            }*/
 
             var canNotify: boolean = this.onPointerEnterObservable.notifyObservers(this, -1, target, this);
 
@@ -868,10 +861,6 @@ module BABYLON.GUI {
         public _onPointerOut(target: Control): void {
             this._enterCount = 0;
 
-            /*if (this.onPointerOutObservable.hasObservers()) {
-                this.onPointerOutObservable.notifyObservers(this);
-            }*/
-
             var canNotify: boolean = this.onPointerOutObservable.notifyObservers(this, -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerOut(target);
@@ -882,10 +871,7 @@ module BABYLON.GUI {
                 return false;
             }
 
-            this._downCount++;            
-            /*if (this.onPointerDownObservable.hasObservers()) {
-                this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
-            }*/
+            this._downCount++;
 
             var canNotify: boolean = this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this);
 
@@ -896,9 +882,6 @@ module BABYLON.GUI {
 
         public _onPointerUp(target: Control, coordinates: Vector2, buttonIndex: number): void {
             this._downCount = 0;
-            /*if (this.onPointerUpObservable.hasObservers()) {
-                this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
-            }*/
             
             var canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this);
             

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -843,7 +843,7 @@ module BABYLON.GUI {
                 this.onPointerMoveObservable.notifyObservers(coordinates);
             }*/
 
-            var canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, null, target, this);
+            var canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerMove(target, coordinates);
         }
@@ -858,7 +858,7 @@ module BABYLON.GUI {
                 this.onPointerEnterObservable.notifyObservers(this);
             }*/
 
-            var canNotify: boolean = this.onPointerEnterObservable.notifyObservers(this, null, target, this);
+            var canNotify: boolean = this.onPointerEnterObservable.notifyObservers(this, -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerEnter(target);
 
@@ -872,7 +872,7 @@ module BABYLON.GUI {
                 this.onPointerOutObservable.notifyObservers(this);
             }*/
 
-            var canNotify: boolean = this.onPointerOutObservable.notifyObservers(this, null, target, this);
+            var canNotify: boolean = this.onPointerOutObservable.notifyObservers(this, -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerOut(target);
         }
@@ -887,7 +887,7 @@ module BABYLON.GUI {
                 this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
             }*/
 
-            var canNotify: boolean = this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), null, target, this);
+            var canNotify: boolean = this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this);
 
             if (canNotify && this.parent != null) this.parent._onPointerDown(target, coordinates, buttonIndex);
 
@@ -900,7 +900,7 @@ module BABYLON.GUI {
                 this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
             }*/
             
-            var canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), null, target, this);
+            var canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this);
             
             if (canNotify && this.parent != null) this.parent._onPointerUp(target, coordinates, buttonIndex);
         }

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -7,6 +7,7 @@ module BABYLON.GUI {
         private _zIndex = 0;
         public _root: Container;
         public _host: AdvancedDynamicTexture;
+        public parent: Container;
         public _currentMeasure = Measure.Empty();
         private _fontFamily = "Arial";
         private _fontStyle = "";

--- a/gui/src/controls/control.ts
+++ b/gui/src/controls/control.ts
@@ -838,68 +838,89 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerMove(coordinates: Vector2): void {
-            if (this.onPointerMoveObservable.hasObservers()) {
+        public _onPointerMove(target: Control, coordinates: Vector2): void {
+            /*if (this.onPointerMoveObservable.hasObservers()) {
                 this.onPointerMoveObservable.notifyObservers(coordinates);
-            }
+            }*/
+
+            var canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, null, target, this);
+
+            if (canNotify && this.parent != null) this.parent._onPointerMove(target, coordinates);
         }
 
-        protected _onPointerEnter(): boolean {
+        public _onPointerEnter(target: Control): boolean {
             if (this._enterCount !== 0) {
                 return false;
             }
 
             this._enterCount++;
-            if (this.onPointerEnterObservable.hasObservers()) {
+            /*if (this.onPointerEnterObservable.hasObservers()) {
                 this.onPointerEnterObservable.notifyObservers(this);
-            }
+            }*/
+
+            var canNotify: boolean = this.onPointerEnterObservable.notifyObservers(this, null, target, this);
+
+            if (canNotify && this.parent != null) this.parent._onPointerEnter(target);
 
             return true;
         }
 
-        public _onPointerOut(): void {
+        public _onPointerOut(target: Control): void {
             this._enterCount = 0;
-            if (this.onPointerOutObservable.hasObservers()) {
+
+            /*if (this.onPointerOutObservable.hasObservers()) {
                 this.onPointerOutObservable.notifyObservers(this);
-            }
+            }*/
+
+            var canNotify: boolean = this.onPointerOutObservable.notifyObservers(this, null, target, this);
+
+            if (canNotify && this.parent != null) this.parent._onPointerOut(target);
         }
 
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
             if (this._downCount !== 0) {
                 return false;
             }
 
             this._downCount++;            
-            if (this.onPointerDownObservable.hasObservers()) {
+            /*if (this.onPointerDownObservable.hasObservers()) {
                 this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
-            }
+            }*/
+
+            var canNotify: boolean = this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), null, target, this);
+
+            if (canNotify && this.parent != null) this.parent._onPointerDown(target, coordinates, buttonIndex);
 
             return true;
         }
 
-        protected _onPointerUp(coordinates: Vector2, buttonIndex: number): void {
+        public _onPointerUp(target: Control, coordinates: Vector2, buttonIndex: number): void {
             this._downCount = 0;
-            if (this.onPointerUpObservable.hasObservers()) {
+            /*if (this.onPointerUpObservable.hasObservers()) {
                 this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex));
-            }           
+            }*/
+            
+            var canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), null, target, this);
+            
+            if (canNotify && this.parent != null) this.parent._onPointerUp(target, coordinates, buttonIndex);
         }
 
         public forcePointerUp() {
-            this._onPointerUp(Vector2.Zero(), 0);
+            this._onPointerUp(this, Vector2.Zero(), 0);
         }
 
         public _processObservables(type: number, x: number, y: number, buttonIndex: number): boolean {
             this._dummyVector2.copyFromFloats(x, y);
             if (type === BABYLON.PointerEventTypes.POINTERMOVE) {
-                this._onPointerMove(this._dummyVector2);
+                this._onPointerMove(this, this._dummyVector2);
 
                 var previousControlOver = this._host._lastControlOver;
                 if (previousControlOver && previousControlOver !== this) {
-                    previousControlOver._onPointerOut();                
+                    previousControlOver._onPointerOut(this);                
                 }
 
                 if (previousControlOver !== this) {
-                    this._onPointerEnter();
+                    this._onPointerEnter(this);
                 }
 
                 this._host._lastControlOver = this;
@@ -907,7 +928,7 @@ module BABYLON.GUI {
             }
 
             if (type === BABYLON.PointerEventTypes.POINTERDOWN) {
-                this._onPointerDown(this._dummyVector2, buttonIndex);
+                this._onPointerDown(this, this._dummyVector2, buttonIndex);
                 this._host._lastControlDown = this;
                 this._host._lastPickedControl = this;
                 return true;
@@ -915,7 +936,7 @@ module BABYLON.GUI {
 
             if (type === BABYLON.PointerEventTypes.POINTERUP) {
                 if (this._host._lastControlDown) {
-                    this._host._lastControlDown._onPointerUp(this._dummyVector2, buttonIndex);
+                    this._host._lastControlDown._onPointerUp(this, this._dummyVector2, buttonIndex);
                 }
                 this._host._lastControlDown = null;
                 return true;

--- a/gui/src/controls/inputText.ts
+++ b/gui/src/controls/inputText.ts
@@ -400,8 +400,8 @@ module BABYLON.GUI {
             context.restore();
         }
 
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }
 
@@ -417,8 +417,8 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerUp(coordinates: Vector2, buttonIndex: number): void {
-            super._onPointerUp(coordinates, buttonIndex);
+        public _onPointerUp(target: Control, coordinates: Vector2, buttonIndex: number): void {
+            super._onPointerUp(target, coordinates, buttonIndex);
         }  
 
         public dispose() {

--- a/gui/src/controls/radioButton.ts
+++ b/gui/src/controls/radioButton.ts
@@ -131,8 +131,8 @@ module BABYLON.GUI {
         }
 
         // Events
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }
             this.isChecked = !this.isChecked;

--- a/gui/src/controls/slider.ts
+++ b/gui/src/controls/slider.ts
@@ -197,7 +197,7 @@ module BABYLON.GUI {
                 this._updateValueFromPointer(coordinates.x);
             }
 
-            //not calling super._onPointerMove on purpose?
+            super._onPointerMove(target, coordinates);
         }
 
         public _onPointerUp (target: Control, coordinates: Vector2, buttonIndex: number): void {

--- a/gui/src/controls/slider.ts
+++ b/gui/src/controls/slider.ts
@@ -179,8 +179,8 @@ module BABYLON.GUI {
             this.value = this._minimum + ((x - this._currentMeasure.left) / this._currentMeasure.width) * (this._maximum - this._minimum);
         }
 
-        protected _onPointerDown(coordinates: Vector2, buttonIndex: number): boolean {
-            if (!super._onPointerDown(coordinates, buttonIndex)) {
+        public _onPointerDown(target: Control, coordinates: Vector2, buttonIndex: number): boolean {
+            if (!super._onPointerDown(target, coordinates, buttonIndex)) {
                 return false;
             }
 
@@ -192,17 +192,19 @@ module BABYLON.GUI {
             return true;
         }
 
-        protected _onPointerMove(coordinates: Vector2): void {
+        public _onPointerMove(target: Control, coordinates: Vector2): void {
             if (this._pointerIsDown) {
                 this._updateValueFromPointer(coordinates.x);
             }
+
+            //not calling super._onPointerMove on purpose?
         }
 
-        protected _onPointerUp (coordinates: Vector2, buttonIndex: number): void {
+        public _onPointerUp (target: Control, coordinates: Vector2, buttonIndex: number): void {
             this._pointerIsDown = false;
             
             this._host._capturingControl = null;
-            super._onPointerUp(coordinates, buttonIndex);
+            super._onPointerUp(target, coordinates, buttonIndex);
         }         
     }    
 }

--- a/src/Tools/babylon.observable.ts
+++ b/src/Tools/babylon.observable.ts
@@ -30,8 +30,14 @@
          */
         public mask: number;
 
+        /**
+         * The object that originally notified the event
+         */
         public target?: any;
         
+        /**
+         * The current object in the bubbling phase
+         */
         public currentTarget?: any;
     }
 

--- a/src/Tools/babylon.observable.ts
+++ b/src/Tools/babylon.observable.ts
@@ -8,13 +8,15 @@
         /**
         * If the callback of a given Observer set skipNextObservers to true the following observers will be ignored
         */
-        constructor(mask: number, skipNextObservers = false) {
-            this.initalize(mask, skipNextObservers);
+        constructor(mask: number, skipNextObservers = false, target?: any, currentTarget?: any) {
+            this.initalize(mask, skipNextObservers, target, currentTarget);
         }
 
-        public initalize(mask: number, skipNextObservers = false): EventState {
+        public initalize(mask: number, skipNextObservers = false, target?: any, currentTarget?: any): EventState {
             this.mask = mask;
             this.skipNextObservers = skipNextObservers;
+            this.target = target;
+            this.currentTarget = currentTarget;
             return this;
         }
 
@@ -27,6 +29,10 @@
          * Get the mask value that were used to trigger the event corresponding to this EventState object
          */
         public mask: number;
+
+        public target?: any;
+        
+        public currentTarget?: any;
     }
 
     /**
@@ -153,11 +159,13 @@
          * @param eventData
          * @param mask
          */
-        public notifyObservers(eventData: T, mask: number = -1): boolean {
+        public notifyObservers(eventData: T, mask: number = -1, target?: any, currentTarget?: any): boolean {
             let state = this._eventState;
             state.mask = mask;
+            state.target = target;
+            state.currentTarget = currentTarget;
             state.skipNextObservers = false;
-
+            
             for (var obs of this._observers) {
                 if (obs.mask & mask) {
                     if(obs.scope){

--- a/src/Tools/babylon.observable.ts
+++ b/src/Tools/babylon.observable.ts
@@ -165,7 +165,7 @@
             state.target = target;
             state.currentTarget = currentTarget;
             state.skipNextObservers = false;
-            
+
             for (var obs of this._observers) {
                 if (obs.mask & mask) {
                     if(obs.scope){


### PR DESCRIPTION
I was thinking of adding event bubbling, which will naturally require each child to have a reference to its parent.

Take this PG for instance:
https://www.babylonjs-playground.com/#XCPP9Y#292

A container that contains an image and a text block.

When clicking on a text block, observers of the text block are notified, but I'd like the event to keep bubbling up as long as there are more parents.

Would you be open to something like that? If so, would you mind if I try to tackle it myself or would you prefer to do it?

I was thinking of something pretty standard, an event-like object that has target, currentTarget, data, stopPropagation() and stopImmediatePropagation().

This event-like object will be notified to observers in current control, and if that control has a parent, the same observable notifying function (e.g. _onPointerDown) will be called on the parent, and so on, until no parent is found.

Since bjs uses observables, it'd look less elegant than an all-purpose event-style solution since it'd have to be manually applied for each different observable, plus it sort of mixes concepts from events and observables which is probably not good) so maybe you have a better direction.