### PR TITLE
Cloning of ShaderMaterial should also clone _shaderPath and _options properties

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -201,6 +201,7 @@
 - Fixed a single frame drop after leaving webxr on some devices ([RaananW](https://github.com/RaananW/))
 - Fixed bug where vignette aspect ratio would be wrong when rendering direct to canvas
 - Fixed Path2 length computation ([Poolminer](https://github.com/Poolminer/))
+- Cloning of `ShaderMaterial` also clone `shaderPath` and `options` properties ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -775,6 +775,21 @@ export class ShaderMaterial extends Material {
         result.name = name;
         result.id = name;
 
+        // Shader code path
+        if (typeof result._shaderPath === 'object') {
+            result._shaderPath = { ...result._shaderPath };
+        }
+
+        // Options
+        this._options = { ...this._options };
+
+        (Object.keys(this._options) as Array<keyof IShaderMaterialOptions>).forEach((propName) => {
+            const propValue = this._options[propName];
+            if (Array.isArray(propValue)) {
+                (<string[]>this._options[propName]) = propValue.slice(0);
+            }
+        });
+
         // Texture
         for (var key in this._textures) {
             result.setTexture(key, this._textures[key]);


### PR DESCRIPTION
As approved by @Deltakosh in the forum (https://forum.babylonjs.com/t/not-all-properties-cloned-when-cloning-shadermaterial/6442/7), I have updated the `ShaderMaterial.Clone` method to also clone the `_shaderPath` and `_options` properties.

_Implementation note_:

I had to cast to `<string[]>` here:
```typescript
    if (Array.isArray(propValue)) {
        (<string[]>this._options[propName]) = propValue.slice(0);
    }
```
to keep Typescript happy, but it would be better without this cast (more future foolproof if new non-string array properties are added to `_options`). 

However, I could not come up with a solution to this problem...