### PR TITLE
non-normalized meshes didn't have the right focus

### DIFF
--- a/Viewer/src/configuration/types/default.ts
+++ b/Viewer/src/configuration/types/default.ts
@@ -95,8 +95,7 @@ export let defaultConfiguration: ViewerConfiguration = {
             bouncing: {
                 type: 1
             }
-        },
-        wheelPrecision: 200,
+        }
     },
     skybox: {
     },

--- a/Viewer/src/managers/sceneManager.ts
+++ b/Viewer/src/managers/sceneManager.ts
@@ -814,9 +814,6 @@ export class SceneManager {
         const sceneDiagonalLenght = sceneDiagonal.length();
         if (isFinite(sceneDiagonalLenght))
             this.camera.upperRadiusLimit = sceneDiagonalLenght * 4;
-        else {
-            this.camera.upperRadiusLimit = 10;
-        }
 
         // sanity check!
         if (this.scene.imageProcessingConfiguration) {
@@ -844,6 +841,12 @@ export class SceneManager {
         this.camera.beta = (this._globalConfiguration.camera && this._globalConfiguration.camera.beta) || this.camera.beta;
         this.camera.radius = (this._globalConfiguration.camera && this._globalConfiguration.camera.radius) || this.camera.radius;
 
+        const sceneDiagonalLenght = sizeVec.length();
+        if (isFinite(sceneDiagonalLenght))
+            this.camera.upperRadiusLimit = sceneDiagonalLenght * 4;
+
+        if (this._configurationContainer.configuration)
+            this._configureEnvironment(this._configurationContainer.configuration.skybox, this._configurationContainer.configuration.ground);
         /*this.scene.lights.filter(light => light instanceof ShadowLight).forEach(light => {
             // casting ais safe, due to the constraints tested before
             (<ShadowLight>light).setDirectionToTarget(center);
@@ -960,7 +963,10 @@ export class SceneManager {
                     this.environmentHelper.dispose();
                     this.environmentHelper = this.scene.createDefaultEnvironment(options)!;
                 } else {
-                    this.environmentHelper.updateOptions(options)!;
+                    //this.environmentHelper.updateOptions(options)!;
+                    // update doesn't change the size of the skybox and ground, so we have to recreate!
+                    this.environmentHelper.dispose();
+                    this.environmentHelper = this.scene.createDefaultEnvironment(options)!;
                 }
             }
 

--- a/Viewer/tests/unit/src/viewer/sceneManager.ts
+++ b/Viewer/tests/unit/src/viewer/sceneManager.ts
@@ -184,7 +184,7 @@ describe(name, function () {
             viewer.sceneManager.groundMirrorEnabled = false;
 
             assert.isDefined(viewer.sceneManager.environmentHelper.groundMaterial);
-            assert.isNull(viewer.sceneManager.environmentHelper.groundMaterial!.reflectionTexture);
+            assert.isNotOk(viewer.sceneManager.environmentHelper.groundMaterial!.reflectionTexture);
 
             viewer.sceneManager.groundMirrorEnabled = true;
 
@@ -198,7 +198,7 @@ describe(name, function () {
             });
 
             assert.isDefined(viewer.sceneManager.environmentHelper.groundMaterial);
-            assert.isNull(viewer.sceneManager.environmentHelper.groundMaterial!.reflectionTexture);
+            assert.isNotOk(viewer.sceneManager.environmentHelper.groundMaterial!.reflectionTexture);
             assert.isTrue(viewer.sceneManager.groundMirrorEnabled);
 
             viewer.dispose();

--- a/Viewer/tsconfig.json
+++ b/Viewer/tsconfig.json
@@ -9,7 +9,7 @@
         "strictNullChecks": true,
         "noImplicitAny": false,
         "noFallthroughCasesInSwitch": true,
-        "inlineSourceMap": true,
+        "sourceMap": true,
         "lib": [
             "es5",
             "dom",

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -84,6 +84,7 @@
 - It wasn't possible to disable camera behavior(s) using configuration  [#4348](https://github.com/BabylonJS/Babylon.js/issues/4348) ([RaananW](https://github.com/RaananW))
 - Animation blending was always set to true, ignoring configuration [#4412](https://github.com/BabylonJS/Babylon.js/issues/4412) ([RaananW](https://github.com/RaananW))
 - Animation navbar now updates correctly when a new model is loaded [#4441](https://github.com/BabylonJS/Babylon.js/issues/4441) ([RaananW](https://github.com/RaananW))
+- Non-normalized meshes didn't center and focus correctly ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 


### PR DESCRIPTION
There were a few problems with the calculation of max-radius and env-size.
Env is now recreated when a model is loaded, since the  env's update function doesn't update ground/skybox's size.