### PR TITLE
Documented breaking changes for vector3 & vector4

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -146,3 +146,6 @@
 - Engine's onCanvasPointerOutObservable will now return a PointerEvent instead of the Engine. ([trevordev](https://github.com/trevordev))
 - Removed public references to default rendering pipeline's internal post process ([trevordev](https://github.com/trevordev))
 - `Bone.setScale` does not support scaleChildren property anymore. You can use `Bone.scale` to achieve the same effect ([deltakosh](https://github.com/deltakosh))
+- Vector3 &amp; Vector4:
+    - `MinimizeInPlace` has been renamed to `minimizeInPlace`
+    - `MaximizeInPlace` has been renamed to `maximizeInPlace`


### PR DESCRIPTION
The commit that did the breaking change:
https://github.com/BabylonJS/Babylon.js/commit/163df345765e4e6e0d9de7ac71b3f2b0866511ad