### PR TITLE
Use correct non-uniform normal transform

### DIFF
--- a/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -43,6 +43,20 @@ mat3 inverseMat3(mat3 inMatrix) {
               b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;
 }
 
+/**
+    Given a transform matrix, the adjugate matrix gives us the equivalent transform matrix for transforming surface normals
+    The cofactor matrix is equivalent to transpose(adjugate(m))
+
+    See https://github.com/graphitemaster/normals_revisited
+**/
+mat3 adjugate(in mat3 m) {
+  return mat3(
+      cross(m[1], m[2]), 
+      cross(m[2], m[0]), 
+      cross(m[0], m[1])
+  );
+}
+
 vec3 toLinearSpace(vec3 color)
 {
     return pow(color, vec3(LinearEncodePowerApprox));

--- a/src/Shaders/background.vertex.fx
+++ b/src/Shaders/background.vertex.fx
@@ -80,7 +80,7 @@ void main(void) {
 	mat3 normalWorld = mat3(finalWorld);
 
 	#ifdef NONUNIFORMSCALING
-		normalWorld = transposeMat3(inverseMat3(normalWorld));
+		normalWorld = adjugate(normalWorld);
 	#endif
 
 	vNormalW = normalize(normalWorld * normal);

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -144,7 +144,7 @@ void main(void) {
 	mat3 normalWorld = mat3(finalWorld);
 
 	#ifdef NONUNIFORMSCALING
-		normalWorld = transposeMat3(inverseMat3(normalWorld));
+		normalWorld = adjugate(normalWorld);
 	#endif
 
 	vNormalW = normalize(normalWorld * normalUpdated);

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -188,7 +188,7 @@ void main(void) {
     mat3 normalWorld = mat3(finalWorld);
 
     #ifdef NONUNIFORMSCALING
-        normalWorld = transposeMat3(inverseMat3(normalWorld));
+        normalWorld = adjugate(normalWorld);
     #endif
 
     vNormalW = normalize(normalWorld * normalUpdated);

--- a/src/Shaders/shadowMap.vertex.fx
+++ b/src/Shaders/shadowMap.vertex.fx
@@ -51,7 +51,7 @@ vec4 worldPos = finalWorld * vec4(positionUpdated, 1.0);
     mat3 normalWorld = mat3(finalWorld);
 
     #ifdef NONUNIFORMSCALING
-        normalWorld = transposeMat3(inverseMat3(normalWorld));
+        normalWorld = adjugate(normalWorld);
     #endif
 
     vec3 worldNor = normalize(normalWorld * normal);


### PR DESCRIPTION
This is best explained by @graphitemaster who raised awareness of the bug in the graphics community, his explanation and derivation:
https://github.com/graphitemaster/normals_revisited

More detailed derivation and discussion in this document (from 1987!)
https://www.glassner.com/wp-content/uploads/2014/04/On-the-Transformation-of-Surface-Normals.pdf

The traditional method for transforming normals with `transpose(inverse(m))` is incorrect since it doesn't fully preserve normal orientation. Here's a demo (change `#define method` to see incorrect example)
https://www.shadertoy.com/view/3s33zj

Fortunately the correct method, which uses the [`adjugate`](https://en.wikipedia.org/wiki/Adjugate_matrix) matrix is cheaper to calculate

In this PR I've replaced instances of `transpose(inverse(m))` with `adjugate` and added an implementation of `adjugate` to helperFunctions.fx

**Don't merge yet, want to see test results**