### PR TITLE
Fix gulp default command (memory consumption)

### DIFF
--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -9,13 +9,13 @@
     "readme": "https://github.com/BabylonJS/Babylon.js/edit/master/readme.md",
     "license": "(Apache-2.0)",
     "devDependencies": {
-        "@types/node": "^8.9.4",
+        "@types/node": "^8.10.21",
         "base64-font-loader": "0.0.4",
         "base64-image-loader": "^1.2.1",
         "chai": "^4.1.2",
         "color-support": "^1.1.3",
         "css-loader": "^0.25.0",
-        "deepmerge": "^2.0.1",
+        "deepmerge": "^2.1.1",
         "del": "2.2.2",
         "es6-promise": "^4.2.4",
         "exports-loader": "^0.6.4",
@@ -27,7 +27,7 @@
         "gulp-debug": "^3.2.0",
         "gulp-expect-file": "^0.0.7",
         "gulp-optimize-js": "^1.0.2",
-        "gulp-rename": "~1.2.2",
+        "gulp-rename": "^1.2.3",
         "gulp-replace": "~0.5.3",
         "gulp-sass": "3.1.0",
         "gulp-sourcemaps": "~1.9.1",
@@ -40,7 +40,7 @@
         "html-loader": "^0.5.5",
         "imports-loader": "^0.7.1",
         "json-loader": "^0.5.7",
-        "karma": "^2.0.0",
+        "karma": "^2.0.4",
         "karma-browserstack-launcher": "^1.3.0",
         "karma-chai": "^0.1.0",
         "karma-chrome-launcher": "^2.2.0",
@@ -53,14 +53,14 @@
         "mocha": "^4.0.1",
         "phantomjs": "^2.1.7",
         "run-sequence": "~1.1.0",
-        "sinon": "^4.3.0",
+        "sinon": "^4.5.0",
         "style-loader": "^0.13.2",
         "through2": "~0.6.5",
         "ts-loader": "^2.3.7",
         "typedoc": "^0.9.0",
-        "typescript": "~2.8.1",
-        "webpack": "^4.16.0",
-        "webpack-stream": "^4.0.1"
+        "typescript": "^2.8.4",
+        "webpack": "^4.16.1",
+        "webpack-stream": "^4.0.3"
     },
     "scripts": {
         "install": "cd ../../gui && npm install && cd ../Tools/Gulp/ &&  cd ../../inspector && npm install && cd ../Tools/Gulp/ && npm --prefix ../../Playground/ install ../../Playground/ && npm --prefix ../../tests/unit/ install ../../tests/unit/ && npm --prefix ../../Viewer/tests/ install ../../Viewer/tests/ && cd ../../Viewer && npm install && cd ../Tools/Gulp/ && gulp deployLocalDev"
@@ -68,6 +68,6 @@
     "dependencies": {
         "dts-bundle": "^0.7.3",
         "gulp-clean": "^0.4.0",
-        "npm": "^5.8.0"
+        "npm": "^5.10.0"
     }
 }

