### PR TITLE
added the default back translation on particle pivot rotations

### DIFF
--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -41,6 +41,12 @@ module BABYLON {
          */
         public pivot: Vector3 = Vector3.Zero();
         /**
+         * Must the particle be translated from its pivot point in its local space ?
+         * In this case, the pivot point is set at the origin of the particle local space and the particle is translated.  
+         * Default : false
+         */
+        public translateFromPivot: boolean = false;
+        /**
          * Is the particle active or not ?
          */
         public alive: boolean = true;

--- a/src/Particles/babylon.solidParticleSystem.ts
+++ b/src/Particles/babylon.solidParticleSystem.ts
@@ -133,6 +133,7 @@
                     return (p2.sqDistance - p1.sqDistance);
                 };
             private _needs32Bits: boolean = false;
+            private _pivotBackTranslation: Vector3 = Vector3.Zero();
 
             /**
              * Creates a SPS (Solid Particle System) object.
@@ -373,6 +374,7 @@
                 this._copy.uvs.z = 1.0;
                 this._copy.uvs.w = 1.0;
                 this._copy.color = null;
+                this._copy.translateFromPivot = false;
             }
     
             // _meshBuilder : inserts the shape model in the global SPS mesh
@@ -397,6 +399,13 @@
                     this._quaternionRotationYPR();
                 }
                 this._quaternionToRotationMatrix();
+                
+                if (this._copy.translateFromPivot) {
+                    this._pivotBackTranslation.copyFromFloats(0.0, 0.0, 0.0);
+                }
+                else {
+                    this._pivotBackTranslation.copyFrom(this._copy.pivot);
+                }
     
                 for (i = 0; i < shape.length; i++) {
                     this._vertex.x = shape[i].x;
@@ -411,11 +420,13 @@
                     this._vertex.y *= this._copy.scaling.y;
                     this._vertex.z *= this._copy.scaling.z;
 
-                    this._vertex.x += this._copy.pivot.x;
-                    this._vertex.y += this._copy.pivot.y;
-                    this._vertex.z += this._copy.pivot.z;
+                    this._vertex.x -= this._copy.pivot.x;
+                    this._vertex.y -= this._copy.pivot.y;
+                    this._vertex.z -= this._copy.pivot.z;
     
                     Vector3.TransformCoordinatesToRef(this._vertex, this._rotMatrix, this._rotated);
+
+                    this._rotated.addInPlace(this._pivotBackTranslation);
                     positions.push(this._copy.position.x + this._rotated.x, this._copy.position.y + this._rotated.y, this._copy.position.z + this._rotated.z);
                     if (meshUV) {
                         uvs.push((this._copy.uvs.z - this._copy.uvs.x) * meshUV[u] + this._copy.uvs.x, (this._copy.uvs.w - this._copy.uvs.y) * meshUV[u + 1] + this._copy.uvs.y);
@@ -570,6 +581,13 @@
                     this._quaternionRotationYPR();
                 }
                 this._quaternionToRotationMatrix();
+
+                if (this._copy.translateFromPivot) {
+                    this._pivotBackTranslation.copyFromFloats(0.0, 0.0, 0.0);
+                }
+                else {
+                    this._pivotBackTranslation.copyFrom(this._copy.pivot);
+                }
     
                 this._shape = particle._model._shape;
                 for (var pt = 0; pt < this._shape.length; pt++) {
@@ -585,11 +603,12 @@
                     this._vertex.y *= this._copy.scaling.y;
                     this._vertex.z *= this._copy.scaling.z;
 
-                    this._vertex.x += this._copy.pivot.x;
-                    this._vertex.y += this._copy.pivot.y;
-                    this._vertex.z += this._copy.pivot.z;
+                    this._vertex.x -= this._copy.pivot.x;
+                    this._vertex.y -= this._copy.pivot.y;
+                    this._vertex.z -= this._copy.pivot.z;
     
                     Vector3.TransformCoordinatesToRef(this._vertex, this._rotMatrix, this._rotated);
+                    this._rotated.addInPlace(this._pivotBackTranslation);
     
                     this._positions32[particle._pos + pt * 3] = this._copy.position.x + this._rotated.x;
                     this._positions32[particle._pos + pt * 3 + 1] = this._copy.position.y + this._rotated.y;
@@ -759,6 +778,16 @@
                             this._particle._rotationMatrix[8] = this._rotMatrix.m[10];
                         }
        
+                        if (this._particle.translateFromPivot) {
+                            this._pivotBackTranslation.x = 0.0;
+                            this._pivotBackTranslation.y = 0.0;
+                            this._pivotBackTranslation.z = 0.0;
+                        }
+                        else {
+                            this._pivotBackTranslation.x = this._particle.pivot.x;
+                            this._pivotBackTranslation.y = this._particle.pivot.y;
+                            this._pivotBackTranslation.z = this._particle.pivot.z;
+                        }
                         // particle vertex loop
                         for (pt = 0; pt < this._shape.length; pt++) {
                             idx = index + pt * 3;
@@ -778,14 +807,18 @@
                             this._vertex.y *= this._particle.scaling.y;
                             this._vertex.z *= this._particle.scaling.z;
 
-                            this._vertex.x += this._particle.pivot.x;
-                            this._vertex.y += this._particle.pivot.y;
-                            this._vertex.z += this._particle.pivot.z;
+                            this._vertex.x -= this._particle.pivot.x;
+                            this._vertex.y -= this._particle.pivot.y;
+                            this._vertex.z -= this._particle.pivot.z;
     
                             this._rotated.x = this._vertex.x * this._particle._rotationMatrix[0] + this._vertex.y * this._particle._rotationMatrix[3] + this._vertex.z * this._particle._rotationMatrix[6];
                             this._rotated.y = this._vertex.x * this._particle._rotationMatrix[1] + this._vertex.y * this._particle._rotationMatrix[4] + this._vertex.z * this._particle._rotationMatrix[7];
                             this._rotated.z = this._vertex.x * this._particle._rotationMatrix[2] + this._vertex.y * this._particle._rotationMatrix[5] + this._vertex.z * this._particle._rotationMatrix[8];
     
+                            this._rotated.x += this._pivotBackTranslation.x;
+                            this._rotated.y += this._pivotBackTranslation.y;
+                            this._rotated.z += this._pivotBackTranslation.z;
+
                             this._positions32[idx] = this._particle.position.x + this._cam_axisX.x * this._rotated.x + this._cam_axisY.x * this._rotated.y + this._cam_axisZ.x * this._rotated.z;
                             this._positions32[idx + 1] = this._particle.position.y + this._cam_axisX.y * this._rotated.x + this._cam_axisY.y * this._rotated.y + this._cam_axisZ.y * this._rotated.z;
                             this._positions32[idx + 2] = this._particle.position.z + this._cam_axisX.z * this._rotated.x + this._cam_axisY.z * this._rotated.y + this._cam_axisZ.z * this._rotated.z;


### PR DESCRIPTION
This adds the particle back translation in their local space by default when rotated around a pivot point.  
The former behavior (keeping the pivot translation) is still accessible by setting now the particle property `.translateFromPivot` to true.