### PR TITLE
Change sandbox to play only the first glTF animation

### DIFF
--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -38,7 +38,6 @@ if (BABYLON.Engine.isSupported()) {
         currentPluginName = plugin.name;
 
         if (plugin.name === "gltf" && plugin instanceof BABYLON.GLTFFileLoader) {
-            plugin.animationStartMode = BABYLON.GLTFLoaderAnimationStartMode.ALL;
             plugin.compileMaterials = true;
         }
     });


### PR DESCRIPTION
Now that the [glTF sample models are updated](https://github.com/KhronosGroup/glTF-Sample-Models/pull/141), update the sandbox to play only the first animation.