--- a/Viewer/tests/validation/karma.conf.js
+++ b/Viewer/tests/validation/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
         ],
         proxies: {
             '/tests/': '/base/tests/',
-            '/dist/assets/': '/base//dist/assets/'
+            '/dist/assets/': '/base/dist/assets/'
         },
 
         port: 3000,

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -1,6 +1,6 @@
 module.exports = function (config) {
-  config.set({
-    basePath: '../../',
+    config.set({
+        basePath: '../../',
         captureTimeout: 3e5,
         browserNoActivityTimeout: 3e5,
         browserDisconnectTimeout: 3e5,
@@ -12,6 +12,7 @@ module.exports = function (config) {
         frameworks: ['mocha', 'chai', 'sinon'],
 
         files: [
+            '!./**/*.d.ts',
             './Tools/DevLoader/BabylonLoader.js',
             './tests/unit/babylon/babylon.example.tests.js',
             './tests/unit/babylon/serializers/babylon.glTFSerializer.tests.js',
@@ -23,13 +24,12 @@ module.exports = function (config) {
             './tests/unit/babylon/src/Mesh/babylon.geometry.tests.js',
             './tests/unit/babylon/src/Mesh/babylon.mesh.vertexData.tests.js',
             './tests/unit/babylon/src/Tools/babylon.promise.tests.js',
-            { pattern: 'dist/**/*', watched: false, included: false, served: true },
+            { pattern: 'dist/preview release/**/*.js', watched: false, included: false, served: true },
             { pattern: 'assets/**/*', watched: false, included: false, served: true },
-            { pattern: 'tests/**/*', watched: false, included: false, served: true },
+            //{ pattern: 'tests/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/scenes/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/textures/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/sounds/**/*', watched: false, included: false, served: true },
-            { pattern: 'Tools/DevLoader/**/*', watched: false, included: false, served: true },
             { pattern: 'Tools/Gulp/config.json', watched: false, included: false, served: true },
         ],
         proxies: {
@@ -46,5 +46,5 @@ module.exports = function (config) {
         logLevel: config.LOG_INFO,
 
         browsers: ['PhantomJS']
-  })
+    })
 }

--- a/tests/validation/karma.conf.browserstack.js
+++ b/tests/validation/karma.conf.browserstack.js
@@ -25,7 +25,6 @@ module.exports = function (config) {
             { pattern: 'Playground/scenes/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/textures/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/sounds/**/*', watched: false, included: false, served: true },
-            { pattern: 'Tools/DevLoader/**/*', watched: false, included: false, served: true },            
             { pattern: 'Tools/Gulp/config.json', watched: false, included: false, served: true },
         ],
         proxies: {
@@ -44,7 +43,7 @@ module.exports = function (config) {
         browserStack: {
             project: 'Babylon JS Validation Tests',
             video: false,
-            debug : 'true',
+            debug: 'true',
             timeout: 1200,
             build: process.env.TRAVIS_BUILD_NUMBER,
             username: process.env.BROWSER_STACK_USERNAME,
@@ -75,16 +74,16 @@ module.exports = function (config) {
             bs_chrome_android: {
                 base: 'BrowserStack',
                 os: 'Android',
-                os_version : '8.0',
-                device : 'Google Pixel',
-                real_mobile : 'true'
+                os_version: '8.0',
+                device: 'Google Pixel',
+                real_mobile: 'true'
             },
             bs_safari_ios: {
                 base: 'BrowserStack',
                 os: 'ios',
-                os_version : '10.3',
-                device : 'iPhone 7',
-                real_mobile : 'true'
+                os_version: '10.3',
+                device: 'iPhone 7',
+                real_mobile: 'true'
             }
         },
         browsers: ['bs_chrome_android'],

--- a/tests/validation/karma.conf.js
+++ b/tests/validation/karma.conf.js
@@ -14,18 +14,18 @@ module.exports = function (config) {
         frameworks: ['mocha', 'chai', 'sinon'],
 
         files: [
+            '!./**/*.d.ts',
             './dist/preview release/earcut.min.js',
             './Tools/DevLoader/BabylonLoader.js',
             './tests/validation/index.css',
             './tests/validation/integration.js',
             './favicon.ico',
-            { pattern: 'dist/**/*', watched: false, included: false, served: true },
+            { pattern: 'dist/preview release/**/*.js', watched: false, included: false, served: true },
             { pattern: 'assets/**/*', watched: false, included: false, served: true },
             { pattern: 'tests/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/scenes/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/textures/**/*', watched: false, included: false, served: true },
             { pattern: 'Playground/sounds/**/*', watched: false, included: false, served: true },
-            { pattern: 'Tools/DevLoader/**/*', watched: false, included: false, served: true },
             { pattern: 'Tools/Gulp/config.json', watched: false, included: false, served: true },
         ],
         proxies: {


### PR DESCRIPTION
Our gulp default task had a meltdown on windows systems due to a problem with memory consumption.

Constant streams are known to consume a lot of memory, and we have a lot of them running in sequence.

As a solution i reduced the memory used by karma (by removing unneeded files). As another solution we can increase the memory provided to node for the task, but this will require creating an npm task for gulp.

