### PR TITLE
Allow multiple spaces for vertex position/color definitions.

### DIFF
--- a/loaders/src/OBJ/objFileLoader.ts
+++ b/loaders/src/OBJ/objFileLoader.ts
@@ -847,9 +847,10 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             if (line.length === 0 || line.charAt(0) === '#') {
                 continue;
 
-                //Get information about one position possible for the vertices
+            //Get information about one position possible for the vertices
             } else if (this.vertexPattern.test(line)) {
-                result = line.split(' ');
+                result = line.match(/\S+/g)!;  // match will return non-null due to passing regex pattern
+
                 //Value of result with line: "v 1.0 2.0 3.0"
                 // ["v", "1.0", "2.0", "3.0"]
                 //Create a Vector3 with the position x, y, z


### PR DESCRIPTION
(https://forum.babylonjs.com/t/invisible-imported-obj-file-with-mtl/1523/9)
This is a fix for a bug introduced in 4.0.  No docs or what's new update needed.