### PR TITLE
ThumbstickValues now stored in a new variable

### DIFF
--- a/src/Gamepads/Controllers/windowsMotionController.ts
+++ b/src/Gamepads/Controllers/windowsMotionController.ts
@@ -597,9 +597,7 @@ export class XRWindowsMotionController extends WindowsMotionController {
     /**
      * holds the thumbstick values (X,Y)
      */
-    public get thumbstickValues(): StickValues {
-        return this.rightStick;
-    }
+    public thumbstickValues: StickValues = { x: 0, y: 0 };
 
     /**
      * Fired when the thumbstick on this controller is clicked


### PR DESCRIPTION
This prevents the pre-updating of the rightstick values and the "cache" issue that prevents triggering the onThumbstickValuesChanged Observers.

Addressing #7217