### PR TITLE
Load local assets from disk if not in browser storage

### DIFF
--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -403,7 +403,9 @@ module BABYLON {
                 return plugin;
             }
 
-            if (fileInfo.rootUrl.indexOf("file:") === -1) {
+            const file = FilesInput.FilesToLoad[fileInfo.name.toLowerCase()];
+
+            if (fileInfo.rootUrl.indexOf("file:") === -1 || (fileInfo.rootUrl.indexOf("file:") !== -1 && !file)) {
                 let engine = scene.getEngine();
                 let canUseOfflineSupport = engine.enableOfflineSupport;
                 if (canUseOfflineSupport) {
@@ -429,7 +431,6 @@ module BABYLON {
             }
             // Loading file from disk via input file or drag'n'drop
             else {
-                const file = FilesInput.FilesToLoad[fileInfo.name.toLowerCase()];
                 if (file) {
                     request = Tools.ReadFile(file, dataCallback, onProgress, useArrayBuffer);
                 } else {


### PR DESCRIPTION
This will allow to load files with a rootUrl of `file://` via `SceneLoader.ImportMeshAync()`