### PR TITLE
Fix glTF loader to default animation sampler interpolation to LINEAR

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -1043,6 +1043,8 @@ module BABYLON.GLTF2 {
                     }
                 }
 
+                sampler.interpolation = sampler.interpolation || "LINEAR";
+
                 let getNextKey: (frameIndex: number) => any;
                 switch (sampler.interpolation) {
                     case "LINEAR": {


### PR DESCRIPTION
As per spec: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/animation.sampler.schema.json#L15