### PR TITLE
Shortcut for Vector3

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1555,8 +1555,13 @@
             /**
              * Defines the third coordinates (on Z axis)
              */
-            public z: number = 0
+            public z: number = 0 
         ) {
+            if(x.x && x.y && x.z) {
+                this.x = x.x;
+                this.y = x.y;
+                this.z = x.z;
+            }
         }
 
         /**


### PR DESCRIPTION
I do not know if it's good to do that, but it's a short cut for vector3.

Just make  : 
BABYLON.Vector3 (mesh.position); //faster version (the param 2 and 3 no longer essential
While also keeping:
BABYLON.Vector3 (mesh.position.x, mesh.position.y, mesh.position.z); // Original version

What do you think, it is possible that we can do that too? If not possible, it does not matter, I only propose a shortcut idea.