### PR TITLE
Arc rotate camera changes/fixes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -135,6 +135,8 @@
 - Added customShaderNameResolve to PBRMaterialBase to allow subclasses to specify custom shader information [MackeyK24](https://github.com/mackeyk24))
 - Added PBRCustomMaterial to material library to allow easy subclassing of PBR materials [MackeyK24](https://github.com/mackeyk24))
 - Added `auto-exposure` support in `StandardRenderingPipeline` when `HDR` is enabled ([julien-moreau](https://github.com/julien-moreau))
+- Added `Matrix.RotationAlignToRef` method to obtain rotation matrix from one vector to another ([sable](https://github.com/thscott))
+- ArcRotateCamera will now cache the necessary matrices when modifying its upVector, instead of calculating them each time they're needed ([sable](https://github.com/thscott))
 
 ### OBJ Loader
 - Add color vertex support (not part of standard) ([brianzinn](https://github.com/brianzinn))
@@ -218,7 +220,9 @@
 - AssetContainer should not dispose objects it doesn't contain. Support for environmentTexture add/remove ([TrevorDev](https://github.com/TrevorDev))
 - Fix `mesh.visibility` not working properly when certain material properties are set that changes the interpretation of alpha (e.g. refraction, specular over alpha, etc.) ([bghgary](https://github.com/bghgary))
 - Fix material and texture leak when loading/removing GLTF/obj/babylon files with AssetContainer ([TrevorDev](https://github.com/TrevorDev))
-- Avoid exception when removing impostor during Cannon world step ([TrevorDev](https://github.com/TrevorDev))
+- Avoid exception when removing impostor during cannon world step ([TrevorDev](https://github.com/TrevorDev))
+- Fix ArcRotateCamera divide by zero error (when looking along up axis) in rebuildAnglesAndRadius ([sable](https://github.com/thscott))
+- Fix ArcRotateCamera rebuildAnglesAndRadius when upVector modified ([sable](https://github.com/thscott))
 
 ### Core Engine
 - Fixed a bug with `mesh.alwaysSelectAsActiveMesh` preventing layerMask to be taken in account ([Deltakosh](https://github.com/deltakosh))

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -892,6 +892,12 @@ export class ArcRotateCamera extends TargetCamera {
      */
     public rebuildAnglesAndRadius(): void {
         this._position.subtractToRef(this._getTargetPosition(), this._computationVector);
+
+        // need to rotate to Y up equivalent if up vector not Axis.Y
+        if (this._upVector.x !== 0 || this._upVector.y !== 1.0 || this._upVector.z !== 0) {
+            Vector3.TransformCoordinatesToRef(this._computationVector, this._upToYMatrix, this._computationVector);
+        }
+
         this.radius = this._computationVector.length();
 
         if (this.radius === 0) {
@@ -899,7 +905,11 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         // Alpha
-        this.alpha = Math.acos(this._computationVector.x / Math.sqrt(Math.pow(this._computationVector.x, 2) + Math.pow(this._computationVector.z, 2)));
+        if (this._computationVector.x === 0 && this._computationVector.z === 0) {
+            this.alpha = Math.PI / 2; // avoid division by zero, and set to acos(0)
+        } else {
+            this.alpha = Math.acos(this._computationVector.x / Math.sqrt(Math.pow(this._computationVector.x, 2) + Math.pow(this._computationVector.z, 2)));
+        }
 
         if (this._computationVector.z < 0) {
             this.alpha = 2 * Math.PI - this.alpha;

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -80,8 +80,9 @@ export class ArcRotateCamera extends TargetCamera {
     protected _upToYMatrix: Matrix;
     protected _YToUpMatrix: Matrix;
 
-    /**The vector the camera should consider as up. (default is Vector3(0, 1, 0) aka Vector3.Up())
-     * Setting this will copy the given vec to the camera's upVector, and set rotation matrices to and from the Y up.  
+    /**
+     * The vector the camera should consider as up. (default is Vector3(0, 1, 0) as returned by Vector3.Up())
+     * Setting this will copy the given vector to the camera's upVector, and set rotation matrices to and from Y up.
      * DO NOT set the up vector using copyFrom or copyFromFloats, as this bypasses setting the above matrices.
      */
     set upVector(vec: Vector3) {
@@ -94,18 +95,21 @@ export class ArcRotateCamera extends TargetCamera {
 
         vec.normalize();
         this._upVector.copyFrom(vec);
-        this.setMatUp(); // still more efficient to calculate this once
+        this.setMatUp();
     }
 
     get upVector() {
         return this._upVector;
     }
 
-    setMatUp() {
+    /**
+     * Sets the Y-up to camera up-vector rotation matrix, and the up-vector to Y-up rotation matrix.
+     */
+    public setMatUp() {
         // from y-up to custom-up (used in _getViewMatrix)
         Matrix.RotationAlignToRef(Vector3.UpReadOnly, this._upVector, this._YToUpMatrix);
 
-        // from custom-up to y-up (used in rebuildAnglesAndRadians)
+        // from custom-up to y-up (used in rebuildAnglesAndRadius)
         Matrix.RotationAlignToRef(this._upVector, Vector3.UpReadOnly, this._upToYMatrix);
     }
 
@@ -906,7 +910,7 @@ export class ArcRotateCamera extends TargetCamera {
 
         // Alpha
         if (this._computationVector.x === 0 && this._computationVector.z === 0) {
-            this.alpha = Math.PI / 2; // avoid division by zero, and set to acos(0)
+            this.alpha = Math.PI / 2; // avoid division by zero when looking along up axis, and set to acos(0)
         } else {
             this.alpha = Math.acos(this._computationVector.x / Math.sqrt(Math.pow(this._computationVector.x, 2) + Math.pow(this._computationVector.z, 2)));
         }

--- a/src/Maths/math.ts
+++ b/src/Maths/math.ts
@@ -5477,7 +5477,7 @@ export class Matrix {
     }
 
     /**
-     * Takes normalised vectors and returns a rotation matrix to align "from" with "to".  
+     * Takes normalised vectors and returns a rotation matrix to align "from" with "to".
      * Taken from http://www.iquilezles.org/www/articles/noacos/noacos.htm
      * @param from defines the vector to align
      * @param to defines the vector to align to
@@ -5489,9 +5489,9 @@ export class Matrix {
         const k = 1 / (1 + c);
 
         const m = result._m;
-        m[0]  = v.x*v.x*k + c;   m[1]  = v.y*v.x*k - v.z; m[2]  = v.z*v.x*k + v.y; m[3]  = 0;
-        m[4]  = v.x*v.y*k + v.z; m[5]  = v.y*v.y*k + c;   m[6]  = v.z*v.y*k - v.x; m[7]  = 0;
-        m[8]  = v.x*v.z*k - v.y; m[9]  = v.y*v.z*k + v.x; m[10] = v.z*v.z*k + c;   m[11] = 0;
+        m[0]  = v.x * v.x * k + c;   m[1]  = v.y * v.x * k - v.z; m[2]  = v.z * v.x * k + v.y; m[3]  = 0;
+        m[4]  = v.x * v.y * k + v.z; m[5]  = v.y * v.y * k + c;   m[6]  = v.z * v.y * k - v.x; m[7]  = 0;
+        m[8]  = v.x * v.z * k - v.y; m[9]  = v.y * v.z * k + v.x; m[10] = v.z * v.z * k + c;   m[11] = 0;
         m[12] = 0;               m[13] = 0;               m[14] = 0;               m[15] = 1;
 
         result._markAsUpdated();

--- a/src/Maths/math.ts
+++ b/src/Maths/math.ts
@@ -5477,6 +5477,27 @@ export class Matrix {
     }
 
     /**
+     * Takes normalised vectors and returns a rotation matrix to align "from" with "to".  
+     * Taken from http://www.iquilezles.org/www/articles/noacos/noacos.htm
+     * @param from defines the vector to align
+     * @param to defines the vector to align to
+     * @param result defines the target matrix
+     */
+    public static RotationAlignToRef(from: DeepImmutable<Vector3>, to: DeepImmutable<Vector3>, result: Matrix): void {
+        const v = Vector3.Cross(to, from);
+        const c = Vector3.Dot(to, from);
+        const k = 1 / (1 + c);
+
+        const m = result._m;
+        m[0]  = v.x*v.x*k + c;   m[1]  = v.y*v.x*k - v.z; m[2]  = v.z*v.x*k + v.y; m[3]  = 0;
+        m[4]  = v.x*v.y*k + v.z; m[5]  = v.y*v.y*k + c;   m[6]  = v.z*v.y*k - v.x; m[7]  = 0;
+        m[8]  = v.x*v.z*k - v.y; m[9]  = v.y*v.z*k + v.x; m[10] = v.z*v.z*k + c;   m[11] = 0;
+        m[12] = 0;               m[13] = 0;               m[14] = 0;               m[15] = 1;
+
+        result._markAsUpdated();
+    }
+
+    /**
      * Creates a rotation matrix
      * @param yaw defines the yaw angle in radians (Y axis)
      * @param pitch defines the pitch angle in radians (X axis)


### PR DESCRIPTION
Pushing some modifications/fixes  I'd made in my custom camera class (which extends arcRotateCamera) to arcRotateCamera.

First, for non Y-up up-vectors, change to only calculate the rotation matrix when the up vector changes, as opposed to each time ```_getViewMatrix``` is called. This also uses a new function I've added to the Matrix class to more efficiently get the rotation matrix to align two vectors.

Second, fixed ```rebuildAnglesAndRadius``` so that it also returns correct results when the up-vector is not (0,1,0), and also fixed a divide by zero error I came across (when setting the camera position to look directly along the up axis).

In fixing the above, I can't understand the point of ever calling ```rebuildAnglesAndRadius``` without setting the first parameter to false. The default value of true means that the position, target and alpha, beta, radius will all agree after the call to ```_getViewMatrix``` (unless I've overlooked something). Made a small pg [here](https://www.babylonjs-playground.com/debug.html#I3V0GW#1).

I'm not sure if the ```serialize``` of ```parse``` functions for the camera need to be changed following these updates.