### PR TITLE
Fix alpha cutoff value issue and remove unecessary code

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -1279,20 +1279,7 @@ module BABYLON.GLTF2 {
                 }
                 case MaterialAlphaMode.MASK: {
                     babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_ALPHATEST;
-
                     babylonMaterial.alphaCutOff = (material.alphaCutoff == undefined ? 0.5 : material.alphaCutoff);
-
-                    if (babylonMaterial.alpha) {
-                        if (babylonMaterial.alpha === 0) {
-                            babylonMaterial.alphaCutOff = 1;
-                        }
-                        else {
-                            babylonMaterial.alphaCutOff /= babylonMaterial.alpha;
-                        }
-
-                        babylonMaterial.alpha = 1;
-                    }
-
                     if (babylonMaterial.albedoTexture) {
                         babylonMaterial.albedoTexture.hasAlpha = true;
                     }
@@ -1300,7 +1287,6 @@ module BABYLON.GLTF2 {
                 }
                 case MaterialAlphaMode.BLEND: {
                     babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_ALPHABLEND;
-
                     if (babylonMaterial.albedoTexture) {
                         babylonMaterial.albedoTexture.hasAlpha = true;
                         babylonMaterial.useAlphaFromAlbedoTexture = true;

--- a/src/Materials/PBR/babylon.pbrBaseMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrBaseMaterial.ts
@@ -26,7 +26,7 @@
         public DEPTHPREPASS = false;
         public ALPHABLEND = false;
         public ALPHAFROMALBEDO = false;
-        public ALPHATESTVALUE = 0.5;
+        public ALPHATESTVALUE = "0.5";
         public SPECULAROVERALPHA = false;
         public RADIANCEOVERALPHA = false;
         public ALPHAFRESNEL = false;
@@ -72,7 +72,7 @@
         public REFLECTIONMAP_SPHERICAL = false;
         public REFLECTIONMAP_PLANAR = false;
         public REFLECTIONMAP_CUBIC = false;
-        public USE_LOCAL_REFLECTIONMAP_CUBIC = false;        
+        public USE_LOCAL_REFLECTIONMAP_CUBIC = false;
         public REFLECTIONMAP_PROJECTION = false;
         public REFLECTIONMAP_SKYBOX = false;
         public REFLECTIONMAP_EXPLICIT = false;
@@ -147,7 +147,7 @@
          */
         public reset(): void {
             super.reset();
-            this.ALPHATESTVALUE = 0.5;
+            this.ALPHATESTVALUE = "0.5";
             this.PBR = true;
         }
     }
@@ -1196,7 +1196,7 @@
                     defines.TWOSIDEDLIGHTING = false;
                 }
 
-                defines.ALPHATESTVALUE = this._alphaCutOff;
+                defines.ALPHATESTVALUE = `${this._alphaCutOff}${this._alphaCutOff % 1 === 0 ? "." : ""}`;
                 defines.PREMULTIPLYALPHA = (this.alphaMode === Engine.ALPHA_PREMULTIPLIED || this.alphaMode === Engine.ALPHA_PREMULTIPLIED_PORTERDUFF);
                 defines.ALPHABLEND = this.needAlphaBlendingForMesh(mesh);
                 defines.ALPHAFRESNEL = this._useAlphaFresnel || this._useLinearAlphaFresnel;

--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -170,12 +170,18 @@
         public reset(): void {
             for (var index = 0; index < this._keys.length; index++) {
                 var prop = this._keys[index];
+                var type = typeof (<any>this)[prop];
 
-                if (typeof ((<any>this)[prop]) === "number") {
-                    (<any>this)[prop] = 0;
-
-                } else {
-                    (<any>this)[prop] = false;
+                switch (type) {
+                    case "number":
+                        (<any>this)[prop] = 0;
+                        break;
+                    case "string":
+                        (<any>this)[prop] = "";
+                        break;
+                    default:
+                        (<any>this)[prop] = false;
+                        break;
                 }
             }
         }
@@ -189,12 +195,18 @@
             for (var index = 0; index < this._keys.length; index++) {
                 var prop = this._keys[index];
                 var value = (<any>this)[prop];
+                var type = typeof value;
 
-                if (typeof (value) === "number") {
-                    result += "#define " + prop + " " + (<any>this)[prop] + "\n";
-
-                } else if (value) {
-                    result += "#define " + prop + "\n";
+                switch (type) {
+                    case "number":
+                    case "string":
+                        result += "#define " + prop + " " + value + "\n";
+                        break;
+                    default:
+                        if (value) {
+                            result += "#define " + prop + "\n";
+                        }
+                        break;
                 }
             }
 


### PR DESCRIPTION
* Fix issue with shader failing to compile when alpha cutoff is a round number (e.g. 0, 1, 2, etc.)
* Remove unnecessary code in glTF loader for computing alpha cutoff that is already handled by the shader.