### PR TITLE
new init-started event

### DIFF
--- a/Viewer/src/managers/observablesManager.ts
+++ b/Viewer/src/managers/observablesManager.ts
@@ -44,6 +44,11 @@ export class ObservablesManager {
     public onViewerInitDoneObservable: Observable<any>;
 
     /**
+     * Will notify when the viewer init started (after configuration was loaded)
+     */
+    public onViewerInitStartedObservable: Observable<any>;
+
+    /**
      * Functions added to this observable will be executed on each frame rendered.
      */
     public onFrameRenderedObservable: Observable<any>;
@@ -57,6 +62,7 @@ export class ObservablesManager {
         this.onModelAddedObservable = new Observable();
         this.onModelRemovedObservable = new Observable();
         this.onViewerInitDoneObservable = new Observable();
+        this.onViewerInitStartedObservable = new Observable();
         this.onLoaderInitObservable = new Observable();
         this.onFrameRenderedObservable = new Observable();
     }

--- a/Viewer/src/viewer/viewer.ts
+++ b/Viewer/src/viewer/viewer.ts
@@ -372,6 +372,8 @@ export abstract class AbstractViewer {
         }
 
         this.templateManager = new TemplateManager(this.containerElement);
+
+        this.observablesManager.onViewerInitStartedObservable.notifyObservers(this);
     }
 
     /**


### PR DESCRIPTION
This will save a bit of boilerplate code and will allow the developer to modify the viewer before the (3d) initialization has started