### PR TITLE
Fix issues with incomplete completions

### DIFF
--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -82,10 +82,16 @@ class MonacoCreator {
             return hooked
                 .apply(this, [model, position, context, token])
                 .then(result => {
-                    if (!result.suggestions)
+                    if (!result || !result.suggestions)
                         return result;
 
-                    return { suggestions: result.suggestions.filter(suggestionFilter)};
+                    const suggestions = result.suggestions.filter(suggestionFilter);
+                    const incomplete = result.incomplete && result.incomplete == true;
+
+                    return { 
+                        suggestions: suggestions,
+                        incomplete: incomplete
+                    };
                 });
         }
     }

--- a/Playground/js/monacoCreator.js
+++ b/Playground/js/monacoCreator.js
@@ -77,22 +77,20 @@ class MonacoCreator {
             return !suggestion.label.startsWith("_");
         }
 
-        provider.prototype.provideCompletionItems = function(model, position, context, token) {
+        provider.prototype.provideCompletionItems = async function(model, position, context, token) {
             // reuse 'this' to preserve context through call (using apply)
-            return hooked
-                .apply(this, [model, position, context, token])
-                .then(result => {
-                    if (!result || !result.suggestions)
-                        return result;
+            var result = await hooked.apply(this, [model, position, context, token]);
+            
+            if (!result || !result.suggestions)
+                return result;
 
-                    const suggestions = result.suggestions.filter(suggestionFilter);
-                    const incomplete = result.incomplete && result.incomplete == true;
+            const suggestions = result.suggestions.filter(suggestionFilter);
+            const incomplete = result.incomplete && result.incomplete == true;
 
-                    return { 
-                        suggestions: suggestions,
-                        incomplete: incomplete
-                    };
-                });
+            return { 
+                suggestions: suggestions,
+                incomplete: incomplete
+            };
         }
     }
 


### PR DESCRIPTION
Fixes
```
errors.ts:22 Uncaught Error: Cannot read property 'suggestions' of undefined

TypeError: Cannot read property 'suggestions' of undefined
    at monacoCreator.js:85
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at errors.ts:22
```
When quickly typing `BABYLON..`

Also properly pass the `incomplete` flag if present, to signal to the editor that further typing needs further completion request. 