### PR TITLE
Trigger onSelectedMeshUnselected observable when ray collides the floor meshes

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -112,12 +112,12 @@ module BABYLON {
 
         /**
          * Observable raised when a new mesh is selected based on meshSelectionPredicate
-         */        
+         */
         public onNewMeshSelected = new Observable<AbstractMesh>();
 
         /**
          * Observable raised when a new mesh is picked based on meshSelectionPredicate
-         */        
+         */
         public onNewMeshPicked = new Observable<PickingInfo>();
 
         private _circleEase: CircleEase;
@@ -152,7 +152,7 @@ module BABYLON {
         /**
          * Set teleportation enabled. If set to false camera teleportation will be disabled but camera rotation will be kept.
          */
-        public teleportationEnabled : boolean = true;
+        public teleportationEnabled: boolean = true;
 
         private _currentHit: Nullable<PickingInfo>;
         private _pointerDownOnMeshAsked = false;
@@ -1407,6 +1407,16 @@ module BABYLON {
                 // The object selected is the floor, we're in a teleportation scenario
                 if (this._teleportationInitialized && this._isTeleportationFloor(hit.pickedMesh) && hit.pickedPoint) {
                     // Moving the teleportation area to this targetted point
+
+                    //Raise Mesh unselected event if we trigger the floor meshes and a non-floor mesh was previously selected
+                    if (this._currentMeshSelected &&
+                        !this._isTeleportationFloor(this._currentMeshSelected) &&
+                        this.onSelectedMeshUnselected.hasObservers()) {
+                        this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
+                    }
+
+                    this._currentMeshSelected = null;
+
                     this._moveTeleportationSelectorTo(hit);
                     return;
                 }
@@ -1428,14 +1438,14 @@ module BABYLON {
                             this._isActionableMesh = false;
                         }
                         try {
-                            this.onNewMeshSelected.notifyObservers(this._currentMeshSelected);                            
+                            this.onNewMeshSelected.notifyObservers(this._currentMeshSelected);
                         }
                         catch (err) {
                             Tools.Warn("Error in your custom logic onNewMeshSelected: " + err);
                         }
                     }
                     else {
-                        if (this._currentMeshSelected) {
+                        if (this._currentMeshSelected && this.onSelectedMeshUnselected.hasObservers()) {
                             this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
                         }
                         this._currentMeshSelected = null;

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -1410,8 +1410,7 @@ module BABYLON {
 
                     //Raise Mesh unselected event if we trigger the floor meshes and a non-floor mesh was previously selected
                     if (this._currentMeshSelected &&
-                        !this._isTeleportationFloor(this._currentMeshSelected) &&
-                        this.onSelectedMeshUnselected.hasObservers()) {
+                        !this._isTeleportationFloor(this._currentMeshSelected)) {
                         this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
                     }
 
@@ -1445,7 +1444,7 @@ module BABYLON {
                         }
                     }
                     else {
-                        if (this._currentMeshSelected && this.onSelectedMeshUnselected.hasObservers()) {
+                        if (this._currentMeshSelected) {
                             this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
                         }
                         this._currentMeshSelected = null;


### PR DESCRIPTION
Right now the VRExperienceHelper has two flows in_castRayAndSelectObject method registered in beforeRender.

When the ray collisions the floor configured meshes it executes the _moveTeleportationSelectorTo and return the execution exiting from method.

If the collided mesh is not part of the floor collection, it continues with the execution that will end triggering onNewMeshSelected / onSelectedMeshUnselected.

The problem is, if I select a mesh I want to interact to and get the onNewMeshSelected observable triggered, and then I immediately look to the floor, the onSelectedMeshUnselected observable will never trigger.

