### PR TITLE
Fix getHashCode() of Colors

### DIFF
--- a/src/Maths/math.ts
+++ b/src/Maths/math.ts
@@ -65,9 +65,9 @@ export class Color3 {
      * @returns an unique number that can be used to hash Color3 objects
      */
     public getHashCode(): number {
-        let hash = this.r || 0;
-        hash = (hash * 397) ^ (this.g || 0);
-        hash = (hash * 397) ^ (this.b || 0);
+        let hash = (this.r * 255) || 0;
+        hash = (hash * 397) ^ ((this.g * 255) || 0);
+        hash = (hash * 397) ^ ((this.b * 255) || 0);
         return hash;
     }
 
@@ -779,10 +779,10 @@ export class Color4 {
      * @returns an unique number that can be used to hash Color4 objects
      */
     public getHashCode(): number {
-        let hash = this.r || 0;
-        hash = (hash * 397) ^ (this.g || 0);
-        hash = (hash * 397) ^ (this.b || 0);
-        hash = (hash * 397) ^ (this.a || 0);
+        let hash = (this.r * 255) || 0;
+        hash = (hash * 397) ^ ((this.g * 255) || 0);
+        hash = (hash * 397) ^ ((this.b * 255) || 0);
+        hash = (hash * 397) ^ ((this.a * 255) || 0);
         return hash;
     }
 


### PR DESCRIPTION
This PR fixes `getHashCode()` of `Color3/4`. See #6355 for the detail.

A bit off topic. What exactly is `|| 0` in `this.xxx || 0` for? Can `.r/g/b/a` be `null`, `undefined`, or something else?