### PR TITLE
Change upperBetaLimit to avoid weird behaviours when beta is PI

### DIFF
--- a/src/Cameras/babylon.arcRotateCamera.ts
+++ b/src/Cameras/babylon.arcRotateCamera.ts
@@ -91,7 +91,7 @@ module BABYLON {
          * This can help limiting how the Camera is able to move in the scene.
          */
         @serialize()
-        public upperBetaLimit = Math.PI;
+        public upperBetaLimit = Math.PI - 0.01;
 
         /**
          * Minimum allowed distance of the camera to the target (The camera can not get closer).


### PR DESCRIPTION
Found out that ArcRotateCamera was doing weird things when beta was exactly PI :

https://www.babylonjs-playground.com/#6D0950 (zoom in/out)

In the doc it says that it is offset by 0.1 to avoid issues (https://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera) but in code it's 0.01 (I have no problem with that) but more concerning, the offset was not applied for upperBetaLimit.