### PR TITLE
Fixing particle systems parse function

### DIFF
--- a/src/Particles/babylon.particleSystem.ts
+++ b/src/Particles/babylon.particleSystem.ts
@@ -1593,10 +1593,19 @@
                 particleSystem.preventAutoStart = parsedParticleSystem.preventAutoStart;
             }
 
-            particleSystem.minEmitBox = Vector3.FromArray(parsedParticleSystem.minEmitBox);
-            particleSystem.maxEmitBox = Vector3.FromArray(parsedParticleSystem.maxEmitBox);
-            particleSystem.direction1 = Vector3.FromArray(parsedParticleSystem.direction1);
-            particleSystem.direction2 = Vector3.FromArray(parsedParticleSystem.direction2);
+            if (parsedParticleSystem.minEmitBox) {
+                particleSystem.minEmitBox = Vector3.FromArray(parsedParticleSystem.minEmitBox);
+            }
+            if (parsedParticleSystem.maxEmitBox) {
+                particleSystem.maxEmitBox = Vector3.FromArray(parsedParticleSystem.maxEmitBox);
+            }
+
+            if (parsedParticleSystem.direction1) {
+                particleSystem.direction1 = Vector3.FromArray(parsedParticleSystem.direction1);
+            }
+            if (parsedParticleSystem.direction2) {
+                particleSystem.direction2 = Vector3.FromArray(parsedParticleSystem.direction2);
+            }
 
             ParticleSystem._Parse(parsedParticleSystem, particleSystem, scene, rootUrl);
 

--- a/src/Particles/babylon.particleSystem.ts
+++ b/src/Particles/babylon.particleSystem.ts
@@ -1593,20 +1593,6 @@
                 particleSystem.preventAutoStart = parsedParticleSystem.preventAutoStart;
             }
 
-            if (parsedParticleSystem.minEmitBox) {
-                particleSystem.minEmitBox = Vector3.FromArray(parsedParticleSystem.minEmitBox);
-            }
-            if (parsedParticleSystem.maxEmitBox) {
-                particleSystem.maxEmitBox = Vector3.FromArray(parsedParticleSystem.maxEmitBox);
-            }
-
-            if (parsedParticleSystem.direction1) {
-                particleSystem.direction1 = Vector3.FromArray(parsedParticleSystem.direction1);
-            }
-            if (parsedParticleSystem.direction2) {
-                particleSystem.direction2 = Vector3.FromArray(parsedParticleSystem.direction2);
-            }
-
             ParticleSystem._Parse(parsedParticleSystem, particleSystem, scene, rootUrl);
 
             particleSystem.textureMask = Color4.FromArray(parsedParticleSystem.textureMask);


### PR DESCRIPTION
minEmitBox etc. are now part of the attached emitter (typically box emitter). These properties must be parsed only for backward compatibility and will not be present in the JSON data produced by .serialize() today