### PR TITLE
Discussion: ArcRotateCamera framing behavior pop

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -877,7 +877,10 @@ module BABYLON {
                     this._targetBoundingCenter = null;
                 }
                 this._targetHost = <AbstractMesh>target;
-                this._target = this._getTargetPosition();
+
+                if (!this.useFramingBehavior) {
+                    this._target = this._getTargetPosition();
+                }
 
                 this.onMeshTargetChangedObservable.notifyObservers(this._targetHost);
             } else {


### PR DESCRIPTION
It was suggested I submit a pull request to start a discussion about what I thought was a bug with the ArcRotateCamera.

What I am trying to do with the arc rotate camera is get functionality similar to what most 3D editors (Unity, Unreal, Maya, etc.) have when you hit the F key to focus the camera on the selected object(s). Here is a quick video of what I am shooting for: [https://youtu.be/2QOEMlmA36o](https://youtu.be/2QOEMlmA36o)

Today when you call setTarget() on the arc rotate camera the camera correctly frames the object, but if the camera's current target position is not equal to the mesh's target position the camera will pop. Here is an example of that: [https://www.babylonjs-playground.com/#GZY2YB#2](https://www.babylonjs-playground.com/#GZY2YB#2)

This felt like a bug to me since the code in babylon.framingBehavior.ts has support for animating the target in zoomOnBoundingInfo(). I made this "fix" to get rid of the camera pop when you call setTarget(). It works, but the actual zoom is a bit weird. You an see what it looks like by commenting out line 18 in my playground and adding in line 21. What I would like to have happen is have a smooth zoom to the target mesh for both position and orientation.

I am new to both Babylon as a library as well as a contributor, so I don't know the proper way to do things and any direction would be great!