### PR TITLE
initial VR support for the viewer

### DIFF
--- a/Viewer/src/managers/sceneManager.ts
+++ b/Viewer/src/managers/sceneManager.ts
@@ -813,9 +813,10 @@ export class SceneManager {
             return !this.environmentHelper || (mesh !== this.environmentHelper.ground && mesh !== this.environmentHelper.rootMesh && mesh !== this.environmentHelper.skybox);
         });
         const sceneDiagonal = sceneExtends.max.subtract(sceneExtends.min);
-        const sceneDiagonalLenght = sceneDiagonal.length();
-        if (isFinite(sceneDiagonalLenght))
-            this.camera.upperRadiusLimit = sceneDiagonalLenght * 4;
+        const sceneDiagonalLength = sceneDiagonal.length();
+        if (isFinite(sceneDiagonalLength)) {
+            this.camera.upperRadiusLimit = sceneDiagonalLength * 4;
+        }
 
         // sanity check!
         if (this.scene.imageProcessingConfiguration) {

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -66,6 +66,7 @@
 - New lab feature - global light rotation [#4347](https://github.com/BabylonJS/Babylon.js/issues/4347) ([RaananW](https://github.com/RaananW))
 - New NPM package - babylonjs-viewer-assets, to separate the binary assets and the code of the viewer ([RaananW](https://github.com/RaananW))
 - A new HD-Toggler button allows setting a better hardware scaling rate ([RaananW](https://github.com/RaananW))
+- An initial support for WebVR is implemented ([RaananW](https://github.com/RaananW))
 
 ### Documentation
 


### PR DESCRIPTION
* A new VR helper will be created when the viewer was done initializing.
* For now there is no UI element to enable this.
* The function toggleVR() will toggle between the two modes.
* In VR mode the object AND environment will be scaled to fit the VR perspective.
* In VR the object will float in front of the user's eyes.
* For now there is no option to move or scale the object in VR.
* Position tracking is turned on and also teleportation on the ground. User can go around the object.

Initial commit for https://github.com/BabylonJS/Babylon.js/issues/4413