### PR TITLE
Animation reset fix

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -1062,14 +1062,12 @@ module BABYLON.GLTF2 {
                             outTangent: key.outTangent ? key.outTangent[targetIndex] : undefined
                         })));
 
-                        const morphTargets = new Array<any>();
                         this._forEachPrimitive(targetNode, babylonMesh => {
                             const morphTarget = babylonMesh.morphTargetManager!.getTarget(targetIndex);
-                            morphTarget.animations.push(babylonAnimation);
-                            morphTargets.push(morphTarget);
+                            const babylonAnimationClone = babylonAnimation.clone();
+                            morphTarget.animations.push(babylonAnimationClone);
+                            babylonAnimationGroup.addTargetedAnimation(babylonAnimationClone, morphTarget);
                         });
-
-                        babylonAnimationGroup.addTargetedAnimation(babylonAnimation, morphTargets);
                     }
                 }
                 else {
@@ -1079,10 +1077,10 @@ module BABYLON.GLTF2 {
 
                     if (targetNode._babylonAnimationTargets) {
                         for (const babylonAnimationTarget of targetNode._babylonAnimationTargets) {
-                            babylonAnimationTarget.animations.push(babylonAnimation);
+                            const babylonAnimationClone = babylonAnimation.clone();
+                            babylonAnimationTarget.animations.push(babylonAnimationClone);
+                            babylonAnimationGroup.addTargetedAnimation(babylonAnimationClone, babylonAnimationTarget);
                         }
-
-                        babylonAnimationGroup.addTargetedAnimation(babylonAnimation, targetNode._babylonAnimationTargets);
                     }
                 }
             });

--- a/src/Animations/babylon.animatable.ts
+++ b/src/Animations/babylon.animatable.ts
@@ -136,13 +136,7 @@
             var runtimeAnimations = this._runtimeAnimations;
 
             for (var index = 0; index < runtimeAnimations.length; index++) {
-                runtimeAnimations[index].reset();
-            }
-
-            // Reset to original value
-            for (index = 0; index < runtimeAnimations.length; index++) {
-                var animation = runtimeAnimations[index];
-                animation.animate(0, this.fromFrame, this.toFrame, false, this._speedRatio);
+                runtimeAnimations[index].reset(true);
             }
 
             this._localDelayOffset = null;

--- a/src/Animations/babylon.runtimeAnimation.ts
+++ b/src/Animations/babylon.runtimeAnimation.ts
@@ -164,8 +164,13 @@
 
         /**
          * Resets the runtime animation to the beginning
+         * @param restoreOriginal defines whether to restore the target property to the original value
          */
