### PR TITLE
Jedi web vr fixes

### DIFF
--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -95,7 +95,7 @@ module BABYLON {
             this._activePointer = false;
         }
 
-        public _updatePointerDistance(distance:number) {
+        public _updatePointerDistance(distance:number = 100) {
         }
 
         public dispose(){
@@ -177,7 +177,7 @@ module BABYLON {
             this._laserPointer.parent = mesh;
         }
 
-        public _updatePointerDistance(distance:number) {
+        public _updatePointerDistance(distance:number = 100) {
             this._laserPointer.scaling.y = distance;
             this._laserPointer.position.z = -distance / 2;  
         }
@@ -1614,6 +1614,7 @@ module BABYLON {
                 gazer._updatePointerDistance(hit.distance);        
             }
             else {
+                gazer._updatePointerDistance();   
                 gazer._gazeTracker.isVisible = false;
             }
 

--- a/src/Cameras/VR/babylon.vrExperienceHelper.ts
+++ b/src/Cameras/VR/babylon.vrExperienceHelper.ts
@@ -43,6 +43,8 @@ module BABYLON {
         public _teleportationEnabled: boolean;
         public _teleportationRequestInitiated = false;
         public _teleportationBackRequestInitiated = false;
+        public _rotationRightAsked = false;
+        public _rotationLeftAsked = false;
         public _dpadPressed = true;
 
         public _activePointer = false;
@@ -99,6 +101,9 @@ module BABYLON {
         public dispose(){
             this._interactionsEnabled = false;
             this._teleportationEnabled = false;
+            if(this._gazeTracker){
+                this._gazeTracker.dispose()
+            }
         }
     }
 
@@ -280,8 +285,6 @@ module BABYLON {
         private _floorMeshesCollection: Mesh[] = [];
         private _rotationAllowed: boolean = true;
         private _teleportBackwardsVector = new Vector3(0, -1, -1);
-        private _rotationRightAsked = false;
-        private _rotationLeftAsked = false;
         private _teleportationTarget: Mesh;
         private _isDefaultTeleportationTarget = true;
         private _postProcessMove: ImageProcessingPostProcess;
@@ -443,7 +446,7 @@ module BABYLON {
                 if (this.rightController) {
                     this.rightController._activatePointer();
                 }
-                else if (this.leftController) {
+                if (this.leftController) {
                     this.leftController._activatePointer();
                 }
             }
@@ -1157,29 +1160,29 @@ module BABYLON {
                 return;
             }
 
-            if (!this._rotationLeftAsked) {
+            if (!gazer._rotationLeftAsked) {
                 if (stateObject.x < -this._padSensibilityUp && gazer._dpadPressed) {
-                    this._rotationLeftAsked = true;
+                    gazer._rotationLeftAsked = true;
                     if (this._rotationAllowed) {
                         this._rotateCamera(false);
                     }
                 }
             } else {
                 if (stateObject.x > -this._padSensibilityDown) {
-                    this._rotationLeftAsked = false;
+                    gazer._rotationLeftAsked = false;
                 }
             }
 
-            if (!this._rotationRightAsked) {
+            if (!gazer._rotationRightAsked) {
                 if (stateObject.x > this._padSensibilityUp && gazer._dpadPressed) {
-                    this._rotationRightAsked = true;
+                    gazer._rotationRightAsked = true;
                     if (this._rotationAllowed) {
                         this._rotateCamera(true);
                     }
                 }
             } else {
                 if (stateObject.x < this._padSensibilityDown) {
-                    this._rotationRightAsked = false;
+                    gazer._rotationRightAsked = false;
                 }
             }
         }
@@ -1243,8 +1246,8 @@ module BABYLON {
                     controller.webVRController.onPadStateChangedObservable.add((stateObject) => {
                         controller._dpadPressed = stateObject.pressed;
                         if (!controller._dpadPressed) {
-                            this._rotationLeftAsked = false;
-                            this._rotationRightAsked = false;
+                            controller._rotationLeftAsked = false;
+                            controller._rotationRightAsked = false;
                             controller._teleportationBackRequestInitiated = false;
                         }
                     });


### PR DESCRIPTION
Fixes: 

- dispose gaze target when controller disposed
- rotation input with 2 controllers
- laser length when not poiting at a mesh

Tested that it didnt break:

- Mansion
- Hill valley
- Sponza