### PR TITLE
 Separate enterPointerlock

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -15,6 +15,7 @@
 
 ### Engine
 - Added preprocessors for shaders to improve how shaders are compiled for WebGL1/2 or WebGPU ([Deltakosh](https://github.com/deltakosh/))
+- Added enterPointerlock and exitPointerlock (Separated from enterFullscreen) ([aWeirdo](https://github.com/aWeirdo/))
 
 ### Inspector
 - Added support for `ShadowGenerator` ([Deltakosh](https://github.com/deltakosh/))
@@ -42,5 +43,6 @@
 - A scene's input manager not adding key listeners when the canvas is already focused ([Poolminer](https://github.com/Poolminer))
 - Runtime animation `goToFrame` when going back in time now correctly triggers future events when reached ([zakhenry](https://github.com/zakhenry))
 - Fixed bug in Ray.intersectsTriangle where the barycentric coordinates `bu` and `bv` being returned is actually `bv` and `bw`. ([bghgary](https://github.com/bghgary))
+- Do not call onError when creating a texture when falling back to another loader ([TrevorDev](https://github.com/TrevorDev))
 
 ## Breaking changes

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1210,14 +1210,7 @@ export class Engine {
 
                 // Pointer lock
                 if (this.isFullscreen && this._pointerLockRequested && canvas) {
-                    canvas.requestPointerLock = canvas.requestPointerLock ||
-                        canvas.msRequestPointerLock ||
-                        canvas.mozRequestPointerLock ||
-                        canvas.webkitRequestPointerLock;
-
-                    if (canvas.requestPointerLock) {
-                        canvas.requestPointerLock();
-                    }
+                    Tools.RequestPointerlock(canvas);
                 }
             };
 
@@ -2070,6 +2063,24 @@ export class Engine {
     public exitFullscreen(): void {
         if (this.isFullscreen) {
             Tools.ExitFullscreen();
+        }
+    }
+
+    /**
+     * Enters Pointerlock mode
+     */
+    public enterPointerlock(): void {
+        if (this._renderingCanvas) {
+            Tools.RequestPointerlock(this._renderingCanvas);
+        }
+    }
+
+    /**
+     * Exits Pointerlock mode
+     */
+    public exitPointerlock(): void {
+        if (this.isFullscreen) {
+            Tools.ExitPointerlock();
         }
     }
 

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -4240,7 +4240,8 @@ export class Engine {
                     customFallback = true;
                     excludeLoaders.push(loader);
                     Tools.Warn((loader.constructor as any).name + " failed when trying to load " + texture.url + ", falling back to the next supported loader");
-                    this.createTexture(urlArg, noMipmap, texture.invertY, scene, samplingMode, null, null, buffer, texture, undefined, undefined, excludeLoaders);
+                    this.createTexture(urlArg, noMipmap, texture.invertY, scene, samplingMode, null, onError, buffer, texture, undefined, undefined, excludeLoaders);
+                    return;
                 }
             }
 
@@ -4249,7 +4250,8 @@ export class Engine {
                     texture.onLoadedObservable.remove(onLoadObserver);
                 }
                 if (Tools.UseFallbackTexture) {
-                    this.createTexture(Tools.fallbackTexture, noMipmap, texture.invertY, scene, samplingMode, null, null, buffer, texture);
+                    this.createTexture(Tools.fallbackTexture, noMipmap, texture.invertY, scene, samplingMode, null, onError, buffer, texture);
+                    return;
                 }
             }
 

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -2079,9 +2079,7 @@ export class Engine {
      * Exits Pointerlock mode
      */
     public exitPointerlock(): void {
-        if (this.isFullscreen) {
-            Tools.ExitPointerlock();
-        }
+        Tools.ExitPointerlock();
     }
 
     /**

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -692,6 +692,29 @@ export class Tools {
     }
 
     /**
+     * Ask the browser to promote the current element to pointerlock mode
+     * @param element defines the DOM element to promote
+     */
+    public static RequestPointerlock(element: HTMLElement): void {
+        element.requestPointerLock = element.requestPointerLock || (<any>element).msRequestPointerLock || (<any>element).mozRequestPointerLock || (<any>element).webkitRequestPointerLock;
+        if (element.requestPointerLock) {
+            element.requestPointerLock();
+        }
+    }
+
+    /**
+     * Asks the browser to exit pointerlock mode
+     */
+    public static ExitPointerlock(): void {
+        let anyDoc = document as any;
+        document.exitPointerLock = document.exitPointerLock || anyDoc.msExitPointerLock || anyDoc.mozExitPointerLock || anyDoc.webkitExitPointerLock;
+
+        if (document.exitPointerLock) {
+            document.exitPointerLock();
+        }
+    }
+
+    /**
      * Sets the cors behavior on a dom element. This will add the required Tools.CorsBehavior to the element.
      * @param url define the url we are trying
      * @param element define the dom element where to configure the cors policy


### PR DESCRIPTION
Separate engine.enterPointerlock from engine.enterFullscreen to allow access to pointerlock on non-fullscreen cases.

https://playground.babylonjs.com/#C2B627#1

Needs more testing, will do so when possible.

-File changes got a bit entangled with https://github.com/BabylonJS/Babylon.js/pull/6397 🙃 