### PR TITLE
Update water.vertex.fx

### DIFF
--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -126,10 +126,6 @@ void main(void) {
 #endif
 
 	vec3 p = position;
-	float newY = (sin(((p.x / 0.05) + time * waveSpeed)) * waveHeight * windDirection.x * 5.0)
-			   + (cos(((p.z / 0.05) +  time * waveSpeed)) * waveHeight * windDirection.y * 5.0);
-	p.y += abs(newY);
-	
 	gl_Position = viewProjection * finalWorld * vec4(p, 1.0);
 
 #ifdef REFLECTION


### PR DESCRIPTION
Fixed a bug where the water rises to make objects below the water and goes down again to make objects above the water.

What I delete is useless and allows the water to stay at this position on the Y axis

Post here : http://www.html5gamedevs.com/topic/36197-watermaterial-level-water-up-or-down/?tab=comments#comment-207516

Fixe test here (Empty the caches to see the corectif) : https://www.babylonjs-playground.com/#1SLLOJ#439