### PR TITLE
get firefox to work with gizmos, fix vr controller dups

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -186,6 +186,7 @@
 - GPUParticleSystem does not get stuck in burst loop when stopped and started ([TrevorDev](https://github.com/TrevorDev))
 - trackPosition:false not working in webVRCamera ([TrevorDev](https://github.com/TrevorDev))
 - Spring Joint could not be removed ([TrevorDev](https://github.com/TrevorDev))
+- Sometimes duplicate controller models are loaded in VR ([TrevorDev](https://github.com/TrevorDev))
 
 ### Core Engine
 

--- a/src/Behaviors/Mesh/babylon.pointerDragBehavior.ts
+++ b/src/Behaviors/Mesh/babylon.pointerDragBehavior.ts
@@ -149,7 +149,7 @@ module BABYLON {
                 }
                 
                 if (pointerInfo.type == BABYLON.PointerEventTypes.POINTERDOWN) {
-                    
+
                     if(!this.dragging && pointerInfo.pickInfo && pointerInfo.pickInfo.hit && pointerInfo.pickInfo.pickedMesh && pointerInfo.pickInfo.pickedPoint && pointerInfo.pickInfo.ray && pickPredicate(pointerInfo.pickInfo.pickedMesh)){
                         this._startDrag((<PointerEvent>pointerInfo.event).pointerId, pointerInfo.pickInfo.ray, pointerInfo.pickInfo.pickedPoint);
                     }
@@ -159,7 +159,7 @@ module BABYLON {
                     }
                 }else if(pointerInfo.type == BABYLON.PointerEventTypes.POINTERMOVE){
                     var pointerId = (<PointerEvent>pointerInfo.event).pointerId;
-
+                    
                     // Keep track of last pointer ray, this is used simulating the start of a drag in startDrag()
                     if(!this._lastPointerRay[pointerId]){
                         this._lastPointerRay[pointerId] = new BABYLON.Ray(new BABYLON.Vector3(), new BABYLON.Vector3());
@@ -237,7 +237,7 @@ module BABYLON {
             var pickedPoint = this._pickWithRayOnDragPlane(this._startDragRay);
             if(pickedPoint){
                 this.dragging = true;
-                this.currentDraggingPointerID = 1;
+                this.currentDraggingPointerID = pointerId;
                 this.lastDragPosition.copyFrom(pickedPoint);
                 this.onDragStartObservable.notifyObservers({dragPlanePoint: pickedPoint, pointerId: this.currentDraggingPointerID});
                 this._targetPosition.copyFrom((this._attachedNode).absolutePosition)

--- a/src/Behaviors/Mesh/babylon.sixDofDragBehavior.ts
+++ b/src/Behaviors/Mesh/babylon.sixDofDragBehavior.ts
@@ -92,6 +92,7 @@ module BABYLON {
 
                         // Attach the virtual drag mesh to the virtual origin mesh so it can be dragged
                         this._virtualOriginMesh.removeChild(this._virtualDragMesh);
+                        pickedMesh.computeWorldMatrix();
                         this._virtualDragMesh.position.copyFrom(pickedMesh.absolutePosition);
                         if(!pickedMesh.rotationQuaternion){
                             pickedMesh.rotationQuaternion = Quaternion.RotationYawPitchRoll(pickedMesh.rotation.y,pickedMesh.rotation.x,pickedMesh.rotation.z);

--- a/src/Cameras/VR/babylon.webVRCamera.ts
+++ b/src/Cameras/VR/babylon.webVRCamera.ts
@@ -736,7 +736,7 @@ module BABYLON {
                                     }
                                     let activateLightOnSubMeshes = function (mesh: AbstractMesh, light: HemisphericLight) {
                                         let children = mesh.getChildren();
-                                        if (children.length !== 0) {
+                                        if (children && children.length !== 0) {
                                             children.forEach((mesh) => {
                                                 light.includedOnlyMeshes.push(<AbstractMesh>mesh);
                                                 activateLightOnSubMeshes(<AbstractMesh>mesh, light);


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/5065

@davrous Let me know if you see the duplicate controller issue again after this fix.
I think I finally found the issue with the duplicate controller models sometimes appearing. All the controller class call SceneLoader.ImportMesh with an onError callback which loads again. There seems to be a weird case where in a loaded gltf the getChildren() is null causing an error in the importMesh's onSuccess callback which then calls the onError loading the model again even though it already succeeded.