### PR TITLE
Fix wrong sky material behaviour on some devices.

### DIFF
--- a/materialsLibrary/src/sky/sky.fragment.fx
+++ b/materialsLibrary/src/sky/sky.fragment.fx
@@ -71,7 +71,7 @@ float hgPhase(float cosTheta, float g)
 
 float sunIntensity(float zenithAngleCos)
 {
-	return EE * max(0.0, 1.0 - exp(-((cutoffAngle - acos(zenithAngleCos))/steepness)));
+	return EE * max(0.0, 1.0 - exp((-(cutoffAngle - acos(zenithAngleCos))/steepness)));
 }
 
 float A = 0.15;


### PR DESCRIPTION
See #3189.

On some devices the sky material appears black.
Moving a single sign within the shader solve the issue, though the reason for why this fix work isn't known yet.