### PR TITLE
Unify preparation of instance attributes.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -6,7 +6,7 @@
 
 ## Updates
 - Support Vive Focus 3Dof controller ([TrevorDev](https://github.com/TrevorDev))
-- Unify preparation of instance attributes. MaterialHelper.PrepareAttributesForInstances now supports Array definitions. ([MarkusBillharz](https://github.com/MarkusBillharz))
+- Unify preparation of instance attributes. Added `MaterialHelper.PushAttributesForInstances` ([MarkusBillharz](https://github.com/MarkusBillharz))
  
 ### Inspector
 - Added support for `ShadowGenerator` ([Deltakosh](https://github.com/deltakosh/))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -6,7 +6,8 @@
 
 ## Updates
 - Support Vive Focus 3Dof controller ([TrevorDev](https://github.com/TrevorDev))
-
+- Unify preparation of instance attributes. MaterialHelper.PrepareAttributesForInstances now supports Array definitions. ([MarkusBillharz](https://github.com/MarkusBillharz))
+ 
 ### Inspector
 - Added support for `ShadowGenerator` ([Deltakosh](https://github.com/deltakosh/))
 - Added support for scene normalization ([Deltakosh](https://github.com/deltakosh/))

--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -496,10 +496,7 @@ export abstract class EffectLayer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         this._addCustomEffectDefines(defines);

--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -496,7 +496,7 @@ export abstract class EffectLayer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         this._addCustomEffectDefines(defines);

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1221,10 +1221,7 @@ export class ShadowGenerator implements IShadowGenerator {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         if (this.customShaderOptions) {

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1221,7 +1221,7 @@ export class ShadowGenerator implements IShadowGenerator {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         if (this.customShaderOptions) {

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -577,7 +577,8 @@ export class MaterialHelper {
      * @param defines The current Defines of the effect
      */
     public static PrepareAttributesForInstances(attribs: string[], defines: any): void {
-        if (defines["INSTANCES"]) {
+        // Check if we are handling a MaterialDefine or an Array containing the #define
+        if (defines["INSTANCES"] || (defines instanceof Array && defines.indexOf("#define INSTANCES") > -1)) {
             attribs.push("world0");
             attribs.push("world1");
             attribs.push("world2");

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -578,7 +578,7 @@ export class MaterialHelper {
      */
     public static PrepareAttributesForInstances(attribs: string[], defines: any): void {
         // Check if we are handling a MaterialDefine or an Array containing the #define
-        if (defines["INSTANCES"] || (defines instanceof Array && defines.indexOf("#define INSTANCES") > -1)) {
+        if (defines["INSTANCES"] || Array.isArray(defines)) {
             attribs.push("world0");
             attribs.push("world1");
             attribs.push("world2");

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -14,6 +14,7 @@ import { UniformBuffer } from "./uniformBuffer";
 import { Effect, EffectFallbacks, EffectCreationOptions } from "./effect";
 import { BaseTexture } from "../Materials/Textures/baseTexture";
 import { WebVRFreeCamera } from '../Cameras/VR/webVRCamera';
+import { MaterialDefines } from "./materialDefines";
 
 /**
  * "Static Class" containing the most commonly used helper while dealing with material for
@@ -572,18 +573,25 @@ export class MaterialHelper {
     }
 
     /**
-     * Prepares the list of attributes required for instances according to the effect defines.
+     * Check and prepare the list of attributes required for instances according to the effect defines.
      * @param attribs The current list of supported attribs
-     * @param defines The current Defines of the effect
+     * @param defines The current MaterialDefines of the effect
      */
-    public static PrepareAttributesForInstances(attribs: string[], defines: any): void {
-        // Check if we are handling a MaterialDefine or an Array containing the #define
-        if (defines["INSTANCES"] || Array.isArray(defines)) {
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+    public static PrepareAttributesForInstances(attribs: string[], defines: MaterialDefines): void {
+        if (defines["INSTANCES"]) {
+            this.PushAttributesForInstances(attribs);
         }
+    }
+
+    /**
+     * Add the list of attributes required for instances to the attribs array.
+     * @param attribs The current list of supported attribs
+     */
+    public static PushAttributesForInstances(attribs: string[]): void {
+        attribs.push("world0");
+        attribs.push("world1");
+        attribs.push("world2");
+        attribs.push("world3");
     }
 
     /**

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -428,7 +428,7 @@ export class ShaderMaterial extends Material {
 
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         // Bones

--- a/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -9,6 +9,7 @@ import { Mesh } from "../Meshes/mesh";
 import { Camera } from "../Cameras/camera";
 import { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
+import { MaterialHelper } from "../Materials/materialHelper";
 import { StandardMaterial } from "../Materials/standardMaterial";
 import { Texture } from "../Materials/Textures/texture";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
@@ -201,10 +202,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         // Get correct effect

--- a/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -202,7 +202,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         // Get correct effect

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -193,7 +193,7 @@ export class DepthRenderer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         // Get correct effect

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -8,6 +8,7 @@ import { Texture } from "../Materials/Textures/texture";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
+import { MaterialHelper } from "../Materials/materialHelper";
 import { Camera } from "../Cameras/camera";
 import { Constants } from "../Engines/constants";
 
@@ -192,10 +193,7 @@ export class DepthRenderer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         // Get correct effect

--- a/src/Rendering/geometryBufferRenderer.ts
+++ b/src/Rendering/geometryBufferRenderer.ts
@@ -230,7 +230,7 @@ export class GeometryBufferRenderer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         // Setup textures count

--- a/src/Rendering/geometryBufferRenderer.ts
+++ b/src/Rendering/geometryBufferRenderer.ts
@@ -8,6 +8,7 @@ import { Texture } from "../Materials/Textures/texture";
 import { MultiRenderTarget } from "../Materials/Textures/multiRenderTarget";
 import { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
+import { MaterialHelper } from "../Materials/materialHelper";
 import { Scene } from "../scene";
 import { AbstractMesh } from "../Meshes/abstractMesh";
 
@@ -229,10 +230,7 @@ export class GeometryBufferRenderer {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         // Setup textures count

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -8,6 +8,7 @@ import { Constants } from "../Engines/constants";
 import { ISceneComponent, SceneComponentConstants } from "../sceneComponent";
 import { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
+import { MaterialHelper } from "../Materials/materialHelper";
 
 import "../Shaders/outline.fragment";
 import "../Shaders/outline.vertex";
@@ -255,10 +256,7 @@ export class OutlineRenderer implements ISceneComponent {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            attribs.push("world0");
-            attribs.push("world1");
-            attribs.push("world2");
-            attribs.push("world3");
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         }
 
         // Get correct effect

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -256,7 +256,7 @@ export class OutlineRenderer implements ISceneComponent {
         // Instances
         if (useInstances) {
             defines.push("#define INSTANCES");
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PushAttributesForInstances(attribs);
         }
 
         // Get correct effect


### PR DESCRIPTION
https://forum.babylonjs.com/t/custom-attributes-for-instanced-mesh-to-be-used-with-custom-shaders/3164/2

- Add Array definition support to MaterialHelper.PrepareAttributesForInstances in order to avoid redundancies when pushing the required attributes where the defines are not of type MaterialDefines.
- Remove redundancies.