### PR TITLE
Optimise Mesh._GetDefaultSideOrientation

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -140,15 +140,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @hidden
      */
     public static _GetDefaultSideOrientation(orientation?: number): number {
-        if (orientation == Mesh.DOUBLESIDE) {
-            return Mesh.DOUBLESIDE;
-        }
-
-        if (orientation === undefined || orientation === null) {
-            return Mesh.FRONTSIDE;
-        }
-
-        return orientation;
+        return orientation || Mesh.FRONTSIDE; // works as Mesh.FRONTSIDE is 0
     }
 
     // Events


### PR DESCRIPTION
See issue https://github.com/BabylonJS/Babylon.js/issues/5902

I'm not sure the function name or description makes sense though, as it's not returning a default orientation, rather it just validates that the passed in orientation is not null or undefined.