### PR TITLE
added option forceDisposeChildren to multiMaterial.dispose

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -89,6 +89,7 @@
 - Added per mesh culling strategy ([jerome](https://github.com/jbousquie))
 - Added InputsManager and keyboard bindings for FollowCamera. ([mrdunk](https://github.com))
 - Added per solid particle culling possibility : `solidParticle.isInFrustum()`  ([jerome](https://github.com/jbousquie))
+- Added option `forceDisposeChildren` to multiMaterial.dispose ([danjpar](https://github.com/danjpar))
 
 ### OBJ Loader
 - Add color vertex support (not part of standard) ([brianzinn](https://github.com/brianzinn))

--- a/src/Materials/babylon.multiMaterial.ts
+++ b/src/Materials/babylon.multiMaterial.ts
@@ -183,11 +183,21 @@ module BABYLON {
          * Dispose the material and release its associated resources
          * @param forceDisposeEffect Define if we want to force disposing the associated effect (if false the shader is not released and could be reuse later on)
          * @param forceDisposeTextures Define if we want to force disposing the associated textures (if false, they will not be disposed and can still be use elsewhere in the app)
+         * @param forceDisposeChildren Define if we want to force disposing the associated submaterials (if false, they will not be disposed and can still be use elsewhere in the app)
          */
-        public dispose(forceDisposeEffect?: boolean, forceDisposeTextures?: boolean): void {
+        public dispose(forceDisposeEffect?: boolean, forceDisposeTextures?: boolean, forceDisposeChildren?: boolean): void {
             var scene = this.getScene();
             if (!scene) {
                 return;
+            }
+
+            if (forceDisposeChildren === true) {
+                for (var index = 0; index < this.subMaterials.length; index++) {
+                    var subMaterial = this.subMaterials[index];
+                    if (subMaterial) {
+                        subMaterial.dispose(forceDisposeEffect, forceDisposeTextures);
+                    }
+                }
             }
 
             var index = scene.multiMaterials.indexOf(this);


### PR DESCRIPTION
Return an array of multi-materials that a single material is used in.