### PR TITLE
keep back compat for gizmos when created on a custom utility layer

### DIFF
--- a/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -167,7 +167,7 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
 
         const manager: GizmoManager = scene.reservedDataStore.gizmoManager;
         // Allow picking of light gizmo when a gizmo mode is selected
-        this._gizmoLayerOnPointerObserver = UtilityLayerRenderer.DefaultGizmoUtilityLayer.utilityLayerScene.onPointerObservable.add((pointerInfo)=>{
+        this._gizmoLayerOnPointerObserver = UtilityLayerRenderer.DefaultUtilityLayer.utilityLayerScene.onPointerObservable.add((pointerInfo)=>{
             if (pointerInfo.type == PointerEventTypes.POINTERDOWN) {
                 if (pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh) {
                     var node: Nullable<any> = pointerInfo.pickInfo.pickedMesh;

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -67,7 +67,7 @@ export class AxisDragGizmo extends Gizmo {
      * @param dragAxis The axis which the gizmo will be able to drag on
      * @param color The color of the gizmo
      */
-    constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer) {
+    constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
 
         // Create Material
@@ -136,6 +136,9 @@ export class AxisDragGizmo extends Gizmo {
                 }
             });
         });
+
+        var light = gizmoLayer._getSharedGizmoLight();
+        light.includedOnlyMeshes = light.includedOnlyMeshes.concat(this._rootMesh.getChildMeshes(false));
     }
     protected _attachedMeshChanged(value: Nullable<AbstractMesh>) {
         if (this.dragBehavior) {

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -42,7 +42,7 @@ export class AxisScaleGizmo extends Gizmo {
      * @param dragAxis The axis which the gizmo will be able to scale on
      * @param color The color of the gizmo
      */
-    constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer) {
+    constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
 
         // Create Material
@@ -131,6 +131,9 @@ export class AxisScaleGizmo extends Gizmo {
                 }
             });
         });
+
+        var light = gizmoLayer._getSharedGizmoLight();
+        light.includedOnlyMeshes = light.includedOnlyMeshes.concat(this._rootMesh.getChildMeshes());
     }
 
     protected _attachedMeshChanged(value: Nullable<AbstractMesh>) {

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -78,7 +78,7 @@ export class Gizmo implements IDisposable {
      */
     constructor(
         /** The utility layer the gizmo will be added to */
-        public gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer) {
+        public gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         this._rootMesh = new Mesh("gizmoRootNode", gizmoLayer.utilityLayerScene);
         this._beforeRenderObserver = this.gizmoLayer.utilityLayerScene.onBeforeRenderObservable.add(() => {
             this._update();

--- a/src/Gizmos/gizmoManager.ts
+++ b/src/Gizmos/gizmoManager.ts
@@ -54,7 +54,7 @@ export class GizmoManager implements IDisposable {
     constructor(private scene: Scene) {
         this._defaultKeepDepthUtilityLayer = new UtilityLayerRenderer(scene);
         this._defaultKeepDepthUtilityLayer.utilityLayerScene.autoClearDepthAndStencil = false;
-        this._defaultUtilityLayer = UtilityLayerRenderer.DefaultGizmoUtilityLayer;
+        this._defaultUtilityLayer = UtilityLayerRenderer.DefaultUtilityLayer;
 
         this.gizmos = { positionGizmo: null, rotationGizmo: null, scaleGizmo: null, boundingBoxGizmo: null };
 

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -41,7 +41,7 @@ export class PlaneRotationGizmo extends Gizmo {
      * @param color The color of the gizmo
      * @param tessellation Amount of tessellation to be used when creating rotation circles
      */
-    constructor(planeNormal: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer, tessellation = 32) {
+    constructor(planeNormal: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, tessellation = 32) {
         super(gizmoLayer);
 
         // Create Material
@@ -185,6 +185,9 @@ export class PlaneRotationGizmo extends Gizmo {
                 }
             });
         });
+
+        var light = gizmoLayer._getSharedGizmoLight();
+        light.includedOnlyMeshes = light.includedOnlyMeshes.concat(this._rootMesh.getChildMeshes(false));
     }
 
     protected _attachedMeshChanged(value: Nullable<AbstractMesh>) {

--- a/src/Gizmos/positionGizmo.ts
+++ b/src/Gizmos/positionGizmo.ts
@@ -45,7 +45,7 @@ export class PositionGizmo extends Gizmo {
      * Creates a PositionGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
      */
-    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
         this.xGizmo = new AxisDragGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), gizmoLayer);
         this.yGizmo = new AxisDragGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), gizmoLayer);

--- a/src/Gizmos/rotationGizmo.ts
+++ b/src/Gizmos/rotationGizmo.ts
@@ -46,7 +46,7 @@ export class RotationGizmo extends Gizmo {
      * @param gizmoLayer The utility layer the gizmo will be added to
      * @param tessellation Amount of tessellation to be used when creating rotation circles
      */
-    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer, tessellation = 32) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, tessellation = 32) {
         super(gizmoLayer);
         this.xGizmo = new PlaneRotationGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), gizmoLayer, tessellation);
         this.yGizmo = new PlaneRotationGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), gizmoLayer, tessellation);

