### PR TITLE
set preserveDrawingBuffer to true in localDev

### DIFF
--- a/localDev/index.html
+++ b/localDev/index.html
@@ -65,7 +65,7 @@
 			.require(indexjs)
 			.load(function() {
 				if (BABYLON.Engine.isSupported()) {
-					engine = new BABYLON.Engine(canvas, true, { stencil: true, disableWebGL2Support: false });
+					engine = new BABYLON.Engine(canvas, true, { stencil: true, disableWebGL2Support: false, preserveDrawingBuffer: true });
 					BABYLONDEVTOOLS.Loader.debugShortcut(engine);
 
 					// call the scene creation from the js.


### PR DESCRIPTION
I needed to set this to true to see webvr on the webpage. Should this be added?