### PR TITLE
Adding Split and moving to dynamic loading of GUI

### DIFF
--- a/inspector/src/adapters/GUIAdapter.ts
+++ b/inspector/src/adapters/GUIAdapter.ts
@@ -4,14 +4,13 @@ import { Helpers } from "../helpers/Helpers";
 import { AbstractTreeTool } from "../treetools/AbstractTreeTool";
 import { Checkbox, IToolVisible } from "../treetools/Checkbox";
 import { Adapter } from "./Adapter";
-import { Control } from "babylonjs-gui";
 
 
 export class GUIAdapter
     extends Adapter
     implements IToolVisible {
 
-    constructor(obj: Control) {
+    constructor(obj: any/*GUI.Control*/) {
         super(obj);
     }
 
@@ -41,10 +40,10 @@ export class GUIAdapter
     }
 
     public setVisible(b: boolean) {
-        (this._obj as Control).isVisible = b;
+        (this._obj).isVisible = b;
     }
 
     public isVisible(): boolean {
-        return (this._obj as Control).isVisible;
+        return (this._obj).isVisible;
     }
 }

--- a/inspector/src/adapters/GUIAdapter.ts
+++ b/inspector/src/adapters/GUIAdapter.ts
@@ -10,7 +10,7 @@ export class GUIAdapter
     extends Adapter
     implements IToolVisible {
 
-    constructor(obj: any/*GUI.Control*/) {
+    constructor(obj: import("babylonjs-gui").Control) {
         super(obj);
     }
 

--- a/inspector/src/properties_gui.ts
+++ b/inspector/src/properties_gui.ts
@@ -1,11 +1,13 @@
 
 import { PROPERTIES } from "./properties";
 
+export type GUITyping = typeof import("babylonjs-gui");
+
 export let guiLoaded: boolean = false;
 /**
   * Function that add gui objects properties to the variable PROPERTIES
   */
-export function loadGUIProperties(GUI: typeof import("babylonjs-gui")) {
+export function loadGUIProperties(GUI: GUITyping) {
 
     guiLoaded = !!GUI;
 

--- a/inspector/src/properties_gui.ts
+++ b/inspector/src/properties_gui.ts
@@ -1,116 +1,123 @@
-import * as GUI from "babylonjs-gui";
+
 import { PROPERTIES } from "./properties";
 
+export let guiLoaded: boolean = false;
 /**
   * Function that add gui objects properties to the variable PROPERTIES
   */
-export function loadGUIProperties() {
-    let PROPERTIES_GUI = {
-        'ValueAndUnit': {
-            type: GUI.ValueAndUnit,
-            properties: ['_value', 'unit'],
-            format: (valueAndUnit: GUI.ValueAndUnit) => { return valueAndUnit }
-        },
-        'Control': {
-            type: GUI.Control,
-            properties: [
-                '_alpha',
-                '_fontFamily',
-                '_color',
-                '_scaleX',
-                '_scaleY',
-                '_rotation',
-                '_currentMeasure',
-                '_width',
-                '_height',
-                '_left',
-                '_top',
-                '_linkedMesh',
-                'isHitTestVisible',
-                'isPointerBlocker',
-            ],
-            format: (control: GUI.Control) => { return control.name }
-        },
-        'Button': {
-            type: GUI.Button,
-            properties: new Array(),
-            format: (button: GUI.Button) => { return button.name }
-        },
-        'ColorPicker': {
-            type: GUI.ColorPicker,
-            properties: ['_value'],
-            format: (colorPicker: GUI.ColorPicker) => { return colorPicker.name }
-        },
-        'Checkbox': {
-            type: GUI.Checkbox,
-            properties: ['_isChecked', '_background'],
-            format: (checkbox: GUI.Checkbox) => { return checkbox.name }
-        },
-        'Ellipse': {
-            type: GUI.Ellipse,
-            properties: ['_thickness'],
-            format: (ellipse: GUI.Ellipse) => { return ellipse.name }
-        },
-        'Image': {
-            type: GUI.Image,
-            properties: [
-                '_imageWidth',
-                '_imageHeight',
-                '_loaded',
-                '_source',
-            ],
-            format: (image: GUI.Image) => { return image.name }
-        },
-        'Line': {
-            type: GUI.Line,
-            properties: ['_lineWidth',
-                '_background',
-                '_x1',
-                '_y1',
-                '_x2',
-                '_y2',
-            ],
-            format: (line: GUI.Line) => { return line.name }
-        },
-        'RadioButton': {
-            type: GUI.RadioButton,
-            properties: ['_isChecked', '_background'],
-            format: (radioButton: GUI.RadioButton) => { return radioButton.name }
-        },
-        'Rectangle': {
-            type: GUI.Rectangle,
-            properties: ['_thickness', '_cornerRadius'],
-            format: (rectangle: GUI.Rectangle) => { return rectangle.name }
-        },
-        'Slider': {
-            type: GUI.Slider,
-            properties: [
-                '_minimum',
-                '_maximum',
-                '_value',
-                '_background',
-                '_borderColor',
-            ],
-            format: (slider: GUI.Slider) => { return slider.name }
-        },
-        'StackPanel': {
-            type: GUI.StackPanel,
-            properties: ['_isVertical'],
-            format: (stackPanel: GUI.StackPanel) => { return stackPanel.name }
-        },
-        'TextBlock': {
-            type: GUI.TextBlock,
-            properties: ['_text', '_textWrapping'],
-            format: (textBlock: GUI.TextBlock) => { return textBlock.name }
-        },
-        'Container': {
-            type: GUI.Container,
-            properties: ['_background'],
-            format: (container: GUI.Container) => { return container.name }
-        },
-    }
+export function loadGUIProperties(GUI: typeof import("babylonjs-gui")) {
 
-    for (let prop in PROPERTIES_GUI) {
-        (<any>PROPERTIES)[prop] = (<any>PROPERTIES_GUI)[prop];
+    guiLoaded = !!GUI;
+
+    if (guiLoaded) {
+
+        let PROPERTIES_GUI = {
+            'ValueAndUnit': {
+                type: GUI.ValueAndUnit,
+                properties: ['_value', 'unit'],
+                format: (valueAndUnit: import("babylonjs-gui").ValueAndUnit) => { return valueAndUnit }
+            },
+            'Control': {
+                type: GUI.Control,
+                properties: [
+                    '_alpha',
+                    '_fontFamily',
+                    '_color',
+                    '_scaleX',
+                    '_scaleY',
+                    '_rotation',
+                    '_currentMeasure',
+                    '_width',
+                    '_height',
+                    '_left',
+                    '_top',
+                    '_linkedMesh',
+                    'isHitTestVisible',
+                    'isPointerBlocker',
+                ],
+                format: (control: import("babylonjs-gui").Control) => { return control.name }
+            },
+            'Button': {
+                type: GUI.Button,
+                properties: new Array(),
+                format: (button: import("babylonjs-gui").Button) => { return button.name }
+            },
+            'ColorPicker': {
+                type: GUI.ColorPicker,
+                properties: ['_value'],
+                format: (colorPicker: import("babylonjs-gui").ColorPicker) => { return colorPicker.name }
+            },
+            'Checkbox': {
+                type: GUI.Checkbox,
+                properties: ['_isChecked', '_background'],
+                format: (checkbox: import("babylonjs-gui").Checkbox) => { return checkbox.name }
+            },
+            'Ellipse': {
+                type: GUI.Ellipse,
+                properties: ['_thickness'],
+                format: (ellipse: import("babylonjs-gui").Ellipse) => { return ellipse.name }
+            },
+            'Image': {
+                type: GUI.Image,
+                properties: [
+                    '_imageWidth',
+                    '_imageHeight',
+                    '_loaded',
+                    '_source',
+                ],
+                format: (image: import("babylonjs-gui").Image) => { return image.name }
+            },
+            'Line': {
+                type: GUI.Line,
+                properties: ['_lineWidth',
+                    '_background',
+                    '_x1',
+                    '_y1',
+                    '_x2',
+                    '_y2',
+                ],
+                format: (line: import("babylonjs-gui").Line) => { return line.name }
+            },
+            'RadioButton': {
+                type: GUI.RadioButton,
+                properties: ['_isChecked', '_background'],
+                format: (radioButton: import("babylonjs-gui").RadioButton) => { return radioButton.name }
+            },
+            'Rectangle': {
+                type: GUI.Rectangle,
+                properties: ['_thickness', '_cornerRadius'],
+                format: (rectangle: import("babylonjs-gui").Rectangle) => { return rectangle.name }
+            },
+            'Slider': {
+                type: GUI.Slider,
+                properties: [
+                    '_minimum',
+                    '_maximum',
+                    '_value',
+                    '_background',
+                    '_borderColor',
+                ],
+                format: (slider: import("babylonjs-gui").Slider) => { return slider.name }
+            },
+            'StackPanel': {
+                type: GUI.StackPanel,
+                properties: ['_isVertical'],
+                format: (stackPanel: import("babylonjs-gui").StackPanel) => { return stackPanel.name }
+            },
+            'TextBlock': {
+                type: GUI.TextBlock,
+                properties: ['_text', '_textWrapping'],
+                format: (textBlock: import("babylonjs-gui").TextBlock) => { return textBlock.name }
+            },
+            'Container': {
+                type: GUI.Container,
+                properties: ['_background'],
+                format: (container: import("babylonjs-gui").Container) => { return container.name }
+            },
+        }
+
+        for (let prop in PROPERTIES_GUI) {
+            (<any>PROPERTIES)[prop] = (<any>PROPERTIES_GUI)[prop];
+        }
     }
 } 

--- a/inspector/src/tabs/ConsoleTab.ts
+++ b/inspector/src/tabs/ConsoleTab.ts
@@ -4,6 +4,8 @@ import { Inspector } from "../Inspector";
 import { Tab } from "./Tab";
 import { TabBar } from "./TabBar";
 
+import * as Split from "Split";
+
 /** 
  * The console tab will have two features : 
  * - hook all console.log call and display them in this panel (and in the browser console as well)

--- a/inspector/src/tabs/GLTFTab.ts
+++ b/inspector/src/tabs/GLTFTab.ts
@@ -9,6 +9,8 @@ import { Inspector } from "../Inspector";
 import { Tab } from "./Tab";
 import { TabBar } from "./TabBar";
 
+import * as Split from "Split";
+
 interface ILoaderDefaults {
     [extensionName: string]: {
         [key: string]: any

--- a/inspector/src/tabs/GUITab.ts
+++ b/inspector/src/tabs/GUITab.ts
@@ -1,4 +1,3 @@
-import { AdvancedDynamicTexture, Container, Control } from "babylonjs-gui";
 import { GUIAdapter } from "../adapters/GUIAdapter";
 import { Inspector } from "../Inspector";
 import { TreeItem } from "../tree/TreeItem";
@@ -13,11 +12,13 @@ export class GUITab extends PropertyTab {
 
     /* Overrides super */
     protected _getTree(): Array<TreeItem> {
-        let arr = [];
+        let arr: Array<TreeItem> = [];
+
+        if (!Inspector.GUIObject) return arr;
 
         // Recursive method building the tree panel
-        let createNode = (obj: Control) => {
-            let descendants = (obj as Container).children;
+        let createNode = (obj: import("babylonjs-gui").Control) => {
+            let descendants = (obj as import("babylonjs-gui").Container).children;
 
             if (descendants && descendants.length > 0) {
                 let node = new TreeItem(this, new GUIAdapter(obj));
@@ -36,8 +37,8 @@ export class GUITab extends PropertyTab {
         let instances = this._inspector.scene;
         for (let tex of instances.textures) {
             //only get GUI's textures
-            if (tex instanceof AdvancedDynamicTexture) {
-                let node = createNode(tex._rootContainer);
+            if (tex instanceof Inspector.GUIObject.AdvancedDynamicTexture) {
+                let node = createNode((<import("babylonjs-gui").AdvancedDynamicTexture>tex)._rootContainer);
                 arr.push(node);
             }
         }

--- a/inspector/src/tabs/PropertyTab.ts
+++ b/inspector/src/tabs/PropertyTab.ts
@@ -7,6 +7,8 @@ import { TreeItem } from "../tree/TreeItem";
 import { Tab } from "./Tab";
 import { TabBar } from "./TabBar";
 
+import * as Split from "Split";
+
 /**
  * A Property tab can creates two panels: 
  * a tree panel and a detail panel, 

--- a/inspector/src/tabs/SceneTab.ts
+++ b/inspector/src/tabs/SceneTab.ts
@@ -7,6 +7,8 @@ import { Inspector } from "../Inspector";
 import { Tab } from "./Tab";
 import { TabBar } from "./TabBar";
 
+import * as Split from "Split";
+
 export class SceneTab extends Tab {
 
     private _inspector: Inspector;

--- a/inspector/src/tabs/TabBar.ts
+++ b/inspector/src/tabs/TabBar.ts
@@ -1,5 +1,4 @@
 import { AbstractMesh, Nullable } from "babylonjs";
-import * as GUI from "babylonjs-gui";
 import { BasicElement } from "../gui/BasicElement";
 import { Helpers } from "../helpers/Helpers";
 import { Inspector } from "../Inspector";
@@ -56,7 +55,7 @@ export class TabBar extends BasicElement {
         if (GLTFTab.IsSupported) {
             this._tabs.push(new GLTFTab(this, this._inspector));
         }
-        if (GUI) {
+        if (Inspector.GUIObject) {
             this._tabs.push(new GUITab(this, this._inspector));
         }
         this._tabs.push(new PhysicsTab(this, this._inspector));

--- a/inspector/src/tabs/TextureTab.ts
+++ b/inspector/src/tabs/TextureTab.ts
@@ -6,6 +6,7 @@ import { TreeItem } from "../tree/TreeItem";
 import { Tab } from "./Tab";
 import { TabBar } from "./TabBar";
 
+import * as Split from "Split";
 
 export class TextureTab extends Tab {
 

--- a/inspector/tsconfig.json
+++ b/inspector/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "experimentalDecorators": true,
-        "module": "commonjs",
+        "module": "esnext",
         "target": "es5",
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
GUI is now loaded dynamically (using esnext import() ). If it is not found it will be downloaded.
note - it is still a dependency ! so for commonjs/amd users - please be aware of that.

There was an issue with split that was also solved with this PR.

Closing this - https://github.com/BabylonJS/Babylon.js/issues/4776