### PR TITLE
Add back support for passing in a File object to sceneLoader

### DIFF
--- a/src/Tools/babylon.filesInput.ts
+++ b/src/Tools/babylon.filesInput.ts
@@ -258,7 +258,7 @@ module BABYLON {
                     this._engine.stopRenderLoop();
                 }
 
-                SceneLoader.LoadAsync("file:", this._sceneFileToLoad.name, this._engine, (progress) => {
+                SceneLoader.LoadAsync("file:", this._sceneFileToLoad, this._engine, (progress) => {
                     if (this._progressCallback) {
                         this._progressCallback(progress);
                     }


### PR DESCRIPTION
Fixes an issue reported from www.html5gamedevs.com/topic/41238-loading-a-local-scene-in-33-without-xmlhttprequest