### PR TITLE
For PBR materials, we also cache the active effect just as the Standa…

### DIFF
--- a/src/Materials/PBR/babylon.pbrBaseMaterial.ts
+++ b/src/Materials/PBR/babylon.pbrBaseMaterial.ts
@@ -1610,7 +1610,7 @@
 
             this._uniformBuffer.update();
 
-            this._afterBind(mesh);
+            this._afterBind(mesh, this._activeEffect);
         }
 
         /**


### PR DESCRIPTION
…rdMaterial to avoid unnecessary rebinding