### PR TITLE
Updating deterministic lockstep to work with 144Hz monitors

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -366,7 +366,7 @@ export class Engine extends ThinEngine {
     public onCanvasFocusObservable = new Observable<Engine>();
 
     /**
-     * Observable event triggered each time the canvas receives pointerout event
+     * Observable event triggered each time the canvas receives pointerout evet
      */
     public onCanvasPointerOutObservable = new Observable<PointerEvent>();
 
@@ -427,6 +427,7 @@ export class Engine extends ThinEngine {
     // Deterministic lockstepMaxSteps
     private _deterministicLockstep: boolean = false;
     private _lockstepMaxSteps: number = 4;
+    private _timeStep: number = 1 / 60;
 
     protected get _supportsHardwareTextureRescaling() {
         return !!Engine._RescalePostProcessFactory;
@@ -586,6 +587,8 @@ export class Engine extends ThinEngine {
 
             this._deterministicLockstep = !!options.deterministicLockstep;
             this._lockstepMaxSteps = options.lockstepMaxSteps || 0;
+            this._timeStep = options.timeStep || 1 / 60;
+
         }
 
         // Load WebVR Devices
@@ -664,6 +667,14 @@ export class Engine extends ThinEngine {
      */
     public getLockstepMaxSteps(): number {
         return this._lockstepMaxSteps;
+    }
+
+    /**
+     * Returns the time in ms between steps when using deterministic lock step.
+     * @returns time step in (ms)
+     */
+    public getTimeStep(): number {
+        return this._timeStep * 1000;
     }
 
     /**

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -366,7 +366,7 @@ export class Engine extends ThinEngine {
     public onCanvasFocusObservable = new Observable<Engine>();
 
     /**
-     * Observable event triggered each time the canvas receives pointerout evet
+     * Observable event triggered each time the canvas receives pointerout event
      */
     public onCanvasPointerOutObservable = new Observable<PointerEvent>();
 

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -88,10 +88,13 @@ export interface EngineOptions extends WebGLContextAttributes {
     deterministicLockstep?: boolean;
     /** Defines the maximum steps to use with deterministic lock step mode */
     lockstepMaxSteps?: number;
+    /** Defines the seconds between each deterministic lock step */
+    timeStep?: number;
     /**
      * Defines that engine should ignore context lost events
      * If this event happens when this parameter is true, you will have to reload the page to restore rendering
      */
+
     doNotHandleContextLost?: boolean;
     /**
      * Defines that engine should ignore modifying touch action attribute and style
@@ -481,6 +484,10 @@ export class ThinEngine {
 
             if (options.lockstepMaxSteps === undefined) {
                 options.lockstepMaxSteps = 4;
+            }
+
+            if (options.timeStep === undefined) {
+                options.timeStep = 1 / 60;
             }
 
             if (options.preserveDrawingBuffer === undefined) {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3739,8 +3739,7 @@ export class Scene extends AbstractScene implements IAnimatable {
      * User updatable function that will return a deterministic frame time when engine is in deterministic lock step mode
      */
     public getDeterministicFrameTime: () => number = () => {
-        // return this._engine.getTimeStep();
-        return 1000.0 / 60.0; // frame time in ms
+        return this._engine.getTimeStep();
     }
 
     /** @hidden */
@@ -3783,27 +3782,6 @@ export class Scene extends AbstractScene implements IAnimatable {
             }
 
             this._timeAccumulator = deltaTime < 0 ? 0 : deltaTime;
-
-            // var internalSteps = Math.floor(deltaTime / (1000 * defaultFPS));
-            // internalSteps = Math.min(internalSteps, maxSubSteps);
-            // do {
-            //     this.onBeforeStepObservable.notifyObservers(this);
-
-            //     // Animations
-            //     this._animationRatio = defaultFrameTime * defaultFPS;
-            //     this._animate();
-            //     this.onAfterAnimationsObservable.notifyObservers(this);
-
-            //     // Physics
-            //     this._advancePhysicsEngineStep(defaultFrameTime);
-
-            //     this.onAfterStepObservable.notifyObservers(this);
-            //     this._currentStepId++;
-
-            //     stepsTaken++;
-            //     deltaTime -= defaultFrameTime;
-
-            // } while (deltaTime > 0 && stepsTaken < internalSteps);
 
         }
         else {


### PR DESCRIPTION
Fixed bug where frame-rates higher than 60 fps would cause physics simulations to run at increased speeds.
Added the ability to set the time step between frames when passed with the EngineOptions interface.