### PR TITLE
Add global exclusion list for compressed textures

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -133,6 +133,7 @@
 - Added `pbrBRDFConfiguration.useSpecularGlossinessInputEnergyConservation` to allow Specular-Workflow energy conservation to be turned off ([ColorDigital-PS](https://github.com/ColorDigital-PS)).
 - Added support for the `freeze` / `unfreeze` functions in `ShaderMaterial` ([Popov72](https://github.com/Popov72))
 - Added `depthFunction` new property to `Material` base class ([Popov72](https://github.com/Popov72))
+- Added `setCompressedTextureExclusions` method to `Engine` to allow for skipping compressed textures on certain files ([abogartz](https://github.com/abogartz))
 
 ### ScreenshotTools
 

--- a/src/Engines/Extensions/engine.cubeTexture.ts
+++ b/src/Engines/Extensions/engine.cubeTexture.ts
@@ -131,7 +131,7 @@ ThinEngine.prototype._createDepthStencilCubeTexture = function(size: number, opt
 };
 
 ThinEngine.prototype._partialLoadFile = function(url: string, index: number, loadedFiles: (string | ArrayBuffer)[],
-        onfinish: (files: (string | ArrayBuffer)[]) => void, onErrorCallBack: Nullable<(message?: string, exception?: any) => void> = null): void {
+    onfinish: (files: (string | ArrayBuffer)[]) => void, onErrorCallBack: Nullable<(message?: string, exception?: any) => void> = null): void {
     var onload = (data: string | ArrayBuffer) => {
         loadedFiles[index] = data;
         (<any>loadedFiles)._internalCount++;
@@ -233,10 +233,11 @@ ThinEngine.prototype.createCubeTexture = function(rootUrl: string, scene: Nullab
 
     var lastDot = rootUrl.lastIndexOf('.');
     var extension = forcedExtension ? forcedExtension : (lastDot > -1 ? rootUrl.substring(lastDot).toLowerCase() : "");
+    const filteredFormat: Nullable<string> = ThinEngine.ExcludedCompressedTextureFormats(rootUrl, this._textureFormatInUse);
 
     let loader: Nullable<IInternalTextureLoader> = null;
     for (let availableLoader of ThinEngine._TextureLoaders) {
-        if (excludeLoaders.indexOf(availableLoader) === -1 && availableLoader.canLoad(extension, this._textureFormatInUse, fallback, false, false)) {
+        if (excludeLoaders.indexOf(availableLoader) === -1 && availableLoader.canLoad(extension, filteredFormat, fallback, false, false)) {
             loader = availableLoader;
             break;
         }
@@ -259,7 +260,7 @@ ThinEngine.prototype.createCubeTexture = function(rootUrl: string, scene: Nullab
     };
 
     if (loader) {
-        rootUrl = loader.transformUrl(rootUrl, this._textureFormatInUse);
+        rootUrl = loader.transformUrl(rootUrl, filteredFormat);
 
         const onloaddata = (data: any) => {
             this._bindTextureDirectly(gl.TEXTURE_CUBE_MAP, texture, true);

--- a/src/Engines/Extensions/engine.cubeTexture.ts
+++ b/src/Engines/Extensions/engine.cubeTexture.ts
@@ -233,7 +233,7 @@ ThinEngine.prototype.createCubeTexture = function(rootUrl: string, scene: Nullab
 
     var lastDot = rootUrl.lastIndexOf('.');
     var extension = forcedExtension ? forcedExtension : (lastDot > -1 ? rootUrl.substring(lastDot).toLowerCase() : "");
-    const filteredFormat: Nullable<string> = ThinEngine.ExcludedCompressedTextureFormats(rootUrl, this._textureFormatInUse);
+    const filteredFormat: Nullable<string> = this.excludedCompressedTextureFormats(rootUrl, this._textureFormatInUse);
 
     let loader: Nullable<IInternalTextureLoader> = null;
     for (let availableLoader of ThinEngine._TextureLoaders) {

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1268,11 +1268,11 @@ export class Engine extends ThinEngine {
         return this._gl.getShaderSource(shaders[0]);
     }
 
-   /**
-    * Gets the source code of the fragment shader associated with a specific webGL program
-    * @param program defines the program to use
-    * @returns a string containing the source code of the fragment shader associated with the program
-    */
+    /**
+     * Gets the source code of the fragment shader associated with a specific webGL program
+     * @param program defines the program to use
+     * @returns a string containing the source code of the fragment shader associated with the program
+     */
     public getFragmentShaderSource(program: WebGLProgram): Nullable<string> {
         var shaders = this._gl.getAttachedShaders(program);
 
@@ -1544,6 +1544,16 @@ export class Engine extends ThinEngine {
     }
 
     /**
+     * Set the compressed texture extensions or file names to skip.
+     *
+     * @param skippedFiles defines the list of those texture files you want to skip
+     * Example: [".dds", ".env", "myfile.png"]
+     */
+    public setCompressedTextureExclusions(skippedFiles: Array<string>): void {
+        ThinEngine.ExcludedCompressedTextures = skippedFiles;
+    }
+
+    /**
      * Force a specific size of the canvas
      * @param width defines the new canvas' width
      * @param height defines the new canvas' height
@@ -1710,12 +1720,12 @@ export class Engine extends ThinEngine {
             width: destination.width,
             height: destination.height,
         }, {
-                generateMipMaps: false,
-                type: Constants.TEXTURETYPE_UNSIGNED_INT,
-                samplingMode: Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
-                generateDepthBuffer: false,
-                generateStencilBuffer: false
-            }
+            generateMipMaps: false,
+            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            samplingMode: Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
+            generateDepthBuffer: false,
+            generateStencilBuffer: false
+        }
         );
 
         if (!this._rescalePostProcess && Engine._RescalePostProcessFactory) {

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1550,7 +1550,7 @@ export class Engine extends ThinEngine {
      * Example: [".dds", ".env", "myfile.png"]
      */
     public setCompressedTextureExclusions(skippedFiles: Array<string>): void {
-        this.excludedCompressedTextures = skippedFiles;
+        this._excludedCompressedTextures = skippedFiles;
     }
 
     /**

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1550,7 +1550,7 @@ export class Engine extends ThinEngine {
      * Example: [".dds", ".env", "myfile.png"]
      */
     public setCompressedTextureExclusions(skippedFiles: Array<string>): void {
-        ThinEngine.ExcludedCompressedTextures = skippedFiles;
+        this.excludedCompressedTextures = skippedFiles;
     }
 
     /**

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1475,7 +1475,7 @@ export class ThinEngine {
         return dataBuffer;
     }
 
-    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array 
+    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array
     {
         if (indices instanceof Uint16Array) {
             return indices;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -174,7 +174,7 @@ export class ThinEngine {
     /**
     * Gets or sets the textures that the engine should not attempt to load as compressed
     */
-    protected excludedCompressedTextures: string[] = [];
+    protected _excludedCompressedTextures: string[] = [];
 
     /**
      * Filters the compressed texture formats to only include
@@ -186,7 +186,7 @@ export class ThinEngine {
      */
     public excludedCompressedTextureFormats(url: Nullable<string>, textureFormatInUse: Nullable<string>): Nullable<string> {
         const skipCompression = (): boolean => {
-            return this.excludedCompressedTextures.some((entry) => {
+            return this._excludedCompressedTextures.some((entry) => {
                 const strRegExPattern: string = '\\b' + entry + '\\b';
                 return (url && (url === entry || url.match(new RegExp(strRegExPattern, 'g'))));
             });

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -171,6 +171,29 @@ export class ThinEngine {
         Effect.ShadersRepository = value;
     }
 
+     /**
+     * Gets or sets the textures that the engine should not attempt to load as compressed
+     */
+    public static ExcludedCompressedTextures: string[] = [];
+
+    /**
+     * Filters the compressed texture formats to only include
+     * files that are not included in the skippable list
+     *
+     * @param url the current extension
+     * @param textureFormatInUse the current compressed texture format
+     * @returns "format" string
+     */
+    public static ExcludedCompressedTextureFormats(url: Nullable<string>, textureFormatInUse: Nullable<string>): Nullable<string> {
+        const skipCompression = (): boolean => {
+            return ThinEngine.ExcludedCompressedTextures.some((entry) => {
+                const strRegExPattern: string = '\\b' + entry + '\\b';
+                return (url && url) === entry || (url && url.match(new RegExp(strRegExPattern, 'g')));
+            });
+        };
+        return skipCompression() ? null : textureFormatInUse;
+    }
+
     // Public members
 
     /** @hidden */
@@ -1050,7 +1073,7 @@ export class ThinEngine {
         }
 
         if (this._activeRenderLoops.length > 0) {
-           this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
+            this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
         } else {
             this._renderingQueueLaunched = false;
         }
@@ -1452,7 +1475,7 @@ export class ThinEngine {
         return dataBuffer;
     }
 
-    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array
+    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array 
     {
         if (indices instanceof Uint16Array) {
             return indices;
@@ -2659,17 +2682,18 @@ export class ThinEngine {
         // establish the file extension, if possible
         var lastDot = url.lastIndexOf('.');
         var extension = forcedExtension ? forcedExtension : (lastDot > -1 ? url.substring(lastDot).toLowerCase() : "");
-
+        const filteredFormat: Nullable<string> = ThinEngine.ExcludedCompressedTextureFormats(url, this._textureFormatInUse);
         let loader: Nullable<IInternalTextureLoader> = null;
+
         for (let availableLoader of ThinEngine._TextureLoaders) {
-            if (excludeLoaders.indexOf(availableLoader) === -1 && availableLoader.canLoad(extension, this._textureFormatInUse, fallback, isBase64, buffer ? true : false)) {
+            if (excludeLoaders.indexOf(availableLoader) === -1 && availableLoader.canLoad(extension, filteredFormat, fallback, isBase64, buffer ? true : false)) {
                 loader = availableLoader;
                 break;
             }
         }
 
         if (loader) {
-            url = loader.transformUrl(url, this._textureFormatInUse);
+            url = loader.transformUrl(url, filteredFormat);
         }
 
         if (scene) {
@@ -3987,7 +4011,7 @@ export class ThinEngine {
 
     /** @hidden */
     public _loadFile(url: string, onSuccess: (data: string | ArrayBuffer, responseURL?: string) => void, onProgress?: (data: any) => void,
-    offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (request?: IWebRequest, exception?: any) => void): IFileRequest {
+        offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (request?: IWebRequest, exception?: any) => void): IFileRequest {
         let request = FileTools.LoadFile(url, onSuccess, onProgress, offlineProvider, useArrayBuffer, onError);
         this._activeRequests.push(request);
         request.onCompleteObservable.add((request) => {

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -174,7 +174,7 @@ export class ThinEngine {
     /**
     * Gets or sets the textures that the engine should not attempt to load as compressed
     */
-    public static ExcludedCompressedTextures: string[] = [];
+    protected excludedCompressedTextures: string[] = [];
 
     /**
      * Filters the compressed texture formats to only include
@@ -184,9 +184,9 @@ export class ThinEngine {
      * @param textureFormatInUse the current compressed texture format
      * @returns "format" string
      */
-    public static ExcludedCompressedTextureFormats(url: Nullable<string>, textureFormatInUse: Nullable<string>): Nullable<string> {
+    public excludedCompressedTextureFormats(url: Nullable<string>, textureFormatInUse: Nullable<string>): Nullable<string> {
         const skipCompression = (): boolean => {
-            return ThinEngine.ExcludedCompressedTextures.some((entry) => {
+            return this.excludedCompressedTextures.some((entry) => {
                 const strRegExPattern: string = '\\b' + entry + '\\b';
                 return (url && (url === entry || url.match(new RegExp(strRegExPattern, 'g'))));
             });
@@ -2681,7 +2681,7 @@ export class ThinEngine {
         // establish the file extension, if possible
         var lastDot = url.lastIndexOf('.');
         var extension = forcedExtension ? forcedExtension : (lastDot > -1 ? url.substring(lastDot).toLowerCase() : "");
-        const filteredFormat: Nullable<string> = ThinEngine.ExcludedCompressedTextureFormats(url, this._textureFormatInUse);
+        const filteredFormat: Nullable<string> = this.excludedCompressedTextureFormats(url, this._textureFormatInUse);
         let loader: Nullable<IInternalTextureLoader> = null;
 
         for (let availableLoader of ThinEngine._TextureLoaders) {

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -188,7 +188,7 @@ export class ThinEngine {
         const skipCompression = (): boolean => {
             return ThinEngine.ExcludedCompressedTextures.some((entry) => {
                 const strRegExPattern: string = '\\b' + entry + '\\b';
-                return (url && url === entry) || (url && url.match(new RegExp(strRegExPattern, 'g')));
+                return (url && (url === entry || url.match(new RegExp(strRegExPattern, 'g'))));
             });
         };
         return skipCompression() ? null : textureFormatInUse;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -171,9 +171,9 @@ export class ThinEngine {
         Effect.ShadersRepository = value;
     }
 
-     /**
-     * Gets or sets the textures that the engine should not attempt to load as compressed
-     */
+    /**
+    * Gets or sets the textures that the engine should not attempt to load as compressed
+    */
     public static ExcludedCompressedTextures: string[] = [];
 
     /**
@@ -188,7 +188,7 @@ export class ThinEngine {
         const skipCompression = (): boolean => {
             return ThinEngine.ExcludedCompressedTextures.some((entry) => {
                 const strRegExPattern: string = '\\b' + entry + '\\b';
-                return (url && url) === entry || (url && url.match(new RegExp(strRegExPattern, 'g')));
+                return (url && url === entry) || (url && url.match(new RegExp(strRegExPattern, 'g')));
             });
         };
         return skipCompression() ? null : textureFormatInUse;
@@ -1475,8 +1475,7 @@ export class ThinEngine {
         return dataBuffer;
     }
 
-    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array
-    {
+    protected _normalizeIndexData(indices: IndicesArray): Uint16Array | Uint32Array {
         if (indices instanceof Uint16Array) {
             return indices;
         }


### PR DESCRIPTION
**Issue:** 

Once compressed texture formats are set, there is no way to exclude certain formats, such as .dds or certain image files from attempting to load the `.ktx` version. 

This allows a new method, `setCompressedTextureExclusions` to provide an array of file extensions or file names to exclude.