### PR TITLE
allowing dev server to run https (self signed)

### DIFF
--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "install": "cd ../../ && npm install && cd Playground/ && npm install && cd ../Viewer && npm install && cd ../Tools/Gulp/",
         "build": "gulp --max-old-space-size=8192 --tsLintFix",
-        "start": "gulp run --max-old-space-size=8192"
+        "start": "gulp run --max-old-space-size=8192",
+        "start-public-ssl": "gulp run --max-old-space-size=8192 --public --ssl"
     }
 }

--- a/Tools/Gulp/tasks/gulpTasks-localRun.js
+++ b/Tools/Gulp/tasks/gulpTasks-localRun.js
@@ -44,5 +44,9 @@ gulp.task("webserver", function() {
         options.host = "0.0.0.0";
     }
 
+    if (commandLineOptions.ssl) {
+        options.https = true;
+    }
+
     connect.server(options);
 });


### PR DESCRIPTION
The reason is WebXR, which doesn't work unless ssl is turned on.
When SSL is not turned on, navigator.xr is null.

