### PR TITLE
Suggested solution to scenes/engines being disposed incorrectly

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1903,8 +1903,6 @@ export class Engine extends ThinEngine {
     public dispose(): void {
         this.hideLoadingUI();
 
-        super.dispose();
-
         this.onNewSceneAddedObservable.clear();
 
         // Release postProcesses
@@ -1952,6 +1950,8 @@ export class Engine extends ThinEngine {
             document.removeEventListener("mozpointerlockchange", this._onPointerLockChange);
             document.removeEventListener("webkitpointerlockchange", this._onPointerLockChange);
         }
+
+        super.dispose();
 
         // Remove from Instances
         var index = Engine.Instances.indexOf(this);


### PR DESCRIPTION
super.dispose() was nulling the rendering canvas, which prevented scene.detachControl to work.