### PR TITLE
Added optional alphaFilter parameter to CreateGroundFromHeightMap

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -126,6 +126,7 @@
 - Improved performance of cached nodes but ensuring parent always updates cache. This removes failed isSynchronized test that meant computeWorldMatrix would always have to rebuild. On large scenes this could double framerate. ([Bolloxim](https://github.com/Bolloxim))
 - Added FXAA and MSAA support to the StandardRenderingPipeline ([julien-moreau](https://github.com/julien-moreau))
 - Make teleportCamera public in VR experience helper ([TrevorDev](https://github.com/TrevorDev))
+- Added optional alphaFilter parameter to ```CreateGroundFromHeightMap``` to allow for heightmaps to be created that ignore any transparent data ([Postman-nz](https://github.com/Postman-nz))
 
 
 ### glTF Loader

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -3136,6 +3136,7 @@
          * The parameter `minHeight` (float, default 0) is the minimum altitude on the ground.     
          * The parameter `maxHeight` (float, default 1) is the maximum altitude on the ground.   
          * The parameter `onReady` is a javascript callback function that will be called  once the mesh is just built (the height map download can last some time).  
+         * The parameter `alphaFilter` will filter any data where the alpha channel is below this value, defaults 0 (all data visible)
          * This function is passed the newly built mesh : 
          * ```javascript
          * function(mesh) { // do things
@@ -3143,7 +3144,7 @@
          * ```
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
          */
-        public static CreateGroundFromHeightMap(name: string, url: string, width: number, height: number, subdivisions: number, minHeight: number, maxHeight: number, scene: Scene, updatable?: boolean, onReady?: (mesh: GroundMesh) => void): GroundMesh {
+        public static CreateGroundFromHeightMap(name: string, url: string, width: number, height: number, subdivisions: number, minHeight: number, maxHeight: number, scene: Scene, updatable?: boolean, onReady?: (mesh: GroundMesh) => void, alphaFilter?: number): GroundMesh {
             var options = {
                 width: width,
                 height: height,
@@ -3151,7 +3152,8 @@
                 minHeight: minHeight,
                 maxHeight: maxHeight,
                 updatable: updatable,
-                onReady: onReady
+                onReady: onReady,
+                alphaFilter: alphaFilter
             };
 
             return MeshBuilder.CreateGroundFromHeightMap(name, url, options, scene);

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -3130,13 +3130,14 @@
          * Creates a ground mesh from a height map.    
          * tuto : http://doc.babylonjs.com/babylon101/height_map   
          * Please consider using the same method from the MeshBuilder class instead.    
-         * The parameter `url` sets the URL of the height map image resource.  
-         * The parameters `width` and `height` (positive floats, default 10) set the ground width and height sizes.     
-         * The parameter `subdivisions` (positive integer, default 1) sets the number of subdivision per side.  
-         * The parameter `minHeight` (float, default 0) is the minimum altitude on the ground.     
-         * The parameter `maxHeight` (float, default 1) is the maximum altitude on the ground.   
-         * The parameter `onReady` is a javascript callback function that will be called  once the mesh is just built (the height map download can last some time).  
-         * The parameter `alphaFilter` will filter any data where the alpha channel is below this value, defaults 0 (all data visible)
+         * @param url sets the URL of the height map image resource.  
+         * @param width (positive float, default 10) set the ground width size.  
+         * @param height (positive float, default 10) set the ground height size.  
+         * @param subdivisions (positive integer, default 1) sets the number of subdivision per side.  
+         * @param minHeight (float, default 0) is the minimum altitude on the ground.     
+         * @param maxHeight (float, default 1) is the maximum altitude on the ground.   
+         * @param onReady is a javascript callback function that will be called  once the mesh is just built (the height map download can last some time).  
+         * @param alphaFilter will filter any data where the alpha channel is below this value, defaults 0 (all data visible).
          * This function is passed the newly built mesh : 
          * ```javascript
          * function(mesh) { // do things

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1769,7 +1769,7 @@
                     var gradient = r * filter.r + g * filter.g + b * filter.b;
                     
                     // If our alpha channel is not within our filter then we will assign a 'special' height 
-                    // Then when building the indicies, we will ignore any vertex that is using the special height
+                    // Then when building the indices, we will ignore any vertex that is using the special height
                     if(a >= alphaFilter)
                         position.y = options.minHeight + (options.maxHeight - options.minHeight) * gradient;
                     else {
@@ -1786,16 +1786,14 @@
             // Indices
             for (row = 0; row < options.subdivisions; row++) {
                 for (col = 0; col < options.subdivisions; col++) {
-                    // Calculate indcies
+                    // Calculate Indices
                     var idx1 = (col + 1 + (row + 1) * (options.subdivisions + 1));
                     var idx2 = (col + 1 + row * (options.subdivisions + 1));
                     var idx3 = (col + row * (options.subdivisions + 1));
                     var idx4 = (col + (row + 1) * (options.subdivisions + 1));
-                    var idx5 = (col + 1 + (row + 1) * (options.subdivisions + 1));
-                    var idx6 = (col + row * (options.subdivisions + 1));
 
-                    // Check that all indicies are visible (based on our special height)
-                    // Only display the vertex if all indcies are visible
+                    // Check that all indices are visible (based on our special height)
+                    // Only display the vertex if all Indices are visible
                     var isVisibleIdx1 = positions[idx1 * 3 + 1] >= options.minHeight;
                     var isVisibleIdx2 = positions[idx2 * 3 + 1] >= options.minHeight;
                     var isVisibleIdx3 = positions[idx3 * 3 + 1] >= options.minHeight;
@@ -1806,12 +1804,10 @@
                     }
 
                     var isVisibleIdx4 = positions[idx4 * 3 + 1] >= options.minHeight;
-                    var isVisibleIdx5 = positions[idx5 * 3 + 1] >= options.minHeight;
-                    var isVisibleIdx6 = positions[idx6 * 3 + 1] >= options.minHeight;
-                    if (isVisibleIdx4 && isVisibleIdx5 && isVisibleIdx6) {
+                    if (isVisibleIdx4 && isVisibleIdx1 && isVisibleIdx3) {
                         indices.push(idx4);
-                        indices.push(idx5);
-                        indices.push(idx6);
+                        indices.push(idx1);
+                        indices.push(idx3);
                     }
                 }
             }

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1739,15 +1739,17 @@
           * * buffer the array holding the image color data 
           * * bufferWidth the width of image
           * * bufferHeight the height of image
+          * * alphaFilter Remove any data where the alpha channel is below this value, defaults 0 (all data visible)
          * @returns the VertexData of the Ground designed from a heightmap   
          */
-        public static CreateGroundFromHeightMap(options: { width: number, height: number, subdivisions: number, minHeight: number, maxHeight: number, colorFilter: Color3, buffer: Uint8Array, bufferWidth: number, bufferHeight: number }): VertexData {
+        public static CreateGroundFromHeightMap(options: { width: number, height: number, subdivisions: number, minHeight: number, maxHeight: number, colorFilter: Color3, buffer: Uint8Array, bufferWidth: number, bufferHeight: number, alphaFilter: number }): VertexData {
             var indices = [];
             var positions = [];
             var normals = [];
             var uvs = [];
             var row, col;
             var filter = options.colorFilter || new Color3(0.3, 0.59, 0.11);
+            var alphaFilter = options.alphaFilter || 0.0;
 
             // Vertices
             for (row = 0; row <= options.subdivisions; row++) {
@@ -1762,10 +1764,17 @@
                     var r = options.buffer[pos] / 255.0;
                     var g = options.buffer[pos + 1] / 255.0;
                     var b = options.buffer[pos + 2] / 255.0;
+                    var a = options.buffer[pos + 3] / 255.0;
 
                     var gradient = r * filter.r + g * filter.g + b * filter.b;
-
-                    position.y = options.minHeight + (options.maxHeight - options.minHeight) * gradient;
+                    
+                    // If our alpha channel is not within our filter then we will assign a 'special' height 
+                    // Then when building the indicies, we will ignore any vertex that is using the special height
+                    if(a >= alphaFilter)
+                        position.y = options.minHeight + (options.maxHeight - options.minHeight) * gradient;
+                    else {
+                        position.y = options.minHeight - 1; // We can't have a height below minHeight, normally.
+                    }
 
                     // Add  vertex
                     positions.push(position.x, position.y, position.z);
@@ -1777,13 +1786,33 @@
             // Indices
             for (row = 0; row < options.subdivisions; row++) {
                 for (col = 0; col < options.subdivisions; col++) {
-                    indices.push(col + 1 + (row + 1) * (options.subdivisions + 1));
-                    indices.push(col + 1 + row * (options.subdivisions + 1));
-                    indices.push(col + row * (options.subdivisions + 1));
+                    // Calculate indcies
+                    var idx1 = (col + 1 + (row + 1) * (options.subdivisions + 1));
+                    var idx2 = (col + 1 + row * (options.subdivisions + 1));
+                    var idx3 = (col + row * (options.subdivisions + 1));
+                    var idx4 = (col + (row + 1) * (options.subdivisions + 1));
+                    var idx5 = (col + 1 + (row + 1) * (options.subdivisions + 1));
+                    var idx6 = (col + row * (options.subdivisions + 1));
 
-                    indices.push(col + (row + 1) * (options.subdivisions + 1));
-                    indices.push(col + 1 + (row + 1) * (options.subdivisions + 1));
-                    indices.push(col + row * (options.subdivisions + 1));
+                    // Check that all indicies are visible (based on our special height)
+                    // Only display the vertex if all indcies are visible
+                    var isVisibleIdx1 = positions[idx1 * 3 + 1] >= options.minHeight;
+                    var isVisibleIdx2 = positions[idx2 * 3 + 1] >= options.minHeight;
+                    var isVisibleIdx3 = positions[idx3 * 3 + 1] >= options.minHeight;
+                    if (isVisibleIdx1 && isVisibleIdx2 && isVisibleIdx3) {
+                        indices.push(idx1);
+                        indices.push(idx2);
+                        indices.push(idx3);
+                    }
+
+                    var isVisibleIdx4 = positions[idx4 * 3 + 1] >= options.minHeight;
+                    var isVisibleIdx5 = positions[idx5 * 3 + 1] >= options.minHeight;
+                    var isVisibleIdx6 = positions[idx6 * 3 + 1] >= options.minHeight;
+                    if (isVisibleIdx4 && isVisibleIdx5 && isVisibleIdx6) {
+                        indices.push(idx4);
+                        indices.push(idx5);
+                        indices.push(idx6);
+                    }
                 }
             }
 

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1773,7 +1773,7 @@
                     if(a >= alphaFilter)
                         position.y = options.minHeight + (options.maxHeight - options.minHeight) * gradient;
                     else {
-                        position.y = options.minHeight - 1; // We can't have a height below minHeight, normally.
+                        position.y = options.minHeight - BABYLON.Epsilon; // We can't have a height below minHeight, normally.
                     }
 
                     // Add  vertex
@@ -1794,6 +1794,7 @@
 
                     // Check that all indices are visible (based on our special height)
                     // Only display the vertex if all Indices are visible
+                    // Positions are stored x,y,z for each vertex, hence the * 3 and + 1 for height
                     var isVisibleIdx1 = positions[idx1 * 3 + 1] >= options.minHeight;
                     var isVisibleIdx2 = positions[idx2 * 3 + 1] >= options.minHeight;
                     var isVisibleIdx3 = positions[idx3 * 3 + 1] >= options.minHeight;

--- a/src/Mesh/babylon.meshBuilder.ts
+++ b/src/Mesh/babylon.meshBuilder.ts
@@ -776,6 +776,7 @@
          * * The parameter `maxHeight` (float, default 1) is the maximum altitude on the ground.   
          * * The parameter `colorFilter` (optional Color3, default (0.3, 0.59, 0.11) ) is the filter to apply to the image pixel colors to compute the height.  
          * * The parameter `onReady` is a javascript callback function that will be called  once the mesh is just built (the height map download can last some time).  
+         * * The parameter `alphaFilter` will filter any data where the alpha channel is below this value, defaults 0 (all data visible)
          * * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.  
          * @param name defines the name of the mesh
          * @param url defines the url to the height map
@@ -785,13 +786,14 @@
          * @see http://doc.babylonjs.com/babylon101/height_map   
          * @see http://doc.babylonjs.com/tutorials/Mesh_CreateXXX_Methods_With_Options_Parameter#ground-from-a-height-map
          */
-        public static CreateGroundFromHeightMap(name: string, url: string, options: { width?: number, height?: number, subdivisions?: number, minHeight?: number, maxHeight?: number, colorFilter?: Color3, updatable?: boolean, onReady?: (mesh: GroundMesh) => void }, scene: Scene): GroundMesh {
+        public static CreateGroundFromHeightMap(name: string, url: string, options: { width?: number, height?: number, subdivisions?: number, minHeight?: number, maxHeight?: number, colorFilter?: Color3, alphaFilter?: number, updatable?: boolean, onReady?: (mesh: GroundMesh) => void }, scene: Scene): GroundMesh {
             var width = options.width || 10.0;
             var height = options.height || 10.0;
             var subdivisions = options.subdivisions || 1 | 0;
             var minHeight = options.minHeight || 0.0;
             var maxHeight = options.maxHeight || 1.0;
             var filter = options.colorFilter || new Color3(0.3, 0.59, 0.11);
+            var alphaFilter = options.alphaFilter || 0.0;
             var updatable = options.updatable;
             var onReady = options.onReady;
 
@@ -834,7 +836,8 @@
                     width: width, height: height,
                     subdivisions: subdivisions,
                     minHeight: minHeight, maxHeight: maxHeight, colorFilter: filter,
-                    buffer: buffer, bufferWidth: bufferWidth, bufferHeight: bufferHeight
+                    buffer: buffer, bufferWidth: bufferWidth, bufferHeight: bufferHeight, 
+                    alphaFilter: alphaFilter
                 });
 
                 vertexData.applyToMesh(ground, updatable);

--- a/what's new.md
+++ b/what's new.md
@@ -122,7 +122,6 @@
 - New `serialize` and `Parse` functions for SSAO2 Rendering Pipeline ([julien-moreau](https://github.com/julien-moreau))
 - Added `furOcclusion` property to FurMaterial to control the occlusion strength ([julien-moreau](https://github.com/julien-moreau))
 - Optimize ephimeral object creation to help GC ([menduz](https://github.com/menduz))
-- Added optional alphaFilter parameter to ```CreateGroundFromHeightMap``` to allow for heightmaps to be created that ignore any transparent data ([Postman-nz](https://github.com/Postman-nz))
 
 ## Bug fixes
 

--- a/what's new.md
+++ b/what's new.md
@@ -122,6 +122,7 @@
 - New `serialize` and `Parse` functions for SSAO2 Rendering Pipeline ([julien-moreau](https://github.com/julien-moreau))
 - Added `furOcclusion` property to FurMaterial to control the occlusion strength ([julien-moreau](https://github.com/julien-moreau))
 - Optimize ephimeral object creation to help GC ([menduz](https://github.com/menduz))
+- Added optional alphaFilter parameter to ```CreateGroundFromHeightMap``` to allow for heightmaps to be created that ignore any transparent data ([Postman-nz](https://github.com/Postman-nz))
 
 ## Bug fixes
 


### PR DESCRIPTION
Based on the discussion [Here](http://www.html5gamedevs.com/topic/39842-prevent-vertical-stripes-in-babylon-mesh/#) I've added an Alpha Filter to the create height map method.

The mesh creation process checks the alpha channel  against the filter, and if it is more transparent than required then the vertex is 'ignored'. The actual vertex still exists, no indices are added for the vertex.

This PR will preserve backwards compatibility, as the alpha filter defaults to 0.0 (all data).
