### PR TITLE
Adding way to serialize all materials in SceneSerializer.SerializeMesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -52,6 +52,7 @@
 
 - VR experience helper will now fire pointer events even when no mesh is currently hit ([TrevorDev](https://github.com/TrevorDev))
 - RawTexture.CreateAlphaTexture no longer fails to create a usable texture ([TrevorDev](https://github.com/TrevorDev))
+- SceneSerializer.SerializeMesh now serializes all materials kinds (not only StandardMaterial) ([julien-moreau](https://github.com/julien-moreau))
 
 ### Core Engine
 

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -60,12 +60,12 @@
         return serializationObject;
     };
 
-    var finalizeSingleMesh = (mesh: Mesh, serializationObject: any) => {
+    var finalizeSingleMesh = (mesh: Mesh, serializationObject: any, withMaterial: boolean = false) => {
         //only works if the mesh is already loaded
         if (mesh.delayLoadState === Engine.DELAYLOADSTATE_LOADED || mesh.delayLoadState === Engine.DELAYLOADSTATE_NONE) {
             //serialize material
             if (mesh.material) {
-                if (mesh.material instanceof StandardMaterial) {
+                if (withMaterial || mesh.material instanceof StandardMaterial) {
                     serializationObject.materials = serializationObject.materials || [];
                     if (!serializationObject.materials.some((mat: Material) => (mat.id === (<Material>mesh.material).id))) {
                         serializationObject.materials.push(mesh.material.serialize());
@@ -318,7 +318,7 @@
             return serializationObject;
         }
 
-        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false, withChildren: boolean = false): any {
+        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false, withChildren: boolean = false, withMaterial: boolean = false): any {
             var serializationObject: any = {};
 
             SceneSerializer.ClearCache();
@@ -343,7 +343,7 @@
             }
 
             toSerialize.forEach((mesh: Mesh) => {
-                finalizeSingleMesh(mesh, serializationObject);
+                finalizeSingleMesh(mesh, serializationObject, withMaterial);
             });
 
             return serializationObject;

--- a/src/Tools/babylon.sceneSerializer.ts
+++ b/src/Tools/babylon.sceneSerializer.ts
@@ -60,22 +60,22 @@
         return serializationObject;
     };
 
-    var finalizeSingleMesh = (mesh: Mesh, serializationObject: any, withMaterial: boolean = false) => {
+    var finalizeSingleMesh = (mesh: Mesh, serializationObject: any) => {
         //only works if the mesh is already loaded
         if (mesh.delayLoadState === Engine.DELAYLOADSTATE_LOADED || mesh.delayLoadState === Engine.DELAYLOADSTATE_NONE) {
             //serialize material
             if (mesh.material) {
-                if (withMaterial || mesh.material instanceof StandardMaterial) {
-                    serializationObject.materials = serializationObject.materials || [];
-                    if (!serializationObject.materials.some((mat: Material) => (mat.id === (<Material>mesh.material).id))) {
-                        serializationObject.materials.push(mesh.material.serialize());
-                    }
-                } else if (mesh.material instanceof MultiMaterial) {
+                if (mesh.material instanceof MultiMaterial) {
                     serializationObject.multiMaterials = serializationObject.multiMaterials || [];
                     if (!serializationObject.multiMaterials.some((mat: Material) => (mat.id === (<Material>mesh.material).id))) {
                         serializationObject.multiMaterials.push(mesh.material.serialize());
                     }
 
+                } else {
+                    serializationObject.materials = serializationObject.materials || [];
+                    if (!serializationObject.materials.some((mat: Material) => (mat.id === (<Material>mesh.material).id))) {
+                        serializationObject.materials.push(mesh.material.serialize());
+                    }
                 }
             }
             //serialize geometry
@@ -318,7 +318,7 @@
             return serializationObject;
         }
 
-        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false, withChildren: boolean = false, withMaterial: boolean = false): any {
+        public static SerializeMesh(toSerialize: any /* Mesh || Mesh[] */, withParents: boolean = false, withChildren: boolean = false): any {
             var serializationObject: any = {};
 
             SceneSerializer.ClearCache();
@@ -343,7 +343,7 @@
             }
 
             toSerialize.forEach((mesh: Mesh) => {
-                finalizeSingleMesh(mesh, serializationObject, withMaterial);
+                finalizeSingleMesh(mesh, serializationObject);
             });
 
             return serializationObject;


### PR DESCRIPTION
This is one solution to force serializing all material types when calling SceneSerializer.SerializeMesh
Do you thing removing like 68 may not create breaking change ? It looks like materials were already serialized but only standard materials