### PR TITLE
Fix serialize-module build

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -1516,6 +1516,9 @@
                     "../../serializers/src/glTF/2.0/babylon.glTFData.ts",
                     "../../serializers/src/glTF/2.0/babylon.glTFMaterial.ts"
                 ],
+                "extraDeclarations": [
+                    "../../dist/babylon.glTF2Interface.d.ts"
+                ],
                 "output": "babylon.glTF2Serializer.js"
             }
         ],

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -405,7 +405,14 @@ var buildExternalLibrary = function (library, settings, watch) {
             .pipe(gulp.dest(outputDirectory));
         /*}*/
 
-        var dts = tsProcess.dts
+        let preDts;
+        if (library.extraDeclarations) {
+            preDts = merge2([tsProcess.dts, gulp.src(library.extraDeclarations)])
+        } else {
+            preDts = tsProcess.dts;
+        }
+
+        var dts = preDts
             .pipe(concat(library.output))
             .pipe(replace(referenceSearchRegex, ""))
             .pipe(rename({ extname: ".d.ts" }))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -47,6 +47,7 @@
 - AssetContainer Class and loading methods. ([trevordev](https://github.com/trevordev))
 - KeepAssets class and AssetContainer.moveAllFromScene ([HoloLite](http://www.html5gamedevs.com/profile/28694-hololite/), [trevordev](https://github.com/trevordev))
 - (Viewer) It is now possible to update parts of the configuration without rcreating the objects. ([RaananW](https://github.com/RaananW))
+- (Gulp) extra/external declarations can be prepended to final declarations during build. ([RaananW](https://github.com/RaananW))
 
 ## Bug fixes
 - `setPivotMatrix` ws not setting pivot correctly. This is now fixed. We also introduced a new `setPreTransformMatrix` to reproduce the sometimes needed behavior of the previous `setPivotMatrix` function ([deltakosh](https://github.com/deltakosh))


### PR DESCRIPTION
A straight-forward solution for https://github.com/BabylonJS/Babylon.js/issues/3654
The missing declarations (that are referenced during development but filtered out during build) are now added to the final declaration during compilation.
Gulp was modified a bit