### PR TITLE
 PolygonMeshBuilder without the mesh

### DIFF
--- a/src/Meshes/polygonMesh.ts
+++ b/src/Meshes/polygonMesh.ts
@@ -3,6 +3,7 @@ import { Scene } from "../scene";
 import { Vector3, Vector2, Path2 } from "../Maths/math";
 import { VertexBuffer } from "../Meshes/buffer";
 import { Mesh } from "../Meshes/mesh";
+import { VertexData } from "../Meshes/mesh.vertexData";
 
 declare var earcut: any;
 /**
@@ -223,17 +224,17 @@ export class PolygonMeshBuilder {
      */
     build(updatable: boolean = false, depth: number = 0): Mesh {
         var result = new Mesh(this._name, this._scene);
-        
+
         var vertexData = this.buildVertexData(depth);
-        
-        result.setVerticesData(VertexBuffer.PositionKind, vertexData.positions, updatable);
-        result.setVerticesData(VertexBuffer.NormalKind, vertexData.normals, updatable);
-        result.setVerticesData(VertexBuffer.UVKind, vertexData.uvs, updatable);
-        result.setIndices(vertexData.indices);
+
+        result.setVerticesData(VertexBuffer.PositionKind, <number[]>vertexData.positions, updatable);
+        result.setVerticesData(VertexBuffer.NormalKind, <number[]>vertexData.normals, updatable);
+        result.setVerticesData(VertexBuffer.UVKind, <number[]>vertexData.uvs, updatable);
+        result.setIndices(<number[]>vertexData.indices);
 
         return result;
     }
-    
+
     /**
      * Creates the polygon
      * @param depth The depth of the mesh created

--- a/src/Meshes/polygonMesh.ts
+++ b/src/Meshes/polygonMesh.ts
@@ -223,6 +223,25 @@ export class PolygonMeshBuilder {
      */
     build(updatable: boolean = false, depth: number = 0): Mesh {
         var result = new Mesh(this._name, this._scene);
+        
+        var vertexData = this.buildVertexData(depth);
+        
+        result.setVerticesData(VertexBuffer.PositionKind, vertexData.positions, updatable);
+        result.setVerticesData(VertexBuffer.NormalKind, vertexData.normals, updatable);
+        result.setVerticesData(VertexBuffer.UVKind, vertexData.uvs, updatable);
+        result.setIndices(vertexData.indices);
+
+        return result;
+    }
+    
+    /**
+     * Creates the polygon
+     * @param updatable If the mesh should be updatable
+     * @param depth The depth of the mesh created
+     * @returns the created mesh
+     */
+    buildVertexData(depth: number = 0): VertexData {
+        var result = new VertexData();
 
         var normals = new Array<number>();
         var positions = new Array<number>();
@@ -271,10 +290,10 @@ export class PolygonMeshBuilder {
             });
         }
 
-        result.setVerticesData(VertexBuffer.PositionKind, positions, updatable);
-        result.setVerticesData(VertexBuffer.NormalKind, normals, updatable);
-        result.setVerticesData(VertexBuffer.UVKind, uvs, updatable);
-        result.setIndices(indices);
+        result.indices = indices;
+        result.positions = positions;
+        result.normals = normals;
+        result.uvs = uvs;
 
         return result;
     }

--- a/src/Meshes/polygonMesh.ts
+++ b/src/Meshes/polygonMesh.ts
@@ -236,9 +236,8 @@ export class PolygonMeshBuilder {
     
     /**
      * Creates the polygon
-     * @param updatable If the mesh should be updatable
      * @param depth The depth of the mesh created
-     * @returns the created mesh
+     * @returns the created VertexData
      */
     buildVertexData(depth: number = 0): VertexData {
         var result = new VertexData();


### PR DESCRIPTION
Allow PolygonMeshBuilder to generate a VertexData object instead of forcing the creation of a new mesh that requires a scene and a mesh that would then need to be disposed if the polygon is to be manually merged with another mesh.

I'm using the polygon mesh builder to build flat area's in a new HeightMap routine that I've created. I wanted to remove the need for requiring a scene and no longer need to create a separate mesh.