### PR TITLE
Add RedefineSerializedUrl for the Textures

### DIFF
--- a/src/Materials/Textures/babylon.texture.ts
+++ b/src/Materials/Textures/babylon.texture.ts
@@ -39,7 +39,12 @@
          * Gets or sets a boolean which defines if the texture url must be build from the serialized URL instead of just using the name and loading them side by side with the scene file
          */
         public static UseSerializedUrlIfAny = false;
-
+        
+        /**
+         * Gets or sets a string that sets the texture URL that must be generated from the serialized URL instead of just using the name and loading them side by side with the scene file
+         */
+		public static RedefineSerializedUrl = null;
+        
         // Members
         @serialize()
         public url: Nullable<string>;
@@ -512,11 +517,16 @@
                     if (parsedTexture.base64String) {
                         texture = Texture.CreateFromBase64String(parsedTexture.base64String, parsedTexture.name, scene, !generateMipMaps);
                     } else {
+                        if (Texture.RedefineSerializedUrl) {
+                            rootUrl = Texture.RedefineSerializedUrl;
+						}
+                        
                         let url = rootUrl + parsedTexture.name;
 
-                        if (Texture.UseSerializedUrlIfAny && parsedTexture.url) {
+                        if (Texture.UseSerializedUrlIfAny && parsedTexture.url && !Texture.RedefineSerializedUrl) {
                             url = parsedTexture.url;
-                        }
+                        }                        
+                        
                         texture = new Texture(url, scene, !generateMipMaps, parsedTexture.invertY);
                     }
 


### PR DESCRIPTION
Allows you to redefine a URl for the search path for images of serialized models that are in a path different from the original models.

If the path is redefine, UseSerializedUrlIfAny will be ignored if it has been set to true.

Why that :
On my project, I have on one side the editor that creates scenes and saves by serializing the models in a folder '_Projets/TitleGame/ scenes/'. The basic models are on another path. On the editor, no problem my models are reloading properly thanks to UseSerializedUrlIfAny.

Now if I run the game, I run it from TitleGame / search for images that made from '_Projects/TitleGame/' and suddenly no images of my models have the correct path.

RedefineSerializedUrl may allow me to redefine the correct path quite easily with this property.