### PR TITLE
 Add absolute scale and rotation to transform node

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -55,6 +55,7 @@
 
 ### Meshes
 - Added new CreateTiledPlane and CreateTiledBox ([JohnK](https://github.com/BabylonJSGuide/))
+- Added absolute scaling and rotation getters ([haroldma](https://github.com/haroldma))
 
 ### Physics
 - Update Ammo.js library to support global collision contact callbacks ([MackeyK24](https://github.com/MackeyK24/))

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -353,7 +353,6 @@ export class TransformNode extends Node {
      * Returns a Vector3.
      */
     public get absolutePosition(): Vector3 {
-        this._syncAbsoluteScalingAndRotation();
         return this._absolutePosition;
     }
 
@@ -371,6 +370,7 @@ export class TransformNode extends Node {
      * Returns a Quaternion.
      */
     public get absoluteRotationQuaternion(): Quaternion {
+        this._syncAbsoluteScalingAndRotation();
         return this._absoluteRotationQuaternion;
     }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -57,6 +57,7 @@ export class TransformNode extends Node {
     protected _scaling = Vector3.One();
     protected _isDirty = false;
     private _transformToBoneReferal: Nullable<TransformNode> = null;
+    private _isAbsoluteSynced = false;
 
     @serialize("billboardMode")
     private _billboardMode = TransformNode.BILLBOARDMODE_NONE;
@@ -352,6 +353,7 @@ export class TransformNode extends Node {
      * Returns a Vector3.
      */
     public get absolutePosition(): Vector3 {
+        this._syncAbsoluteScalingAndRotation();
         return this._absolutePosition;
     }
 
@@ -360,6 +362,7 @@ export class TransformNode extends Node {
      * Returns a Vector3.
      */
     public get absoluteScaling(): Vector3 {
+        this._syncAbsoluteScalingAndRotation();
         return this._absoluteScaling;
     }
 
@@ -1096,8 +1099,9 @@ export class TransformNode extends Node {
 
         this._afterComputeWorldMatrix();
 
-        // Update absolute transform values
-        this._worldMatrix.decompose(this._absoluteScaling, this._absoluteRotationQuaternion, this._absolutePosition);
+        // Absolute position
+        this._absolutePosition.copyFromFloats(this._worldMatrix.m[12], this._worldMatrix.m[13], this._worldMatrix.m[14]);
+        this._isAbsoluteSynced = false;
 
         // Callbacks
         this.onAfterWorldMatrixUpdateObservable.notifyObservers(this);
@@ -1327,5 +1331,12 @@ export class TransformNode extends Node {
         }
 
         return this;
+    }
+
+    private _syncAbsoluteScalingAndRotation(): void {
+        if (!this._isAbsoluteSynced) {
+            this._worldMatrix.decompose(this._absoluteScaling, this._absoluteRotationQuaternion);
+            this._isAbsoluteSynced = true;
+        }
     }
 }

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -145,6 +145,8 @@ export class TransformNode extends Node {
 
     private _usePivotMatrix = false;
     private _absolutePosition = Vector3.Zero();
+    private _absoluteScaling = Vector3.Zero();
+    private _absoluteRotationQuaternion = Quaternion.Identity();
     private _pivotMatrix = Matrix.Identity();
     private _pivotMatrixInverse: Matrix;
     protected _postMultiplyPivotMatrix = false;
@@ -351,6 +353,22 @@ export class TransformNode extends Node {
      */
     public get absolutePosition(): Vector3 {
         return this._absolutePosition;
+    }
+
+    /**
+     * Returns the current mesh absolute scaling.
+     * Returns a Vector3.
+     */
+    public get absoluteScaling(): Vector3 {
+        return this._absoluteScaling;
+    }
+
+    /**
+     * Returns the current mesh absolute scaling.
+     * Returns a Vector3.
+     */
+    public get absoluteRotationQuaternion(): Quaternion {
+        return this._absoluteRotationQuaternion;
     }
 
     /**
@@ -1078,8 +1096,8 @@ export class TransformNode extends Node {
 
         this._afterComputeWorldMatrix();
 
-        // Absolute position
-        this._absolutePosition.copyFromFloats(this._worldMatrix.m[12], this._worldMatrix.m[13], this._worldMatrix.m[14]);
+        // Update absolute transform values
+        this._worldMatrix.decompose(this._absoluteScaling, this._absoluteRotationQuaternion, this._absolutePosition);
 
         // Callbacks
         this.onAfterWorldMatrixUpdateObservable.notifyObservers(this);

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -364,8 +364,8 @@ export class TransformNode extends Node {
     }
 
     /**
-     * Returns the current mesh absolute scaling.
-     * Returns a Vector3.
+     * Returns the current mesh absolute rotation.
+     * Returns a Quaternion.
      */
     public get absoluteRotationQuaternion(): Quaternion {
         return this._absoluteRotationQuaternion;


### PR DESCRIPTION
Our team ends up using decompose in some cases when working with scale and rotation. Since there's an absolutePosition, it made sense to do this change.

Thoughts?