### PR TITLE
fix gltf loader to respect vertexAlpha

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -358,7 +358,6 @@ module BABYLON.GLTF2 {
             }
 
             node.babylonMesh = new Mesh(node.name || "mesh" + node.index, this._babylonScene);
-            node.babylonMesh.hasVertexAlpha = true;
 
             this._loadTransform(node);
 
@@ -426,7 +425,7 @@ module BABYLON.GLTF2 {
                 for (const primitive of primitives) {
                     vertexData.merge(primitive.vertexData);
                 }
-
+                node.babylonMesh.hasVertexAlpha = mesh.hasVertexAlpha;
                 new Geometry(node.babylonMesh.name, this._babylonScene, vertexData, false, node.babylonMesh);
 
                 // TODO: optimize this so that sub meshes can be created without being overwritten after setting vertex data.
@@ -647,6 +646,10 @@ module BABYLON.GLTF2 {
                         }
                         case "COLOR_0": {
                             vertexData.colors = this._convertToFloat4ColorArray(context, data, accessor);
+                            const hasVertexAlpha = GLTFLoader._GetNumComponents(context, accessor.type) === 4;
+                            if (!mesh.hasVertexAlpha && hasVertexAlpha) {
+                                mesh.hasVertexAlpha = hasVertexAlpha;
+                            }
                             break;
                         }
                         default: {
@@ -678,7 +681,7 @@ module BABYLON.GLTF2 {
                 });
             }
         }
-
+        
         private _createMorphTargets(context: string, node: IGLTFNode, mesh: IGLTFMesh): void {
             const primitives = mesh.primitives;
 

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
@@ -217,6 +217,7 @@ module BABYLON.GLTF2 {
 
         // Runtime values
         index: number;
+        hasVertexAlpha: boolean;
     }
 
     export interface IGLTFNode extends IGLTFChildRootProperty {


### PR DESCRIPTION
https://www.babylonjs-playground.com/#NNZZL9#2
this example shows, that hasVertexAlpha simply set to true when parsed by GLTF2FileLoader.
Green color - hasVertexAlpha = true, red - false. spheres on bottom are original, on top - serialzied and loaded back.
I fixed that, unfortunatly it adds O(N) to parsing time when VertexColor present, where N is vertices count, but I haven't found better universal solution. Example also demostrate problem with loader, when switching hands from right to left.(remove flipHand call, to see the difference). __root__ not helping at all.

  