### PR TITLE
fix build order for extra files

### DIFF
--- a/Tools/Gulp/gulpfile.js
+++ b/Tools/Gulp/gulpfile.js
@@ -230,14 +230,13 @@ gulp.task("buildWorker", gulp.series(gulp.parallel("workers", "shaders"), functi
 gulp.task("build", gulp.series("shaders", function build() {
     var filesToProcess = determineFilesToProcess("files");
     var directFilesToProcess = determineFilesToProcess("directFiles");
-    let merged = [gulp.src(filesToProcess).
-        pipe(expect.real({ errorOnFailure: true }, filesToProcess)),
+    let mergedStreams = merge2(gulp.src(filesToProcess)
+        .pipe(expect.real({ errorOnFailure: true }, filesToProcess)),
         shadersStream,
-        includeShadersStream];
+        includeShadersStream);
     if (directFilesToProcess.length) {
-        merged.push(gulp.src(directFilesToProcess));
+      mergedStreams.add(gulp.src(directFilesToProcess));
     }
-    let mergedStreams = merge2(merged);
     return merge2(
         mergedStreams
             .pipe(concat(config.build.noModuleFilename))


### PR DESCRIPTION
merg2 works in paralel when you supply it with array. It is probably unintended for workloads(aka 'files') and extra(aka directFiles). When adding some extra materials,loaders etc to build via buildConfiguration this extra files goes unordered with main engine files. This can lead to errors when extras have dependencies from engine. For example like this:
`

        "customBuild": [
            "pbrMaterial",
            "freeCamera",
              ......
            "transformFeedback",
            "noise",
            "videoRecorder",
            "materialsLibrary/babylon.gridMaterial.js"
`