### PR TITLE
missing check in sceneTreeItemComponent resulting in gizmo to not end…

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -151,6 +151,7 @@
 - Fixed `CubeTexture` to keep custom `filesList` when serializing/parsing ([julien-moreau](https://github.com/julien-moreau))
 - Fixed `StandardRenderingPipeline` to properly dispose post-processes from attached cameras ([julien-moreau](https://github.com/julien-moreau))
 - Fixed `VolumetricLightScattering` post-process to use a custom vertex shader instead of the depth vertex shader. ([julien-moreau](https://github.com/julien-moreau))
+- Fixed missing check in sceneTreeItemComponent resulting in gizmo to not end drag ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Added missing callback triggers within texture loaders ([PierreLeBlond](https://github.com/PierreLeBlond))
 - Fixed `TextureLinkLineComponent` to no longer invert inspector-loaded textures ([Drigax](https://github.com/drigax))
 

--- a/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -230,7 +230,7 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
                     if (!this._posDragEnd) {
                         // Record movement for generating replay code
                         this._posDragEnd = manager.gizmos.positionGizmo!.onDragEndObservable.add(() => {
-                            if (manager.gizmos.positionGizmo && manager.gizmos.positionGizmo.attachedMesh) {
+                            if (manager.gizmos.positionGizmo && manager.gizmos.positionGizmo.attachedMesh && manager.gizmos.positionGizmo.attachedMesh.reservedDataStore) {
                                 var lightGizmo: Nullable<LightGizmo> = manager.gizmos.positionGizmo.attachedMesh.reservedDataStore.lightGizmo;
                                 var obj: any = (lightGizmo && lightGizmo.light) ? lightGizmo.light : manager.gizmos.positionGizmo.attachedMesh;
 


### PR DESCRIPTION
Fix issue reported here https://forum.babylonjs.com/t/debuglayer-position-mode-move-mesh-in-playground/5894