### PR TITLE
Removed unused property 'bllomThreshold'

### DIFF
--- a/Viewer/src/configuration/configuration.ts
+++ b/Viewer/src/configuration/configuration.ts
@@ -157,7 +157,6 @@ export interface IDefaultRenderingPipelineConfiguration {
     bloomKernel?: number;
     hardwareScaleLevel?: number;
     bloomWeight?: number;
-    bllomThreshold?: number;
     hdr?: boolean;
     samples?: number;
     glowLayerEnabled?: boolean;


### PR DESCRIPTION
Removed unused property 'bllomThreshold' from IDefaultRenderingPipelineConfiguration