### PR TITLE
Fix issue when adding and removing observers

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -69,5 +69,6 @@
 - Context loss should not cause PBR materials to render black or instances to stop rendering ([TrevorDev](https://github.com/TrevorDev))
 - Only cast pointer ray input when pointer is locked in webVR ([TrevorDev](https://github.com/TrevorDev))
 - Avoid using default utility layer in gizmo manager to support multiple scenes ([TrevorDev](https://github.com/TrevorDev))
+- Fix bug when adding and removing observers in quick succession ([sable](https://github.com/thscott))
 
 ## Breaking changes

--- a/src/Misc/observable.ts
+++ b/src/Misc/observable.ts
@@ -233,8 +233,12 @@ export class Observable<T> {
     public removeCallback(callback: (eventData: T, eventState: EventState) => void, scope?: any): boolean {
 
         for (var index = 0; index < this._observers.length; index++) {
-            if (this._observers[index].callback === callback && (!scope || scope === this._observers[index].scope)) {
-                this._deferUnregister(this._observers[index]);
+            const observer = this._observers[index];
+            if (observer._willBeUnregistered) {
+                continue;
+            }
+            if (observer.callback === callback && (!scope || scope === observer.scope)) {
+                this._deferUnregister(observer);
                 return true;
             }
         }


### PR DESCRIPTION
When adding and removing observers with the same callback in quick succession, only the first observer will be removed from the observable.

See [this pg](https://playground.babylonjs.com/debug.html#VFX196) for a fairly contrived example. I noticed it though when adding a move observer on pointerdown and removing it on pointerup, where spam clicking would sometimes result in observers not being removed (due to observer removal being deferred).