### PR TITLE
add updateUpVectorFromRotation to children of xrCamera

### DIFF
--- a/src/Cameras/XR/babylon.webXRCamera.ts
+++ b/src/Cameras/XR/babylon.webXRCamera.ts
@@ -28,6 +28,7 @@ module BABYLON {
                 newCamera.minZ = 0;
                 newCamera.parent = this;
                 newCamera.rotationQuaternion = new BABYLON.Quaternion();
+                newCamera.updateUpVectorFromRotation = true;
                 this.rigCameras.push(newCamera);
             }
             while (this.rigCameras.length > viewCount) {

--- a/tests/validation/config.json
+++ b/tests/validation/config.json
@@ -2,6 +2,11 @@
   "root": "https://rawgit.com/BabylonJS/Website/master",
   "tests": [
     {
+      "title": "Camera rig",
+      "playgroundId": "#ATL1CS#9",
+      "referenceImage": "cameraRig.png"
+    },
+    {
       "title": "XR camera container rotation",
       "playgroundId": "#JV98QW#5",
       "referenceImage": "xrCameraContainerRotation.png",


### PR DESCRIPTION
This change https://github.com/BabylonJS/Babylon.js/commit/b6ddab2d2d3c8e9a11dd39ba4294abd9528d3335  updated child camera up vectors. Added compute up vector from rotation on child to get this to work.