### PR TITLE
Fix File Loading if hosted from `file:`-Protocol

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -155,6 +155,7 @@
 - Fixed issue where VRExperienceHelper.onExitingVR observable was being fired twice ([atulyar](https://github.com/atulyar))
 - GizmoManager should hide existing gizmos if a non-attachable mesh is selected ([TrevorDev](https://github.com/TrevorDev))
 - Ignore isPickable = false for vr ray casting if the mesh's name matches the specified floorMeshName to maintain backwards compatability ([TrevorDev](https://github.com/TrevorDev))
+- Fix File Loading if hosted from `file:`-Protocol ([ltetzlaff](https://github.com/ltetzlaff))
 
 ### Core Engine
 

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -1505,7 +1505,11 @@
                 Tools.Error = Tools._ErrorDisabled;
             }
         }
-	    
+	
+	/** 
+         * Check if the loaded document was accessed via `file:`-Protocol.
+         * @returns boolean
+         */
 	public static IsFileURL(): boolean {
 	    return location.protocol === "file:";
 	}

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -753,7 +753,7 @@
                             // Some browsers have issues where onreadystatechange can be called multiple times with the same value.
                             request.removeEventListener("readystatechange", onReadyStateChange);
 
-                            if (request.status >= 200 && request.status < 300 || (!Tools.IsWindowObjectExist() && (request.status === 0))) {
+                            if ((request.status >= 200 && request.status < 300) || (request.status === 0 && (!Tools.IsWindowObjectExist() || Tools.IsFileURL()))) {
                                 onSuccess(!useArrayBuffer ? request.responseText : <ArrayBuffer>request.response, request.responseURL);
                                 return;
                             }
@@ -1505,6 +1505,10 @@
                 Tools.Error = Tools._ErrorDisabled;
             }
         }
+	    
+	public static IsFileURL(): boolean {
+	    return location.protocol === "file:";
+	}
 
         public static IsWindowObjectExist(): boolean {
             return (typeof window) !== "undefined";


### PR DESCRIPTION
When loading a file using `file:`-Protocol loading does not work in a Safari-Webview because request-Status will be `0`.

I added a simple check for that edge case while not changing overall behavior.

Related changes before:
https://github.com/BabylonJS/Babylon.js/commit/63f753c3b51492ac66d81a2555f000f62d255c92#diff-5e88dca888b9e41c0e61475ba80ae286R502