### PR TITLE
Expose VRDisplay ready observable on VR Experience Helper

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -44,6 +44,10 @@ module BABYLON {
          */
         public onEnteringVRObservable = new Observable<VRExperienceHelper>();
 
+         /**
+         * Observable raised when VR Display is ready.
+         */
+        public onVRDeviceReadyObservable = new Observable<VRExperienceHelper>();
 
         /**
          * Observable raised when exiting VR.
@@ -435,6 +439,8 @@ module BABYLON {
             this._webVRsupported = eventArgs.vrSupported;
             this._webVRready = !!eventArgs.vrDisplay;
             this._webVRpresenting = eventArgs.vrDisplay && eventArgs.vrDisplay.isPresenting;
+
+            this._webVRready && this.onVRDeviceReadyObservable.notifyObservers(this);
 
             this.updateButtonVisibility();
         }


### PR DESCRIPTION
Right now VRExperienceHelper allow user to pass an HTMLElement button, or it creates the default one. Once the VRDisplay is ready it updates de button visibility so it can be shown and clicked.

I have a user interface menu, where user can select game mode (normal / VR), I need to handle code and want to initialize VR on the fly. 

If I click the button after creating the VRHelper, the VRDisplay is not ready and it fallbacks to deviceOrientationCamera or freeCamera depending on configuration.

Right now I was using a workaround with:

```javascript
scene.getEngine().onVRDisplayChangedObservable.add((e) => {
       if (e.vrDisplay) {
         vrCustomButton.click();
      }
```

But I would find interesting exposing the moment whenever the device is ready on the VR Helper:

```javascript

//custom button that will be dynamically triggered
    let vrCustomButton = createCustomVRButton();

    var vrHelper = new BABYLON.VRExperienceHelper(scene, { useCustomVRButton: true, customVRButton: vrCustomButton });
    vrHelper.onVRDeviceReadyObservable.add(e => {
        //Device is ready, and I come from a selection mode menu click, I can enter now in VRMode
        vrCustomButton.click();
    });

````