### PR TITLE
[Draft] use Pool and decorators to make the use temprary Vectors/Matrix less error-prone

### DIFF
--- a/src/Culling/babylon.boundingBox.ts
+++ b/src/Culling/babylon.boundingBox.ts
@@ -117,14 +117,15 @@ module BABYLON {
          * @param factor defines the scale factor to apply
          * @returns the current bounding box
          */
+        @automaticPoolRelease(Tmp.PoolVector3)
         public scale(factor: number): BoundingBox {
-            const diff = Tmp.Vector3[0].copyFrom(this.maximum).subtractInPlace(this.minimum);
+            const diff = Tmp.PoolVector3.getTemp().copyFrom(this.maximum).subtractInPlace(this.minimum);
             let distance = diff.length() * factor;
             diff.normalize();
             let newRadius = diff.scaleInPlace(distance * 0.5);
 
-            const min = Tmp.Vector3[1].copyFrom(this.center).subtractInPlace(newRadius);
-            const max = Tmp.Vector3[2].copyFrom(this.center).addInPlace(newRadius);
+            const min = Tmp.PoolVector3.getTemp().copyFrom(this.center).subtractInPlace(newRadius);
+            const max = Tmp.PoolVector3.getTemp().copyFrom(this.center).addInPlace(newRadius);
 
             this.reConstruct(min, max);
 


### PR DESCRIPTION
[Disclaimer] PR not meant to merged as is, it is a draft

I had some hard time debugging something because I was using already allocated vectors from `Tmp.Vector`, and it can be very easy to mess up things when we use them in a function and call another that use them as well. To make sure there is no issue with them one has to check each function implementation, which  is a bit error prone and can be a bit cumbersome :)

This PR contains an overview of what we could use to get rid of that using a Pool from which we can get and release items, and possibly with a decorator to automatically release the used items on function leave. 
