### PR TITLE
Returns line index when the pickedMesh is a LinesMesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -137,6 +137,7 @@
 - Fixed inspector dynamic loading ([Sebavan](https://github.com/Sebavan))
 - Fixed infiniteDistance not working anymore ([Sebavan](https://github.com/Sebavan))
 - Fixed bug in SolidParticle BoundingSphere update within the SolidParticleSystem ([barroij](https://github.com/barroij))
+- Update Picking so that when the picked Mesh is a LinesMesh, the index of the picked line is returned in the `faceId` property of the `PickingInfo`, as we do with face index the picked Mesh is made of triangle faces ([barroij](https://github.com/barroij))
 
 ### Viewer
 

--- a/src/Collisions/babylon.pickingInfo.ts
+++ b/src/Collisions/babylon.pickingInfo.ts
@@ -38,7 +38,7 @@ module BABYLON {
         public bu = 0;
         /** (See getTextureCoordinates) The barycentric V coordinate that is used when calulating the texture coordinates of the collision.*/
         public bv = 0;
-        /** The index of the face on the mesh that was picked, or the index of the Line it the picked Mesh is a LinesMesh */
+        /** The index of the face on the mesh that was picked, or the index of the Line if the picked Mesh is a LinesMesh */
         public faceId = -1;
         /** Id of the the submesh that was picked */
         public subMeshId = 0;

--- a/src/Collisions/babylon.pickingInfo.ts
+++ b/src/Collisions/babylon.pickingInfo.ts
@@ -38,7 +38,7 @@ module BABYLON {
         public bu = 0;
         /** (See getTextureCoordinates) The barycentric V coordinate that is used when calulating the texture coordinates of the collision.*/
         public bv = 0;
-        /** The id of the face on the mesh that was picked  */
+        /** The index of the face on the mesh that was picked, or the index of the Line it the picked Mesh is a LinesMesh */
         public faceId = -1;
         /** Id of the the submesh that was picked */
         public subMeshId = 0;

--- a/src/Mesh/babylon.subMesh.ts
+++ b/src/Mesh/babylon.subMesh.ts
@@ -368,7 +368,7 @@ module BABYLON {
 
                 if (fastCheck || !intersectInfo || length < intersectInfo.distance) {
                     intersectInfo = new IntersectionInfo(null, null, length);
-
+                    intersectInfo.faceId = index / 2;
                     if (fastCheck) {
                         break;
                     }


### PR DESCRIPTION
When Picking occurs on a classical triangle Mesh, the index of the face is returned as part of the `PickingInfo`

This PR fills the `faceId` property with the line index when the picked mesh is LinesMesh