### PR TITLE
glTFSerializer: Refactor alpha mode handling

### DIFF
--- a/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFMaterial.ts
@@ -370,7 +370,7 @@ module BABYLON.GLTF2 {
 
                         proceduralTexture.setTexture('textureSampler', texture);
                         proceduralTexture.onGenerated = () => {    
-                            resolve(proceduralTexture) 
+                            resolve(proceduralTexture);
                         };
 
                     }


### PR DESCRIPTION
- Simplify the alpha mode calculation
- Use `onGenerated` for `ProceduralTexture`  instead of `onLoadObservable`