### PR TITLE
Add support for Tools.LoadFile retry

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -34,8 +34,8 @@ module BABYLON.GLTF2 {
     }
 
     interface GLTFLoaderRequest extends XMLHttpRequest {
-        _loaded: Nullable<number>;
-        _total: Nullable<number>;
+        _loaded?: number;
+        _total?: number;
     }
 
     interface IProgressEventData {
@@ -1644,11 +1644,11 @@ module BABYLON.GLTF2 {
                 this._tryCatchOnError(() => {
                     throw new LoadFileError(context + ": Failed to load '" + uri + "'" + (request ? ": " + request.status + " " + request.statusText : ""), request);
                 });
+            }, (oldRequest, newRequest) => {
+                this._requests.splice(this._requests.indexOf(oldRequest), 1, newRequest);
             }) as GLTFLoaderRequest;
 
             if (request) {
-                request._loaded = null;
-                request._total = null;
                 this._requests.push(request);
             }
         }


### PR DESCRIPTION
With this change, by default, if a non-local request returns a status of 0, `Tools.LoadFile` will automatically retry using an exponential backoff strategy with max retries of 3 and a starting interval of 500ms.

This can be overridden by replacing `Tools.DefaultRetryStrategy` or passing in a different strategy to `Tools.LoadFile`. The strategy can be replaced with `RetryStrategy.ExponentialBackoff` passing in non-default parameters or a custom strategy.

The `onRetry` callback can be used to track requests like in `glTFLoader`.