### PR TITLE
[Viewer] Lab feature - global light rotation for the configuration

### DIFF
--- a/Viewer/src/configuration/configuration.ts
+++ b/Viewer/src/configuration/configuration.ts
@@ -43,7 +43,10 @@ export interface ViewerConfiguration {
     skybox?: boolean | ISkyboxConfiguration;
 
     ground?: boolean | IGroundConfiguration;
-    lights?: { [name: string]: boolean | ILightConfiguration },
+    lights?: {
+        //globalRotation: number,
+        [name: string]: number | boolean | ILightConfiguration
+    },
     // engine configuration. optional!
     engine?: {
         renderInBackground?: boolean;
@@ -107,6 +110,7 @@ export interface ViewerConfiguration {
             tintLevel: number;
         }
         defaultRenderingPipelines?: boolean | IDefaultRenderingPipelineConfiguration;
+        globalLightRotation?: number;
     }
 }
 

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -481,7 +481,7 @@ export class DefaultViewer extends AbstractViewer {
      * @param lightsConfiguration the light configuration to use
      * @param model the model that will be used to configure the lights (if the lights are model-dependant)
      */
-    private _configureLights(lightsConfiguration: { [name: string]: ILightConfiguration | boolean } = {}, model?: ViewerModel) {
+    private _configureLights(lightsConfiguration: { [name: string]: ILightConfiguration | boolean | number } = {}, model?: ViewerModel) {
         // labs feature - flashlight
         if (this._configuration.lab && this._configuration.lab.flashlight) {
             let pointerPosition = Vector3.Zero();

--- a/Viewer/src/viewer/sceneManager.ts
+++ b/Viewer/src/viewer/sceneManager.ts
@@ -142,6 +142,7 @@ export class SceneManager {
                 if (this._forceShadowUpdate || (scene.animatables && scene.animatables.length > 0)) {
                     // make sure all models are loaded
                     updateShadows();
+                    this._forceShadowUpdate = false;
                 } else if (!(this.models.every((model) => {
                     if (!model.shadowsRenderedAfterLoad) {
                         model.shadowsRenderedAfterLoad = true;
@@ -800,7 +801,7 @@ export class SceneManager {
         if (this.scene.imageProcessingConfiguration) {
             this.scene.imageProcessingConfiguration.colorCurvesEnabled = true;
             this.scene.imageProcessingConfiguration.vignetteEnabled = true;
-            this.scene.imageProcessingConfiguration.toneMappingEnabled = !!cameraConfig.toneMappingEnabled;
+            this.scene.imageProcessingConfiguration.toneMappingEnabled = !!getConfigurationKey("camera.toneMappingEnabled", this._viewer.configuration);
         }
 
         extendClassWithConfig(this.camera, cameraConfig);
@@ -821,6 +822,11 @@ export class SceneManager {
         this.camera.alpha = (this._viewer.configuration.camera && this._viewer.configuration.camera.alpha) || this.camera.alpha;
         this.camera.beta = (this._viewer.configuration.camera && this._viewer.configuration.camera.beta) || this.camera.beta;
         this.camera.radius = (this._viewer.configuration.camera && this._viewer.configuration.camera.radius) || this.camera.radius;
+
+        /*this.scene.lights.filter(light => light instanceof ShadowLight).forEach(light => {
+            // casting ais safe, due to the constraints tested before
+            (<ShadowLight>light).setDirectionToTarget(center);
+        });*/
     }
 
     protected _configureEnvironment(skyboxConifguration?: ISkyboxConfiguration | boolean, groundConfiguration?: IGroundConfiguration | boolean) {

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -33,6 +33,7 @@
 - Viewer configuration supports deprecated values using the new configurationCompatibility processor  ([RaananW](https://github.com/RaananW))
 - Shadows will only render while models are entering the scene or animating ([RaananW](https://github.com/RaananW))
 - Support for model drag and drop onto the canvas ([RaananW](https://github.com/RaananW))
+- New lab feature - global light rotation [#4347](https://github.com/BabylonJS/Babylon.js/issues/4347) ([RaananW](https://github.com/RaananW))
 
 ## Bug fixes
 


### PR DESCRIPTION
The global light rotation will turn the shadow lights in the scene around the UP axis and will set the target again (per default to 0,0,0) so that the shadows will be updated correctly.
Note that the changes are from the current state of the light, so a second call with global light rotation of 0.1 will result in 0.2 rotation.

Demo (updating global light rotation on every frame, amount 0.01):

![babylonjs viewer - basic usage - edited](https://user-images.githubusercontent.com/1381702/40327921-dae6907c-5d44-11e8-82cc-ebd4206983f0.gif)

Code for the demo:

```javascript
viewer.sceneManager.scene.registerBeforeRender(() => {
                            viewer.updateConfiguration({
                                lab: {
                                    globalLightRotation: 0.01
                                }
                            })
                        });
```
Issue - https://github.com/BabylonJS/Babylon.js/issues/4347