### PR TITLE
Path3D (bi)normal computation edge case fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -218,6 +218,7 @@
 - Fixed missing properties in serialization / parsing of `coneParticleEmitter` ([Popov72](https://github.com/Popov72))
 - Fix a bug with exit VR and Edge ([RaananW](https://github.com/RaananW/))
 - Fixed an issue with size of texture in multiview ([RaananW](https://github.com/RaananW/))
+- Fixed Path3D (bi)normals computation for specific edge cases ([Poolminer](https://github.com/Poolminer/))
 
 ## Breaking changes
 

--- a/src/Maths/math.path.ts
+++ b/src/Maths/math.path.ts
@@ -632,14 +632,15 @@ export class Path3D {
             // normals and binormals
             // http://www.cs.cmu.edu/afs/andrew/scs/cs/15-462/web/old/asst2camera.html
             curTang = this._tangents[i];
-            prevNor = this._normals[i - 1];
             prevBinor = this._binormals[i - 1];
             this._normals[i] = Vector3.Cross(prevBinor, curTang);
-            if (this._normals[i].length() === 0) {
-                this._normals[i] = prevNor;
-            }
             if (!this._raw) {
-                this._normals[i].normalize();
+                if (this._normals[i].length() === 0) {
+                    prevNor = this._normals[i - 1];
+                    this._normals[i] = prevNor.clone();
+                } else {
+                    this._normals[i].normalize();
+                }
             }
             this._binormals[i] = Vector3.Cross(curTang, this._normals[i]);
             if (!this._raw) {

--- a/src/Maths/math.path.ts
+++ b/src/Maths/math.path.ts
@@ -616,6 +616,7 @@ export class Path3D {
         var cur: Vector3;         // current vector (segment)
         var curTang: Vector3;     // current tangent
         // previous normal
+        var prevNor: Vector3;    // previous normal
         var prevBinor: Vector3;   // previous binormal
 
         for (var i = 1; i < l; i++) {
@@ -631,8 +632,12 @@ export class Path3D {
             // normals and binormals
             // http://www.cs.cmu.edu/afs/andrew/scs/cs/15-462/web/old/asst2camera.html
             curTang = this._tangents[i];
+            prevNor = this._normals[i - 1];
             prevBinor = this._binormals[i - 1];
             this._normals[i] = Vector3.Cross(prevBinor, curTang);
+            if (this._normals[i].length() === 0) {
+                this._normals[i] = prevNor;
+            }
             if (!this._raw) {
                 this._normals[i].normalize();
             }


### PR DESCRIPTION
Regarding: the computation of normals and binormals of Path3D

The computation:
For each segment, the tangent (forward axis) is taken and crossed with the previous binormal (up axis) to get a normal.

The problem:
If the previous binormal is along the same axis as the tangent, the normal will be zero, as will the derived binormal.

The fix:
Use the normal of the previous segment