### PR TITLE
[DO NOT MERGE] feat: Allow CustomMaterial to use UVs > 2

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -48,6 +48,7 @@
 - Added preprocessors for shaders to improve how shaders are compiled for WebGL1/2 or WebGPU ([Deltakosh](https://github.com/deltakosh/))
 - Added enterPointerlock and exitPointerlock (Separated from enterFullscreen) ([aWeirdo](https://github.com/aWeirdo/))
 - Added support for `vertexSource` and `fragmentSource` parameters to `ShaderMaterial` ([Deltakosh](https://github.com/deltakosh/))
+- Added support for UV3-UV6 in the CustomMaterial ([Azukaar](https://github.com/azukaar/))
 
 ### Inspector
 

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -251,7 +251,7 @@ export class MaterialHelper {
         defines["UV4"] = mesh.isVerticesDataPresent(VertexBuffer.UV4Kind);
         defines["UV5"] = mesh.isVerticesDataPresent(VertexBuffer.UV5Kind);
         defines["UV6"] = mesh.isVerticesDataPresent(VertexBuffer.UV6Kind);
-        
+
         if (useBones) {
             this.PrepareDefinesForBones(mesh, defines);
         }

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -247,6 +247,11 @@ export class MaterialHelper {
             defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
         }
 
+        defines["UV3"] = mesh.isVerticesDataPresent(VertexBuffer.UV3Kind);
+        defines["UV4"] = mesh.isVerticesDataPresent(VertexBuffer.UV4Kind);
+        defines["UV5"] = mesh.isVerticesDataPresent(VertexBuffer.UV5Kind);
+        defines["UV6"] = mesh.isVerticesDataPresent(VertexBuffer.UV6Kind);
+        
         if (useBones) {
             this.PrepareDefinesForBones(mesh, defines);
         }

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -46,7 +46,7 @@ export class MaterialHelper {
     }
 
     /**
-     * Helps preparing the defines values about the UVs in used in the effect.
+     * Helps preparing the defines values about the UVs used in the effect.
      * UVs are shared as much as we can accross channels in the shaders.
      * @param texture The texture we are preparing the UVs for
      * @param defines The defines to update
@@ -236,9 +236,17 @@ export class MaterialHelper {
         if (defines._needUVs) {
             defines["UV1"] = mesh.isVerticesDataPresent(VertexBuffer.UVKind);
             defines["UV2"] = mesh.isVerticesDataPresent(VertexBuffer.UV2Kind);
+            defines["UV3"] = mesh.isVerticesDataPresent(VertexBuffer.UV3Kind);
+            defines["UV4"] = mesh.isVerticesDataPresent(VertexBuffer.UV4Kind);
+            defines["UV5"] = mesh.isVerticesDataPresent(VertexBuffer.UV5Kind);
+            defines["UV6"] = mesh.isVerticesDataPresent(VertexBuffer.UV6Kind);
         } else {
             defines["UV1"] = false;
             defines["UV2"] = false;
+            defines["UV3"] = false;
+            defines["UV4"] = false;
+            defines["UV5"] = false;
+            defines["UV6"] = false;
         }
 
         if (useVertexColor) {
@@ -246,11 +254,6 @@ export class MaterialHelper {
             defines["VERTEXCOLOR"] = hasVertexColors;
             defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
         }
-
-        defines["UV3"] = mesh.isVerticesDataPresent(VertexBuffer.UV3Kind);
-        defines["UV4"] = mesh.isVerticesDataPresent(VertexBuffer.UV4Kind);
-        defines["UV5"] = mesh.isVerticesDataPresent(VertexBuffer.UV5Kind);
-        defines["UV6"] = mesh.isVerticesDataPresent(VertexBuffer.UV6Kind);
 
         if (useBones) {
             this.PrepareDefinesForBones(mesh, defines);

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -1133,7 +1133,7 @@ export class StandardMaterial extends PushMaterial {
             }
 
             MaterialHelper.PrepareAttributesForBones(attribs, mesh, defines, fallbacks);
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines); 
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
             MaterialHelper.PrepareAttributesForMorphTargets(attribs, mesh, defines);
 
             var shaderName = "default";

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -72,6 +72,10 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public NORMAL = false;
     public UV1 = false;
     public UV2 = false;
+    public UV3 = false;
+    public UV4 = false;
+    public UV5 = false;
+    public UV6 = false;
     public VERTEXCOLOR = false;
     public VERTEXALPHA = false;
     public NUM_BONE_INFLUENCERS = 0;
@@ -1108,12 +1112,28 @@ export class StandardMaterial extends PushMaterial {
                 attribs.push(VertexBuffer.UV2Kind);
             }
 
+            if (defines.UV3) {
+                attribs.push(VertexBuffer.UV3Kind);
+            }
+
+            if (defines.UV4) {
+                attribs.push(VertexBuffer.UV4Kind);
+            }
+
+            if (defines.UV5) {
+                attribs.push(VertexBuffer.UV5Kind);
+            }
+
+            if (defines.UV6) {
+                attribs.push(VertexBuffer.UV6Kind);
+            }
+
             if (defines.VERTEXCOLOR) {
                 attribs.push(VertexBuffer.ColorKind);
             }
 
             MaterialHelper.PrepareAttributesForBones(attribs, mesh, defines, fallbacks);
-            MaterialHelper.PrepareAttributesForInstances(attribs, defines);
+            MaterialHelper.PrepareAttributesForInstances(attribs, defines); 
             MaterialHelper.PrepareAttributesForMorphTargets(attribs, mesh, defines);
 
             var shaderName = "default";

--- a/src/Shaders/default.fragment.fx
+++ b/src/Shaders/default.fragment.fx
@@ -35,6 +35,22 @@ varying vec4 vColor;
 	varying vec2 vMainUV2;
 #endif
 
+#ifdef UV3
+	varying vec2 vUV3;
+#endif
+
+#ifdef UV4
+	varying vec2 vUV4;
+#endif
+
+#ifdef UV5
+	varying vec2 vUV5;
+#endif
+
+#ifdef UV6
+	varying vec2 vUV6;
+#endif
+
 // Helper functions
 #include<helperFunctions>
 

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -16,6 +16,18 @@ attribute vec2 uv;
 #ifdef UV2
 attribute vec2 uv2;
 #endif
+#ifdef UV3
+attribute vec2 uv3;
+#endif
+#ifdef UV4
+attribute vec2 uv4;
+#endif
+#ifdef UV5
+attribute vec2 uv5;
+#endif
+#ifdef UV6
+attribute vec2 uv6;
+#endif
 #ifdef VERTEXCOLOR
 attribute vec4 color;
 #endif
@@ -33,6 +45,22 @@ attribute vec4 color;
 
 #ifdef MAINUV2
 	varying vec2 vMainUV2;
+#endif
+
+#ifdef UV3
+	varying vec2 vUV3;
+#endif
+
+#ifdef UV4
+	varying vec2 vUV4;
+#endif
+
+#ifdef UV5
+	varying vec2 vUV5;
+#endif
+
+#ifdef UV6
+	varying vec2 vUV6;
 #endif
 
 #if defined(DIFFUSE) && DIFFUSEDIRECTUV == 0
@@ -168,6 +196,22 @@ void main(void) {
 
 #ifdef MAINUV2
 	vMainUV2 = uv2;
+#endif
+
+#ifdef UV3
+	vUV3 = uv3;
+#endif
+
+#ifdef UV4
+	vUV4 = uv4;
+#endif
+
+#ifdef UV5
+	vUV5 = uv5;
+#endif
+
+#ifdef UV6
+	vUV6 = uv6;
 #endif
 
 #if defined(DIFFUSE) && DIFFUSEDIRECTUV == 0


### PR DESCRIPTION
Allow CustomMaterial to use UVs values up to UVs6.

This piggy back on existing values in VertexData, and edit slightly the StandardMaterial to use those values if they exists (Since CustomMaterial is based on StandardMaterial).

It doesnt impact performance since you wouldnt normally have uvs > 2 if you are using StandardMaterial and it checks for the existance of those before feeding them in.

[DO NOT MERGE]

There seems to be an index issue now with the standardMaterial I'm investigating, but somehow, now my projected light texture randomly mixes with normal maps all around (and it's extremmly random depending on positiion, rotation, etc...). Hopfuly i can find out why, or if someone has any idea, help welcomed! 

![image](https://user-images.githubusercontent.com/7872597/66707133-ebff4180-ed33-11e9-9b27-cadc609af60c.png)

![image](https://user-images.githubusercontent.com/7872597/66707129-cd994600-ed33-11e9-8455-86557fd5915d.png)

