### PR TITLE
Flip triangles when calling MergeMeshes on a mesh with negative scaling.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -85,6 +85,7 @@
 - WindowsMotionController's trackpad field will be updated prior to it's onTrackpadChangedObservable event ([TrevorDev](https://github.com/TrevorDev))
 - VR experience helper's controllers will not fire pointer events when laser's are disabled, instead the camera ray pointer event will be used ([TrevorDev](https://github.com/TrevorDev))
 - Node's setParent(node.parent) will no longer throw an exception when parent is undefined and will behave the same as setParent(null) ([TrevorDev](https://github.com/TrevorDev))
+- Mesh.MergeMeshes flips triangles on meshes with negative scaling ([SvenFrankson](http://svenfrankson.com))
 
 ### Core Engine
 

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -326,9 +326,7 @@
          * @returns the VertexData 
          */
         public transform(matrix: Matrix): VertexData {
-            var scaling = Vector3.One();
-            matrix.decompose(scaling, BABYLON.Tmp.Quaternion[0], BABYLON.Tmp.Vector3[0]);
-            var flip = scaling.x * scaling.y * scaling.z < 0;
+            var flip = matrix.m[0] * matrix.m[5] * matrix.m[10] < 0;
             var transformed = Vector3.Zero();
             var index: number;
             if (this.positions) {

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -326,6 +326,9 @@
          * @returns the VertexData 
          */
         public transform(matrix: Matrix): VertexData {
+            var scaling = Vector3.One();
+            matrix.decompose(scaling, BABYLON.Tmp.Quaternion[0], BABYLON.Tmp.Vector3[0]);
+            var flip = scaling.x * scaling.y * scaling.z < 0;
             var transformed = Vector3.Zero();
             var index: number;
             if (this.positions) {
@@ -366,6 +369,14 @@
                     this.tangents[index + 1] = tangentTransformed.y;
                     this.tangents[index + 2] = tangentTransformed.z;
                     this.tangents[index + 3] = tangentTransformed.w;
+                }
+            }
+
+            if (flip && this.indices) {
+                for (index = 0; index < this.indices!.length; index += 3) {
+                    let tmp = this.indices[index + 1];
+                    this.indices[index + 1] = this.indices[index + 2];
+                    this.indices[index + 2] = tmp;
                 }
             }
 

--- a/what's new.md
+++ b/what's new.md
@@ -121,6 +121,7 @@
 - Added `alphaCutOff` support for StandardMaterial ([deltakosh](https://github.com/deltakosh))
 - New `serialize` and `Parse` functions for SSAO2 Rendering Pipeline ([julien-moreau](https://github.com/julien-moreau))
 - Added `furOcclusion` property to FurMaterial to control the occlusion strength ([julien-moreau](https://github.com/julien-moreau))
+- Mesh.MergeMeshes flips triangles on meshes with negative scaling ([SvenFrankson](http://svenfrankson.com))
 
 ## Bug fixes
 

--- a/what's new.md
+++ b/what's new.md
@@ -121,7 +121,6 @@
 - Added `alphaCutOff` support for StandardMaterial ([deltakosh](https://github.com/deltakosh))
 - New `serialize` and `Parse` functions for SSAO2 Rendering Pipeline ([julien-moreau](https://github.com/julien-moreau))
 - Added `furOcclusion` property to FurMaterial to control the occlusion strength ([julien-moreau](https://github.com/julien-moreau))
-- Mesh.MergeMeshes flips triangles on meshes with negative scaling ([SvenFrankson](http://svenfrankson.com))
 
 ## Bug fixes
 


### PR DESCRIPTION
Hi,

Here's a playground showing the issue I'd like to solve with this PR.

http://playground.babylonjs.com/#0FCSSC#1

Some recent update made BabylonJS compliant with the fact mesh triangles should be flipped when mesh.scaling is negative, both when rendering a mesh and when calling mesh.bakeTransformIntoVertices.

This PR flips triangles when calling Mesh.MergeMeshes.