### PR TITLE
Fixed issues with CreateTexture when compressed Texture is enabled.

### DIFF
--- a/src/Engine/babylon.engine.ts
+++ b/src/Engine/babylon.engine.ts
@@ -4171,7 +4171,7 @@
 
             // determine if a ktx file should be substituted
             var isKTX = false;
-            if (this._textureFormatInUse && !isBase64 && !fallback) {
+            if (this._textureFormatInUse && !isBase64 && !fallback && !buffer) {
                 url = url.substring(0, lastDot) + this._textureFormatInUse;
                 isKTX = true;
             }
@@ -4201,7 +4201,8 @@
                     scene._removePendingData(texture);
                 }
 
-                if (onLoadObserver) {
+                if (onLoadObserver && !isKTX) {
+                    //dont remove the observer if its a ktx file, since the fallback createTexture call will require it.
                     texture.onLoadedObservable.remove(onLoadObserver);
                 }
 


### PR DESCRIPTION
1.) Added check in CreateTexture to disallow use of compressed Texture when a buffer is passed. This allows use of Texture.CreateFromBase64String while compressed textures are enabled.

2.) Added isKTX check before removing LoadObserver when error is due to unavailability of .ktx format image. This allows fallback CreateTexture call to run the onLoad.