### PR TITLE
reduce the number of created Vector3 during ExtractMinAndMax function

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1880,10 +1880,7 @@
          * @returns the current updated Vector3  
          */
         public minimizeInPlace(other: Vector3): Vector3 {
-            if (other.x < this.x) this.x = other.x;
-            if (other.y < this.y) this.y = other.y;
-            if (other.z < this.z) this.z = other.z;
-            return this;
+            return this.minimizeInPlaceFromFloats(other.x, other.y, other.z);
         }
 
         /**
@@ -1892,9 +1889,34 @@
          * @returns the current updated Vector3
          */
         public maximizeInPlace(other: Vector3): Vector3 {
-            if (other.x > this.x) this.x = other.x;
-            if (other.y > this.y) this.y = other.y;
-            if (other.z > this.z) this.z = other.z;
+            return this.maximizeInPlaceFromFloats(other.x, other.y, other.z);
+        }
+
+        /**
+         * Updates the current Vector3 with the minimal coordinate values between its and the given coordinates
+         * @param x defines the x coordinate of the operand
+         * @param y defines the y coordinate of the operand
+         * @param z defines the z coordinate of the operand
+         * @returns the current updated Vector3  
+         */
+        public minimizeInPlaceFromFloats(x: number, y: number, z: number): Vector3 {
+            this.x = Math.min(this.x, x);
+            this.y = Math.min(this.y, y);
+            this.z = Math.min(this.z, z);
+            return this;
+        }
+
+        /**
+         * Updates the current Vector3 with the maximal coordinate values between its and the given coordinates.
+         * @param x defines the x coordinate of the operand
+         * @param y defines the y coordinate of the operand
+         * @param z defines the z coordinate of the operand
+         * @returns the current updated Vector3
+         */
+        public maximizeInPlaceFromFloats(x: number, y: number, z: number): Vector3 {
+            this.x = Math.max(this.x, x);
+            this.y = Math.max(this.y, y);
+            this.z = Math.max(this.z, z);
             return this;
         }
 

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -503,10 +503,12 @@
             var maximum = new Vector3(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
 
             for (var index = indexStart; index < indexStart + indexCount; index++) {
-                var current = new Vector3(positions[indices[index] * 3], positions[indices[index] * 3 + 1], positions[indices[index] * 3 + 2]);
-
-                minimum = Vector3.Minimize(current, minimum);
-                maximum = Vector3.Maximize(current, maximum);
+                const offset = indices[index];
+                const x = positions[offset];
+                const y = positions[offset + 1];
+                const z = positions[offset + 2];
+                minimum.minimizeInPlaceFromFloats(x, y, z);
+                maximum.maximizeInPlaceFromFloats(x, y, z);
             }
 
             if (bias) {

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -541,12 +541,13 @@
                 stride = 3;
             }
 
-            for (var index = start; index < start + count; index++) {
-                var current = new Vector3(positions[index * stride], positions[index * stride + 1], positions[index * stride + 2]);
-
-                minimum = Vector3.Minimize(current, minimum);
-                maximum = Vector3.Maximize(current, maximum);
-            }
+            for (var index = start, offset = start*stride; index < start + count; index++, offset+=stride) {
+                const x = positions[offset];
+                const y = positions[offset + 1];
+                const z = positions[offset + 2];
+                minimum.minimizeInPlaceFromFloats(x, y, z);
+                maximum.maximizeInPlaceFromFloats(x, y, z);
+              }
 
             if (bias) {
                 minimum.x -= minimum.x * bias.x + bias.y;


### PR DESCRIPTION
During some memory profiling I notticed that there were alot of Vector3 allocation in function `ExtractMinAndMax`, which is not really needed as there are only temporary values.