### PR TITLE
Fixed Solid Particle System particle's idx and idxInShape initialization

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -130,6 +130,7 @@
 - Fix VR button not positioning correctly in canvas ([haroldma](https://github.com/haroldma))
 - Fix check for material needing alpha blending in OutlineRenderer ([mkmc](https://github.com/mkmc))
 - Fixed: scene's input manager's detachControl doesn't remove a wheel event listener ([RamilKadyrov](https://github.com/RamilKadyrov))
+- Fixed Solid Particle System particle's idx and idxInShape initialization ([RamilKadyrov](https://github.com/RamilKadyrov))
 
 ## Breaking changes
 - Setting mesh.scaling to a new vector will no longer automatically call forceUpdate (this should be done manually when needed) ([TrevorDev](https://github.com/TrevorDev))

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -79,7 +79,7 @@ export class SolidParticle {
      */
     public shapeId: number = 0;
     /**
-     * Index of the particle in its shape id (Internal use)
+     * Index of the particle in its shape id
      */
     public idxInShape: number = 0;
     /**

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -363,6 +363,8 @@ export class SolidParticleSystem implements IDisposable {
 
         this._resetCopy();
         const copy = this._copy;
+        copy.idx = idx;
+        copy.idxInShape = idxInShape;
         if (options && options.positionFunction) {        // call to custom positionFunction
             options.positionFunction(copy, idx, idxInShape);
             this._mustUnrotateFixedNormals = true;


### PR DESCRIPTION
Solid Particle System have possibility to modify the shape of each particle at creation time by using the VertexFunction property . It may be useful to know inside VertexFunction particle's idx and idxInShape but they are not initialized.