### PR TITLE
Deterministic step correction

### DIFF
--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -3377,7 +3377,7 @@
                 let defaultFrameTime = 1000 / 60; // frame time in MS
 
                 if (this._physicsEngine) {
-                    defaultFrameTime = this._physicsEngine.getTimeStep() / 1000;
+                    defaultFrameTime = this._physicsEngine.getTimeStep() * 1000;
                 }
                 let stepsTaken = 0;
 
@@ -3397,7 +3397,7 @@
                     // Physics
                     if (this._physicsEngine) {
                         this.onBeforePhysicsObservable.notifyObservers(this);
-                        this._physicsEngine._step(defaultFPS);
+                        this._physicsEngine._step(defaultFrameTime / 1000);
                         this.onAfterPhysicsObservable.notifyObservers(this);
                     }
 
@@ -3411,9 +3411,9 @@
                     stepsTaken++;
                     deltaTime -= defaultFrameTime;
 
-                } while (deltaTime > 0 && stepsTaken < maxSubSteps);
+                } while (deltaTime > 0 && stepsTaken < internalSteps);
 
-                this._timeAccumulator = deltaTime;
+                this._timeAccumulator = deltaTime < 0 ? 0 : deltaTime;
 
             }
             else {


### PR DESCRIPTION
Fixing https://github.com/BabylonJS/Babylon.js/issues/3293

We should notice how deterministic step is working, and how we deal with max steps. If the scene is running at 20 FPS and we set the nax step to 3 and up, the scene will run in "simulated" 60 fps (as the max FPS target is 60 fps). if, however, we will set it to 1 or 2, the simulated fps will be lower (20 or 40 respectively).