### PR TITLE
Viewer - 2 issues

### DIFF
--- a/Viewer/src/configuration/types/extended.ts
+++ b/Viewer/src/configuration/types/extended.ts
@@ -61,8 +61,8 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 7,
             intensityMode: 0,
-            radius: 4.2,
-            range: 4.2,
+            radius: 0.6,
+            range: 4.4,
             spotAngle: 60,
             diffuse: {
                 r: 1,
@@ -100,7 +100,7 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 7,
             intensityMode: 0,
-            radius: 5.8,
+            radius: 0.4,
             range: 5.8,
             spotAngle: 57,
             diffuse: {
@@ -131,7 +131,7 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 1,
             intensityMode: 0,
-            radius: 6,
+            radius: 0.5,
             range: 6,
             spotAngle: 42.85,
             diffuse: {

--- a/Viewer/src/configuration/types/extended.ts
+++ b/Viewer/src/configuration/types/extended.ts
@@ -61,8 +61,8 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 7,
             intensityMode: 0,
-            radius: 0.6,
-            range: 0.6,
+            radius: 4.2,
+            range: 4.2,
             spotAngle: 60,
             diffuse: {
                 r: 1,
@@ -100,8 +100,8 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 7,
             intensityMode: 0,
-            radius: 0.4,
-            range: 0.4,
+            radius: 5.8,
+            range: 5.8,
             spotAngle: 57,
             diffuse: {
                 r: 1,
@@ -131,8 +131,8 @@ export let extendedConfiguration: ViewerConfiguration = {
             frustumEdgeFalloff: 0,
             intensity: 1,
             intensityMode: 0,
-            radius: 0.5,
-            range: 0.5,
+            radius: 6,
+            range: 6,
             spotAngle: 42.85,
             diffuse: {
                 r: 0.8,

--- a/Viewer/src/managers/sceneManager.ts
+++ b/Viewer/src/managers/sceneManager.ts
@@ -7,6 +7,7 @@ import { ViewerLabs } from '../labs/viewerLabs';
 import { getCustomOptimizerByName } from '../optimizer/custom/';
 import { ObservablesManager } from '../managers/observablesManager';
 import { ConfigurationContainer } from '../configuration/configurationContainer';
+import { deepmerge } from '../helper';
 
 /**
  * This interface describes the structure of the variable sent with the configuration observables of the scene manager.

--- a/Viewer/src/managers/sceneManager.ts
+++ b/Viewer/src/managers/sceneManager.ts
@@ -796,11 +796,11 @@ export class SceneManager {
             }
             return;
         }
-        let vrOptions: VRExperienceHelperOptions = vrConfig.vrOptions || {
+        let vrOptions: VRExperienceHelperOptions = deepmerge({
             useCustomVRButton: true,
             createDeviceOrientationCamera: false,
             trackPosition: true
-        }
+        }, vrConfig.vrOptions || {});
 
         this._vrHelper = this.scene.createDefaultVRExperience(vrOptions);
         if (!vrConfig.disableInteractions) {


### PR DESCRIPTION
1) if vrOptions were set, the default values would be completely ignored. They are now being extended.
2) non-pbr materials had a very short light range in the extended configuration. It is now lighting the materials correctly. PBR is left untouched.