### PR TITLE
 Now use "diffuse" instead of "diffuseColor" in materials in order to resolve conflicts with other materials when serializing/parsing

### DIFF
--- a/materialsLibrary/src/cell/babylon.cellMaterial.ts
+++ b/materialsLibrary/src/cell/babylon.cellMaterial.ts
@@ -32,7 +32,7 @@ module BABYLON {
         @expandToProperty("_markAllSubMeshesAsTexturesDirty")
         public diffuseTexture: BaseTexture;
 
-        @serializeAsColor3("diffuseColor")
+        @serializeAsColor3("diffuse")
         public diffuseColor = new Color3(1, 1, 1);
 
         @serialize("computeHighLevel")

--- a/materialsLibrary/src/fire/babylon.fireMaterial.ts
+++ b/materialsLibrary/src/fire/babylon.fireMaterial.ts
@@ -38,7 +38,7 @@ module BABYLON {
         @expandToProperty("_markAllSubMeshesAsTexturesDirty")
         public opacityTexture: Nullable<BaseTexture>;
         
-        @serialize("diffuse")
+        @serializeAsColor3("diffuse")
         public diffuseColor = new Color3(1, 1, 1);
         
         @serialize()

--- a/materialsLibrary/src/fire/babylon.fireMaterial.ts
+++ b/materialsLibrary/src/fire/babylon.fireMaterial.ts
@@ -38,7 +38,7 @@ module BABYLON {
         @expandToProperty("_markAllSubMeshesAsTexturesDirty")
         public opacityTexture: Nullable<BaseTexture>;
         
-        @serialize("diffuseColor")
+        @serialize("diffuse")
         public diffuseColor = new Color3(1, 1, 1);
         
         @serialize()

--- a/materialsLibrary/src/simple/babylon.simpleMaterial.ts
+++ b/materialsLibrary/src/simple/babylon.simpleMaterial.ts
@@ -29,7 +29,7 @@ module BABYLON {
         @expandToProperty("_markAllSubMeshesAsTexturesDirty")
         public diffuseTexture: BaseTexture;
 
-        @serializeAsColor3("diffuseColor")
+        @serializeAsColor3("diffuse")
         public diffuseColor = new Color3(1, 1, 1);
         
         @serialize("disableLighting")


### PR DESCRIPTION
this line should do the trick for compatibility: https://github.com/BabylonJS/Babylon.js/blob/master/src/Tools/babylon.decorators.ts#L258

@deltakosh do you agree?