### PR TITLE
Implement touch sensibility for camera

### DIFF
--- a/inspector/src/properties.ts
+++ b/inspector/src/properties.ts
@@ -116,6 +116,8 @@ module INSPECTOR {
                 'radius',
                 'angularSensibilityX',
                 'angularSensibilityY',
+                'angularTouchSensibilityX',
+                'angularTouchSensibilityY',
                 'target',
                 'lowerAlphaLimit',
                 'lowerBetaLimit',

--- a/src/Cameras/Inputs/babylon.arcRotateCameraPointersInput.ts
+++ b/src/Cameras/Inputs/babylon.arcRotateCameraPointersInput.ts
@@ -12,6 +12,12 @@ module BABYLON {
         public angularSensibilityY = 1000.0;
 
         @serialize()
+        public angularTouchSensibilityX = this.angularSensibilityX;
+
+        @serialize()
+        public angularTouchSensibilityY = this.angularSensibilityY;
+
+        @serialize()
         public pinchPrecision = 12.0;
 
         /**
@@ -32,6 +38,9 @@ module BABYLON {
 
         private _isPanClick: boolean = false;
         public pinchInwards = true;
+
+        private _angularSensibilityX = this.angularSensibilityX;
+        private _angularSensibilityY = this.angularSensibilityY;
 
         private _pointerInput: (p: PointerInfo, s: EventState) => void;
         private _observer: Nullable<Observer<PointerInfo>>;
@@ -54,7 +63,11 @@ module BABYLON {
 
             this._pointerInput = (p, s) => {
                 var evt = <PointerEvent>p.event;
-
+                let isTouch = (<any>p.event).pointerType === "touch";
+                
+                this._angularSensibilityX = isTouch ? this.angularTouchSensibilityX : this.angularSensibilityX;
+                this._angularSensibilityY = isTouch ? this.angularTouchSensibilityY : this.angularSensibilityY;
+                
                 if (engine.isInVRExclusivePointerMode) {
                     return;
                 }
@@ -105,7 +118,7 @@ module BABYLON {
                     twoFingerActivityCount = 0;
                     initialDistance = 0;
 
-                    if ((<any>p.event).pointerType !== "touch") {
+                    if (!isTouch) {
                         pointB = null; // Mouse and pen are mono pointer
                     }
 
@@ -150,8 +163,8 @@ module BABYLON {
                         } else {
                             var offsetX = evt.clientX - cacheSoloPointer.x;
                             var offsetY = evt.clientY - cacheSoloPointer.y;
-                            this.camera.inertialAlphaOffset -= offsetX / this.angularSensibilityX;
-                            this.camera.inertialBetaOffset -= offsetY / this.angularSensibilityY;
+                            this.camera.inertialAlphaOffset -= offsetX / this._angularSensibilityX;
+                            this.camera.inertialBetaOffset -= offsetY / this._angularSensibilityY;
                         }
 
                         cacheSoloPointer.x = evt.clientX;
@@ -184,7 +197,7 @@ module BABYLON {
                             } else {
                                 this.camera.inertialRadiusOffset += (pinchSquaredDistance - previousPinchSquaredDistance) /
                                     (this.pinchPrecision *
-                                        ((this.angularSensibilityX + this.angularSensibilityY) / 2) *
+                                        ((this._angularSensibilityX + this._angularSensibilityY) / 2) *
                                         direction);
                             }
 
@@ -210,7 +223,7 @@ module BABYLON {
                                 } else {
                                     this.camera.inertialRadiusOffset += (pinchSquaredDistance - previousPinchSquaredDistance) /
                                         (this.pinchPrecision *
-                                            ((this.angularSensibilityX + this.angularSensibilityY) / 2) *
+                                            ((this._angularSensibilityX + this._angularSensibilityY) / 2) *
                                             direction);
                                 }
                                 previousMultiTouchPanPosition.isPaning = false;

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -96,6 +96,36 @@
             }
         }
 
+        public get angularTouchSensibilityX(): number {
+            var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];
+            if (pointers)
+                return pointers.angularTouchSensibilityX;
+
+            return 0;
+        }
+
+        public set angularTouchSensibilityX(value: number) {
+            var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];
+            if (pointers) {
+                pointers.angularTouchSensibilityX = value;
+            }
+        }
+
+        public get angularTouchSensibilityY(): number {
+            var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];
+            if (pointers)
+                return pointers.angularTouchSensibilityY;
+
+            return 0;
+        }
+
+        public set angularTouchSensibilityY(value: number) {
+            var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];
+            if (pointers) {
+                pointers.angularTouchSensibilityY = value;
+            }
+        }
+
         public get pinchPrecision(): number {
             var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];
             if (pointers)


### PR DESCRIPTION
The current sensibility for the camera movement is slower on touch
than desktop. It seems the sensibility should be quicker on touch
to make it feel more responsive on mobile device. The value
should be set to 500 if users want it.