### PR TITLE
Fixed `MixMaterial.isReadyForSubMesh` to remove WebGL warnings

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -139,6 +139,7 @@
 - Fixed `GradientMaterial` to consider disableLighting working as emissive ([julien-moreau](https://github.com/julien-moreau))
 - Fixed fresnel term computation in `WaterMaterial` ([julien-moreau](https://github.com/julien-moreau))
 - Fixed `TerrainMaterial.isReadyForSubMesh` to remove WebGL warnings ([julien-moreau](https://github.com/julien-moreau))
+- Fixed `MixMaterial.isReadyForSubMesh` to remove WebGL warnings ([dad72](https://github.com/dad72))
 
 ## Bug fixes
 - Fixed ArcRotateCamera.setTarget (position was sometimes wrong) ([Deltakosh](https://github.com/deltakosh))

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -201,7 +201,7 @@ export class MixMaterial extends PushMaterial {
                     return false;
                 }
 
-                if (this._mixTexture2 !== null) {
+                if (this._mixTexture2) {
                     if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
                         return false;
                     }

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -195,7 +195,7 @@ export class MixMaterial extends PushMaterial {
                 }
 
                 if (this._mixTexture2) {
-                    if (!this._mixTexture2 || !this._mixTexture2.isReady()) {
+                    if (!this._mixTexture2.isReady()) {
                         return false;
                     }
                     

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -170,27 +170,27 @@ export class MixMaterial extends PushMaterial {
         var engine = scene.getEngine();
 
         // Textures
-        if (scene.texturesEnabled) {            
+        if (scene.texturesEnabled) {
             if (this._mixTexture1 && !this._mixTexture1.isReady()) {
                 return false;
             }
-                    
+
             defines._needUVs = true;
-            
+
             if (this._mixTexture2) {
                 defines.MIXMAP2 = true;
             }
-            if (this._mixTexture2 && !this._mixTexture2.isReady()) { 
+            if (this._mixTexture2 && !this._mixTexture2.isReady()) {
                 return false;
-            }          
-            
-            if (MaterialFlags.DiffuseTextureEnabled) {                 
+            }
+
+            if (MaterialFlags.DiffuseTextureEnabled) {
                 if (!this._diffuseTexture1 || !this._diffuseTexture1.isReady()) {
                     return false;
                 }
-                
+
                 defines.DIFFUSE = true;
-                
+
                 if (!this._diffuseTexture2 || !this._diffuseTexture2.isReady()) {
                     return false;
                 }
@@ -199,18 +199,21 @@ export class MixMaterial extends PushMaterial {
                 }
                 if (!this._diffuseTexture4 || !this._diffuseTexture4.isReady()) {
                     return false;
-                }                
-                if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
-                    return false;
                 }
-                if (!this._diffuseTexture6 || !this._diffuseTexture6.isReady()) {
-                    return false;
-                }
-                if (!this._diffuseTexture7 || !this._diffuseTexture7.isReady()) {
-                    return false;
-                }
-                if (!this._diffuseTexture8 || !this._diffuseTexture8.isReady()) {
-                    return false;
+
+                if (this._mixTexture2 !== null) {
+                    if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
+                        return false;
+                    }
+                    if (!this._diffuseTexture6 || !this._diffuseTexture6.isReady()) {
+                        return false;
+                    }
+                    if (!this._diffuseTexture7 || !this._diffuseTexture7.isReady()) {
+                        return false;
+                    }
+                    if (!this._diffuseTexture8 || !this._diffuseTexture8.isReady()) {
+                        return false;
+                    }
                 }
             }
         }

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -171,17 +171,18 @@ export class MixMaterial extends PushMaterial {
 
         // Textures
         if (scene.texturesEnabled) {            
-            if (this._mixTexture1 && this._mixTexture1.isReady()) {
+            if (this._mixTexture1 && !this._mixTexture1.isReady()) {
                 return false;
             }
                     
             defines._needUVs = true;
             
-            if (this._mixTexture2 && this._mixTexture2.isReady()) { 
-                return false;
-            } else {
+            if (this._mixTexture2) {
                 defines.MIXMAP2 = true;
             }
+            if (this._mixTexture2 && !this._mixTexture2.isReady()) { 
+                return false;
+            }          
             
             if (MaterialFlags.DiffuseTextureEnabled) {                 
                 if (!this._diffuseTexture1 || !this._diffuseTexture1.isReady()) {

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -170,25 +170,51 @@ export class MixMaterial extends PushMaterial {
         var engine = scene.getEngine();
 
         // Textures
-        if (scene.texturesEnabled) {
-            if (MaterialFlags.DiffuseTextureEnabled) {
-                if (this._mixTexture1) {
-                    if (!this._mixTexture1.isReady()) {
-                        return false;
-                    } else {
-                        defines._needUVs = true;
-                        defines.DIFFUSE = true;
-                    }
+        if (scene.texturesEnabled) {            
+            if (!this._mixTexture1 || !this._mixTexture1.isReady()) {
+                return false;
+            }
+                    
+            defines._needUVs = true;
+            
+            if (!this._mixTexture2 || !this._mixTexture2.isReady()) {                   
+                return false;
+            } else {                    
+                defines.MIXMAP2 = true;
+            }
+            
+            if (MaterialFlags.DiffuseTextureEnabled) { 
+                if (!this._diffuseTexture1 || !this._diffuseTexture1.isReady()) {
+                    return false;
                 }
-                if (this._mixTexture2) {
-                    if (!this._mixTexture2.isReady()) {
-                        return false;
-                    } else {
-                        defines.MIXMAP2 = true;
-                    }
+                if (!this._diffuseTexture2 || !this._diffuseTexture2.isReady()) {
+                    return false;
                 }
+                if (!this._diffuseTexture3 || !this._diffuseTexture3.isReady()) {
+                    return false;
+                }
+                if (!this._diffuseTexture4 || !this._diffuseTexture4.isReady()) {
+                    return false;
+                }  
+                
+                defines.DIFFUSE = true;
+                
+                if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
+                    return false;
+                }
+                if (!this._diffuseTexture6 || !this._diffuseTexture6.isReady()) {
+                    return false;
+                }
+                if (!this._diffuseTexture7 || !this._diffuseTexture7.isReady()) {
+                    return false;
+                }
+                if (!this._diffuseTexture8 || !this._diffuseTexture8.isReady()) {
+                    return false;
+                }          
+                                 
             }
         }
+       
 
         // Misc.
         MaterialHelper.PrepareDefinesForMisc(mesh, scene, false, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -177,13 +177,6 @@ export class MixMaterial extends PushMaterial {
 
             defines._needUVs = true;
 
-            if (this._mixTexture2) {
-                defines.MIXMAP2 = true;
-            }
-            if (!this._mixTexture2 || !this._mixTexture2.isReady()) {
-                return false;
-            }
-
             if (MaterialFlags.DiffuseTextureEnabled) {
                 if (!this._diffuseTexture1 || !this._diffuseTexture1.isReady()) {
                     return false;
@@ -202,6 +195,12 @@ export class MixMaterial extends PushMaterial {
                 }
 
                 if (this._mixTexture2) {
+                    if (!this._mixTexture2 || !this._mixTexture2.isReady()) {
+                        return false;
+                    }
+                    
+                    defines.MIXMAP2 = true;
+
                     if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
                         return false;
                     }

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -171,7 +171,7 @@ export class MixMaterial extends PushMaterial {
 
         // Textures
         if (scene.texturesEnabled) {
-            if (this._mixTexture1 && !this._mixTexture1.isReady()) {
+            if (!this._mixTexture1 || !this._mixTexture1.isReady()) {
                 return false;
             }
 
@@ -180,7 +180,7 @@ export class MixMaterial extends PushMaterial {
             if (this._mixTexture2) {
                 defines.MIXMAP2 = true;
             }
-            if (this._mixTexture2 && !this._mixTexture2.isReady()) {
+            if (!this._mixTexture2 || !this._mixTexture2.isReady()) {
                 return false;
             }
 

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -171,22 +171,25 @@ export class MixMaterial extends PushMaterial {
 
         // Textures
         if (scene.texturesEnabled) {            
-            if (!this._mixTexture1 || !this._mixTexture1.isReady()) {
+            if (this._mixTexture1 && this._mixTexture1.isReady()) {
                 return false;
             }
                     
             defines._needUVs = true;
             
-            if (!this._mixTexture2 || !this._mixTexture2.isReady()) {                   
+            if (this._mixTexture2 && this._mixTexture2.isReady()) { 
                 return false;
-            } else {                    
+            } else {
                 defines.MIXMAP2 = true;
             }
             
-            if (MaterialFlags.DiffuseTextureEnabled) { 
+            if (MaterialFlags.DiffuseTextureEnabled) {                 
                 if (!this._diffuseTexture1 || !this._diffuseTexture1.isReady()) {
                     return false;
                 }
+                
+                defines.DIFFUSE = true;
+                
                 if (!this._diffuseTexture2 || !this._diffuseTexture2.isReady()) {
                     return false;
                 }
@@ -195,10 +198,7 @@ export class MixMaterial extends PushMaterial {
                 }
                 if (!this._diffuseTexture4 || !this._diffuseTexture4.isReady()) {
                     return false;
-                }  
-                
-                defines.DIFFUSE = true;
-                
+                }                
                 if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {
                     return false;
                 }
@@ -210,11 +210,9 @@ export class MixMaterial extends PushMaterial {
                 }
                 if (!this._diffuseTexture8 || !this._diffuseTexture8.isReady()) {
                     return false;
-                }          
-                                 
+                }
             }
         }
-       
 
         // Misc.
         MaterialHelper.PrepareDefinesForMisc(mesh, scene, false, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -198,7 +198,7 @@ export class MixMaterial extends PushMaterial {
                     if (!this._mixTexture2.isReady()) {
                         return false;
                     }
-                    
+
                     defines.MIXMAP2 = true;
 
                     if (!this._diffuseTexture5 || !this._diffuseTexture5.isReady()) {


### PR DESCRIPTION
Hi,
I took over this PR which corrected the TerrainMaterial and had the same problem with MixMaterial.
So I copy the patches on MixMaterial hoping it's good for you @julien-moreau 

https://github.com/BabylonJS/Babylon.js/commit/1a29f504d33f5031b4ec3aae90fadfd67c814e91