### PR TITLE
Remove leaf node culling from gltf2 exporter.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -253,3 +253,4 @@
 - Removed external data from Engine (`addExternalData`, `getExternalData`, `getOrAddExternalDataWithFactory`, `removeExternalData`) ([Deltakosh](https://github.com/deltakosh/))
 - The glTF loader extensions that map to glTF 2.0 extensions will now be disabled if the extension is not present in `extensionsUsed`. ([bghgary](https://github.com/bghgary))
 - The STL loader does not create light or camera automatically, please use `scene.createDefaultCameraOrLight();` in your code [Sebavan](https://github.com/sebavan/)
+- The glTF2 exporter extension no longer ignores childless empty nodes.([drigax](https://github.com/drigax))

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1331,12 +1331,9 @@ export class _Exporter {
                         }
                         else {
                             return promise.then((node) => {
-                                const directDescendents = babylonNode.getDescendants(true, (node: Node) => { return (node instanceof Node); });
-                                if (directDescendents.length || node.mesh != null || (node.extensions)) {
-                                    this._nodes.push(node);
-                                    nodeIndex = this._nodes.length - 1;
-                                    nodeMap[babylonNode.uniqueId] = nodeIndex;
-                                }
+                                this._nodes.push(node);
+                                nodeIndex = this._nodes.length - 1;
+                                nodeMap[babylonNode.uniqueId] = nodeIndex;
 
                                 if (!babylonScene.animationGroups.length && babylonNode.animations.length) {
                                     _GLTFAnimation._CreateNodeAnimationFromNodeAnimations(babylonNode, runtimeGLTFAnimation, idleGLTFAnimations, nodeMap, this._nodes, binaryWriter, this._bufferViews, this._accessors, this._convertToRightHandedSystem, this._animationSampleRate);


### PR DESCRIPTION
This PR removes the leaf node culling behavior from the gltf2 exporter, addressing #7152 . This change should improve consistency of exported glTF scenes by no longer removing empty leaf nodes from the scene.