### PR TITLE
Added support for MultiMaterials to the SPS

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -164,6 +164,7 @@
 - Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature `removeParticles()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
+- Added the support for MultiMaterials to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 
 ### Navigation Mesh
 

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -112,6 +112,10 @@ export class SolidParticle {
      */
     public parentId: Nullable<number> = null;
     /**
+     * The particle material identifier (integer) when MultiMaterials are enabled in the SPS.
+     */
+    public materialIndex: Nullable<number> = null;
+    /**
      * The culling strategy to use to check whether the solid particle must be culled or not when using isInFrustum().
      * The possible values are :
      * - AbstractMesh.CULLINGSTRATEGY_STANDARD
@@ -140,8 +144,9 @@ export class SolidParticle {
      * @param idxInShape (integer) is the index of the particle in the current model (ex: the 10th box of addShape(box, 30))
      * @param sps defines the sps it is associated to
      * @param modelBoundingInfo is the reference to the model BoundingInfo used for intersection computations.
+     * @param materialIndex is the particle material identifier (integer) when the MultiMaterials are enabled in the SPS.
      */
-    constructor(particleIndex: number, particleId: number, positionIndex: number, indiceIndex: number, model: Nullable<ModelShape>, shapeId: number, idxInShape: number, sps: SolidParticleSystem, modelBoundingInfo: Nullable<BoundingInfo> = null) {
+    constructor(particleIndex: number, particleId: number, positionIndex: number, indiceIndex: number, model: Nullable<ModelShape>, shapeId: number, idxInShape: number, sps: SolidParticleSystem, modelBoundingInfo: Nullable<BoundingInfo> = null, materialIndex: Nullable<number> = null) {
         this.idx = particleIndex;
         this.id = particleId;
         this._pos = positionIndex;
@@ -153,6 +158,9 @@ export class SolidParticle {
         if (modelBoundingInfo) {
             this._modelBoundingInfo = modelBoundingInfo;
             this._boundingInfo = new BoundingInfo(modelBoundingInfo.minimum, modelBoundingInfo.maximum);
+        }
+        if (materialIndex !== null) {
+            this.materialIndex = materialIndex;
         }
     }
     /**
@@ -188,6 +196,9 @@ export class SolidParticle {
         target.isVisible = this.isVisible;
         target.parentId = this.parentId;
         target.cullingStrategy = this.cullingStrategy;
+        if (this.materialIndex !== null) {
+            target.materialIndex = this.materialIndex;
+        }
         return this;
     }
     /**
@@ -335,6 +346,7 @@ export class ModelShape {
 
 /**
  * Represents a Depth Sorted Particle in the solid particle system.
+ * @hidden
  */
 export class DepthSortedParticle {
     /**
@@ -349,4 +361,16 @@ export class DepthSortedParticle {
      * Squared distance from the particle to the camera
      */
     public sqDistance: number = 0.0;
+    /**
+     * Material index when used with MultiMaterials
+     */
+    public materialIndex: number = 0;
+
+    /**
+     * Creates a new sorted particle
+     * @param materialIndex
+     */
+    constructor(materialIndex: number) {
+        this.materialIndex = materialIndex;
+    }
 }


### PR DESCRIPTION
Now solid particles can be given different materials from the other ones.  
Like for standard meshes, first create your MultiMaterial : 
```javascript
    var mat1 = new BABYLON.StandardMaterial("m1", scene);
    var mat2 = new BABYLON.StandardMaterial("m2", scene);
    var mat3 = new BABYLON.StandardMaterial("m3", scene);
    mat2.diffuseColor = BABYLON.Color3.Red();
    mat1.diffuseColor = BABYLON.Color3.Green();
    mat3.diffuseColor = BABYLON.Color3.Yellow();

    var mat = new BABYLON.MultiMaterial("mm", scene);
    mat.subMaterials.push(mat1);
    mat.subMaterials.push(mat2);
    mat.subMaterials.push(mat3);
```
Then create a SPS with the parameter `enableMultiMaterial` set to `true` and assign this multimaterial to its mesh like you would do for any other BJS mesh :
```javascript
    var sps = new BABYLON.SolidParticleSystem("sps", scene, { enableMultiMaterial: true});
    var model = BABYLON.MeshBuilder.CreateBox("m", {}, scene);
    sps.addShape(model, 1000);
    sps.buildMesh();
    var particles = sps.mesh;
    particles.material = mat;
```
Now, you can assign a different material from the MultiMaterial object to each particle with the particle property `materialIndex`. 
Then instead of manually creating the submeshes, just call `computeSubMeshes()` once the particle values are set with `setParticles()` : 
```javascript
    // particle initialization function
    var initParticle = function(particle) {      
        particle.position.x = areaSize * (Math.random() - 0.5);
        particle.position.y = areaSize * (Math.random() - 0.5);
        particle.position.z = areaSize * (Math.random() - 0.5);

        particle.materialIndex = (Math.random() * mat.subMaterials.length)|0;
    };
    // init particles
    sps.updateParticle = initParticle;
    sps.setParticles();  // sets the particle locations
    sps.computeSubMeshes();  // creates the submeshes from the particle materialIndex values
```
The SPS geometry is then recomputed so particle vertices and indices are grouped by materials in order to reduce the number of draw calls to its possible minimum (one by used material).

This feature also works with an expandable SPS, so you can add, remove or store particles with materials.
It doesn't work (doesn't crash but leads to weird visible results) with the particle depth sort when you use transparent materials : particles can't be sorted in the same time by material and by the distance to the camera.