### PR TITLE
Dev add remove materials observables

### DIFF
--- a/src/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -73,7 +73,6 @@
                     var parsedMaterial = parsedData.materials[index];
                     var mat = Material.Parse(parsedMaterial, scene, rootUrl);
                     container.materials.push(mat);
-                    container.scene.onNewMaterialAddedObservable.notifyObservers(mat);
                     log += (index === 0 ? "\n\tMaterials:" : "");
                     log += "\n\t\t" + mat.toString(fullDetails);
                 }

--- a/src/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -73,6 +73,7 @@
                     var parsedMaterial = parsedData.materials[index];
                     var mat = Material.Parse(parsedMaterial, scene, rootUrl);
                     container.materials.push(mat);
+                    container.scene.onNewMaterialAddedObservable.notifyObservers(mat);
                     log += (index === 0 ? "\n\tMaterials:" : "");
                     log += "\n\t\t" + mat.toString(fullDetails);
                 }

--- a/src/Materials/Textures/babylon.baseTexture.ts
+++ b/src/Materials/Textures/babylon.baseTexture.ts
@@ -185,6 +185,7 @@
             this._scene = scene || Engine.LastCreatedScene;
             if (this._scene) {
                 this._scene.textures.push(this);
+                this._scene.onNewTextureAddedObservable.notifyObservers(this);
             }
             this._uid = null;
         }
@@ -410,6 +411,7 @@
             if (index >= 0) {
                 this._scene.textures.splice(index, 1);
             }
