### PR TITLE
Module changes

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -37,6 +37,11 @@
                 "name": "earcut",
                 "module": "earcut",
                 "optional": true
+            },
+            {
+                "name": "INSPECTOR",
+                "module": "babylonjs-inspector",
+                "optional": true
             }
         ]
     },

--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -37,11 +37,6 @@
                 "name": "earcut",
                 "module": "earcut",
                 "optional": true
-            },
-            {
-                "name": "INSPECTOR",
-                "module": "babylonjs-inspector",
-                "optional": true
             }
         ]
     },

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -455,7 +455,6 @@ var buildExternalLibrary = function (library, settings, watch) {
                     if (!out.minified) {
                         wpConfig.mode = "development";
                     }
-                    console.log(wpConfig)
                     let wpBuild = webpackStream(wpConfig, webpack);
 
                     //shoud dtsBundle create the declaration?
@@ -558,6 +557,8 @@ var buildExternalLibrary = function (library, settings, watch) {
                                 if (err) throw err;
                                 var newData = processDeclaration(data, settings.build.processDeclaration);
                                 fs.writeFile(fileLocation.replace('.module', ''), newData);
+                                //legacy module support
+                                fs.writeFile(fileLocation, data + "\n" + newData);
                             });
                         }
                     });

--- a/Tools/Gulp/processViewerDeclaration.js
+++ b/Tools/Gulp/processViewerDeclaration.js
@@ -59,7 +59,14 @@ module.exports = function (data, options) {
 
     str = str.replace(/export {(.*)};/g, '');
 
+    str = str.replace(/import (.*);/g, "");
+
     str = str.split("\n").filter(line => line.trim()).filter(line => line.indexOf("export * from") === -1).join("\n");
+
+    //empty declare regex
+    let emptyDeclareRegexp = new RegExp("declare module " + options.moduleName + " {\n}", "g");
+
+    str = str.replace(emptyDeclareRegexp, "");
 
     return str;
 }

--- a/Tools/Publisher/index.js
+++ b/Tools/Publisher/index.js
@@ -51,7 +51,8 @@ let packages = [
         required: [
             basePath + '/viewer/readme.md',
             basePath + '/viewer/package.json',
-            basePath + '/viewer/babylon.viewer.js'
+            basePath + '/viewer/babylon.viewer.js',
+            basePath + '/viewer/babylon.viewer.max.js'
         ]
     },
     {

--- a/gui/src/legacy.ts
+++ b/gui/src/legacy.ts
@@ -1,0 +1,13 @@
+import * as GUI from "./index";
+
+/**
+ * Legacy support, defining window.BABYLON.GUI (global variable).
+ * 
+ * This is the entry point for the UMD module. 
+ * The entry point for a future ESM package should be index.ts
+ */
+var globalObject = (typeof global !== 'undefined') ? global : ((typeof window !== 'undefined') ? window : undefined);
+if (typeof globalObject !== "undefined") {
+    (<any>globalObject).BABYLON = (<any>globalObject).BABYLON || {};
+    (<any>globalObject).BABYLON.GUI = GUI;
+}

--- a/gui/src/legacy.ts
+++ b/gui/src/legacy.ts
@@ -11,3 +11,5 @@ if (typeof globalObject !== "undefined") {
     (<any>globalObject).BABYLON = (<any>globalObject).BABYLON || {};
     (<any>globalObject).BABYLON.GUI = GUI;
 }
+
+export * from "./index";

--- a/gui/webpack.config.js
+++ b/gui/webpack.config.js
@@ -6,7 +6,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 module.exports = {
     context: __dirname,
     entry: {
-        'babylonjs-gui': path.resolve(__dirname, './src/index.ts'),
+        'babylonjs-gui': path.resolve(__dirname, './src/legacy.ts'),
     },
     output: {
         path: path.resolve(__dirname, '../dist/preview release/gui'),

--- a/inspector/src/Inspector.ts
+++ b/inspector/src/Inspector.ts
@@ -54,7 +54,7 @@ export class Inspector {
 
         import("babylonjs-gui").then(GUI => {
             // Load GUI library if not already done
-            if (!GUI || (<Object>GUI).hasOwnProperty("default")) {
+            if (!GUI || (typeof GUI !== "undefined" && Object.keys(GUI).indexOf("default") !== -1)) {
                 Tools.LoadScript("https://preview.babylonjs.com/gui/babylon.gui.min.js", () => {
                     Inspector.GUIObject = (<any>BABYLON).GUI;
                     this.onGUILoaded.notifyObservers(Inspector.GUIObject);

--- a/inspector/src/legacy.ts
+++ b/inspector/src/legacy.ts
@@ -1,0 +1,13 @@
+import * as INSPECTOR from "./index";
+
+/**
+ * Legacy support, defining window.INSPECTOR (global variable).
+ * 
+ * This is the entry point for the UMD module. 
+ * The entry point for a future ESM package should be index.ts
+ */
+
+var globalObject = (typeof global !== 'undefined') ? global : ((typeof window !== 'undefined') ? window : undefined);
+if (typeof globalObject !== "undefined") {
+    (<any>globalObject).INSPECTOR = INSPECTOR;
+}

--- a/inspector/src/legacy.ts
+++ b/inspector/src/legacy.ts
@@ -11,3 +11,5 @@ var globalObject = (typeof global !== 'undefined') ? global : ((typeof window !=
 if (typeof globalObject !== "undefined") {
     (<any>globalObject).INSPECTOR = INSPECTOR;
 }
+
+export * from "./index";

--- a/inspector/webpack.config.js
+++ b/inspector/webpack.config.js
@@ -7,7 +7,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 module.exports = {
     context: __dirname,
     entry: {
-        'babylonjs-inspector': path.resolve(__dirname, './src/index.ts'),
+        'babylonjs-inspector': path.resolve(__dirname, './src/legacy.ts'),
     },
     output: {
         path: path.resolve(__dirname, '../dist/preview release/inspector'),
@@ -69,7 +69,7 @@ module.exports = {
             ]
         }]
     },
-    mode: "production",
+    mode: "development",
     devServer: {
         contentBase: path.join(__dirname, "dist"),
         compress: false,


### PR DESCRIPTION
Some changes to the way  modules are built:

1) d.ts files will now habe both legacy NAMESPACE support AND module definitions. This means that the declaration if the inspector will have both `declare module "babylonjs-inspector" {....}` and `declare module INSPECTOR`. This will not influence the size of the built package at all, and will only make the d.ts file larger in size.
2) Legacy support for global variables - both inspector and gui now populate the global namespace. As written in the comment, this is needed ONLY for the UMD package. the entry file (legacy.ts) will import everything from index.ts, export it back, and will populate the global namespace with all of the imports. When we get to the point that we also provide a full esm package we will only use index.ts and will ignore legacy.ts
3) module d.ts is cleaned better.

Tested with webpack 4.16 and ts 2.9.2
