### PR TITLE
NPM - adding "preview" tag to alpha and beta releases

### DIFF
--- a/Tools/Publisher/index.js
+++ b/Tools/Publisher/index.js
@@ -185,8 +185,15 @@ function processCore(package, version) {
     fs.writeFileSync(basePath + '/package/' + 'package.json', JSON.stringify(packageJson, null, 4));
 
     console.log('Publishing ' + package.name + " from " + basePath + '/package/');
+
+    let tagDef = "";
+    // check for alpha or beta
+    if (version.indexOf('alpha') !== -1 || version.indexOf('beta') !== -1) {
+        tagDef = '--tag preview';
+    }
+
     //publish the respected package
-    shelljs.exec('npm publish \"' + basePath + '/package/' + "\"");
+    shelljs.exec('npm publish \"' + basePath + '/package/' + "\"" + ' ' + tagDef);
 
     // remove package directory
     fs.removeSync(basePath + '/package/');

--- a/Tools/Publisher/index.js
+++ b/Tools/Publisher/index.js
@@ -84,8 +84,13 @@ function processPackages(version) {
             if (packageJson.peerDependencies) packageJson.peerDependencies.babylonjs = minimumDependency;
             fs.writeFileSync(package.path + 'package.json', JSON.stringify(packageJson, null, 4));
             console.log('Publishing ' + package.name + " from " + package.path);
+            let tagDef = "";
+            // check for alpha or beta
+            if (version.indexOf('alpha') !== -1 || version.indexOf('beta') !== -1) {
+                tagDef = '--tag preview';
+            }
             //publish the respected package
-            shelljs.exec('npm publish \"' + package.path + "\"");
+            shelljs.exec('npm publish \"' + package.path + "\"" + ' ' + tagDef);
         }
 
     });

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -6,9 +6,11 @@
 
 ## Updates
 
+- All NPM packages have `latest`and `preview` streams [#3055](https://github.com/BabylonJS/Babylon.js/issues/3055) ([RaananW](https://github.com/RaananW))
+
 ### Core Engine
 
-- Added new `Animatable.waitAsync` function to use Promises with animations. Demo [Here](https://www.babylonjs-playground.com/#HZBCXR) ([Deltakosh](https://github.com/deltakosh)) 
+- Added new `Animatable.waitAsync` function to use Promises with animations. Demo [Here](https://www.babylonjs-playground.com/#HZBCXR) ([Deltakosh](https://github.com/deltakosh))
 - Added the choice of [forming a closed loop](http://doc.babylonjs.com/how_to/how_to_use_curve3#catmull-rom-spline) to the catamull-rom-spline curve3 ([johnk](https://github.com/babylonjsguide))
 - Added support for specifying the center of rotation to textures ([bghgary](http://www.github.com/bghgary))
 - Added webVR support for Oculus Go ([TrevorDev](https://github.com/TrevorDev))
@@ -34,7 +36,7 @@
 - Fixed ```shadowEnabled``` property on lights. Shadows are not visble anymore when disabled ([sebavan](http://www.github.com/sebavan))
 - Physics `unregisterOnPhysicsCollide` didn't remove callback correctly [#4291](https://github.com/BabylonJS/Babylon.js/issues/4291) ([RaananW](https://github.com/RaananW))
 - Added missing getter and setter for global exposure in ColorCurves ([RaananW](https://github.com/RaananW))
-- Fixed an issue with view matrix when `ArcRotateCamera` was used with collisions ([Deltakosh](https://github.com/deltakosh)) 
+- Fixed an issue with view matrix when `ArcRotateCamera` was used with collisions ([Deltakosh](https://github.com/deltakosh))
 
 ### Viewer
 


### PR DESCRIPTION
Addressing  #3055
alpha and beta releases will not show as latest from the moment this script is used to publish.
The latest preview release will be available using `npm install babylonjs@preview`