### PR TITLE
Added isInFrustum() to solid particles

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -87,6 +87,7 @@
 - Invert vScale of compressed ktx textures as they are inverted in the file and UNPACK_FLIP_Y_WEBGL is not supported by ktx ([TrevorDev](https://github.com/TrevorDev))
 - Enable dragging in boundingBoxGizmo without needing a parent ([TrevorDev](https://github.com/TrevorDev))
 - Added per mesh culling strategy ([jerome](https://github.com/jbousquie))
+- Added per solid particle culling possibility : `solidParticle.isInFrustum()`  ([jerome](https://github.com/jbousquie))
 
 ### OBJ Loader
 - Add color vertex support (not part of standard) ([brianzinn](https://github.com/brianzinn))

--- a/src/Particles/babylon.solidParticle.ts
+++ b/src/Particles/babylon.solidParticle.ts
@@ -100,6 +100,18 @@ module BABYLON {
          */
         public parentId: Nullable<number> = null;
         /**
+         * The culling strategy to use to check whether the solid particle must be culled or not when using isInFrustum().
+         * The possible values are :
+         * - AbstractMesh.CULLINGSTRATEGY_STANDARD
+         * - AbstractMesh.CULLINGSTRATEGY_BOUNDINGSPHERE_ONLY
+         * - AbstractMesh.CULLINGSTRATEGY_OPTIMISTIC_INCLUSION
+         * - AbstractMesh.CULLINGSTRATEGY_OPTIMISTIC_INCLUSION_THEN_BSPHERE_ONLY
+         * The default value for solid particles is AbstractMesh.CULLINGSTRATEGY_BOUNDINGSPHERE_ONLY
+         * Please read each static variable documentation in the class AbstractMesh to get details about the culling process.
+         * */
+        public cullingStrategy = AbstractMesh.CULLINGSTRATEGY_BOUNDINGSPHERE_ONLY;
+
+        /**
          * @hidden Internal global position in the SPS.
          */
         public _globalPosition: Vector3 = Vector3.Zero();
@@ -171,6 +183,16 @@ module BABYLON {
                 return BoundingSphere.Intersects(this._boundingInfo.boundingSphere, target._boundingInfo.boundingSphere);
             }
             return this._boundingInfo.intersects(target._boundingInfo, false);
+        }
+
+        /**
+         * Returns `true` if the solid particle is within the frustum defined by the passed array of planes.
+         * A particle is in the frustum if its bounding box intersects the frustum
+         * @param frustumPlanes defines the frustum to test
+         * @returns true if the particle is in the frustum planes
+         */
+        public isInFrustum(frustumPlanes: Plane[]): boolean {
+            return this._boundingInfo !== null && this._boundingInfo.isInFrustum(frustumPlanes, this.cullingStrategy);
         }
 
         /**


### PR DESCRIPTION
Added `isInFrustum()` to Solid Particles.  
Note that the SPS doesn't use it by default because it's agnostic by design.  

This feature can be useful when the culling process is faster than the particle user behavior process (so it's a choice to use or not).

Example 
```javascript
var planes = scene._frustumPlanes;
SPS.updateParticle = function(particle) {
  if (!particle.isInFrustum(planes)) {
    particle.alive = false; // don't compute it any longer
  }
  else {
    particle.alive = true;
    // user custom behavior
  }
}
```