### PR TITLE
fixing a small issue with edge

### DIFF
--- a/Viewer/src/model/viewerModel.ts
+++ b/Viewer/src/model/viewerModel.ts
@@ -102,6 +102,8 @@ export class ViewerModel implements IDisposable {
     private _animatables: Array<Animatable> = [];
     private _frameRate: number = 60;
 
+    private _shadowsRenderedAfterLoad: boolean = false;
+
     constructor(protected _viewer: AbstractViewer, modelConfiguration: IModelConfiguration) {
         this.onLoadedObservable = new Observable();
         this.onLoadErrorObservable = new Observable();
@@ -139,6 +141,18 @@ export class ViewerModel implements IDisposable {
         this.onCompleteObservable.add(() => {
             this.state = ModelState.COMPLETE;
         });
+    }
+
+    public get shadowsRenderedAfterLoad() {
+        return this._shadowsRenderedAfterLoad;
+    }
+
+    public set shadowsRenderedAfterLoad(rendered: boolean) {
+        if (!rendered) {
+            throw new Error("can only be enabled");
+        } else {
+            this._shadowsRenderedAfterLoad = rendered;
+        }
     }
 
     /**

--- a/Viewer/src/viewer/sceneManager.ts
+++ b/Viewer/src/viewer/sceneManager.ts
@@ -140,7 +140,13 @@ export class SceneManager {
                 if (scene.animatables && scene.animatables.length > 0) {
                     // make sure all models are loaded
                     updateShadows();
-                } else if (!(this.models.every((model) => model.state === ModelState.COMPLETE && !model.currentAnimation))) {
+                } else if (!(this.models.every((model) => {
+                    if (!model.shadowsRenderedAfterLoad) {
+                        model.shadowsRenderedAfterLoad = true;
+                        return false;
+                    }
+                    return model.state === ModelState.COMPLETE && !model.currentAnimation
+                }))) {
                     updateShadows();
                 }
             });


### PR DESCRIPTION
if the code
```javascript
viewer.onInitDoneObservable.add(() => {
});
```
was added in *edge*, shadows wouldn't render. Edge would skip the frame where they are rendered, probably due to its promises implementation.

the solution is to make sure a model's shadow is rendered at least once.