### PR TITLE
add disable prompt option for OculusQuest

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -78,6 +78,9 @@
 ### Ray
 - Added `Ray.intersectsAxis` to translate screen to axis coordinates without checking collisions ([horusscope](https://github.com/horusscope))
 
+### GUI  
+- Added `disableMobilePrompt` option to InputText for OculusQuest(and other android base VR devices) ([shinyoshiaki](https://github.com/shinyoshiaki))
+
 ### Documentation
 - Added a note on shallow bounding of getBoundingInfo ([tibotiber](https://github.com/tibotiber))
 

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -50,6 +50,8 @@ export class InputText extends Control implements IFocusableControl {
 
     /** Gets or sets a string representing the message displayed on mobile when the control gets the focus */
     public promptMessage = "Please enter text:";
+    /** Force disable prompt on mobile device */
+    public disableMobilePrompt = false;
 
     /** Observable raised when the text changes */
     public onTextChangedObservable = new Observable<InputText>();
@@ -364,7 +366,7 @@ export class InputText extends Control implements IFocusableControl {
 
         this.onFocusObservable.notifyObservers(this);
 
-        if (navigator.userAgent.indexOf("Mobile") !== -1) {
+        if (navigator.userAgent.indexOf("Mobile") !== -1 && !this.disableMobilePrompt) {
             let value = prompt(this.promptMessage);
 
             if (value !== null) {


### PR DESCRIPTION
In OculusQuest Using VirtualKeyboard then , babylon.js show prompt because OculusQuest is android mobile device.
When prompt shown , browser stop webvr until resolved prompt. So can not input virtualKeyboard via vr controller until resolved prompt.
So we should to add disable prompt option for OculusQuest(and other android base vr devices).