### PR TITLE
Allow a Float32Array to be passed to ShaderMaterial.setMatrices

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -108,6 +108,7 @@
 
 - Added `ShaderMaterial.setColor4Array` ([JonathanTron](https://github.com/JonathanTron/))
 - Added `ShaderMaterial.setArray4` ([JonathanTron](https://github.com/JonathanTron/))
+- Updated signature of `ShaderMaterial.setMatrices` to `Mat4[] | Float32Array` ([Popov72](https://github.com/Popov72))
 - Added `scene.environmentIntensity` to control the IBL strength overall in a scene ([Sebavan](https://github.com/sebavan/))
 - Added support of image processing for `WaterMaterial` ([julien-moreau](https://github.com/julien-moreau))
 - Added `pbrBRDFConfiguration.useSpecularGlossinessInputEnergyConservation` to allow Specular-Workflow energy conservation to be turned off ([ColorDigital-PS](https://github.com/ColorDigital-PS)).

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -342,15 +342,21 @@ export class ShaderMaterial extends Material {
      * @param value Define the value to give to the uniform
      * @return the material itself allowing "fluent" like uniform updates
      */
-    public setMatrices(name: string, value: Matrix[]): ShaderMaterial {
+    public setMatrices(name: string, value: Matrix[] | Float32Array): ShaderMaterial {
         this._checkUniform(name);
 
-        let float32Array = new Float32Array(value.length * 16);
+        let float32Array;
 
-        for (var index = 0; index < value.length; index++) {
-            let matrix = value[index];
+        if (Array.isArray(value)) {
+            float32Array = new Float32Array(value.length * 16);
 
-            matrix.copyToArray(float32Array, index * 16);
+            for (var index = 0; index < value.length; index++) {
+                let matrix = value[index];
+
+                matrix.copyToArray(float32Array, index * 16);
+            }
+        } else {
+            float32Array = value;
         }
 
         this._matrixArrays[name] = float32Array;


### PR DESCRIPTION
As title says, this PR is to allow to pass directly a `Float32Array` to `ShaderMaterial.setMatrices`.

Currently, it takes a `Mat4[]` which is then converted to `Float32Array`, so the change is really a small one, it bypasses the conversion if a `Float32Array` is passed in.

Let me know if it's ok for you, and if yes if the attached PR is also ok (it's my first PR!).

Thanks.