### PR TITLE
Fix vignette aspect ratio when not using postProcessing

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -189,6 +189,7 @@
 - Added missing callback triggers within texture loaders ([PierreLeBlond](https://github.com/PierreLeBlond))
 - Fixed `TextureLinkLineComponent` to no longer invert inspector-loaded textures ([Drigax](https://github.com/drigax))
 - Fixed a single frame drop after leaving webxr on some devices ([RaananW](https://github.com/RaananW/))
+- Fixed bug where vignette aspect ratio would be wrong when rendering direct to canvas
 
 ## Breaking changes
 

--- a/src/Materials/imageProcessingConfiguration.ts
+++ b/src/Materials/imageProcessingConfiguration.ts
@@ -508,7 +508,7 @@ export class ImageProcessingConfiguration {
             var inverseHeight = 1 / effect.getEngine().getRenderHeight();
             effect.setFloat2("vInverseScreenSize", inverseWidth, inverseHeight);
 
-            let aspectRatio = overrideAspectRatio != null ? overrideAspectRatio : (inverseHeight/inverseWidth);
+            let aspectRatio = overrideAspectRatio != null ? overrideAspectRatio : (inverseHeight / inverseWidth);
 
             let vignetteScaleY = Math.tan(this.vignetteCameraFov * 0.5);
             let vignetteScaleX = vignetteScaleY * aspectRatio;

--- a/src/Materials/imageProcessingConfiguration.ts
+++ b/src/Materials/imageProcessingConfiguration.ts
@@ -494,9 +494,9 @@ export class ImageProcessingConfiguration {
     /**
      * Binds the image processing to the shader.
      * @param effect The effect to bind to
-     * @param aspectRatio Define the current aspect ratio of the effect
+     * @param overrideAspectRatio Override the aspect ratio of the effect
      */
-    public bind(effect: Effect, aspectRatio = 1): void {
+    public bind(effect: Effect, overrideAspectRatio?: number): void {
         // Color Curves
         if (this._colorCurvesEnabled && this.colorCurves) {
             ColorCurves.Bind(this.colorCurves, effect);
@@ -507,6 +507,8 @@ export class ImageProcessingConfiguration {
             var inverseWidth = 1 / effect.getEngine().getRenderWidth();
             var inverseHeight = 1 / effect.getEngine().getRenderHeight();
             effect.setFloat2("vInverseScreenSize", inverseWidth, inverseHeight);
+
+            let aspectRatio = overrideAspectRatio != null ? overrideAspectRatio : (inverseHeight/inverseWidth);
 
             let vignetteScaleY = Math.tan(this.vignetteCameraFov * 0.5);
             let vignetteScaleX = vignetteScaleY * aspectRatio;


### PR DESCRIPTION
If you're not using the post processing rendering pipeline (i.e. rendering directly to the canvas drawing buffer) then the vignette aspect ratio will be wrong.

This happens because when binding the `imageProcessingConfiguration` in the material, no value is provided for the aspectRatio parameter so it defaults to 1, whereas when binding via the post processing pipeline the correct aspect is provided. This change resolves this by using the current render target (or canvas drawing buffer) aspect ratio when the aspect ratio isn't supplied. And semantically, the aspect ratio parameter has been changed to `overrideAspectRatio` to clarify

![OffscreenVignetteBug](https://user-images.githubusercontent.com/3742992/66604964-15d72d80-eba7-11e9-986f-380d9369a816.gif)
In the gif, the circular vignette is correct