### PR TITLE
Fix check for material needing alpha blending in OutlineRenderer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -105,6 +105,7 @@
 - Make planeDragGizmo usable on its own ([TrevorDev](https://github.com/TrevorDev))
 - Fix useObjectOrienationForDragging for pointerDragBehavior when using a single axis drag ([TrevorDev](https://github.com/TrevorDev))
 - Fix VR button not positioning correctly in canvas ([haroldma](https://github.com/haroldma))
+- Fix check for material needing alpha blending in OutlineRenderer [mkmc](https://github.com/mkmc)
 
 ## Breaking changes
 - Setting mesh.scaling to a new vector will no longer automatically call forceUpdate (this should be done manually when needed) ([TrevorDev](https://github.com/TrevorDev))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -105,7 +105,7 @@
 - Make planeDragGizmo usable on its own ([TrevorDev](https://github.com/TrevorDev))
 - Fix useObjectOrienationForDragging for pointerDragBehavior when using a single axis drag ([TrevorDev](https://github.com/TrevorDev))
 - Fix VR button not positioning correctly in canvas ([haroldma](https://github.com/haroldma))
-- Fix check for material needing alpha blending in OutlineRenderer [mkmc](https://github.com/mkmc)
+- Fix check for material needing alpha blending in OutlineRenderer ([mkmc](https://github.com/mkmc))
 
 ## Breaking changes
 - Setting mesh.scaling to a new vector will no longer automatically call forceUpdate (this should be done manually when needed) ([TrevorDev](https://github.com/TrevorDev))

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -296,7 +296,7 @@ export class OutlineRenderer implements ISceneComponent {
         this._savedDepthWrite = this._engine.getDepthWrite();
         if (mesh.renderOutline) {
             var material = subMesh.getMaterial();
-            if (material && material.needAlphaBlending) {
+            if (material && material.needAlphaBlending()) {
                 this._engine.cacheStencilState();
                 // Draw only to stencil buffer for the original mesh
                 // The resulting stencil buffer will be used so the outline is not visible inside the mesh when the mesh is transparent
@@ -318,7 +318,7 @@ export class OutlineRenderer implements ISceneComponent {
             this.render(subMesh, batch);
             this._engine.setDepthWrite(this._savedDepthWrite);
 
-            if (material && material.needAlphaBlending) {
+            if (material && material.needAlphaBlending()) {
                 this._engine.restoreStencilState();
             }
         }


### PR DESCRIPTION
Resolves an issue where parts of the outline were missing. This happens for opaque meshes, where the mesh in front is rendered after the mesh in the back. The part of the outline, that would occlude the other mesh was missing.

See also:
https://forum.babylonjs.com/t/how-to-achieve-render-order-independent-outline-rendering/4649