### PR TITLE
WebVRCamera - Consider user configured default height and allow zero …

### DIFF
--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -75,7 +75,7 @@ module BABYLON {
 
         private _lightOnControllers: HemisphericLight;
 
-        private _defaultHeight = 0;
+        private _defaultHeight?: number = undefined;
         constructor(name: string, position: Vector3, scene: Scene, private webVROptions: WebVROptions = {}) {
             super(name, position, scene);
             this._cache.position = Vector3.Zero();
@@ -165,13 +165,13 @@ module BABYLON {
         }
 
         public deviceDistanceToRoomGround = () => {
-            if (this._standingMatrix) {
+            if (this._standingMatrix && this._defaultHeight === undefined) {
                 // Add standing matrix offset to get real offset from ground in room
                 this._standingMatrix.getTranslationToRef(this._workingVector);
                 return this._deviceRoomPosition.y + this._workingVector.y
-            } else {
-                return this._defaultHeight;
             }
+            //If VRDisplay does not inform stage parameters and no default height is set we fallback to zero.
+            return this._defaultHeight || 0;            
         }
 
         public useStandingMatrix = (callback = (bool: boolean) => { }) => {


### PR DESCRIPTION
WebVRCamera is not considering now the defaultHeight configured by the user when a device is reporting stage parameters and the standingMatrix is initialized. In addition, checking conditions with defaultHeight default value 0 won't allow it to be a valid value.

I used 0 as default height when user does not set it and display either, but If you consider another value would be better just tell. For example VRExperienceHelper initializes it as 1.7 if defaultHeight property not set in VR options.

I realized of this when I changed my Mixed Reality Portal headset that is not reporting sittingToStandingTransform parameters to Oculus Rift that reports it.

