### PR TITLE
Don't generate mipmaps for RawCubeTexture if rendering to float textures is disabled

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -118,7 +118,7 @@
 - Parse geometry when load binary mesh ([SinhNQ](https://github.com/quocsinh))
 - Removing observers during observable notify should not skip over valid observers ([TrevorDev](https://github.com/TrevorDev))
 - Initializing gamepadManager should register the gamepad update events ([TrevorDev](https://github.com/TrevorDev))
-- Do not generate mipmaps for HDRCubeTexture if OES_texture_float_linear isn't supported ([PeapBoy](https://github.com/NicolasBuecher))
+- Do not generate mipmaps for RawCubeTexture if OES_texture_float_linear and/or EXT_color_buffer_float extensions are not supported ([PeapBoy](https://github.com/NicolasBuecher))
 
 ### Core Engine
 

--- a/src/Engine/babylon.webgl2.ts
+++ b/src/Engine/babylon.webgl2.ts
@@ -12,6 +12,7 @@ interface WebGLRenderingContext {
     readonly TEXTURE_COMPARE_MODE: number;
     readonly COMPARE_REF_TO_TEXTURE: number;
     readonly TEXTURE_WRAP_R: number;
+    readonly HALF_FLOAT: number;
 
     texImage3D(target: number, level: number, internalformat: number, width: number, height: number, depth: number, border: number, format: number, type: number, pixels: ArrayBufferView | null): void;
     texImage3D(target: number, level: number, internalformat: number, width: number, height: number, depth: number, border: number, format: number, type: number, pixels: ArrayBufferView, offset: number): void;


### PR DESCRIPTION
Exactly for the same reasons as for [this PR](https://github.com/BabylonJS/Babylon.js/pull/4675), mipmap generation fails if rendering to float texture isn't supported.

And a fix: security checks about mipmap generation done in createRawCubeTexture() function were overwritten in the createRawCubeTextureFromUrl() function by [this line](https://github.com/BabylonJS/Babylon.js/blob/master/src/Engine/babylon.engine.ts#L5816).
