### PR TITLE
ShaderMaterial serialization fix

### DIFF
--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -733,7 +733,7 @@ export class ShaderMaterial extends Material {
      */
     public serialize(): any {
         var serializationObject = SerializationHelper.Serialize(this);
-        serializationObject.customType = "ShaderMaterial";
+        serializationObject.customType = "BABYLON.ShaderMaterial";
 
         serializationObject.options = this._options;
         serializationObject.shaderPath = this._shaderPath;


### PR DESCRIPTION
Fixed ShaderMaterial serialization. Changed customType in serialized JSON from "ShaderMaterial" to "BABYLON.ShaderMaterial".