### PR TITLE
Preparing for including the inspector in npm

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -242,7 +242,7 @@
             "dependUpon": [
                 "core"
             ]
-        },    
+        },
         "instrumentation": {
             "files": [
                 "../../src/Instrumentation/babylon.engineInstrumentation.js",
@@ -252,7 +252,7 @@
             "dependUpon": [
                 "core"
             ]
-        },      
+        },
         "cameraBehaviors": {
             "files": [
                 "../../src/Behaviors/Cameras/babylon.framingBehavior.js",
@@ -405,7 +405,7 @@
                 "defaultUboDeclaration",
                 "shadowsFragmentFunctions",
                 "fresnelFunction",
-                "reflectionFunction",                
+                "reflectionFunction",
                 "imageProcessingDeclaration",
                 "imageProcessingFunctions",
                 "bumpFragmentFunctions",
@@ -461,7 +461,7 @@
                 "shadowsFragmentFunctions",
                 "pbrFunctions",
                 "imageProcessingDeclaration",
-                "imageProcessingFunctions",                
+                "imageProcessingFunctions",
                 "harmonicsFunctions",
                 "pbrLightFunctions",
                 "helperFunctions",
@@ -1594,7 +1594,8 @@
                 ],
                 "output": "babylon.inspector.js",
                 "webpack": "../../inspector/webpack.config.js",
-                "bundle": "true"
+                "bundle": "true",
+                "moduleDeclaration": "GUI"
             }
         ],
         "build": {

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -402,6 +402,7 @@ var buildExternalLibrary = function (library, settings, watch) {
             return waitAll.on("end", function () {
                 webpack(require(library.webpack))
                     .pipe(rename(library.output.replace(".js", ".bundle.js")))
+                    .pipe(addModuleExports(library.moduleDeclaration, false, false, true))
                     .pipe(gulp.dest(outputDirectory))
             });
         }
@@ -474,21 +475,21 @@ gulp.task("typescript-all", function (cb) {
  */
 gulp.task("watch", [], function () {
     var interval = 1000;
-    var tasks = [gulp.watch(config.typescript, { interval: interval}, ["typescript-compile"])];
+    var tasks = [gulp.watch(config.typescript, { interval: interval }, ["typescript-compile"])];
 
     config.modules.map(function (module) {
         config[module].libraries.map(function (library) {
-            tasks.push(gulp.watch(library.files, { interval: interval}, function () {
+            tasks.push(gulp.watch(library.files, { interval: interval }, function () {
                 console.log(library.output);
                 return buildExternalLibrary(library, config[module], true)
                     .pipe(debug());
             }));
-            tasks.push(gulp.watch(library.shaderFiles, { interval: interval}, function () {
+            tasks.push(gulp.watch(library.shaderFiles, { interval: interval }, function () {
                 console.log(library.output);
                 return buildExternalLibrary(library, config[module], true)
                     .pipe(debug())
             }));
-            tasks.push(gulp.watch(library.sassFiles, { interval: interval}, function () {
+            tasks.push(gulp.watch(library.sassFiles, { interval: interval }, function () {
                 console.log(library.output);
                 return buildExternalLibrary(library, config[module], true)
                     .pipe(debug())

--- a/Tools/Publisher/index.js
+++ b/Tools/Publisher/index.js
@@ -35,6 +35,10 @@ let packages = [
     {
         name: 'proceduralTextures',
         path: basePath + '/proceduralTexturesLibrary/'
+    },
+    {
+        name: 'inspector',
+        path: basePath + '/inspector/'
     }
 ];
 

--- a/dist/preview release/inspector/package.json
+++ b/dist/preview release/inspector/package.json
@@ -1,0 +1,33 @@
+{
+    "author": {
+        "name": "David CATUHE"
+    },
+    "name": "babylonjs-inspector",
+    "description": "The Babylon.js inspector.",
+    "version": "3.1.0-beta1.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/BabylonJS/Babylon.js.git"
+    },
+    "main": "babylonjs.inspector.bundle.js",
+    "files": [
+        "babylonjs.inspector.bundle.js",
+        "readme.md",
+        "package.json"
+    ],
+    "keywords": [
+        "3D",
+        "javascript",
+        "html5",
+        "webgl",
+        "babylonjs",
+        "inspector"
+    ],
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "babylonjs": ">=3.1.0-alpha"
+    },
+    "engines": {
+        "node": "*"
+    }
+}

--- a/dist/preview release/inspector/readme.md
+++ b/dist/preview release/inspector/readme.md
@@ -1,0 +1,34 @@
+Babylon.js inspector module
+=====================
+
+For usage documentation please visit http://doc.babylonjs.com/how_to/debug_layer and search "inspector".
+
+# Installation instructions
+
+The inspector will be **automatically** (async) loaded when starting the debug layer, if not already included. So technically, nothing needs to be done!
+
+If you wish however to use a different version of the inspector or host it on your own, follow these instructions:
+
+## CDN
+
+The latest compiled js file is offered on our public CDN here:
+
+* https://preview.babylonjs.com/inspector/babylonjs.inspector.bundle.js
+
+## NPM
+
+To install using npm :
+
+```
+npm install --save babylonjs babylonjs-inspector
+```
+Afterwards it can be imported to the project using:
+
+```
+import * as BABYLON from 'babylonjs';
+import 'babylonjs-inspector';
+```
+
+This will create a global INSPECTOR variable that will be used bay BabylonJS
+
+Webpack is supported.

--- a/inspector/webpack.config.js
+++ b/inspector/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
         "../../dist/preview release/inspector/babylon.inspector.min.js"
     ],
     output: {
-        libraryTarget: "var",
+        libraryTarget: "umd",
         library: "INSPECTOR",
         umdNamedDefine: true
     },


### PR DESCRIPTION
When we have full control over babylonjs-inspector we will need to build and deploy our own version of it. This is the preparation for this process.

Another change here is that the BABYLON object is now assigned to the global object so that the inspector can find it without a problem.

This way we can also develop including any version of BABYLON we wish (instead of the npm package).
See the nullEngine test as an example.

The (webpack) warning is now gone! 🎆 🎉 