### PR TITLE
GLTFLoader: Allow extensions to override buffer view loading

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1397,6 +1397,11 @@ export class GLTFLoader implements IGLTFLoader {
      * @returns A promise that resolves with the loaded data when the load is complete
      */
     public loadBufferViewAsync(context: string, bufferView: IBufferView): Promise<ArrayBufferView> {
+        const extensionPromise = this._extensionsLoadBufferViewAsync(context, bufferView);
+        if (extensionPromise) {
+            return extensionPromise;
+        }
+
         if (bufferView._data) {
             return bufferView._data;
         }
@@ -2272,6 +2277,10 @@ export class GLTFLoader implements IGLTFLoader {
 
     private _extensionsLoadUriAsync(context: string, property: IProperty, uri: string): Nullable<Promise<ArrayBufferView>> {
         return this._applyExtensions(property, "loadUri", (extension) => extension._loadUriAsync && extension._loadUriAsync(context, property, uri));
+    }
+
+    private _extensionsLoadBufferViewAsync(context: string, bufferView: IBufferView): Nullable<Promise<ArrayBufferView>> {
+        return this._applyExtensions(bufferView, "loadBufferView", (extension) => extension.loadBufferViewAsync && extension.loadBufferViewAsync(context, bufferView));
     }
 
     /**

--- a/loaders/src/glTF/2.0/glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/glTFLoaderExtension.ts
@@ -9,7 +9,7 @@ import { Mesh } from "babylonjs/Meshes/mesh";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 import { IDisposable } from "babylonjs/scene";
 
-import { IScene, INode, IMesh, ISkin, ICamera, IMeshPrimitive, IMaterial, ITextureInfo, IAnimation } from "./glTFLoaderInterfaces";
+import { IScene, INode, IMesh, ISkin, ICamera, IMeshPrimitive, IMaterial, ITextureInfo, IAnimation, IBufferView } from "./glTFLoaderInterfaces";
 import { IGLTFLoaderExtension as IGLTFBaseLoaderExtension } from "../glTFFileLoader";
 import { IProperty } from 'babylonjs-gltf2interface';
 
@@ -134,4 +134,12 @@ export interface IGLTFLoaderExtension extends IGLTFBaseLoaderExtension, IDisposa
      * @returns A promise that resolves with the loaded data when the load is complete or null if not handled
      */
     _loadUriAsync?(context: string, property: IProperty, uri: string): Nullable<Promise<ArrayBufferView>>;
+
+    /**
+     * Define this method to modify the default behavior when loading buffer views.
+     * @param context The context when loading the asset
+     * @param primitive The glTF buffer view property
+     * @returns A promise that resolves with the loaded buffer view when the load is complete or null if not handled
+     */
+    loadBufferViewAsync?(context: string, bufferView: IBufferView): Nullable<Promise<ArrayBufferView>>;
 }

--- a/loaders/src/glTF/2.0/glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/glTFLoaderExtension.ts
@@ -138,7 +138,7 @@ export interface IGLTFLoaderExtension extends IGLTFBaseLoaderExtension, IDisposa
     /**
      * Define this method to modify the default behavior when loading buffer views.
      * @param context The context when loading the asset
-     * @param primitive The glTF buffer view property
+     * @param bufferView The glTF buffer view property
      * @returns A promise that resolves with the loaded buffer view when the load is complete or null if not handled
      */
     loadBufferViewAsync?(context: string, bufferView: IBufferView): Nullable<Promise<ArrayBufferView>>;


### PR DESCRIPTION
This adds a way for extensions to override buffer view loading by
implementing loadBufferViewAsync; this is useful for decompression
extensions.

Specifically this is useful for an (upcoming) extension, MESHOPT_compression,
that is used by gltfpack (https://github.com/zeux/meshoptimizer#gltfpack); the
extension specifies compression on the buffer view level and decompresses each
view.

I'm not sure what logic governs whether underscore should be used for function
names or not so I left it out to match the name of GLTFLoader method.