### PR TITLE
Fix bug with loading animations in glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -930,7 +930,10 @@ module BABYLON.GLTF2 {
 
         private _loadAnimationChannelAsync(context: string, animationContext: string, animation: _ILoaderAnimation, channel: _ILoaderAnimationChannel, babylonAnimationGroup: AnimationGroup): Promise<void> {
             const targetNode = GLTFLoader._GetProperty(`${context}/target/node`, this._gltf.nodes, channel.target.node);
-            if (!targetNode._babylonMesh) {
+
+            // Ignore animations that have no animation targets.
+            if ((channel.target.path === AnimationChannelTargetPath.WEIGHTS && !targetNode._numMorphTargets) ||
+                (channel.target.path !== AnimationChannelTargetPath.WEIGHTS && !targetNode._babylonAnimationTargets)) {
                 return Promise.resolve();
             }
 


### PR DESCRIPTION
There is an edge case that is not handled properly where the loader will ignore an animation channel that targets a skin joint that is not part of the scene hierarchy.

The specific model that doesn't load correctly is here: https://github.com/cx20/gltf-test/blob/master/tutorialModels/SimpleSkin/glTF/SimpleSkin.gltf

Test coverage will happen when we implement skeletons in asset generator. https://github.com/bghgary/glTF-Asset-Generator/issues/346