### PR TITLE
Physics pivot fix

### DIFF
--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -267,6 +267,13 @@
                     var rawVerts = object.getVerticesData ? object.getVerticesData(VertexBuffer.PositionKind) : [];
                     var rawFaces = object.getIndices ? object.getIndices() : [];
                     if (!rawVerts) return;
+                    // get only scale! so the object could transform correctly.
+                    let oldPosition = object.position.clone();
+                    let oldRotation = object.rotation && object.rotation.clone();
+                    let oldQuaternion = object.rotationQuaternion && object.rotationQuaternion.clone();
+                    object.position.copyFromFloats(0, 0, 0);
+                    object.rotation && object.rotation.copyFromFloats(0, 0, 0);
+                    object.rotationQuaternion && object.rotationQuaternion.copyFromFloats(0, 0, 0, 1);
                     let transform = object.computeWorldMatrix(true);
                     // convert rawVerts to object space
                     var temp = new Array<number>();
@@ -277,6 +284,10 @@
 
                     Tools.Warn("MeshImpostor only collides against spheres.");
                     returnValue = new this.BJSCANNON.Trimesh(temp, <number[]>rawFaces);
+                    //now set back the transformation!
+                    object.position.copyFrom(oldPosition);
+                    oldRotation && object.rotation && object.rotation.copyFrom(oldRotation);
+                    oldQuaternion && object.rotationQuaternion && object.rotationQuaternion.copyFrom(oldQuaternion);
                     break;
                 case PhysicsImpostor.HeightmapImpostor:
                     returnValue = this._createHeightmap(object);
@@ -413,7 +424,7 @@
                 mesh.setPivotMatrix(oldPivot);
                 mesh.computeWorldMatrix(true);
             } else if (impostor.type === PhysicsImpostor.MeshImpostor) {
-                //this._tmpDeltaPosition.copyFromFloats(0, 0, 0);
+                this._tmpDeltaPosition.copyFromFloats(0, 0, 0);
                 //this._tmpPosition.copyFrom(object.position);
             }
 
@@ -427,11 +438,15 @@
             impostor.object.position.copyFrom(impostor.physicsBody.position);
             if (impostor.object.rotationQuaternion) {
                 impostor.object.rotationQuaternion.copyFrom(impostor.physicsBody.quaternion);
+                //impostor.object.rotationQuaternion.y *= -1;
+                //impostor.object.rotationQuaternion.z *= -1;
             }
         }
 
         public setPhysicsBodyTransformation(impostor: PhysicsImpostor, newPosition: Vector3, newRotation: Quaternion) {
             impostor.physicsBody.position.copy(newPosition);
+            //newRotation.y *= -1;
+            //newRotation.z *= -1;
             impostor.physicsBody.quaternion.copy(newRotation);
         }
 

--- a/src/Physics/Plugins/babylon.cannonJSPlugin.ts
+++ b/src/Physics/Plugins/babylon.cannonJSPlugin.ts
@@ -363,7 +363,7 @@
             if (!bInfo) return;
             var center = impostor.getObjectCenter();
             //m.getAbsolutePosition().subtract(m.getBoundingInfo().boundingBox.centerWorld)
-            this._tmpDeltaPosition.copyFrom(object.getAbsolutePosition().subtract(center));
+            this._tmpDeltaPosition.copyFrom(object.getAbsolutePivotPoint().subtract(center));
             this._tmpPosition.copyFrom(center);
             var quaternion = object.rotationQuaternion;
 

--- a/src/Physics/babylon.physicsImpostor.ts
+++ b/src/Physics/babylon.physicsImpostor.ts
@@ -387,7 +387,7 @@ module BABYLON {
 
             if (!this._options.disableBidirectionalTransformation) {
                 let bInfo = this.object.getBoundingInfo();
-                bInfo && this.object.rotationQuaternion && this._physicsEngine.getPhysicsPlugin().setPhysicsBodyTransformation(this, /*bInfo.boundingBox.centerWorld*/ this.object.getAbsolutePosition(), this.object.rotationQuaternion);
+                bInfo && this.object.rotationQuaternion && this._physicsEngine.getPhysicsPlugin().setPhysicsBodyTransformation(this, /*bInfo.boundingBox.centerWorld*/ this.object.getAbsolutePivotPoint(), this.object.rotationQuaternion);
             }
 
             this._onBeforePhysicsStepCallbacks.forEach((func) => {


### PR DESCRIPTION
Where do I start?...

We had a few problems with the mesh-impostor from glTF files, which had a very interesting parent transformation (that is completely correct, we simply never took the parent into account).

The following changes fully take the object'S parent transformation into account when calculating the physics step of an object. A pivot can now also be set (the object doesn't have to be centered).

The following playground simulates it simply - the sphere has a parent and a pivot point set. 

Without the changes: https://playground.babylonjs.com/#I6EIED#16 . 
With: https://playground.babylonjs.com/#I6EIED#17

Here it is in action:
![nov 6 2017 3-15 pm - edited](https://user-images.githubusercontent.com/1381702/32445707-e9adb578-c306-11e7-8456-a36ab54ff99a.gif)
