### PR TITLE
Add missing callback triggers within texture loaders

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -141,6 +141,7 @@
 - Fixed `CubeTexture` to keep custom `filesList` when serializing/parsing ([julien-moreau](https://github.com/julien-moreau))
 - Fixed `StandardRenderingPipeline` to properly dispose post-processes from attached cameras ([julien-moreau](https://github.com/julien-moreau))
 - Fixed `VolumetricLightScattering` post-process to use a custom vertex shader instead of the depth vertex shader. ([julien-moreau](https://github.com/julien-moreau))
+- Added missing callback triggers within texture loaders ([PierreLeBlond](https://github.com/PierreLeBlond))
 
 ## Breaking changes
 - Setting mesh.scaling to a new vector will no longer automatically call forceUpdate (this should be done manually when needed) ([TrevorDev](https://github.com/TrevorDev))

--- a/src/Materials/Textures/Loaders/basisTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/basisTextureLoader.ts
@@ -75,6 +75,11 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
             BasisTools.LoadTextureFromTranscodeResult(texture, result);
             texture.getEngine()._setCubeMapTextureParams(hasMipmap);
             texture.isReady = true;
+            texture.onLoadedObservable.notifyObservers(texture);
+            texture.onLoadedObservable.clear();
+            if (onLoad) {
+              onLoad();
+            }
         }).catch((err) => {
             Tools.Warn("Failed to transcode Basis file, transcoding may not be supported on this device");
             texture.isReady = true;

--- a/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -103,6 +103,8 @@ export class _DDSTextureLoader implements IInternalTextureLoader {
 
         engine._setCubeMapTextureParams(loadMipmap);
         texture.isReady = true;
+        texture.onLoadedObservable.notifyObservers(texture);
+        texture.onLoadedObservable.clear();
 
         if (onLoad) {
             onLoad({ isDDS: true, width: texture.width, info, data: imgs, texture });

--- a/src/Materials/Textures/Loaders/envTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/envTextureLoader.ts
@@ -70,6 +70,8 @@ export class _ENVTextureLoader implements IInternalTextureLoader {
             EnvironmentTextureTools.UploadEnvSpherical(texture, info);
             EnvironmentTextureTools.UploadEnvLevelsAsync(texture, data, info).then(() => {
                 texture.isReady = true;
+                texture.onLoadedObservable.notifyObservers(texture);
+                texture.onLoadedObservable.clear();
                 if (onLoad) {
                     onLoad();
                 }

--- a/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -87,6 +87,12 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
 
         engine._setCubeMapTextureParams(loadMipmap);
         texture.isReady = true;
+        texture.onLoadedObservable.notifyObservers(texture);
+        texture.onLoadedObservable.clear();
+
+        if (onLoad) {
+            onLoad();
+        }
     }
 
     /**


### PR DESCRIPTION
When loading .dds files for instance, multiple load of same file won't result in the right number of callback trigger, whereas it will for standard cube texture format.

It can be seen in this playground : https://www.babylonjs-playground.com/#2FDQT5#117

Therefore missing observers calls are added for several texture loader.