### PR TITLE
Specify --max-old-space-size for gulp run invocation

### DIFF
--- a/Tools/Gulp/readme.md
+++ b/Tools/Gulp/readme.md
@@ -44,7 +44,7 @@ gulp tests-all
 
 ## Run Integrated Web Server and watch for changes (dev build):
 ```
-gulp run
+gulp run --max-old-space-size=8192
 ```
 
 you can now freely test in the following URLs:

--- a/Tools/Gulp/readme.md
+++ b/Tools/Gulp/readme.md
@@ -44,7 +44,7 @@ gulp tests-all
 
 ## Run Integrated Web Server and watch for changes (dev build):
 ```
-gulp run --max-old-space-size=8192
+npm start
 ```
 
 you can now freely test in the following URLs:


### PR DESCRIPTION
In the dev documentation, `gulp run` is used to run the integrated web server.

You need to specify `--max-old-space-size=8192` (as done in the CI/CD configuration), to prevent the heap to run out of memory:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 00007FF7D508C6AA v8::internal::GCIdleTimeHandler::GCIdleTimeHandler+4506
 2: 00007FF7D5067416 node::MakeCallback+4534
 3: 00007FF7D5067D90 node_module_register+2032
 4: 00007FF7D538189E v8::internal::FatalProcessOutOfMemory+846
 5: 00007FF7D53817CF v8::internal::FatalProcessOutOfMemory+639
 6: 00007FF7D5567F94 v8::internal::Heap::MaxHeapGrowingFactor+9620
 7: 00007FF7D555EF76 v8::internal::ScavengeJob::operator=+24550
 8: 00007FF7D555D5CC v8::internal::ScavengeJob::operator=+17980
 9: 00007FF7D5566317 v8::internal::Heap::MaxHeapGrowingFactor+2327
10: 00007FF7D5566396 v8::internal::Heap::MaxHeapGrowingFactor+2454
11: 00007FF7D5690637 v8::internal::Factory::NewFillerObject+55
12: 00007FF7D570D826 v8::internal::operator<<+73494
13: 000001DFA5CDC5C1
```

Perhaps there is a way to better share this options across all gulp invocations ? 