### PR TITLE
added `useModelMaterial` feature to SPS MultiMaterial support

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -174,7 +174,7 @@
 - Added the feature `expandable` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature `removeParticles()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 - Added the feature "storable particles" and `insertParticlesFromArray()` to the Solid Particle System ([jerome](https://github.com/jbousquie/))
-- Added the support for MultiMaterials to the Solid Particle System ([jerome](https://github.com/jbousquie/))  
+- Added the support for MultiMaterials to the Solid Particle System ([jerome](https://github.com/jbousquie/))
 
 ### Navigation Mesh
 

--- a/src/Particles/solidParticle.ts
+++ b/src/Particles/solidParticle.ts
@@ -7,6 +7,7 @@ import { BoundingSphere } from "../Culling/boundingSphere";
 import { SolidParticleSystem } from "./solidParticleSystem";
 import { AbstractMesh } from '../Meshes/abstractMesh';
 import { Plane } from '../Maths/math.plane';
+import { Material } from '../Materials/material';
 /**
  * Represents one particle of a solid particle system.
  */
@@ -324,6 +325,11 @@ export class ModelShape {
      * @hidden
      */
     public _vertexFunction: Nullable<(particle: SolidParticle, vertex: Vector3, i: number) => void>;
+    /**
+     * Model material (internal use)
+     * @hidden
+     */
+    public _material: Nullable<Material>;
 
     /**
      * Creates a ModelShape object. This is an internal simplified reference to a mesh used as for a model to replicate particles from by the SPS.
@@ -331,7 +337,8 @@ export class ModelShape {
      * @hidden
      */
     constructor(id: number, shape: Vector3[], indices: number[], normals: number[], colors: number[], shapeUV: number[],
-        posFunction: Nullable<(particle: SolidParticle, i: number, s: number) => void>, vtxFunction: Nullable<(particle: SolidParticle, vertex: Vector3, i: number) => void>) {
+        posFunction: Nullable<(particle: SolidParticle, i: number, s: number) => void>, vtxFunction: Nullable<(particle: SolidParticle, vertex: Vector3, i: number) => void>,
+        material: Nullable<Material>) {
         this.shapeID = id;
         this._shape = shape;
         this._indices = indices;
@@ -341,6 +348,7 @@ export class ModelShape {
         this._normals = normals;
         this._positionFunction = posFunction;
         this._vertexFunction = vtxFunction;
+        this._material = material;
     }
 }
 


### PR DESCRIPTION
```javascript
// model1, model2 and model3 are meshes with already set materials at this step
var sps = new BABYLON.SolidParticleSystem('sps', scene, {useModelMaterial: true});
sps.addShape(model1, 300);
sps.addShape(model2, 300)
sps.addShape(model3, 300);
sps.buildMesh();
```
This enables the multimaterial support, then copies the model geometries AND creates automatically the SPS multimaterial with the model materials, with the following rule : 
- if several models share the same material, this material is used only once in the SPS (particles are sorted in this purpose to minimize the draw call numbers)
- if a model has no material, a standard material is created
- if another following model has also no material, the first rule applies : the newly created standard material is shared among the particles depicting all the model with no material.

Moreover, whatever using the model materials, another method is added : `sps.setMultiMaterial()`.  
This automatically computes the subMeshes, then creates and assigns a MultiMaterial object to the SPS mesh from a passed array of materials.
```javascript
var sps = new BABYLON.SolidParticleSystem('sps', scene, {enableMultiMaterial: true});
sps.addShape(model1, 300);
sps.buildMesh();
sps.setMultiMaterial(material1, material2, material3);   // that's it, nothing more to do.
```