### PR TITLE
Set the scene render mode to intermediate before texture.render

### DIFF
--- a/src/Misc/screenshotTools.ts
+++ b/src/Misc/screenshotTools.ts
@@ -151,6 +151,7 @@ export class ScreenshotTools {
         const renderToTexture = () => {
             scene.incrementRenderId();
             scene.resetCachedMaterial();
+            scene._intermediateRendering = true;
             texture.render(true);
             texture.dispose();
 


### PR DESCRIPTION
When i tried to do screenshot on scenes containing instances, the first screenshot worked well, everything was displayed, as you can see below.

![Test_rals-Version-191127154654667](https://user-images.githubusercontent.com/7492041/69735383-8242c780-1128-11ea-92e3-c6a48bface00.png)

But when i tried to do screenshot a second time some meshes disappeared, all of them are instances.

![Test_rals-Version-191127154125626](https://user-images.githubusercontent.com/7492041/69735474-a56d7700-1128-11ea-90c7-d8bd5b62c78f.png)


When doing a screenshot using render target for the first time, the scene
intermediate rendering is set to false at the end of the
texture.render().

Next time the function is called it makes all instances being avoided
during the render.

This PR is essentially a hotfix and should be edited in order to fix the bug in a correct way.