### PR TITLE
fullscreen button will be hidden on small devices

### DIFF
--- a/Viewer/assets/templates/default/navbar.html
+++ b/Viewer/assets/templates/default/navbar.html
@@ -231,6 +231,12 @@
         display: none;
     }
 
+    /* Disable fullscreen button for small screens */
+
+    .fullscreen {
+        display: none;
+    }
+
     @media screen and (min-width: 540px) {
         .help,
         .types-icon,
@@ -256,6 +262,10 @@
 
         .speed .menu-options {
             width: 64px;
+        }
+
+        .fullscreen {
+            display: block;
         }
     }
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -13,6 +13,11 @@
 
 - Add support for KHR_texture_transform ([bghgary](http://www.github.com/bghgary))
 
+### Viewer
+
+- No fullscreen button on small devices ([RaananW](https://github.com/RaananW))
+- Nav-Bar is now disaplayed on fullscreen per default  ([RaananW](https://github.com/RaananW))
+
 ## Bug fixes
 
 ### Core Engine


### PR DESCRIPTION
Not a full solution for https://github.com/BabylonJS/Babylon.js/issues/4276 , but will hide the fullscreen button on devices with lower width than 540px.