### PR TITLE
Don't generate mipmaps for HDRCubeTexture if texture float filtering is disabled

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -107,6 +107,7 @@
 - Parse geometry when load binary mesh ([SinhNQ](https://github.com/quocsinh))
 - Removing observers during observable notify should not skip over valid observers ([TrevorDev](https://github.com/TrevorDev))
 - Initializing gamepadManager should register the gamepad update events ([TrevorDev](https://github.com/TrevorDev))
+- Do not generate mipmaps for HDRCubeTexture if OES_texture_float_linear isn't supported ([PeapBoy](https://github.com/NicolasBuecher))
 
 ### Core Engine
 

--- a/src/Engine/babylon.engine.ts
+++ b/src/Engine/babylon.engine.ts
@@ -5912,6 +5912,9 @@
                 }
                 else {
                     texture.generateMipMaps = !noMipmap;
+                    if (type === Engine.TEXTURETYPE_FLOAT && !this._caps.textureFloatLinearFiltering) {
+                        texture.generateMipMaps = false;
+                    }
                     this.updateRawCubeTexture(texture, faceDataArrays, format, type, invertY);
                 }
 

--- a/src/Materials/Textures/babylon.hdrCubeTexture.ts
+++ b/src/Materials/Textures/babylon.hdrCubeTexture.ts
@@ -118,7 +118,7 @@ module BABYLON {
             this._onError = onError;
             this.gammaSpace = gammaSpace;
 
-            this._noMipmap = noMipmap;
+            this._noMipmap = noMipmap || !scene.getEngine()._caps.textureFloatLinearFiltering;
             this._size = size;
 
             this._texture = this._getFromCache(url, this._noMipmap);

--- a/src/Materials/Textures/babylon.hdrCubeTexture.ts
+++ b/src/Materials/Textures/babylon.hdrCubeTexture.ts
@@ -118,7 +118,7 @@ module BABYLON {
             this._onError = onError;
             this.gammaSpace = gammaSpace;
 
-            this._noMipmap = noMipmap || !scene.getEngine()._caps.textureFloatLinearFiltering;
+            this._noMipmap = noMipmap;
             this._size = size;
 
             this._texture = this._getFromCache(url, this._noMipmap);


### PR DESCRIPTION
If OES_texture_float_linear extension is not supported, enabling mipmaps leads to:

![hdrcubetexturefix](https://user-images.githubusercontent.com/6748903/42270743-e640dbb2-7f81-11e8-9cd4-80b07e547875.PNG)

From [here at 3.8.10.5](https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf), we can read: 

> If the levelbase array was not specified with an unsized internal format from table
3.3 or a sized internal format that is both color-renderable and texture-filterable
according to table 3.13, an INVALID_OPERATION error is generated.

As far as I understand, because RGBA32F is not texture-filterable in this specific case, mipmaps generation fails.

I suggest to not generate mipmaps if OES_texture_float_linear is not supported thus.

I don't think I have to update What's new for this, do I ? (I'll do it just in case...)