### PR TITLE
Lines useVertexAlpha now true by default

### DIFF
--- a/src/Mesh/babylon.linesMesh.ts
+++ b/src/Mesh/babylon.linesMesh.ts
@@ -48,15 +48,18 @@
             var options = {
                 attributes: [VertexBuffer.PositionKind],
                 uniforms: ["world", "viewProjection"],
-                needAlphaBlending: false,
+                needAlphaBlending: true,
                 defines: defines
             };
+            
+            if (useVertexAlpha === false) {
+                options.needAlphaBlending = false;
+            }
             
             if (!useVertexColor) {
                 options.uniforms.push("color");
             }
             else {
-                options.needAlphaBlending = (useVertexAlpha) ? true : false;
                 options.defines.push("#define VERTEXCOLOR");
                 options.attributes.push(VertexBuffer.ColorKind);
             }

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -359,7 +359,7 @@
          * The parameter `lines` is an array of lines, each line being an array of successive Vector3.   
          * The optional parameter `instance` is an instance of an existing LineSystem object to be updated with the passed `lines` parameter. The way to update it is the same than for 
          * The optional parameter `colors` is an array of line colors, each line colors being an array of successive Color4, one per line point.  
-         * The optional parameter `useVertexAlpha' is to be set to `true` (default `false`) when the alpha value from the former `Color4` array must be used.  
+         * The optional parameter `useVertexAlpha' is to be set to `false` (default `true`) when you don't need the alpha blending (faster).  
          * updating a simple Line mesh, you just need to update every line in the `lines` array : http://doc.babylonjs.com/tutorials/How_to_dynamically_morph_a_mesh#lines-and-dashedlines   
          * When updating an instance, remember that only line point positions can change, not the number of points, neither the number of lines.      
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
@@ -418,7 +418,7 @@
          * The parameter `points` is an array successive Vector3.   
          * The optional parameter `instance` is an instance of an existing LineMesh object to be updated with the passed `points` parameter : http://doc.babylonjs.com/tutorials/How_to_dynamically_morph_a_mesh#lines-and-dashedlines    
          * The optional parameter `colors` is an array of successive Color4, one per line point.  
-         * The optional parameter `useVertexAlpha' is to be set to `true` (default `false`) when the alpha value from the former `Color4` array must be used.  
+         * The optional parameter `useVertexAlpha' is to be set to `false` (default `true`) when you don't need alpha blending (faster).  
          * When updating an instance, remember that only point positions can change, not the number of points.      
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
          */


### PR DESCRIPTION
Like the title says ...
fixes this issue : https://github.com/BabylonJS/Babylon.js/issues/3200