### PR TITLE
glTF Loader extension and compileMaterials fixes

### DIFF
--- a/loaders/src/glTF/1.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/1.0/babylon.glTFLoader.ts
@@ -1572,9 +1572,9 @@ module BABYLON.GLTF1 {
         public onTextureLoadedObservable = new Observable<BaseTexture>();
         public onMaterialLoadedObservable = new Observable<Material>();
         public onCompleteObservable = new Observable<IGLTFLoader>();
+        public onExtensionLoadedObservable = new Observable<IGLTFLoaderExtension>();
 
         public state: Nullable<GLTFLoaderState> = null;
-        public extensions: Nullable<IGLTFLoaderExtensions> = null;
 
         public dispose(): void {}
         // #endregion

--- a/loaders/src/glTF/2.0/Extensions/KHR_lights.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights.ts
@@ -31,10 +31,8 @@ module BABYLON.GLTF2.Extensions {
         lights: ILight[];
     }
 
-    export class KHRLights extends GLTFLoaderExtension {
-        protected get _name(): string {
-            return NAME;
-        }
+    export class KHR_lights extends GLTFLoaderExtension {
+        public readonly name = NAME;
 
         protected _loadSceneAsync(context: string, scene: ILoaderScene): Nullable<Promise<void>> { 
             return this._loadExtensionAsync<ILightReference>(context, scene, (context, extension) => {
@@ -94,14 +92,14 @@ module BABYLON.GLTF2.Extensions {
 
         private get _lights(): Array<ILight> {
             const extensions = this._loader._gltf.extensions;
-            if (!extensions || !extensions[this._name]) {
-                throw new Error("#/extensions: " + this._name + " not found");
+            if (!extensions || !extensions[this.name]) {
+                throw new Error("#/extensions: " + this.name + " not found");
             }
 
-            const extension = extensions[this._name] as ILights;
+            const extension = extensions[this.name] as ILights;
             return extension.lights;
         }
     }
 
-    GLTFLoader._Register(NAME, loader => new KHRLights(loader));
+    GLTFLoader._Register(NAME, loader => new KHR_lights(loader));
 }

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -13,10 +13,8 @@ module BABYLON.GLTF2.Extensions {
         specularGlossinessTexture: ITextureInfo;
     }
 
-    export class KHRMaterialsPbrSpecularGlossiness extends GLTFLoaderExtension {
-        protected get _name(): string {
-            return NAME;
-        }
+    export class KHR_materials_pbrSpecularGlossiness extends GLTFLoaderExtension {
+        public readonly name = NAME;
 
         protected _loadMaterialAsync(context: string, material: ILoaderMaterial, babylonMesh: Mesh): Nullable<Promise<void>> {
             return this._loadExtensionAsync<IKHRMaterialsPbrSpecularGlossiness>(context, material, (context, extension) => {
@@ -81,5 +79,5 @@ module BABYLON.GLTF2.Extensions {
         }
     }
 
-    GLTFLoader._Register(NAME, loader => new KHRMaterialsPbrSpecularGlossiness(loader));
+    GLTFLoader._Register(NAME, loader => new KHR_materials_pbrSpecularGlossiness(loader));
 }

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
@@ -1,7 +1,7 @@
 ﻿/// <reference path="../../../../dist/preview release/babylon.d.ts"/>
 
 module BABYLON.GLTF2 {
-    export abstract class GLTFLoaderExtension {
+    export abstract class GLTFLoaderExtension implements IGLTFLoaderExtension {
         public enabled = true;
 
         protected _loader: GLTFLoader;
@@ -10,7 +10,7 @@ module BABYLON.GLTF2 {
             this._loader = loader;
         }
 
-        protected abstract get _name(): string;
+        public abstract readonly name: string;
 
         // #region Overridable Methods
 
@@ -36,17 +36,17 @@ module BABYLON.GLTF2 {
 
             const extensions = property.extensions;
 
-            const extension = extensions[this._name] as T;
+            const extension = extensions[this.name] as T;
             if (!extension) {
                 return null;
             }
 
             // Clear out the extension before executing the action to avoid recursing into the same property.
-            delete extensions[this._name];
+            delete extensions[this.name];
 
-            return actionAsync(context + "extensions/" + this._name, extension).then(() => {
+            return actionAsync(context + "/extensions/" + this.name, extension).then(() => {
                 // Restore the extension after completing the action.
-                extensions[this._name] = extension;
+                extensions[this.name] = extension;
             });
         }
 

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -35,18 +35,22 @@ module BABYLON {
         bin: Nullable<ArrayBufferView>;
     }
 
+    export interface IGLTFLoaderExtension {
+        /**
+         * The name of this extension.
+         */
+        readonly name: string;
+
+        /**
+         * Whether this extension is enabled.
+         */
+        enabled: boolean;
+    }
+
     export enum GLTFLoaderState {
         Loading,
         Ready,
         Complete
-    }
-
-    export interface IGLTFLoaderExtension {
-        enabled: boolean;
-    }
-
-    export interface IGLTFLoaderExtensions {
-        [name: string]: IGLTFLoaderExtension;
     }
 
     export interface IGLTFLoader extends IDisposable {
@@ -56,14 +60,14 @@ module BABYLON {
         useClipPlane: boolean;
         compileShadowGenerators: boolean;
 
-        onDisposeObservable: Observable<IGLTFLoader>;
         onMeshLoadedObservable: Observable<AbstractMesh>;
         onTextureLoadedObservable: Observable<BaseTexture>;
         onMaterialLoadedObservable: Observable<Material>;
         onCompleteObservable: Observable<IGLTFLoader>;
+        onDisposeObservable: Observable<IGLTFLoader>;
+        onExtensionLoadedObservable: Observable<IGLTFLoaderExtension>;
 
         state: Nullable<GLTFLoaderState>;
-        extensions: Nullable<IGLTFLoaderExtensions>;
 
         importMeshAsync: (meshesNames: any, scene: Scene, data: IGLTFLoaderData, rootUrl: string, onProgress?: (event: SceneLoaderProgressEvent) => void) => Promise<{ meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[] }>;
         loadAsync: (scene: Scene, data: IGLTFLoaderData, rootUrl: string, onProgress?: (event: SceneLoaderProgressEvent) => void) => Promise<void>;
@@ -195,17 +199,24 @@ module BABYLON {
         }
 
         /**
+         * Raised after a loader extension is created.
+         * Set additional options for a loader extension in this event.
+         */
+        public readonly onExtensionLoadedObservable = new Observable<IGLTFLoaderExtension>();
+
+        private _onExtensionLoadedObserver: Nullable<Observer<IGLTFLoaderExtension>>;
+        public set onExtensionLoaded(callback: (extension: IGLTFLoaderExtension) => void) {
+            if (this._onExtensionLoadedObserver) {
+                this.onExtensionLoadedObservable.remove(this._onExtensionLoadedObserver);
+            }
+            this._onExtensionLoadedObserver = this.onExtensionLoadedObservable.add(callback);
+        }
+
+        /**
          * The loader state or null if not active.
          */
         public get loaderState(): Nullable<GLTFLoaderState> {
             return this._loader ? this._loader.state : null;
-        }
-
-        /**
-         * The loader extensions or null if not active.
-         */
-        public get loaderExtensions(): Nullable<IGLTFLoaderExtensions> {
-            return this._loader ? this._loader.extensions : null;
         }
 
         // #endregion
@@ -336,6 +347,7 @@ module BABYLON {
             loader.onTextureLoadedObservable.add(texture => this.onTextureLoadedObservable.notifyObservers(texture));
             loader.onMaterialLoadedObservable.add(material => this.onMaterialLoadedObservable.notifyObservers(material));
             loader.onCompleteObservable.add(() => this.onCompleteObservable.notifyObservers(this));
+            loader.onExtensionLoadedObservable.add(extension => this.onExtensionLoadedObservable.notifyObservers(extension));
             return loader;
         }
 

--- a/src/Engine/babylon.engine.ts
+++ b/src/Engine/babylon.engine.ts
@@ -2626,14 +2626,10 @@
             var name = vertex + "+" + fragment + "@" + (defines ? defines : (<EffectCreationOptions>attributesNamesOrOptions).defines);
             if (this._compiledEffects[name]) {
                 var compiledEffect = <Effect>this._compiledEffects[name];
-                if (onCompiled) {
-                    if (compiledEffect.isReady()) {
-                        onCompiled(compiledEffect);
-                    }
-                    else {
-                        compiledEffect.onCompileObservable.add(onCompiled, undefined, undefined, true);
-                    }
+                if (onCompiled && compiledEffect.isReady()) {
+                    onCompiled(compiledEffect);
                 }
+
                 return compiledEffect;
             }
             var effect = new Effect(baseName, attributesNamesOrOptions, uniformsNamesOrEngine, samplers, this, defines, fallbacks, onCompiled, onError, indexParameters);

--- a/src/Materials/PBR/babylon.pbrBaseMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrBaseMaterial.ts
@@ -1222,11 +1222,19 @@
             };
 
             const defines = new PBRMaterialDefines();
-            this._prepareEffect(mesh, defines, () => {
+            const effect = this._prepareEffect(mesh, defines, undefined, undefined, undefined, localOptions.clipPlane)!;
+            if (effect.isReady()) {
                 if (onCompiled) {
                     onCompiled(this);
                 }
-            }, undefined, undefined, localOptions.clipPlane);
+            }
+            else {
+                effect.onCompileObservable.add(() => {
+                    if (onCompiled) {
+                        onCompiled(this);
+                    }
+                });
+            }
         }
 
         /**

--- a/tests/unit/babylon/src/Material/babylon.material.tests.ts
+++ b/tests/unit/babylon/src/Material/babylon.material.tests.ts
@@ -1,0 +1,61 @@
+/**
+ * Describes the test suite.
+ */
+describe('Babylon Material', function () {
+    let subject: BABYLON.Engine;
+
+    /**
+     * Loads the dependencies.
+     */
+    before(function (done) {
+        this.timeout(180000);
+        (BABYLONDEVTOOLS).Loader
+            .useDist()
+            .load(function () {
+                // Force apply promise polyfill for consistent behavior between PhantomJS, IE11, and other browsers.
+                BABYLON.PromisePolyfill.Apply(true);
+                done();
+            });
+    });
+
+    /**
+     * Create a new engine subject before each test.
+     */
+    beforeEach(function () {
+        subject = new BABYLON.NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1
+        });
+    });
+
+    describe('#PBRMaterial', () => {
+        it('forceCompilation of a single material', () => {
+            const scene = new BABYLON.Scene(subject);
+            const mesh = BABYLON.Mesh.CreateBox("mesh", 1, scene);
+            const material = new BABYLON.PBRMaterial("material", scene);
+            return material.forceCompilationAsync(mesh);
+        });
+        it('forceCompilation of already compiled material', () => {
+            const scene = new BABYLON.Scene(subject);
+            const mesh = BABYLON.Mesh.CreateBox("mesh", 1, scene);
+            const material = new BABYLON.PBRMaterial("material", scene);
+            material.albedoTexture = new BABYLON.Texture("/Playground/scenes/BoomBox/BoomBox_baseColor.png", scene);
+            return material.forceCompilationAsync(mesh).then(() => {
+                return material.forceCompilationAsync(mesh);
+            });
+        });
+        it('forceCompilation of same material in parallel', () => {
+            const scene = new BABYLON.Scene(subject);
+            const mesh = BABYLON.Mesh.CreateBox("mesh", 1, scene);
+            const material = new BABYLON.PBRMaterial("material", scene);
+            material.albedoTexture = new BABYLON.Texture("/Playground/scenes/BoomBox/BoomBox_baseColor.png", scene);
+            return Promise.all([
+                material.forceCompilationAsync(mesh),
+                material.forceCompilationAsync(mesh)
+            ]);
+        });
+    });
+});

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function (config) {
             './tests/unit/babylon/babylon.example.tests.js',
             './tests/unit/babylon/serializers/babylon.glTFSerializer.tests.js',
             './tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.js',
+            './tests/unit/babylon/src/Material/babylon.material.tests.js',
             './tests/unit/babylon/src/Mesh/babylon.mesh.vertexData.tests.js',
             './tests/unit/babylon/src/Tools/babylon.promise.tests.js',
             { pattern: 'dist/**/*', watched: false, included: false, served: true },


### PR DESCRIPTION
- Fix a bug with `pbrBaseMaterial.forceCompilation`
- Fix issue with glTF loader extensions
- Add unit tests for `material.forceCompilation`

`what's new.md` is intentionally not updated since these are follow ups to the previous change.