### PR TITLE
Addition of "isForeground" property.

### DIFF
--- a/gui/src/advancedDynamicTexture.ts
+++ b/gui/src/advancedDynamicTexture.ts
@@ -113,6 +113,17 @@ module BABYLON.GUI {
 
             this._focusedControl = control;
         }
+        
+        public get isForeground(): boolean {
+            return (!this.layer.isBackground);
+        }
+
+        public set isForeground(value: boolean) {
+            if (this.layer.isBackground === !value) {
+                return;
+            }
+            this.layer.isBackground = !value;
+        }   
        
         constructor(name: string, width = 0, height = 0, scene: Nullable<Scene>, generateMipMaps = false, samplingMode = Texture.NEAREST_SAMPLINGMODE) {
             super(name, {width: width, height: height}, scene, generateMipMaps, samplingMode, Engine.TEXTUREFORMAT_RGBA);


### PR DESCRIPTION
Addition of "isForeground" to AdvancedDynamicTexture, 
allowing easy on-the-go switch between rendering in foreground and background.

Useful when working with multiple GUI's in a single AdvancedDynamicTexture.
e.g. out-of-game GUI rendered in background to allow rendering 3d models infront of the GUI, 
and in-game GUI rendered in foreground.
PG repo; https://www.babylonjs-playground.com/#XCPP9Y#321