### PR TITLE
Bug fixes to KHR_lights_punctual implementation

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -68,8 +68,8 @@ module BABYLON.GLTF2.Extensions {
                 return this._loader.loadNodeAsync(context, node, babylonMesh => {
                     let babylonLight: Light;
 
-                    const name = babylonMesh.name;
                     const light = ArrayItem.Get(extensionContext, this._lights, extension.light);
+                    const name = light.name || babylonMesh.name;
 
                     switch (light.type) {
                         case LightType.DIRECTIONAL: {
@@ -81,9 +81,9 @@ module BABYLON.GLTF2.Extensions {
                             break;
                         }
                         case LightType.SPOT: {
-                            const babylonSpotLight = new SpotLight(name, Vector3.Zero(), Vector3.Backward(), 0, 2, this._loader.babylonScene);
-                            babylonSpotLight.angle = light.spot && light.spot.outerConeAngle || Math.PI / 4;
-                            babylonSpotLight.innerAngle = light.spot && light.spot.innerConeAngle || 0;
+                            const babylonSpotLight = new SpotLight(name, Vector3.Zero(), Vector3.Backward(), 0, 1, this._loader.babylonScene);
+                            babylonSpotLight.angle = ((light.spot && light.spot.outerConeAngle) || Math.PI / 4) * 2;
+                            babylonSpotLight.innerAngle = ((light.spot && light.spot.innerConeAngle) || 0) * 2;
                             babylonLight = babylonSpotLight;
                             break;
                         }

--- a/src/Lights/babylon.spotLight.ts
+++ b/src/Lights/babylon.spotLight.ts
@@ -56,7 +56,7 @@
          */
         @serialize()
         public get innerAngle(): number {
-            return this._angle
+            return this._innerAngle;
         }
         /**
          * Only used in gltf falloff mode, this defines the angle where 


### PR DESCRIPTION
* Use light.name if available
* Multiple inner and outer angle by 2 since spec and Babylon conventions are different
* Fix typo in getting innerAngle
