### PR TITLE
Removing a line that was causing the theme to reset at each script loading

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -591,8 +591,6 @@ class Main {
                         }
                     }
 
-                    // Restore theme
-                    this.parent.settingsPG.restoreTheme(this.parent.monacoCreator);
                     // Restore language
                     this.parent.settingsPG.setScriptLanguage();
                 }


### PR DESCRIPTION
The theme of the code editor is now staying the one in the localStorage.

I wanted to save the safe mode in the localStorage as well but since it activate itself at each code modification, it's not needed anymore.