### PR TITLE
[Viewer] using the previously set value for enableBlending

### DIFF
--- a/Viewer/src/model/viewerModel.ts
+++ b/Viewer/src/model/viewerModel.ts
@@ -280,9 +280,10 @@ export class ViewerModel implements IDisposable {
      */
     private _enterScene(completeCallback?: () => void): void {
         const scene = this.rootMesh.getScene();
+        let previousValue = scene.animationPropertiesOverride!.enableBlending;
         let callback = () => {
             this.state = ModelState.ENTRYDONE;
-            scene.animationPropertiesOverride!.enableBlending = true;
+            scene.animationPropertiesOverride!.enableBlending = previousValue;
             this._checkCompleteState();
             if (completeCallback) completeCallback();
         }

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -68,6 +68,7 @@
 - Ground material didn't take the default main color is no material definition was provided ([RaananW](https://github.com/RaananW))
 - Model configuration was not extended correctly if loaded more than one model ([RaananW](https://github.com/RaananW))
 - It wasn't possible to disable camera behavior(s) using configuration  [#4348](https://github.com/BabylonJS/Babylon.js/issues/4348) ([RaananW](https://github.com/RaananW))
+- Animation blending was always set to true, ignoring configuration [#4412](https://github.com/BabylonJS/Babylon.js/issues/4412) ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 


### PR DESCRIPTION
Until now I forced "true" after the model was loaded.
now It will check for the previous value.
It will force "false" when a  model is loaded, otherwise the  enter aniamtion will not work.

Fixing #4412 