### PR TITLE
add error message for unsupported cascade

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -5801,8 +5801,12 @@ export class Engine {
                 if (loader.supportCascades) {
                     this._cascadeLoadFiles(scene, onloaddata, files, onError);
                 }
-                else if (onError) {
-                    onError("Textures type does not support cascades.");
+                else {
+                    if (onError) {
+                        onError("Textures type does not support cascades.");
+                    } else {
+                        Logger.Warn("Texture loader does not support cascades.");
+                    }
                 }
             }
             else {


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/6049

After investigating, it looks that multiple file loading isn’t supported by the ktx loader.

```
/**
 * Defines wether the loader supports cascade loading the different faces.
 */
public readonly supportCascades = false;
```
I added an error message to catch this. It looks cubemap is only supported by a single ktx file (not multiple) 