### PR TITLE
VRHelper usage issues

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -13,7 +13,7 @@ module BABYLON {
         private _scene: BABYLON.Scene;
         private _position: Vector3;
         private _btnVR: HTMLButtonElement;
-        private _btnVRDisplayed: Boolean;
+        private _btnVRDisplayed: boolean;
 
         // Can the system support WebVR, even if a headset isn't plugged in?
         private _webVRsupported = false;
@@ -39,8 +39,8 @@ module BABYLON {
         private _onVRRequestPresentStart: () => void;
         private _onVRRequestPresentComplete: (success: boolean) => void;
 
-        public onEnteringVR = new Observable();
-        public onExitingVR = new Observable();
+        public onEnteringVR = new Observable<VRExperienceHelper>();
+        public onExitingVR = new Observable<VRExperienceHelper>();
         public onControllerMeshLoaded = new Observable<WebVRController>();
 
         private _rayLength: number;
@@ -413,7 +413,7 @@ module BABYLON {
 
             if (this.onEnteringVR) {
                 try {
-                    this.onEnteringVR.notifyObservers({});
+                    this.onEnteringVR.notifyObservers(this);
                 }
                 catch (err) {
                     Tools.Warn("Error in your custom logic onEnteringVR: " + err);
@@ -447,7 +447,7 @@ module BABYLON {
         public exitVR() {
             if (this.onExitingVR) {
                 try {
-                    this.onExitingVR.notifyObservers({});
+                    this.onExitingVR.notifyObservers(this);
                 }
                 catch (err) {
                     Tools.Warn("Error in your custom logic onExitingVR: " + err);

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -1050,8 +1050,13 @@ module BABYLON {
 
             // Teleport the hmd to where the user is looking by moving the anchor to where they are looking minus the
             // offset of the headset from the anchor. Then add the helper's position to account for user's height offset
-            this.webVRCamera.leftCamera!.globalPosition.subtractToRef(this.webVRCamera.position, this._workingVector);
-            this._haloCenter.subtractToRef(this._workingVector, this._workingVector);
+            if(this.webVRCamera.leftCamera){
+                this._workingVector.copyFrom(this.webVRCamera.leftCamera.globalPosition);
+                this._workingVector.subtractInPlace(this.webVRCamera.position);
+                this._haloCenter.subtractToRef(this._workingVector, this._workingVector);
+            }else{
+                this._workingVector.copyFrom(this._haloCenter);
+            }
             this._workingVector.y += this._defaultHeight;
 
             // Create animation from the camera's position to the new location

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -148,6 +148,7 @@ module BABYLON {
 
         constructor(scene: Scene, public webVROptions: VRExperienceHelperOptions = {}) {
             this._scene = scene;
+            this._canvas = scene.getEngine().getRenderingCanvas();
 
             this._defaultHeight = webVROptions.defaultHeight || 1.7;
             
@@ -180,8 +181,7 @@ module BABYLON {
                         this._deviceOrientationCamera.rotation = targetCamera.rotation.clone();
                     }
                 }
-                this._scene.activeCamera = this._deviceOrientationCamera;
-                this._canvas = scene.getEngine().getRenderingCanvas();
+                this._scene.activeCamera = this._deviceOrientationCamera;                
                 if (this._canvas) {
                     this._scene.activeCamera.attachControl(this._canvas);
                 }

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -1033,7 +1033,7 @@ module BABYLON {
                 }
                 this._haloCenter.copyFrom(hit.pickedPoint);
                 this._teleportationCircle.position.copyFrom(hit.pickedPoint);
-                var pickNormal = hit.getNormal();
+                var pickNormal = hit.getNormal(true, false);
                 if (pickNormal) {
                     var axis1 = BABYLON.Vector3.Cross(BABYLON.Axis.Y, pickNormal);
                     var axis2 = BABYLON.Vector3.Cross(pickNormal, axis1);

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -283,7 +283,6 @@ module BABYLON {
 
         // Raised when one of the controller has loaded successfully its associated default mesh
         private _onDefaultMeshLoaded(webVRController: WebVRController) {
-            console.log("mesh loaded")
             if (webVRController.hand === "left") {
                 this._leftControllerReady = true;
                 if (this._interactionsRequested && !this._interactionsEnabledOnLeftController) {
@@ -548,7 +547,6 @@ module BABYLON {
         }
 
         private _onNewGamepadConnected(gamepad: Gamepad) {
-            console.log("gamepad connected!")
             if (gamepad.type !== BABYLON.Gamepad.POSE_ENABLED) {
                 if (gamepad.leftStick) {
                     gamepad.onleftstickchanged((stickValues) => {
@@ -608,7 +606,6 @@ module BABYLON {
                 }
                 if (gamepad.type === BABYLON.Gamepad.XBOX) {
                     (<Xbox360Pad>gamepad).onbuttondown((buttonPressed: Xbox360Button) => {
-                        console.log("bdown")
                         if (this._interactionsEnabled && buttonPressed === Xbox360Button.A) {
                             this._pointerDownOnMeshAsked = true;
                             if (this._currentMeshSelected && this._currentHit) {
@@ -617,7 +614,6 @@ module BABYLON {
                         }
                     });
                     (<Xbox360Pad>gamepad).onbuttonup((buttonPressed: Xbox360Button) => {
-                        console.log("bup")
                         if (this._interactionsEnabled && buttonPressed === Xbox360Button.A) {
                             if (this._currentMeshSelected && this._currentHit) {
                                 this._scene.simulatePointerUp(this._currentHit);
@@ -1061,7 +1057,6 @@ module BABYLON {
         }
 
         private _castRayAndSelectObject () {
-            //console.log("cast")
             var ray;
             if (this._leftLaserPointer && this._leftLaserPointer.isVisible && (<any>this.currentVRCamera).leftController) {
                 ray = (<any>this.currentVRCamera).leftController.getForwardRay(this._rayLength);

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -1113,8 +1113,8 @@ module BABYLON {
             animationPP2.setKeys(vignetteStretchKeys);
             this._postProcessMove.animations.push(animationPP2);
 
-            this._postProcessMove.imageProcessingConfiguration.vignetteWeight = 8;
-            this._postProcessMove.imageProcessingConfiguration.vignetteStretch = 10;
+            this._postProcessMove.imageProcessingConfiguration.vignetteWeight = 0;
+            this._postProcessMove.imageProcessingConfiguration.vignetteStretch = 0;
 
             this._webVRCamera.attachPostProcess(this._postProcessMove)
             this._scene.beginAnimation(this._postProcessMove, 0, 11, false, 1, () => {

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -351,6 +351,14 @@ module BABYLON {
                     if (webVrController.defaultModel) {
                         webVrController.defaultModel.setEnabled(false);
                     }
+
+                    if(webVrController.hand === "right"){
+                        this._rightController = null;
+                    }
+                    if(webVrController.hand === "left"){
+                        this._rightController = null;
+                    }
+                    this.controllers.splice(this.controllers.indexOf(webVrController), 1)
                 }
             });
 

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -358,7 +358,10 @@ module BABYLON {
                     if(webVrController.hand === "left"){
                         this._rightController = null;
                     }
-                    this.controllers.splice(this.controllers.indexOf(webVrController), 1)
+                    const controllerIndex = this.controllers.indexOf(webVrController);
+                    if (controllerIndex !== -1) {
+                        this.controllers.splice(controllerIndex, 1);
+                    }
                 }
             });
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -4475,7 +4475,7 @@
             return null;
         }
 
-        public createDefaultVRExperience(webVROptions: WebVROptions = {}): VRExperienceHelper {
+        public createDefaultVRExperience(webVROptions: VRExperienceHelperOptions = {}): VRExperienceHelper {
             return new BABYLON.VRExperienceHelper(this, webVROptions);
         }
 


### PR DESCRIPTION
#3280
- [x] if you disconnect & reconnect the controllers while in VR, the teleportation no longer works.
- [x] The helper will always creates a new DeviceOrientationCamera, which is used when not in VR. It would be great if you could provide an option such that the developer could choose to use provide their own camera rather than the Experience Helper creating one. By default the DeviceOrientationCamera is created. The option can be used to avoid this behavior, Alternatively, move the onExitingVR observable to after you set the active camera, so that the developer re-apply a custom camera on VR exit?
   - Added option to disable the creation of the DeviceOrientationCamera. If disabled and an existing camera is present on the scene no DeviceOrientationCamera will be created
Also added an option to disable creation of vrDeviceOrientationCamera. If disabled the enter vr button will only appear when an HMD is connected,
- [x] Fix Vignette flickering
- [x] http://playground.babylonjs.com/#JA1ND3#24 has an issue to align teleportation circle on stairs
- [x] multi mesh configurations for teleport
   - Validated this is working