### PR TITLE
Preserve updatable option for Mesh.flipFaces and Mesh.forceSharedVertices

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2459,7 +2459,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             }
         }
 
-        vertex_data.applyToMesh(this);
+        vertex_data.applyToMesh(this, this.isVertexBufferUpdatable(VertexBuffer.PositionKind));
         return this;
     }
 
@@ -2665,7 +2665,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             vertex_data.normals = normals;
             vertex_data.uvs = uvs;
 
-            vertex_data.applyToMesh(this);
+            vertex_data.applyToMesh(this, this.isVertexBufferUpdatable(VertexBuffer.PositionKind));
         }
     }
 


### PR DESCRIPTION
Similarly like in https://github.com/BabylonJS/Babylon.js/pull/6330 the updatable option is not preserved for `flipFaces` and  `forceSharedVertices`.

Sad that you do not have any unit tests solution :(