### PR TITLE
Send request url to custom webRequest modifiers

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -22,6 +22,7 @@
 - Added support for sound sprites [Doc](https://doc.babylonjs.com/how_to/playing_sounds_and_music#playing-a-sound-sprite) ([Deltakosh](https://github.com/deltakosh/))
 - Display Oculus Quest controller when using a Quest in WebVR ([TrevorDev](https://github.com/TrevorDev))
 - Added startAndReleaseDragOnPointerEvents property to pointerDragBehavior which can be set to false for custom drag triggering ([TrevorDev](https://github.com/TrevorDev))
+- Added url parameters to web request modifiers ([PierreLeBlond](https://github.com/PierreLeBlond))
 
 ### Engine
 - Morph targets now can morph UV channel as well ([Deltakosh](https://github.com/deltakosh/))

--- a/src/Misc/webRequest.ts
+++ b/src/Misc/webRequest.ts
@@ -13,7 +13,7 @@ export class WebRequest {
     /**
      * Add callback functions in this array to update all the requests before they get sent to the network
      */
-    public static CustomRequestModifiers = new Array<(request: XMLHttpRequest) => void>();
+    public static CustomRequestModifiers = new Array<(request: XMLHttpRequest, url: string) => void>();
 
     private _injectCustomRequestHeaders(): void {
         for (let key in WebRequest.CustomRequestHeaders) {
@@ -126,7 +126,7 @@ export class WebRequest {
      */
     public open(method: string, url: string): void {
         for (var update of WebRequest.CustomRequestModifiers) {
-            update(this._xhr);
+            update(this._xhr, url);
         }
 
         // Clean url


### PR DESCRIPTION
It would be helpful to change web request headers according to request url, e.g. for known protected urls.