+            this._scene.onTextureRemovedObservable.notifyObservers(this);
 
             if (this._texture === undefined) {
                 return;

--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -789,6 +789,7 @@ module BABYLON {
 
             if (!doNotAdd) {
                 this._scene.materials.push(this);
+                this._scene.onNewMaterialAddedObservable.notifyObservers(this);
             }
         }
 

--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -1,4 +1,4 @@
-module BABYLON {
+﻿module BABYLON {
     /**
      * Manages the defines for the Material
      */
@@ -1270,6 +1270,7 @@ module BABYLON {
             if (index >= 0) {
                 this._scene.materials.splice(index, 1);
             }
+            this._scene.onMaterialRemovedObservable.notifyObservers(this);
 
             // Remove from meshes
             for (index = 0; index < this._scene.meshes.length; index++) {

--- a/src/Materials/babylon.material.ts
+++ b/src/Materials/babylon.material.ts
@@ -1,4 +1,4 @@
-﻿module BABYLON {
+module BABYLON {
     /**
      * Manages the defines for the Material
      */
@@ -466,8 +466,10 @@
         /**
          * Gets a boolean indicating that current material needs to register RTT
          */
-        public hasRenderTargetTextures = false;
-
+        public get hasRenderTargetTextures(): boolean {
+          return false;
+        }
+        
         /**
          * Specifies if the material should be serialized
          */

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -3230,6 +3230,7 @@ module BABYLON {
          */
         public addMaterial(newMaterial: Material): void {
             this.materials.push(newMaterial);
+            this.onNewMaterialAddedObservable.notifyObservers(newMesh);
         }
 
         /**

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -3118,6 +3118,8 @@ module BABYLON {
             if (index !== -1) {
                 this.materials.splice(index, 1);
             }
+            this.onMaterialRemovedObservable.notifyObservers(toRemove);
+            
             return index;
         }
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -1,4 +1,4 @@
-﻿module BABYLON {
+module BABYLON {
     /**
      * Define an interface for all classes that will hold resources
      */
@@ -439,6 +439,16 @@
         * An event triggered when a mesh is removed
         */
         public onMeshRemovedObservable = new Observable<AbstractMesh>();
+        
+        /**
+        * An event triggered when a mesh is created
+        */
+        public onNewMaterialAddedObservable = new Observable<Material>();
+
+        /**
+        * An event triggered when a mesh is removed
+        */
+        public onMaterialRemovedObservable = new Observable<Material>();
 
         /**
         * An event triggered when render targets are about to be rendered

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -441,12 +441,12 @@ module BABYLON {
         public onMeshRemovedObservable = new Observable<AbstractMesh>();
         
         /**
-        * An event triggered when a mesh is created
+        * An event triggered when a material is created
         */
         public onNewMaterialAddedObservable = new Observable<Material>();
 
         /**
-        * An event triggered when a mesh is removed
+        * An event triggered when a material is removed
         */
         public onMaterialRemovedObservable = new Observable<Material>();
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -3232,7 +3232,7 @@ module BABYLON {
          */
         public addMaterial(newMaterial: Material): void {
             this.materials.push(newMaterial);
-            this.onNewMaterialAddedObservable.notifyObservers(newMesh);
+            this.onNewMaterialAddedObservable.notifyObservers(newMaterial);
         }
 
         /**

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -4669,6 +4669,25 @@ module BABYLON {
             this.onBeforeRenderingGroupObservable.clear();
             this.onAfterRenderingGroupObservable.clear();
             this.onMeshImportedObservable.clear();
+            this.onBeforeCameraRenderObservable.clear();
+            this.onAfterCameraRenderObservable.clear();
+            this.onReadyObservable.clear();
+            this.onNewCameraAddedObservable.clear();
+            this.onCameraRemovedObservable.clear();
+            this.onNewLightAddedObservable.clear();
+            this.onLightRemovedObservable.clear();
+            this.onNewGeometryAddedObservable.clear();
+            this.onGeometryRemovedObservable.clear();
+            this.onNewTransformNodeAddedObservable.clear();
+            this.onTransformNodeRemovedObservable.clear();
+            this.onNewMeshAddedObservable.clear();
+            this.onMeshRemovedObservable.clear();
+            this.onNewMaterialAddedObservable.clear();
+            this.onMaterialRemovedObservable.clear();
+            this.onPrePointerObservable.clear();
+            this.onPointerObservable.clear();
+            this.onPreKeyboardObservable.clear();
+            this.onKeyboardObservable.clear();
 
             this.detachControl();
 

--- a/src/babylon.scene.ts
+++ b/src/babylon.scene.ts
@@ -449,6 +449,16 @@ module BABYLON {
         * An event triggered when a material is removed
         */
         public onMaterialRemovedObservable = new Observable<Material>();
+        
+        /**
+        * An event triggered when a texture is created
+        */
+        public onNewTextureAddedObservable = new Observable<BaseTexture>();
+
+        /**
+        * An event triggered when a texture is removed
+        */
+        public onTextureRemovedObservable = new Observable<BaseTexture>();
 
         /**
         * An event triggered when render targets are about to be rendered
@@ -3146,6 +3156,8 @@ module BABYLON {
             if (index !== -1) {
                 this.textures.splice(index, 1);
             }
+            this.onTextureRemovedObservable.notifyObservers(toRemove);
+            
             return index;
         }
 
@@ -3265,6 +3277,7 @@ module BABYLON {
          */
         public addTexture(newTexture: BaseTexture): void {
             this.textures.push(newTexture);
+            this.onNewTextureAddedObservable.notifyObservers(newTexture);
         }
 
         /**
@@ -4684,6 +4697,8 @@ module BABYLON {
             this.onMeshRemovedObservable.clear();
             this.onNewMaterialAddedObservable.clear();
             this.onMaterialRemovedObservable.clear();
+            this.onNewTextureAddedObservable.clear();
+            this.onTextureRemovedObservable.clear();
             this.onPrePointerObservable.clear();
             this.onPointerObservable.clear();
             this.onPreKeyboardObservable.clear();


### PR DESCRIPTION
Hi @deltakosh,

First, I fixed a bug regarding "hasRenderTargetTextures" property of Material class. It should be a getter like its child classes. Unless, we have a writing error because "hasRenderTargetTextures" is a getter in the child class but it is a property set to false in Material constructor class.

The main subject of this PR is about to add two observables for notifying materials change : "onNewMaterialAddedObservable" and "onMaterialRemovedObservable".
This is similar to the existing observables : "onNewMeshAddedObservable" and "onMeshRemovedObservable".

What do you think about these kind of observables and about the way they are implemented ?
Is it relevant ? 
I also like to do the same with textures, is it also relevant ? If yes, can I keep the same PR or should I create a new one ?