### PR TITLE
dont remove texture if texture coords are not present

### DIFF
--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1067,7 +1067,6 @@ export class _Exporter {
         let promises: Promise<IMeshPrimitive>[] = [];
         let bufferMesh: Nullable<Mesh> = null;
         let bufferView: IBufferView;
-        let uvCoordsPresent: boolean;
         let minMax: { min: Nullable<number[]>, max: Nullable<number[]> };
 
         if (babylonTransformNode instanceof Mesh) {
@@ -1123,7 +1122,6 @@ export class _Exporter {
             if (bufferMesh.subMeshes) {
                 // go through all mesh primitives (submeshes)
                 for (const submesh of bufferMesh.subMeshes) {
-                    uvCoordsPresent = false;
                     let babylonMaterial = submesh.getMaterial() || bufferMesh.getScene().defaultMaterial;
 
                     let materialIndex: Nullable<number> = null;
@@ -1179,9 +1177,6 @@ export class _Exporter {
                                     const accessor = _GLTFUtilities._CreateAccessor(bufferViewIndex, attributeKind + " - " + babylonTransformNode.name, attribute.accessorType, AccessorComponentType.FLOAT, vertexData.length / stride, 0, minMax.min, minMax.max);
                                     this._accessors.push(accessor);
                                     this.setAttributeKind(meshPrimitive, attributeKind);
-                                    if (meshPrimitive.attributes.TEXCOORD_0 != null || meshPrimitive.attributes.TEXCOORD_1 != null) {
-                                        uvCoordsPresent = true;
-                                    }
                                 }
                             }
                         }
@@ -1218,12 +1213,6 @@ export class _Exporter {
                                     }
                                 }
                             }
-                        }
-
-                        if (!uvCoordsPresent && this._glTFMaterialExporter._hasTexturesPresent(this._materials[materialIndex])) {
-                            const newMat = this._glTFMaterialExporter._stripTexturesFromMaterial(this._materials[materialIndex]);
-                            this._materials.push(newMat);
-                            materialIndex = this._materials.length - 1;
                         }
 
                         meshPrimitive.material = materialIndex;


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/6373
https://forum.babylonjs.com/t/material-sideorientation-normal-flipped-during-glb-export/2046/17

TestPG: #95MJI8#35

![image](https://user-images.githubusercontent.com/3753071/58215284-fac65880-7cad-11e9-9210-f78df5ab6b4f.png)

@bghgary I'm not sure if my fix here is correct and I am removing code which explicitly tries to avoid this. When exporting multimaterials each submesh is exported instead as it's own mesh which references a single material. In the repro it appears that the submesh does not have UV attributes. Before this change it creates a clone of the material but without the texture causing the export to be incorrect so I just removed that logic and babylon seems to handle this without any errors but I have a feeling it might not be the best change. The material also looks faded but that may be expected from the standard mat -> pbr conversion.