### PR TITLE
GUI getMeshPosition()

### DIFF
--- a/gui/src/advancedDynamicTexture.ts
+++ b/gui/src/advancedDynamicTexture.ts
@@ -512,6 +512,22 @@ module BABYLON.GUI {
             this._attachToOnPointerOut(scene);
         }
 
+        public getMeshPosition(mesh: BABYLON.Mesh): BABYLON.Vector3 {
+            var scene = this.getScene();
+
+            if (!scene) {
+                return BABYLON.Vector3.Zero();
+            }
+
+            var globalViewport = this._getGlobalViewport(scene);
+            var position = mesh.getBoundingInfo().boundingSphere.center;
+            var projectedPosition = Vector3.Project(position, mesh.getWorldMatrix(), scene.getTransformMatrix(), globalViewport);
+
+            projectedPosition.scaleInPlace(this.renderScale);
+            
+            return projectedPosition;
+        }
+
         public moveFocusToControl(control: IFocusableControl): void {
             this.focusedControl = control;
             this._lastPickedControl = <any>control;


### PR DESCRIPTION
Returns the position of a mesh for use in AdvancedDynamicTexture as a 2d point - use only x and y of the returned vector?

This is not working but I suppose it's enough to help you understand what's on my mind. What am I missing?

The projectedPosition returns x, y, z - NAN