### PR TITLE
Adding onError observable to the environment helper

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -84,6 +84,7 @@
 - WebVRExperienceHelper will create an empty controller model so that controller interactions can be used while the actual model is still loading ([trevordev](https://github.com/trevordev))
 - Default fragment shader will clamp negative values to avoid underflow, webVR post processing will render to eye texture size ([trevordev](https://github.com/trevordev))
 - Supports Environment Drag and Drop in Sandbox ([sebavan](https://github.com/sebavan))
+- EnvironmentHelper has no an onError observable to handle errors when loading the textures ([RaananW](https://github.com/RaananW))
 
 ## Bug fixes
 

--- a/src/Helpers/babylon.environmentHelper.ts
+++ b/src/Helpers/babylon.environmentHelper.ts
@@ -309,6 +309,8 @@ module BABYLON {
         private readonly _scene: Scene;
         private _options: IEnvironmentHelperOptions;
 
+        public onErrorObservable: Observable<{ message?: string, exception?: any }>;
+
         /**
          * constructor
          * @param options 
@@ -320,6 +322,7 @@ module BABYLON {
                 ...options
             }
             this._scene = scene;
+            this.onErrorObservable = new Observable();
 
             this._setupBackground();
             this._setupImageProcessing();
@@ -557,7 +560,7 @@ module BABYLON {
                 return;
             }
 
-            const diffuseTexture = new Texture(this._options.groundTexture, this._scene);
+            const diffuseTexture = new Texture(this._options.groundTexture, this._scene, undefined, undefined, undefined, undefined, this._errorHandler);
             diffuseTexture.gammaSpace = false;
             diffuseTexture.hasAlpha = true;
             this._groundMaterial.diffuseTexture = diffuseTexture;
@@ -664,10 +667,14 @@ module BABYLON {
                 return;
             }
 
-            this._skyboxTexture = new CubeTexture(this._options.skyboxTexture, this._scene);
+            this._skyboxTexture = new CubeTexture(this._options.skyboxTexture, this._scene, undefined, undefined, undefined, undefined, this._errorHandler);
             this._skyboxTexture.coordinatesMode = Texture.SKYBOX_MODE;
             this._skyboxTexture.gammaSpace = false;
             this._skyboxMaterial.reflectionTexture = this._skyboxTexture;
+        }
+
+        private _errorHandler = (message?: string, exception?: any) => {
+            this.onErrorObservable.notifyObservers({ message: message, exception: exception });
         }
 
         /**

--- a/src/Helpers/babylon.environmentHelper.ts
+++ b/src/Helpers/babylon.environmentHelper.ts
@@ -309,6 +309,10 @@ module BABYLON {
         private readonly _scene: Scene;
         private _options: IEnvironmentHelperOptions;
 
+        /**
+         * This observable will be notified with any error during the creation of the environment, 
+         * mainly texture creation errors.
+         */
         public onErrorObservable: Observable<{ message?: string, exception?: any }>;
 
         /**


### PR DESCRIPTION
This way errors when creating textures can be registered.
The error type needs to be detected by the developer using the message and exception.

Until now those errors were ignored. To unify error handling of the environment helper it is done in a single observable.  The developer has always the possibility to already provide a texture object instead of a string, this way they can control the error handler on their own.