### PR TITLE
Fix Material.Parse

### DIFF
--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -1307,7 +1307,7 @@
          * @returns - Parsed material.
          */
         public static Parse(parsedMaterial: any, scene: Scene, rootUrl: string): any {
-            if (!parsedMaterial.customType) {
+            if (!parsedMaterial.customType || parsedMaterial.customType === "BABYLON.StandardMaterial" ) {
                 return StandardMaterial.Parse(parsedMaterial, scene, rootUrl);
             }
 


### PR DESCRIPTION
Should call StandardMaterial.Parse() while the parsedMaterial.customType is "BABYLON.StandardMaterial".