### PR TITLE
Fix bug in glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -438,6 +438,8 @@ module BABYLON.GLTF2 {
                 promises.push(this._loadMaterialAsync("#/materials/" + material._index, material, babylonMesh));
             }
 
+            this.onMeshLoadedObservable.notifyObservers(babylonMesh);
+
             return Promise.all(promises).then(() => {
                 babylonMesh.setEnabled(true);
             });

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -39,19 +39,25 @@ describe('Babylon Scene Loader', function () {
     describe('#glTF', () => {
         it('Load BoomBox', () => {
             const scene = new BABYLON.Scene(subject);
-            return BABYLON.SceneLoader.AppendAsync("/Playground/scenes/BoomBox/", "BoomBox.gltf", scene);
+            return BABYLON.SceneLoader.AppendAsync("/Playground/scenes/BoomBox/", "BoomBox.gltf", scene).then(scene => {
+                expect(scene.meshes.length, "scene.meshes.length").to.equal(3);
+                expect(scene.materials.length, "scene.materials.length").to.equal(1);
+            });
         });
 
         it('Load BoomBox GLB', () => {
             const scene = new BABYLON.Scene(subject);
-            return BABYLON.SceneLoader.AppendAsync("/Playground/scenes/", "BoomBox.glb", scene);
+            return BABYLON.SceneLoader.AppendAsync("/Playground/scenes/", "BoomBox.glb", scene).then(scene => {
+                expect(scene.meshes.length, "scene.meshes.length").to.equal(3);
+                expect(scene.materials.length, "scene.materials.length").to.equal(1);
+            });
         });
 
         it('Load BoomBox with callbacks', () => {
             let parsedCount = 0;
-            let primaryMeshLoadCount = 0;
-            let primaryMaterialLoadCount = 0;
-            let textureLoadCounts: { [name: string]: number } = {};
+            let meshCount = 0;
+            let materialCount = 0;
+            let textureCounts: { [name: string]: number } = {};
             let ready = false;
 
             const deferred = new BABYLON.Deferred();
@@ -61,18 +67,14 @@ describe('Babylon Scene Loader', function () {
                 };
 
                 loader.onMeshLoaded = mesh => {
-                    if (mesh.name === "BoomBox") {
-                        primaryMeshLoadCount++;
-                    }
+                    meshCount++;
                 };
                 loader.onMaterialLoaded = material => {
-                    if (material.name === "BoomBox_Mat") {
-                        primaryMaterialLoadCount++;
-                    }
+                    materialCount++;
                 };
                 loader.onTextureLoaded = texture => {
-                    textureLoadCounts[texture.name] = textureLoadCounts[texture.name] || 0;
-                    textureLoadCounts[texture.name]++;
+                    textureCounts[texture.name] = textureCounts[texture.name] || 0;
+                    textureCounts[texture.name]++;
                 };
 
                 loader.onComplete = () => {
@@ -91,8 +93,8 @@ describe('Babylon Scene Loader', function () {
                 ready = true;
 
                 expect(parsedCount, "parsedCount").to.equal(1);
-                expect(primaryMeshLoadCount, "primaryMeshLoadCount").to.equal(1);
-                expect(primaryMaterialLoadCount, "primaryMaterialLoadCount").to.equal(1);
+                expect(meshCount, "meshCount").to.equal(scene.meshes.length);
+                expect(materialCount, "materialCount").to.equal(scene.materials.length);
 
                 const expectedTextureLoadCounts = {
                     "baseColor": 1,
@@ -100,9 +102,9 @@ describe('Babylon Scene Loader', function () {
                     "normal": 1,
                     "emissive": 1
                 };
-                expect(Object.keys(textureLoadCounts), "Object.keys(textureLoadCounts)").to.have.lengthOf(Object.keys(expectedTextureLoadCounts).length);
+                expect(Object.keys(textureCounts), "Object.keys(textureCounts)").to.have.lengthOf(Object.keys(expectedTextureLoadCounts).length);
                 for (const textureName in expectedTextureLoadCounts) {
-                    expect(textureLoadCounts, "textureLoadCounts").to.have.property(textureName, expectedTextureLoadCounts[textureName]);
+                    expect(textureCounts, "textureCounts").to.have.property(textureName, expectedTextureLoadCounts[textureName]);
                 }
             });
 


### PR DESCRIPTION
onMeshLoadedObservable is not fired for the primitive meshes