### PR TITLE
Fix Scroll Viewer Attach Wheel before container has been registered

### DIFF
--- a/gui/src/2D/controls/scrollViewers/scrollViewer.ts
+++ b/gui/src/2D/controls/scrollViewers/scrollViewer.ts
@@ -340,7 +340,7 @@ export class ScrollViewer extends Rectangle {
 
     /** @hidden */
     private _attachWheel() {
-        if (this._onPointerObserver) {
+        if (!this._host || this._onPointerObserver) {
             return;
         }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/bug-when-adding-scrollviewer-to-another-control-before-adding-parent-control-to-advancedtexture/1630