### PR TITLE
Add support for color vertices in OBJ file (not part of standard)

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -88,6 +88,9 @@
 - Enable dragging in boundingBoxGizmo without needing a parent ([TrevorDev](https://github.com/TrevorDev))
 - Added per mesh culling strategy ([jerome](https://github.com/jbousquie))
 
+### OBJ Loader
+- Add color vertex support (not part of standard) ([brianzinn](https://github.com/brianzinn))
+
 ### glTF Loader
 
 - Added support for mesh instancing for improved performance when multiple nodes point to the same mesh ([bghgary](https://github.com/bghgary))

--- a/loaders/src/OBJ/babylon.objFileLoader.ts
+++ b/loaders/src/OBJ/babylon.objFileLoader.ts
@@ -209,7 +209,7 @@ module BABYLON {
         colors?: Array<number>;
         uvs?: Array<number>;
         materialName: string;
-    }
+    };
 
     export class OBJFileLoader implements ISceneLoaderPluginAsync {
 
@@ -351,7 +351,7 @@ module BABYLON {
             var handledMesh: MeshObject;      //The current mesh of meshes array
             var indicesForBabylon: Array<number> = [];      //The list of indices for VertexData
             var wrappedPositionForBabylon: Array<BABYLON.Vector3> = [];      //The list of position in vectors
-            var wrappedColorsForBabylon: Array<BABYLON.Color4> = [] // Array with all color values to match with the indices
+            var wrappedColorsForBabylon: Array<BABYLON.Color4> = []; // Array with all color values to match with the indices
             var wrappedUvsForBabylon: Array<BABYLON.Vector2> = [];      //Array with all value of uvs to match with the indices
             var wrappedNormalsForBabylon: Array<BABYLON.Vector3> = [];      //Array with all value of normals to match with the indices
             var tuplePosNorm: Array<{ normals: Array<number>; idx: Array<number>; uv: Array<number> }> = [];      //Create a tuple with indice of Position, Normal, UV  [pos, norm, uvs]
@@ -369,7 +369,7 @@ module BABYLON {
             var increment: number = 1;      //Id for meshes created by the multimaterial
             var isFirstMaterial: boolean = true;
 
-            var grayColor = new BABYLON.Color4(0.5, 0.5, 0.5, 1)
+            var grayColor = new BABYLON.Color4(0.5, 0.5, 0.5, 1);
 
             /**
              * Search for obj in the given array.
@@ -478,7 +478,7 @@ module BABYLON {
                     unwrappedUVForBabylon.push(wrappedUvsForBabylon[l].x, wrappedUvsForBabylon[l].y); //z is an optional value not supported by BABYLON
                     if (OBJFileLoader.IMPORT_VERTEX_COLORS === true) {
                         //Push the r, g, b, a values of each element in the unwrapped array
-                        unwrappedColorsForBabylon.push(wrappedColorsForBabylon[l].r, wrappedColorsForBabylon[l].g, wrappedColorsForBabylon[l].b, wrappedColorsForBabylon[l].a)
+                        unwrappedColorsForBabylon.push(wrappedColorsForBabylon[l].r, wrappedColorsForBabylon[l].g, wrappedColorsForBabylon[l].b, wrappedColorsForBabylon[l].a);
                     }
                 }
                 // Reset arrays for the next new meshes
@@ -739,7 +739,7 @@ module BABYLON {
 
                     if (OBJFileLoader.IMPORT_VERTEX_COLORS === true) {
                         if (result.length >= 7) {
-                            // TODO: if these numbers are > 1 we can use Color4.FromInts(r,g,b,a)                            
+                            // TODO: if these numbers are > 1 we can use Color4.FromInts(r,g,b,a)
                             colors.push(new BABYLON.Color4(
                                 parseFloat(result[4]),
                                 parseFloat(result[5]),
@@ -978,7 +978,7 @@ module BABYLON {
                 }
 
                 if (OBJFileLoader.IMPORT_VERTEX_COLORS === true) {
-                    vertexData.colors = handledMesh.colors as FloatArray
+                    vertexData.colors = handledMesh.colors as FloatArray;
                 }
 
                 //Set the data from the VertexBuffer to the current BABYLON.Mesh

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -519,6 +519,39 @@ describe('Babylon Scene Loader', function() {
         // TODO: test KHR_lights
     });
 
+    /**
+     * Integration tests for loading OBJ assets.
+     */
+    describe('#OBJ', () => {
+        it('should load a tetrahedron (without colors)', () => {
+            var fileContents = `               
+                g tetrahedron
+                
+                v 1.00 1.00 1.00 0.666 0 0
+                v 2.00 1.00 1.00 0.666 0 0
+                v 1.00 2.00 1.00 0.666 0 0
+                v 1.00 1.00 2.00 0.666 0 0
+                
+                f 1 3 2
+                f 1 4 3
+                f 1 2 4
+                f 2 3 4
+            `;
+
+            var scene = new BABYLON.Scene(subject);
+            return BABYLON.SceneLoader.LoadAssetContainerAsync('', 'data:' + fileContents, scene, ()=> {}, ".obj").then(container => {
+                expect(container.meshes.length).to.eq(1);
+                let tetrahedron = container.meshes[0];
+
+                var positions : BABYLON.FloatArray = tetrahedron.getVerticesData(BABYLON.VertexBuffer.PositionKind);
+                var colors : BABYLON.FloatArray = tetrahedron.getVerticesData(BABYLON.VertexBuffer.ColorKind);
+
+                expect(positions).to.deep.equal([1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 2]);
+                assert.isNull(colors, 'expecting colors vertex buffer to be null')
+            })
+        })
+    })
+
     describe('#AssetContainer', () => {
         it('should be loaded from BoomBox GLTF', () => {
             var scene = new BABYLON.Scene(subject);


### PR DESCRIPTION
Started as a forum feature request: https://forum.babylonjs.com/t/import-vertex-colored-meshes-with-obj-files/545/11

I have issues with current PR:
1. Are we going for backwards compatibility or sensible defaults, because otherwise using available color vertices would seem more like an opt-out to me.
2. The OBJ file from the forum request has no normals, so I added an option to generate normals.  I'm happy to remove this as it was more to verify the sandbox would work like MeshLab.
3. Can you verify this is where tests belong?  I was unable to access the static member flags on ObjFileLoader.

I think the tougher question to address is why we are doing static flags like this.  These flags are read when the object model is being parsed.  If I want two models to download simultaneously with different flags then the last set flags will be used from this race condition.  I was going to add some context for parsing, but the mesh loader is called *after* the download has completed.  One option is that the loaders themselves can create a context, which is a capture of current set flags.  That would require augmenting the loader interface.