### PR TITLE
iOS 10's video tags are in BGR instead of RGB

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -50,7 +50,7 @@
 - (Viewer) Scene Optimizer intergrated in viewer. ([RaananW](https://github.com/RaananW))
 - (Viewer) The viewer supports custom shaders in the configuration. ([RaananW](https://github.com/RaananW))
 - Documented PostProcessRenderEffect, DefaultRenderingPipeline, BlurPostProcess, DepthOfFieldEffect, PostProcess, PostProcessManager, Effect classes ([trevordev](https://github.com/trevordev))
-- SPS internal storage of each solid particle rotation matrix ([jbousquie](https://github.com/jbousquie)) 
+- SPS internal storage of each solid particle rotation matrix ([jbousquie](https://github.com/jbousquie))
 - SPS particle parenting feature ([jbousquie](https://github.com/jbousquie))
 - (Viewer) Introducing the viewer labs - testing new features. ([RaananW](https://github.com/RaananW))
 - KeepAssets class and AssetContainer.moveAllFromScene ([HoloLite](http://www.html5gamedevs.com/profile/28694-hololite/) [trevordev](https://github.com/trevordev))

--- a/src/Materials/Background/babylon.backgroundMaterial.ts
+++ b/src/Materials/Background/babylon.backgroundMaterial.ts
@@ -64,7 +64,14 @@
          */
         public NOISE = false;
 
-        // Image Processing Configuration.
+
+
+        /**
+         * is the reflection texture in BGR color scheme? 
+         * Mainly used to solve a bug in ios10 video tag
+         */
+        public REFLECTIONBGR = false;
+
         public IMAGEPROCESSING = false;
         public VIGNETTE = false;
         public VIGNETTEBLENDMODEMULTIPLY = false;
@@ -521,6 +528,12 @@
             (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorCurves = value;
         }
 
+        /**
+         * Due to a bug in iOS10, video tags (which are using the background material) are in BGR and not RGB.
+         * Setting this flag to true (not done automatically!) will convert it back to RGB.
+         */
+        public switchToBGR: boolean = false;
+
         // Temp values kept as cache in the material.
         private _renderTargets = new SmartArray<RenderTargetTexture>(16);
         private _reflectionControls = Vector4.Zero();
@@ -635,6 +648,7 @@
                         defines.REFLECTIONMAP_OPPOSITEZ = this.getScene().useRightHandedSystem ? !reflectionTexture.invertZ : reflectionTexture.invertZ;
                         defines.LODINREFLECTIONALPHA = reflectionTexture.lodLevelInAlpha;
                         defines.EQUIRECTANGULAR_RELFECTION_FOV = this.useEquirectangularFOV;
+                        defines.REFLECTIONBGR = this.switchToBGR;
 
                         if (reflectionTexture.coordinatesMode === Texture.INVCUBIC_MODE) {
                             defines.INVERTCUBICMAP = true;

--- a/src/Shaders/background.fragment.fx
+++ b/src/Shaders/background.fragment.fx
@@ -190,6 +190,10 @@ vec3 reflectionColor = vec3(1., 1., 1.);
         reflectionColor = toLinearSpace(reflectionColor.rgb);
     #endif
 
+    #ifdef REFLECTIONBGR
+        reflectionColor = reflectionColor.bgr;
+    #endif
+
     // _____________________________ Levels _____________________________________
     reflectionColor *= vReflectionInfos.x;
 #endif


### PR DESCRIPTION
This solves it with a flag in the background material (and a small change in the background shader).

See - http://www.html5gamedevs.com/topic/27723-ios-video-texture-display-issues/?tab=comments#comment-205081 for a discussion about it.

It is the developer's responsibility to set this flag (as I am not sure if it is all iOS 10, or only specific versions).

Note that this is just a suggestion for a solution, if there is a cleaner/better way please comment :smile: