### PR TITLE
Picking support for UnIndexed meshes

### DIFF
--- a/src/Meshes/subMesh.ts
+++ b/src/Meshes/subMesh.ts
@@ -404,11 +404,11 @@ export class SubMesh extends BaseSubMesh implements ICullable {
     private _intersectTriangles(ray: Ray, positions: Vector3[], indices: IndicesArray,
         fastCheck?: boolean, trianglePredicate?: TrianglePickingPredicate): Nullable<IntersectionInfo> {
         var intersectInfo: Nullable<IntersectionInfo> = null;
-        
+
         var start = this.indexStart;
         var count = this.indexCount;
 
-        if(!indices.length){
+        if(!indices.length) {
             start = this.verticesStart;
             count = this.verticesCount;
         }
@@ -416,7 +416,7 @@ export class SubMesh extends BaseSubMesh implements ICullable {
         // Triangles test
         var p0, p1, p2;
         for (var index = start; index < start + count; index += 3) {
-            if(!indices.length){
+            if(!indices.length) {
                 p0 = positions[index];
                 p1 = positions[index + 1];
                 p2 = positions[index + 2];
@@ -426,7 +426,7 @@ export class SubMesh extends BaseSubMesh implements ICullable {
                 p1 = positions[indices[index + 1]];
                 p2 = positions[indices[index + 2]];
             }
-
+            
             if (trianglePredicate && !trianglePredicate(p0, p1, p2, ray)) {
                 continue;
             }

--- a/src/Meshes/subMesh.ts
+++ b/src/Meshes/subMesh.ts
@@ -404,11 +404,28 @@ export class SubMesh extends BaseSubMesh implements ICullable {
     private _intersectTriangles(ray: Ray, positions: Vector3[], indices: IndicesArray,
         fastCheck?: boolean, trianglePredicate?: TrianglePickingPredicate): Nullable<IntersectionInfo> {
         var intersectInfo: Nullable<IntersectionInfo> = null;
+        
+        var start = this.indexStart;
+        var count = this.indexCount;
+
+        if(!indices.length){
+            start = this.verticesStart;
+            count = this.verticesCount;
+        }
+
         // Triangles test
-        for (var index = this.indexStart; index < this.indexStart + this.indexCount; index += 3) {
-            var p0 = positions[indices[index]];
-            var p1 = positions[indices[index + 1]];
-            var p2 = positions[indices[index + 2]];
+        var p0, p1, p2;
+        for (var index = start; index < start + count; index += 3) {
+            if(!indices.length){
+                p0 = positions[index];
+                p1 = positions[index + 1];
+                p2 = positions[index + 2];
+            }
+            else {
+                p0 = positions[indices[index]];
+                p1 = positions[indices[index + 1]];
+                p2 = positions[indices[index + 2]];
+            }
 
             if (trianglePredicate && !trianglePredicate(p0, p1, p2, ray)) {
                 continue;


### PR DESCRIPTION
Small change, but still unsure if this should be done as a separate function or if/how much it'll impact picking perf, it does run like a million times..

PGs; (see console)
sphere is indexed, half-box is unindexed.
Without change:  https://playground.babylonjs.com/#8QNBES#3
With change; https://playground.babylonjs.com/#8QNBES#4