### PR TITLE
Node's setParent(node.parent) will no longer throw an exception when …

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -83,6 +83,7 @@
 - SceneSerializer.SerializeMesh now serializes all materials kinds (not only StandardMaterial) ([julien-moreau](https://github.com/julien-moreau))
 - WindowsMotionController's trackpad field will be updated prior to it's onTrackpadChangedObservable event ([TrevorDev](https://github.com/TrevorDev))
 - VR experience helper's controllers will not fire pointer events when laser's are disabled, instead the camera ray pointer event will be used ([TrevorDev](https://github.com/TrevorDev))
+- Node's setParent(node.parent) will no longer throw an exception when parent is undefined and will behave the same as setParent(null) ([TrevorDev](https://github.com/TrevorDev))
 
 ### Core Engine
 

--- a/src/Mesh/babylon.transformNode.ts
+++ b/src/Mesh/babylon.transformNode.ts
@@ -536,10 +536,10 @@ module BABYLON {
          * Returns the TransformNode.
          */
         public setParent(node: Nullable<Node>): TransformNode {
-            if (node === null && this.parent === null) {
+            if (!node && !this.parent) {
                 return this;
             }
-            if (node === null) {
+            if (!node) {
                 var rotation = Tmp.Quaternion[0];
                 var position = Tmp.Vector3[0];
                 var scale = Tmp.Vector3[1];


### PR DESCRIPTION
…parent is undefined and will behave the same as setParent(null)