### PR TITLE
No-Module Babylon is vanilla-js-only babylon version.

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -3,6 +3,7 @@
         "filename": "babylon.max.js",
         "minFilename": "babylon.js",
         "minWorkerFilename": "babylon.worker.js",
+        "noModuleFilename": "babylon.no-module.max.js",
         "declarationFilename": "babylon.d.ts",
         "declarationModuleFilename": "babylon.module.d.ts",
         "outputDirectory": "../../dist/preview release",

--- a/Tools/Gulp/gulp-addModuleExports.js
+++ b/Tools/Gulp/gulp-addModuleExports.js
@@ -87,13 +87,6 @@ if(typeof earcut !== 'undefined') {
 `;
         }
 
-        var extendsAddition =
-            `var __extends=this&&this.__extends||function(){var t=Object.setPrototypeOf||{__proto__:[]}instanceof Array&&function(t,o){t.__proto__=o}||function(t,o){for(var n in o)o.hasOwnProperty(n)&&(t[n]=o[n])};return function(o,n){function r(){this.constructor=o}t(o,n),o.prototype=null===n?Object.create(n):(r.prototype=n.prototype,new r)}}();
-`;
-
-        var decorateAddition = `var __decorate=this&&this.__decorate||function(e,t,r,c){var o,f=arguments.length,n=f<3?t:null===c?c=Object.getOwnPropertyDescriptor(t,r):c;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)n=Reflect.decorate(e,t,r,c);else for(var l=e.length-1;l>=0;l--)(o=e[l])&&(n=(f<3?o(n):f>3?o(t,r,n):o(t,r))||n);return f>3&&n&&Object.defineProperty(t,r,n),n};
-`;
-
         if (file.isNull()) {
             cb(null, file);
             return;
@@ -105,12 +98,12 @@ if(typeof earcut !== 'undefined') {
         }
 
         try {
-            if (config.externalUsingBabylon) {
-                file.contents = new Buffer(String('').concat(moduleExportAddition(varName)));
-            } else {
+            //if (config.externalUsingBabylon) {
+            file.contents = new Buffer(String('').concat(moduleExportAddition(varName)));
+            /*} else {
                 let pretext = '';
                 file.contents = new Buffer(decorateAddition.concat(new Buffer(extendsAddition.concat(String('')).concat(moduleExportAddition(varName)))));
-            }
+            }*/
             this.push(file);
         } catch (err) {
             this.emit('error', new gutil.PluginError('gulp-add-module-exports', err, { fileName: file.path }));

--- a/Tools/Gulp/gulp-decorateAndExtends.js
+++ b/Tools/Gulp/gulp-decorateAndExtends.js
@@ -1,0 +1,37 @@
+var gutil = require('gulp-util');
+var through = require('through2');
+
+/**
+ * The parameters for this function has grown during development.
+ * Eventually, this function will need to be reorganized. 
+ */
+//  subModule, extendsRoot, externalUsingBabylon, noBabylonInit
+module.exports = function (varName, config) {
+    return through.obj(function (file, enc, cb) {
+
+        var extendsAddition =
+            `var __extends=this&&this.__extends||function(){var t=Object.setPrototypeOf||{__proto__:[]}instanceof Array&&function(t,o){t.__proto__=o}||function(t,o){for(var n in o)o.hasOwnProperty(n)&&(t[n]=o[n])};return function(o,n){function r(){this.constructor=o}t(o,n),o.prototype=null===n?Object.create(n):(r.prototype=n.prototype,new r)}}();
+`;
+
+        var decorateAddition = `var __decorate=this&&this.__decorate||function(e,t,r,c){var o,f=arguments.length,n=f<3?t:null===c?c=Object.getOwnPropertyDescriptor(t,r):c;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)n=Reflect.decorate(e,t,r,c);else for(var l=e.length-1;l>=0;l--)(o=e[l])&&(n=(f<3?o(n):f>3?o(t,r,n):o(t,r))||n);return f>3&&n&&Object.defineProperty(t,r,n),n};
+`;
+
+        if (file.isNull()) {
+            cb(null, file);
+            return;
+        }
+
+        if (file.isStream()) {
+            //streams not supported, no need for now.
+            return;
+        }
+
+        try {
+            file.contents = new Buffer(decorateAddition.concat(extendsAddition).concat(file.contents));
+            this.push(file);
+        } catch (err) {
+            this.emit('error', new gutil.PluginError('gulp-decorate-and-extends', err, { fileName: file.path }));
+        }
+        cb();
+    });
+};

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -5,6 +5,7 @@ var sourcemaps = require("gulp-sourcemaps");
 var srcToVariable = require("gulp-content-to-variable");
 var appendSrcToVariable = require("./gulp-appendSrcToVariable");
 var addDtsExport = require("./gulp-addDtsExport");
+var addDecorateAndExtends = require("./gulp-decorateAndExtends");
 var addModuleExports = require("./gulp-addModuleExports");
 var addES6Exports = require("./gulp-addES6Exports");
 var babylonModuleExports = require("./gulp-babylonModule");
@@ -239,10 +240,13 @@ gulp.task("build", ["shaders"], function () {
     )
     return merge2(
         mergedStreams
-            .pipe(concat(config.build.filename))
+            .pipe(concat(config.build.noModuleFilename))
             .pipe(cleants())
             .pipe(replace(extendsSearchRegex, ""))
             .pipe(replace(decorateSearchRegex, ""))
+            .pipe(addDecorateAndExtends())
+            .pipe(gulp.dest(config.build.outputDirectory))
+            .pipe(rename(config.build.filename))
             .pipe(addModuleExports("BABYLON", {
                 dependencies: config.build.dependencies
             }))
@@ -322,6 +326,7 @@ var buildExternalLibraries = function (settings) {
                 .pipe(replace(extendsSearchRegex, ""))
                 .pipe(replace(decorateSearchRegex, ""))
                 .pipe(replace(referenceSearchRegex, ""))
+                .pipe(addDecorateAndExtends())
                 .pipe(addModuleExports(settings.build.moduleDeclaration, { subModule: true, extendsRoot: settings.build.extendsRoot }))
                 .pipe(gulp.dest(outputDirectory))
                 .pipe(cleants())
@@ -405,6 +410,7 @@ var buildExternalLibrary = function (library, settings, watch) {
         if (library.buildAsModule) {
             code = code.pipe(replace(extendsSearchRegex, ""))
                 .pipe(replace(decorateSearchRegex, ""))
+                .pipe(addDecorateAndExtends())
                 .pipe(addModuleExports(library.moduleDeclaration, { subModule: true, extendsRoot: library.extendsRoot }))
         }
 


### PR DESCRIPTION
This will create an unminified no-module version, without the UMD definitions.
It can be used when you use babylon in a vanilla project as a vanilla-dependency and not using a module-loader.