### PR TITLE
Use the Monaco TS Language service for the Playground

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -40,7 +40,7 @@ compileAndRun = function(parent, fpsLabel) {
         var createEngineFunction = "createDefaultEngine";
         var createSceneFunction;
 
-        parent.monacoCreator.getRunCode(function (code) {
+        parent.monacoCreator.getRunCode().then(function (code) {
             var createDefaultEngine = function () {
                 return new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
             }

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -40,7 +40,7 @@ compileAndRun = function(parent, fpsLabel) {
         var createEngineFunction = "createDefaultEngine";
         var createSceneFunction;
 
-        parent.monacoCreator.getRunCode().then(function (code) {
+        parent.monacoCreator.getRunCode().then(code => {
             var createDefaultEngine = function () {
                 return new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
             }
@@ -172,7 +172,7 @@ compileAndRun = function(parent, fpsLabel) {
                     }
                 }
             }
-        }.bind(this));
+        });
 
     } catch (e) {
         parent.utils.showError(e.message, e);

--- a/Playground/js/mainWebGPU.js
+++ b/Playground/js/mainWebGPU.js
@@ -45,7 +45,7 @@ compileAndRun = function(parent, fpsLabel) {
             return;
         }
 
-        parent.monacoCreator.getRunCode().then((async function (code) {
+        parent.monacoCreator.getRunCode().then(async code => {
             try {
                 var createDefaultEngine = function () {
                     return new BABYLON.WebGPUEngine(canvas);
@@ -196,7 +196,7 @@ compileAndRun = function(parent, fpsLabel) {
                 // Also log error in console to help debug playgrounds
                 console.error(e);
             }
-        }).bind(this));
+        });
     } catch (e) {
         parent.utils.showError(e.message, e);
         // Also log error in console to help debug playgrounds

--- a/Playground/js/mainWebGPU.js
+++ b/Playground/js/mainWebGPU.js
@@ -45,7 +45,7 @@ compileAndRun = function(parent, fpsLabel) {
             return;
         }
 
-        parent.monacoCreator.getRunCode((async function (code) {
+        parent.monacoCreator.getRunCode().then((async function (code) {
             try {
                 var createDefaultEngine = function () {
                     return new BABYLON.WebGPUEngine(canvas);

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -157,7 +157,7 @@ class MonacoCreator {
                 worker(uri)
                 .then(function(languageService) {
                      languageService.getEmitOutput(uri.toString())
-                     .then((result) => {
+                     .then(function(result) {
                           var output = result.outputFiles[0].text;
                           var stub = "var createScene = function() { return Playground.CreateScene(engine, engine.getRenderingCanvas()); }";
                           callBack(output + stub);

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -153,7 +153,9 @@ class MonacoCreator {
         if (parent.settingsPG.ScriptLanguage == "JS")
             callBack(this.jsEditor.getValue());
         else if (parent.settingsPG.ScriptLanguage == "TS") {
-            var uri = this.jsEditor.getModel().uri;
+            var model = this.jsEditor.getModel();
+            var uri = model.uri;
+
             monaco.languages.typescript.getTypeScriptWorker()
             .then(function(worker) {
                 worker(uri)
@@ -164,7 +166,11 @@ class MonacoCreator {
                     .then(function(diagnostics) {
                         diagnostics.forEach(function(diagset) {
                             if (diagset.length) {
-                                parent.utils.showError(diagset[0].messageText);
+                                var diagnostic = diagset[0];
+                                var position = model.getPositionAt(diagnostic.start);
+                                
+                                parent.utils.showError(`Line ${position.lineNumber}:${position.column} - ${diagnostic.messageText}`);
+                                return;
                             }
                         });
                     });

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -58,11 +58,16 @@ class MonacoCreator {
                 if (xhr.status === 200) {
                     require.config({ paths: { 'vs': 'node_modules/monaco-editor/min/vs' } });
                     require(['vs/editor/editor.main'], function () {
-                        if (this.monacoMode === "javascript") {
-                            monaco.languages.typescript.javascriptDefaults.addExtraLib(xhr.responseText, 'babylon.d.ts');
-                        } else {
-                            var typescript = monaco.languages.typescript;
+                        const typescript = monaco.languages.typescript;
 
+                        if (this.monacoMode === "javascript") {
+                            typescript.javascriptDefaults.setCompilerOptions({
+                                noLib: true,
+                                allowNonTsExtensions: true // required to prevent Uncaught Error: Could not find file: 'inmemory://model/1'.
+                            });
+
+                            typescript.javascriptDefaults.addExtraLib(xhr.responseText, 'babylon.d.ts');
+                        } else {
                             typescript.typescriptDefaults.setCompilerOptions({
                                 module: typescript.ModuleKind.AMD,
                                 target: typescript.ScriptTarget.ES5,
@@ -72,7 +77,6 @@ class MonacoCreator {
 
                                 allowNonTsExtensions: true // required to prevent Uncaught Error: Could not find file: 'inmemory://model/1'.
                             });
-
                             typescript.typescriptDefaults.addExtraLib(xhr.responseText, 'babylon.d.ts');
                         }
 

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -150,8 +150,8 @@ class MonacoCreator {
         var parent = this.parent;
 
         if (parent.settingsPG.ScriptLanguage == "JS")
-            callBack(this.jsEditor.getValue());
-            
+            return this.jsEditor.getValue();
+
         else if (parent.settingsPG.ScriptLanguage == "TS") {
             const model = this.jsEditor.getModel();
             const uri = model.uri;
@@ -160,6 +160,7 @@ class MonacoCreator {
             const languageService = await worker(uri);
 
             const uriStr = uri.toString();
+            const result = await languageService.getEmitOutput(uriStr);
             const diagnostics = await Promise.all([languageService.getSyntacticDiagnostics(uriStr), languageService.getSemanticDiagnostics(uriStr)]);
 
             diagnostics.forEach(function(diagset) {
@@ -172,7 +173,6 @@ class MonacoCreator {
                 }
             });
 
-            const result = await languageService.getEmitOutput(uri.toString());
             const output = result.outputFiles[0].text;
             const stub = "var createScene = function() { return Playground.CreateScene(engine, engine.getRenderingCanvas()); }";
 

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -63,7 +63,6 @@ class MonacoCreator {
                         } else {
                             var typescript = monaco.languages.typescript;
 
-                            // setup compiler option for typescript
                             typescript.typescriptDefaults.setCompilerOptions({
                                 module: typescript.ModuleKind.AMD,
                                 target: typescript.ScriptTarget.ES5,
@@ -74,7 +73,7 @@ class MonacoCreator {
                                 allowNonTsExtensions: true // required to prevent Uncaught Error: Could not find file: 'inmemory://model/1'.
                             });
 
-                            monaco.languages.typescript.typescriptDefaults.addExtraLib(xhr.responseText, 'babylon.d.ts');
+                            typescript.typescriptDefaults.addExtraLib(xhr.responseText, 'babylon.d.ts');
                         }
 
                         this.parent.main.run();

--- a/Playground/package.json
+++ b/Playground/package.json
@@ -9,7 +9,7 @@
   "readme": "https://github.com/BabylonJS/Babylon.js/blob/master/readme.md",
   "license": "(Apache-2.0)",
   "devDependencies": {
-    "monaco-editor": "~0.10.1"
+    "monaco-editor": "~0.18.1"
   },
   "scripts": {
     "test": "browser-sync start --server --files **/* --no-inject-changes --startPath index.html"

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -73,6 +73,7 @@
 - Added support for side by side and top bottom images in the `PhotoDome` ([Deltakosh](https://github.com/deltakosh/))
 - Added playground ts-local (TypeScript support for local playground) ([pjoe](https://github.com/pjoe/))
 - Added RGBD Texture tools [Sebavan](https://github.com/sebavan/)
+- Bumped Monaco Editor to 0.18.1 and improved TypeScript compilation pipeline in the playground ([sailro](http://www.github.com/sailro))
 
 ### Meshes
 

--- a/what's new.md
+++ b/what's new.md
@@ -64,7 +64,6 @@
 - All NPM packages have `latest` and `preview` streams ([RaananW](https://github.com/RaananW))
 - Added New Tools Tab in the inspector (env texture and screenshot tools so far) ([sebavan](http://www.github.com/sebavan))
 - Moved to gulp 4, updated dependencies to latest ([RaananW](https://github.com/RaananW))
-- Bumped Monaco Editor to 0.18.1 and improved TypeScript compilation pipeline in the Playground ([sailro](http://www.github.com/sailro))
 
 ### GUI
 - Added dead key support and before key add observable to InputText. [Doc](https://doc.babylonjs.com/how_to/gui#using-onbeforekeyaddobservable-for-extended-keyboard-layouts-and-input-masks) ([theom](https://github.com/theom))

--- a/what's new.md
+++ b/what's new.md
@@ -64,6 +64,7 @@
 - All NPM packages have `latest` and `preview` streams ([RaananW](https://github.com/RaananW))
 - Added New Tools Tab in the inspector (env texture and screenshot tools so far) ([sebavan](http://www.github.com/sebavan))
 - Moved to gulp 4, updated dependencies to latest ([RaananW](https://github.com/RaananW))
+- Bumped Monaco Editor to 0.18.1 and improved TypeScript compilation pipeline in the Playground ([sailro](http://www.github.com/sailro))
 
 ### GUI
 - Added dead key support and before key add observable to InputText. [Doc](https://doc.babylonjs.com/how_to/gui#using-onbeforekeyaddobservable-for-extended-keyboard-layouts-and-input-masks) ([theom](https://github.com/theom))


### PR DESCRIPTION
Creating a draft pull request for now, because it needs to be tested on other browsers (only tried with Chrome Version 77.0.3865.120 (Official Build) (64-bit)).

So the main idea is to remove the custom compilation step when using the typescript language in the Playground.

If I'm not wrong, currently the code is compiled twice: by the Monaco Editor, and by a custom invocation to `ts.createProgram` as well.

Given Monaco is giving access to the JS/TS language service, it seems easier to get the generated javascript directly from it without recompiling the same stuff for nothing.