-        public reset(): void {
+        public reset(restoreOriginal = false): void {
+            if (restoreOriginal && this._originalValue != null) {
+                this.setValue(this._originalValue, -1);
+            }
+
             this._offsetsCache = {};
             this._highLimitsCache = {};
             this._currentFrame = 0;
@@ -212,28 +217,11 @@
         }
 
         /**
-         * Affect the interpolated value to the target
+         * Apply the interpolated value to the target
          * @param currentValue defines the value computed by the animation
-         * @param weight defines the weight to apply to this value
+         * @param weight defines the weight to apply to this value (Defaults to 1.0)
          */
         public setValue(currentValue: any, weight = 1.0): void {
-            if (this._target instanceof Array) {
-                for (const target of this._target) {
-                    this._setValue(target, currentValue, weight);
-                }
-            }
-            else {
-                this._setValue(this._target, currentValue, weight);
-            }
-        }
-
-        /**
-         * Sets the value of the runtime animation
-         * @param target The target property of the runtime animation
-         * @param currentValue The current value to use for the runtime animation
-         * @param weight The weight to use for the runtime animation (Defaults to 1.0)
-         */
-        private _setValue(target: any, currentValue: any, weight = 1.0): void {
             // Set value
             var path: any;
             var destination: any;
@@ -241,7 +229,7 @@
             let targetPropertyPath = this._animation.targetPropertyPath
 
             if (targetPropertyPath.length > 1) {
-                var property = target[targetPropertyPath[0]];
+                var property = this._target;
 
                 for (var index = 1; index < targetPropertyPath.length - 1; index++) {
                     property = property[targetPropertyPath[index]];
@@ -251,17 +239,31 @@
                 destination = property;
             } else {
                 path = targetPropertyPath[0];
-                destination = target;
+                destination = this._target;
             }
 
             this._targetPath = path;
             this._activeTarget = destination;
             this._weight = weight;
 
+            if (!this._originalValue) {
+                let originalValue: any;
+
+                if (destination.getRestPose && path === "_matrix") { // For bones
+                    originalValue = destination.getRestPose();
+                } else {
+                    originalValue = destination[path];
+                }
+
+                if (originalValue.clone) {
+                    this._originalValue = originalValue.clone();
+                } else {
+                    this._originalValue = originalValue;
+                }
+            }
+
             // Blending
-            let enableBlending = target && target.animationPropertiesOverride ? target.animationPropertiesOverride.enableBlending : this._animation.enableBlending;
-            let blendingSpeed = target && target.animationPropertiesOverride ? target.animationPropertiesOverride.blendingSpeed : this._animation.blendingSpeed;
-            
+            const enableBlending = this._target && this._target.animationPropertiesOverride ? this._target.animationPropertiesOverride.enableBlending : this._animation.enableBlending;
             if (enableBlending && this._blendingFactor <= 1.0) {
                 if (!this._originalBlendValue) {
                     let originalValue = destination[path];
@@ -272,27 +274,7 @@
                         this._originalBlendValue = originalValue;
                     }
                 }
-            }
 
-            if (weight !== -1.0) {
-                if (!this._originalValue) {
-                    let originalValue: any;
-
-                    if (destination.getRestPose && path === "_matrix") { // For bones
-                        originalValue = destination.getRestPose();
-                    } else {
-                        originalValue = destination[path];
-                    }
-
-                    if (originalValue.clone) {
-                        this._originalValue = originalValue.clone();
-                    } else {
-                        this._originalValue = originalValue;
-                    }
-                }
-            }
-
-            if (enableBlending && this._blendingFactor <= 1.0) {
                 if (this._originalBlendValue.m) { // Matrix
                     if (Animation.AllowMatrixDecomposeForInterpolation) {
                         if (this._currentValue) {
@@ -319,6 +301,8 @@
                         this._currentValue = currentValue;
                     }
                 }
+
+                const blendingSpeed = this._target && this._target.animationPropertiesOverride ? this._target.animationPropertiesOverride.blendingSpeed : this._animation.blendingSpeed;
                 this._blendingFactor += blendingSpeed;
             } else {
                 this._currentValue = currentValue;
@@ -330,8 +314,8 @@
                 destination[path] = this._currentValue;
             }
 
-            if (target.markAsDirty) {
-                target.markAsDirty(this._animation.targetProperty);
+            if (this._target.markAsDirty) {
+                this._target.markAsDirty(this._animation.targetProperty);
             }
         }
 

--- a/src/Animations/babylon.runtimeAnimation.ts
+++ b/src/Animations/babylon.runtimeAnimation.ts
@@ -229,7 +229,7 @@
             let targetPropertyPath = this._animation.targetPropertyPath
 
             if (targetPropertyPath.length > 1) {
-                var property = this._target;
+                var property = this._target[targetPropertyPath[0]];
 
                 for (var index = 1; index < targetPropertyPath.length - 1; index++) {
                     property = property[targetPropertyPath[index]];

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -260,11 +260,11 @@ describe('Babylon Scene Loader', function () {
 
                 const animationGroup = result.animationGroups[0];
                 expect(animationGroup.name, "animationGroup.name").to.equal("TwoTargetBlend");
-                expect(animationGroup.targetedAnimations, "animationGroup.targetedAnimations").to.have.lengthOf(7);
+                expect(animationGroup.targetedAnimations, "animationGroup.targetedAnimations").to.have.lengthOf(19);
                 const influenceAnimations = animationGroup.targetedAnimations.filter(_ => _.animation.targetProperty === "influence");
                 expect(influenceAnimations, "influenceAnimations").to.have.lengthOf(2);
                 const rotationAnimations = animationGroup.targetedAnimations.filter(_ => _.animation.targetProperty === "rotationQuaternion");
-                expect(rotationAnimations, "rotationAnimations").to.have.lengthOf(4);
+                expect(rotationAnimations, "rotationAnimations").to.have.lengthOf(16);
                 const positionAnimations = animationGroup.targetedAnimations.filter(_ => _.animation.targetProperty === "position");
                 expect(positionAnimations, "positionAnimations").to.have.lengthOf(1);
             });


### PR DESCRIPTION
_Engine fixes_
* Fix bug with animations not resetting back to original value (fixes #4174). I also reverted the code to allow animations to apply to multiple targets as with blending since it doesn't work in all cases.

@deltakosh Please review the animations change. I have tested blending with https://www.babylonjs-playground.com/#IQN716#9.