### PR TITLE
Lasers on when entering VR on the oculus quest

### DIFF
--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -831,7 +831,7 @@ export class VRExperienceHelper {
 
         // Exiting VR mode double tapping the touch screen
         this._scene.onPrePointerObservable.add(() => {
-            if (this.isInVRMode && this.exitVROnDoubleTap) {
+            if (this._hasEnteredVR && this.exitVROnDoubleTap) {
                 this.exitVR();
                 if (this._fullscreenVRpresenting) {
                     this._scene.getEngine().exitFullscreen();


### PR DESCRIPTION
Use the flag _hasEnteredVR instead of inVRMode to avoid wrong conditions when controller is connected.
CLosing https://github.com/BabylonJS/Babylon.js/issues/6967