### PR TITLE
Fix Vector3.toQuaternion

### DIFF
--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -1616,7 +1616,7 @@ module BABYLON {
          * @returns a new Quaternion object, computed from the Vector3 coordinates
          */
         public toQuaternion(): Quaternion {
-            return BABYLON.Quaternion.RotationYawPitchRoll(this.x, this.y, this.z);
+            return BABYLON.Quaternion.RotationYawPitchRoll(this.y, this.x, this.z);
         }
 
         /**


### PR DESCRIPTION
When a vector3 is used to store Euler Angles, the Y coordinate is the Yaw, and the X coordinate is the Pitch (https://doc.babylonjs.com/resources/rotation_conventions). 

This PR fixes the Vector3.toQuaternion implementation to reflect that.