### PR TITLE
More flexible Video Texture

### DIFF
--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -1,4 +1,11 @@
 ﻿module BABYLON {
+    /**
+     * Settings for finer control over video usage
+     * @typedef {Object} VideoTextureSettings
+     * @property {boolean} [autoPlay] Applies `autoplay` to video, if specified
+     * @property {boolean} [loop] - Applies `loop` to video, if specified
+     * @property {boolean} autoUpdateTexture - Automatically updates internal texture from video at every frame in the render loop
+     */
     export interface VideoTextureSettings {
         autoPlay?: boolean;
         loop?: boolean;
@@ -130,10 +137,16 @@
             this._texture = null;
         };
 
+        /**
+         * Internal method to initiate `update`.
+         */
         public _rebuild(): void {
             this.update();
         }
 
+        /**
+         * Update Texture in the `auto` mode. Does not do anything if `settings.autoUpdateTexture` is false.
+         */
         public update(): void {
             if (!this.autoUpdateTexture) {
                 // Expecting user to call `updateTexture` manually
@@ -143,6 +156,10 @@
             this.updateTexture(true);
         }
 
+        /**
+         * Update Texture in `manual` mode. Does not do anything if not visible or paused.
+         * @param isVisible Visibility state, detected by user using `scene.getActiveMeshes()` or othervise.
+         */
         public updateTexture(isVisible: boolean): void {
             if (!isVisible) {
                 return;
@@ -164,6 +181,10 @@
             this._engine.updateVideoTexture(this._texture, this.video, this._invertY);
         };
 
+        /**
+         * Change video content. Changing video instance or setting multiple urls (as in constructor) is not supported.
+         * @param url New url.
+         */
         public updateURL(url: string): void {
             this.video.src = url;
         }

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -82,17 +82,17 @@
                 this.video.loop = settings.loop;
             }
 
-            this.video.addEventListener("canplay", this.createInternalTexture);
+            this.video.addEventListener("canplay", this._createInternalTexture);
             this.video.addEventListener("paused", this.updateInternalTexture);
             this.video.addEventListener("seeked", this.updateInternalTexture);
             this.video.addEventListener("emptied", this.reset);
 
             if (this.video.readyState >= this.video.HAVE_CURRENT_DATA) {
-                this.createInternalTexture();
+                this._createInternalTexture();
             }
         }
 
-        private createInternalTexture = (): void => {
+        private _createInternalTexture = (): void => {
             if (this._texture != null) {
                 return;
             }
@@ -170,7 +170,7 @@
 
         public dispose(): void {
             super.dispose();
-            this.video.removeEventListener("canplay", this.createInternalTexture);
+            this.video.removeEventListener("canplay", this._createInternalTexture);
             this.video.removeEventListener("paused", this.updateInternalTexture);
             this.video.removeEventListener("seeked", this.updateInternalTexture);
             this.video.removeEventListener("emptied", this.reset);

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -67,7 +67,7 @@
         ) {
             super(null, scene, !generateMipMaps, invertY);
 
-            this._engine = (<Scene>this.getScene()).getEngine();
+            this._engine = this.getScene()!.getEngine();
             this._generateMipMaps = generateMipMaps;
             this._samplingMode = samplingMode;
             this.autoUpdateTexture = settings.autoUpdateTexture;

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -176,53 +176,65 @@
             this.video.removeEventListener("emptied", this.reset);
         }
 
-        public static CreateFromWebCam(scene: Scene, onReady: (videoTexture: VideoTexture) => void, constraints: {
-            minWidth: number,
-            maxWidth: number,
-            minHeight: number,
-            maxHeight: number,
-            deviceId: string
-        }): void {
+        public static CreateFromWebCam(
+            scene: Scene,
+            onReady: (videoTexture: VideoTexture) => void,
+            constraints: {
+                minWidth: number;
+                maxWidth: number;
+                minHeight: number;
+                maxHeight: number;
+                deviceId: string;
+            }
+        ): void {
             var video = document.createElement("video");
             var constraintsDeviceId;
             if (constraints && constraints.deviceId) {
                 constraintsDeviceId = {
-                    exact: constraints.deviceId
-                }
+                    exact: constraints.deviceId,
+                };
             }
 
-            navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
+            navigator.getUserMedia =
+                navigator.getUserMedia ||
+                navigator.webkitGetUserMedia ||
+                navigator.mozGetUserMedia ||
+                navigator.msGetUserMedia;
             window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
 
             if (navigator.getUserMedia) {
-                navigator.getUserMedia({
-                    video: {
-                        deviceId: constraintsDeviceId,
-                        width: {
-                            min: (constraints && constraints.minWidth) || 256,
-                            max: (constraints && constraints.maxWidth) || 640
+                navigator.getUserMedia(
+                    {
+                        video: {
+                            deviceId: constraintsDeviceId,
+                            width: {
+                                min: (constraints && constraints.minWidth) || 256,
+                                max: (constraints && constraints.maxWidth) || 640,
+                            },
+                            height: {
+                                min: (constraints && constraints.minHeight) || 256,
+                                max: (constraints && constraints.maxHeight) || 480,
+                            },
                         },
-                        height: {
-                            min: (constraints && constraints.minHeight) || 256,
-                            max: (constraints && constraints.maxHeight) || 480
+                    },
+                    (stream: any) => {
+                        if (video.mozSrcObject !== undefined) {
+                            // hack for Firefox < 19
+                            video.mozSrcObject = stream;
+                        } else {
+                            video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
                         }
-                    }
-                }, (stream: any) => {
 
-                    if (video.mozSrcObject !== undefined) { // hack for Firefox < 19
-                        video.mozSrcObject = stream;
-                    } else {
-                        video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
-                    }
+                        video.play();
 
-                    video.play();
-
-                    if (onReady) {
-                        onReady(new VideoTexture("video", video, scene, true, true));
+                        if (onReady) {
+                            onReady(new VideoTexture("video", video, scene, true, true));
+                        }
+                    },
+                    function(e: MediaStreamError) {
+                        Tools.Error(e.name);
                     }
-                }, function (e: MediaStreamError) {
-                    Tools.Error(e.name);
-                });
+                );
             }
         }
     }

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -72,9 +72,6 @@
          * @param {boolean} invertY is false by default but can be used to invert video on Y axis
          * @param {number} samplingMode controls the sampling method and is set to TRILINEAR_SAMPLINGMODE by default
          * @param {VideoTextureSettings} [settings] allows finer control over video usage
-         * @param {boolean} [settings.autoPlay] Applies `autoplay` to video, if specified
-         * @param {boolean} [settings.loop] - Applies `loop` to video, if specified
-         * @param {boolean} settings.autoUpdateTexture - Automatically updates internal texture from video at every frame in the render loop
          */
         constructor(
             name: Nullable<string>,

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -58,6 +58,9 @@
          * @param {boolean} invertY is false by default but can be used to invert video on Y axis
          * @param {number} samplingMode controls the sampling method and is set to TRILINEAR_SAMPLINGMODE by default
          * @param {VideoTextureSettings} [settings] allows finer control over video usage
+         * @param {boolean} [settings.autoPlay] Applies `autoplay` to video, if specified
+         * @param {boolean} [settings.loop] - Applies `loop` to video, if specified
+         * @param {boolean} settings.autoUpdateTexture - Automatically updates internal texture from video at every frame in the render loop
          */
         constructor(
             name: Nullable<string>,

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -1,14 +1,21 @@
 ﻿module BABYLON {
     /**
      * Settings for finer control over video usage
-     * @typedef {Object} VideoTextureSettings
-     * @property {boolean} [autoPlay] Applies `autoplay` to video, if specified
-     * @property {boolean} [loop] - Applies `loop` to video, if specified
-     * @property {boolean} autoUpdateTexture - Automatically updates internal texture from video at every frame in the render loop
      */
     export interface VideoTextureSettings {
+        /**
+         * Applies `autoplay` to video, if specified
+         */
         autoPlay?: boolean;
+
+        /**
+         * Applies `loop` to video, if specified
+         */
         loop?: boolean;
+
+        /**
+         * Automatically updates internal texture from video at every frame in the render loop
+         */
         autoUpdateTexture: boolean;
     }
 

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -90,8 +90,8 @@
             }
 
             this.video.addEventListener("canplay", this._createInternalTexture);
-            this.video.addEventListener("paused", this.updateInternalTexture);
-            this.video.addEventListener("seeked", this.updateInternalTexture);
+            this.video.addEventListener("paused", this._updateInternalTexture);
+            this.video.addEventListener("seeked", this._updateInternalTexture);
             this.video.addEventListener("emptied", this.reset);
 
             if (this.video.readyState >= this.video.HAVE_CURRENT_DATA) {
@@ -124,7 +124,7 @@
             );
             this._texture.width;
 
-            this.updateInternalTexture();
+            this._updateInternalTexture();
 
             this._texture.isReady = true;
         };
@@ -167,10 +167,10 @@
             if (this.video.paused) {
                 return;
             }
-            this.updateInternalTexture();
+            this._updateInternalTexture();
         }
 
-        protected updateInternalTexture = (e?: Event): void => {
+        protected _updateInternalTexture = (e?: Event): void => {
             if (this._texture == null || !this._texture.isReady) {
                 return;
             }
@@ -192,8 +192,8 @@
         public dispose(): void {
             super.dispose();
             this.video.removeEventListener("canplay", this._createInternalTexture);
-            this.video.removeEventListener("paused", this.updateInternalTexture);
-            this.video.removeEventListener("seeked", this.updateInternalTexture);
+            this.video.removeEventListener("paused", this._updateInternalTexture);
+            this.video.removeEventListener("seeked", this._updateInternalTexture);
             this.video.removeEventListener("emptied", this.reset);
         }
 

--- a/src/Materials/Textures/babylon.videoTexture.ts
+++ b/src/Materials/Textures/babylon.videoTexture.ts
@@ -42,8 +42,15 @@
     };
 
     export class VideoTexture extends Texture {
-        readonly autoUpdateTexture: boolean;
-        readonly video: HTMLVideoElement;
+        /**
+         * Tells whether textures will be updated automatically or user is required to call `updateTexture` manually
+         */
+        public readonly autoUpdateTexture: boolean;
+
+        /**
+         * The video instance used by the texture internally
+         */
+        public readonly video: HTMLVideoElement;
 
         private _generateMipMaps: boolean;
         private _engine: Engine;


### PR DESCRIPTION
Allows to override `autoPlay` and `loop` values
Allows to use manual texture updating
Maintains backwards-compatibility

As a fallow-up on http://www.html5gamedevs.com/topic/34582-videotexture-1-frame-per-render-loop/?do=findComment&comment=201701