### PR TITLE
Fix vertex alpha for glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -323,6 +323,7 @@ module BABYLON.GLTF2 {
             }
 
             node.babylonMesh = new Mesh(node.name || "mesh" + node.index, this._babylonScene);
+            node.babylonMesh.hasVertexAlpha = true;
 
             this._loadTransform(node);
 
@@ -1383,10 +1384,12 @@ module BABYLON.GLTF2 {
             const alphaMode = material.alphaMode || "OPAQUE";
             switch (alphaMode) {
                 case "OPAQUE": {
-                    // default is opaque
+                    babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_OPAQUE;
                     break;
                 }
                 case "MASK": {
+                    babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_ALPHATEST;
+
                     babylonMaterial.alphaCutOff = (material.alphaCutoff == null ? 0.5 : material.alphaCutoff);
 
                     if (colorFactor) {
@@ -1404,6 +1407,8 @@ module BABYLON.GLTF2 {
                     break;
                 }
                 case "BLEND": {
+                    babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_ALPHABLEND;
+
                     if (colorFactor) {
                         babylonMaterial.alpha = colorFactor[3];
                     }

--- a/src/Materials/PBR/babylon.pbrBaseSimpleMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrBaseSimpleMaterial.ts
@@ -84,32 +84,6 @@
         @expandToProperty("_markAllSubMeshesAsTexturesDirty", "_alphaCutOff")
         public alphaCutOff: number;
 
-        protected _transparencyMode: number = PBRMaterial.PBRMATERIAL_OPAQUE;
-        /**
-         * Gets the current transparency mode.
-         */
-        @serialize()
-        public get transparencyMode(): number {
-            return this._transparencyMode;
-        }
-        /**
-         * Sets the transparency mode of the material.
-         */
-        public set transparencyMode(value: number) {
-            if (this._transparencyMode === value) {
-                return;
-            }
-            this._transparencyMode = value;
-            if (value === PBRMaterial.PBRMATERIAL_ALPHATESTANDBLEND) {
-                this._forceAlphaTest = true;
-            }
-            else {
-                this._forceAlphaTest = false;
-            }
-            
-            this._markAllSubMeshesAsTexturesDirty();
-        }
-
         /**
          * Gets the current double sided mode.
          */
@@ -127,39 +101,6 @@
             this._twoSidedLighting = value;
             this.backFaceCulling = !value;
             this._markAllSubMeshesAsTexturesDirty();
-        }
-
-        /**
-         * Specifies wether or not the alpha value of the albedo texture should be used.
-         */
-        protected _shouldUseAlphaFromAlbedoTexture(): boolean {
-            return this._albedoTexture && this._albedoTexture.hasAlpha && this._transparencyMode !== PBRMaterial.PBRMATERIAL_OPAQUE;
-        }
-
-        /**
-         * Specifies wether or not the meshes using this material should be rendered in alpha blend mode.
-         */
-        public needAlphaBlending(): boolean {
-            if (this._linkRefractionWithTransparency) {
-                return false;
-            }
-
-            return (this.alpha < 1.0) || 
-                    (this._shouldUseAlphaFromAlbedoTexture() &&
-                        (this._transparencyMode === PBRMaterial.PBRMATERIAL_ALPHABLEND ||
-                            this._transparencyMode === PBRMaterial.PBRMATERIAL_ALPHATESTANDBLEND));
-        }
-
-        /**
-         * Specifies wether or not the meshes using this material should be rendered in alpha test mode.
-         */
-        public needAlphaTesting(): boolean {
-            if (this._linkRefractionWithTransparency) {
-                return false;
-            }
-
-            return this._shouldUseAlphaFromAlbedoTexture() &&
-                 this._transparencyMode === PBRMaterial.PBRMATERIAL_ALPHATEST;
         }
 
         /**
@@ -196,11 +137,13 @@
         constructor(name: string, scene: Scene) {
             super(name, scene);
 
+            this._transparencyMode = PBRMaterial.PBRMATERIAL_OPAQUE;
+            this._useAlphaFromAlbedoTexture = true;
             this._useAmbientInGrayScale = true;
         }
 
         public getClassName(): string {
             return "PBRBaseSimpleMaterial";
-        }        
+        }
     }
 }

--- a/src/Materials/PBR/babylon.pbrMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrMaterial.ts
@@ -222,7 +222,7 @@
         public useLightmapAsShadowmap = false;
         
         /**
-         * Specifies that the alpha is coming form the albedo channel alpha channel.
+         * Specifies that the alpha is coming form the albedo channel alpha channel for alpha blending.
          */
         @serialize()
         @expandToProperty("_markAllSubMeshesAsTexturesDirty")

--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -450,6 +450,10 @@
             return (this.alpha < 1.0);
         }
 
+        public needAlphaBlendingForMesh(mesh: AbstractMesh): boolean {
+            return (mesh.visibility < 1.0) || mesh.hasVertexAlpha;
+        }
+
         public needAlphaTesting(): boolean {
             return false;
         }

--- a/src/Materials/babylon.materialHelper.ts
+++ b/src/Materials/babylon.materialHelper.ts
@@ -69,10 +69,10 @@
             }
         }
 
-        public static PrepareDefinesForAttributes(mesh: AbstractMesh, defines: any, useVertexColor: boolean, useBones: boolean, useMorphTargets = false): boolean {
+        public static PrepareDefinesForAttributes(mesh: AbstractMesh, defines: any, useVertexColor: boolean, useBones: boolean, useMorphTargets = false, useVertexAlpha = true): boolean {
             if (!defines._areAttributesDirty && defines._needNormals === defines._normals && defines._needUVs === defines._uvs) {
                 return false;
-            }               
+            }
 
             defines._normals = defines._needNormals;
             defines._uvs = defines._needUVs;
@@ -92,8 +92,9 @@
             }
 
             if (useVertexColor) {
-                defines["VERTEXCOLOR"] = mesh.useVertexColors && mesh.isVerticesDataPresent(VertexBuffer.ColorKind);
-                defines["VERTEXALPHA"] = mesh.hasVertexAlpha;
+                var hasVertexColors = mesh.useVertexColors && mesh.isVerticesDataPresent(VertexBuffer.ColorKind);
+                defines["VERTEXCOLOR"] = hasVertexColors;
+                defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
             }
 
             if (useBones) {
@@ -103,7 +104,7 @@
                 } else {
                     defines["NUM_BONE_INFLUENCERS"] = 0;
                     defines["BonesPerMesh"] = 0;
-                }           
+                }
             }
 
             if (useMorphTargets) {

--- a/src/Rendering/babylon.renderingGroup.ts
+++ b/src/Rendering/babylon.renderingGroup.ts
@@ -324,7 +324,7 @@
                 return;
             }
 
-            if (material.needAlphaBlending() || mesh.visibility < 1.0 || mesh.hasVertexAlpha) { // Transparent
+            if (material.needAlphaBlending() || material.needAlphaBlendingForMesh(mesh)) { // Transparent
                 this._transparentSubMeshes.push(subMesh);
             } else if (material.needAlphaTesting()) { // Alpha test
                 if (material.needDepthPrePass) {


### PR DESCRIPTION
- Move transparencyMode from pbrBaseSimpleMaterial to pbrBaseMaterial
- Added Material.needAlphaBlendingForMesh() to decide whether blending should happen instead of renderGroup deciding based on mesh directly