### PR TITLE
fix node names in serializer

### DIFF
--- a/serializers/src/glTF/2.0/babylon.glTFSerializer.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFSerializer.ts
@@ -10,6 +10,7 @@ module BABYLON {
     }
     interface OGLTFNode {
         mesh: number;
+        name?: string;
         translation?: number[];
         scale?: number[];
         rotation?: number[];
@@ -623,6 +624,9 @@ module BABYLON {
                     }
                     gltf.meshes.push(mesh);
                     node.mesh = gltf.meshes.length - 1;
+                    if (babylonMesh.name) {
+                      node.name = babylonMesh.name;
+                    }
                     gltf.nodes.push(node);
 
                     scene.nodes.push(gltf.nodes.length - 1);


### PR DESCRIPTION
serializer write mesh name to mesh.name field in gltf, but laoder read it from node.name
I added name to node.name in serialzier, but left name in mesh.name for compatibility, you might want to remove it probably...