### PR TITLE
mark bone as dirty before updating axes viewer

### DIFF
--- a/src/Bones/bone.ts
+++ b/src/Bones/bone.ts
@@ -372,7 +372,8 @@ export class Bone extends Node {
         this._skeleton._markAsDirty();
     }
 
-    private _markAsDirtyAndCompose() {
+    /** @hidden */
+    public _markAsDirtyAndCompose() {
         this.markAsDirty();
         this._needToCompose = true;
     }

--- a/src/Debug/boneAxesViewer.ts
+++ b/src/Debug/boneAxesViewer.ts
@@ -62,7 +62,7 @@ export class BoneAxesViewer extends AxesViewer {
         bone.getDirectionToRef(Axis.Z, this.mesh, this.zaxis);
 
         super.update(this.pos, this.xaxis, this.yaxis, this.zaxis);
-        
+
     }
 
     /** Releases resources */

--- a/src/Debug/boneAxesViewer.ts
+++ b/src/Debug/boneAxesViewer.ts
@@ -55,13 +55,14 @@ export class BoneAxesViewer extends AxesViewer {
         }
 
         var bone = this.bone;
+        bone._markAsDirtyAndCompose();
         bone.getAbsolutePositionToRef(this.mesh, this.pos);
         bone.getDirectionToRef(Axis.X, this.mesh, this.xaxis);
         bone.getDirectionToRef(Axis.Y, this.mesh, this.yaxis);
         bone.getDirectionToRef(Axis.Z, this.mesh, this.zaxis);
 
         super.update(this.pos, this.xaxis, this.yaxis, this.zaxis);
-
+        
     }
 
     /** Releases resources */


### PR DESCRIPTION
https://forum.babylonjs.com/t/babylon-debug-boneaxesviewer-modify-the-behavior/3300

TestPG: #IG8AJ2#2 (object should be animating with axes viewer working)