### PR TITLE
Collision workers fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -94,6 +94,7 @@
 - (Viewer) Fixed a bug where loading another mesh positioned it incorrectly ([RaananW](https://github.com/RaananW))
 - (Viewer) Disabling templates now work correctly ([RaananW](https://github.com/RaananW))
 - AMD "define" declaration is no longer anonymous ([RaananW](https://github.com/RaananW))
+- Collision worker didn't initialize instanced meshes correctly - [#3819](https://github.com/BabylonJS/Babylon.js/issues/3819) ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Collisions/babylon.collisionCoordinator.ts
+++ b/src/Collisions/babylon.collisionCoordinator.ts
@@ -58,11 +58,11 @@ module BABYLON {
         positions: Float32Array;
         /**
          * Defines the array containing the indices
-         */        
+         */
         indices: Uint32Array;
         /**
          * Defines the array containing the normals
-         */        
+         */
         normals: Float32Array;
     }
 
@@ -173,7 +173,7 @@ module BABYLON {
                 let geometry = (<Mesh>mesh).geometry;
                 geometryId = geometry ? geometry.id : null;
             } else if (mesh instanceof InstancedMesh) {
-                let geometry = (<InstancedMesh>mesh).sourceMesh.geometry;
+                let geometry = (<InstancedMesh>mesh).sourceMesh && (<InstancedMesh>mesh).sourceMesh.geometry;
                 geometryId = geometry ? geometry.id : null;
             }
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -934,7 +934,7 @@
 
         private _debugLayer: DebugLayer;
 
-        private _depthRenderer: {[id:string]:DepthRenderer} = {};
+        private _depthRenderer: { [id: string]: DepthRenderer } = {};
         private _geometryBufferRenderer: Nullable<GeometryBufferRenderer>;
 
         /**
@@ -1008,7 +1008,7 @@
                 return;
             }
 
-            enabled = (enabled && !!Worker);
+            enabled = (enabled && !!Worker && !!CollisionWorker);
 
             this._workerCollisions = enabled;
             if (this.collisionCoordinator) {
@@ -3420,7 +3420,7 @@
                 this._renderTargets.concatWithNoDuplicate(rigParent.customRenderTargets);
             }
 
-            if (this.renderTargetsEnabled && this._renderTargets.length > 0) {                
+            if (this.renderTargetsEnabled && this._renderTargets.length > 0) {
                 this._intermediateRendering = true;
                 Tools.StartPerformanceCounter("Render targets", this._renderTargets.length > 0);
                 for (var renderIndex = 0; renderIndex < this._renderTargets.length; renderIndex++) {
@@ -3573,7 +3573,7 @@
             }
 
             this.activeCamera = camera;
-            this.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix());           
+            this.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix());
         }
 
         private _checkIntersections(): void {
@@ -3803,7 +3803,7 @@
             }
 
             // Depth renderer
-            for(var key in this._depthRenderer){
+            for (var key in this._depthRenderer) {
                 this._renderTargets.push(this._depthRenderer[key].getDepthMap());
             }
 
@@ -3998,12 +3998,12 @@
          */
         public enableDepthRenderer(camera?: Nullable<Camera>): DepthRenderer {
             camera = camera || this.activeCamera;
-            if(!camera){
+            if (!camera) {
                 throw "No camera available to enable depth renderer";
             }
             if (!this._depthRenderer[camera.id]) {
                 this._depthRenderer[camera.id] = new DepthRenderer(this, Engine.TEXTURETYPE_FLOAT, camera);
-            }            
+            }
 
             return this._depthRenderer[camera.id];
         }
@@ -4069,7 +4069,7 @@
 
             this.resetCachedMaterial();
 
-            for(var key in this._depthRenderer){
+            for (var key in this._depthRenderer) {
                 this._depthRenderer[key].dispose();
             }
 


### PR DESCRIPTION
Fixing #3819
Worker collisions are not enabled in the playground , it will only be enabled if the worker is available from now on.