### PR TITLE
Fix a bug with bounding box calculation when using skeleton.overrideMesh #2

### DIFF
--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -93,31 +93,32 @@ export class Gizmo implements IDisposable {
      */
     protected _update() {
         if (this.attachedMesh) {
+            const effectiveMesh = this.attachedMesh._effectiveMesh || this.attachedMesh;
             if (this.updateGizmoRotationToMatchAttachedMesh) {
                 if (!this._rootMesh.rotationQuaternion) {
                     this._rootMesh.rotationQuaternion = Quaternion.RotationYawPitchRoll(this._rootMesh.rotation.y, this._rootMesh.rotation.x, this._rootMesh.rotation.z);
                 }
 
                 // Remove scaling before getting rotation matrix to get rotation matrix unmodified by scale
-                this._tempVector.copyFrom(this.attachedMesh.scaling);
-                if (this.attachedMesh.scaling.x < 0) {
-                    this.attachedMesh.scaling.x *= -1;
+                this._tempVector.copyFrom(effectiveMesh.scaling);
+                if (effectiveMesh.scaling.x < 0) {
+                    effectiveMesh.scaling.x *= -1;
                 }
-                if (this.attachedMesh.scaling.y < 0) {
-                    this.attachedMesh.scaling.y *= -1;
+                if (effectiveMesh.scaling.y < 0) {
+                    effectiveMesh.scaling.y *= -1;
                 }
-                if (this.attachedMesh.scaling.z < 0) {
-                    this.attachedMesh.scaling.z *= -1;
+                if (effectiveMesh.scaling.z < 0) {
+                    effectiveMesh.scaling.z *= -1;
                 }
-                this.attachedMesh.computeWorldMatrix().getRotationMatrixToRef(this._tmpMatrix);
-                this.attachedMesh.scaling.copyFrom(this._tempVector);
-                this.attachedMesh.computeWorldMatrix();
+                effectiveMesh.computeWorldMatrix().getRotationMatrixToRef(this._tmpMatrix);
+                effectiveMesh.scaling.copyFrom(this._tempVector);
+                effectiveMesh.computeWorldMatrix();
                 Quaternion.FromRotationMatrixToRef(this._tmpMatrix, this._rootMesh.rotationQuaternion);
             } else if (this._rootMesh.rotationQuaternion) {
                 this._rootMesh.rotationQuaternion.set(0, 0, 0, 1);
             }
             if (this.updateGizmoPositionToMatchAttachedMesh) {
-                this._rootMesh.position.copyFrom(this.attachedMesh.absolutePosition);
+                this._rootMesh.position.copyFrom(effectiveMesh.absolutePosition);
             }
             if (this._updateScale && this.gizmoLayer.utilityLayerScene.activeCamera && this.attachedMesh) {
                 var cameraPosition = this.gizmoLayer.utilityLayerScene.activeCamera.globalPosition;

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1205,7 +1205,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
                 var matricesWeightsExtraData = needExtras ? this.getVerticesData(VertexBuffer.MatricesWeightsExtraKind) : null;
 
                 this.skeleton.prepare();
-                var skeletonMatrices = this.skeleton.getTransformMatrices(this._effectiveMesh);
+                var skeletonMatrices = this.skeleton.getTransformMatrices(this);
 
                 var tempVector = Tmp.Vector3[0];
                 var finalMatrix = Tmp.Matrix[0];
@@ -1277,7 +1277,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._updateBoundingInfo();
     }
 
-    protected get _effectiveMesh(): AbstractMesh {
+    /** @hidden */
+    public get _effectiveMesh(): AbstractMesh {
         return (this.skeleton && this.skeleton.overrideMesh) || this;
     }
 


### PR DESCRIPTION
The gizmos now take the overrideMesh into account and use the proper transform.