### PR TITLE
XR in VRExperienceHelper

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -155,6 +155,7 @@
 - UI Button has options to set different session mode and reference type ([RaananW](https://github.com/RaananW/))
 - Added option to change the teleportation duration in the VRExperienceHelper class ([https://github.com/LeoRodz](https://github.com/LeoRodz))
 - Added support to teleport the camera at constant speed in the VRExperienceHelper class ([https://github.com/LeoRodz](https://github.com/LeoRodz))
+- VRExperienceHelper has now an XR fallback to force XR usage (Beta) ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/XR/webXRDefaultExperience.ts
+++ b/src/Cameras/XR/webXRDefaultExperience.ts
@@ -21,7 +21,7 @@ export class WebXRDefaultExperienceOptions {
     /**
      * Enable or disable default UI to enter XR
      */
-    public disableDefaultUI: boolean;
+    public disableDefaultUI?: boolean;
 
     /**
      * optional configuration for the output canvas

--- a/src/Cameras/XR/webXRSessionManager.ts
+++ b/src/Cameras/XR/webXRSessionManager.ts
@@ -208,21 +208,7 @@ export class WebXRSessionManager implements IDisposable {
      * @returns true if supported
      */
     public supportsSessionAsync(sessionMode: XRSessionMode) {
-        if (!(navigator as any).xr) {
-            return Promise.resolve(false);
-        }
-        // When the specs are final, remove supportsSession!
-        const functionToUse = (navigator as any).xr.isSessionSupported || (navigator as any).xr.supportsSession;
-        if (!functionToUse) {
-            return Promise.resolve(false);
-        } else {
-            return functionToUse.call((navigator as any).xr, sessionMode).then(() => {
-                return Promise.resolve(true);
-            }).catch((e: any) => {
-                Logger.Warn(e);
-                return Promise.resolve(false);
-            });
-        }
+        return WebXRSessionManager.IsSessionSupported(sessionMode);
     }
 
     /**
@@ -269,5 +255,23 @@ export class WebXRSessionManager implements IDisposable {
     public dispose() {
         this.onXRFrameObservable.clear();
         this.onXRSessionEnded.clear();
+    }
+
+    public static IsSessionSupported(sessionMode: XRSessionMode): Promise<boolean> {
+        if (!(navigator as any).xr) {
+            return Promise.resolve(false);
+        }
+        // When the specs are final, remove supportsSession!
+        const functionToUse = (navigator as any).xr.isSessionSupported || (navigator as any).xr.supportsSession;
+        if (!functionToUse) {
+            return Promise.resolve(false);
+        } else {
+            return functionToUse.call((navigator as any).xr, sessionMode).then(() => {
+                return Promise.resolve(true);
+            }).catch((e: any) => {
+                Logger.Warn(e);
+                return Promise.resolve(false);
+            });
+        }
     }
 }


### PR DESCRIPTION
The VRExperienceHelper has now a new flag to force using XR, if XR is supported.

If the flag is set to true but XR is not supported, it will continue as before.
If the flag is not set, XR will not be used (default behavior can be changed when we are sure it is working as expected).

Working examples:

https://playground.babylonjs.com/#TAFSN0#323
https://www.babylonjs-playground.com/#B4C2AH#1

Controller interaction SHOULD be the same (and in my tests IS the same), but the XR mapping of the buttons is different than VR, so this might be an issue until https://github.com/BabylonJS/Babylon.js/issues/7091 is closed.

Part task of  https://github.com/BabylonJS/Babylon.js/issues/6993