### PR TITLE
Correct DEL overrun

### DIFF
--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -351,7 +351,7 @@ export class InputText extends Control implements IFocusableControl {
         if (key &&
             ((keyCode === -1) ||                     // Direct access
                 (keyCode === 32) ||                     // Space
-                (keyCode > 47 && keyCode < 58) ||       // Numbers
+                (keyCode > 47 && keyCode < 60) ||       // Numbers
                 (keyCode > 64 && keyCode < 91) ||       // Letters
                 (keyCode > 185 && keyCode < 193) ||     // Special characters
                 (keyCode > 218 && keyCode < 223) ||     // Special characters

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -351,7 +351,7 @@ export class InputText extends Control implements IFocusableControl {
         if (key &&
             ((keyCode === -1) ||                     // Direct access
                 (keyCode === 32) ||                     // Space
-                (keyCode > 47 && keyCode < 60) ||       // Numbers
+                (keyCode > 47 && keyCode < 64) ||       // Numbers
                 (keyCode > 64 && keyCode < 91) ||       // Letters
                 (keyCode > 185 && keyCode < 193) ||     // Special characters
                 (keyCode > 218 && keyCode < 223) ||     // Special characters

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -307,7 +307,7 @@ export class InputText extends Control implements IFocusableControl {
                 }
                 return;
             case 46: // DELETE
-                if (this._text && this._text.length > 0) {
+                if (this._text && this._text.length > 0  && this._cursorOffset > 0) {
                     let deletePosition = this._text.length - this._cursorOffset;
                     this.text = this._text.slice(0, deletePosition) + this._text.slice(deletePosition + 1);
                     this._cursorOffset--;


### PR DESCRIPTION
Holding down the DEL key as a quick way to delete to end of text continued to decrease the cursorOffset thus for example preventing the use of the BackSpace key. The additional condition prevents this. 

Also added  - the use of 59 as keycode for : in FF (as opposed to 186) prevented its use in inputText control so changed condition to < 60. 

Extended to < 64 to include = and ? in FF