### PR TITLE
Cloning a Mesh might throws an uncaught exception

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -258,6 +258,7 @@
 - Auto Update Touch Action [#5674](https://github.com/BabylonJS/Babylon.js/issues/5674)([Sebavan](https://github.com/Sebavan))
 - Add hemispheric lighting to gizmos to avoid flat look ([TrevorDev](https://github.com/TrevorDev))
 - Fix a bug causing `WebRequest.open` to crash if `WebRequest.CustomRequestHeaders` are set [#6055](https://github.com/BabylonJS/Babylon.js/issues/6055)([susares](https://github.com/susares))
+- Fix a bug causing `Mesh.clone` to crash if no physicsEngineComponent is used  ([barroij](https://github.com/barroij))
 
 ### Viewer
 

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -328,7 +328,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             // Deep copy
             DeepCopier.DeepCopy(source, this, ["name", "material", "skeleton", "instances", "parent", "uniqueId",
                 "source", "metadata", "hasLODLevels", "geometry", "isBlocked", "areNormalsFrozen",
-                "onBeforeDrawObservable", "onBeforeRenderObservable", "onAfterRenderObservable", "onBeforeDraw",
+                "onBeforeDrawObservable", "onBeforeRenderObservable", "onBeforeBindObservable", "onAfterRenderObservable", "onBeforeDraw",
                 "onAfterWorldMatrixUpdateObservable", "onCollideObservable", "onCollisionPositionChangeObservable", "onRebuildObservable",
                 "onDisposeObservable"
             ],

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -400,11 +400,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             }
 
             // Physics clone
-            var physicsEngine = this.getScene().getPhysicsEngine();
-            if (clonePhysicsImpostor && physicsEngine) {
-                var impostor = physicsEngine.getImpostorForPhysicsObject(source);
-                if (impostor) {
-                    this.physicsImpostor = impostor.clone(this);
+            if (scene.getPhysicsEngine) {
+                var physicsEngine = scene.getPhysicsEngine();
+                if (clonePhysicsImpostor && physicsEngine) {
+                    var impostor = physicsEngine.getImpostorForPhysicsObject(source);
+                    if (impostor) {
+                        this.physicsImpostor = impostor.clone(this);
+                    }
                 }
             }
 

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -328,7 +328,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             // Deep copy
             DeepCopier.DeepCopy(source, this, ["name", "material", "skeleton", "instances", "parent", "uniqueId",
                 "source", "metadata", "hasLODLevels", "geometry", "isBlocked", "areNormalsFrozen",
-                "onBeforeDrawObservable", "onBeforeRenderObservable", "onBeforeBindObservable", "onAfterRenderObservable", "onBeforeDraw",
+                "onBeforeDrawObservable", "onBeforeRenderObservable", "onAfterRenderObservable", "onBeforeDraw",
                 "onAfterWorldMatrixUpdateObservable", "onCollideObservable", "onCollisionPositionChangeObservable", "onRebuildObservable",
                 "onDisposeObservable"
             ],


### PR DESCRIPTION
The exception is `TypeError: _this.getScene(...).getPhysicsEngine is not a function`

from line 
````javascript
var physicsEngine = scene.getPhysicsEngine();
````
I guess it happens when no physics is used at all and the scene has not been enhanced when physics related methods such has `isPhysicsEnabled` or `getPhysicsEngine`
