### PR TITLE
Update babylon.action.ts

### DIFF
--- a/src/Actions/babylon.action.ts
+++ b/src/Actions/babylon.action.ts
@@ -37,6 +37,8 @@
             if (triggerOptions.parameter) {
                 this.trigger = triggerOptions.trigger;
                 this._triggerParameter = triggerOptions.parameter;
+            } else if(triggerOptions.trigger) {
+                this.trigger = triggerOptions.trigger;
             } else {
                 this.trigger = triggerOptions;
             }


### PR DESCRIPTION
To allow a trigger in brackets without a parameter. When you first have both a trigger and a parameter, it's not clear why it wouldn't work if you remove the parameter. Took me a while to figure out.