### PR TITLE
do not allow particle lifetime ratio to exceed 1

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -170,6 +170,7 @@
 - Exiting VR can result in messed up view ([TrevorDev](https://github.com/TrevorDev))
 - Dispose existing gazeTrackers when setting a new one, remove pivot matrix of meshes using boundingBoxGizmo ([TrevorDev](https://github.com/TrevorDev))
 - Set missing parentId in Mesh.serialize() for instances ([julien-moreau](https://github.com/julien-moreau))
+- Particle system unexpectedly creates a particle with an invalid lifetime ratio  ([TrevorDev](https://github.com/TrevorDev))
 
 ### Core Engine
 

--- a/src/Shaders/gpuRenderParticles.vertex.fx
+++ b/src/Shaders/gpuRenderParticles.vertex.fx
@@ -71,7 +71,7 @@ void main() {
 	#else	
    	vUV = uv;
 	#endif
-  float ratio = age / life;
+  float ratio = min(age / life, 1.);
 #ifdef COLORGRADIENTS
 	vColor = texture(colorGradientSampler, vec2(ratio, 0));
 #else


### PR DESCRIPTION
Fixes playground:
http://localhost:1338/Playground/index-local.html#PU4WYI#51

@deltakosh in the cpu version it does:
if (particle.age >= particle.lifeTime) { // Recycle by swapping with last particle
    this._emitFromParticle(particle);
    this.recycleParticle(particle);
    index--;
    continue;
}

gpu doesn't have this logic so age/lifetime is > 1 so I added the clamp.  Might be a good idea to have the same age >= lifetime logic in gpuUpdateParticles but I wasn't sure how/if i should do this.