### PR TITLE
Change glb extension, it is registered as .glb in SceneLoader._regist…

### DIFF
--- a/src/Gamepad/Controllers/babylon.windowsMotionController.ts
+++ b/src/Gamepad/Controllers/babylon.windowsMotionController.ts
@@ -204,7 +204,7 @@ module BABYLON {
             let filename: string;
 
             // Checking if GLB loader is present
-            if (SceneLoader.IsPluginForExtensionAvailable("glb")) {
+            if (SceneLoader.IsPluginForExtensionAvailable(".glb")) {
                 // Determine the device specific folder based on the ID suffix
                 let device = 'default';
                 if (this.id && !forceDefault) {


### PR DESCRIPTION
```javascript
 Object.keys(SceneLoader._registeredPlugins)
```
 list the following registered plugins by the loader:

".babylon", ".stl", ".obj", ".gltf", ".glb"

WindowsMotionController.initControllerMesh is invoking:

```javascript
  if (SceneLoader.IsPluginForExtensionAvailable("glb"))
```
append the dot to match the plugin in this method:

```javascript
public static IsPluginForExtensionAvailable(extension: string): boolean {
      return !!SceneLoader._registeredPlugins[extension];
}
```

