### PR TITLE
Fix one bug about DynamicTexture's size

### DIFF
--- a/src/Materials/Textures/babylon.dynamicTexture.ts
+++ b/src/Materials/Textures/babylon.dynamicTexture.ts
@@ -35,7 +35,7 @@
             } else {
                 this._canvas = document.createElement("canvas");
 
-                if (options.width) {
+                if (options.width || options.width === 0) {
                     this._texture = this._engine.createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
                 } else {
                     this._texture = this._engine.createDynamicTexture(options, options, generateMipMaps, samplingMode);


### PR DESCRIPTION
When create a DynamicTexture with size {width:0, height:number} , the code `if (options.width) { ... }` will take a wrong result.

example : 
in babylon.gui , there is one line  like this : 
```
var result = new AdvancedDynamicTexture(name, 0, 0, scene, false, sampling);
```

When run above line , the code below will with mistake: 
```
        function DynamicTexture(name, options, scene, generateMipMaps, samplingMode, format) {
            if (scene === void 0) { scene = null; }
            if (samplingMode === void 0) { samplingMode = BABYLON.Texture.TRILINEAR_SAMPLINGMODE; }
            if (format === void 0) { format = BABYLON.Engine.TEXTUREFORMAT_RGBA; }
            var _this = _super.call(this, null, scene, !generateMipMaps, undefined, samplingMode, undefined, undefined, undefined, undefined, format) || this;
            _this.name = name;
            _this._engine = _this.getScene().getEngine();
            _this.wrapU = BABYLON.Texture.CLAMP_ADDRESSMODE;
            _this.wrapV = BABYLON.Texture.CLAMP_ADDRESSMODE;
            _this._generateMipMaps = generateMipMaps;
            if (options.getContext) {
                _this._canvas = options;
                _this._texture = _this._engine.createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
            }
            else {
                _this._canvas = document.createElement("canvas");
                if (options.width) {
                    _this._texture = _this._engine.createDynamicTexture(options.width, options.height, generateMipMaps, samplingMode);
                }
                else {
                    _this._texture = _this._engine.createDynamicTexture(options, options, generateMipMaps, samplingMode);
                }
            }
            var textureSize = _this.getSize();
            _this._canvas.width = textureSize.width;
            _this._canvas.height = textureSize.height;
            _this._context = _this._canvas.getContext("2d");
            return _this;
        }
```
after ` var textureSize = _this.getSize();` , the `textureSize` will be 
```
 { 
  width: {width:0, height:0}, 
  height: {width:0, height:0}
}
```