### PR TITLE
ideal size - always take smallest

### DIFF
--- a/gui/src/advancedDynamicTexture.ts
+++ b/gui/src/advancedDynamicTexture.ts
@@ -28,6 +28,7 @@ module BABYLON.GUI {
         private _fullscreenViewport = new Viewport(0, 0, 1, 1);
         private _idealWidth = 0;
         private _idealHeight = 0;
+        private _useSmallestIdeal: boolean = false;
         private _renderAtIdealSize = false;
         private _focusedControl: Nullable<IFocusableControl>;
         private _blockNextFocusCheck = false;
@@ -84,6 +85,20 @@ module BABYLON.GUI {
             }
 
             this._idealHeight = value;
+            this.markAsDirty();
+            this._rootContainer._markAllAsDirty();
+        }
+
+        public get useSmallestIdeal(): boolean {
+            return this._useSmallestIdeal;
+        }
+
+        public set useSmallestIdeal(value: boolean) {
+            if (this._useSmallestIdeal === value) {
+                return;
+            }
+
+            this._useSmallestIdeal = value;
             this.markAsDirty();
             this._rootContainer._markAllAsDirty();
         }

--- a/gui/src/valueAndUnit.ts
+++ b/gui/src/valueAndUnit.ts
@@ -31,14 +31,12 @@ module BABYLON.GUI {
 
         public getValue(host: AdvancedDynamicTexture): number {
             if (host && !this.ignoreAdaptiveScaling && this.unit !== ValueAndUnit.UNITMODE_PERCENTAGE) {
+                var width: number = (this._value * host.getSize().width) / host.idealWidth;
+                var height: number = (this._value * host.getSize().height) / host.idealHeight;
 
-                if (host.idealWidth) { // horizontal
-                    return (this._value * host.getSize().width) / host.idealWidth;
-                }
-
-                if (host.idealHeight) { // vertical
-                    return (this._value * host.getSize().height) / host.idealHeight;
-                }
+                if (host.useSmallestIdeal && host.idealWidth && host.idealHeight) return window.innerWidth < window.innerHeight ? width : height;
+                if (host.idealWidth) return width; // horizontal
+                if (host.idealHeight) return height; // vertical
             }
             return this._value;
         }

--- a/gui/src/valueAndUnit.ts
+++ b/gui/src/valueAndUnit.ts
@@ -31,8 +31,8 @@ module BABYLON.GUI {
 
         public getValue(host: AdvancedDynamicTexture): number {
             if (host && !this.ignoreAdaptiveScaling && this.unit !== ValueAndUnit.UNITMODE_PERCENTAGE) {
-                var width: number = (this._value * host.getSize().width) / host.idealWidth;
-                var height: number = (this._value * host.getSize().height) / host.idealHeight;
+                var width: number = host.idealWidth ? (this._value * host.getSize().width) / host.idealWidth : 0;
+                var height: number = host.idealHeight ? (this._value * host.getSize().height) / host.idealHeight : 0;
 
                 if (host.useSmallestIdeal && host.idealWidth && host.idealHeight) return window.innerWidth < window.innerHeight ? width : height;
                 if (host.idealWidth) return width; // horizontal

--- a/gui/src/valueAndUnit.ts
+++ b/gui/src/valueAndUnit.ts
@@ -31,12 +31,28 @@ module BABYLON.GUI {
 
         public getValue(host: AdvancedDynamicTexture): number {
             if (host && !this.ignoreAdaptiveScaling && this.unit !== ValueAndUnit.UNITMODE_PERCENTAGE) {
-                var width: number = host.idealWidth ? (this._value * host.getSize().width) / host.idealWidth : 0;
-                var height: number = host.idealHeight ? (this._value * host.getSize().height) / host.idealHeight : 0;
+                var width: number = 0;
+                var height: number = 0;
 
-                if (host.useSmallestIdeal && host.idealWidth && host.idealHeight) return window.innerWidth < window.innerHeight ? width : height;
-                if (host.idealWidth) return width; // horizontal
-                if (host.idealHeight) return height; // vertical
+                if (host.idealWidth) {
+                    width = (this._value * host.getSize().width) / host.idealWidth;
+                }
+                
+                if (host.idealHeight) {
+                    height = (this._value * host.getSize().height) / host.idealHeight;
+                }
+
+                if (host.useSmallestIdeal && host.idealWidth && host.idealHeight) {
+                    return window.innerWidth < window.innerHeight ? width : height;
+                }
+
+                if (host.idealWidth) { // horizontal
+                    return width;
+                }
+                
+                if (host.idealHeight) { // vertical
+                    return height;
+                }
             }
             return this._value;
         }


### PR DESCRIPTION
I added to AdvancedDynamicTexture a boolean useSmallestIdeal, if window width is smaller than height, using idealWidth, otherwise idealHeight. I'm now working on being able to match the game to all possible screen sizes so it should actually be a quite useful feature, it looks good that way.

I had problems compiling the source as you can see in the forum, but it should work.