### PR TITLE
Fix geometry getVerticesData when not using the default element stride

### DIFF
--- a/src/Mesh/babylon.geometry.ts
+++ b/src/Mesh/babylon.geometry.ts
@@ -389,7 +389,7 @@
 
             const defaultStride = VertexBuffer.DeduceStride(vertexBuffer.getKind());
             const defaultByteStride = defaultStride * VertexBuffer.GetTypeByteLength(vertexBuffer.type);
-            const count = this._totalVertices * defaultStride;
+            const count = this._totalVertices * vertexBuffer.getSize();
 
             if (vertexBuffer.type !== VertexBuffer.FLOAT || vertexBuffer.byteStride !== defaultByteStride) {
                 const copy = new Array<number>(count);

--- a/src/Mesh/babylon.geometry.ts
+++ b/src/Mesh/babylon.geometry.ts
@@ -387,11 +387,10 @@
                  return null;
             }
 
-            const defaultStride = VertexBuffer.DeduceStride(vertexBuffer.getKind());
-            const defaultByteStride = defaultStride * VertexBuffer.GetTypeByteLength(vertexBuffer.type);
+            const tightlyPackedByteStride = vertexBuffer.getSize() * VertexBuffer.GetTypeByteLength(vertexBuffer.type);
             const count = this._totalVertices * vertexBuffer.getSize();
 
-            if (vertexBuffer.type !== VertexBuffer.FLOAT || vertexBuffer.byteStride !== defaultByteStride) {
+            if (vertexBuffer.type !== VertexBuffer.FLOAT || vertexBuffer.byteStride !== tightlyPackedByteStride) {
                 const copy = new Array<number>(count);
                 vertexBuffer.forEach(count, (value, index) => {
                     copy[index] = value;
@@ -399,7 +398,7 @@
                 return copy;
             }
 
-            if (!(data instanceof Array || data instanceof Float32Array) || vertexBuffer.byteOffset !== 0 || data.length !== count) {
+            if (!((data instanceof Array) || (data instanceof Float32Array)) || vertexBuffer.byteOffset !== 0 || data.length !== count) {
                 if (data instanceof Array) {
                     const offset = vertexBuffer.byteOffset / 4;
                     return Tools.Slice(data, offset, offset + count);

--- a/src/Mesh/babylon.vertexBuffer.ts
+++ b/src/Mesh/babylon.vertexBuffer.ts
@@ -423,7 +423,7 @@
                 case VertexBuffer.BYTE: {
                     let value = dataView.getInt8(byteOffset);
                     if (normalized) {
-                        value = (value + 0.5) / 127.5;
+                        value = Math.max(value / 127, -1);
                     }
                     return value;
                 }
@@ -437,7 +437,7 @@
                 case VertexBuffer.SHORT: {
                     let value = dataView.getInt16(byteOffset, true);
                     if (normalized) {
-                        value = (value + 0.5) / 16383.5;
+                        value = Math.max(value / 16383, -1);
                     }
                     return value;
                 }

--- a/tests/unit/babylon/src/Mesh/babylon.geometry.tests.ts
+++ b/tests/unit/babylon/src/Mesh/babylon.geometry.tests.ts
@@ -32,7 +32,22 @@ describe('Babylon Geometry', () => {
     });
 
     describe('#Geometry get vertices data', () => {
-        it('should be able to get vertices data for interleaved buffer with offset', () => {
+        it('vec3 float color tightly packed', () => {
+            const scene = new BABYLON.Scene(subject);
+            const data = new Float32Array([0.4, 0.4, 0.4, 0.6, 0.6, 0.6, 0.8, 0.8, 0.8, 1, 1, 1]);
+            const buffer = new BABYLON.Buffer(subject, data, false);
+            var vertexBuffer = new BABYLON.VertexBuffer(subject, buffer, BABYLON.VertexBuffer.ColorKind,
+                undefined, undefined, undefined, undefined, undefined, 3);
+
+            var geometry = new BABYLON.Geometry("geometry1", scene);
+            geometry.setVerticesBuffer(vertexBuffer);
+            geometry.setIndices([0, 1, 2, 3], 4);
+
+            var result = geometry.getVerticesData(BABYLON.VertexBuffer.ColorKind);
+            expect(result).to.equal(data);
+        });
+
+        it('vec3 unsigned byte normalized color with offset of 3 and byte stride of 4', () => {
             const scene = new BABYLON.Scene(subject);
             const data = new Uint8Array([0, 0, 0, 102, 102, 102, 0, 153, 153, 153, 0, 204, 204, 204, 0, 255, 255, 255, 0]);
             const buffer = new BABYLON.Buffer(subject, data, false, 4, undefined, undefined, true);

--- a/tests/unit/babylon/src/Mesh/babylon.geometry.tests.ts
+++ b/tests/unit/babylon/src/Mesh/babylon.geometry.tests.ts
@@ -1,0 +1,50 @@
+/**
+ * Describes the test suite.
+ */
+describe('Babylon Geometry', () => {
+    let subject: BABYLON.Engine;
+
+    /**
+     * Loads the dependencies.
+     */
+    before(function (done) {
+        this.timeout(180000);
+        (BABYLONDEVTOOLS).Loader
+            .useDist()
+            .load(function () {
+                // Force apply promise polyfill for consistent behavior between PhantomJS, IE11, and other browsers.
+                BABYLON.PromisePolyfill.Apply(true);
+                done();
+            });
+    });
+
+    /**
+     * Create a new engine subject before each test.
+     */
+    beforeEach(function () {
+        subject = new BABYLON.NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1
+        });
+    });
+
+    describe('#Geometry get vertices data', () => {
+        it('should be able to get vertices data for interleaved buffer with offset', () => {
+            const scene = new BABYLON.Scene(subject);
+            const data = new Uint8Array([0, 0, 0, 102, 102, 102, 0, 153, 153, 153, 0, 204, 204, 204, 0, 255, 255, 255, 0]);
+            const buffer = new BABYLON.Buffer(subject, data, false, 4, undefined, undefined, true);
+            var vertexBuffer = new BABYLON.VertexBuffer(subject, buffer, BABYLON.VertexBuffer.ColorKind,
+                undefined, undefined, undefined, false, 3, 3, BABYLON.VertexBuffer.UNSIGNED_BYTE, true, true);
+
+            var geometry = new BABYLON.Geometry("geometry1", scene);
+            geometry.setVerticesBuffer(vertexBuffer);
+            geometry.setIndices([0, 1, 2, 3], 4);
+
+            var result = geometry.getVerticesData(BABYLON.VertexBuffer.ColorKind);
+            expect(result).to.have.ordered.members([0.4, 0.4, 0.4, 0.6, 0.6, 0.6, 0.8, 0.8, 0.8, 1, 1, 1]);
+        });
+    });
+});

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function (config) {
             './tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.js',
             './tests/unit/babylon/src/PostProcess/babylon.postProcess.tests.js',
             './tests/unit/babylon/src/Material/babylon.material.tests.js',
+            './tests/unit/babylon/src/Mesh/babylon.geometry.tests.js',
             './tests/unit/babylon/src/Mesh/babylon.mesh.vertexData.tests.js',
             './tests/unit/babylon/src/Tools/babylon.promise.tests.js',
             { pattern: 'dist/**/*', watched: false, included: false, served: true },


### PR DESCRIPTION
Also add unit tests and fix normalized math according to https://github.com/KhronosGroup/glTF/issues/1317