### PR TITLE
Drag and drop

### DIFF
--- a/Viewer/src/configuration/configuration.ts
+++ b/Viewer/src/configuration/configuration.ts
@@ -166,7 +166,7 @@ export interface IModelConfiguration {
     id?: string;
     url?: string;
     root?: string; //optional
-    file?: string; // is a file being loaded? root and url ignored
+    file?: string | File; // is a file being loaded? root and url ignored
     loader?: string; // obj, gltf?
     position?: { x: number, y: number, z: number };
     rotation?: { x: number, y: number, z: number, w?: number };

--- a/Viewer/src/configuration/types/default.ts
+++ b/Viewer/src/configuration/types/default.ts
@@ -28,7 +28,10 @@ export let defaultConfiguration: ViewerConfiguration = {
             }
         },
         viewer: {
-            html: require("../../../assets/templates/default/defaultViewer.html")
+            html: require("../../../assets/templates/default/defaultViewer.html"),
+            params: {
+                disableDragAndDrop: false
+            }
         },
         navBar: {
             html: require("../../../assets/templates/default/navbar.html"),

--- a/Viewer/src/configuration/types/default.ts
+++ b/Viewer/src/configuration/types/default.ts
@@ -30,7 +30,7 @@ export let defaultConfiguration: ViewerConfiguration = {
         viewer: {
             html: require("../../../assets/templates/default/defaultViewer.html"),
             params: {
-                disableDragAndDrop: false
+                enableDragAndDrop: false
             }
         },
         navBar: {

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -47,9 +47,7 @@ export class DefaultViewer extends AbstractViewer {
         }
 
         if (this.configuration.templates && this.configuration.templates.viewer) {
-            if (this.configuration.templates.viewer.params && this.configuration.templates.viewer.params.disableDragAndDrop) {
-                // noop for now
-            } else {
+            if (this.configuration.templates.viewer.params && this.configuration.templates.viewer.params.enableDragAndDrop) {
                 let filesInput = new FilesInput(this.engine, this.sceneManager.scene, () => {
                 }, () => {
                 }, () => {

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -46,16 +46,23 @@ export class DefaultViewer extends AbstractViewer {
             });
         }
 
-        let filesInput = new FilesInput(this.engine, this.sceneManager.scene, () => {
-        }, () => {
-        }, () => {
-        }, () => {
-        }, function () {
-        }, (file: File) => {
-            this.loadModel(file);
-        }, () => {
-        });
-        filesInput.monitorElementForDragNDrop(this.templateManager.getCanvas()!);
+        if (this.configuration.templates && this.configuration.templates.viewer) {
+            if (this.configuration.templates.viewer.params && this.configuration.templates.viewer.params.disableDragAndDrop) {
+                // noop for now
+            } else {
+                let filesInput = new FilesInput(this.engine, this.sceneManager.scene, () => {
+                }, () => {
+                }, () => {
+                }, () => {
+                }, function () {
+                }, (file: File) => {
+                    this.loadModel(file);
+                }, () => {
+                });
+                filesInput.monitorElementForDragNDrop(this.templateManager.getCanvas()!);
+            }
+        }
+
 
         return super._onTemplatesLoaded();
     }

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -3,7 +3,7 @@
 import { ViewerConfiguration, IModelConfiguration, ILightConfiguration } from './../configuration/configuration';
 import { Template, EventCallback } from './../templateManager';
 import { AbstractViewer } from './viewer';
-import { SpotLight, MirrorTexture, Plane, ShadowGenerator, Texture, BackgroundMaterial, Observable, ShadowLight, CubeTexture, BouncingBehavior, FramingBehavior, Behavior, Light, Engine, Scene, AutoRotationBehavior, AbstractMesh, Quaternion, StandardMaterial, ArcRotateCamera, ImageProcessingConfiguration, Color3, Vector3, SceneLoader, Mesh, HemisphericLight } from 'babylonjs';
+import { SpotLight, MirrorTexture, Plane, ShadowGenerator, Texture, BackgroundMaterial, Observable, ShadowLight, CubeTexture, BouncingBehavior, FramingBehavior, Behavior, Light, Engine, Scene, AutoRotationBehavior, AbstractMesh, Quaternion, StandardMaterial, ArcRotateCamera, ImageProcessingConfiguration, Color3, Vector3, SceneLoader, Mesh, HemisphericLight, FilesInput } from 'babylonjs';
 import { CameraBehavior } from '../interfaces';
 import { ViewerModel } from '../model/viewerModel';
 import { extendClassWithConfig } from '../helper';
@@ -43,10 +43,25 @@ export class DefaultViewer extends AbstractViewer {
         if (closeButton) {
             closeButton.addEventListener('pointerdown', () => {
                 this.hideOverlayScreen();
-            })
+            });
         }
 
+        let filesInput = new FilesInput(this.engine, this.sceneManager.scene, () => {
+        }, () => {
+        }, () => {
+        }, () => {
+        }, function () {
+        }, (file: File) => {
+            this.loadModel(file);
+        }, () => {
+        });
+        filesInput.monitorElementForDragNDrop(this.templateManager.getCanvas()!);
+
         return super._onTemplatesLoaded();
+    }
+
+    private _dropped(evt: EventCallback) {
+
     }
 
     private _initNavbar() {
@@ -302,7 +317,7 @@ export class DefaultViewer extends AbstractViewer {
      * The scene will automatically be cleared of the old models, if exist.
      * @param model the configuration object (or URL) to load.
      */
-    public loadModel(model?: string | IModelConfiguration): Promise<ViewerModel> {
+    public loadModel(model?: string | File | IModelConfiguration): Promise<ViewerModel> {
         if (!model) {
             model = this.configuration.model;
         }

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -30,6 +30,7 @@
 - Nav-Bar is now disaplayed on fullscreen per default ([RaananW](https://github.com/RaananW))
 - Viewer configuration supports deprecated values using the new configurationCompatibility processor  ([RaananW](https://github.com/RaananW))
 - Shadows will only render while models are entering the scene or animating ([RaananW](https://github.com/RaananW))
+- Support for model drag and drop onto the canvas ([RaananW](https://github.com/RaananW))
 
 ## Bug fixes
 


### PR DESCRIPTION
viewer now supports drag and drop and has it enabled per default.
That means - you can paste the model's files (including subfolders) and the viewer will display the model according to the predefined configuration.

To disable the feature you can use the param "disableDrapAndDrop" in the params of the viewer template. html example:

```html
<babylon templates.viewer.params.disable-drag-and-drop="true">...</babylon>
```

or JSON:

```javascript
{
    templates: {
        viewer: {
            params: {
                disableDragAndDrop: true
            }
        }
    }
}
```

Addressing https://github.com/BabylonJS/Babylon.js/issues/3075