### PR TITLE
glTF Serializer: Added procedural texture to prevent premultiplication of alpha when exporting opaque models to glTF

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -1601,6 +1601,9 @@
                     "../../serializers/src/glTF/2.0/babylon.glTFAnimation.ts",
                     "../../serializers/src/glTF/2.0/babylon.glTFUtilities.ts"
                 ],
+                "shaderFiles": [
+                    "../../serializers/src/glTF/2.0/shaders/setAlphaToOne.fragment.fx"
+                ],
                 "output": "babylon.glTF2Serializer.js"
             }
         ],

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -106,9 +106,7 @@ module BABYLON.GLTF2 {
                 }
             }
 
-            return Promise.all(promises).then(() => {
-
-            });
+            return Promise.all(promises).then(() => { /* do nothing */ });
         }
 
         /**
@@ -330,7 +328,7 @@ module BABYLON.GLTF2 {
             if (hasTextureCoords) {
                 if (babylonStandardMaterial.diffuseTexture) {
                     let promise = _GLTFMaterial._ExportTextureAsync(babylonStandardMaterial.diffuseTexture, mimeType, images, textures, samplers, imageData, useAlpha).then(glTFTexture => {
-                        if (glTFTexture != null) {
+                        if (glTFTexture) {
                             glTFPbrMetallicRoughness.baseColorTexture = glTFTexture;
                         }
                     });
@@ -386,9 +384,7 @@ module BABYLON.GLTF2 {
 
             materials.push(glTFMaterial);
 
-            return Promise.all(promises).then(() => {
-
-            });
+            return Promise.all(promises).then(() => { /* do nothing */ });
         }
 
         /**
@@ -398,27 +394,29 @@ module BABYLON.GLTF2 {
          * @returns Promise with texture
          */
         public static _SetAlphaToOneAsync(texture: BaseTexture, useAlpha: boolean): Promise<Texture> {
-            if (useAlpha) {
-                return Promise.resolve(texture as Texture);
-            }
-            else {
-                const scene = texture.getScene();
-                if (scene == null) {
-                    return Promise.reject(`Scene not available for texture ${texture.name}`);
+            return Promise.resolve().then((() => {
+                if (useAlpha) {
+                    return Promise.resolve(texture as Texture);
                 }
                 else {
-                    const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
-                    if (proceduralTexture == null) {
-                        return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
+                    const scene = texture.getScene();
+                    if (scene == null) {
+                        return Promise.reject(`Scene not available for texture ${texture.name}`);
                     }
                     else {
-                        proceduralTexture.setTexture('textureSampler', texture as Texture);
-                        return scene.whenReadyAsync().then(() => {
-                            return proceduralTexture;
-                        });
+                        const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
+                        if (proceduralTexture == null) {
+                            return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
+                        }
+                        else {
+                            proceduralTexture.setTexture('textureSampler', texture as Texture);
+                            return scene.whenReadyAsync().then(() => {
+                                return proceduralTexture;
+                            });
+                        }
                     }
                 }
-            }
+            }));
         }
 
         /**
@@ -477,7 +475,7 @@ module BABYLON.GLTF2 {
             if (hasTextureCoords) {
                 if (babylonPBRMetalRoughMaterial.baseTexture != null) {
                     let promise = _GLTFMaterial._ExportTextureAsync(babylonPBRMetalRoughMaterial.baseTexture, mimeType, images, textures, samplers, imageData, useAlpha).then(glTFTexture => {
-                        if (glTFTexture != null) {
+                        if (glTFTexture) {
                             glTFPbrMetallicRoughness.baseColorTexture = glTFTexture;
                         }
                     });
@@ -507,7 +505,7 @@ module BABYLON.GLTF2 {
                 }
                 if (babylonPBRMetalRoughMaterial.emissiveTexture) {
                     let promise = _GLTFMaterial._ExportTextureAsync(babylonPBRMetalRoughMaterial.emissiveTexture, mimeType, images, textures, samplers, imageData, useAlpha).then(glTFTexture => {
-                        if (glTFTexture != null) {
+                        if (glTFTexture) {
                             glTFMaterial.emissiveTexture = glTFTexture;
                         }
                     });
@@ -523,8 +521,7 @@ module BABYLON.GLTF2 {
 
             materials.push(glTFMaterial);
 
-            return Promise.all(promises).then(() => {
-            });
+            return Promise.all(promises).then(() => { /* do nothing */ });
         }
 
         /**
@@ -840,7 +837,7 @@ module BABYLON.GLTF2 {
                 }
                 if (babylonPBRMaterial.metallicTexture) {
                     let promise = _GLTFMaterial._ExportTextureAsync(babylonPBRMaterial.metallicTexture, mimeType, images, textures, samplers, imageData, useAlpha).then(glTFTexture => {
-                        if (glTFTexture != null) {
+                        if (glTFTexture) {
                             glTFPbrMetallicRoughness.metallicRoughnessTexture = glTFTexture;
                         }
                     });
@@ -1115,7 +1112,7 @@ module BABYLON.GLTF2 {
                     }
                     if (babylonPBRMaterial.emissiveTexture) {
                         let promise = _GLTFMaterial._ExportTextureAsync(babylonPBRMaterial.emissiveTexture, mimeType, images, textures, samplers, imageData, useAlpha).then(glTFTexture => {
-                            if (glTFTexture != null) {
+                            if (glTFTexture) {
                                 glTFMaterial.emissiveTexture = glTFTexture;
                             }
                         });
@@ -1129,7 +1126,7 @@ module BABYLON.GLTF2 {
                 glTFMaterial.pbrMetallicRoughness = glTFPbrMetallicRoughness;
                 materials.push(glTFMaterial);
             }
-            return Promise.all(promises).then(result => { });
+            return Promise.all(promises).then(result => { /* do nothing */ });
         }
 
         private static GetPixelsFromTexture(babylonTexture: Texture): Uint8Array | Float32Array {

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -394,29 +394,27 @@ module BABYLON.GLTF2 {
          * @returns Promise with texture
          */
         public static _SetAlphaToOneAsync(texture: BaseTexture, useAlpha: boolean): Promise<Texture> {
-            return Promise.resolve().then((() => {
-                if (useAlpha) {
-                    return Promise.resolve(texture as Texture);
+            if (useAlpha) {
+                return Promise.resolve(texture as Texture);
+            }
+            else {
+                const scene = texture.getScene();
+                if (scene == null) {
+                    return Promise.reject(`Scene not available for texture ${texture.name}`);
                 }
                 else {
-                    const scene = texture.getScene();
-                    if (scene == null) {
-                        return Promise.reject(`Scene not available for texture ${texture.name}`);
+                    const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
+                    if (proceduralTexture == null) {
+                        return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
                     }
                     else {
-                        const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
-                        if (proceduralTexture == null) {
-                            return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
-                        }
-                        else {
-                            proceduralTexture.setTexture('textureSampler', texture as Texture);
-                            return scene.whenReadyAsync().then(() => {
-                                return proceduralTexture;
-                            });
-                        }
+                        proceduralTexture.setTexture('textureSampler', texture as Texture);
+                        return new Promise((resolve, reject) => {
+                            proceduralTexture.onLoadObservable.add(() => { return proceduralTexture });
+                        })
                     }
                 }
-            }));
+            }
         }
 
         /**

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -402,12 +402,13 @@ module BABYLON.GLTF2 {
                     const scene = texture.getScene();
                     if (scene) {
                         const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
-                        if (proceduralTexture == null) {
-                            reject(`Cannot create procedural texture for ${texture.name}!`);
-                        }
-                        else {
+                        
+                        if (proceduralTexture) {
                             proceduralTexture.setTexture('textureSampler', texture as Texture);
                             proceduralTexture.onLoadObservable.add(() => { resolve(proceduralTexture) });
+                        }
+                        else {
+                            reject(`Cannot create procedural texture for ${texture.name}!`);
                         }
                     }
                     else {

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -400,10 +400,7 @@ module BABYLON.GLTF2 {
                 }
                 else {
                     const scene = texture.getScene();
-                    if (scene == null) {
-                        reject(`Scene not available for texture ${texture.name}`);
-                    }
-                    else {
+                    if (scene) {
                         const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
                         if (proceduralTexture == null) {
                             reject(`Cannot create procedural texture for ${texture.name}!`);
@@ -412,6 +409,9 @@ module BABYLON.GLTF2 {
                             proceduralTexture.setTexture('textureSampler', texture as Texture);
                             proceduralTexture.onLoadObservable.add(() => { resolve(proceduralTexture) });
                         }
+                    }
+                    else {
+                        reject(`Scene not available for texture ${texture.name}`);
                     }
                 }
 

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -408,9 +408,9 @@ module BABYLON.GLTF2 {
                         return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
                     }
                     else {
-                        proceduralTexture.setTexture('textureSampler', texture as Texture);
                         return new Promise((resolve, reject) => {
-                            proceduralTexture.onLoadObservable.add(() => { return proceduralTexture });
+                            proceduralTexture.setTexture('textureSampler', texture as Texture);
+                            proceduralTexture.onLoadObservable.add(() => { resolve(proceduralTexture) });
                         })
                     }
                 }

--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -394,27 +394,29 @@ module BABYLON.GLTF2 {
          * @returns Promise with texture
          */
         public static _SetAlphaToOneAsync(texture: BaseTexture, useAlpha: boolean): Promise<Texture> {
-            if (useAlpha) {
-                return Promise.resolve(texture as Texture);
-            }
-            else {
-                const scene = texture.getScene();
-                if (scene == null) {
-                    return Promise.reject(`Scene not available for texture ${texture.name}`);
+            return new Promise((resolve, reject) => {
+                if (useAlpha) {
+                    resolve(texture as Texture);
                 }
                 else {
-                    const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
-                    if (proceduralTexture == null) {
-                        return Promise.reject(`Cannot create procedural texture for ${texture.name}!`);
+                    const scene = texture.getScene();
+                    if (scene == null) {
+                        reject(`Scene not available for texture ${texture.name}`);
                     }
                     else {
-                        return new Promise((resolve, reject) => {
+                        const proceduralTexture = new ProceduralTexture('texture', texture.getSize(), 'setAlphaToOne', scene);
+                        if (proceduralTexture == null) {
+                            reject(`Cannot create procedural texture for ${texture.name}!`);
+                        }
+                        else {
                             proceduralTexture.setTexture('textureSampler', texture as Texture);
                             proceduralTexture.onLoadObservable.add(() => { resolve(proceduralTexture) });
-                        })
+                        }
                     }
                 }
-            }
+
+            })
+
         }
 
         /**

--- a/serializers/src/glTF/2.0/babylon.glTFSerializer.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFSerializer.ts
@@ -22,20 +22,6 @@ module BABYLON {
      */
     export class GLTF2Export {
         /**
-         * Exports the geometry of the scene to .gltf file format synchronously
-         * @param scene Babylon scene with scene hierarchy information
-         * @param filePrefix File prefix to use when generating the glTF file
-         * @param options Exporter options
-         * @returns Returns an object with a .gltf file and associates texture names
-         * as keys and their data and paths as values
-         */
-        private static GLTF(scene: Scene, filePrefix: string, options?: IExportOptions): GLTFData {
-            const glTFPrefix = filePrefix.replace(/\.[^/.]+$/, "");
-            const gltfGenerator = new GLTF2._Exporter(scene, options);
-            return gltfGenerator._generateGLTF(glTFPrefix);
-        }
-
-        /**
          * Exports the geometry of the scene to .gltf file format asynchronously
          * @param scene Babylon scene with scene hierarchy information
          * @param filePrefix File prefix to use when generating the glTF file
@@ -44,22 +30,11 @@ module BABYLON {
          * as keys and their data and paths as values
          */
         public static GLTFAsync(scene: Scene, filePrefix: string, options?: IExportOptions): Promise<GLTFData> {
-            return Promise.resolve(scene.whenReadyAsync()).then(() => {
-                return GLTF2Export.GLTF(scene, filePrefix, options);
+            return scene.whenReadyAsync().then(() => {
+                const glTFPrefix = filePrefix.replace(/\.[^/.]+$/, "");
+                const gltfGenerator = new GLTF2._Exporter(scene, options);
+                return gltfGenerator._generateGLTFAsync(glTFPrefix);
             });
-        }
-
-        /**
-         * Exports the geometry of the scene to .glb file format synchronously
-         * @param scene Babylon scene with scene hierarchy information
-         * @param filePrefix File prefix to use when generating glb file
-         * @param options Exporter options
-         * @returns Returns an object with a .glb filename as key and data as value
-         */
-        private static GLB(scene: Scene, filePrefix: string, options?: IExportOptions): GLTFData {
-            const glTFPrefix = filePrefix.replace(/\.[^/.]+$/, "");
-            const gltfGenerator = new GLTF2._Exporter(scene, options);
-            return gltfGenerator._generateGLB(glTFPrefix);
         }
 
         /**
@@ -70,8 +45,10 @@ module BABYLON {
          * @returns Returns an object with a .glb filename as key and data as value
          */
         public static GLBAsync(scene: Scene, filePrefix: string, options?: IExportOptions): Promise<GLTFData> {
-            return Promise.resolve(scene.whenReadyAsync()).then(() => {
-                return GLTF2Export.GLB(scene, filePrefix, options);
+            return scene.whenReadyAsync().then(() => {
+                const glTFPrefix = filePrefix.replace(/\.[^/.]+$/, "");
+                const gltfGenerator = new GLTF2._Exporter(scene, options);
+                return gltfGenerator._generateGLBAsync(glTFPrefix);
             });
         }
     }

--- a/serializers/src/glTF/2.0/shaders/setAlphaToOne.fragment.fx
+++ b/serializers/src/glTF/2.0/shaders/setAlphaToOne.fragment.fx
@@ -1,0 +1,10 @@
+precision highp float;
+
+uniform sampler2D textureSampler;
+
+varying vec2 vUV;
+
+void main(void) {
+    vec4 color = texture2D(textureSampler, vUV);
+    gl_FragColor = vec4(color.rgb, 1.0);
+}

--- a/tests/unit/babylon/serializers/babylon.glTFSerializer.tests.ts
+++ b/tests/unit/babylon/serializers/babylon.glTFSerializer.tests.ts
@@ -12,6 +12,8 @@ describe('Babylon glTF Serializer', () => {
         (BABYLONDEVTOOLS).Loader
             .useDist()
             .load(function () {
+                // Force apply promise polyfill for consistent behavior between PhantomJS, IE11, and other browsers.
+                BABYLON.PromisePolyfill.Apply(true);
                 done();
             });
     });
@@ -78,63 +80,53 @@ describe('Babylon glTF Serializer', () => {
             BABYLON.GLTF2._GLTFMaterial._SolveMetallic(0.0, 1.0, 1.0).should.be.approximately(1, 1e-6);
         });
 
-        it('should serialize empty Babylon scene to glTF with only asset property', (done) => {
-            mocha.timeout(10000);
-
+        it('should serialize empty Babylon scene to glTF with only asset property', () => {
             const scene = new BABYLON.Scene(subject);
-            scene.executeWhenReady(function () {
-                const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-                const glTFData = glTFExporter._generateGLTF('test');
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
                 const jsonString = glTFData.glTFFiles['test.gltf'] as string;
                 const jsonData = JSON.parse(jsonString);
 
                 Object.keys(jsonData).length.should.be.equal(1);
                 jsonData.asset.version.should.be.equal("2.0");
                 jsonData.asset.generator.should.be.equal("BabylonJS");
-
-                done();
             });
         });
 
-        it('should serialize sphere geometry in scene to glTF', (done) => {
-            mocha.timeout(10000);
+        it('should serialize sphere geometry in scene to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             BABYLON.Mesh.CreateSphere('sphere', 16, 2, scene);
 
-            scene.executeWhenReady(function () {
-                const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-                const glTFData = glTFExporter._generateGLTF('test');
-                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-                const jsonData = JSON.parse(jsonString);
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test')
+                .then(glTFData => {
+                    const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                    const jsonData = JSON.parse(jsonString);
 
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials
-                Object.keys(jsonData).length.should.be.equal(9);
+                    // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials
+                    Object.keys(jsonData).length.should.be.equal(9);
 
-                // positions, normals, texture coords, indices
-                jsonData.accessors.length.should.be.equal(4);
+                    // positions, normals, indices
+                    jsonData.accessors.length.should.be.equal(3);
 
-                // generator, version
-                Object.keys(jsonData.asset).length.should.be.equal(2);
+                    // generator, version
+                    Object.keys(jsonData.asset).length.should.be.equal(2);
 
-                jsonData.buffers.length.should.be.equal(1);
+                    jsonData.buffers.length.should.be.equal(1);
 
-                // positions, normals, texture coords, indices
-                jsonData.bufferViews.length.should.be.equal(4);
+                    // positions, normals, texture coords, indices
+                    jsonData.bufferViews.length.should.be.equal(4);
 
-                jsonData.meshes.length.should.be.equal(1);
+                    jsonData.meshes.length.should.be.equal(1);
 
-                jsonData.nodes.length.should.be.equal(1);
+                    jsonData.nodes.length.should.be.equal(1);
 
-                jsonData.scenes.length.should.be.equal(1);
+                    jsonData.scenes.length.should.be.equal(1);
 
-                jsonData.scene.should.be.equal(0);
-
-                done();
-            });
+                    jsonData.scene.should.be.equal(0);
+                });
         });
 
-        it('should serialize alpha mode and cutoff', (done) => {
-            mocha.timeout(10000);
+        it('should serialize alpha mode and cutoff', () => {
             const scene = new BABYLON.Scene(subject);
 
             const plane = BABYLON.Mesh.CreatePlane('plane', 120, scene);
@@ -145,9 +137,8 @@ describe('Babylon glTF Serializer', () => {
 
             plane.material = babylonPBRMetalRoughMaterial;
 
-            scene.executeWhenReady(function () {
-                const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-                const glTFData = glTFExporter._generateGLTF('test');
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
                 const jsonString = glTFData.glTFFiles['test.gltf'] as string;
                 const jsonData = JSON.parse(jsonString);
 
@@ -159,243 +150,228 @@ describe('Babylon glTF Serializer', () => {
                 jsonData.materials[0].alphaMode.should.be.equal('MASK');
 
                 jsonData.materials[0].alphaCutoff.should.be.equal(alphaCutoff);
-
-                done();
             });
         });
-        it('should serialize single component translation animation to glTF', (done) => {
-            mocha.timeout(10000);
+        it('should serialize single component translation animation to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             const box = BABYLON.Mesh.CreateBox('box', 1, scene);
             let keys: BABYLON.IAnimationKey[] = [];
             keys.push({
-            frame: 0,
-            value: 1
+                frame: 0,
+                value: 1
             });
             keys.push({
-            frame: 20,
-            value: 0.2
+                frame: 20,
+                value: 0.2
             });
             keys.push({
-            frame: 40,
-            value: 1
+                frame: 40,
+                value: 1
             });
             let animationBoxT = new BABYLON.Animation('boxAnimation_translation', 'position.y', 30, BABYLON.Animation.ANIMATIONTYPE_FLOAT, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             animationBoxT.setKeys(keys);
             box.animations.push(animationBoxT);
-            scene.executeWhenReady(function () {
-            const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-            const glTFData = glTFExporter._generateGLTF('test');
-            const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-            const jsonData = JSON.parse(jsonString);
-            jsonData.animations.length.should.be.equal(1);
-            const animation = jsonData.animations[0];
-            animation.channels.length.should.be.equal(1);
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('translation');
-            jsonData.animations[0].samplers.length.should.be.equal(1);
-            // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-            Object.keys(jsonData).length.should.be.equal(10);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.accessors.length.should.be.equal(6);
-            // generator, version
-            Object.keys(jsonData.asset).length.should.be.equal(2);
-            jsonData.buffers.length.should.be.equal(1);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.bufferViews.length.should.be.equal(6);
-            jsonData.meshes.length.should.be.equal(1);
-            jsonData.nodes.length.should.be.equal(1);
-            jsonData.scenes.length.should.be.equal(1);
-            jsonData.scene.should.be.equal(0);
-            done();
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
+                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                const jsonData = JSON.parse(jsonString);
+                jsonData.animations.length.should.be.equal(1);
+                const animation = jsonData.animations[0];
+                animation.channels.length.should.be.equal(1);
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('translation');
+                jsonData.animations[0].samplers.length.should.be.equal(1);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
+                Object.keys(jsonData).length.should.be.equal(10);
+                // positions, normals, indices, animation keyframe data, animation data
+                jsonData.accessors.length.should.be.equal(5);
+                // generator, version
+                Object.keys(jsonData.asset).length.should.be.equal(2);
+                jsonData.buffers.length.should.be.equal(1);
+                // positions, normals, texture coords, indices, animation keyframe data, animation data
+                jsonData.bufferViews.length.should.be.equal(6);
+                jsonData.meshes.length.should.be.equal(1);
+                jsonData.nodes.length.should.be.equal(1);
+                jsonData.scenes.length.should.be.equal(1);
+                jsonData.scene.should.be.equal(0);
             });
-            });
-            it('should serialize translation animation to glTF', (done) => {
-            mocha.timeout(10000);
+        });
+        it('should serialize translation animation to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             const box = BABYLON.Mesh.CreateBox('box', 1, scene);
             let keys: BABYLON.IAnimationKey[] = [];
             keys.push({
-            frame: 0,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 0,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             keys.push({
-            frame: 20,
-            value: BABYLON.Vector3.One()
+                frame: 20,
+                value: BABYLON.Vector3.One()
             });
             keys.push({
-            frame: 40,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 40,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             let animationBoxT = new BABYLON.Animation('boxAnimation_translation', 'position', 30, BABYLON.Animation.ANIMATIONTYPE_VECTOR3, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             animationBoxT.setKeys(keys);
             box.animations.push(animationBoxT);
-            scene.executeWhenReady(function () {
-            const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-            const glTFData = glTFExporter._generateGLTF('test');
-            const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-            const jsonData = JSON.parse(jsonString);
-            jsonData.animations.length.should.be.equal(1);
-            const animation = jsonData.animations[0];
-            animation.channels.length.should.be.equal(1);
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('translation');
-            animation.samplers.length.should.be.equal(1);
-            animation.samplers[0].interpolation.should.be.equal('LINEAR');
-            animation.samplers[0].input.should.be.equal(4);
-            animation.samplers[0].output.should.be.equal(5);
-            jsonData.animations[0].samplers.length.should.be.equal(1);
-            // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-            Object.keys(jsonData).length.should.be.equal(10);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.accessors.length.should.be.equal(6);
-            // generator, version
-            Object.keys(jsonData.asset).length.should.be.equal(2);
-            jsonData.buffers.length.should.be.equal(1);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.bufferViews.length.should.be.equal(6);
-            jsonData.meshes.length.should.be.equal(1);
-            jsonData.nodes.length.should.be.equal(1);
-            jsonData.scenes.length.should.be.equal(1);
-            jsonData.scene.should.be.equal(0);
-            done();
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
+                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                const jsonData = JSON.parse(jsonString);
+                jsonData.animations.length.should.be.equal(1);
+                const animation = jsonData.animations[0];
+                animation.channels.length.should.be.equal(1);
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('translation');
+                animation.samplers.length.should.be.equal(1);
+                animation.samplers[0].interpolation.should.be.equal('LINEAR');
+                animation.samplers[0].input.should.be.equal(3);
+                animation.samplers[0].output.should.be.equal(4);
+                jsonData.animations[0].samplers.length.should.be.equal(1);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
+                Object.keys(jsonData).length.should.be.equal(10);
+                // positions, normals, indices, animation keyframe data, animation data
+                jsonData.accessors.length.should.be.equal(5);
+                // generator, version
+                Object.keys(jsonData.asset).length.should.be.equal(2);
+                jsonData.buffers.length.should.be.equal(1);
+                // positions, normals, texture coords, indices, animation keyframe data, animation data
+                jsonData.bufferViews.length.should.be.equal(6);
+                jsonData.meshes.length.should.be.equal(1);
+                jsonData.nodes.length.should.be.equal(1);
+                jsonData.scenes.length.should.be.equal(1);
+                jsonData.scene.should.be.equal(0);
             });
-            });
-            it('should serialize scale animation to glTF', (done) => {
-            mocha.timeout(10000);
+        });
+        it('should serialize scale animation to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             const box = BABYLON.Mesh.CreateBox('box', 1, scene);
             let keys: BABYLON.IAnimationKey[] = [];
             keys.push({
-            frame: 0,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 0,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             keys.push({
-            frame: 20,
-            value: BABYLON.Vector3.One()
+                frame: 20,
+                value: BABYLON.Vector3.One()
             });
             keys.push({
-            frame: 40,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 40,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             let animationBoxT = new BABYLON.Animation('boxAnimation_translation', 'scaling', 30, BABYLON.Animation.ANIMATIONTYPE_VECTOR3, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             animationBoxT.setKeys(keys);
             box.animations.push(animationBoxT);
-            scene.executeWhenReady(function () {
-            const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-            const glTFData = glTFExporter._generateGLTF('test');
-            const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-            const jsonData = JSON.parse(jsonString);
-            jsonData.animations.length.should.be.equal(1);
-            const animation = jsonData.animations[0];
-            animation.channels.length.should.be.equal(1);
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('scale');
-            animation.samplers.length.should.be.equal(1);
-            animation.samplers[0].interpolation.should.be.equal('LINEAR');
-            animation.samplers[0].input.should.be.equal(4);
-            animation.samplers[0].output.should.be.equal(5);
-            jsonData.animations[0].samplers.length.should.be.equal(1);
-            // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-            Object.keys(jsonData).length.should.be.equal(10);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.accessors.length.should.be.equal(6);
-            // generator, version
-            Object.keys(jsonData.asset).length.should.be.equal(2);
-            jsonData.buffers.length.should.be.equal(1);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.bufferViews.length.should.be.equal(6);
-            jsonData.meshes.length.should.be.equal(1);
-            jsonData.nodes.length.should.be.equal(1);
-            jsonData.scenes.length.should.be.equal(1);
-            jsonData.scene.should.be.equal(0);
-            done();
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
+                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                const jsonData = JSON.parse(jsonString);
+                jsonData.animations.length.should.be.equal(1);
+                const animation = jsonData.animations[0];
+                animation.channels.length.should.be.equal(1);
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('scale');
+                animation.samplers.length.should.be.equal(1);
+                animation.samplers[0].interpolation.should.be.equal('LINEAR');
+                animation.samplers[0].input.should.be.equal(3);
+                animation.samplers[0].output.should.be.equal(4);
+                jsonData.animations[0].samplers.length.should.be.equal(1);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
+                Object.keys(jsonData).length.should.be.equal(10);
+                // positions, normals, indices, animation keyframe data, animation data
+                jsonData.accessors.length.should.be.equal(5);
+                // generator, version
+                Object.keys(jsonData.asset).length.should.be.equal(2);
+                jsonData.buffers.length.should.be.equal(1);
+                // positions, normals, texture coords, indices, animation keyframe data, animation data
+                jsonData.bufferViews.length.should.be.equal(6);
+                jsonData.meshes.length.should.be.equal(1);
+                jsonData.nodes.length.should.be.equal(1);
+                jsonData.scenes.length.should.be.equal(1);
+                jsonData.scene.should.be.equal(0);
             });
-            });
-            it('should serialize rotation quaternion animation to glTF', (done) => {
-            mocha.timeout(10000);
+        });
+        it('should serialize rotation quaternion animation to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             const box = BABYLON.Mesh.CreateBox('box', 1, scene);
             let keys: BABYLON.IAnimationKey[] = [];
             keys.push({
-            frame: 0,
-            value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
+                frame: 0,
+                value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
             });
             keys.push({
-            frame: 20,
-            value: BABYLON.Quaternion.Identity()
+                frame: 20,
+                value: BABYLON.Quaternion.Identity()
             });
             keys.push({
-            frame: 40,
-            value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
+                frame: 40,
+                value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
             });
             let animationBoxT = new BABYLON.Animation('boxAnimation_translation', 'rotationQuaternion', 30, BABYLON.Animation.ANIMATIONTYPE_QUATERNION, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             animationBoxT.setKeys(keys);
             box.animations.push(animationBoxT);
-            scene.executeWhenReady(function () {
-            const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-            const glTFData = glTFExporter._generateGLTF('test');
-            const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-            const jsonData = JSON.parse(jsonString);
-            jsonData.animations.length.should.be.equal(1);
-            const animation = jsonData.animations[0];
-            animation.channels.length.should.be.equal(1);
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('rotation');
-            animation.samplers.length.should.be.equal(1);
-            animation.samplers[0].interpolation.should.be.equal('LINEAR');
-            animation.samplers[0].input.should.be.equal(4);
-            animation.samplers[0].output.should.be.equal(5);
-            jsonData.animations[0].samplers.length.should.be.equal(1);
-            // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-            Object.keys(jsonData).length.should.be.equal(10);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.accessors.length.should.be.equal(6);
-            // generator, version
-            Object.keys(jsonData.asset).length.should.be.equal(2);
-            jsonData.buffers.length.should.be.equal(1);
-            // positions, normals, texture coords, indices, animation keyframe data, animation data
-            jsonData.bufferViews.length.should.be.equal(6);
-            jsonData.meshes.length.should.be.equal(1);
-            jsonData.nodes.length.should.be.equal(1);
-            jsonData.scenes.length.should.be.equal(1);
-            jsonData.scene.should.be.equal(0);
-            done();
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
+                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                const jsonData = JSON.parse(jsonString);
+                jsonData.animations.length.should.be.equal(1);
+                const animation = jsonData.animations[0];
+                animation.channels.length.should.be.equal(1);
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('rotation');
+                animation.samplers.length.should.be.equal(1);
+                animation.samplers[0].interpolation.should.be.equal('LINEAR');
+                animation.samplers[0].input.should.be.equal(3);
+                animation.samplers[0].output.should.be.equal(4);
+                jsonData.animations[0].samplers.length.should.be.equal(1);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
+                Object.keys(jsonData).length.should.be.equal(10);
+                // positions, normals, indices, animation keyframe data, animation data
+                jsonData.accessors.length.should.be.equal(5);
+                // generator, version
+                Object.keys(jsonData.asset).length.should.be.equal(2);
+                jsonData.buffers.length.should.be.equal(1);
+                // positions, normals, texture coords, indices, animation keyframe data, animation data
+                jsonData.bufferViews.length.should.be.equal(6);
+                jsonData.meshes.length.should.be.equal(1);
+                jsonData.nodes.length.should.be.equal(1);
+                jsonData.scenes.length.should.be.equal(1);
+                jsonData.scene.should.be.equal(0);
             });
-            });
-            it('should serialize combined animations to glTF', (done) => {
-            mocha.timeout(10000);
+        });
+        it('should serialize combined animations to glTF', () => {
             const scene = new BABYLON.Scene(subject);
             const box = BABYLON.Mesh.CreateBox('box', 1, scene);
             const rotationKeyFrames: BABYLON.IAnimationKey[] = [];
             rotationKeyFrames.push({
-            frame: 0,
-            value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
+                frame: 0,
+                value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
             });
             rotationKeyFrames.push({
-            frame: 20,
-            value: BABYLON.Quaternion.Identity()
+                frame: 20,
+                value: BABYLON.Quaternion.Identity()
             });
             rotationKeyFrames.push({
-            frame: 40,
-            value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
+                frame: 40,
+                value: new BABYLON.Quaternion(0.707, 0.0, 0.0, 0.707)
             });
             const scaleKeyFrames: BABYLON.IAnimationKey[] = [];
             scaleKeyFrames.push({
-            frame: 0,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 0,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             scaleKeyFrames.push({
-            frame: 20,
-            value: BABYLON.Vector3.One()
+                frame: 20,
+                value: BABYLON.Vector3.One()
             });
             scaleKeyFrames.push({
-            frame: 40,
-            value: new BABYLON.Vector3(0.1, 0.1, 0.1)
+                frame: 40,
+                value: new BABYLON.Vector3(0.1, 0.1, 0.1)
             });
             let rotationAnimationBox = new BABYLON.Animation('boxAnimation_rotation', 'rotationQuaternion', 30, BABYLON.Animation.ANIMATIONTYPE_QUATERNION, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             rotationAnimationBox.setKeys(rotationKeyFrames);
@@ -403,46 +379,43 @@ describe('Babylon glTF Serializer', () => {
             let scaleAnimationBox = new BABYLON.Animation('boxAnimation_scale', 'scaling', 30, BABYLON.Animation.ANIMATIONTYPE_VECTOR3, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
             scaleAnimationBox.setKeys(scaleKeyFrames);
             box.animations.push(scaleAnimationBox);
-            scene.executeWhenReady(function () {
-            const glTFExporter = new BABYLON.GLTF2._Exporter(scene);
-            const glTFData = glTFExporter._generateGLTF('test');
-            const jsonString = glTFData.glTFFiles['test.gltf'] as string;
-            const jsonData = JSON.parse(jsonString);
-            jsonData.animations.length.should.be.equal(2);
-            
-            let animation = jsonData.animations[0];
-            animation.channels.length.should.be.equal(1);
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('rotation');
-            animation.samplers.length.should.be.equal(1);
-            animation.samplers[0].interpolation.should.be.equal('LINEAR');
-            animation.samplers[0].input.should.be.equal(4);
-            animation.samplers[0].output.should.be.equal(5);
-            animation = jsonData.animations[1];
-            animation.channels[0].sampler.should.be.equal(0);
-            animation.channels[0].target.node.should.be.equal(0);
-            animation.channels[0].target.path.should.be.equal('scale');
-            animation.samplers.length.should.be.equal(1);
-            animation.samplers[0].interpolation.should.be.equal('LINEAR');
-            animation.samplers[0].input.should.be.equal(6);
-            animation.samplers[0].output.should.be.equal(7);
-            // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-            Object.keys(jsonData).length.should.be.equal(10);
-            // positions, normals, texture coords, indices, rotation animation keyframe data, rotation animation data, scale animation keyframe data, scale animation data
-            jsonData.accessors.length.should.be.equal(8);
-            // generator, version
-            Object.keys(jsonData.asset).length.should.be.equal(2);
-            jsonData.buffers.length.should.be.equal(1);
-            // positions, normals, texture coords, indices, rotation animation keyframe data, rotation animation data, scale animation keyframe data, scale animation data 
-            jsonData.bufferViews.length.should.be.equal(8);
-            jsonData.meshes.length.should.be.equal(1);
-            jsonData.nodes.length.should.be.equal(1);
-            jsonData.scenes.length.should.be.equal(1);
-            jsonData.scene.should.be.equal(0);
-            done();
+
+            return BABYLON.GLTF2Export.GLTFAsync(scene, 'test').then(glTFData => {
+                const jsonString = glTFData.glTFFiles['test.gltf'] as string;
+                const jsonData = JSON.parse(jsonString);
+                jsonData.animations.length.should.be.equal(2);
+
+                let animation = jsonData.animations[0];
+                animation.channels.length.should.be.equal(1);
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('rotation');
+                animation.samplers.length.should.be.equal(1);
+                animation.samplers[0].interpolation.should.be.equal('LINEAR');
+                animation.samplers[0].input.should.be.equal(3);
+                animation.samplers[0].output.should.be.equal(4);
+                animation = jsonData.animations[1];
+                animation.channels[0].sampler.should.be.equal(0);
+                animation.channels[0].target.node.should.be.equal(0);
+                animation.channels[0].target.path.should.be.equal('scale');
+                animation.samplers.length.should.be.equal(1);
+                animation.samplers[0].interpolation.should.be.equal('LINEAR');
+                animation.samplers[0].input.should.be.equal(5);
+                animation.samplers[0].output.should.be.equal(6);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
+                Object.keys(jsonData).length.should.be.equal(10);
+                // positions, normals, indices, rotation animation keyframe data, rotation animation data, scale animation keyframe data, scale animation data
+                jsonData.accessors.length.should.be.equal(7);
+                // generator, version
+                Object.keys(jsonData.asset).length.should.be.equal(2);
+                jsonData.buffers.length.should.be.equal(1);
+                // positions, normals, texture coords, indices, rotation animation keyframe data, rotation animation data, scale animation keyframe data, scale animation data 
+                jsonData.bufferViews.length.should.be.equal(8);
+                jsonData.meshes.length.should.be.equal(1);
+                jsonData.nodes.length.should.be.equal(1);
+                jsonData.scenes.length.should.be.equal(1);
+                jsonData.scene.should.be.equal(0);
             });
-            });
-            
+        });
     });
 });


### PR DESCRIPTION
- Added procedural texture to prevent premultiplication of alpha when exporting opaque models to glTF
- Used the Babylon default material instead of omitting and using the glTF default material 
- Refactored to use promises in more functions to support the async shader call