### PR TITLE
Target camera constructor documentation

### DIFF
--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -85,7 +85,7 @@ export class TargetCamera extends Camera {
     private _defaultUp = Vector3.Up();
 
     /**
-     * Instantiates a target camera that takes a meshor position as a target and continues to look at it while it moves.
+     * Instantiates a target camera that takes a mesh or position as a target and continues to look at it while it moves.
      * This is the base of the follow, arc rotate cameras and Free camera
      * @see http://doc.babylonjs.com/features/cameras
      * @param name Defines the name of the camera in the scene


### PR DESCRIPTION
In the TargetCamera constructor, I believe "meshor" is errata.

Update to state: “mesh or position as target”