### PR TITLE
Updates to glTF lights extensions

### DIFF
--- a/Tools/Gulp/config.json
+++ b/Tools/Gulp/config.json
@@ -1804,9 +1804,9 @@
                     "../../loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts",
-                    "../../loaders/src/glTF/2.0/Extensions/KHR_lights.ts",
+                    "../../loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts",
-                    "../../loaders/src/glTF/2.0/Extensions/EXT_lights_imageBased.ts"
+                    "../../loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts"
                 ],
                 "doNotIncludeInBundle": true,
                 "output": "babylon.glTF2FileLoader.js"
@@ -1830,9 +1830,9 @@
                     "../../loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts",
-                    "../../loaders/src/glTF/2.0/Extensions/KHR_lights.ts",
+                    "../../loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts",
                     "../../loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts",
-                    "../../loaders/src/glTF/2.0/Extensions/EXT_lights_imageBased.ts"
+                    "../../loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts"
                 ],
                 "output": "babylon.glTFFileLoader.js"
             }

--- a/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
 module BABYLON.GLTF2.Extensions {
-    const NAME = "EXT_lights_imageBased";
+    const NAME = "EXT_lights_image_based";
 
     interface ILightReference {
         light: number;
@@ -23,9 +23,9 @@ module BABYLON.GLTF2.Extensions {
     }
 
     /**
-     * [Specification](TODO) (Experimental)
+     * [Specification](https://github.com/KhronosGroup/glTF/blob/eb3e32332042e04691a5f35103f8c261e50d8f1e/extensions/2.0/Khronos/EXT_lights_image_based/README.md) (Experimental)
      */
-    export class EXT_lights_imageBased implements IGLTFLoaderExtension {
+    export class EXT_lights_image_based implements IGLTFLoaderExtension {
         /** The name of this extension. */
         public readonly name = NAME;
 
@@ -138,5 +138,5 @@ module BABYLON.GLTF2.Extensions {
         }
     }
 
-    GLTFLoader.RegisterExtension(NAME, loader => new EXT_lights_imageBased(loader));
+    GLTFLoader.RegisterExtension(NAME, loader => new EXT_lights_image_based(loader));
 }

--- a/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -1,10 +1,9 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
 module BABYLON.GLTF2.Extensions {
-    const NAME = "KHR_lights";
+    const NAME = "KHR_lights_punctual";
 
     enum LightType {
-        AMBIENT = "ambient",
         DIRECTIONAL = "directional",
         POINT = "point",
         SPOT = "spot"
@@ -14,10 +13,11 @@ module BABYLON.GLTF2.Extensions {
         light: number;
     }
 
-    interface ILight {
+    interface ILight extends IChildRootProperty {
         type: LightType;
         color?: number[];
         intensity?: number;
+        range?: number;
         spot?: {
             innerConeAngle?: number;
             outerConeAngle?: number;
@@ -29,7 +29,7 @@ module BABYLON.GLTF2.Extensions {
     }
 
     /**
-     * [Specification](https://github.com/MiiBond/glTF/tree/khr_lights_v1/extensions/Khronos/KHR_lights) (Experimental)
+     * [Specification](https://github.com/KhronosGroup/glTF/blob/1048d162a44dbcb05aefc1874bfd423cf60135a6/extensions/2.0/Khronos/KHR_lights_punctual/README.md) (Experimental)
      */
     export class KHR_lights implements IGLTFLoaderExtension {
         /** The name of this extension. */
@@ -62,22 +62,6 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadSceneAsync(context: string, scene: ILoaderScene): Nullable<Promise<void>> { 
-            return GLTFLoader.LoadExtensionAsync<ILightReference>(context, scene, this.name, (extensionContext, extension) => {
-                const promise = this._loader.loadSceneAsync(context, scene);
-
-                const light = ArrayItem.Get(extensionContext, this._lights, extension.light);
-                if (light.type !== LightType.AMBIENT) {
-                    throw new Error(`${extensionContext}: Only ambient lights are allowed on a scene`);
-                }
-
-                this._loader.babylonScene.ambientColor = light.color ? Color3.FromArray(light.color) : Color3.Black();
-
-                return promise;
-            });
-        }
-
-        /** @hidden */
         public loadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> { 
             return GLTFLoader.LoadExtensionAsync<ILightReference, Mesh>(context, node, this.name, (extensionContext, extension) => {
                 return this._loader.loadNodeAsync(context, node, babylonMesh => {
@@ -85,12 +69,10 @@ module BABYLON.GLTF2.Extensions {
 
                     const name = babylonMesh.name;
                     const light = ArrayItem.Get(extensionContext, this._lights, extension.light);
+
                     switch (light.type) {
-                        case LightType.AMBIENT: {
-                            throw new Error(`${extensionContext}: Ambient lights are not allowed on a node`);
-                        }
                         case LightType.DIRECTIONAL: {
-                            babylonLight = new DirectionalLight(name, Vector3.Forward(), this._loader.babylonScene);
+                            babylonLight = new DirectionalLight(name, Vector3.Backward(), this._loader.babylonScene);
                             break;
                         }
                         case LightType.POINT: {
@@ -98,10 +80,10 @@ module BABYLON.GLTF2.Extensions {
                             break;
                         }
                         case LightType.SPOT: {
-                            // TODO: support inner and outer cone angles
-                            //const innerConeAngle = spotLight.innerConeAngle || 0;
-                            const outerConeAngle = light.spot && light.spot.outerConeAngle || Math.PI / 4;
-                            babylonLight = new SpotLight(name, Vector3.Zero(), Vector3.Forward(), outerConeAngle, 2, this._loader.babylonScene);
+                            const babylonSpotLight = new SpotLight(name, Vector3.Zero(), Vector3.Backward(), 0, 2, this._loader.babylonScene);
+                            babylonSpotLight.angle = light.spot && light.spot.outerConeAngle || Math.PI / 4;
+                            babylonSpotLight.innerAngle = light.spot && light.spot.innerConeAngle || 0;
+                            babylonLight = babylonSpotLight;
                             break;
                         }
                         default: {
@@ -109,8 +91,10 @@ module BABYLON.GLTF2.Extensions {
                         }
                     }
 
+                    babylonLight.falloffType = Light.FALLOFF_GLTF;
                     babylonLight.diffuse = light.color ? Color3.FromArray(light.color) : Color3.White();
                     babylonLight.intensity = light.intensity == undefined ? 1 : light.intensity;
+                    babylonLight.range = light.range == undefined ? Number.MAX_VALUE : light.range;
                     babylonLight.parent = babylonMesh;
 
                     assign(babylonMesh);

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -2164,6 +2164,13 @@
             return new Vector3(0.0, 0.0, 1.0);
         }
         /**
+         * Returns a new Vector3 set to (0.0, 0.0, -1.0)
+         * @returns a new forward Vector3
+         */
+        public static Backward(): Vector3 {
+            return new Vector3(0.0, 0.0, -1.0);
+        }
+        /**
          * Returns a new Vector3 set to (1.0, 0.0, 0.0)
          * @returns a new right Vector3
          */


### PR DESCRIPTION
Updates to the glTF loader for the following glTF extensions:
* KHR_lights_punctual (https://github.com/KhronosGroup/glTF/pull/1223)
* EXT_lights_image_based (https://github.com/KhronosGroup/glTF/pull/1377)