### PR TITLE
Add onSelectedMeshUnselectedObservable in VRHelper

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -113,6 +113,11 @@ module BABYLON {
         public onNewMeshSelected = new Observable<AbstractMesh>();
         private _circleEase: CircleEase;
 
+         /**
+         * Observable raised when current selected mesh gets unselected
+         */
+        public onSelectedMeshUnselected = new Observable<AbstractMesh>();
+
         private _raySelectionPredicate: (mesh: AbstractMesh) => boolean;
 
         /**
@@ -1395,6 +1400,7 @@ module BABYLON {
                         }
                     }
                     else {
+                        this._currentMeshSelected && this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
                         this._currentMeshSelected = null;
                         this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
                         this.changeLaserColor(new Color3(0.7, 0.7, 0.7));

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -113,9 +113,9 @@ module BABYLON {
         public onNewMeshSelected = new Observable<AbstractMesh>();
         private _circleEase: CircleEase;
 
-         /**
-         * Observable raised when current selected mesh gets unselected
-         */
+        /**
+        * Observable raised when current selected mesh gets unselected
+        */
         public onSelectedMeshUnselected = new Observable<AbstractMesh>();
 
         private _raySelectionPredicate: (mesh: AbstractMesh) => boolean;
@@ -643,7 +643,7 @@ module BABYLON {
 
                 if (!vrTeleportationOptions.disableInteractions) {
                     this.enableInteractions();
-                }    
+                }
 
                 if (vrTeleportationOptions.floorMeshName) {
                     this._floorMeshName = vrTeleportationOptions.floorMeshName;
@@ -1400,7 +1400,9 @@ module BABYLON {
                         }
                     }
                     else {
-                        this._currentMeshSelected && this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
+                        if (this._currentMeshSelected) {
+                            this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
+                        }
                         this._currentMeshSelected = null;
                         this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
                         this.changeLaserColor(new Color3(0.7, 0.7, 0.7));


### PR DESCRIPTION
Add an observable to notify about last selected mesh being unselected when  you are working with predicates.  In my case, I would need this to interact with user interfaces, Add/remove highlights on GUI controls etc.

Usage:

```Javascript
 vrHelper.meshSelectionPredicate = (mesh) => {
      return mesh === this._mesh;
 };

vrHelper.onNewMeshSelected.add( c => console.log(` Entering ${c.name}`));
vrHelper.onSelectedMeshUnselected .add( c => console.log(` Exiting ${c.name}`));

```