### PR TITLE
Fix missing properties in serialization/parsing of coneParticleEmitter

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -206,6 +206,7 @@
 - Fixed Path2 length computation ([Poolminer](https://github.com/Poolminer/))
 - Cloning of `ShaderMaterial` also clone `shaderPath` and `options` properties ([Popov72](https://github.com/Popov72))
 - Prevent an infinite loop when calling `engine.dispose()` in a scene with multiple `SoundTracks` defined ([kirbysayshi](https://github.com/kirbysayshi))
+- Fixed missing properties in serialization / parsing of `coneParticleEmitter` ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Particles/EmitterTypes/coneParticleEmitter.ts
+++ b/src/Particles/EmitterTypes/coneParticleEmitter.ts
@@ -183,6 +183,9 @@ export class ConeParticleEmitter implements IParticleEmitterType {
         serializationObject.radius = this._radius;
         serializationObject.angle = this._angle;
         serializationObject.directionRandomizer = this.directionRandomizer;
+        serializationObject.radiusRange = this.radiusRange;
+        serializationObject.heightRange = this.heightRange;
+        serializationObject.emitFromSpawnPointOnly = this.emitFromSpawnPointOnly;
 
         return serializationObject;
     }
@@ -195,5 +198,8 @@ export class ConeParticleEmitter implements IParticleEmitterType {
         this.radius = serializationObject.radius;
         this.angle = serializationObject.angle;
         this.directionRandomizer = serializationObject.directionRandomizer;
+        this.radiusRange = serializationObject.radiusRange;
+        this.heightRange = serializationObject.heightRange;
+        this.emitFromSpawnPointOnly = serializationObject.emitFromSpawnPointOnly;
     }
 }


### PR DESCRIPTION
Three properties were not serialized / parsed in the `coneParticleEmitter` class.