### PR TITLE
Fix Alpha changes detection for dirty defines

### DIFF
--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1475,13 +1475,15 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 defines.TWOSIDEDLIGHTING = false;
             }
 
+            defines.SPECULARAA = scene.getEngine().getCaps().standardDerivatives && this._enableSpecularAntiAliasing;
+        }
+
+        if (defines._areTexturesDirty || defines._areMiscDirty) {
             defines.ALPHATESTVALUE = `${this._alphaCutOff}${this._alphaCutOff % 1 === 0 ? "." : ""}`;
             defines.PREMULTIPLYALPHA = (this.alphaMode === Constants.ALPHA_PREMULTIPLIED || this.alphaMode === Constants.ALPHA_PREMULTIPLIED_PORTERDUFF);
             defines.ALPHABLEND = this.needAlphaBlendingForMesh(mesh);
             defines.ALPHAFRESNEL = this._useAlphaFresnel || this._useLinearAlphaFresnel;
             defines.LINEARALPHAFRESNEL = this._useLinearAlphaFresnel;
-
-            defines.SPECULARAA = scene.getEngine().getCaps().standardDerivatives && this._enableSpecularAntiAliasing;
         }
 
         if (defines._areImageProcessingDirty && this._imageProcessingConfiguration) {


### PR DESCRIPTION
Ref: https://forum.babylonjs.com/t/pbr-material-doesnt-update-alpha-under-some-circumstances/4083/3