### PR TITLE
adding depth of field to default pipeline

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -58,6 +58,8 @@
             "additionalPostProcesses",
             "additionalPostProcess_blur",
             "additionalPostProcess_fxaa",
+            "additionalPostProcess_circleOfConfusion",
+            "additionalPostProcess_depthOfFieldMerge",
             "additionalPostProcess_imageProcessing",
             "bones",
             "hdr",
@@ -721,6 +723,28 @@
                 "kernelBlurVertex"
             ]
         },
+        "additionalPostProcess_circleOfConfusion": {
+            "files": [
+                "../../src/PostProcess/babylon.circleOfConfusionPostProcess.js"
+            ],
+            "dependUpon": [
+                "postProcesses"
+            ],
+            "shaders": [
+                "circleOfConfusion.fragment"
+            ]
+        },
+        "additionalPostProcess_depthOfFieldMerge": {
+            "files": [
+                "../../src/PostProcess/babylon.depthOfFieldMergePostProcess.js"
+            ],
+            "dependUpon": [
+                "postProcesses"
+            ],
+            "shaders": [
+                "depthOfFieldMerge.fragment"
+            ]
+        },
         "additionalPostProcess_fxaa": {
             "files": [
                 "../../src/PostProcess/babylon.fxaaPostProcess.js"
@@ -826,7 +850,9 @@
             ],
             "dependUpon": [
                 "renderingPipeline",
-                "additionalPostProcess_fxaa"
+                "additionalPostProcess_fxaa",
+                "additionalPostProcess_circleOfConfusion",
+                "additionalPostProcess_depthOfFieldMerge"
             ]
         },
         "bones": {

--- a/src/PostProcess/babylon.circleOfConfusionPostProcess.ts
+++ b/src/PostProcess/babylon.circleOfConfusionPostProcess.ts
@@ -1,0 +1,29 @@
+module BABYLON {
+    export class CircleOfConfusionPostProcess extends PostProcess {
+        fStop = 4; // Aperture = focalLength/fStop
+        focusDistance = 15; // in scene units (eg. meter)
+        focalLength = 10; // in scene units/1000 (eg. millimeter)
+
+        
+        constructor(name: string, depthTexture: RenderTargetTexture, options: number | PostProcessOptions, camera: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType: number = Engine.TEXTURETYPE_UNSIGNED_INT) {
+            super(name, "circleOfConfusion", ["near", "far", "focusDistance", "cocPrecalculation"], ["depthSampler"], options, camera, samplingMode, engine, reusable, null, textureType);
+            this.onApplyObservable.add((effect: Effect) => {
+                effect.setTexture("depthSampler", depthTexture);
+                
+                // Circle of confusion calculation, See https://developer.nvidia.com/gpugems/GPUGems/gpugems_ch23.html
+                var aperture = this.focalLength/this.fStop;
+                var cocPrecalculation = ((aperture * this.focalLength)/((this.focusDistance - this.focalLength)));// * ((this.focusDistance - pixelDistance)/pixelDistance) [This part is done in shader]
+                
+                effect.setFloat('focusDistance', this.focusDistance);
+                effect.setFloat('cocPrecalculation', cocPrecalculation);
+                
+                // TODO: is there a better way to get camera?
+                var camera = this.getEngine().scenes[0].activeCamera;
+                if(camera){
+                    effect.setFloat('near', camera.minZ);
+                    effect.setFloat('far', camera.maxZ);
+                }
+            })
+        }
+    }
+}

--- a/src/PostProcess/babylon.depthOfFieldMergePostProcess.ts
+++ b/src/PostProcess/babylon.depthOfFieldMergePostProcess.ts
@@ -1,0 +1,11 @@
+module BABYLON {
+    export class DepthOfFieldMergePostProcess extends PostProcess {
+        constructor(name: string, original: PostProcess, circleOfConfusion: PostProcess, options: number | PostProcessOptions, camera: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType: number = Engine.TEXTURETYPE_UNSIGNED_INT) {
+            super(name, "depthOfFieldMerge", [], ["circleOfConfusionSampler", "originalSampler"], options, camera, samplingMode, engine, reusable, null, textureType);
+            this.onApplyObservable.add((effect: Effect) => {
+                effect.setTextureFromPostProcess("circleOfConfusionSampler", circleOfConfusion);
+                effect.setTextureFromPostProcess("originalSampler", original);
+            })
+        }
+    }
+}

--- a/src/Shaders/ShadersInclude/kernelBlurFragment.fx
+++ b/src/Shaders/ShadersInclude/kernelBlurFragment.fx
@@ -1,5 +1,14 @@
-﻿#ifdef PACKEDFLOAT
-    blend += unpack(texture2D(textureSampler, sampleCoord{X})) * KERNEL_WEIGHT{X};
+﻿#ifdef DOF
+    sampleDepth = sampleDistance(sampleCoord{X});
+    factor = clamp(1.0-((centerSampleDepth - sampleDepth)/centerSampleDepth),0.0,1.0);
+    computedWeight = KERNEL_WEIGHT{X} * factor;
+    sumOfWeights += computedWeight;
 #else
-    blend += texture2D(textureSampler, sampleCoord{X}) * KERNEL_WEIGHT{X};
+    computedWeight = KERNEL_WEIGHT{X};
+#endif
+
+#ifdef PACKEDFLOAT
+    blend += unpack(texture2D(textureSampler, sampleCoord{X})) * computedWeight;
+#else
+    blend += texture2D(textureSampler, sampleCoord{X}) * computedWeight;
 #endif

--- a/src/Shaders/ShadersInclude/kernelBlurFragment2.fx
+++ b/src/Shaders/ShadersInclude/kernelBlurFragment2.fx
@@ -1,5 +1,14 @@
-﻿#ifdef PACKEDFLOAT
-    blend += unpack(texture2D(textureSampler, sampleCenter + delta * KERNEL_DEP_OFFSET{X})) * KERNEL_DEP_WEIGHT{X};
+﻿#ifdef DOF
+    sampleDepth = sampleDistance(sampleCoord{X});
+    factor = clamp(1.0-((centerSampleDepth - sampleDepth)/centerSampleDepth),0.0,1.0);
+    computedWeight = KERNEL_DEP_WEIGHT{X} * factor;
+    sumOfWeights += computedWeight;
 #else
-    blend += texture2D(textureSampler, sampleCenter + delta * KERNEL_DEP_OFFSET{X}) * KERNEL_DEP_WEIGHT{X};
+    computedWeight = KERNEL_DEP_WEIGHT{X};
+#endif
+
+#ifdef PACKEDFLOAT
+    blend += unpack(texture2D(textureSampler, sampleCenter + delta * KERNEL_DEP_OFFSET{X})) * computedWeight;
+#else
+    blend += texture2D(textureSampler, sampleCenter + delta * KERNEL_DEP_OFFSET{X}) * computedWeight;
 #endif

--- a/src/Shaders/circleOfConfusion.fragment.fx
+++ b/src/Shaders/circleOfConfusion.fragment.fx
@@ -1,0 +1,26 @@
+// samplers
+uniform sampler2D depthSampler;
+
+// varyings
+varying vec2 vUV;
+
+// preconputed uniforms (not effect parameters)
+uniform float near;
+uniform float far;
+
+// uniforms
+uniform float focusDistance;
+uniform float cocPrecalculation;
+
+float sampleDistance(const in vec2 offset) {
+    float depth = texture2D(depthSampler, offset).r;	// depth value from DepthRenderer: 0 to 1
+	return near + (far - near)*depth;		            // actual distance from the lens
+}
+
+void main(void)
+{
+    float pixelDistance = sampleDistance(vUV);
+    float coc = abs(cocPrecalculation* ((focusDistance - pixelDistance)/pixelDistance));
+    coc = clamp(coc, 0.0, 1.0);
+    gl_FragColor = vec4(coc, coc, coc, 1.0);
+}

--- a/src/Shaders/depthOfFieldMerge.fragment.fx
+++ b/src/Shaders/depthOfFieldMerge.fragment.fx
@@ -1,0 +1,15 @@
+// samplers
+uniform sampler2D textureSampler;
+uniform sampler2D originalSampler;
+uniform sampler2D circleOfConfusionSampler;
+
+// varyings
+varying vec2 vUV;
+
+void main(void)
+{
+    vec4 blurred = texture2D(textureSampler, vUV);
+    vec4 original = texture2D(originalSampler, vUV);
+    float coc = texture2D(circleOfConfusionSampler, vUV).r;
+    gl_FragColor = (original * (1.0-coc))+(blurred*coc);
+}


### PR DESCRIPTION
Open issues:
- [ ]  Depth buffer seems 1 frame behind color buffer
- [ ]  setTextureFromPostProcess does not work as originally expected
- [ ]  Not sure how to expose dials on default pipeline (option1: expose them all hanging off of default pipeline like the current bloom, option2: add new dofControl class hanging off of default pipeline)
- [ ]  Documentation for all the files
- [ ]  There is possible refactoring that could be done to move the circleOfConfusion pass into the depthOfFieldMerge pass to avoid another pass
- [ ]  Rendering optimizations such as avoiding clears