### PR TITLE
Ammo.btConvexHullShape Support

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -1,9 +1,9 @@
 # 4.0.0
 
 ## Major updates
-
 - New [fancy forum](https://forum.babylonjs.com)!! ([Deltakosh](https://github.com/deltakosh))
 - [Inspector v2.0](https://doc.babylonjs.com/features/playground_debuglayer). [Dev log](https://medium.com/@babylonjs/dev-log-creating-the-new-inspector-b15c50900205) ([Deltakosh](https://github.com/deltakosh))
+- Added support for [Convex Hull Impostor][https://github.com/kripken/ammo.js/blob/master/bullet/src/BulletCollision/CollisionShapes/btConvexHullShape.h] using Ammo.js plugin ([MackeyK24](https://github.com/mackeyk24))
 - Added support for [parallel shader compilation](https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/) ([Deltakosh](https://github.com/deltakosh))
 - Added [Object Based Motion Blur](http://doc.babylonjs.com/how_to/using_motionblurpostprocess) post-process ([julien-moreau](https://github.com/julien-moreau))
 - Added [support for AmmoJS](https://doc.babylonjs.com/how_to/using_the_physics_engine) as a physics plugin (Composite objects, motors, joints) ([TrevorDev](https://github.com/TrevorDev))

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -532,27 +532,26 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 returnValue = new Ammo.btBoxShape(this._tmpAmmoVectorA);
                 break;
             case PhysicsImpostor.MeshImpostor:
-                if ((<any>impostor)._options.useConvexHullShape) {
-                    var convexMesh = new Ammo.btConvexHullShape();
-                    var triangeCount = this._addHullVerts(convexMesh, object, object);
-                    if (triangeCount == 0) {
-                        // Cleanup Unused Convex Hull Shape
-                        impostor._pluginData.toDispose.concat([convexMesh]);
-                        returnValue = new Ammo.btCompoundShape();
-                    } else {
-                        returnValue = convexMesh;
-                    }
+                var tetraMesh = new Ammo.btTriangleMesh();
+                impostor._pluginData.toDispose.concat([tetraMesh]);
+                var triangeCount = this._addMeshVerts(tetraMesh, object, object);
+                if (triangeCount == 0) {
+                    returnValue = new Ammo.btCompoundShape();
                 } else {
-                    var tetraMesh = new Ammo.btTriangleMesh();
-                    impostor._pluginData.toDispose.concat([tetraMesh]);
-                    var triangeCount = this._addMeshVerts(tetraMesh, object, object);
-                    if (triangeCount == 0) {
-                        returnValue = new Ammo.btCompoundShape();
-                    } else {
-                        returnValue = new Ammo.btBvhTriangleMeshShape(tetraMesh);
-                    }
+                    returnValue = new Ammo.btBvhTriangleMeshShape(tetraMesh);
                 }
-            break;
+                break;
+            case PhysicsImpostor.ConvexHullImpostor:
+                var convexMesh = new Ammo.btConvexHullShape();
+                var triangeCount = this._addHullVerts(convexMesh, object, object);
+                if (triangeCount == 0) {
+                    // Cleanup Unused Convex Hull Shape
+                    impostor._pluginData.toDispose.concat([convexMesh]);
+                    returnValue = new Ammo.btCompoundShape();
+                } else {
+                    returnValue = convexMesh;
+                }
+                break;
             case PhysicsImpostor.NoImpostor:
                 // Fill with sphere but collision is disabled on the rigid body in generatePhysicsBody, using an empty shape caused unexpected movement with joints
                 returnValue = new Ammo.btSphereShape(extendSize.x / 2);

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -36,6 +36,10 @@ export interface PhysicsImpostorParameters {
      */
     ignoreParent?: boolean;
     /**
+     * Specifies if the mesh imposter should use a convex hull shape (Ammo.js plugin only)
+     */
+    useConvexHullShape?: boolean;
+    /**
      * Specifies if bi-directional transformations should be disabled
      */
     disableBidirectionalTransformation?: boolean;

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -36,10 +36,6 @@ export interface PhysicsImpostorParameters {
      */
     ignoreParent?: boolean;
     /**
-     * Specifies if the mesh imposter should use a convex hull shape (Ammo.js plugin only)
-     */
-    useConvexHullShape?: boolean;
-    /**
      * Specifies if bi-directional transformations should be disabled
      */
     disableBidirectionalTransformation?: boolean;
@@ -1029,4 +1025,8 @@ export class PhysicsImpostor {
      * Heightmap-Imposter type
      */
     public static HeightmapImpostor = 9;
+    /**
+     * ConvexHull-Impostor type (Ammo.js plugin only)
+     */
+    public static ConvexHullImpostor = 10;
 }


### PR DESCRIPTION
Added support for Ammo.btConvexHullShape. To use set the 'useConvexHullShape' physics imposter option.

Example: mesh.physicsImpostor = new BABYLON.PhysicsImpostor(mesh, BABYLON.PhysicsImpostor.MeshImpostor, { mass:1, useConvexHullShape: true});