--- a/src/Gizmos/scaleGizmo.ts
+++ b/src/Gizmos/scaleGizmo.ts
@@ -49,7 +49,7 @@ export class ScaleGizmo extends Gizmo {
      * Creates a ScaleGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
      */
-    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultGizmoUtilityLayer) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
         this.xGizmo = new AxisScaleGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), gizmoLayer);
         this.yGizmo = new AxisScaleGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), gizmoLayer);
@@ -66,6 +66,8 @@ export class ScaleGizmo extends Gizmo {
         octahedron.scaling.scaleInPlace(0.007);
         uniformScalingMesh.addChild(octahedron);
         this.uniformScaleGizmo.setCustomMesh(uniformScalingMesh, true);
+        var light = gizmoLayer._getSharedGizmoLight();
+        light.includedOnlyMeshes = light.includedOnlyMeshes.concat(octahedron);
 
         // Relay drag events
         [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -17,6 +17,20 @@ export class UtilityLayerRenderer implements IDisposable {
     private static _DefaultGizmoUtilityLayer: Nullable<UtilityLayerRenderer> = null;
     private static _DefaultUtilityLayer: Nullable<UtilityLayerRenderer> = null;
     private static _DefaultKeepDepthUtilityLayer: Nullable<UtilityLayerRenderer> = null;
+    private _sharedGizmoLight: Nullable<HemisphericLight> = null;
+    /**
+     * @hidden
+     * Light which used by gizmos to get light shading
+     */
+    public _getSharedGizmoLight(): HemisphericLight {
+        if (!this._sharedGizmoLight) {
+            this._sharedGizmoLight = new HemisphericLight("shared gizmo light", new Vector3(0, 1, 0), this.utilityLayerScene);
+            this._sharedGizmoLight.intensity = 2;
+            this._sharedGizmoLight.groundColor = Color3.Gray();
+            this._sharedGizmoLight.includedOnlyMeshes = [new AbstractMesh("", this.utilityLayerScene)];
+        }
+        return this._sharedGizmoLight;
+    }
 
     /**
      * If the picking should be done on the utility layer prior to the actual scene (Default: true)
@@ -33,21 +47,6 @@ export class UtilityLayerRenderer implements IDisposable {
             });
         }
         return UtilityLayerRenderer._DefaultUtilityLayer;
-    }
-    /**
-     * A shared utility layer that can be used to overlay objects into a scene (Depth map of the previous scene is cleared before drawing on top of it)
-     */
-    public static get DefaultGizmoUtilityLayer(): UtilityLayerRenderer {
-        if (UtilityLayerRenderer._DefaultGizmoUtilityLayer == null) {
-            UtilityLayerRenderer._DefaultGizmoUtilityLayer = new UtilityLayerRenderer(EngineStore.LastCreatedScene!);
-            var light = new HemisphericLight("light1", new Vector3(0, 1, 0), UtilityLayerRenderer._DefaultGizmoUtilityLayer.utilityLayerScene);
-            light.intensity = 2;
-            light.groundColor = Color3.Gray();
-            UtilityLayerRenderer._DefaultGizmoUtilityLayer.originalScene.onDisposeObservable.addOnce(() => {
-                UtilityLayerRenderer._DefaultGizmoUtilityLayer = null;
-            });
-        }
-        return UtilityLayerRenderer._DefaultGizmoUtilityLayer;
     }
     /**
      * A shared utility layer that can be used to embed objects into a scene (Depth map of the previous scene is not cleared before drawing on top of it)

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -27,7 +27,6 @@ export class UtilityLayerRenderer implements IDisposable {
             this._sharedGizmoLight = new HemisphericLight("shared gizmo light", new Vector3(0, 1, 0), this.utilityLayerScene);
             this._sharedGizmoLight.intensity = 2;
             this._sharedGizmoLight.groundColor = Color3.Gray();
-            this._sharedGizmoLight.includedOnlyMeshes = [new AbstractMesh("", this.utilityLayerScene)];
         }
         return this._sharedGizmoLight;
     }


### PR DESCRIPTION
https://forum.babylonjs.com/t/gizmo-positiongizmo-arrows-are-black-v4/1782