### PR TITLE
Prevent an infinite loop during engine dispose in a scene with multiple soundtracks

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -204,6 +204,7 @@
 - Fixed bug where vignette aspect ratio would be wrong when rendering direct to canvas
 - Fixed Path2 length computation ([Poolminer](https://github.com/Poolminer/))
 - Cloning of `ShaderMaterial` also clone `shaderPath` and `options` properties ([Popov72](https://github.com/Popov72))
+- Prevent an infinite loop when calling `engine.dispose()` in a scene with multiple `SoundTracks` defined ([kirbysayshi](https://github.com/kirbysayshi))
 
 ## Breaking changes
 

--- a/src/Audio/soundTrack.ts
+++ b/src/Audio/soundTrack.ts
@@ -51,7 +51,7 @@ export class SoundTrack {
         this.soundCollection = new Array();
         this._options = options;
 
-        if (!this.options.mainTrack && this._scene.soundTracks) {
+        if (!this._options.mainTrack && this._scene.soundTracks) {
             this._scene.soundTracks.push(this);
             this.id = this._scene.soundTracks.length - 1;
         }

--- a/src/Audio/soundTrack.ts
+++ b/src/Audio/soundTrack.ts
@@ -35,7 +35,6 @@ export class SoundTrack {
 
     private _outputAudioNode: Nullable<GainNode>;
     private _scene: Scene;
-    private _isMainTrack: boolean = false;
     private _connectedAnalyser: Analyser;
     private _options: ISoundTrackOptions;
     private _isInitialized = false;
@@ -64,7 +63,6 @@ export class SoundTrack {
 
             if (this._options) {
                 if (this._options.volume) { this._outputAudioNode.gain.value = this._options.volume; }
-                if (this._options.mainTrack) { this._isMainTrack = this._options.mainTrack; }
             }
 
             this._isInitialized = true;

--- a/src/Audio/soundTrack.ts
+++ b/src/Audio/soundTrack.ts
@@ -51,7 +51,7 @@ export class SoundTrack {
         this.soundCollection = new Array();
         this._options = options;
 
-        if (!this._isMainTrack && this._scene.soundTracks) {
+        if (!this.options.mainTrack && this._scene.soundTracks) {
             this._scene.soundTracks.push(this);
             this.id = this._scene.soundTracks.length - 1;
         }

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -517,9 +517,9 @@ describe('Babylon Scene Loader', function() {
                 expect(result.meshes.length, "meshes.length").to.equal(scene.meshes.length);
                 expect(result.particleSystems.length, "particleSystems.length").to.equal(0);
                 expect(result.animationGroups.length, "animationGroups.length").to.equal(3);
-                expect(scene.soundTracks.length, "scene.soundTracks.length").to.equal(1);
-                expect(scene.soundTracks[0].soundCollection.length, "scene.soundTracks[0].soundCollection.length").to.equal(3);
-                expect(scene.soundTracks[0].soundCollection[0].onEndedObservable.hasObservers(), "scene.soundTracks[0].soundCollection[0].onEndedObservable.hasObservers()").to.be.true;
+                expect(scene.soundTracks.length, "scene.soundTracks.length").to.equal(0);
+                expect(scene.mainSoundTrack.soundCollection.length, "scene.mainSoundTrack.soundCollection.length").to.equal(3);
+                expect(scene.mainSoundTrack.soundCollection[0].onEndedObservable.hasObservers(), "scene.mainSoundTrack.soundCollection[0].onEndedObservable.hasObservers()").to.be.true;
             });
         });
 


### PR DESCRIPTION
Hello!

Found this bug while trying to cleanup the entire engine to save battery while developing.

Seems like the option for mainTrack wasn't being passed through. This resulted in the main soundtrack being added as a normal sound track. There is separate code that handles deleting entities from the main sound track, _before_ the other soundtracks have been cleaned up. When `dispose` is called on each soundtrack, the Sound is no longer present, having been deleted by the mainSoundTrack dispose code. This results in the soundtrack remaining in the scene, never being removed, and the dispose loop continues again.

Pretty severe bug that resulted in a browser lockup.

I hope I did everything right regarding contributing!

Edit: After a few CI tries, it's passing. But the test case I modified raises a larger issue: is the intent that even the mainSoundTrack is present in the soundTracks array of a scene?