### PR TITLE
avoid multiple 3D button pointer events with multitouch

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -228,7 +228,7 @@
 - Fix ArcRotateCamera rebuildAnglesAndRadius when upVector modified ([sable](https://github.com/thscott))
 - Fix code branch, that does not try to (re)load an `EquiRectangularCubeTexture`/`HDRCubeTexture` when the caching returns an empty or corrupt `InternalTexture` ([Dennis Dervisis](https://github.com/ddervisis))
 - Add error eventlistener (bubbling up the onError callback chain) in case an `EquiRectangularCubeTexture` cannot be loaded, because of a wrong path or IO problems ([Dennis Dervisis](https://github.com/ddervisis))
-- 3D GUI buttons no longer will scale up when pressing with multitouch devices ([TrevorDev](https://github.com/TrevorDev))
+- 3D GUI buttons no longer will scale up when pressing with a multitouch device ([TrevorDev](https://github.com/TrevorDev))
 
 ### Core Engine
 - Fixed a bug with `mesh.alwaysSelectAsActiveMesh` preventing layerMask to be taken in account ([Deltakosh](https://github.com/deltakosh))

--- a/gui/src/3D/controls/button3D.ts
+++ b/gui/src/3D/controls/button3D.ts
@@ -22,7 +22,6 @@ export class Button3D extends AbstractButton3D {
     private _content: Control;
     private _contentResolution = 512;
     private _contentScaleRatio = 2;
-    private _pressed = false;
 
     /**
      * Gets or sets the texture resolution used to render content (512 by default)
@@ -92,10 +91,8 @@ export class Button3D extends AbstractButton3D {
             if (!this.mesh) {
                 return;
             }
-            if (!this._pressed) {
-                this.mesh.scaling.scaleInPlace(0.95);
-                this._pressed = true;
-            }
+
+            this.mesh.scaling.scaleInPlace(0.95);
         };
 
         this.pointerUpAnimation = () => {
@@ -103,10 +100,7 @@ export class Button3D extends AbstractButton3D {
                 return;
             }
 
-            if (this._pressed) {
-                this.mesh.scaling.scaleInPlace(1.0 / 0.95);
-                this._pressed = false;
-            }
+            this.mesh.scaling.scaleInPlace(1.0 / 0.95);
         };
     }
 

--- a/gui/src/3D/controls/control3D.ts
+++ b/gui/src/3D/controls/control3D.ts
@@ -333,6 +333,7 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
     /** @hidden */
     public _onPointerDown(target: Control3D, coordinates: Vector3, pointerId: number, buttonIndex: number): boolean {
         if (this._downCount !== 0) {
+            this._downCount++;
             return false;
         }
 
@@ -351,17 +352,24 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
 
     /** @hidden */
     public _onPointerUp(target: Control3D, coordinates: Vector3, pointerId: number, buttonIndex: number, notifyClick: boolean): void {
-        this._downCount = 0;
-
+        this._downCount--;
         delete this._downPointerIds[pointerId];
 
-        if (notifyClick && (this._enterCount > 0 || this._enterCount === -1)) {
-            this.onPointerClickObservable.notifyObservers(new Vector3WithInfo(coordinates, buttonIndex), -1, target, this);
+        if (this._downCount < 0) {
+            // Handle if forcePointerUp was called prior to this
+            this._downCount = 0;
+            return;
         }
-        this.onPointerUpObservable.notifyObservers(new Vector3WithInfo(coordinates, buttonIndex), -1, target, this);
 
-        if (this.pointerUpAnimation) {
-            this.pointerUpAnimation();
+        if (this._downCount == 0) {
+            if (notifyClick && (this._enterCount > 0 || this._enterCount === -1)) {
+                this.onPointerClickObservable.notifyObservers(new Vector3WithInfo(coordinates, buttonIndex), -1, target, this);
+            }
+            this.onPointerUpObservable.notifyObservers(new Vector3WithInfo(coordinates, buttonIndex), -1, target, this);
+
+            if (this.pointerUpAnimation) {
+                this.pointerUpAnimation();
+            }
         }
     }
 
@@ -373,6 +381,11 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
             for (var key in this._downPointerIds) {
                 this._onPointerUp(this, Vector3.Zero(), +key as number, 0, true);
             }
+            if (this._downCount > 0) {
+                this._downCount = 1;
+                this._onPointerUp(this, Vector3.Zero(), 0, 0, true);
+            }
+
         }
     }
 


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/6163

This will make it such that if two fingers press the same button, onDownObservable is fired once for the first finger and then when they are released onUpObservable will only be fired once when the last finger is released.

Test PG: https://playground.babylonjs.com/#LXLCQ4