### PR TITLE
SPS particle rotation matrix storage

### DIFF
--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -84,6 +84,10 @@ module BABYLON {
          * Still set as invisible in order to skip useless computations (Internal use)
          */
         public _stillInvisible: boolean = false;
+        /**
+         * Last computed particle rotation matrix
+         */
+        public _rotationMatrix: number[] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
 
         /**
          * Creates a Solid Particle object.

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -748,6 +748,15 @@
                                 this._quaternionRotationYPR();
                             }
                             this._quaternionToRotationMatrix();
+                            this._particle._rotationMatrix[0] = this._rotMatrix.m[0];
+                            this._particle._rotationMatrix[1] = this._rotMatrix.m[1];
+                            this._particle._rotationMatrix[2] = this._rotMatrix.m[2];
+                            this._particle._rotationMatrix[3] = this._rotMatrix.m[4];
+                            this._particle._rotationMatrix[4] = this._rotMatrix.m[5];
+                            this._particle._rotationMatrix[5] = this._rotMatrix.m[6];
+                            this._particle._rotationMatrix[6] = this._rotMatrix.m[8];
+                            this._particle._rotationMatrix[7] = this._rotMatrix.m[9];
+                            this._particle._rotationMatrix[8] = this._rotMatrix.m[10];
                         }
        
                         // particle vertex loop
@@ -773,9 +782,9 @@
                             this._vertex.y += this._particle.pivot.y;
                             this._vertex.z += this._particle.pivot.z;
     
-                            this._rotated.x = this._vertex.x * this._rotMatrix.m[0] + this._vertex.y * this._rotMatrix.m[4] + this._vertex.z * this._rotMatrix.m[8];
-                            this._rotated.y = this._vertex.x * this._rotMatrix.m[1] + this._vertex.y * this._rotMatrix.m[5] + this._vertex.z * this._rotMatrix.m[9];
-                            this._rotated.z = this._vertex.x * this._rotMatrix.m[2] + this._vertex.y * this._rotMatrix.m[6] + this._vertex.z * this._rotMatrix.m[10];
+                            this._rotated.x = this._vertex.x * this._particle._rotationMatrix[0] + this._vertex.y * this._particle._rotationMatrix[3] + this._vertex.z * this._particle._rotationMatrix[6];
+                            this._rotated.y = this._vertex.x * this._particle._rotationMatrix[1] + this._vertex.y * this._particle._rotationMatrix[4] + this._vertex.z * this._particle._rotationMatrix[7];
+                            this._rotated.z = this._vertex.x * this._particle._rotationMatrix[2] + this._vertex.y * this._particle._rotationMatrix[5] + this._vertex.z * this._particle._rotationMatrix[8];
     
                             this._positions32[idx] = this._particle.position.x + this._cam_axisX.x * this._rotated.x + this._cam_axisY.x * this._rotated.y + this._cam_axisZ.x * this._rotated.z;
                             this._positions32[idx + 1] = this._particle.position.y + this._cam_axisX.y * this._rotated.x + this._cam_axisY.y * this._rotated.y + this._cam_axisZ.y * this._rotated.z;
@@ -808,9 +817,9 @@
                                 this._normal.y = this._fixedNormal32[idx + 1];
                                 this._normal.z = this._fixedNormal32[idx + 2];
     
-                                this._rotated.x = this._normal.x * this._rotMatrix.m[0] + this._normal.y * this._rotMatrix.m[4] + this._normal.z * this._rotMatrix.m[8];
-                                this._rotated.y = this._normal.x * this._rotMatrix.m[1] + this._normal.y * this._rotMatrix.m[5] + this._normal.z * this._rotMatrix.m[9];
-                                this._rotated.z = this._normal.x * this._rotMatrix.m[2] + this._normal.y * this._rotMatrix.m[6] + this._normal.z * this._rotMatrix.m[10];
+                                this._rotated.x = this._normal.x * this._particle._rotationMatrix[0] + this._normal.y * this._particle._rotationMatrix[3] + this._normal.z * this._particle._rotationMatrix[6];
+                                this._rotated.y = this._normal.x * this._particle._rotationMatrix[1] + this._normal.y * this._particle._rotationMatrix[4] + this._normal.z * this._particle._rotationMatrix[7];
+                                this._rotated.z = this._normal.x * this._particle._rotationMatrix[2] + this._normal.y * this._particle._rotationMatrix[5] + this._normal.z * this._particle._rotationMatrix[8];
     
                                 this._normals32[idx] = this._cam_axisX.x * this._rotated.x + this._cam_axisY.x * this._rotated.y + this._cam_axisZ.x * this._rotated.z;
                                 this._normals32[idx + 1] = this._cam_axisX.y * this._rotated.x + this._cam_axisY.y * this._rotated.y + this._cam_axisZ.y * this._rotated.z;
@@ -868,9 +877,9 @@
                                 this._vertex.x = this._particle._modelBoundingInfo.boundingBox.vectors[b].x * this._particle.scaling.x;
                                 this._vertex.y = this._particle._modelBoundingInfo.boundingBox.vectors[b].y * this._particle.scaling.y;
                                 this._vertex.z = this._particle._modelBoundingInfo.boundingBox.vectors[b].z * this._particle.scaling.z;
-                                this._rotated.x = this._vertex.x * this._rotMatrix.m[0] + this._vertex.y * this._rotMatrix.m[4] + this._vertex.z * this._rotMatrix.m[8];
-                                this._rotated.y = this._vertex.x * this._rotMatrix.m[1] + this._vertex.y * this._rotMatrix.m[5] + this._vertex.z * this._rotMatrix.m[9];
-                                this._rotated.z = this._vertex.x * this._rotMatrix.m[2] + this._vertex.y * this._rotMatrix.m[6] + this._vertex.z * this._rotMatrix.m[10];
+                                this._rotated.x = this._vertex.x * this._particle._rotationMatrix[0] + this._vertex.y * this._particle._rotationMatrix[3] + this._vertex.z * this._particle._rotationMatrix[6];
+                                this._rotated.y = this._vertex.x * this._particle._rotationMatrix[1] + this._vertex.y * this._particle._rotationMatrix[4] + this._vertex.z * this._particle._rotationMatrix[7];
+                                this._rotated.z = this._vertex.x * this._particle._rotationMatrix[2] + this._vertex.y * this._particle._rotationMatrix[5] + this._vertex.z * this._particle._rotationMatrix[8];
                                 bBox.vectors[b].x = this._particle.position.x + this._cam_axisX.x * this._rotated.x + this._cam_axisY.x * this._rotated.y + this._cam_axisZ.x * this._rotated.z;
                                 bBox.vectors[b].y = this._particle.position.y + this._cam_axisX.y * this._rotated.x + this._cam_axisY.y * this._rotated.y + this._cam_axisZ.y * this._rotated.z;
                                 bBox.vectors[b].z = this._particle.position.z + this._cam_axisX.z * this._rotated.x + this._cam_axisY.z * this._rotated.y + this._cam_axisZ.z * this._rotated.z;


### PR DESCRIPTION
SPS internal modification : 
This feature now stores a simplified representation of each particle rotation matrix.
* This improves the SPS former behavior : when setting `sps.computeParticleRotation`to false, now the last rotation status of all the particles is kept.  Old discussion here : http://www.html5gamedevs.com/topic/33038-setting-material-on-sps-causes-webgl-error/?tab=comments#comment-189720
* This also opens the way to implement later (soon, I hope) the particle parenting feature.  

The cost of this feature is 9 more floats stored per created particle and 9 simple affectations per particle in the global loop.

_... and glad to be back in the contribution process_  :-)