### PR TITLE
Do not validate program if linking failed

### DIFF
--- a/src/Engine/babylon.engine.ts
+++ b/src/Engine/babylon.engine.ts
@@ -3537,7 +3537,16 @@
             var linked = context.getProgramParameter(shaderProgram, context.LINK_STATUS);
 
             if (!linked) {
-                context.validateProgram(shaderProgram);
+                var error = context.getProgramInfoLog(shaderProgram);
+                if (error) {
+                    throw new Error(error);
+                }
+            }
+
+            context.validateProgram(shaderProgram);
+            var validated = context.getProgramParameter(shaderProgram, context.VALIDATE_STATUS);
+
+            if(!validated) {
                 var error = context.getProgramInfoLog(shaderProgram);
                 if (error) {
                     throw new Error(error);


### PR DESCRIPTION
Program validation should be executed for all programs.

In previous case, the validation occurred if link phase failed. Then the error would always be "program not linked", hiding the real error.