### PR TITLE
Fix issue with alpha mode in glTF exporter

### DIFF
--- a/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -266,19 +266,17 @@ export class _GLTFMaterialExporter {
     }
 
     /**
-     * Gets the glTF alpha mode from the Babylon Material
-     * @param babylonMaterial Babylon Material
-     * @returns The Babylon alpha mode value
+     * Sets the glTF alpha mode to a glTF material from the Babylon Material
+     * @param glTFMaterial glTF material
+     * @param babylonMaterial Babylon material
      */
-    public _getAlphaMode(babylonMaterial: Material): MaterialAlphaMode {
+    private static _SetAlphaMode(glTFMaterial: IMaterial, babylonMaterial: Material & { alphaCutOff: number }): void {
         if (babylonMaterial.needAlphaBlending()) {
-            return MaterialAlphaMode.BLEND;
+            glTFMaterial.alphaMode = MaterialAlphaMode.BLEND;
         }
         else if (babylonMaterial.needAlphaTesting()) {
-            return MaterialAlphaMode.MASK;
-        }
-        else {
-            return MaterialAlphaMode.OPAQUE;
+            glTFMaterial.alphaMode = MaterialAlphaMode.MASK;
+            glTFMaterial.alphaCutoff = babylonMaterial.alphaCutOff;
         }
     }
 
@@ -295,8 +293,7 @@ export class _GLTFMaterialExporter {
     public _convertStandardMaterialAsync(babylonStandardMaterial: StandardMaterial, mimeType: ImageMimeType, hasTextureCoords: boolean): Promise<void> {
         const materialMap = this._exporter._materialMap;
         const materials = this._exporter._materials;
-        const alphaMode = this._getAlphaMode(babylonStandardMaterial);
-        let promises = [];
+        const promises = [];
         const glTFPbrMetallicRoughness = this._convertToGLTFPBRMetallicRoughness(babylonStandardMaterial);
 
         const glTFMaterial: IMaterial = { name: babylonStandardMaterial.name };
@@ -359,22 +356,7 @@ export class _GLTFMaterialExporter {
         }
 
         glTFMaterial.pbrMetallicRoughness = glTFPbrMetallicRoughness;
-        if (alphaMode !== MaterialAlphaMode.OPAQUE) {
-            switch (alphaMode) {
-                case MaterialAlphaMode.BLEND: {
-                    glTFMaterial.alphaMode = MaterialAlphaMode.BLEND;
-                    break;
-                }
-                case MaterialAlphaMode.MASK: {
-                    glTFMaterial.alphaMode = MaterialAlphaMode.MASK;
-                    glTFMaterial.alphaCutoff = babylonStandardMaterial.alphaCutOff;
-                    break;
-                }
-                default: {
-                    Tools.Warn(`Unsupported alpha mode ${alphaMode}`);
-                }
-            }
-        }
+        _GLTFMaterialExporter._SetAlphaMode(glTFMaterial, babylonStandardMaterial);
 
         materials.push(glTFMaterial);
         materialMap[babylonStandardMaterial.uniqueId] = materials.length - 1;
@@ -420,18 +402,7 @@ export class _GLTFMaterialExporter {
         if (babylonPBRMetalRoughMaterial.doubleSided) {
             glTFMaterial.doubleSided = babylonPBRMetalRoughMaterial.doubleSided;
         }
-        let alphaMode: Nullable<MaterialAlphaMode> = null;
-        if (babylonPBRMetalRoughMaterial.transparencyMode != null) {
-            alphaMode = this._getAlphaMode(babylonPBRMetalRoughMaterial);
-            if (alphaMode) {
-                if (alphaMode !== MaterialAlphaMode.OPAQUE) { //glTF defaults to opaque
-                    glTFMaterial.alphaMode = alphaMode;
-                    if (alphaMode === MaterialAlphaMode.MASK) {
-                        glTFMaterial.alphaCutoff = babylonPBRMetalRoughMaterial.alphaCutOff;
-                    }
-                }
-            }
-        }
+        _GLTFMaterialExporter._SetAlphaMode(glTFMaterial, babylonPBRMetalRoughMaterial);
         if (hasTextureCoords) {
             if (babylonPBRMetalRoughMaterial.baseTexture != null) {
                 promises.push(this._exportTextureAsync(babylonPBRMetalRoughMaterial.baseTexture, mimeType).then((glTFTexture) => {
@@ -1062,18 +1033,7 @@ export class _GLTFMaterialExporter {
         const materials = this._exporter._materials;
         let promises = [];
         if (metallicRoughness) {
-            let alphaMode: Nullable<MaterialAlphaMode> = null;
-            if (babylonPBRMaterial.transparencyMode != null) {
-                alphaMode = this._getAlphaMode(babylonPBRMaterial);
-                if (alphaMode) {
-                    if (alphaMode !== MaterialAlphaMode.OPAQUE) { //glTF defaults to opaque
-                        glTFMaterial.alphaMode = alphaMode;
-                        if (alphaMode === MaterialAlphaMode.MASK) {
-                            glTFMaterial.alphaCutoff = babylonPBRMaterial.alphaCutOff;
-                        }
-                    }
-                }
-            }
+            _GLTFMaterialExporter._SetAlphaMode(glTFMaterial, babylonPBRMaterial);
             if (!(_GLTFMaterialExporter.FuzzyEquals(metallicRoughness.baseColor, Color3.White(), _GLTFMaterialExporter._Epsilon) && babylonPBRMaterial.alpha >= _GLTFMaterialExporter._Epsilon)) {
                 glTFPbrMetallicRoughness.baseColorFactor = [
                     metallicRoughness.baseColor.r,


### PR DESCRIPTION
See https://forum.babylonjs.com/t/translucent-meshes-are-exported-opaque-from-babylonjs-scene-when-using-gltf2export-class/3785