### PR TITLE
add ray length and update mesh selection predicate

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -35,6 +35,7 @@ module BABYLON {
         public onExitingVR: () => void;
         public onControllerMeshLoaded: (controller: WebVRController) => void;
 
+        private _rayLength: number;
         private _useCustomVRButton: boolean = false;
         private _teleportationRequested: boolean = false;
         private _teleportationEnabledOnLeftController: boolean = false;
@@ -116,6 +117,10 @@ module BABYLON {
                     if (webVROptions.customVRButton) {
                         this._btnVR = webVROptions.customVRButton;
                     }
+                }
+
+                if (webVROptions.rayLength) {
+                    this._rayLength = webVROptions.rayLength
                 }
             }
 
@@ -414,7 +419,7 @@ module BABYLON {
                         && mesh.name.indexOf("teleportationCircle") === -1
                         && mesh.name.indexOf("torusTeleportation") === -1
                         && mesh.name.indexOf("laserPointer") === -1)) {
-                    return true;
+                    return (mesh.isEnabled() && mesh.isVisible && mesh.isPickable);
                 }
                 return false;
             }
@@ -906,14 +911,14 @@ module BABYLON {
                 (this._leftLaserPointer && !this._leftLaserPointer.isVisible && !this._rightLaserPointer) || 
                 (this._rightLaserPointer && !this._rightLaserPointer.isVisible && !this._leftLaserPointer) || 
                 (this._rightLaserPointer && this._leftLaserPointer && !this._rightLaserPointer.isVisible && !this._leftLaserPointer.isVisible)) {
-                    ray = this.currentVRCamera.getForwardRay();
+                    ray = this.currentVRCamera.getForwardRay(this._rayLength);
                 
             } else {
                 if (this._leftLaserPointer && this._leftLaserPointer.isVisible) {
-                    ray = (<any>this.currentVRCamera).leftController.getForwardRay();
+                    ray = (<any>this.currentVRCamera).leftController.getForwardRay(this._rayLength);
                 }
                 else {
-                    ray = (<any>this.currentVRCamera).rightController.getForwardRay();
+                    ray = (<any>this.currentVRCamera).rightController.getForwardRay(this._rayLength);
                 }
             }
         

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -63,9 +63,18 @@ module BABYLON {
         private _currentMeshSelected: Nullable<AbstractMesh>;
         public onNewMeshSelected = new Observable<AbstractMesh>();
 
-        private _meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
-        public meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
+        private _raySelectionPredicate: (mesh: AbstractMesh) => boolean;
 
+        /**
+         * To be optionaly changed by user to define custom ray selection
+         */
+        public raySelectionPredicate: (mesh: AbstractMesh) => boolean;
+
+        /**
+         * To be optionaly changed by user to define custom selection logic (after ray selection)
+         */
+        public meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
+        
         private _currentHit: Nullable<PickingInfo>;
         private _pointerDownOnMeshAsked = false;
         private _isActionableMesh = false;
@@ -409,17 +418,20 @@ module BABYLON {
             this._createGazeTracker();
             this._createTeleportationCircles();
 
-            // To be optionnaly changed by user to define his custom selection logic
+            this.raySelectionPredicate = (mesh) => {
+                return true;
+            }
+
             this.meshSelectionPredicate = (mesh) => {
                 return true;
             }
 
-            this._meshSelectionPredicate = (mesh) => {
+            this._raySelectionPredicate = (mesh) => {
                 if (mesh.name.indexOf(this._floorMeshName) !== -1 || (mesh.isVisible && mesh.name.indexOf("gazeTracker") === -1 
                         && mesh.name.indexOf("teleportationCircle") === -1
                         && mesh.name.indexOf("torusTeleportation") === -1
                         && mesh.name.indexOf("laserPointer") === -1)) {
-                    return (mesh.isEnabled() && mesh.isVisible && mesh.isPickable);
+                    return this.raySelectionPredicate(mesh);
                 }
                 return false;
             }
@@ -922,7 +934,7 @@ module BABYLON {
                 }
             }
         
-            var hit = this._scene.pickWithRay(ray, this._meshSelectionPredicate);
+            var hit = this._scene.pickWithRay(ray, this._raySelectionPredicate);
 
             // Moving the gazeTracker on the mesh face targetted
             if (hit && hit.pickedPoint) {

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -37,6 +37,7 @@ module BABYLON {
         defaultLightingOnControllers?: boolean; // creating a default HemiLight only on controllers
         useCustomVRButton?: boolean; // if you don't want to use the default VR button of the helper
         customVRButton?: HTMLButtonElement; //if you'd like to provide your own button to the VRHelper
+        rayLength?: number; // to change the length of the ray for gaze/controllers.
     }
 
     export class WebVRFreeCamera extends FreeCamera implements PoseControlled {


### PR DESCRIPTION
Update: Mesh predicate for scene.pickWithRay().  _meshSelectionPredicate would ideally call a user configurable predicate (like public meshSelectionPredicate).  Needs to be a way to pickWithRay beyond hidden/non-pickable meshes.