### PR TITLE
glTFSerializer: Fix for handling negative scale

### DIFF
--- a/serializers/src/glTF/2.0/babylon.glTFExporter.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFExporter.ts
@@ -1205,7 +1205,7 @@ module BABYLON.GLTF2 {
             if (rootNodes.length === 1) {
                 const node = rootNodes[0];
                 if (node.scaling.equalsToFloats(1,1, -1)) {
-                    this._convertToRightHandedSystem = false;
+                    this._convertToRightHandedSystem = !this._convertToRightHandedSystem;
                     negScaleRootNode = node;
                 }  
             }

--- a/serializers/src/glTF/2.0/babylon.glTFExporter.ts
+++ b/serializers/src/glTF/2.0/babylon.glTFExporter.ts
@@ -1168,6 +1168,18 @@ module BABYLON.GLTF2 {
             });
         }
 
+        private getRootNodes(babylonScene: Scene, nodes: TransformNode[], shouldExportTransformNode: (babylonTransformNode: TransformNode) => boolean): TransformNode[] {
+            const rootNodes: TransformNode[] = [];
+            for (let babylonTransformNode of nodes) {
+                if (shouldExportTransformNode(babylonTransformNode)) {
+                    if (babylonTransformNode.parent == null) {
+                        rootNodes.push(babylonTransformNode);
+                    }
+                }
+            }
+            return rootNodes;
+        }
+
         /**
          * Creates a mapping of Node unique id to node index and handles animations
          * @param babylonScene Babylon Scene
@@ -1187,9 +1199,24 @@ module BABYLON.GLTF2 {
             let idleGLTFAnimations: IAnimation[] = [];
             let node: INode;
 
+            let negScaleRootNode: Nullable<TransformNode> = null;
+
+            const rootNodes = this.getRootNodes(babylonScene, nodes, shouldExportTransformNode);
+            if (rootNodes.length === 1) {
+                const node = rootNodes[0];
+                if (node.scaling.equalsToFloats(1,1, -1)) {
+                    this._convertToRightHandedSystem = false;
+                    negScaleRootNode = node;
+                }  
+            }
+
             for (let babylonTransformNode of nodes) {
                 if (shouldExportTransformNode(babylonTransformNode)) {
                     node = this.createNode(babylonTransformNode, binaryWriter);
+                    if (negScaleRootNode && babylonTransformNode === negScaleRootNode) {
+                        node.scale = [1,1,1];
+                        node.rotation = [0,0,0,1];
+                    }
 
                     this._nodes.push(node);
                     nodeIndex = this._nodes.length - 1;


### PR DESCRIPTION
- Fixes an issue where the winding order breaks when reimporting a mesh exported from the glTF serializer