### PR TITLE
Move glTF loader extensions into a more unique namespace

### DIFF
--- a/Viewer/src/loader/plugins/msftLodLoaderPlugin.ts
+++ b/Viewer/src/loader/plugins/msftLodLoaderPlugin.ts
@@ -17,7 +17,7 @@ export class MSFTLodLoaderPlugin implements ILoaderPlugin {
 
     public onExtensionLoaded(extension: IGLTFLoaderExtension) {
         if (extension.name === "MSFT_lod" && this._model.configuration.loaderConfiguration) {
-            const MSFT_lod = extension as GLTF2.Extensions.MSFT_lod;
+            const MSFT_lod = extension as GLTF2.Loader.Extensions.MSFT_lod;
             MSFT_lod.enabled = !!this._model.configuration.loaderConfiguration.progressiveLoading;
             MSFT_lod.maxLODsToLoad = this._model.configuration.loaderConfiguration.maxLODsToLoad || Number.MAX_VALUE;
         }

--- a/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "EXT_lights_image_based";
 
     interface ILightReference {
@@ -56,7 +56,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadSceneAsync(context: string, scene: ILoaderScene): Nullable<Promise<void>> { 
+        public loadSceneAsync(context: string, scene: IScene): Nullable<Promise<void>> { 
             return GLTFLoader.LoadExtensionAsync<ILightReference>(context, scene, this.name, (extensionContext, extension) => {
                 const promises = new Array<Promise<any>>();
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "KHR_draco_mesh_compression";
 
     interface IKHRDracoMeshCompression {
@@ -8,7 +8,7 @@ module BABYLON.GLTF2.Extensions {
         attributes: { [name: string]: number };
     }
 
-    interface ILoaderBufferViewDraco extends ILoaderBufferView {
+    interface IBufferViewDraco extends IBufferView {
         _dracoBabylonGeometry?: Promise<Geometry>;
     }
 
@@ -41,7 +41,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public _loadVertexDataAsync(context: string, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>> {
+        public _loadVertexDataAsync(context: string, primitive: IMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>> {
             return GLTFLoader.LoadExtensionAsync<IKHRDracoMeshCompression, Geometry>(context, primitive, this.name, (extensionContext, extension) => {
                 if (primitive.mode != undefined) {
                     if (primitive.mode !== MeshPrimitiveMode.TRIANGLE_STRIP &&
@@ -79,7 +79,7 @@ module BABYLON.GLTF2.Extensions {
                 loadAttribute("WEIGHTS_0", VertexBuffer.MatricesWeightsKind);
                 loadAttribute("COLOR_0", VertexBuffer.ColorKind);
 
-                var bufferView = ArrayItem.Get(extensionContext, this._loader.gltf.bufferViews, extension.bufferView) as ILoaderBufferViewDraco;
+                var bufferView = ArrayItem.Get(extensionContext, this._loader.gltf.bufferViews, extension.bufferView) as IBufferViewDraco;
                 if (!bufferView._dracoBabylonGeometry) {
                     bufferView._dracoBabylonGeometry = this._loader.loadBufferViewAsync(`#/bufferViews/${bufferView.index}`, bufferView).then(data => {
                         if (!this._dracoCompression) {

--- a/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "KHR_lights_punctual";
 
     enum LightType {
@@ -63,7 +63,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> { 
+        public loadNodeAsync(context: string, node: INode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> { 
             return GLTFLoader.LoadExtensionAsync<ILightReference, Mesh>(context, node, this.name, (extensionContext, extension) => {
                 return this._loader.loadNodeAsync(context, node, babylonMesh => {
                     let babylonLight: Light;

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "KHR_materials_pbrSpecularGlossiness";
 
     interface IKHRMaterialsPbrSpecularGlossiness {
@@ -34,7 +34,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return GLTFLoader.LoadExtensionAsync<IKHRMaterialsPbrSpecularGlossiness>(context, material, this.name, (extensionContext, extension) => {
                 const promises = new Array<Promise<any>>();
                 promises.push(this._loader.loadMaterialBasePropertiesAsync(context, material, babylonMaterial));
@@ -44,7 +44,7 @@ module BABYLON.GLTF2.Extensions {
             });
         }
 
-        private _loadSpecularGlossinessPropertiesAsync(context: string, material: ILoaderMaterial, properties: IKHRMaterialsPbrSpecularGlossiness, babylonMaterial: Material): Promise<void> {
+        private _loadSpecularGlossinessPropertiesAsync(context: string, material: IMaterial, properties: IKHRMaterialsPbrSpecularGlossiness, babylonMaterial: Material): Promise<void> {
             if (!(babylonMaterial instanceof PBRMaterial)) {
                 throw new Error(`${context}: Material type not supported`);
             }

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "KHR_materials_unlit";
 
     /**
@@ -26,13 +26,13 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return GLTFLoader.LoadExtensionAsync(context, material, this.name, () => {
                 return this._loadUnlitPropertiesAsync(context, material, babylonMaterial);
             });
         }
 
-        private _loadUnlitPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Promise<void> {
+        private _loadUnlitPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Promise<void> {
             if (!(babylonMaterial instanceof PBRMaterial)) {
                 throw new Error(`${context}: Material type not supported`);
             }

--- a/loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "KHR_texture_transform";
 
     interface IKHRTextureTransform {
@@ -11,7 +11,7 @@ module BABYLON.GLTF2.Extensions {
     }
 
     /**
-     * [Specification](https://github.com/AltspaceVR/glTF/blob/avr-sampler-offset-tile/extensions/2.0/Khronos/KHR_texture_transform/README.md) (Experimental)
+     * [Specification](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_transform/README.md)
      */
     export class KHR_texture_transform implements IGLTFLoaderExtension {
         /** The name of this extension. */

--- a/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "MSFT_audio_emitter";
 
     interface IClipReference {
@@ -119,7 +119,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadSceneAsync(context: string, scene: ILoaderScene): Nullable<Promise<void>> {
+        public loadSceneAsync(context: string, scene: IScene): Nullable<Promise<void>> {
             return GLTFLoader.LoadExtensionAsync<IEmittersReference>(context, scene, this.name, (extensionContext, extension) => {
                 const promises = new Array<Promise<any>>();
 
@@ -140,7 +140,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
+        public loadNodeAsync(context: string, node: INode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
             return GLTFLoader.LoadExtensionAsync<IEmittersReference, Mesh>(context, node, this.name, (extensionContext, extension) => {
                 const promises = new Array<Promise<any>>();
 
@@ -171,7 +171,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadAnimationAsync(context: string, animation: ILoaderAnimation): Nullable<Promise<AnimationGroup>> {
+        public loadAnimationAsync(context: string, animation: IAnimation): Nullable<Promise<AnimationGroup>> {
             return GLTFLoader.LoadExtensionAsync<ILoaderAnimationEvents, AnimationGroup>(context, animation, this.name, (extensionContext, extension) => {
                 return this._loader.loadAnimationAsync(context, animation).then(babylonAnimationGroup => {
                     const promises = new Array<Promise<any>>();
@@ -274,7 +274,7 @@ module BABYLON.GLTF2.Extensions {
             }
         }
 
-        private _loadAnimationEventAsync(context: string, animationContext: string, animation: ILoaderAnimation, event: ILoaderAnimationEvent, babylonAnimationGroup: AnimationGroup): Promise<void> {
+        private _loadAnimationEventAsync(context: string, animationContext: string, animation: IAnimation, event: ILoaderAnimationEvent, babylonAnimationGroup: AnimationGroup): Promise<void> {
             if (babylonAnimationGroup.targetedAnimations.length == 0) {
                 return Promise.resolve();
             }

--- a/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "MSFT_lod";
 
     interface IMSFTLOD {
@@ -111,7 +111,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public loadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
+        public loadNodeAsync(context: string, node: INode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
             return GLTFLoader.LoadExtensionAsync<IMSFTLOD, Mesh>(context, node, this.name, (extensionContext, extension) => {
                 let firstPromise: Promise<Mesh>;
 
@@ -157,7 +157,7 @@ module BABYLON.GLTF2.Extensions {
         }
 
         /** @hidden */
-        public _loadMaterialAsync(context: string, material: ILoaderMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
+        public _loadMaterialAsync(context: string, material: IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
             // Don't load material LODs if already loading a node LOD.
             if (this._nodeIndexLOD) {
                 return null;

--- a/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "MSFT_minecraftMesh";
 
     /** @hidden */
@@ -18,7 +18,7 @@ module BABYLON.GLTF2.Extensions {
             delete this._loader;
         }
 
-        public loadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return GLTFLoader.LoadExtraAsync<boolean>(context, material, this.name, (extraContext, extra) => {
                 if (extra) {
                     if (!(babylonMaterial instanceof PBRMaterial)) {

--- a/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
     const NAME = "MSFT_sRGBFactors";
 
     /** @hidden */
@@ -18,7 +18,7 @@ module BABYLON.GLTF2.Extensions {
             delete this._loader;
         }
 
-        public loadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return GLTFLoader.LoadExtraAsync<boolean>(context, material, this.name, (extraContext, extra) => {
                 if (extra) {
                     if (!(babylonMaterial instanceof PBRMaterial)) {

--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -37,7 +37,7 @@ module BABYLON.GLTF2 {
          * Assign an `index` field to each item of the given array.
          * @param array The array of items
          */
-        public static Assign(array?: IArrayItem[]): void {
+        public static Assign(array?: Loader.IArrayItem[]): void {
             if (array) {
                 for (let index = 0; index < array.length; index++) {
                     array[index].index = index;
@@ -51,7 +51,7 @@ module BABYLON.GLTF2 {
      */
     export class GLTFLoader implements IGLTFLoader {
         /** The glTF object parsed from the JSON. */
-        public gltf: ILoaderGLTF;
+        public gltf: Loader.IGLTF;
 
         /** The Babylon scene when loading the asset. */
         public babylonScene: Scene;
@@ -71,7 +71,7 @@ module BABYLON.GLTF2 {
         private _progressCallback?: (event: SceneLoaderProgressEvent) => void;
         private _requests = new Array<IFileRequestInfo>();
 
-        private static readonly _DefaultSampler: ILoaderSampler = { index: -1 };
+        private static readonly _DefaultSampler: Loader.ISampler = { index: -1 };
 
         private static _ExtensionNames = new Array<string>();
         private static _ExtensionFactories: { [name: string]: (loader: GLTFLoader) => IGLTFLoaderExtension } = {};
@@ -293,7 +293,7 @@ module BABYLON.GLTF2 {
         }
 
         private _loadData(data: IGLTFLoaderData): void {
-            this.gltf = data.json as ILoaderGLTF;
+            this.gltf = data.json as Loader.IGLTF;
             this._setupData();
 
             if (data.bin) {
@@ -372,10 +372,10 @@ module BABYLON.GLTF2 {
             this.log(GLTFLoaderState[this._state]);
         }
 
-        private _createRootNode(): ILoaderNode {
+        private _createRootNode(): Loader.INode {
             this._rootBabylonMesh = new Mesh("__root__", this.babylonScene);
 
-            const rootNode: ILoaderNode = {
+            const rootNode: Loader.INode = {
                 _babylonMesh: this._rootBabylonMesh,
                 index: -1
             };
@@ -408,7 +408,7 @@ module BABYLON.GLTF2 {
          * @param scene The glTF scene property
          * @returns A promise that resolves when the load is complete
          */
-        public loadSceneAsync(context: string, scene: ILoaderScene): Promise<void> {
+        public loadSceneAsync(context: string, scene: Loader.IScene): Promise<void> {
             const extensionPromise = this._extensionsLoadSceneAsync(context, scene);
             if (extensionPromise) {
                 return extensionPromise;
@@ -434,7 +434,7 @@ module BABYLON.GLTF2 {
             return Promise.all(promises).then(() => {});
         }
 
-        private _forEachPrimitive(node: ILoaderNode, callback: (babylonMesh: Mesh) => void): void {
+        private _forEachPrimitive(node: Loader.INode, callback: (babylonMesh: Mesh) => void): void {
             if (node._primitiveBabylonMeshes) {
                 for (const babylonMesh of node._primitiveBabylonMeshes) {
                     callback(babylonMesh);
@@ -533,7 +533,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon mesh when the load is complete
          */
-        public loadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void = () => {}): Promise<Mesh> {
+        public loadNodeAsync(context: string, node: Loader.INode, assign: (babylonMesh: Mesh) => void = () => {}): Promise<Mesh> {
             const extensionPromise = this._extensionsLoadNodeAsync(context, node, assign);
             if (extensionPromise) {
                 return extensionPromise;
@@ -591,7 +591,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _loadMeshAsync(context: string, node: ILoaderNode, mesh: ILoaderMesh, babylonMesh: Mesh): Promise<void> {
+        private _loadMeshAsync(context: string, node: Loader.INode, mesh: Loader.IMesh, babylonMesh: Mesh): Promise<void> {
             const promises = new Array<Promise<any>>();
 
             this.logOpen(`${context} ${mesh.name || ""}`);
@@ -630,7 +630,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _loadMeshPrimitiveAsync(context: string, node: ILoaderNode, mesh: ILoaderMesh, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): Promise<void> {
+        private _loadMeshPrimitiveAsync(context: string, node: Loader.INode, mesh: Loader.IMesh, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh): Promise<void> {
             const promises = new Array<Promise<any>>();
 
             this.logOpen(`${context}`);
@@ -664,7 +664,7 @@ module BABYLON.GLTF2 {
             return Promise.all(promises).then(() => {});
         }
 
-        private _loadVertexDataAsync(context: string, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): Promise<Geometry> {
+        private _loadVertexDataAsync(context: string, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh): Promise<Geometry> {
             const extensionPromise = this._extensionsLoadVertexDataAsync(context, primitive, babylonMesh);
             if (extensionPromise) {
                 return extensionPromise;
@@ -689,7 +689,7 @@ module BABYLON.GLTF2 {
                 }));
             }
 
-            const loadAttribute = (attribute: string, kind: string, callback?: (accessor: ILoaderAccessor) => void) => {
+            const loadAttribute = (attribute: string, kind: string, callback?: (accessor: Loader.IAccessor) => void) => {
                 if (attributes[attribute] == undefined) {
                     return;
                 }
@@ -727,7 +727,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _createMorphTargets(context: string, node: ILoaderNode, mesh: ILoaderMesh, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): void {
+        private _createMorphTargets(context: string, node: Loader.INode, mesh: Loader.IMesh, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh): void {
             if (!primitive.targets) {
                 return;
             }
@@ -747,7 +747,7 @@ module BABYLON.GLTF2 {
             }
         }
 
-        private _loadMorphTargetsAsync(context: string, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh, babylonGeometry: Geometry): Promise<void> {
+        private _loadMorphTargetsAsync(context: string, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh, babylonGeometry: Geometry): Promise<void> {
             if (!primitive.targets) {
                 return Promise.resolve();
             }
@@ -814,7 +814,7 @@ module BABYLON.GLTF2 {
             return Promise.all(promises).then(() => {});
         }
 
-        private static _LoadTransform(node: ILoaderNode, babylonNode: TransformNode): void {
+        private static _LoadTransform(node: Loader.INode, babylonNode: TransformNode): void {
             let position = Vector3.Zero();
             let rotation = Quaternion.Identity();
             let scaling = Vector3.One();
@@ -834,7 +834,7 @@ module BABYLON.GLTF2 {
             babylonNode.scaling = scaling;
         }
 
-        private _loadSkinAsync(context: string, node: ILoaderNode, skin: ILoaderSkin): Promise<void> {
+        private _loadSkinAsync(context: string, node: Loader.INode, skin: Loader.ISkin): Promise<void> {
             const assignSkeleton = (skeleton: Skeleton) => {
                 this._forEachPrimitive(node, babylonMesh => {
                     babylonMesh.skeleton = skeleton;
@@ -864,7 +864,7 @@ module BABYLON.GLTF2 {
             }));
         }
 
-        private _loadBones(context: string, skin: ILoaderSkin): void {
+        private _loadBones(context: string, skin: Loader.ISkin): void {
             const babylonBones: { [index: number]: Bone } = {};
             for (const index of skin.joints) {
                 const node = ArrayItem.Get(`${context}/joints/${index}`, this.gltf.nodes, index);
@@ -872,7 +872,7 @@ module BABYLON.GLTF2 {
             }
         }
 
-        private _loadBone(node: ILoaderNode, skin: ILoaderSkin, babylonBones: { [index: number]: Bone }): Bone {
+        private _loadBone(node: Loader.INode, skin: Loader.ISkin, babylonBones: { [index: number]: Bone }): Bone {
             let babylonBone = babylonBones[node.index];
             if (babylonBone) {
                 return babylonBone;
@@ -894,7 +894,7 @@ module BABYLON.GLTF2 {
             return babylonBone;
         }
 
-        private _loadSkinInverseBindMatricesDataAsync(context: string, skin: ILoaderSkin): Promise<Nullable<Float32Array>> {
+        private _loadSkinInverseBindMatricesDataAsync(context: string, skin: Loader.ISkin): Promise<Nullable<Float32Array>> {
             if (skin.inverseBindMatrices == undefined) {
                 return Promise.resolve(null);
             }
@@ -922,7 +922,7 @@ module BABYLON.GLTF2 {
             }
         }
 
-        private _getNodeMatrix(node: ILoaderNode): Matrix {
+        private _getNodeMatrix(node: Loader.INode): Matrix {
             return node.matrix ?
                 Matrix.FromArray(node.matrix) :
                 Matrix.Compose(
@@ -938,7 +938,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon camera when the load is complete
          */
-        public loadCameraAsync(context: string, camera: ILoaderCamera, assign: (babylonCamera: Camera) => void = () => {}): Promise<Camera> {
+        public loadCameraAsync(context: string, camera: Loader.ICamera, assign: (babylonCamera: Camera) => void = () => {}): Promise<Camera> {
             const extensionPromise = this._extensionsLoadCameraAsync(context, camera, assign);
             if (extensionPromise) {
                 return extensionPromise;
@@ -1012,7 +1012,7 @@ module BABYLON.GLTF2 {
          * @param animation The glTF animation property
          * @returns A promise that resolves with the loaded Babylon animation group when the load is complete
          */
-        public loadAnimationAsync(context: string, animation: ILoaderAnimation): Promise<AnimationGroup> {
+        public loadAnimationAsync(context: string, animation: Loader.IAnimation): Promise<AnimationGroup> {
             const promise = this._extensionsLoadAnimationAsync(context, animation);
             if (promise) {
                 return promise;
@@ -1036,7 +1036,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _loadAnimationChannelAsync(context: string, animationContext: string, animation: ILoaderAnimation, channel: ILoaderAnimationChannel, babylonAnimationGroup: AnimationGroup): Promise<void> {
+        private _loadAnimationChannelAsync(context: string, animationContext: string, animation: Loader.IAnimation, channel: Loader.IAnimationChannel, babylonAnimationGroup: AnimationGroup): Promise<void> {
             const targetNode = ArrayItem.Get(`${context}/target/node`, this.gltf.nodes, channel.target.node);
 
             // Ignore animations that have no animation targets.
@@ -1192,7 +1192,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _loadAnimationSamplerAsync(context: string, sampler: ILoaderAnimationSampler): Promise<_ILoaderAnimationSamplerData> {
+        private _loadAnimationSamplerAsync(context: string, sampler: Loader.IAnimationSampler): Promise<Loader._IAnimationSamplerData> {
             if (sampler._data) {
                 return sampler._data;
             }
@@ -1225,7 +1225,7 @@ module BABYLON.GLTF2 {
             return sampler._data;
         }
 
-        private _loadBufferAsync(context: string, buffer: ILoaderBuffer): Promise<ArrayBufferView> {
+        private _loadBufferAsync(context: string, buffer: Loader.IBuffer): Promise<ArrayBufferView> {
             if (buffer._data) {
                 return buffer._data;
             }
@@ -1245,7 +1245,7 @@ module BABYLON.GLTF2 {
          * @param bufferView The glTF buffer view property
          * @returns A promise that resolves with the loaded data when the load is complete
          */
-        public loadBufferViewAsync(context: string, bufferView: ILoaderBufferView): Promise<ArrayBufferView> {
+        public loadBufferViewAsync(context: string, bufferView: Loader.IBufferView): Promise<ArrayBufferView> {
             if (bufferView._data) {
                 return bufferView._data;
             }
@@ -1263,7 +1263,7 @@ module BABYLON.GLTF2 {
             return bufferView._data;
         }
 
-        private _loadIndicesAccessorAsync(context: string, accessor: ILoaderAccessor): Promise<IndicesArray> {
+        private _loadIndicesAccessorAsync(context: string, accessor: Loader.IAccessor): Promise<IndicesArray> {
             if (accessor.type !== AccessorType.SCALAR) {
                 throw new Error(`${context}/type: Invalid value ${accessor.type}`);
             }
@@ -1286,7 +1286,7 @@ module BABYLON.GLTF2 {
             return accessor._data as Promise<IndicesArray>;
         }
 
-        private _loadFloatAccessorAsync(context: string, accessor: ILoaderAccessor): Promise<Float32Array> {
+        private _loadFloatAccessorAsync(context: string, accessor: Loader.IAccessor): Promise<Float32Array> {
             // TODO: support normalized and stride
 
             if (accessor.componentType !== AccessorComponentType.FLOAT) {
@@ -1338,7 +1338,7 @@ module BABYLON.GLTF2 {
             return accessor._data as Promise<Float32Array>;
         }
 
-        private _loadVertexBufferViewAsync(bufferView: ILoaderBufferView, kind: string): Promise<Buffer> {
+        private _loadVertexBufferViewAsync(bufferView: Loader.IBufferView, kind: string): Promise<Buffer> {
             if (bufferView._babylonBuffer) {
                 return bufferView._babylonBuffer;
             }
@@ -1350,7 +1350,7 @@ module BABYLON.GLTF2 {
             return bufferView._babylonBuffer;
         }
 
-        private _loadVertexAccessorAsync(context: string, accessor: ILoaderAccessor, kind: string): Promise<VertexBuffer> {
+        private _loadVertexAccessorAsync(context: string, accessor: Loader.IAccessor, kind: string): Promise<VertexBuffer> {
             if (accessor._babylonVertexBuffer) {
                 return accessor._babylonVertexBuffer;
             }
@@ -1379,7 +1379,7 @@ module BABYLON.GLTF2 {
             return accessor._babylonVertexBuffer;
         }
 
-        private _loadMaterialMetallicRoughnessPropertiesAsync(context: string, material: ILoaderMaterial, properties: ILoaderMaterialPbrMetallicRoughness, babylonMaterial: Material): Promise<void> {
+        private _loadMaterialMetallicRoughnessPropertiesAsync(context: string, properties: Loader.IMaterialPbrMetallicRoughness, babylonMaterial: Material): Promise<void> {
             if (!(babylonMaterial instanceof PBRMaterial)) {
                 throw new Error(`${context}: Material type not supported`);
             }
@@ -1419,7 +1419,7 @@ module BABYLON.GLTF2 {
         }
 
         /** @hidden */
-        public _loadMaterialAsync(context: string, material: ILoaderMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void = () => {}): Promise<Material> {
+        public _loadMaterialAsync(context: string, material: Loader.IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void = () => {}): Promise<Material> {
             const extensionPromise = this._extensionsLoadMaterialAsync(context, material, babylonMesh, babylonDrawMode, assign);
             if (extensionPromise) {
                 return extensionPromise;
@@ -1481,7 +1481,7 @@ module BABYLON.GLTF2 {
          * @param babylonDrawMode The draw mode for the Babylon material
          * @returns The Babylon material
          */
-        public createMaterial(context: string, material: ILoaderMaterial, babylonDrawMode: number): Material {
+        public createMaterial(context: string, material: Loader.IMaterial, babylonDrawMode: number): Material {
             const extensionPromise = this._extensionsCreateMaterial(context, material, babylonDrawMode);
             if (extensionPromise) {
                 return extensionPromise;
@@ -1498,7 +1498,7 @@ module BABYLON.GLTF2 {
          * @param babylonMaterial The Babylon material
          * @returns A promise that resolves when the load is complete
          */
-        public loadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Promise<void> {
+        public loadMaterialPropertiesAsync(context: string, material: Loader.IMaterial, babylonMaterial: Material): Promise<void> {
             const extensionPromise = this._extensionsLoadMaterialPropertiesAsync(context, material, babylonMaterial);
             if (extensionPromise) {
                 return extensionPromise;
@@ -1509,7 +1509,7 @@ module BABYLON.GLTF2 {
             promises.push(this.loadMaterialBasePropertiesAsync(context, material, babylonMaterial));
 
             if (material.pbrMetallicRoughness) {
-                promises.push(this._loadMaterialMetallicRoughnessPropertiesAsync(`${context}/pbrMetallicRoughness`, material, material.pbrMetallicRoughness, babylonMaterial));
+                promises.push(this._loadMaterialMetallicRoughnessPropertiesAsync(`${context}/pbrMetallicRoughness`, material.pbrMetallicRoughness, babylonMaterial));
             }
 
             this.loadMaterialAlphaProperties(context, material, babylonMaterial);
@@ -1524,7 +1524,7 @@ module BABYLON.GLTF2 {
          * @param babylonMaterial The Babylon material
          * @returns A promise that resolves when the load is complete
          */
-        public loadMaterialBasePropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Promise<void> {
+        public loadMaterialBasePropertiesAsync(context: string, material: Loader.IMaterial, babylonMaterial: Material): Promise<void> {
             if (!(babylonMaterial instanceof PBRMaterial)) {
                 throw new Error(`${context}: Material type not supported`);
             }
@@ -1576,7 +1576,7 @@ module BABYLON.GLTF2 {
          * @param material The glTF material property
          * @param babylonMaterial The Babylon material
          */
-        public loadMaterialAlphaProperties(context: string, material: ILoaderMaterial, babylonMaterial: Material): void {
+        public loadMaterialAlphaProperties(context: string, material: Loader.IMaterial, babylonMaterial: Material): void {
             if (!(babylonMaterial instanceof PBRMaterial)) {
                 throw new Error(`${context}: Material type not supported`);
             }
@@ -1616,7 +1616,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon texture when the load is complete
          */
-        public loadTextureInfoAsync(context: string, textureInfo: ILoaderTextureInfo, assign: (babylonTexture: BaseTexture) => void = () => {}): Promise<BaseTexture> {
+        public loadTextureInfoAsync(context: string, textureInfo: Loader.ITextureInfo, assign: (babylonTexture: BaseTexture) => void = () => {}): Promise<BaseTexture> {
             const extensionPromise = this._extensionsLoadTextureInfoAsync(context, textureInfo, assign);
             if (extensionPromise) {
                 return extensionPromise;
@@ -1635,7 +1635,7 @@ module BABYLON.GLTF2 {
             return promise;
         }
 
-        private _loadTextureAsync(context: string, texture: ILoaderTexture, assign: (babylonTexture: BaseTexture) => void = () => {}): Promise<BaseTexture> {
+        private _loadTextureAsync(context: string, texture: Loader.ITexture, assign: (babylonTexture: BaseTexture) => void = () => {}): Promise<BaseTexture> {
             const promises = new Array<Promise<any>>();
 
             this.logOpen(`${context} ${texture.name || ""}`);
@@ -1676,7 +1676,7 @@ module BABYLON.GLTF2 {
             });
         }
 
-        private _loadSampler(context: string, sampler: ILoaderSampler): _ILoaderSamplerData {
+        private _loadSampler(context: string, sampler: Loader.ISampler): Loader._ISamplerData {
             if (!sampler._data) {
                 sampler._data = {
                     noMipMaps: (sampler.minFilter === TextureMinFilter.NEAREST || sampler.minFilter === TextureMinFilter.LINEAR),
@@ -1695,7 +1695,7 @@ module BABYLON.GLTF2 {
          * @param image The glTF image property
          * @returns A promise that resolves with the loaded data when the load is complete
          */
-        public loadImageAsync(context: string, image: ILoaderImage): Promise<ArrayBufferView> {
+        public loadImageAsync(context: string, image: Loader.IImage): Promise<ArrayBufferView> {
             if (!image._data) {
                 this.logOpen(`${context} ${image.name || ""}`);
 
@@ -1810,7 +1810,7 @@ module BABYLON.GLTF2 {
             }
         }
 
-        private static _GetTextureSamplingMode(context: string, sampler: ILoaderSampler): number {
+        private static _GetTextureSamplingMode(context: string, sampler: Loader.ISampler): number {
             // Set defaults if undefined
             const magFilter = sampler.magFilter == undefined ? TextureMagFilter.LINEAR : sampler.magFilter;
             const minFilter = sampler.minFilter == undefined ? TextureMinFilter.LINEAR_MIPMAP_LINEAR : sampler.minFilter;
@@ -1994,39 +1994,39 @@ module BABYLON.GLTF2 {
             this._forEachExtensions(extension => extension.onReady && extension.onReady());
         }
 
-        private _extensionsLoadSceneAsync(context: string, scene: ILoaderScene): Nullable<Promise<void>> {
+        private _extensionsLoadSceneAsync(context: string, scene: Loader.IScene): Nullable<Promise<void>> {
             return this._applyExtensions(scene, extension => extension.loadSceneAsync && extension.loadSceneAsync(context, scene));
         }
 
-        private _extensionsLoadNodeAsync(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
+        private _extensionsLoadNodeAsync(context: string, node: Loader.INode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>> {
             return this._applyExtensions(node, extension => extension.loadNodeAsync && extension.loadNodeAsync(context, node, assign));
         }
 
-        private _extensionsLoadCameraAsync(context: string, camera: ILoaderCamera, assign: (babylonCamera: Camera) => void): Nullable<Promise<Camera>> {
+        private _extensionsLoadCameraAsync(context: string, camera: Loader.ICamera, assign: (babylonCamera: Camera) => void): Nullable<Promise<Camera>> {
             return this._applyExtensions(camera, extension => extension.loadCameraAsync && extension.loadCameraAsync(context, camera, assign));
         }
 
-        private _extensionsLoadVertexDataAsync(context: string, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>> {
+        private _extensionsLoadVertexDataAsync(context: string, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>> {
             return this._applyExtensions(primitive, extension => extension._loadVertexDataAsync && extension._loadVertexDataAsync(context, primitive, babylonMesh));
         }
 
-        private _extensionsLoadMaterialAsync(context: string, material: ILoaderMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
+        private _extensionsLoadMaterialAsync(context: string, material: Loader.IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
             return this._applyExtensions(material, extension => extension._loadMaterialAsync && extension._loadMaterialAsync(context, material, babylonMesh, babylonDrawMode, assign));
         }
 
-        private _extensionsCreateMaterial(context: string, material: ILoaderMaterial, babylonDrawMode: number): Nullable<Material> {
+        private _extensionsCreateMaterial(context: string, material: Loader.IMaterial, babylonDrawMode: number): Nullable<Material> {
             return this._applyExtensions({}, extension => extension.createMaterial && extension.createMaterial(context, material, babylonDrawMode));
         }
 
-        private _extensionsLoadMaterialPropertiesAsync(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        private _extensionsLoadMaterialPropertiesAsync(context: string, material: Loader.IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
             return this._applyExtensions(material, extension => extension.loadMaterialPropertiesAsync && extension.loadMaterialPropertiesAsync(context, material, babylonMaterial));
         }
 
-        private _extensionsLoadTextureInfoAsync(context: string, textureInfo: ITextureInfo, assign: (babylonTexture: BaseTexture) => void): Nullable<Promise<BaseTexture>> {
+        private _extensionsLoadTextureInfoAsync(context: string, textureInfo: Loader.ITextureInfo, assign: (babylonTexture: BaseTexture) => void): Nullable<Promise<BaseTexture>> {
             return this._applyExtensions(textureInfo, extension => extension.loadTextureInfoAsync && extension.loadTextureInfoAsync(context, textureInfo, assign));
         }
 
-        private _extensionsLoadAnimationAsync(context: string, animation: ILoaderAnimation): Nullable<Promise<AnimationGroup>> {
+        private _extensionsLoadAnimationAsync(context: string, animation: Loader.IAnimation): Nullable<Promise<AnimationGroup>> {
             return this._applyExtensions(animation, extension => extension.loadAnimationAsync && extension.loadAnimationAsync(context, animation));
         }
 

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderExtension.ts
@@ -21,7 +21,7 @@ module BABYLON.GLTF2 {
          * @param scene The glTF scene property
          * @returns A promise that resolves when the load is complete or null if not handled
          */
-        loadSceneAsync?(context: string, scene: ILoaderScene): Nullable<Promise<void>>;
+        loadSceneAsync?(context: string, scene: Loader.IScene): Nullable<Promise<void>>;
 
         /**
          * Define this method to modify the default behavior when loading nodes.
@@ -30,7 +30,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon mesh when the load is complete or null if not handled
          */
-        loadNodeAsync?(context: string, node: ILoaderNode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>>;
+        loadNodeAsync?(context: string, node: Loader.INode, assign: (babylonMesh: Mesh) => void): Nullable<Promise<Mesh>>;
 
         /**
          * Define this method to modify the default behavior when loading cameras.
@@ -39,7 +39,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon camera when the load is complete or null if not handled
          */
-        loadCameraAsync?(context: string, camera: ILoaderCamera, assign: (babylonCamera: Camera) => void): Nullable<Promise<Camera>>;
+        loadCameraAsync?(context: string, camera: Loader.ICamera, assign: (babylonCamera: Camera) => void): Nullable<Promise<Camera>>;
 
         /**
          * @hidden Define this method to modify the default behavior when loading vertex data for mesh primitives.
@@ -47,7 +47,7 @@ module BABYLON.GLTF2 {
          * @param primitive The glTF mesh primitive property
          * @returns A promise that resolves with the loaded geometry when the load is complete or null if not handled
          */
-        _loadVertexDataAsync?(context: string, primitive: ILoaderMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>>;
+        _loadVertexDataAsync?(context: string, primitive: Loader.IMeshPrimitive, babylonMesh: Mesh): Nullable<Promise<Geometry>>;
 
         /**
          * @hidden Define this method to modify the default behavior when loading materials. Load material creates the material and then loads material properties.
@@ -56,7 +56,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon material when the load is complete or null if not handled
          */
-        _loadMaterialAsync?(context: string, material: ILoaderMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>>;
+        _loadMaterialAsync?(context: string, material: Loader.IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>>;
 
         /**
          * Define this method to modify the default behavior when creating materials.
@@ -65,7 +65,7 @@ module BABYLON.GLTF2 {
          * @param babylonDrawMode The draw mode for the Babylon material
          * @returns The Babylon material or null if not handled
          */
-        createMaterial?(context: string, material: ILoaderMaterial, babylonDrawMode: number): Nullable<Material>;
+        createMaterial?(context: string, material: Loader.IMaterial, babylonDrawMode: number): Nullable<Material>;
 
         /**
          * Define this method to modify the default behavior when loading material properties.
@@ -74,7 +74,7 @@ module BABYLON.GLTF2 {
          * @param babylonMaterial The Babylon material
          * @returns A promise that resolves when the load is complete or null if not handled
          */
-        loadMaterialPropertiesAsync?(context: string, material: ILoaderMaterial, babylonMaterial: Material): Nullable<Promise<void>>;
+        loadMaterialPropertiesAsync?(context: string, material: Loader.IMaterial, babylonMaterial: Material): Nullable<Promise<void>>;
 
         /**
          * Define this method to modify the default behavior when loading texture infos.
@@ -83,7 +83,7 @@ module BABYLON.GLTF2 {
          * @param assign A function called synchronously after parsing the glTF properties
          * @returns A promise that resolves with the loaded Babylon texture when the load is complete or null if not handled
          */
-        loadTextureInfoAsync?(context: string, textureInfo: ITextureInfo, assign: (babylonTexture: BaseTexture) => void): Nullable<Promise<BaseTexture>>;
+        loadTextureInfoAsync?(context: string, textureInfo: Loader.ITextureInfo, assign: (babylonTexture: BaseTexture) => void): Nullable<Promise<BaseTexture>>;
 
         /**
          * Define this method to modify the default behavior when loading animations.
@@ -91,7 +91,7 @@ module BABYLON.GLTF2 {
          * @param animation The glTF animation property
          * @returns A promise that resolves with the loaded Babylon animation group when the load is complete or null if not handled
          */
-        loadAnimationAsync?(context: string, animation: IAnimation): Nullable<Promise<AnimationGroup>>;
+        loadAnimationAsync?(context: string, animation: Loader.IAnimation): Nullable<Promise<AnimationGroup>>;
 
         /**
          * Define this method to modify the default behavior when loading uris.
@@ -106,5 +106,5 @@ module BABYLON.GLTF2 {
 /**
  * Defines the module for the built-in glTF 2.0 loader extensions.
  */
-module BABYLON.GLTF2.Extensions {
+module BABYLON.GLTF2.Loader.Extensions {
 }

--- a/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoaderInterfaces.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../dist/preview release/babylon.d.ts"/>
 
-module BABYLON.GLTF2 {
+module BABYLON.GLTF2.Loader {
     /**
      * Loader interface with an index field.
      */
@@ -14,7 +14,7 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderAccessor extends IAccessor, IArrayItem {
+    export interface IAccessor extends GLTF2.IAccessor, IArrayItem {
         /** @hidden */
         _data?: Promise<ArrayBufferView>;
 
@@ -25,11 +25,11 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderAnimationChannel extends IAnimationChannel, IArrayItem {
+    export interface IAnimationChannel extends GLTF2.IAnimationChannel, IArrayItem {
     }
 
     /** @hidden */
-    export interface _ILoaderAnimationSamplerData {
+    export interface _IAnimationSamplerData {
         input: Float32Array;
         interpolation: AnimationSamplerInterpolation;
         output: Float32Array;
@@ -38,17 +38,17 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderAnimationSampler extends IAnimationSampler, IArrayItem {
+    export interface IAnimationSampler extends GLTF2.IAnimationSampler, IArrayItem {
         /** @hidden */
-        _data?: Promise<_ILoaderAnimationSamplerData>;
+        _data?: Promise<_IAnimationSamplerData>;
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderAnimation extends IAnimation, IArrayItem {
-        channels: ILoaderAnimationChannel[];
-        samplers: ILoaderAnimationSampler[];
+    export interface IAnimation extends GLTF2.IAnimation, IArrayItem {
+        channels: IAnimationChannel[];
+        samplers: IAnimationSampler[];
 
         /** @hidden */
         _babylonAnimationGroup?: AnimationGroup;
@@ -57,7 +57,7 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderBuffer extends IBuffer, IArrayItem {
+    export interface IBuffer extends GLTF2.IBuffer, IArrayItem {
         /** @hidden */
         _data?: Promise<ArrayBufferView>;
     }
@@ -65,7 +65,7 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderBufferView extends IBufferView, IArrayItem {
+    export interface IBufferView extends GLTF2.IBufferView, IArrayItem {
         /** @hidden */
         _data?: Promise<ArrayBufferView>;
 
@@ -76,13 +76,13 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderCamera extends ICamera, IArrayItem {
+    export interface ICamera extends GLTF2.ICamera, IArrayItem {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderImage extends IImage, IArrayItem {
+    export interface IImage extends GLTF2.IImage, IArrayItem {
         /** @hidden */
         _data?: Promise<ArrayBufferView>;
     }
@@ -90,31 +90,31 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMaterialNormalTextureInfo extends IMaterialNormalTextureInfo, ILoaderTextureInfo {
+    export interface IMaterialNormalTextureInfo extends GLTF2.IMaterialNormalTextureInfo, ITextureInfo {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMaterialOcclusionTextureInfo extends IMaterialOcclusionTextureInfo, ILoaderTextureInfo {
+    export interface IMaterialOcclusionTextureInfo extends GLTF2.IMaterialOcclusionTextureInfo, ITextureInfo {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMaterialPbrMetallicRoughness extends IMaterialPbrMetallicRoughness {
-        baseColorTexture?: ILoaderTextureInfo;
-        metallicRoughnessTexture?: ILoaderTextureInfo;
+    export interface IMaterialPbrMetallicRoughness extends GLTF2.IMaterialPbrMetallicRoughness {
+        baseColorTexture?: ITextureInfo;
+        metallicRoughnessTexture?: ITextureInfo;
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMaterial extends IMaterial, IArrayItem {
-        pbrMetallicRoughness?: ILoaderMaterialPbrMetallicRoughness;
-        normalTexture?: ILoaderMaterialNormalTextureInfo;
-        occlusionTexture?: ILoaderMaterialOcclusionTextureInfo;
-        emissiveTexture?: ILoaderTextureInfo;
+    export interface IMaterial extends GLTF2.IMaterial, IArrayItem {
+        pbrMetallicRoughness?: IMaterialPbrMetallicRoughness;
+        normalTexture?: IMaterialNormalTextureInfo;
+        occlusionTexture?: IMaterialOcclusionTextureInfo;
+        emissiveTexture?: ITextureInfo;
 
         /** @hidden */
         _babylonData?: {
@@ -129,24 +129,24 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMesh extends IMesh, IArrayItem {
-        primitives: ILoaderMeshPrimitive[];
+    export interface IMesh extends GLTF2.IMesh, IArrayItem {
+        primitives: IMeshPrimitive[];
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderMeshPrimitive extends IMeshPrimitive, IArrayItem {
+    export interface IMeshPrimitive extends GLTF2.IMeshPrimitive, IArrayItem {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderNode extends INode, IArrayItem {
+    export interface INode extends GLTF2.INode, IArrayItem {
         /**
          * The parent glTF node.
          */
-        parent?: ILoaderNode;
+        parent?: INode;
 
         /** @hidden */
         _babylonMesh?: Mesh;
@@ -162,7 +162,7 @@ module BABYLON.GLTF2 {
     }
 
     /** @hidden */
-    export interface _ILoaderSamplerData {
+    export interface _ISamplerData {
         noMipMaps: boolean;
         samplingMode: number;
         wrapU: number;
@@ -172,21 +172,21 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderSampler extends ISampler, IArrayItem {
+    export interface ISampler extends GLTF2.ISampler, IArrayItem {
         /** @hidden */
-        _data?: _ILoaderSamplerData;
+        _data?: _ISamplerData;
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderScene extends IScene, IArrayItem {
+    export interface IScene extends GLTF2.IScene, IArrayItem {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderSkin extends ISkin, IArrayItem {
+    export interface ISkin extends GLTF2.ISkin, IArrayItem {
         /** @hidden */
         _babylonSkeleton?: Skeleton;
 
@@ -197,31 +197,31 @@ module BABYLON.GLTF2 {
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderTexture extends ITexture, IArrayItem {
+    export interface ITexture extends GLTF2.ITexture, IArrayItem {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderTextureInfo extends ITextureInfo {
+    export interface ITextureInfo extends GLTF2.ITextureInfo {
     }
 
     /**
      * Loader interface with additional members.
      */
-    export interface ILoaderGLTF extends IGLTF {
-        accessors?: ILoaderAccessor[];
-        animations?: ILoaderAnimation[];
-        buffers?: ILoaderBuffer[];
-        bufferViews?: ILoaderBufferView[];
-        cameras?: ILoaderCamera[];
-        images?: ILoaderImage[];
-        materials?: ILoaderMaterial[];
-        meshes?: ILoaderMesh[];
-        nodes?: ILoaderNode[];
-        samplers?: ILoaderSampler[];
-        scenes?: ILoaderScene[];
-        skins?: ILoaderSkin[];
-        textures?: ILoaderTexture[];
+    export interface IGLTF extends GLTF2.IGLTF {
+        accessors?: IAccessor[];
+        animations?: IAnimation[];
+        buffers?: IBuffer[];
+        bufferViews?: IBufferView[];
+        cameras?: ICamera[];
+        images?: IImage[];
+        materials?: IMaterial[];
+        meshes?: IMesh[];
+        nodes?: INode[];
+        samplers?: ISampler[];
+        scenes?: IScene[];
+        skins?: ISkin[];
+        textures?: ITexture[];
     }
 }

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -351,7 +351,7 @@ describe('Babylon Scene Loader', function () {
 
             BABYLON.SceneLoader.OnPluginActivatedObservable.addOnce((loader: BABYLON.GLTFFileLoader) => {
                 const observer = loader.onExtensionLoadedObservable.add(extension => {
-                    if (extension instanceof BABYLON.GLTF2.Extensions.MSFT_lod) {
+                    if (extension instanceof BABYLON.GLTF2.Loader.Extensions.MSFT_lod) {
                         loader.onExtensionLoadedObservable.remove(observer);
                         extension.onMaterialLODsLoadedObservable.add(indexLOD => {
                             const expectedMaterialName = `LOD${2 - indexLOD}`;
@@ -377,7 +377,7 @@ describe('Babylon Scene Loader', function () {
 
             BABYLON.SceneLoader.OnPluginActivatedObservable.addOnce((loader: BABYLON.GLTFFileLoader) => {
                 const observer = loader.onExtensionLoadedObservable.add(extension => {
-                    if (extension instanceof BABYLON.GLTF2.Extensions.MSFT_lod) {
+                    if (extension instanceof BABYLON.GLTF2.Loader.Extensions.MSFT_lod) {
                         loader.onExtensionLoadedObservable.remove(observer);
                         extension.onMaterialLODsLoadedObservable.add(indexLOD => {
                             expect(indexLOD, "indexLOD").to.equal(0);


### PR DESCRIPTION
This avoid conflicts with the extensions in the glTF exporter and makes documentation clearer.