### PR TITLE
Add MeshMorph support to the OutlineRenderer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -19,7 +19,7 @@
 - Ability to set render camera on utility layer instead of using the latest active camera ([TrevorDev](https://github.com/TrevorDev))
 - Move normalizeToUnitCube to transformNode instead of abstract mesh and add predicate to exclude sub objects when scaling ([TrevorDev](https://github.com/TrevorDev))
 - Method to check if device orientation is available ([TrevorDev](https://github.com/TrevorDev))
-- Added MorphTarget support to the DepthRenderer and GeometryBufferRenderer ([MarkusBillharz](https://github.com/MarkusBillharz))
+- Added MorphTarget support to the DepthRenderer, GeometryBufferRenderer and OutlineRenderer ([MarkusBillharz](https://github.com/MarkusBillharz))
 
 ### Engine
 - Added preprocessors for shaders to improve how shaders are compiled for WebGL1/2 or WebGPU ([Deltakosh](https://github.com/deltakosh/))

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -1,6 +1,6 @@
 import { VertexBuffer } from "../Meshes/buffer";
 import { SubMesh } from "../Meshes/subMesh";
-import {_InstancesBatch, Mesh} from "../Meshes/mesh";
+import { _InstancesBatch, Mesh } from "../Meshes/mesh";
 import { AbstractMesh } from "../Meshes/abstractMesh";
 import { Scene } from "../scene";
 import { Engine } from "../Engines/engine";

--- a/src/Shaders/outline.vertex.fx
+++ b/src/Shaders/outline.vertex.fx
@@ -4,6 +4,9 @@ attribute vec3 normal;
 
 #include<bonesDeclaration>
 
+#include<morphTargetsVertexGlobalDeclaration>
+#include<morphTargetsVertexDeclaration>[0..maxSimultaneousMorphTargets]
+
 // Uniform
 uniform float offset;
 
@@ -25,7 +28,11 @@ attribute vec2 uv2;
 
 void main(void)
 {
-	vec3 offsetPosition = position + normal * offset;
+    vec3 positionUpdated = position;
+    vec3 normalUpdated = normal;
+    #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]
+
+	vec3 offsetPosition = positionUpdated + (normalUpdated * offset);
 
 #include<instancesVertex>
 #include<bonesVertex>


### PR DESCRIPTION
I think that's the last of the renderers that was missing it.

Test:
https://www.babylonjs-playground.com/#4ZI604#2

Before:
![image](https://user-images.githubusercontent.com/50644328/58920046-ab157180-8730-11e9-82f0-8afa247206ea.png)

After:
![image](https://user-images.githubusercontent.com/50644328/58920059-bb2d5100-8730-11e9-983b-44ad4f23944e.png)

Thanks!