### PR TITLE
Add Missing Link Transform Node To File Loader

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -272,6 +272,7 @@
 ### Loaders
 
 - Added missing `loadedAnimationGroups` to `MeshAssetTask` ([bghgary](https://github.com/bghgary))
+- Added missing `linkTransformNode` to `BabylonFileLoader` ([MackeyK24](https://github.com/mackeyk24))
 
 ## Breaking changes
 

--- a/src/Bones/bone.ts
+++ b/src/Bones/bone.ts
@@ -60,6 +60,9 @@ export class Bone extends Node {
     public _linkedTransformNode: Nullable<TransformNode> = null;
 
     /** @hidden */
+    public _waitingTransformNodeId: Nullable<string> = null;
+
+    /** @hidden */
     get _matrix(): Matrix {
         this._compose();
         return this._localMatrix;

--- a/src/Bones/skeleton.ts
+++ b/src/Bones/skeleton.ts
@@ -63,6 +63,9 @@ export class Skeleton implements IAnimatable {
     /** @hidden */
     public _numBonesWithLinkedTransformNode = 0;
 
+    /** @hidden */
+    public _hasWaitingData: Nullable<boolean> = null;
+
     /**
      * Specifies if the skeleton should be serialized
      */
@@ -690,6 +693,11 @@ export class Skeleton implements IAnimatable {
 
             if (parsedBone.animation) {
                 bone.animations.push(Animation.Parse(parsedBone.animation));
+            }
+
+            if (parsedBone.linkedTransformNodeId !== undefined && parsedBone.linkedTransformNodeId !== null) {
+                skeleton._hasWaitingData = true;
+                bone._waitingTransformNodeId = parsedBone.linkedTransformNodeId;
             }
         }
 

--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -345,6 +345,25 @@ var loadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError?:
             }
         }
 
+        // link skeleton transform nodes
+        for (index = 0, cache = scene.skeletons.length; index < cache; index++) {
+            var skeleton = scene.skeletons[index];
+            if (skeleton._hasWaitingData) {
+                if (skeleton.bones != null) {
+                    skeleton.bones.forEach((bone) => {
+                        if (bone._waitingTransformNodeId) {
+                            var linkTransformNode = scene.getLastEntryByID(bone._waitingTransformNodeId) as TransformNode;
+                            if (linkTransformNode) {
+                                bone.linkTransformNode(linkTransformNode);
+                            }
+                            bone._waitingTransformNodeId = null;
+                        }
+                    });
+                }
+                skeleton._hasWaitingData = null;
+            }
+        }
+
         // freeze world matrix application
         for (index = 0, cache = scene.meshes.length; index < cache; index++) {
             var currentMesh = scene.meshes[index];
@@ -566,6 +585,25 @@ SceneLoader.RegisterPlugin({
                     }
                     if (currentMesh._waitingData.lods) {
                         loadDetailLevels(scene, currentMesh);
+                    }
+                }
+
+                // link skeleton transform nodes
+                for (index = 0, cache = scene.skeletons.length; index < cache; index++) {
+                    var skeleton = scene.skeletons[index];
+                    if (skeleton._hasWaitingData) {
+                        if (skeleton.bones != null) {
+                            skeleton.bones.forEach((bone) => {
+                                if (bone._waitingTransformNodeId) {
+                                    var linkTransformNode = scene.getLastEntryByID(bone._waitingTransformNodeId) as TransformNode;
+                                    if (linkTransformNode) {
+                                        bone.linkTransformNode(linkTransformNode);
+                                    }
+                                    bone._waitingTransformNodeId = null;
+                                }
+                            });
+                        }
+                        skeleton._hasWaitingData = null;
                     }
                 }
 


### PR DESCRIPTION
Unity Uses Transforms To Control Animations.

@bghgary uses Linked Transform Nodes to maintain parity with GLTF/UNITY Skins and Animations.

This fixes a few issues with existing Unity Exported content. Like the funny 90 degree rotation. It also allow support for the main Unity Transforms to hold items like weapons in hand etc.

Kudos @bghgary :)
