### PR TITLE
Fix bug in getWorldExtends

### DIFF
--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -4232,11 +4232,12 @@
             for (var index = 0; index < this.meshes.length; index++) {
                 var mesh = this.meshes[index];
 
+                mesh.computeWorldMatrix(true);
+
                 if (!mesh.subMeshes || mesh.subMeshes.length === 0 || mesh.infiniteDistance) {
                     continue;
                 }
 
-                mesh.computeWorldMatrix(true);
                 let boundingInfo = mesh.getBoundingInfo();
 
                 var minBox = boundingInfo.boundingBox.minimumWorld;


### PR DESCRIPTION
World matrix should always compute or the bounding box will be wrong if a parent mesh has a transform.