### PR TITLE
Feature.sps.removable particle

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -113,6 +113,7 @@
 
 ### Particles
 - Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
+- Added the feature `removeParticles()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 
 ### Navigation Mesh
 - Added moveAlong function to cast a segment on mavmesh ([CedricGuillemet](https://github.com/CedricGuillemet/))

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -244,6 +244,21 @@ export class ModelShape {
      */
     public _shapeUV: number[];
     /**
+     * color array of the model
+     * @hidden
+     */
+    public _shapeColors: number[];
+    /**
+     * indices array of the model
+     * @hidden
+     */
+    public _indices: number[];
+    /**
+     * normals array of the model
+     * @hidden
+     */
+    public _normals: number[];
+    /**
      * length of the shape in the model indices array (internal use)
      * @hidden
      */
@@ -264,12 +279,15 @@ export class ModelShape {
      * SPS internal tool, don't use it manually.
      * @hidden
      */
-    constructor(id: number, shape: Vector3[], indicesLength: number, shapeUV: number[],
+    constructor(id: number, shape: Vector3[], indices: number[], normals: number[], colors: number[], shapeUV: number[],
         posFunction: Nullable<(particle: SolidParticle, i: number, s: number) => void>, vtxFunction: Nullable<(particle: SolidParticle, vertex: Vector3, i: number) => void>) {
         this.shapeID = id;
         this._shape = shape;
-        this._indicesLength = indicesLength;
+        this._indices = indices;
+        this._indicesLength = indices.length;
         this._shapeUV = shapeUV;
+        this._shapeColors = colors;
+        this._normals = normals;
         this._positionFunction = posFunction;
         this._vertexFunction = vtxFunction;
     }

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -635,8 +635,8 @@ export class SolidParticleSystem implements IDisposable {
      *  If the number of particles to remove is lower than zero or greater than the global remaining particle number, then an empty array is returned.
      *  The SPS can't be empty so at least one particle needs to remain in place.
      *  Under the hood, the VertexData array, so the VBO buffer, is recreated each call.
-     * @param start
-     * @param end
+     * @param start index of the first particle to remove
+     * @param end index of the last particle to remove (included)
      * @returns an array populated with the removed particles
      */
     public removeParticles(start: number, end: number): SolidParticle[] {

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -317,7 +317,7 @@ export class SolidParticleSystem implements IDisposable {
             if (this._particlesIntersect) {
                 bInfo = new BoundingInfo(minimum, maximum);
             }
-            var modelShape = new ModelShape(this._shapeCounter, shape, shapeInd, shapeNor, shapeUV, shapeCol, null, null);
+            var modelShape = new ModelShape(this._shapeCounter, shape, shapeInd, shapeNor, shapeCol, shapeUV, null, null);
 
             // add the particle in the SPS
             var currentPos = this._positions.length;
@@ -537,7 +537,7 @@ export class SolidParticleSystem implements IDisposable {
         var posfunc = options ? options.positionFunction : null;
         var vtxfunc = options ? options.vertexFunction : null;
 
-        var modelShape = new ModelShape(this._shapeCounter, shape, indices, shapeNormals, shapeUV, shapeColors, posfunc, vtxfunc);
+        var modelShape = new ModelShape(this._shapeCounter, shape, indices, shapeNormals, shapeColors, shapeUV, posfunc, vtxfunc);
 
         // particles
         var sp;
@@ -640,10 +640,19 @@ export class SolidParticleSystem implements IDisposable {
      * @returns an array populated with the removed particles
      */
     public removeParticles(start: number, end: number): SolidParticle[] {
-        const particles = this.particles;
         var nb = end - start + 1;
         if (!this._expandable || nb <= 0 || nb >= this.nbParticles) {
             return [];
+        }
+        const particles = this.particles;
+        const currentNb = this.nbParticles;
+        if (end < currentNb - 1) {              // update the particle indexes in the positions array in case they're remaining particles after the last removed
+            var startPositionIndex = particles[start]._pos;
+            var firstRemaining = end + 1;
+            var shift = particles[firstRemaining]._pos - startPositionIndex;
+            for (var i = firstRemaining; i < currentNb; i++) {
+                particles[i]._pos -= shift;
+            }
         }
         var removed = particles.splice(start, nb);
         this._positions.length = 0;


### PR DESCRIPTION
New feature for the expandable SPS : removable particles.
Usage : 
```javascript
    // expandable sps creation with 1000 boxes
    var sps = new BABYLON.SolidParticleSystem("sps", scene, {expandable: true});
    var model = BABYLON.MeshBuilder.CreateBox("m", {}, scene);
    sps.addShape(model, 1000);
    sps.buildMesh();

     // ... further in the code
    sps.removeParticles(700, 999);  // removes the last 300 particles
    sps.removeParticles(0, 9);      // then removes the first 10
    sps.buildMesh();                // like for adding particles after the sps creation,
                                    // the call to buildMesh() is required
```
[EDIT] : please don't merge now, I think there's still a little bug to fix about the particle 0.