### PR TITLE
glTF: Implement support for morph target names

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -866,10 +866,13 @@ export class GLTFLoader implements IGLTFLoader {
             throw new Error(`${context}: Primitives do not have the same number of targets`);
         }
 
+        const targetNames = mesh.extras ? mesh.extras.targetNames : null;
+
         babylonMesh.morphTargetManager = new MorphTargetManager(babylonMesh.getScene());
         for (let index = 0; index < primitive.targets.length; index++) {
             const weight = node.weights ? node.weights[index] : mesh.weights ? mesh.weights[index] : 0;
-            babylonMesh.morphTargetManager.addTarget(new MorphTarget(`morphTarget${index}`, weight, babylonMesh.getScene()));
+            const name = targetNames ? targetNames[index] : `morphTarget${index}`;
+            babylonMesh.morphTargetManager.addTarget(new MorphTarget(name, weight, babylonMesh.getScene()));
             // TODO: tell the target whether it has positions, normals, tangents
         }
     }

--- a/what's new.md
+++ b/what's new.md
@@ -147,6 +147,7 @@
 - Added support for custom loader extensions ([bghgary](http://www.github.com/bghgary))
 - Added support for validating assets using [glTF-Validator](https://github.com/KhronosGroup/glTF-Validator) ([bghgary](http://www.github.com/bghgary))
 - Added automatically renormalizes skinweights when loading geometry. Calls core mesh functions to do this ([Bolloxim](https://github.com/Bolloxim))
+- Added support for morph target names via `mesh.extras.targetNames` ([zeux](https://github.com/zeux))
 
 ### glTF Serializer
 - Added support for exporting the scale, rotation and offset texture properties ([kcoley](http://www.github.com/kcoley))


### PR DESCRIPTION
While morph target names aren't technically part of glTF spec, there is one de-facto standard for specifying them via mesh.extras, which is also called out in glTF specification as an implementation note. See https://github.com/KhronosGroup/glTF/issues/1036.

This change adds support for using the names if they are present - the default morphTarget0, etc names are generated as a fallback.