### PR TITLE
First version of module-testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
     - set -e
     - gulp typescript-all
     - gulp tests-unit
+    - gulp tests-modules
 #    - travis_retry gulp tests-validation-virtualscreen
 #    - travis_retry gulp tests-validation-browserstack
     - travis_retry gulp tests-viewer-validation-virtualscreen

--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -1246,6 +1246,92 @@ gulp.task("tests-viewer-unit", ["tests-viewer-transpile"], function (done) {
     server.start();
 });
 
+gulp.task("tests-modules", function () {
+    let testsToRun = require('../../tests/modules/tests.json');
+
+    let sequencePromise = Promise.resolve();
+
+    testsToRun.tests.forEach(test => {
+        sequencePromise = sequencePromise.then(() => {
+            console.log("Running " + test.name);
+            let basePath = '../../tests/modules/' + test.name + '/';
+            rmDir("../../tests/modules/build/");
+            let compilePromise = Promise.resolve();
+
+            if (test.dependencies) {
+                compilePromise = new Promise(function (resolve, reject) {
+                    let counter = 0;
+                    let copyTask = gulp.src(test.dependencies.map(dep => config.build.outputDirectory + '/' + dep)).pipe(rename(function (path) {
+                        path.basename = (counter++) + '';
+                    })).pipe(gulp.dest("../../tests/modules/build/dependencies/"))
+                    copyTask.once("finish", resolve);
+                })
+            }
+            // any compilation needed?
+            if (test.typescript || test.bundler) {
+                //typescript only
+                if (test.typescript && !test.bundler) {
+                    compilePromise = compilePromise.then(() => {
+                        return new Promise(function (resolve, reject) {
+                            var tsProject = typescript.createProject(basePath + (test.tsconfig || 'tsconfig.json'));
+
+                            var tsResult = gulp.src(basePath + '/src/**/*.ts', { base: basePath })
+                                .pipe(tsProject());
+
+                            let error = false;
+                            tsResult.once("error", function () {
+                                error = true;
+                            });
+
+                            let jsPipe = tsResult.js.pipe(gulp.dest("../../tests/modules/"));
+
+                            jsPipe.once("finish", function () {
+                                if (error)
+                                    reject('error compiling test');
+                                else
+                                    resolve();
+                            });
+                        });
+                    });
+                } else {
+                    if (test.bundler === 'webpack') {
+                        console.log("webpack");
+                        compilePromise = compilePromise.then(() => {
+                            return new Promise(function (resolve, reject) {
+                                let wpBuild = webpackStream(require(basePath + '/webpack.config.js'), webpack);
+
+                                wpBuild = wpBuild
+                                    .pipe(rename(function (path) {
+                                        if (path.extname === '.js') {
+                                            path.basename = "tests-loader";
+                                        }
+                                    }))
+                                    .pipe(gulp.dest("../../tests/modules/build/"));
+
+                                wpBuild.once("finish", resolve);
+                            })
+                        });
+                    }
+                }
+            }
+
+            return compilePromise.then(() => {
+                return new Promise(function (resolve, reject) {
+                    var kamaServerOptions = {
+                        configFile: __dirname + "/../../tests/modules/karma.conf.js",
+                        singleRun: true
+                    };
+
+                    var server = new karmaServer(kamaServerOptions, resolve);
+                    server.start();
+                });
+            })
+        })
+    });
+
+    return sequencePromise;
+});
+
 gulp.task("tests-whatsnew", function (done) {
     // Only checks on Travis
     if (!process.env.TRAVIS) {

--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -9,6 +9,7 @@
     "readme": "https://github.com/BabylonJS/Babylon.js/edit/master/readme.md",
     "license": "(Apache-2.0)",
     "devDependencies": {
+        "@types/lodash": "^4.14.113",
         "@types/node": "^8.10.21",
         "base64-font-loader": "0.0.4",
         "base64-image-loader": "^1.2.1",
@@ -56,9 +57,9 @@
         "sinon": "^4.5.0",
         "style-loader": "^0.13.2",
         "through2": "~0.6.5",
-        "ts-loader": "^2.3.7",
+        "ts-loader": "^4.4.2",
         "typedoc": "^0.9.0",
-        "typescript": "^2.8.4",
+        "typescript": "^2.9.2",
         "webpack": "^4.16.1",
         "webpack-stream": "^4.0.3"
     },

--- a/tests/modules/karma.conf.js
+++ b/tests/modules/karma.conf.js
@@ -1,0 +1,39 @@
+module.exports = function (config) {
+    config.set({
+        basePath: '../../',
+        captureTimeout: 3e5,
+        browserNoActivityTimeout: 3e5,
+        browserDisconnectTimeout: 3e5,
+        browserDisconnectTolerance: 3,
+        concurrency: 1,
+
+        urlRoot: '/karma/',
+
+        frameworks: ['mocha', 'chai', 'sinon'],
+
+        files: [
+            './tests/modules/tests-karma.js',
+            // load the latest build
+            { pattern: './tests/modules/build/dependencies/**/*.js', watched: false, included: true, served: true },
+            './tests/modules/build/tests-loader.js',
+            { pattern: 'assets/**/*', watched: false, included: false, served: true },
+            { pattern: 'Playground/scenes/**/*', watched: false, included: false, served: true },
+            { pattern: 'Playground/textures/**/*', watched: false, included: false, served: true },
+            { pattern: 'Playground/sounds/**/*', watched: false, included: false, served: true }
+        ],
+        proxies: {
+            '/': '/base/'
+        },
+
+        port: 3000,
+        colors: true,
+        autoWatch: false,
+        singleRun: false,
+
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+        browsers: ['PhantomJS']
+    })
+}

--- a/tests/modules/tests-karma.js
+++ b/tests/modules/tests-karma.js
@@ -1,10 +1,17 @@
 
 
-function runTests(testType, BABYLON, GUI, INSPECTOR, LOADERS, SERIALIZERS, POSTPROCESS) {
+function runTests(testType, BABYLON, GUI, INSPECTOR) {
 
     console.log("running tests");
 
     describe(testType + ' module tests', function () {
+
+        it("should have the dependencies loaded", function () {
+            assert.isDefined(BABYLON);
+            assert.isDefined(GUI);
+            assert.isDefined(INSPECTOR);
+            assert.isDefined(BABYLON.GLTF2);
+        })
 
         var subject;
 

--- a/tests/modules/tests-karma.js
+++ b/tests/modules/tests-karma.js
@@ -1,0 +1,40 @@
+
+
+function runTests(testType, BABYLON, GUI, INSPECTOR, LOADERS, SERIALIZERS, POSTPROCESS) {
+
+    console.log("running tests");
+
+    describe(testType + ' module tests', function () {
+
+        var subject;
+
+        /**
+         * Create a nu engine subject before each test.
+         */
+        beforeEach(function () {
+            subject = new BABYLON.NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1
+            });
+        });
+        /**
+         * This test is more an integration test than a regular unit test but highlights how to rely
+         * on the BABYLON.NullEngine in order to create complex test cases.
+         */
+        describe('#GLTF', function () {
+            it('should load BoomBox GLTF', function (done) {
+                mocha.timeout(10000);
+                var scene = new BABYLON.Scene(subject);
+                BABYLON.SceneLoader.Append("/Playground/scenes/BoomBox/", "BoomBox.gltf", scene, function () {
+                    scene.meshes.length.should.be.equal(2);
+                    scene.materials.length.should.be.equal(1);
+                    scene.multiMaterials.length.should.be.equal(0);
+                    done();
+                });
+            });
+        });
+    });
+}

--- a/tests/modules/tests-loader.js
+++ b/tests/modules/tests-loader.js
@@ -1,0 +1,4 @@
+/// <reference path="../../../../dist/preview release/babylon.d.ts"/>
+/// <reference path="../../../../dist/preview release/gui/babylon.gui.d.ts"/>
+// an error in typescript prevents us from using types instead of path
+runTests("typescript-vanilla", BABYLON, BABYLON.GUI, window.INSPECTOR);

--- a/tests/modules/tests.json
+++ b/tests/modules/tests.json
@@ -1,0 +1,20 @@
+{
+    "tests": [
+        {
+            "name": "typescript-webpack",
+            "typescript": true,
+            "bundler": "webpack"
+        },
+        {
+            "name": "typescript-vanilla",
+            "typescript": true,
+            "tsconfig": "tsconfig.json",
+            "dependencies": [
+                "babylon.js",
+                "gui/babylon.gui.min.js",
+                "inspector/babylon.inspector.bundle.js",
+                "loaders/babylonjs.loaders.min.js"
+            ]
+        }
+    ]
+}

--- a/tests/modules/typescript-vanilla/src/tests-loader.ts
+++ b/tests/modules/typescript-vanilla/src/tests-loader.ts
@@ -1,0 +1,8 @@
+/// <reference path="../../../../dist/preview release/babylon.d.ts"/>
+/// <reference path="../../../../dist/preview release/gui/babylon.gui.d.ts"/>
+// an error in typescript prevents us from using types instead of path
+
+
+declare function runTests(name: string, babylon: any, gui: any, inspector: any);
+
+runTests("typescript-vanilla", BABYLON, BABYLON.GUI, (<any>window).INSPECTOR);

--- a/tests/modules/typescript-vanilla/tsconfig.json
+++ b/tests/modules/typescript-vanilla/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "none",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "strictNullChecks": true,
+        "noImplicitAny": false,
+        "noFallthroughCasesInSwitch": true,
+        "sourceMap": true,
+        "lib": [
+            "es5",
+            "dom",
+            "es2015.promise",
+            "es2015.collection",
+            "es2015.iterable"
+        ],
+        "baseUrl": "./src/",
+        "rootDir": "./src/",
+        "outDir": "../build/",
+        "paths": {
+            "babylonjs-gui": [
+                "../../../../dist/preview release/gui/babylon.gui.modules.d.ts"
+            ]
+        }
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/tests/modules/typescript-webpack/index.ts
+++ b/tests/modules/typescript-webpack/index.ts
@@ -1,0 +1,12 @@
+import * as BABYLON from "babylonjs";
+import * as GUI from "babylonjs-gui";
+import * as INSPECTOR from "babylonjs-inspector";
+
+import "babylonjs-loaders";
+import "babylonjs-serializers";
+// an error in typescript prevents us from using types instead of path
+
+
+declare function runTests(name: string, babylon: any, gui: any, inspector: any);
+
+runTests("typescript-vanilla", BABYLON, GUI, INSPECTOR);

--- a/tests/modules/typescript-webpack/tsconfig.json
+++ b/tests/modules/typescript-webpack/tsconfig.json
@@ -1,0 +1,41 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "noResolve": false,
+        "noImplicitAny": false,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "isolatedModules": false,
+        "lib": [
+            "dom",
+            "es2015.promise",
+            "es5"
+        ],
+        "declaration": true,
+        "outDir": "./",
+        "baseUrl": "./",
+        "paths": {
+            "babylonjs": [
+                "../../../dist/preview release/babylon.d.ts"
+            ],
+            "babylonjs-gui": [
+                "../../../dist/preview release/gui/babylon.gui.module.d.ts"
+            ],
+            "babylonjs-inspector": [
+                "../../../dist/preview release/inspector/babylon.inspector.module.d.ts"
+            ],
+            "babylonjs-loaders": [
+                "../../../dist/preview release/loaders/babylonjs.loaders.module.d.ts"
+            ],
+            "babylonjs-gltf2interface": [
+                "../../../dist/babylon.glTF2Interface.d.ts"
+            ],
+        }
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/tests/modules/typescript-webpack/webpack.config.js
+++ b/tests/modules/typescript-webpack/webpack.config.js
@@ -1,0 +1,26 @@
+const path = require("path");
+
+module.exports = {
+    entry: __dirname + '/index.ts',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    },
+    resolve: {
+        extensions: ['.ts', '.js'],
+        alias: {
+            "babylonjs": __dirname + '/../../../dist/preview release/babylon.max.js',
+            "babylonjs-gui": __dirname + '/../../../dist/preview release/gui/babylon.gui.js',
+            "babylonjs-inspector": __dirname + '/../../../dist/preview release/inspector/babylon.inspector.js',
+            "babylonjs-loaders": __dirname + '/../../../dist/preview release/loaders/babylonjs.loaders.js',
+            "babylonjs-serializers": __dirname + '/../../../dist/preview release/serializers/babylonjs.serializers.js',
+        }
+    },
+    devtool: "source-map",
+    module: {
+        rules: [
+            { test: /\.tsx?$/, loader: "ts-loader" },
+        ]
+    },
+    mode: "development"
+};


### PR DESCRIPTION
There are curently two tests that are running one after the other - 
1) vanilla-typescript that loads the dependencies and calling the runTests function wit the global namespace
2) webpack-typescript that bundles the dependencies and loading them using es6 imports.

the source is being compiled and bundled (when using a bundler).

There are two iunternal tests running - checking that the dependencies actually loaded, and loading a GLTF model.

Further tests will be added shortly.

At the moment this is not part of the "tests" task. to trigger this test, call gulp tests-modules.