### PR TITLE
Add perf counters to glTF loader

### DIFF
--- a/inspector/src/tabs/GLTFTab.ts
+++ b/inspector/src/tabs/GLTFTab.ts
@@ -159,8 +159,8 @@ module INSPECTOR {
                 defaults.extensions[extension.name] = extensionDefaults;
             });
 
-            const data = '{ "asset": { "version": "2.0" }, "scenes": [ { } ] }';
-            return loader.loadAsync(scene, data, "").then(() => {
+            const data = '{ "asset": { "version": "2.0" } }';
+            return loader.importMeshAsync([], scene, data, "").then(() => {
                 scene.dispose();
                 engine.dispose();
 

--- a/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -45,23 +45,39 @@ module BABYLON.GLTF2.Extensions {
 
             this._loader._readyPromise.then(() => {
                 for (let indexLOD = 0; indexLOD < this._nodePromiseLODs.length; indexLOD++) {
-                    Promise.all(this._nodePromiseLODs[indexLOD]).then(() => {
+                    const promise = Promise.all(this._nodePromiseLODs[indexLOD]).then(() => {
+                        if (indexLOD !== 0) {
+                            this._loader._parent._endPerformanceCounter(`Node LOD ${indexLOD}`);
+                        }
+
                         this._loader._parent._log(`Loaded node LOD ${indexLOD}`);
                         this.onNodeLODsLoadedObservable.notifyObservers(indexLOD);
+
                         if (indexLOD !== this._nodePromiseLODs.length - 1) {
+                            this._loader._parent._startPerformanceCounter(`Node LOD ${indexLOD + 1}`);
                             this._nodeSignalLODs[indexLOD].resolve();
                         }
                     });
+
+                    this._loader._completePromises.push(promise);
                 }
 
                 for (let indexLOD = 0; indexLOD < this._materialPromiseLODs.length; indexLOD++) {
-                    Promise.all(this._materialPromiseLODs[indexLOD]).then(() => {
+                    const promise = Promise.all(this._materialPromiseLODs[indexLOD]).then(() => {
+                        if (indexLOD !== 0) {
+                            this._loader._parent._endPerformanceCounter(`Material LOD ${indexLOD}`);
+                        }
+
                         this._loader._parent._log(`Loaded material LOD ${indexLOD}`);
                         this.onMaterialLODsLoadedObservable.notifyObservers(indexLOD);
-                        if (indexLOD !==  this._materialPromiseLODs.length - 1) {
+
+                        if (indexLOD !== this._materialPromiseLODs.length - 1) {
+                            this._loader._parent._startPerformanceCounter(`Material LOD ${indexLOD + 1}`);
                             this._materialSignalLODs[indexLOD].resolve();
                         }
                     });
+
+                    this._loader._completePromises.push(promise);
                 }
             });
         }
@@ -110,7 +126,6 @@ module BABYLON.GLTF2.Extensions {
                         firstPromise = promise;
                     }
                     else {
-                        this._loader._completePromises.push(promise);
                         this._nodeIndexLOD = null;
                     }
 
@@ -159,7 +174,6 @@ module BABYLON.GLTF2.Extensions {
                         firstPromise = promise;
                     }
                     else {
-                        this._loader._completePromises.push(promise);
                         this._materialIndexLOD = null;
                     }
 

--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -147,8 +147,11 @@ module BABYLON.GLTF2 {
 
         private _loadAsync(nodes: Nullable<Array<number>>): Promise<void> {
             return Promise.resolve().then(() => {
+                this._parent._startPerformanceCounter("Loading => Ready");
+                this._parent._startPerformanceCounter("Loading => Complete");
+
                 this._state = GLTFLoaderState.LOADING;
-                this._parent._log(`Loading`);
+                this._parent._log("Loading");
 
                 const readyDeferred = new Deferred<void>();
                 this._readyPromise = readyDeferred.promise;
@@ -176,7 +179,7 @@ module BABYLON.GLTF2 {
 
                 const resultPromise = Promise.all(promises).then(() => {
                     this._state = GLTFLoaderState.READY;
-                    this._parent._log(`Ready`);
+                    this._parent._log("Ready");
 
                     readyDeferred.resolve();
 
@@ -184,6 +187,8 @@ module BABYLON.GLTF2 {
                 });
 
                 resultPromise.then(() => {
+                    this._parent._endPerformanceCounter("Loading => Ready");
+
                     if (this._rootBabylonMesh) {
                         this._rootBabylonMesh.setEnabled(true);
                     }
@@ -191,8 +196,10 @@ module BABYLON.GLTF2 {
                     Tools.SetImmediate(() => {
                         if (!this._disposed) {
                             Promise.all(this._completePromises).then(() => {
+                                this._parent._endPerformanceCounter("Loading => Complete");
+
                                 this._state = GLTFLoaderState.COMPLETE;
-                                this._parent._log(`Complete`);
+                                this._parent._log("Complete");
 
                                 this._parent.onCompleteObservable.notifyObservers(undefined);
                                 this._parent.onCompleteObservable.clear();
@@ -1667,6 +1674,8 @@ module BABYLON.GLTF2 {
         }
 
         private _compileMaterialsAsync(): Promise<void> {
+            this._parent._startPerformanceCounter("Compile materials");
+
             const promises = new Array<Promise<void>>();
 
             if (this._gltf.materials) {
@@ -1689,10 +1698,14 @@ module BABYLON.GLTF2 {
                 }
             }
 
-            return Promise.all(promises).then(() => {});
+            return Promise.all(promises).then(() => {
+                this._parent._endPerformanceCounter("Compile materials");
+            });
         }
 
         private _compileShadowGeneratorsAsync(): Promise<void> {
+            this._parent._startPerformanceCounter("Compile shadow generators");
+
             const promises = new Array<Promise<void>>();
 
             const lights = this._babylonScene.lights;
@@ -1703,7 +1716,9 @@ module BABYLON.GLTF2 {
                 }
             }
 
-            return Promise.all(promises).then(() => {});
+            return Promise.all(promises).then(() => {
+                this._parent._endPerformanceCounter("Compile shadow generators");
+            });
         }
 
         public _applyExtensions<T>(actionAsync: (extension: GLTFLoaderExtension) => Nullable<Promise<T>>): Nullable<Promise<T>> {

--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -264,8 +264,9 @@ if (BABYLON.Engine.isSupported()) {
 
     window.addEventListener("keydown", function (event) {
         // Press R to reload
-        if (event.keyCode === 82 && event.target.nodeName !== "INPUT") {
+        if (event.keyCode === 82 && event.target.nodeName !== "INPUT" && currentScene) {
             debugLayerLastActiveTab = currentScene.debugLayer.getActiveTab();
+
             if (assetUrl) {
                 loadFromAssetUrl();
             }

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -4477,8 +4477,6 @@
             if (!this.activeCamera)
                 throw new Error("Active camera not set");
 
-            Tools.StartPerformanceCounter("Rendering camera " + this.activeCamera.name);
-
             // Viewport
             engine.setViewport(this.activeCamera.viewport);
 
@@ -4657,8 +4655,6 @@
             this._alternateRendering = false;
 
             this.onAfterCameraRenderObservable.notifyObservers(this.activeCamera);
-
-            Tools.EndPerformanceCounter("Rendering camera " + this.activeCamera.name);
         }
 
         private _processSubCameras(camera: Camera): void {


### PR DESCRIPTION
User timings in performance tab in Chrome.
![image](https://user-images.githubusercontent.com/19158740/41196472-b86d4f44-6bf5-11e8-81b8-ef50c7bf620b.png)

Improved LOD loading code. Log entries for LODs now show up in the right order.
```
BJS - [14:51:57]: Loaded TwoQuads.bin (104 bytes)
babylon.max.js:9663 BJS - [14:51:57]: Loaded LOD2.png (206 bytes)
babylon.max.js:9663 BJS - [14:51:57]: Ready
babylon.max.js:9663 BJS - [14:51:57]: Loaded material LOD 0
babylon.max.js:9663 BJS - [14:51:57]: Loading LOD1.png
babylon.max.js:9663 BJS - [14:51:59]: Loaded LOD1.png (209 bytes)
babylon.max.js:9663 BJS - [14:51:59]: Loaded material LOD 1
babylon.max.js:9663 BJS - [14:51:59]: Loading LOD0.png
babylon.max.js:9663 BJS - [14:52:01]: Loaded LOD0.png (686 bytes)
babylon.max.js:9663 BJS - [14:52:01]: Loaded material LOD 2
babylon.max.js:9663 BJS - [14:52:01]: Complete
```