### PR TITLE
fix insertParticlesFromArray : normals rotation was computed twice

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -151,7 +151,7 @@
 
 - Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature `removeParticles()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
-- Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))  
+- Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 
 ### Navigation Mesh
 

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -164,7 +164,12 @@ export class SolidParticle {
         target.position.copyFrom(this.position);
         target.rotation.copyFrom(this.rotation);
         if (this.rotationQuaternion) {
-            target.rotationQuaternion!.copyFrom(this.rotationQuaternion!);
+            if (target.rotationQuaternion) {
+                target.rotationQuaternion!.copyFrom(this.rotationQuaternion!);
+            }
+            else {
+                target.rotationQuaternion = this.rotationQuaternion.clone();
+            }
         }
         target.scaling.copyFrom(this.scaling);
         if (this.color) {


### PR DESCRIPTION
Fix : on particle restoring from an array, the normals were rotated twice in case _setParticles()_ was called just after.
Now, the behavior on restoring from an array is exactly the same than when using the method _addShape()_ : 
- if  a _positionFunction_ is associated to the restored particle shape, it's executed (so the particle may be given a rotation by this stored custom function) on restore
- then if the particle is given manually some other rotation (ex : in the method _updateParticle()_ ), this rotation will be computed only on the next call to _setParticles()_

It's been a long time I hadn't such a difficult bug to find and to solve, aaarggg...