### PR TITLE
Fixes bug in TiledGround when x/z min/max are 0

### DIFF
--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1401,10 +1401,10 @@
          * Creates the VertexData of the TiledGround.  
          */
         public static CreateTiledGround(options: { xmin: number, zmin: number, xmax: number, zmax: number, subdivisions?: { w: number; h: number; }, precision?: { w: number; h: number; } }): VertexData {
-            var xmin = options.xmin || -1.0;
-            var zmin = options.zmin || -1.0;
-            var xmax = options.xmax || 1.0;
-            var zmax = options.zmax || 1.0;
+            var xmin = typeof options.xmin === 'number' ? options.xmin : -1.0;
+            var zmin = typeof options.zmin === 'number' ? options.zmin : -1.0;
+            var xmax = typeof options.xmax === 'number' ? options.xmax : 1.0;
+            var zmax = typeof options.zmax === 'number' ? options.zmax : 1.0;
             var subdivisions = options.subdivisions || { w: 1, h: 1 };
             var precision = options.precision || { w: 1, h: 1 };
 


### PR DESCRIPTION
When creating a TiledGround from (0, 0) to (10, 10) there is a bug causing 0 to be treated as -1.  This fixes that.

I tried to follow convention of using `typeof` but could change it to use `xmin.constructor === Number` or other if there is a better solution.

See bug: https://www.babylonjs-playground.com/#163UOW#1