### PR TITLE
Cache-busting query string for files loaded into DB

### DIFF
--- a/src/Tools/babylon.database.ts
+++ b/src/Tools/babylon.database.ts
@@ -570,7 +570,7 @@ module BABYLON {
                 // Create XHR
                 var xhr = new XMLHttpRequest();
                 var fileData: any;
-                xhr.open("GET", url, true);
+                xhr.open("GET", url + "?" + Date.now(), true);
 
                 if (useArrayBuffer) {
                     xhr.responseType = "arraybuffer";


### PR DESCRIPTION
Chrome is extremely stubborn and will often stick to a cached version of a .babylon, even if the .manifest version has been updated. Adding a date-based query string to file requests, as is the case with .manifest requests, solves this.