### PR TITLE
Improved _isSyncronized performance in computeWorldMatrix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -107,6 +107,7 @@
 - Added EdgesLineRenderer to address [#4919](https://github.com/BabylonJS/Babylon.js/pull/4919) ([barteq100](https://github.com/barteq100))
 - Added ```ambientTextureImpactOnAnalyticalLights``` in PBRMaterial to allow fine grained control of the AmbientTexture on the analytical diffuse light ([sebavan](http://www.github.com/sebavan))
 - BoundingBoxGizmo scalePivot field that can be used to always scale objects from the bottom ([TrevorDev](https://github.com/TrevorDev))
+- Improved _isSyncronized performance and reduced GC in TransformNode.computeWorldMatrix by directly reading property. ([Bolloxim](https://github.com/Bolloxim))
 
 ### glTF Loader
 

--- a/src/Mesh/babylon.transformNode.ts
+++ b/src/Mesh/babylon.transformNode.ts
@@ -229,8 +229,8 @@ module BABYLON {
             if (!this._cache.position.equals(this.position))
                 return false;
 
-            if (this.rotationQuaternion) {
-                if (!this._cache.rotationQuaternion.equals(this.rotationQuaternion))
+            if (this._rotationQuaternion) {
+                if (!this._cache.rotationQuaternion.equals(this._rotationQuaternion))
                     return false;
             }
 


### PR DESCRIPTION
Fixed an issue with using a getter to read rotationQuaternion vs _rotationQuaterion property which saved both performance and large GC hits due to temporaries created.   I was asked to investigate a GC and performance issue with large scenes for a project.  I created a 1000 object static scene of sphere's.  I ran tests comparing frozen matrices to _isSyncronized pass and also dynamic. 
The result showed GC heap hits on the getter for rotationQuaternion and optional parameter. This read a property which is also nullable  (unsure if its nullable that is causing a creation of a temp) .  However changing this to a direct property read increased performance 10% and drastically curbed GC. (got graph captures) up shot was a saving of 5% in off the top performance over the getter method (although frozen was 13% faster) however the GC spike disappeared which was a much larger benefit in smoothness capture over a 20s period