### PR TITLE
include "AbstractActionManager" and "FollowCameraInputsManager" with es6 default export

### DIFF
--- a/src/Actions/index.ts
+++ b/src/Actions/index.ts
@@ -1,3 +1,4 @@
+export * from "./abstractActionManager";
 export * from "./action";
 export * from "./actionEvent";
 export * from "./actionManager";

--- a/src/Cameras/index.ts
+++ b/src/Cameras/index.ts
@@ -11,6 +11,7 @@ export * from "./deviceOrientationCamera";
 export * from "./flyCamera";
 export * from "./flyCameraInputsManager";
 export * from "./followCamera";
+export * from "./followCameraInputsManager";
 export * from "./gamepadCamera";
 export * from "./Stereoscopic/index";
 export * from "./universalCamera";


### PR DESCRIPTION
I am getting errors with this code - I think this will add to legacy export:
```
import BABYLON from "babylonjs";

...
BABYLON.FollowCameraInputsManager
BABYLON.AbstractActionManager
```
Fixing TS errors like `Namespace '"babylonjs"' has no exported member 'AbstractActionManager'.`