### PR TITLE
Fix line picking

### DIFF
--- a/src/Culling/babylon.ray.ts
+++ b/src/Culling/babylon.ray.ts
@@ -385,14 +385,16 @@ module BABYLON {
             // get the difference of the two closest points
             const qtc = Tmp.Vector3[4];
             v.scaleToRef(tc, qtc);
-            const dP = Tmp.Vector3[5];
-            u.scaleToRef(sc, dP);
-            dP.addInPlace(w).subtractInPlace(qtc);  // = S1(sc) - S2(tc)
+            const qsc = Tmp.Vector3[5];
+            u.scaleToRef(sc, qsc);
+            qsc.addInPlace(w)
+            const dP = Tmp.Vector3[6];
+            qsc.subtractToRef(qtc, dP); // = S1(sc) - S2(tc)
 
             var isIntersected = (tc > 0) && (tc <= this.length) && (dP.lengthSquared() < (threshold * threshold));   // return intersection result
 
             if (isIntersected) {
-                return qtc.length();
+                return qsc.length();
             }
             return -1;
         }

--- a/src/Culling/babylon.ray.ts
+++ b/src/Culling/babylon.ray.ts
@@ -387,7 +387,7 @@ module BABYLON {
             v.scaleToRef(tc, qtc);
             const qsc = Tmp.Vector3[5];
             u.scaleToRef(sc, qsc);
-            qsc.addInPlace(w)
+            qsc.addInPlace(w);
             const dP = Tmp.Vector3[6];
             qsc.subtractToRef(qtc, dP); // = S1(sc) - S2(tc)
 


### PR DESCRIPTION
There is something wrong with the picking and LinesMesh, as line that is returned might not be the closest one  (https://www.babylonjs-playground.com/#CIFSQS#2).

scrrenshot (the white little box is the origin of the ray goes backward orthogonal to the screen, the higlighted line in cyan is the picked line):
before the fix :
![image](https://user-images.githubusercontent.com/17083144/47842381-c8f6ae80-ddbc-11e8-9d38-28e0b8e5c632.png)

after the fix :
![image](https://user-images.githubusercontent.com/17083144/47842440-ec215e00-ddbc-11e8-9399-fd8ef90c4775.png)


