### PR TITLE
Check for base64 uri more strictly in engine.createTexture

### DIFF
--- a/src/Engine/babylon.engine.ts
+++ b/src/Engine/babylon.engine.ts
@@ -4117,7 +4117,7 @@
             var url = String(urlArg); // assign a new string, so that the original is still available in case of fallback
             var fromData = url.substr(0, 5) === "data:";
             var fromBlob = url.substr(0, 5) === "blob:";
-            var isBase64 = fromData && url.indexOf("base64") !== -1;
+            var isBase64 = fromData && url.indexOf(";base64,") !== -1;
 
             let texture = fallback ? fallback : new InternalTexture(this, InternalTexture.DATASOURCE_URL);
 


### PR DESCRIPTION
This covers a case where a full uri has the word "base64" in it causing the function to think the uri is base64 when it is not.