### PR TITLE
Fix performance issue related to the rootNodes array

### DIFF
--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -223,10 +223,6 @@
 
             scene = this.getScene();
 
-            if (parent || (source && source.parent)) {
-                this.removeFromSceneRootNodes();
-            }
-
             if (source) {
                 // Geometry
                 if (source._geometry) {

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -223,6 +223,10 @@
 
             scene = this.getScene();
 
+            if (parent || (source && source.parent)) {
+                this.popFromSceneRootNodes();
+            }
+
             if (source) {
                 // Geometry
                 if (source._geometry) {
@@ -280,9 +284,6 @@
                 if (Tags && Tags.HasTags(source)) {
                     Tags.AddTagsTo(this, Tags.GetTags(source, true));
                 }
-
-                // Parent
-                this.parent = source.parent;
 
                 // Pivot
                 this.setPivotMatrix(source.getPivotMatrix());

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -224,7 +224,7 @@
             scene = this.getScene();
 
             if (parent || (source && source.parent)) {
-                this.popFromSceneRootNodes();
+                this.removeFromSceneRootNodes();
             }
 
             if (source) {

--- a/src/Mesh/babylon.mesh.ts
+++ b/src/Mesh/babylon.mesh.ts
@@ -281,6 +281,9 @@
                     Tags.AddTagsTo(this, Tags.GetTags(source, true));
                 }
 
+                // Parent
+                this.parent = source.parent;
+
                 // Pivot
                 this.setPivotMatrix(source.getPivotMatrix());
 

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -169,7 +169,7 @@
             }
         }
 
-        protected removeFromSceneRootNodes() {
+        private removeFromSceneRootNodes() {
             if (this._sceneRootNodsIndex !== -1) {
                 const rootNodes = this._scene.rootNodes;
                 const lastIdx = rootNodes.length - 1;

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -111,7 +111,7 @@
         public _worldMatrixDeterminant = 0;        
 
         /** @hidden */
-        private _sceneRootNodsIndex = -1;
+        private _sceneRootNodesIndex = -1;
 
         /**
          * Gets a boolean indicating if the node has been disposed
@@ -129,8 +129,6 @@
                 return;
             }
 
-            const previousParentNode = this._parentNode;
-
             // Remove self from list of children of parent
             if (this._parentNode && this._parentNode._children !== undefined && this._parentNode._children !== null) {
                 var index = this._parentNode._children.indexOf(this);
@@ -138,7 +136,7 @@
                     this._parentNode._children.splice(index, 1);
                 }
 
-                if (!parent) this.addToSceneRootNodes();
+                this.addToSceneRootNodes();
             }
 
             // Store new parent
@@ -151,7 +149,7 @@
                 }
                 this._parentNode._children.push(this);
 
-                if (!previousParentNode) this.removeFromSceneRootNodes();
+                this.removeFromSceneRootNodes();
             }
 
             // Enabled state
@@ -163,20 +161,20 @@
         }
 
         private addToSceneRootNodes() {
-            if (this._sceneRootNodsIndex === -1) {
-                this._sceneRootNodsIndex = this._scene.rootNodes.length;
+            if (this._sceneRootNodesIndex === -1) {
+                this._sceneRootNodesIndex = this._scene.rootNodes.length;
                 this._scene.rootNodes.push(this);
             }
         }
 
         private removeFromSceneRootNodes() {
-            if (this._sceneRootNodsIndex !== -1) {
+            if (this._sceneRootNodesIndex !== -1) {
                 const rootNodes = this._scene.rootNodes;
                 const lastIdx = rootNodes.length - 1;
-                rootNodes[this._sceneRootNodsIndex] = rootNodes[lastIdx];
-                rootNodes[this._sceneRootNodsIndex]._sceneRootNodsIndex = this._sceneRootNodsIndex;
+                rootNodes[this._sceneRootNodesIndex] = rootNodes[lastIdx];
+                rootNodes[this._sceneRootNodesIndex]._sceneRootNodesIndex = this._sceneRootNodesIndex;
                 this._scene.rootNodes.pop();
-                this._sceneRootNodsIndex = -1;
+                this._sceneRootNodesIndex = -1;
             }
         }
 

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -129,6 +129,8 @@
                 return;
             }
 
+            const previousParentNode = this._parentNode;
+
             // Remove self from list of children of parent
             if (this._parentNode && this._parentNode._children !== undefined && this._parentNode._children !== null) {
                 var index = this._parentNode._children.indexOf(this);
@@ -136,7 +138,9 @@
                     this._parentNode._children.splice(index, 1);
                 }
 
-                this.addToSceneRootNodes();
+                if (!parent) {
+                    this.addToSceneRootNodes();
+                }
             }
 
             // Store new parent
@@ -149,7 +153,9 @@
                 }
                 this._parentNode._children.push(this);
 
-                this.removeFromSceneRootNodes();
+                if (previousParentNode) {
+                    this.removeFromSceneRootNodes();
+                }
             }
 
             // Enabled state

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -153,7 +153,7 @@
                 }
                 this._parentNode._children.push(this);
 
-                if (previousParentNode) {
+                if (!previousParentNode) {
                     this.removeFromSceneRootNodes();
                 }
             }

--- a/src/babylon.node.ts
+++ b/src/babylon.node.ts
@@ -111,7 +111,7 @@
         public _worldMatrixDeterminant = 0;        
 
         /** @hidden */
-        private _isInSceneRootNodes = false;
+        private _sceneRootNodsIndex = -1;
 
         /**
          * Gets a boolean indicating if the node has been disposed
@@ -138,7 +138,7 @@
                     this._parentNode._children.splice(index, 1);
                 }
 
-                if (!parent) this.pushToSceneRootNodes();
+                if (!parent) this.addToSceneRootNodes();
             }
 
             // Store new parent
@@ -162,31 +162,21 @@
             return this._parentNode;
         }
 
-        private pushToSceneRootNodes() {
-            if (this._isInSceneRootNodes) return;
-
-            this._isInSceneRootNodes = true;
-            this._scene.rootNodes.push(this);
+        private addToSceneRootNodes() {
+            if (this._sceneRootNodsIndex === -1) {
+                this._sceneRootNodsIndex = this._scene.rootNodes.length;
+                this._scene.rootNodes.push(this);
+            }
         }
 
-        protected popFromSceneRootNodes() {
-            if (!this._isInSceneRootNodes) return;
-
-            this._isInSceneRootNodes = false;
-            if (this._scene.rootNodes.length && this._scene.rootNodes[this._scene.rootNodes.length - 1] === this)
-              this._scene.rootNodes.pop();
-        }
-
-        private removeFromSceneRootNodes() {
-            if (this._isInSceneRootNodes) {
-              const rootNodes = this._scene.rootNodes;
-              const rootNodeIndex = rootNodes.indexOf(this);
-              const lastIdx = rootNodes.length - 1;
-              if (rootNodeIndex > -1 && rootNodeIndex !== lastIdx) {
-                // put the last element at the current position to be able to safely pop
-                rootNodes[rootNodeIndex] = rootNodes[lastIdx];
-              }
-              this.popFromSceneRootNodes();
+        protected removeFromSceneRootNodes() {
+            if (this._sceneRootNodsIndex !== -1) {
+                const rootNodes = this._scene.rootNodes;
+                const lastIdx = rootNodes.length - 1;
+                rootNodes[this._sceneRootNodsIndex] = rootNodes[lastIdx];
+                rootNodes[this._sceneRootNodsIndex]._sceneRootNodsIndex = this._sceneRootNodsIndex;
+                this._scene.rootNodes.pop();
+                this._sceneRootNodsIndex = -1;
             }
         }
 
@@ -242,7 +232,7 @@
             this.uniqueId = this._scene.getUniqueId();
             this._initCache();
 
-            this.pushToSceneRootNodes();
+            this.addToSceneRootNodes();
         }
 
         /**


### PR DESCRIPTION
All the nodes that does not have any parent are store in an array since commit  9094b709 (part of https://github.com/BabylonJS/Babylon.js/issues/5050). 

This change caused a performance regression as each time a node is switched from a "no parent" state to a "with parent" state, ther is a O(n) lookup in the array in order to remove it.  And it happens even if a parent is passed in the constructor of a Mesh, as the the addition to the array is always done in the Node base class constructor.


This PR fix this issue by storing and keeping up-to-date, in the Node, the index within the rootNodes array, so that removal can be done in O(1)

Please note that it assumes that the rootNodes array is NEVER modified from elsewhere. If so, it is up to the culprit to make sure that the indices remain up-to-date

Some discussion about this issue and the profiling that leads to this PR can be found here : http://www.html5gamedevs.com/topic/40058-linesmesh-and-createinstance/?do=findComment&comment=228801