### PR TITLE
Material Node texture blocks now check rootUrl to avoid loading embed…

### DIFF
--- a/src/Materials/Node/Blocks/Dual/reflectionTextureBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/reflectionTextureBlock.ts
@@ -430,6 +430,7 @@ export class ReflectionTextureBlock extends NodeMaterialBlock {
         super._deserialize(serializationObject, scene, rootUrl);
 
         if (serializationObject.texture) {
+            rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? rootUrl : "";
             if (serializationObject.texture.isCube) {
                 this.texture = CubeTexture.Parse(serializationObject.texture, scene, rootUrl);
             } else {

--- a/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -375,6 +375,7 @@ export class TextureBlock extends NodeMaterialBlock {
         super._deserialize(serializationObject, scene, rootUrl);
 
         if (serializationObject.texture) {
+            rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? rootUrl : "";
             this.texture = Texture.Parse(serializationObject.texture, scene, rootUrl) as Texture;
         }
     }


### PR DESCRIPTION
…ed textures with a rootUrl.