### PR TITLE
Serialize cubeTexture matrix so that cloning works properly

### DIFF
--- a/src/Materials/Textures/cubeTexture.ts
+++ b/src/Materials/Textures/cubeTexture.ts
@@ -81,7 +81,10 @@ export class CubeTexture extends BaseTexture {
     private _noMipmap: boolean;
     private _files: string[];
     private _extensions: string[];
+
+    @serialize("textureMatrix")
     private _textureMatrix: Matrix;
+
     private _format: number;
     private _createPolynomials: boolean;
 


### PR DESCRIPTION
This affects glTF models with the EXT_lights_image_based extension with a rotation.