### PR TITLE
VRHelper onNewMeshSelected now notifies PickingInfo to subscribers instead of AbstractMesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -20,3 +20,5 @@
 ## Bug fixes
 
 ## Breaking changes
+
+- VRHelper onNewMeshSelected will notify a PickingInfo to subscribers instead of an AbstractMesh ([carloslanderas](https://github.com/carloslanderas))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -21,4 +21,4 @@
 
 ## Breaking changes
 
-- VRHelper onNewMeshSelected will notify a PickingInfo to subscribers instead of an AbstractMesh ([carloslanderas](https://github.com/carloslanderas))
+- VRHelper onNewMeshSelected now notifies a PickingInfo to subscribers instead of an AbstractMesh ([carloslanderas](https://github.com/carloslanderas))

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -109,7 +109,12 @@ module BABYLON {
         private _leftLaserPointer: Nullable<Mesh>;
         private _rightLaserPointer: Nullable<Mesh>;
         private _currentMeshSelected: Nullable<AbstractMesh>;
-        public onNewMeshSelected = new Observable<AbstractMesh>();
+
+        /**
+         * Observable raised when a new mesh is selected based on meshSelectionPredicate
+         */
+        
+        public onNewMeshSelected = new Observable<PickingInfo>();
         private _circleEase: CircleEase;
 
         /**
@@ -1417,7 +1422,7 @@ module BABYLON {
                             this._isActionableMesh = false;
                         }
                         try {
-                            this.onNewMeshSelected.notifyObservers(this._currentMeshSelected);
+                            this.onNewMeshSelected.notifyObservers(hit);
                         }
                         catch (err) {
                             Tools.Warn("Error in your custom logic onNewMeshSelected: " + err);

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -112,8 +112,7 @@ module BABYLON {
 
         /**
          * Observable raised when a new mesh is selected based on meshSelectionPredicate
-         */
-        
+         */        
         public onNewMeshSelected = new Observable<PickingInfo>();
         private _circleEase: CircleEase;
 


### PR DESCRIPTION
onNewMeshSelected is now an Observable<PickingInfo> so distance, picked point, picked mesh and other important values are notified to subscribers.