### PR TITLE
Animations with more than one word in its name wouldn't work correctly

### DIFF
--- a/Viewer/assets/templates/default/navbar.html
+++ b/Viewer/assets/templates/default/navbar.html
@@ -457,7 +457,7 @@
             </button>
             <div class="menu-options">
                 {{#each animations}} {{#unless (eq ../selectedAnimation (add @index 1))}}
-                <button class="flex-container label-option-button animation-buttons" data-value="{{this.value}}">
+                <button class="flex-container label-option-button animation-buttons" data-value="{{this.value}} ">
                     <!-- <div> -->
                     <span class="icon types-icon"></span>
                     <span class="control-text animation-label">{{this.label}}</span>

--- a/Viewer/src/model/viewerModel.ts
+++ b/Viewer/src/model/viewerModel.ts
@@ -354,7 +354,7 @@ export class ViewerModel implements IDisposable {
      */
     protected _getAnimationByName(name: string): Nullable<IModelAnimation> {
         // can't use .find, noe available on IE
-        let filtered = this._animations.filter(a => a.name === name);
+        let filtered = this._animations.filter(a => a.name === name.trim());
         // what the next line means - if two animations have the same name, they will not be returned!
         if (filtered.length === 1) {
             return filtered[0];
@@ -377,7 +377,7 @@ export class ViewerModel implements IDisposable {
     }
 
     public setCurrentAnimationByName(name: string) {
-        let animation = this._getAnimationByName(name);
+        let animation = this._getAnimationByName(name.trim());
         if (animation) {
             if (this.currentAnimation && this.currentAnimation.state !== AnimationState.STOPPED) {
                 this.currentAnimation.stop();

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -198,7 +198,7 @@ export class DefaultViewer extends AbstractViewer {
                 var value = element.dataset["value"];
                 var label = element.querySelector("span.animation-label");
                 if (label && value) {
-                    this._updateAnimationType({ value, label: label.innerHTML });
+                    this._updateAnimationType({ value: value.trim(), label: label.innerHTML });
                 }
                 break;
             case "speed-option-button":

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -166,6 +166,7 @@
 - Drag and Drop only worked if a model was already loaded before ([RaananW](https://github.com/RaananW))
 - It was not possible to add new custom optimizers, only use existing ones ([RaananW](https://github.com/RaananW))
 - Button texts were truncated incorrectly ([RaananW](https://github.com/RaananW))
+- Animation names with more than one word didn't work correctly ([RaananW](https://github.com/RaananW))
 
 ### Loaders
 


### PR DESCRIPTION
Due to handlebars escaping incorrectly. Fixed with trimming a string with an extra " " character