### PR TITLE
Tools.DeepCopy now checks for the property descriptor

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -113,6 +113,7 @@
 - Fixed WebCam Texture on Firefox and Edge - [#3825](https://github.com/BabylonJS/Babylon.js/issues/3825) ([sebavan](https://github.com/sebavan))
 - Add onLoadObservable on VideoTexture - [#3845](https://github.com/BabylonJS/Babylon.js/issues/3845) ([sebavan](https://github.com/sebavan))
 - beforeRender is now triggered after the camera updated its state - [#3873](https://github.com/BabylonJS/Babylon.js/issues/3873) ([RaananW](https://github.com/RaananW))
+- Tools.DeepCopy no longer copying getter-only elements - [#3929](https://github.com/BabylonJS/Babylon.js/issues/3929) ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -814,6 +814,12 @@
                 if (doNotCopyList && doNotCopyList.indexOf(prop) !== -1) {
                     continue;
                 }
+
+                let descriptor = Object.getOwnPropertyDescriptor(source, prop);
+                //descriptor should exist, should be writable, and should not be a getter.
+                if (!descriptor || !descriptor.writable || descriptor.get) {
+                    continue;
+                }
                 var sourceValue = source[prop];
                 var typeOfSourceValue = typeof sourceValue;
 


### PR DESCRIPTION
This prevents DeepCopy from copying getter elements (which will prevent the extended class to work correctly)

Fixing https://github.com/BabylonJS/Babylon.js/issues/3929