### PR TITLE
Added feature expandable to the SPS

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -111,7 +111,8 @@
 - Added `StackPanel.ignoreLayoutWarnings` to disable console warnings when controls with percentage size are added to a StackPanel ([Deltakosh](https://github.com/deltakosh/))
 - Added `_getSVGAttribs` functionality for loading multiple svg icons from an external svg file via icon id.([lockphase](https://github.com/lockphase/))
 
-
+### Particles
+- Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 
 ### Navigation Mesh
 - Added moveAlong function to cast a segment on mavmesh ([CedricGuillemet](https://github.com/CedricGuillemet/))

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -189,7 +189,7 @@ export class SolidParticleSystem implements IDisposable {
         if (this._colors32.length > 0) {
             vertexData.set(this._colors32, VertexBuffer.ColorKind);
         }
-        if (!this.mesh && this._expandable) {       // in case it's expanded
+        if (!this.mesh) {       // in case it's already expanded
             var mesh = new Mesh(this.name, this._scene);
             this.mesh = mesh;
         }

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -189,7 +189,7 @@ export class SolidParticleSystem implements IDisposable {
         if (this._colors32.length > 0) {
             vertexData.set(this._colors32, VertexBuffer.ColorKind);
         }
-        if (!this.mesh) {       // in case it's expanded
+        if (!this.mesh && this._expandable) {       // in case it's expanded
             var mesh = new Mesh(this.name, this._scene);
             this.mesh = mesh;
         }

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -125,7 +125,7 @@ export class SolidParticleSystem implements IDisposable {
      * * updatable (optional boolean, default true) : if the SPS must be updatable or immutable.
      * * isPickable (optional boolean, default false) : if the solid particles must be pickable.
      * * enableDepthSort (optional boolean, default false) : if the solid particles must be sorted in the geometry according to their distance to the camera.
-     * * expandable (optional boolean, default false) : if particles can still be added after the initial SPS mesh creation.  
+     * * expandable (optional boolean, default false) : if particles can still be added after the initial SPS mesh creation.
      * * particleIntersection (optional boolean, default false) : if the solid particle intersections must be computed.
      * * boundingSphereOnly (optional boolean, default false) : if the particle intersection must be computed only with the bounding sphere (no bounding box computation, so faster).
      * * bSphereRadiusFactor (optional float, default 1.0) : a number to multiply the boundind sphere radius by in order to reduce it for instance.


### PR DESCRIPTION
Long time expected feature... as old as the SPS actually : expandable SPS.

Now, solid particles can be added even once the SPS is built.
```javascript
// create an expandable SPS with 500 particles
var sps = new BABYLON.SolidParticleSystem('sps', scene, {expandable: true});
sps.addShape(model, 500);
sps.buildMesh();

// ... further in the code
// add 60 more particles
sps.addShape(otherModel, 30);
sps.addShape(thirdModel, 30);
sps.buildMesh();   // again, that simple

// and you can do it as many times you need
```