### PR TITLE
Allow setting custom audio listener position

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -88,6 +88,7 @@
 
 ### Sounds
 - Added `ISoundOptions.skipCodecCheck` to make `Sound` more flexible with URLs ([nbduke](https://github.com/nbduke))
+- Added `Scene.audioListenerPositionProvider` property, to enable setting custom position of audio listener ([Foxhoundn](https://github.com/foxhoundn))
 
 ### Ray
 - Added `Ray.intersectsAxis` to translate screen to axis coordinates without checking collisions ([horusscope](https://github.com/horusscope))

--- a/src/Audio/audioSceneComponent.ts
+++ b/src/Audio/audioSceneComponent.ts
@@ -84,6 +84,12 @@ declare module "../scene" {
          * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
          */
         headphone: boolean;
+
+        /**
+         * Gets or sets custom audio listener position provider
+         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+         */
+        audioListenerPositionProvider: Nullable<() => Vector3>;
     }
 }
 

--- a/src/Audio/audioSceneComponent.ts
+++ b/src/Audio/audioSceneComponent.ts
@@ -198,7 +198,6 @@ Object.defineProperty(Scene.prototype, "audioListenerPositionProvider", {
             compo = new AudioSceneComponent(this);
             this._addComponent(compo);
         }
-        
 
         if (typeof value !== 'function') {
             throw new Error('The value passed to [Scene.audioListenerPositionProvider] must be a function that returns a Vector3');
@@ -448,7 +447,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
                 audioEngine.audioContext.listener.setPosition(position.x, position.y, position.z);
             } else {
                 var listeningCamera: Nullable<Camera>;
-                
+
                 if (scene.activeCameras.length > 0) {
                     listeningCamera = scene.activeCameras[0];
                 } else {


### PR DESCRIPTION
This PR allows setting custom audio listener position.

The position is determined by calling a user-provided function on `_afterRender` instead of using the first active camera's globalPosition.

It is entirely up to user to determine the listener position.

Ref. issue #6700 

@deltakosh let me know if I forgot to update any documentation / file