### PR TITLE
Fix glTF loader bug when the node of animation channel target is missing

### DIFF
--- a/loaders/src/glTF/2.0/babylon.glTFLoader.ts
+++ b/loaders/src/glTF/2.0/babylon.glTFLoader.ts
@@ -1037,6 +1037,10 @@ module BABYLON.GLTF2 {
         }
 
         private _loadAnimationChannelAsync(context: string, animationContext: string, animation: Loader.IAnimation, channel: Loader.IAnimationChannel, babylonAnimationGroup: AnimationGroup): Promise<void> {
+            if (channel.target.node == undefined) {
+                return Promise.resolve();
+            }
+
             const targetNode = ArrayItem.Get(`${context}/target/node`, this.gltf.nodes, channel.target.node);
 
             // Ignore animations that have no animation targets.

--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -119,11 +119,14 @@ if (BABYLON.Engine.isSupported()) {
 
         // Sync the slider with the current frame
         babylonScene.registerBeforeRender(function() {
-            if (currentGroup != null && currentGroup.targetedAnimations[0].animation.runtimeAnimations[0] != null) {
-                var currentValue = slider.valueAsNumber;
-                var newValue = currentGroup.targetedAnimations[0].animation.runtimeAnimations[0].currentFrame;
-                var range = Math.abs(currentGroup.from - currentGroup.to);
-                slider.value = newValue;
+            if (currentGroup) {
+                var targetedAnimations = currentGroup.targetedAnimations;
+                if (targetedAnimations.length > 0) {
+                    var runtimeAnimations = currentGroup.targetedAnimations[0].animation.runtimeAnimations;
+                    if (runtimeAnimations.length > 0) {
+                        slider.value = runtimeAnimations[0].currentFrame;
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
Also fixes a bug in the sandbox that causes an exception when an animation group has no targeted animations.

Fixes #5360