### PR TITLE
Avoid geometry copy error

### DIFF
--- a/src/Mesh/babylon.geometry.ts
+++ b/src/Mesh/babylon.geometry.ts
@@ -912,18 +912,20 @@ module BABYLON {
             for (kind in this._vertexBuffers) {
                 // using slice() to make a copy of the array and not just reference it
                 var data = this.getVerticesData(kind);
+                
+                if (data) {
+                    if (data instanceof Float32Array) {
+                        vertexData.set(new Float32Array(<Float32Array>data), kind);
+                    } else {
+                        vertexData.set((<number[]>data).slice(0), kind);
+                    }
+                    if (!stopChecking) {
+                        let vb = this.getVertexBuffer(kind);
 
-                if (data instanceof Float32Array) {
-                    vertexData.set(new Float32Array(<Float32Array>data), kind);
-                } else {
-                    vertexData.set((<number[]>data).slice(0), kind);
-                }
-                if (!stopChecking) {
-                    let vb = this.getVertexBuffer(kind);
-
-                    if (vb) {
-                        updatable = vb.isUpdatable();
-                        stopChecking = !updatable;
+                        if (vb) {
+                            updatable = vb.isUpdatable();
+                            stopChecking = !updatable;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Some meshes can have some weird vertexBuffer with no vertexData associated to, like the one imported from the obj file format : world0, world1...
This MR avoid to get an error copying the geometry and just keep copying vertexBuffers with actual vertex data