### PR TITLE
fix SPS insertParticlesFromArray : now the positionFunction can be run

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -151,7 +151,7 @@
 
 - Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature `removeParticles()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
-- Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
+- Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))  
 
 ### Navigation Mesh
 

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -168,7 +168,12 @@ export class SolidParticle {
         }
         target.scaling.copyFrom(this.scaling);
         if (this.color) {
-            target.color!.copyFrom(this.color!);
+            if (target.color) {
+                target.color!.copyFrom(this.color!);
+            }
+            else {
+                target.color = this.color.clone();
+            }
         }
         target.uvs.copyFrom(this.uvs);
         target.velocity.copyFrom(this.velocity);


### PR DESCRIPTION
When restoring formerly saved particles (in an external storage or previously removed ones), if a positionFunction is associated to thoses particles, it can be executed back on the insertion in the SPS

+
fix on particle.copyToRef() in case of missing color in the target