### PR TITLE
Add default value to Nullable<T> types

### DIFF
--- a/src/Mesh/babylon.abstractMesh.ts
+++ b/src/Mesh/babylon.abstractMesh.ts
@@ -351,10 +351,10 @@
          * This scene's action manager
          * @type {BABYLON.ActionManager}
         */
-        public actionManager: Nullable<ActionManager>;
+        public actionManager: Nullable<ActionManager> = null;
 
         // Physics
-        public physicsImpostor: Nullable<PhysicsImpostor>;
+        public physicsImpostor: Nullable<PhysicsImpostor> = null;
 
         // Collisions
         private _checkCollisions = false;


### PR DESCRIPTION
Add default value to Nullable<T> types, which match the expected discriminated union (T | null) from TypeScript definition.  This is not backwards compatible. There are many more cases of undefined (T | null); this builds upon the strict type checking recently added.

See discussion: http://www.html5gamedevs.com/topic/34533-csg-tomesh-material-required/?tab=comments#comment-198439