### PR TITLE
Add a refresh rate input in the inspector Stats Tab

### DIFF
--- a/inspector/src/tabs/StatsTab.ts
+++ b/inspector/src/tabs/StatsTab.ts
@@ -362,7 +362,6 @@ module INSPECTOR {
             
             if(this._refreshRateCounter > 1){
                 this._refreshRateCounter--;
-                console.log(this._refreshRateCounter);
             }else{
                 for (let prop of this._updatableProperties) {
                     prop.elem.textContent = prop.updateFct();


### PR DESCRIPTION
Hi,

I have added an input in the stats tab of the inspector for a refresh rate for this issue : https://github.com/BabylonJS/Babylon.js/issues/4302