### PR TITLE
onControllerModelLoaded observable

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -147,6 +147,7 @@
 - Added option to configure the output canvas ([RaananW](https://github.com/RaananW/))
 - Supporting multisampled multiview rendering using the oculus multiview extension ([RaananW](https://github.com/RaananW/))
 - Preparing to deprecate supportsSession in favor of isSupportedSession ([RaananW](https://github.com/RaananW/))
+- Added onControllerModelLoaded observable for WebXR ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/XR/webXRControllerModelLoader.ts
+++ b/src/Cameras/XR/webXRControllerModelLoader.ts
@@ -4,11 +4,15 @@ import { OculusTouchController } from '../../Gamepads/Controllers/oculusTouchCon
 import { WebXRInput } from './webXRInput';
 import { ViveController } from '../../Gamepads/Controllers/viveController';
 import { WebVRController } from '../../Gamepads/Controllers/webVRController';
+import { Observable } from '../../Misc/observable';
+import { WebXRController } from './webXRController';
 
 /**
  * Loads a controller model and adds it as a child of the WebXRControllers grip when the controller is created
  */
 export class WebXRControllerModelLoader {
+
+    public onControllerModelLoaded = new Observable<WebXRController>();
     /**
      * Creates the WebXRControllerModelLoader
      * @param input xr input that creates the controllers
@@ -63,6 +67,8 @@ export class WebXRControllerModelLoader {
             });
 
             c.gamepadController = controllerModel;
+
+            this.onControllerModelLoaded.notifyObservers(c);
         });
     }
 }

--- a/src/Cameras/XR/webXRControllerModelLoader.ts
+++ b/src/Cameras/XR/webXRControllerModelLoader.ts
@@ -12,6 +12,10 @@ import { WebXRController } from './webXRController';
  */
 export class WebXRControllerModelLoader {
 
+    /**
+     * an observable that triggers when a new model (the mesh itself) was initialized.
+     * To know when the mesh was loaded use the controller's own modelLoaded() method
+     */
     public onControllerModelLoaded = new Observable<WebXRController>();
     /**
      * Creates the WebXRControllerModelLoader
@@ -64,11 +68,10 @@ export class WebXRControllerModelLoader {
                 m.getChildMeshes(false).forEach((m) => {
                     m.isPickable = false;
                 });
+                this.onControllerModelLoaded.notifyObservers(c);
             });
 
             c.gamepadController = controllerModel;
-
-            this.onControllerModelLoaded.notifyObservers(c);
         });
     }
 }


### PR DESCRIPTION
Closing #7102

Usage:

```javascript
// xr is the default webxr experience helper
xr.controllerModelLoader.onControllerModelLoaded.add((controller: WebXRController) => {
    // do whatever you want with the controller, including controller.gamepadObject
});
```