### PR TITLE
AmmoJS - Custom Impostor Shapes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -102,6 +102,7 @@
 - Update Ammo.js library to support global collision contact callbacks ([MackeyK24](https://github.com/MackeyK24/))
 - Update Ammo.js library to allow native capsule shape impostors ([MackeyK24](https://github.com/MackeyK24/))
 - Update Ammo.js library to allow your own broadphase overlapping pair cache ([MackeyK24](https://github.com/MackeyK24/))
+- Update Ammo.js library for custom impostor shapes. PhysicsImpostor.CustomImposter type and AmmoJSPlugin.OnCreateCustomShape factoty function ([MackeyK24](https://github.com/MackeyK24/))
 - Update Ammo.js library and AmmoJS plugin to support ellipsoid ([CedricGuillemet](https://github.com/CedricGuillemet/))
 
 ### Loaders

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -145,8 +145,6 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
 
     /**
      * The create custom shape handler function to be called when using BABYLON.PhysicsImposter.CustomImpostor
-     * @param impostor to create the custom shape for
-     * @returns the custom physics impostor shape
      */
     public onCreateCustomShape: (impostor: PhysicsImpostor) => any;
 

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -145,7 +145,8 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
 
     /**
      * The create custom shape handler function to be called when using BABYLON.PhysicsImposter.CustomImpostor
-     * @returns the current timestep in seconds
+     * @param impostor to create the custom shape for
+     * @returns the custom physics impostor shape
      */
     public onCreateCustomShape: (impostor: PhysicsImpostor) => any;
 

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -1263,6 +1263,10 @@ export class PhysicsImpostor {
      */
     public static ConvexHullImpostor = 10;
     /**
+     * Custom-Imposter type (Ammo.js plugin only)
+     */
+    public static CustomImpostor = 100;
+    /**
      * Rope-Imposter type
      */
     public static RopeImpostor = 101;


### PR DESCRIPTION
AmmoJS - Update to allow the use of custom impostor shapes within the native babylon.js physics plugin system.