### PR TITLE
hasNewParent(true) which drastically improves performance.  Definitely needs review! :)

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -115,6 +115,7 @@
 - BoundingBoxGizmo scalePivot field that can be used to always scale objects from the bottom ([TrevorDev](https://github.com/TrevorDev))
 - Improved _isSyncronized performance and reduced GC in TransformNode.computeWorldMatrix by directly reading property. ([Bolloxim](https://github.com/Bolloxim))
 - Added supports for reflectionMatrix in Skybox Mode Cube Texture allowing offsetting the world center or rotating the matrix ([sebavan](http://www.github.com/sebavan))
+- Improved performance of cached nodes but ensuring parent always updates cache. This removes failed isSynchronized test that meant computeWorldMatrix would always have to rebuild. On large scenes this could double framerate. ([Bolloxim](https://github.com/Bolloxim))
 
 ### glTF Loader
 

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -351,7 +351,7 @@
 
         /** @hidden */
         public isSynchronized(updateCache?: boolean): boolean {
-            var check = this.hasNewParent();
+            var check = this.hasNewParent(true);
 
             check = check || !this.isSynchronizedWithParent();
 


### PR DESCRIPTION
Minor change to node.ts so that we update the cache always in hasNewParent(true). I tried using updateCache and pass it on through to hasNewParent(updateCache) but this did not work. hence TRUE. Doubled scene rendering performance for us with this change.  
The problem is that if (update) fails with the undefined behaviour, which basically means the topmost parent never gets to set  if (this._cache.parent === this.parent).  this means in computeWorldMatrix will always fail the sync test because of this topmost node.  Graphs I show for existing system basically shows nesting call as only 1 level ever, which is obviously wrong :) the working version shows a deeply nested recursion (something that needs addressing too, I would like to talk about, do you use slack? as this now takes a large chunk of processing time) 

note: I grep'd all files and did not see anything calling this but the isSynchronized function. Hence felt save for now to just set the parameter to true.  

so graphs,  these speak volumes.  I sample over 10 seconds.  They are named hasNewParent() or hasNewParent(true).  They are either frame time snapshot or a 10 second topdown tree view with isSynchronized() unwound so we can see recursive code nest cost (which can be fixed) 

its hard to argue with same data and view setup but quite literally twice as fast.  I also have content lists of objects that were not getting parented out even though we had frozen matrices on a lot of content colliders and some other elements.  This pruned that list from 1416 items down to less than 200 for the animated tree/dancer/bear.   In this view it prunes it down to basically nothing.  So huge cost in computeWorldMatrix and therefore evaluateActiveMeshes drastically reduces but a large increase isSynchronized().  

btw in these samples I deliberately chose best time from old system against worst time in new version.  I've sub 30ms for this view in the new and 120ms + for the old.  which technically I could claim 4 increase but lets keep it at the best old case and worst new case.. seems then we get no surprises :)

I've tested on validation tests seemed good, playground physics always ran 60 as well as instances. Took a lot of logging and stacktraces to figure this buggar out so hope this is a good fix! :)

![hasnewparent -10s-stack frame](https://user-images.githubusercontent.com/4536370/44831243-8527d300-abda-11e8-9414-506a7a21e172.png)
![hasnewparent -74ms frame](https://user-images.githubusercontent.com/4536370/44831244-85c06980-abda-11e8-9af6-67a98fcfeba5.png)
![hasnewparent true -10s-stack](https://user-images.githubusercontent.com/4536370/44831245-85c06980-abda-11e8-97b0-8dfc9e88b9cf.png)
![hasnewparent true -36ms frame](https://user-images.githubusercontent.com/4536370/44831246-85c06980-abda-11e8-8e35-64585157b3ad.png)



