### PR TITLE
Add teleportationInputsEnabled to VRHelper 

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -92,6 +92,7 @@ module BABYLON {
         private _rotationAllowed: boolean = true;
         private _teleportationRequestInitiated = false;
         private _teleportationBackRequestInitiated = false;
+        private _teleportationInputsEnabled = true;
         private teleportBackwardsVector = new Vector3(0, -1, -1);
         private _rotationRightAsked = false;
         private _rotationLeftAsked = false;
@@ -153,6 +154,20 @@ module BABYLON {
 
         public get teleportationTarget(): Mesh {
             return this._teleportationTarget;
+        }
+
+        /**
+        * Set if VR Controllers / Gamepad inputs are enabled to teleport camera
+        */
+        public set teleportationInputsEnabled(value: boolean) {
+            this._teleportationInputsEnabled = value;
+        }
+
+        /**
+        * Get if VR Controllers / Gamepad inputs are enabled to teleport camera
+        */
+        public get teleportationInputsEnabled() {
+            return this._teleportationInputsEnabled;
         }
 
         public set teleportationTarget(value: Mesh) {
@@ -700,7 +715,7 @@ module BABYLON {
             if (gamepad.type !== Gamepad.POSE_ENABLED) {
                 if (gamepad.leftStick) {
                     gamepad.onleftstickchanged((stickValues) => {
-                        if (this._teleportationEnabled) {
+                        if (this._teleportationEnabled && this._teleportationInputsEnabled) {
                             // Listening to classic/xbox gamepad only if no VR controller is active
                             if ((!this._leftLaserPointer && !this._rightLaserPointer) ||
                                 ((this._leftLaserPointer && !this._leftLaserPointer.isVisible) &&
@@ -997,9 +1012,11 @@ module BABYLON {
                     });
                 }
                 webVRController.onPadValuesChangedObservable.add((stateObject) => {
-                    this._checkTeleportBackwards(stateObject);
-                    this._checkTeleportWithRay(stateObject, webVRController);
-                    this._checkRotate(stateObject)
+                    if (this._teleportationInputsEnabled) {
+                        this._checkTeleportBackwards(stateObject);
+                        this._checkTeleportWithRay(stateObject, webVRController);
+                    }
+                    this._checkRotate(stateObject);
                 });
             }
         }

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -92,7 +92,6 @@ module BABYLON {
         private _rotationAllowed: boolean = true;
         private _teleportationRequestInitiated = false;
         private _teleportationBackRequestInitiated = false;
-        private _teleportationInputsEnabled = true;
         private teleportBackwardsVector = new Vector3(0, -1, -1);
         private _rotationRightAsked = false;
         private _rotationLeftAsked = false;
@@ -140,11 +139,16 @@ module BABYLON {
          */
         public meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
 
+        /**
+         * Set teleportation enabled. If set to false camera teleportation will be disabled but camera rotation will be kept.
+         */
+        public teleportationEnabled : boolean = true;
+
         private _currentHit: Nullable<PickingInfo>;
         private _pointerDownOnMeshAsked = false;
         private _isActionableMesh = false;
         private _defaultHeight: number;
-        private _teleportationEnabled = false;
+        private _teleportationInitialized = false;
         private _interactionsEnabled = false;
         private _interactionsRequested = false;
         private _displayGaze = true;
@@ -154,20 +158,6 @@ module BABYLON {
 
         public get teleportationTarget(): Mesh {
             return this._teleportationTarget;
-        }
-
-        /**
-        * Set if VR Controllers / Gamepad inputs are enabled to teleport camera
-        */
-        public set teleportationInputsEnabled(value: boolean) {
-            this._teleportationInputsEnabled = value;
-        }
-
-        /**
-        * Get if VR Controllers / Gamepad inputs are enabled to teleport camera
-        */
-        public get teleportationInputsEnabled() {
-            return this._teleportationInputsEnabled;
         }
 
         public set teleportationTarget(value: Mesh) {
@@ -668,7 +658,7 @@ module BABYLON {
         }
 
         public enableTeleportation(vrTeleportationOptions: VRTeleportationOptions = {}) {
-            if (!this._teleportationEnabled) {
+            if (!this._teleportationInitialized) {
                 this._teleportationRequested = true;
 
                 this.enableInteractions();
@@ -704,7 +694,7 @@ module BABYLON {
 
                 this._webVRCamera.detachPostProcess(this._postProcessMove)
                 this._passProcessMove = new PassPostProcess("pass", 1.0, this._webVRCamera);
-                this._teleportationEnabled = true;
+                this._teleportationInitialized = true;
                 if (this._isDefaultTeleportationTarget) {
                     this._createTeleportationCircles();
                 }
@@ -715,7 +705,7 @@ module BABYLON {
             if (gamepad.type !== Gamepad.POSE_ENABLED) {
                 if (gamepad.leftStick) {
                     gamepad.onleftstickchanged((stickValues) => {
-                        if (this._teleportationEnabled && this._teleportationInputsEnabled) {
+                        if (this._teleportationInitialized && this.teleportationEnabled) {
                             // Listening to classic/xbox gamepad only if no VR controller is active
                             if ((!this._leftLaserPointer && !this._rightLaserPointer) ||
                                 ((this._leftLaserPointer && !this._leftLaserPointer.isVisible) &&
@@ -728,7 +718,7 @@ module BABYLON {
                 }
                 if (gamepad.rightStick) {
                     gamepad.onrightstickchanged((stickValues) => {
-                        if (this._teleportationEnabled) {
+                        if (this._teleportationInitialized) {
                             this._checkRotate(stickValues);
                         }
                     });
@@ -1012,7 +1002,7 @@ module BABYLON {
                     });
                 }
                 webVRController.onPadValuesChangedObservable.add((stateObject) => {
-                    if (this._teleportationInputsEnabled) {
+                    if (this.teleportationEnabled) {
                         this._checkTeleportBackwards(stateObject);
                         this._checkTeleportWithRay(stateObject, webVRController);
                     }
@@ -1097,7 +1087,7 @@ module BABYLON {
         }
 
         private _displayTeleportationTarget() {
-            if (this._teleportationEnabled) {
+            if (this._teleportationInitialized) {
                 this._teleportationTarget.isVisible = true;
                 if (this._isDefaultTeleportationTarget) {
                     (<Mesh>this._teleportationTarget.getChildren()[0]).isVisible = true;
@@ -1106,7 +1096,7 @@ module BABYLON {
         }
 
         private _hideTeleportationTarget() {
-            if (this._teleportationEnabled) {
+            if (this._teleportationInitialized) {
                 this._teleportationTarget.isVisible = false;
                 if (this._isDefaultTeleportationTarget) {
                     (<Mesh>this._teleportationTarget.getChildren()[0]).isVisible = false;
@@ -1405,7 +1395,7 @@ module BABYLON {
                     this._scene.simulatePointerMove(this._currentHit);
                 }
                 // The object selected is the floor, we're in a teleportation scenario
-                if (this._teleportationEnabled && this._isTeleportationFloor(hit.pickedMesh) && hit.pickedPoint) {
+                if (this._teleportationInitialized && this._isTeleportationFloor(hit.pickedMesh) && hit.pickedPoint) {
                     // Moving the teleportation area to this targetted point
                     this._moveTeleportationSelectorTo(hit);
                     return;


### PR DESCRIPTION
When using VRHelper, I miss a way to enable / disable gamepad/vr controller inputs, so It would be nice to have a public property to allow changing this setting,

As rotation does not mean teleportation it stays out of the check.

In my case, in the game user needs to interact with GUI elements, and VR is not head-locked so he can stare where he wants, allowing non desired teleporation at that moment.


  
  