### PR TITLE
ScreenshotTools. Implementation usage of precision in combination height and width params

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -78,6 +78,7 @@
 
 ### ScreenshotTools
 - Added interface for argument `size` of screenshot methods ([Dok11](https://github.com/Dok11/))
+- Implementation usage of precision in combination height and width params ([Dok11](https://github.com/Dok11/))
 
 ### Sounds
 - Added `ISoundOptions.skipCodecCheck` to make `Sound` more flexible with URLs ([nbduke](https://github.com/nbduke))

--- a/src/Misc/screenshotTools.ts
+++ b/src/Misc/screenshotTools.ts
@@ -32,41 +32,9 @@ export class ScreenshotTools {
      * Check your browser for supported MIME types
      */
     public static CreateScreenshot(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType: string = "image/png"): void {
-        let width = 0;
-        let height = 0;
+        const { height, width } = ScreenshotTools._getScreenshotSize(engine, camera, size);
 
-        //If a size value defined as object
-        if (typeof(size) === 'object') {
-            // If a precision value is specified
-            if (size.precision) {
-                width = Math.round(engine.getRenderWidth() * size.precision);
-                height = Math.round(width / engine.getAspectRatio(camera));
-            }
-            else if (size.width && size.height) {
-                width = size.width;
-                height = size.height;
-            }
-            //If passing only width, computing height to keep display canvas ratio.
-            else if (size.width && !size.height) {
-                width = size.width;
-                height = Math.round(width / engine.getAspectRatio(camera));
-            }
-            //If passing only height, computing width to keep display canvas ratio.
-            else if (size.height && !size.width) {
-                height = size.height;
-                width = Math.round(height * engine.getAspectRatio(camera));
-            }
-            else {
-                width = Math.round(engine.getRenderWidth());
-                height = Math.round(width / engine.getAspectRatio(camera));
-            }
-        }
-        //Assuming here that "size" parameter is a number
-        else if (!isNaN(size)) {
-            height = size;
-            width = size;
-        }
-        else {
+        if (!(height && width)) {
             Logger.Error("Invalid 'size' parameter !");
             return;
         }
@@ -146,48 +114,10 @@ export class ScreenshotTools {
      * @param fileName A name for for the downloaded file.
      */
     public static CreateScreenshotUsingRenderTarget(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType: string = "image/png", samples: number = 1, antialiasing: boolean = false, fileName?: string): void {
-        let width = 0;
-        let height = 0;
-        let targetTextureSize: number | { width: number, height: number } = 0;
+        const { height, width } = ScreenshotTools._getScreenshotSize(engine, camera, size);
+        let targetTextureSize = { width, height };
 
-        //If a size value defined as object
-        if (typeof(size) === 'object') {
-            //If a precision value is specified
-            if (size.precision) {
-                width = Math.round(engine.getRenderWidth() * size.precision);
-                height = Math.round(width / engine.getAspectRatio(camera));
-                size = { width: width, height: height };
-            }
-            else if (size.width && size.height) {
-                width = size.width;
-                height = size.height;
-            }
-            //If passing only width, computing height to keep display canvas ratio.
-            else if (size.width && !size.height) {
-                width = size.width;
-                height = Math.round(width / engine.getAspectRatio(camera));
-                size = { width: width, height: height };
-            }
-            //If passing only height, computing width to keep display canvas ratio.
-            else if (size.height && !size.width) {
-                height = size.height;
-                width = Math.round(height * engine.getAspectRatio(camera));
-                size = { width: width, height: height };
-            }
-            else {
-                width = Math.round(engine.getRenderWidth());
-                height = Math.round(width / engine.getAspectRatio(camera));
-            }
-
-            targetTextureSize = {width, height};
-        }
-        //Assuming here that "size" parameter is a number
-        else if (!isNaN(size)) {
-            height = size;
-            width = size;
-            targetTextureSize = size;
-        }
-        else {
+        if (!(height && width)) {
             Logger.Error("Invalid 'size' parameter !");
             return;
         }

--- a/src/Misc/screenshotTools.ts
+++ b/src/Misc/screenshotTools.ts
@@ -262,6 +262,49 @@ export class ScreenshotTools {
             }, mimeType, samples, antialiasing, fileName);
         });
     }
+
+    /**
+     * Gets height and width for screenshot size
+     * @private
+     */
+    private static _getScreenshotSize(engine: Engine, camera: Camera, size: IScreenshotSize | number): {height: number, width: number} {
+        let height = 0;
+        let width = 0;
+
+        //If a size value defined as object
+        if (typeof(size) === 'object') {
+            const precision = size.precision
+              ? Math.abs(size.precision) // prevent GL_INVALID_VALUE : glViewport: negative width/height
+              : 1;
+
+            //If a width and height values is specified
+            if (size.width && size.height) {
+                height = size.height * precision;
+                width = size.width * precision;
+            }
+            //If passing only width, computing height to keep display canvas ratio.
+            else if (size.width && !size.height) {
+                width = size.width * precision;
+                height = Math.round(width / engine.getAspectRatio(camera));
+            }
+            //If passing only height, computing width to keep display canvas ratio.
+            else if (size.height && !size.width) {
+                height = size.height * precision;
+                width = Math.round(height * engine.getAspectRatio(camera));
+            }
+            else {
+                width = Math.round(engine.getRenderWidth() * precision);
+                height = Math.round(width / engine.getAspectRatio(camera));
+            }
+        }
+        //Assuming here that "size" parameter is a number
+        else if (!isNaN(size)) {
+            height = size;
+            width = size;
+        }
+
+        return { height, width };
+    }
 }
 
 Tools.CreateScreenshot = ScreenshotTools.CreateScreenshot;


### PR DESCRIPTION
Now CreateScreenshot method provide possible to use precision with height and width parameters in any combination.
Early `precision` param ignore height and width even them was declarated.