### PR TITLE
beforeRender repositioning

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -104,6 +104,7 @@
 - postMessage calls in webworkers were fixed. ([RaananW](https://github.com/RaananW))
 - Fixed WebCam Texture on Firefox and Edge - [#3825](https://github.com/BabylonJS/Babylon.js/issues/3825) ([sebavan](https://github.com/sebavan))
 - Add onLoadObservable on VideoTexture - [#3845](https://github.com/BabylonJS/Babylon.js/issues/3845) ([sebavan](https://github.com/sebavan))
+- beforeRender is now triggered after the camera updated its state - [#3873](https://github.com/BabylonJS/Babylon.js/issues/3873) ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -338,6 +338,8 @@
 
         protected _targetBoundingCenter: Nullable<Vector3>;
 
+        private _computationVector: Vector3 = Vector3.Zero();
+
         constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene: Scene) {
             super(name, Vector3.Zero(), scene);
 
@@ -584,22 +586,22 @@
         }
 
         public rebuildAnglesAndRadius() {
-            var radiusv3 = this.position.subtract(this._getTargetPosition());
-            this.radius = radiusv3.length();
+            this.position.subtractToRef(this._getTargetPosition(), this._computationVector);
+            this.radius = this._computationVector.length();
 
             if (this.radius === 0) {
                 this.radius = 0.0001; // Just to avoid division by zero
             }
 
             // Alpha
-            this.alpha = Math.acos(radiusv3.x / Math.sqrt(Math.pow(radiusv3.x, 2) + Math.pow(radiusv3.z, 2)));
+            this.alpha = Math.acos(this._computationVector.x / Math.sqrt(Math.pow(this._computationVector.x, 2) + Math.pow(this._computationVector.z, 2)));
 
-            if (radiusv3.z < 0) {
+            if (this._computationVector.z < 0) {
                 this.alpha = 2 * Math.PI - this.alpha;
             }
 
             // Beta
-            this.beta = Math.acos(radiusv3.y / this.radius);
+            this.beta = Math.acos(this._computationVector.y / this.radius);
 
             this._checkLimits();
         }
@@ -652,7 +654,8 @@
             }
 
             var target = this._getTargetPosition();
-            target.addToRef(new Vector3(this.radius * cosa * sinb, this.radius * cosb, this.radius * sina * sinb), this._newPosition);
+            this._computationVector.copyFromFloats(this.radius * cosa * sinb, this.radius * cosb, this.radius * sina * sinb);
+            target.addToRef(this._computationVector, this._newPosition);
             if (this.getScene().collisionsEnabled && this.checkCollisions) {
                 if (!this._collider) {
                     this._collider = new Collider();
@@ -709,7 +712,8 @@
             }
 
             var target = this._getTargetPosition();
-            target.addToRef(new Vector3(this.radius * cosa * sinb, this.radius * cosb, this.radius * sina * sinb), this._newPosition);
+            this._computationVector.copyFromFloats(this.radius * cosa * sinb, this.radius * cosb, this.radius * sina * sinb);
+            target.addToRef(this._computationVector, this._newPosition);
             this.position.copyFrom(this._newPosition);
 
             var up = this.upVector;

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -3706,9 +3706,6 @@
                 this._gamepadManager._checkGamepadsStatus();
             }
 
-            // Before render
-            this.onBeforeRenderObservable.notifyObservers(this);
-
             // Update Cameras
             if (this.activeCameras.length > 0) {
                 for (var cameraIndex = 0; cameraIndex < this.activeCameras.length; cameraIndex++) {
@@ -3730,6 +3727,9 @@
                     }
                 }
             }
+
+            // Before render
+            this.onBeforeRenderObservable.notifyObservers(this);
 
             // Customs render targets
             this.OnBeforeRenderTargetsRenderObservable.notifyObservers(this);


### PR DESCRIPTION
the beforeRender observers should be called after the camera updated its state. If it is triggered before, the position provided in beforeRender callbacks will have the camera's position of the last frame, and not the upcoming frame.

This solves https://github.com/BabylonJS/Babylon.js/issues/3873

Also removed a few object-creations in the arc-rotate camera using a temporary vector.

(I am submitting this mainly to see that the scenes are still being rendered correctly. There might be unwanted side-effects for moving the beforeRender to this position and I want to make sure it is not causing any problems)