### PR TITLE
Fix a bug with MSFT_lod extension throwing exception

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/EXT_lights_imageBased.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_lights_imageBased.ts
@@ -28,6 +28,16 @@ module BABYLON.GLTF2.Extensions {
     export class EXT_lights_imageBased extends GLTFLoaderExtension {
         public readonly name = NAME;
 
+        private _lights?: ILight[];
+
+        protected _onLoading(): void {
+            const extensions = this._loader._gltf.extensions;
+            if (extensions && extensions[this.name]) {
+                const extension = extensions[this.name] as ILights;
+                this._lights = extension.lights;
+            }
+        }
+
         protected _loadSceneAsync(context: string, scene: _ILoaderScene): Nullable<Promise<void>> { 
             return this._loadExtensionAsync<ILightReference>(context, scene, (extensionContext, extension) => {
                 const promises = new Array<Promise<void>>();
@@ -107,16 +117,6 @@ module BABYLON.GLTF2.Extensions {
             return light._loaded.then(() => {
                 return light._babylonTexture!;
             });
-        }
-
-        private get _lights(): Array<ILight> {
-            const extensions = this._loader._gltf.extensions;
-            if (!extensions || !extensions[this.name]) {
-                throw new Error(`#/extensions: '${this.name}' not found`);
-            }
-
-            const extension = extensions[this.name] as ILights;
-            return extension.lights;
         }
     }
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_lights.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights.ts
@@ -34,6 +34,16 @@ module BABYLON.GLTF2.Extensions {
     export class KHR_lights extends GLTFLoaderExtension {
         public readonly name = NAME;
 
+        private _lights?: ILight[];
+
+        protected _onLoading(): void {
+            const extensions = this._loader._gltf.extensions;
+            if (extensions && extensions[this.name]) {
+                const extension = extensions[this.name] as ILights;
+                this._lights = extension.lights;
+            }
+        }
+
         protected _loadSceneAsync(context: string, scene: _ILoaderScene): Nullable<Promise<void>> { 
             return this._loadExtensionAsync<ILightReference>(context, scene, (extensionContext, extension) => {
                 const promise = this._loader._loadSceneAsync(extensionContext, scene);
@@ -87,16 +97,6 @@ module BABYLON.GLTF2.Extensions {
 
                 return promise;
             });
-        }
-
-        private get _lights(): Array<ILight> {
-            const extensions = this._loader._gltf.extensions;
-            if (!extensions || !extensions[this.name]) {
-                throw new Error(`#/extensions: '${this.name}' not found`);
-            }
-
-            const extension = extensions[this.name] as ILights;
-            return extension.lights;
         }
     }
 

--- a/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
@@ -7,24 +7,26 @@ module BABYLON.GLTF2.Extensions {
     export class MSFT_sRGBFactors extends GLTFLoaderExtension {
         public readonly name = NAME;
 
-        protected _loadMaterialAsync(context: string, material: _ILoaderMaterial, mesh: _ILoaderMesh, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<void>> {
+        protected _loadMaterialPropertiesAsync(context: string, material: _ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return this._loadExtrasValueAsync<boolean>(context, material, (extensionContext, value) => {
                 if (value) {
-                    return this._loader._loadMaterialAsync(context, material, mesh, babylonMesh, babylonDrawMode, (babylonMaterial: PBRMaterial) => {
-                        if (!babylonMaterial.albedoTexture) {
-                            babylonMaterial.albedoColor.toLinearSpaceToRef(babylonMaterial.albedoColor);
-                        }
-
-                        if (!babylonMaterial.reflectivityTexture) {
-                            babylonMaterial.reflectivityColor.toLinearSpaceToRef(babylonMaterial.reflectivityColor);
-                        }
-
-                        assign(babylonMaterial);
-                    });
+                    const promise = this._loader._loadMaterialPropertiesAsync(context, material, babylonMaterial);
+                    this._convertColorsToLinear(babylonMaterial as PBRMaterial);
+                    return promise;
                 }
 
                 return null;
             });
+        }
+
+        private _convertColorsToLinear(babylonMaterial: PBRMaterial): void {
+            if (!babylonMaterial.albedoTexture) {
+                babylonMaterial.albedoColor.toLinearSpaceToRef(babylonMaterial.albedoColor);
+            }
+
+            if (!babylonMaterial.reflectivityTexture) {
+                babylonMaterial.reflectivityColor.toLinearSpaceToRef(babylonMaterial.reflectivityColor);
+            }
         }
     }
 

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
@@ -35,6 +35,16 @@ module BABYLON.GLTF2 {
         // #region Overridable Methods
 
         /**
+         * Override this method to do work after the state changes to LOADING.
+         */
+        protected _onLoading(): void {}
+
+        /**
+         * Override this method to do work after the state changes to READY.
+         */
+        protected _onReady(): void {}
+
+        /**
          * Override this method to modify the default behavior for loading scenes.
          * @hidden
          */
@@ -138,6 +148,22 @@ module BABYLON.GLTF2 {
                 // Restore the extras value after executing the action.
                 extras[this.name] = value;
             }
+        }
+
+        /**
+         * Helper method called by the loader after the state changes to LOADING.
+         * @hidden
+         */
+        public static _OnLoading(loader: GLTFLoader): void {
+            loader._forEachExtensions(extension => extension._onLoading());
+        }
+
+        /**
+         * Helper method called by the loader after the state changes to READY.
+         * @hidden
+         */
+        public static _OnReady(loader: GLTFLoader): void {
+            loader._forEachExtensions(extension => extension._onReady());
         }
 
         /**

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -264,12 +264,31 @@ module BABYLON {
 
         /**
          * Callback raised when the asset is completely loaded, immediately before the loader is disposed.
+         * For assets with LODs, raised when all of the LODs are complete.
+         * For assets without LODs, raised when the model is complete, immediately after the loader resolves the returned promise.
          */
         public set onComplete(callback: () => void) {
             if (this._onCompleteObserver) {
                 this.onCompleteObservable.remove(this._onCompleteObserver);
             }
             this._onCompleteObserver = this.onCompleteObservable.add(callback);
+        }
+
+        /**
+         * Observable raised when an error occurs.
+         */
+        public readonly onErrorObservable = new Observable<any>();
+
+        private _onErrorObserver: Nullable<Observer<any>>;
+
+        /**
+         * Callback raised when an error occurs.
+         */
+        public set onError(callback: (reason: any) => void) {
+            if (this._onErrorObserver) {
+                this.onErrorObservable.remove(this._onErrorObserver);
+            }
+            this._onErrorObserver = this.onErrorObservable.add(callback);
         }
 
         /**
@@ -312,9 +331,12 @@ module BABYLON {
          * @returns a promise that resolves when the asset is completely loaded.
          */
         public whenCompleteAsync(): Promise<void> {
-            return new Promise(resolve => {
+            return new Promise((resolve, reject) => {
                 this.onCompleteObservable.addOnce(() => {
                     resolve();
+                });
+                this.onErrorObservable.addOnce(reason => {
+                    reject(reason);
                 });
             });
         }

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -74,7 +74,7 @@ describe('Babylon Scene Loader', function () {
             });
         });
 
-        it('Load TwoQuads with ImporMesh and two node names', () => {
+        it('Load TwoQuads with ImportMesh and two node names', () => {
             const scene = new BABYLON.Scene(subject);
             return BABYLON.SceneLoader.ImportMeshAsync(["node0", "node1"], "http://models.babylonjs.com/Tests/TwoQuads/", "TwoQuads.gltf", scene).then(() => {
                 expect(scene.getMeshByName("node0"), "node0").to.exist;
@@ -393,6 +393,20 @@ describe('Babylon Scene Loader', function () {
             promises.push(BABYLON.SceneLoader.AppendAsync("http://models.babylonjs.com/Tests/TwoQuads/", "TwoQuads.gltf", scene).then(() => {
                 // do nothing
             }));
+
+            return Promise.all(promises);
+        });
+
+        it('Load TwoQuadsNoTextures with LODs', () => {
+            const scene = new BABYLON.Scene(subject);
+
+            const promises = new Array<Promise<any>>();
+
+            BABYLON.SceneLoader.OnPluginActivatedObservable.addOnce((loader: BABYLON.GLTFFileLoader) => {
+                promises.push(loader.whenCompleteAsync());
+            });
+
+            promises.push(BABYLON.SceneLoader.AppendAsync("http://models.babylonjs.com/Tests/TwoQuads/", "TwoQuadsNoTextures.gltf", scene));
 
             return Promise.all(promises);
         });


### PR DESCRIPTION
If two glTF mesh primitives both point to the same material that does not have textures and uses MSFT_lod extension, then the code throws an exception. This change reorganizes the code a bit to fix the problem. Includes a new unit test.

https://github.com/BabylonJS/MeshesLibrary/pull/11 needs to be merged before the unit test will work.