### PR TITLE
click event for gui controls: onPointerClickObservable

### DIFF
--- a/gui/src/controls/button.ts
+++ b/gui/src/controls/button.ts
@@ -84,12 +84,12 @@ module BABYLON.GUI {
             return true;
         }
 
-        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number): void {
+        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number, notifyClick: boolean): void {
             if (this.pointerUpAnimation) {
                 this.pointerUpAnimation();
             }
 
-            super._onPointerUp(target, coordinates, pointerId, buttonIndex);
+            super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
         }        
 
         // Statics

--- a/gui/src/controls/colorpicker.ts
+++ b/gui/src/controls/colorpicker.ts
@@ -407,11 +407,11 @@ module BABYLON.GUI {
             super._onPointerMove(target, coordinates);
         }
 
-        public _onPointerUp (target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number): void {
+        public _onPointerUp (target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number, notifyClick: boolean): void {
             this._pointerIsDown = false;
             
             delete this._host._capturingControl[pointerId];
-            super._onPointerUp(target, coordinates, pointerId, buttonIndex);
+            super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
         }     
     }    
 }

--- a/gui/src/controls/inputText.ts
+++ b/gui/src/controls/inputText.ts
@@ -449,8 +449,8 @@ module BABYLON.GUI {
             return true;
         }
 
-        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number): void {
-            super._onPointerUp(target, coordinates, pointerId, buttonIndex);
+        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number, notifyClick: boolean): void {
+            super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
         }
 
         public dispose() {

--- a/gui/src/controls/slider.ts
+++ b/gui/src/controls/slider.ts
@@ -287,11 +287,11 @@ module BABYLON.GUI {
             super._onPointerMove(target, coordinates);
         }
 
-        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number): void {
+        public _onPointerUp(target: Control, coordinates: Vector2, pointerId:number, buttonIndex: number, notifyClick: boolean): void {
             this._pointerIsDown = false;
 
             delete this._host._capturingControl[pointerId];
-            super._onPointerUp(target, coordinates, pointerId, buttonIndex);
+            super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
         }
     }
 }


### PR DESCRIPTION
In reference to this thread on the forums:

http://www.html5gamedevs.com/topic/35775-babylon-gui-missing-button-event-click

gui controls only had pointer up and pointer down events, but no event that only fires on valid "clicks".
(click: cursor down while the cursor is over the control, cursor up while the mouse is still over the control)

Adding this to any playground the click event can be tested:
(The button toggles color and text on click)

```
var gui = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("myUI");
var button = BABYLON.GUI.Button.CreateSimpleButton("button", "Clicks: 0");
button.top = "0px";
button.left = "0px";
button.width = "150px";
button.height = "50px";
button.cornerRadius = 20;
button.thickness = 4;
button.children[0].color = "#DFF9FB";
button.children[0].fontSize = 24;
button.color = "#FF7979";
button.background = "#EB4D4B";

var clicks = 0;
button.onPointerClickObservable.add(function () {
	clicks++;
	if (clicks % 2 == 0) {
	  button.background = "#EB4D4B";
	} else {
	  button.background = "#007900";
	}
	button.children[0].text = "Clicks: " + clicks;
});

gui.addControl(button);

```

Explanation:

When the Up event is fired there is now a check if the cursor is still over the control.
If it is, the Click event is fired too.
The private _onPointerUp has a new boolean argument "notifyClick" that decides if the "click" event should propagate to the parent control or not. 
(This is set by the return value from the onPointerUpObservable.)