### PR TITLE
Viewer public API extension

### DIFF
--- a/Viewer/src/index.ts
+++ b/Viewer/src/index.ts
@@ -1,3 +1,4 @@
+import { viewerManager } from './viewer/viewerManager';
 import { DefaultViewer } from './viewer/defaultViewer';
 import { AbstractViewer } from './viewer/viewer';
 
@@ -26,4 +27,4 @@ setTimeout(() => {
 });
 
 // public API for initialization
-export { InitTags, DefaultViewer, AbstractViewer };
+export { InitTags, DefaultViewer, AbstractViewer, viewerManager };

--- a/Viewer/src/index.ts
+++ b/Viewer/src/index.ts
@@ -1,3 +1,4 @@
+import { DefaultViewer } from './viewer/defaultViewer';
 import { AbstractViewer } from './viewer/viewer';
 
 /**
@@ -25,4 +26,4 @@ setTimeout(() => {
 });
 
 // public API for initialization
-export { InitTags };
+export { InitTags, DefaultViewer, AbstractViewer };

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -9,7 +9,7 @@ window['BABYLON'] = BABYLON;
 
 export class DefaultViewer extends AbstractViewer {
 
-    private camera: ArcRotateCamera;
+    public camera: ArcRotateCamera;
 
     public initScene(): Promise<Scene> {
         return super.initScene().then(() => {

--- a/Viewer/src/viewer/viewer.ts
+++ b/Viewer/src/viewer/viewer.ts
@@ -1,3 +1,4 @@
+import { viewerManager } from './viewerManager';
 import { TemplateManager } from './../templateManager';
 import configurationLoader from './../configuration/loader';
 import { Observable, Engine, Scene, ArcRotateCamera, Vector3, SceneLoader, AbstractMesh, Mesh, HemisphericLight } from 'babylonjs';
@@ -21,6 +22,10 @@ export abstract class AbstractViewer {
             this.baseId = containerElement.id = 'bjs' + Math.random().toString(32).substr(2, 8);
         }
 
+        // add this viewer to the viewer manager
+        viewerManager.addViewer(this);
+
+        // create a new template manager. TODO - singleton?
         this.templateManager = new TemplateManager(containerElement);
 
         this.prepareContainerElement();

--- a/Viewer/src/viewer/viewerManager.ts
+++ b/Viewer/src/viewer/viewerManager.ts
@@ -1,0 +1,28 @@
+import { AbstractViewer } from './viewer';
+
+class ViewerManager {
+
+    private viewers: { [key: string]: AbstractViewer };
+
+    constructor() {
+        this.viewers = {};
+    }
+
+    public addViewer(viewer: AbstractViewer) {
+        this.viewers[viewer.getBaseId()] = viewer;
+    }
+
+    public getViewerById(id: string): AbstractViewer {
+        return this.viewers[id];
+    }
+
+    public getViewerByHTMLElement(element: HTMLElement) {
+        for (let id in this.viewers) {
+            if (this.viewers[id].containerElement === element) {
+                return this.getViewerById(id);
+            }
+        }
+    }
+}
+
+export let viewerManager = new ViewerManager();


### PR DESCRIPTION
The default viewer and abstract viewer classees are now exposed and can be used to create new viewers using code.

There is now a new viewerManager that has a reference to all existing viewers in the current page. This is useful if you want access to an already-initialized viewer, which provides public access to the engine, scene and camera objects.

To use the new viewerManager:

```javascript
// get by an HTML element
let myElement = document.querySelector('my-amazing-viewer-element')
let viewer1 = BabylonViewer.viewerManager.getViewerByHTMLElement(myElement);
// OR
let knownIdOfViewer = 'earth-is-round'; // the Id of the containing HTML element, unless modified
let viewer2 = BabylonViewer.viewerManager.getViewerById(knownIdOfViewer);
```
