### PR TITLE
A mechanism for viewer configuration backwards compatibility

### DIFF
--- a/Viewer/src/configuration/configuration.ts
+++ b/Viewer/src/configuration/configuration.ts
@@ -4,7 +4,7 @@ import { EngineOptions, IGlowLayerOptions, DepthOfFieldEffectBlurLevel } from 'b
 export function getConfigurationKey(key: string, configObject: any) {
     let splits = key.split('.');
 
-    if (splits.length === 0 || !configObject) return false;
+    if (splits.length === 0 || !configObject) return;
     else if (splits.length === 1) {
         if (configObject[key] !== undefined) {
             return configObject[key];
@@ -160,6 +160,7 @@ export interface IDefaultRenderingPipelineConfiguration {
     bllomThreshold?: number;
     hdr?: boolean;
     samples?: number;
+    glowLayerEnabled?: boolean;
 }
 
 export interface IModelConfiguration {
@@ -271,6 +272,9 @@ export interface ISceneConfiguration {
     environmentTexture?: string;
     colorGrading?: IColorGradingConfiguration;
     environmentRotationY?: number;
+    /**
+     * Deprecated, please use default rendering pipeline
+     */
     glow?: boolean | IGlowLayerOptions;
     disableHdr?: boolean;
     renderInBackground?: boolean;

--- a/Viewer/src/configuration/configurationCompatibility.ts
+++ b/Viewer/src/configuration/configurationCompatibility.ts
@@ -1,0 +1,47 @@
+import { ViewerConfiguration, getConfigurationKey } from './'
+/**
+ * This function will make sure the configuration file is taking deprecated fields into account
+ * and is setting them to the correct keys and values.
+ * 
+ * @param configuration The configuration to process. Mutable!
+ */
+export function processConfigurationCompatibility(configuration: ViewerConfiguration) {
+
+
+
+    if (configuration.camera) {
+        // camera contrast -> image processing contrast
+        if (configuration.camera.contrast !== undefined) {
+            setKeyInObject(configuration, "scene.imageProcessingConfiguration.contrast", configuration.camera.contrast);
+        }
+
+        // camera exposure -> image processing exposure
+        if (configuration.camera.exposure !== undefined) {
+            setKeyInObject(configuration, "scene.imageProcessingConfiguration.exposure", configuration.camera.exposure);
+        }
+    }
+
+    if (configuration.scene) {
+        //glow
+        if (configuration.scene.glow) {
+            setKeyInObject(configuration, "lab.defaultRenderingPipelines.glowLayerEnabled", true);
+            let enabledProcessing = getConfigurationKey("scene.imageProcessingConfiguration.isEnabled", configuration);
+            if (enabledProcessing !== false) {
+                setKeyInObject(configuration, "scene.imageProcessingConfiguration.isEnabled", true);
+            }
+        }
+    }
+}
+
+function setKeyInObject(object: any, keys: string, value: any) {
+    let keySplit = keys.split(".");
+    if (keySplit.length === 0) return;
+    let lastKey = keySplit.pop();
+    if (!lastKey) return;
+    let curObj = object;
+    keySplit.forEach(key => {
+        curObj[key] = curObj[key] || {};
+        curObj = curObj[key];
+    });
+    curObj[lastKey] = value;
+}

--- a/Viewer/src/configuration/configurationCompatibility.ts
+++ b/Viewer/src/configuration/configurationCompatibility.ts
@@ -33,7 +33,7 @@ export function processConfigurationCompatibility(configuration: ViewerConfigura
     }
 }
 
-function setKeyInObject(object: any, keys: string, value: any) {
+function setKeyInObject(object: any, keys: string, value: any, shouldOverwrite?: boolean) {
     let keySplit = keys.split(".");
     if (keySplit.length === 0) return;
     let lastKey = keySplit.pop();
@@ -43,5 +43,6 @@ function setKeyInObject(object: any, keys: string, value: any) {
         curObj[key] = curObj[key] || {};
         curObj = curObj[key];
     });
+    if (curObj[lastKey] !== undefined && !shouldOverwrite) return;
     curObj[lastKey] = value;
 }

--- a/Viewer/src/configuration/loader.ts
+++ b/Viewer/src/configuration/loader.ts
@@ -1,6 +1,7 @@
 import { mapperManager } from './mappers';
 import { ViewerConfiguration } from './configuration';
 import { getConfigurationType } from './types';
+import { processConfigurationCompatibility } from './configurationCompatibility';
 
 import * as deepmerge from '../../assets/deepmerge.min.js';
 import { Tools, IFileRequest } from 'babylonjs';
@@ -73,10 +74,12 @@ export class ConfigurationLoader {
                 let mapper = mapperManager.getMapper(mapperType);
                 let parsed = mapper.map(data);
                 let merged = deepmerge(loadedConfig, parsed);
+                processConfigurationCompatibility(merged);
                 if (callback) callback(merged);
                 return merged;
             });
         } else {
+            processConfigurationCompatibility(loadedConfig);
             if (callback) callback(loadedConfig);
             return Promise.resolve(loadedConfig);
         }

--- a/Viewer/src/viewer/sceneManager.ts
+++ b/Viewer/src/viewer/sceneManager.ts
@@ -331,7 +331,7 @@ export class SceneManager {
 
         this._mainColor = Color3.White();
 
-        if (sceneConfiguration.glow) {
+        /*if (sceneConfiguration.glow) {
             let options: Partial<IGlowLayerOptions> = {
                 mainTextureFixedSize: 512
             };
@@ -339,7 +339,7 @@ export class SceneManager {
                 options = sceneConfiguration.glow
             }
             var gl = new BABYLON.GlowLayer("glow", this.scene, options);
-        }
+        }*/
 
         return this.onSceneInitObservable.notifyObserversWithPromise(this.scene);
     }
@@ -603,22 +603,14 @@ export class SceneManager {
 
             this._reflectionColor.copyFrom(this.mainColor);
 
-            if (this._viewer.configuration.camera && this._viewer.configuration.camera.exposure) {
 
-                let environmentTint = getConfigurationKey("lab.environmentMap.tintLevel", this._viewer.configuration) || 0;
+            let environmentTint = getConfigurationKey("lab.environmentMap.tintLevel", this._viewer.configuration) || 0;
 
-                /*this._mainColor.toLinearSpaceToRef(this._mainColor);
-                let exposure = Math.pow(2.0, -(this._viewer.configuration.camera.exposure) * Math.PI);
-                this._mainColor.scaleToRef(1 / exposure, this._mainColor);
-                let tmpColor = Color3.Lerp(this._white, this._mainColor, environmentTint);
-                this._mainColor.copyFrom(tmpColor);*/
-
-                // reflection color
-                this._reflectionColor.toLinearSpaceToRef(this._reflectionColor);
-                this._reflectionColor.scaleToRef(1 / this._viewer.configuration.camera.exposure, this._reflectionColor);
-                let tmpColor3 = Color3.Lerp(this._white, this._reflectionColor, environmentTint);
-                this._reflectionColor.copyFrom(tmpColor3);
-            }
+            // reflection color
+            this._reflectionColor.toLinearSpaceToRef(this._reflectionColor);
+            this._reflectionColor.scaleToRef(1 / this.scene.imageProcessingConfiguration.exposure, this._reflectionColor);
+            let tmpColor3 = Color3.Lerp(this._white, this._reflectionColor, environmentTint);
+            this._reflectionColor.copyFrom(tmpColor3);
 
             //update the environment, if exists
             if (this.environmentHelper) {
@@ -786,10 +778,6 @@ export class SceneManager {
         if (this.scene.imageProcessingConfiguration) {
             this.scene.imageProcessingConfiguration.colorCurvesEnabled = true;
             this.scene.imageProcessingConfiguration.vignetteEnabled = true;
-            if (cameraConfig.contrast !== undefined)
-                this.scene.imageProcessingConfiguration.contrast = cameraConfig.contrast;
-            if (cameraConfig.exposure !== undefined)
-                this.scene.imageProcessingConfiguration.exposure = cameraConfig.exposure;
             this.scene.imageProcessingConfiguration.toneMappingEnabled = !!cameraConfig.toneMappingEnabled;
         }
 
@@ -942,8 +930,8 @@ export class SceneManager {
             if (this.environmentHelper.groundMirror) {
                 const mirrorClearColor = this.environmentHelper.groundMaterial._perceptualColor.toLinearSpace();
                 // TODO user camera exposure value to set the mirror clear color
-                //let exposure = Math.pow(2.0, -this.configuration.camera.exposure) * Math.PI;
-                //mirrorClearColor.scaleToRef(1 / exposure, mirrorClearColor);
+                let exposure = Math.pow(2.0, -this.scene.imageProcessingConfiguration.exposure) * Math.PI;
+                mirrorClearColor.scaleToRef(1 / exposure, mirrorClearColor);
 
                 this.environmentHelper.groundMirror.clearColor.r = Scalar.Clamp(mirrorClearColor.r);
                 this.environmentHelper.groundMirror.clearColor.g = Scalar.Clamp(mirrorClearColor.g);

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -18,6 +18,7 @@
 
 - No fullscreen button on small devices ([RaananW](https://github.com/RaananW))
 - Nav-Bar is now disaplayed on fullscreen per default  ([RaananW](https://github.com/RaananW))
+- Viewer configuration supports deprecated values using the new configurationCompatibility processor  ([RaananW](https://github.com/RaananW))
 
 ## Bug fixes
 


### PR DESCRIPTION
the new configuration compatibility function will make sure deprecated values of the viewer's configuration will be set correctly. 
An example would be camera.contrast which actually is set in the imageProcessingConfiguration of the scene itself. Another example would be the glow support that moves to the default rendering pipeline.