### PR TITLE
VRHelper - Notify unselected mesh when ray predicate doesn't hit

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -26,6 +26,8 @@
 - `AssetsManager` will now clear its `tasks` list from all successfully loaded tasks ([deltakosh](https://github.com/deltakosh))
 - Added documentation to WebVRCamera and VRExperienceHelper ([trevordev](https://github.com/trevordev))
 - Introduced `isStroke` on `HighlightLayerOptions` which makes the highlight solid ([PixelsCommander](https://github.com/pixelscommander))
+- VRHelper will notify now onSelectedMeshUnselected observable to subscribers when the applied ray selection predicate does not produce a hit and a mesh compliant with the meshSelectionPredicate was previously selected
+   ([carloslanderas](https://github.com/carloslanderas))
 
 ## Bug fixes
 

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -1487,9 +1487,8 @@ module BABYLON {
                     // Moving the teleportation area to this targetted point
 
                     //Raise onSelectedMeshUnselected observable if ray collided floor mesh/meshes and a non floor mesh was previously selected
-                    if (this._currentMeshSelected &&
-                        !this._isTeleportationFloor(this._currentMeshSelected)) {
-                        this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
+                    if (this._currentMeshSelected && !this._isTeleportationFloor(this._currentMeshSelected)) {
+                        this._notifySelectedMeshUnselected();
                     }
 
                     this._currentMeshSelected = null;
@@ -1522,9 +1521,7 @@ module BABYLON {
                         }
                     }
                     else {
-                        if (this._currentMeshSelected) {
-                            this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
-                        }
+                        this._notifySelectedMeshUnselected();
                         this._currentMeshSelected = null;
                         this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
                         this.changeLaserColor(new Color3(0.7, 0.7, 0.7));
@@ -1533,11 +1530,18 @@ module BABYLON {
             }
             else {
                 this._currentHit = null;
+                this._notifySelectedMeshUnselected();
                 this._currentMeshSelected = null;
                 this._teleportationAllowed = false;
                 this._hideTeleportationTarget();
                 this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
                 this.changeLaserColor(new Color3(0.7, 0.7, 0.7));
+            }
+        }
+        
+        private _notifySelectedMeshUnselected( ) {
+            if(this._currentMeshSelected) {
+                this.onSelectedMeshUnselected.notifyObservers(this._currentMeshSelected);
             }
         }
 


### PR DESCRIPTION
Right now the observable onSelectedMeshUnselected is notified when there is a ray hit and the target mesh is the floor (teleport zone), or when there is a hit and the picked mesh is diferent to the previous selected and is not meshSelectionPredicate compliant.

However, if our raySelectionPredicate is very restricted and the ray hits an object making it the current and no other meshes in the predicate are close, we will never get notified about the gaze/controller losing the focus on that particular mesh.