### PR TITLE
pass buffer to new texture when cloning material if present

### DIFF
--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -548,7 +548,7 @@ export class Texture extends BaseTexture {
      */
     public clone(): Texture {
         return SerializationHelper.Clone(() => {
-            return new Texture(this._texture ? this._texture.url : null, this.getScene(), this._noMipmap, this._invertY, this.samplingMode);
+            return new Texture(this._texture ? this._texture.url : null, this.getScene(), this._noMipmap, this._invertY, this.samplingMode, undefined, undefined, this._texture ? this._texture._buffer : undefined);
         }, this);
     }
 


### PR DESCRIPTION
Fix https://playground.babylonjs.com/#8Y780Y#46 from failing on data:BRDFTexture without a buffer