### PR TITLE
Do not force VRHelper to interact only with visible meshes

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -607,7 +607,7 @@ module BABYLON {
                 this._createGazeTracker();
 
                 this.raySelectionPredicate = (mesh) => {
-                    return true;
+                    return mesh.isVisible;
                 }
 
                 this.meshSelectionPredicate = (mesh) => {
@@ -615,7 +615,7 @@ module BABYLON {
                 }
 
                 this._raySelectionPredicate = (mesh) => {
-                    if (this._isTeleportationFloor(mesh) || (mesh.isVisible && mesh.name.indexOf("gazeTracker") === -1
+                    if (this._isTeleportationFloor(mesh) || (mesh.name.indexOf("gazeTracker") === -1
                         && mesh.name.indexOf("teleportationTarget") === -1
                         && mesh.name.indexOf("torusTeleportation") === -1
                         && mesh.name.indexOf("laserPointer") === -1)) {


### PR DESCRIPTION
As a VRHelper user some times I want to interact with non visible meshes. Instead of forcing it in a private member, set it as the default rayPredicate instead of return true, because this member can be overriden with custom logic.