### PR TITLE
XR "viewer" reference space fallback

### DIFF
--- a/src/Cameras/XR/webXRSessionManager.ts
+++ b/src/Cameras/XR/webXRSessionManager.ts
@@ -6,7 +6,7 @@ import { InternalTexture, InternalTextureSource } from "../../Materials/Textures
 import { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
 import { WebXRRenderTarget } from './webXRTypes';
 import { WebXRManagedOutputCanvas } from './webXRManagedOutputCanvas';
-import { WebXRState } from '../../Legacy/legacy';
+import { WebXRState, Tools } from '../../Legacy/legacy';
 
 interface IRenderTargetProvider {
     getRenderTargetForEye(eye: XREye): RenderTargetTexture;
@@ -117,6 +117,17 @@ export class WebXRSessionManager implements IDisposable {
     public setReferenceSpaceAsync(referenceSpace: XRReferenceSpaceType) {
         return this.session.requestReferenceSpace(referenceSpace).then((referenceSpace: XRReferenceSpace) => {
             this.referenceSpace = referenceSpace;
+        }, rejectionReason => {
+            Tools.Error("XR.requestReferenceSpace failed for the following reason: ");
+            Tools.Error(rejectionReason);
+            Tools.Log("Defaulting to universally-supported \"viewer\" reference space type.");
+
+            return this.session.requestReferenceSpace("viewer").then((referenceSpace: XRReferenceSpace) => {
+                this.referenceSpace = referenceSpace;
+            }, rejectionReason => {
+                Tools.Error(rejectionReason);
+                throw "XR initialization failed: required \"viewer\" reference space type not supported.";
+            });
         });
     }
 


### PR DESCRIPTION
Fall back to viewer reference space type when requested reference space type is unsupported. Change precipitated by behavior of Edge beta, which does not support the 'local-floor' reference space type even though it supports the 'local' reference space type. This is likely a stopgap solution.