### PR TITLE
Change return type of addTextureTask to IAssetTask

### DIFF
--- a/src/Tools/babylon.assetsManager.ts
+++ b/src/Tools/babylon.assetsManager.ts
@@ -304,7 +304,7 @@ module BABYLON {
             return task;
         }
 
-        public addTextureTask(taskName: string, url: string, noMipmap?: boolean, invertY?: boolean, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE): ITextureAssetTask {
+        public addTextureTask(taskName: string, url: string, noMipmap?: boolean, invertY?: boolean, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE): IAssetTask {
             var task = new TextureAssetTask(taskName, url, noMipmap, invertY, samplingMode);
             this.tasks.push(task);
 


### PR DESCRIPTION
Currently it uses the more specific ITextureAssetTask which will disallow e.g. that:
```typescript
const task = this.loader.addTextureTask("download texture", "/textures/" + file)
task.onError = (task, message, exception) => { }
```
Which works for all the other tasks.

Current workaround:
typecasting