### PR TITLE
add scalePivot to bounding box gizmo

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -106,6 +106,7 @@
 - StartDrag method added to pointerDragBehavior to simulate the start of a drag ([TrevorDev](https://github.com/TrevorDev))
 - Added EdgesLineRenderer to address [#4919](https://github.com/BabylonJS/Babylon.js/pull/4919) ([barteq100](https://github.com/barteq100))
 - Added ```ambientTextureImpactOnAnalyticalLights``` in PBRMaterial to allow fine grained control of the AmbientTexture on the analytical diffuse light ([sebavan](http://www.github.com/sebavan))
+- BoundingBoxGizmo scalePivot field that can be used to always scale objects from the bottom ([TrevorDev](https://github.com/TrevorDev))
 
 ### glTF Loader
 


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/4953

This will allow scaling on a pivot to work for the gizmo. 
Test PG: http://localhost:1338/Playground/index-local.html#XCPP9Y#614
http://playground.babylonjs.com/#JVMFIH#6

There still does seem to be some unexpected behavior when using pivot though which is why this PR will set pivot to identity always when the mesh has a pivot. 


@deltakosh @sebavan 
See this PG: http://playground.babylonjs.com/#JVMFIH#2

1. Press a (to scale the box smaller)
2. Press s (to set the pivot)
3. observe the box changes position (I did not think this should happen according to the docs I read here)

Any idea if I am doing something wrong or if this is expected? 

I'd recommending merging this PR if this is okay, and making the above a separate bug if it is not intended.