### PR TITLE
Fix normalize weights

### DIFF
--- a/dist/preview release/babylon.d.ts
+++ b/dist/preview release/babylon.d.ts
@@ -25072,6 +25072,13 @@ declare module BABYLON {
          * Normalize matrix weights so that all vertices have a total weight set to 1
          */
         cleanMatrixWeights(): void;
+        /**
+         *   Renormalize the mesh and patch it up if there are no weights
+         *   Similar to normalization by adding the weights comptue the reciprical and multiply all elements. this wil ensure that everything adds to 1. 
+         *   However in the case of 0 weights then we set just a single influence to 1. 
+         *   We check in the function for extra's present and if so we use the normalizeSkinWeightsWithExtras rather than the FourWeights version. 
+         */
+        public normalizeSkinWeights(): void;
         /** @hidden */
         _checkDelayState(): Mesh;
         private _queueLoad;

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -128,7 +128,7 @@
 - Added FXAA and MSAA support to the StandardRenderingPipeline ([julien-moreau](https://github.com/julien-moreau))
 - Make teleportCamera public in VR experience helper ([TrevorDev](https://github.com/TrevorDev))
 - Added optional alphaFilter parameter to ```CreateGroundFromHeightMap``` to allow for heightmaps to be created that ignore any transparent data ([Postman-nz](https://github.com/Postman-nz))
-
+- Added renormalization of mesh weights to babylon.mesh. This is used automatically by GLTFLoader but can be called manually as well.  ([Bolloxim](https://github.com/Bolloxim))
 
 ### glTF Loader
 
@@ -140,6 +140,7 @@
 - Added support for MSFT_audio_emitter ([najadojo](http://www.github.com/najadojo))
 - Added support for custom loader extensions ([bghgary](http://www.github.com/bghgary))
 - Added support for validating assets using [glTF-Validator](https://github.com/KhronosGroup/glTF-Validator) ([bghgary](http://www.github.com/bghgary))
+- Added automatically renormalizes skinweights when loading geometry. Calls core mesh functions to do this ([Bolloxim](https://github.com/Bolloxim))
 
 ### glTF Serializer
 - Added support for exporting the scale, rotation and offset texture properties ([kcoley](http://www.github.com/kcoley))

--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -639,6 +639,7 @@ module BABYLON.GLTF2 {
             promises.push(this._loadVertexDataAsync(context, primitive, babylonMesh).then(babylonGeometry => {
                 return this._loadMorphTargetsAsync(context, primitive, babylonMesh, babylonGeometry).then(() => {
                     babylonGeometry.applyToMesh(babylonMesh);
+                    babylonMesh.normalizeSkinWeights();
                 });
             }));
 

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1672,13 +1672,13 @@
             }
         }
 
-        /*
-            Renormalize the mesh and patch it up if there are no weights
-            Similar to normalization by adding the weights comptue the reciprical and multiply all elements. this wil ensure that everything adds to 1. 
-            However in the case of 0 weights then we set just a single influence to 1. 
-            We check in the function for extra's present and if so we use the normalizeSkinWeightsWithExtras rather than the FourWeights version. 
+        /**
+         *   Renormalize the mesh and patch it up if there are no weights
+         *   Similar to normalization by adding the weights comptue the reciprical and multiply all elements. this wil ensure that everything adds to 1. 
+         *   However in the case of 0 weights then we set just a single influence to 1. 
+         *   We check in the function for extra's present and if so we use the normalizeSkinWeightsWithExtras rather than the FourWeights version. 
          */
-        public normalizeSkinWeights():void {
+        public normalizeSkinWeights(): void {
             if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsKind)) {
                 if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsExtraKind)) {
                     this.normalizeSkinWeightsAndExtra();
@@ -1688,8 +1688,8 @@
                 }
             }    
         }
-
-        private normalizeSkinFourWeights():void {
+        // faster 4 weight version. 
+        private normalizeSkinFourWeights(): void {
             let matricesWeights = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsKind));
             let numWeights = matricesWeights.length;
             for (var a=0; a<numWeights; a+=4){
@@ -1697,7 +1697,7 @@
                 // check for invalid weight and just set it to 1.
                 if (t===0) matricesWeights[a] = 1;
                 else{
-                    // renormalize so everything adds to 1
+                    // renormalize so everything adds to 1 use reciprical
                     let recip = 1 / t;
                     matricesWeights[a]*=recip;
                     matricesWeights[a+1]*=recip;
@@ -1708,8 +1708,8 @@
             }
             this.setVerticesData(VertexBuffer.MatricesWeightsKind, matricesWeights);
         }
-
-        private normalizeSkinWeightsAndExtra():void {
+        // handle special case of extra verts.  (in theory gltf can handle 12 influences)
+        private normalizeSkinWeightsAndExtra(): void {
             let matricesWeightsExtra = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsExtraKind));
             let matricesWeights = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsKind));
             let numWeights = matricesWeights.length;
@@ -1719,12 +1719,13 @@
                 // check for invalid weight and just set it to 1.
                 if (t===0) matricesWeights[a] = 1;
                 else{
-                    // renormalize so everything adds to 1
+                    // renormalize so everything adds to 1 use reciprical 
                     let recip = 1 / t;
                     matricesWeights[a]*=recip;
                     matricesWeights[a+1]*=recip;
                     matricesWeights[a+2]*=recip;
                     matricesWeights[a+3]*=recip;
+                    // same goes for extras
                     matricesWeightsExtra[a]*=recip;
                     matricesWeightsExtra[a+1]*=recip;
                     matricesWeightsExtra[a+2]*=recip;

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -1672,6 +1672,69 @@
             }
         }
 
+        /*
+            Renormalize the mesh and patch it up if there are no weights
+            Similar to normalization by adding the weights comptue the reciprical and multiply all elements. this wil ensure that everything adds to 1. 
+            However in the case of 0 weights then we set just a single influence to 1. 
+            We check in the function for extra's present and if so we use the normalizeSkinWeightsWithExtras rather than the FourWeights version. 
+         */
+        public normalizeSkinWeights():void {
+            if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsKind)) {
+                if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsExtraKind)) {
+                    this.normalizeSkinWeightsAndExtra();
+                }
+                else {
+                    this.normalizeSkinFourWeights();
+                }
+            }    
+        }
+
+        private normalizeSkinFourWeights():void {
+            let matricesWeights = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsKind));
+            let numWeights = matricesWeights.length;
+            for (var a=0; a<numWeights; a+=4){
+                var t = matricesWeights[a] + matricesWeights[a+1] +matricesWeights[a+2] +matricesWeights[a+3];
+                // check for invalid weight and just set it to 1.
+                if (t===0) matricesWeights[a] = 1;
+                else{
+                    // renormalize so everything adds to 1
+                    let recip = 1 / t;
+                    matricesWeights[a]*=recip;
+                    matricesWeights[a+1]*=recip;
+                    matricesWeights[a+2]*=recip;
+                    matricesWeights[a+3]*=recip;
+                }
+                
+            }
+            this.setVerticesData(VertexBuffer.MatricesWeightsKind, matricesWeights);
+        }
+
+        private normalizeSkinWeightsAndExtra():void {
+            let matricesWeightsExtra = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsExtraKind));
+            let matricesWeights = (<FloatArray>this.getVerticesData(VertexBuffer.MatricesWeightsKind));
+            let numWeights = matricesWeights.length;
+            for (var a=0; a<numWeights; a+=4){
+                var t = matricesWeights[a] + matricesWeights[a+1] +matricesWeights[a+2] +matricesWeights[a+3];
+                t += matricesWeightsExtra[a] + matricesWeightsExtra[a+1] +matricesWeightsExtra[a+2] +matricesWeightsExtra[a+3];
+                // check for invalid weight and just set it to 1.
+                if (t===0) matricesWeights[a] = 1;
+                else{
+                    // renormalize so everything adds to 1
+                    let recip = 1 / t;
+                    matricesWeights[a]*=recip;
+                    matricesWeights[a+1]*=recip;
+                    matricesWeights[a+2]*=recip;
+                    matricesWeights[a+3]*=recip;
+                    matricesWeightsExtra[a]*=recip;
+                    matricesWeightsExtra[a+1]*=recip;
+                    matricesWeightsExtra[a+2]*=recip;
+                    matricesWeightsExtra[a+3]*=recip;
+                }
+                
+            }
+            this.setVerticesData(VertexBuffer.MatricesWeightsKind, matricesWeights);
+            this.setVerticesData(VertexBuffer.MatricesWeightsKind, matricesWeightsExtra);
+        }
 
         /** @hidden */
         public _checkDelayState(): Mesh {


### PR DESCRIPTION
Fixed an issue with badly weighted GLTF models.  (see attached tree)  On reviewing the weights it was pretty obvious the weights were all off and even had some set to 0,0,0,0 which is pretty bad data.  however on correcting for this by renormalizing the mesh (did this in a playground test, script attached).   So this has been added now to babylon.mesh.ts.  I noticed there was a cleanMatrixWeights I test this but it did not clean up the model.  However I added functions after this.    It should handle extra weights fine but I've no test data to attempt it.  I split the functionality into two private functions so that its much cleaner if something goes awry its self contained .   
Tougher implementation was adding this call to the GLTFLoader I put this in a promise right after we bind the gometry to the mesh and then I process renormalization.  It works in sandbox and playground. modes I tested both.  I had to update manually declaration modules in preview release to get loaders to rebuild.  This likely needs some review but it does clean up nicely.   i will open an issue for supporting weight / influence debugging and optimizations to reduce large influence counts, which I will like implement at somepoint. 

[tree-fix.js.txt](https://github.com/BabylonJS/Babylon.js/files/2400317/tree-fix.js.txt)
[Tree1.gltf.zip](https://github.com/BabylonJS/Babylon.js/files/2400321/Tree1.gltf.zip)
