### PR TITLE
Add follow on twitter badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,10 @@ If you want to contribute, please read our [contribution guidelines](https://git
 - [Documentation](https://doc.babylonjs.com)
 - [Examples](https://doc.babylonjs.com/examples)
 
+## Contributing
+
+Please see the [Contributing Guidelines](./contributing.md)
+
 ## Useful links
 
 - Official web site: [www.babylonjs.com](https://www.babylonjs.com/)

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ Getting started? Play directly with the Babylon.js API using our [playground](ht
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/BabylonJS/Babylon.js.svg)](http://isitmaintained.com/project/BabylonJS/Babylon.js "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/babylonJS/babylon.js.svg)](https://isitmaintained.com/project/babylonJS/babylon.js "Percentage of issues still open")
 [![Build Size](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)
+[![Twitter](https://img.shields.io/twitter/follow/babylonjs.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=babylonjs)
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).
 
@@ -110,10 +111,6 @@ If you want to contribute, please read our [contribution guidelines](https://git
 
 - [Documentation](https://doc.babylonjs.com)
 - [Examples](https://doc.babylonjs.com/examples)
-
-## Contributing
-
-Please see the [Contributing Guidelines](./contributing.md)
 
 ## Useful links
 


### PR DESCRIPTION
I think it's a good idea to have `follow on twitter` badge as part of the Docs.
> This is how it looks like:


[![Twitter](https://img.shields.io/twitter/follow/babylonjs.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=babylonjs)