### PR TITLE
WebXR Teleportation 

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -175,6 +175,7 @@
 - Windows motion controller mapping corrected to XR ([RaananW](https://github.com/RaananW/))
 - Pointer-Event simulation for screen target ray mode ([RaananW](https://github.com/RaananW/))
 - New observable that triggers when a session was initialized ([RaananW](https://github.com/RaananW/))
+- WebXR teleportation can now be disabled after initialized ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/XR/webXRControllerTeleportation.ts
+++ b/src/Cameras/XR/webXRControllerTeleportation.ts
@@ -21,7 +21,7 @@ export class WebXRControllerTeleportation {
     /**
      * when set to true (default) teleportation will wait for thumbstick changes.
      * When set to false teleportation will be disabled.
-     * 
+     *
      * If set to false while teleporting results can be unexpected.
      */
     public enabled: boolean = true;

--- a/src/Cameras/XR/webXRControllerTeleportation.ts
+++ b/src/Cameras/XR/webXRControllerTeleportation.ts
@@ -100,13 +100,13 @@ export class WebXRControllerTeleportation {
                 }
 
                 if (c.inputSource.gamepad) {
-                    if (c.inputSource.gamepad.axes[1] !== undefined) {
+                    if (c.inputSource.gamepad.axes[3] !== undefined) {
                         // Forward teleportation
-                        if (c.inputSource.gamepad.axes[1] < -0.7) {
+                        if (c.inputSource.gamepad.axes[3] < -0.7) {
                             forwardReadyToTeleport = true;
                         } else {
                             if (forwardReadyToTeleport) {
-                                // Teleport the users feet to where they targetted
+                                // Teleport the users feet to where they targeted
                                 this._tmpVector.copyFrom(teleportationTarget.position);
                                 this._tmpVector.y += input.baseExperience.camera.position.y;
                                 input.baseExperience.setPositionOfCameraUsingContainer(this._tmpVector);
@@ -115,7 +115,7 @@ export class WebXRControllerTeleportation {
                         }
 
                         // Backward teleportation
-                        if (c.inputSource.gamepad.axes[1] > 0.7) {
+                        if (c.inputSource.gamepad.axes[3] > 0.7) {
                             backwardReadyToTeleport = true;
                         } else {
                             if (backwardReadyToTeleport) {
@@ -145,8 +145,8 @@ export class WebXRControllerTeleportation {
                         }
                     }
 
-                    if (c.inputSource.gamepad.axes[0] !== undefined) {
-                        if (c.inputSource.gamepad.axes[0] < -0.7) {
+                    if (c.inputSource.gamepad.axes[2] !== undefined) {
+                        if (c.inputSource.gamepad.axes[2] < -0.7) {
                             leftReadyToTeleport = true;
                         } else {
                             if (leftReadyToTeleport) {
@@ -154,7 +154,7 @@ export class WebXRControllerTeleportation {
                             }
                             leftReadyToTeleport = false;
                         }
-                        if (c.inputSource.gamepad.axes[0] > 0.7) {
+                        if (c.inputSource.gamepad.axes[2] > 0.7) {
                             rightReadyToTeleport = true;
                         } else {
                             if (rightReadyToTeleport) {

--- a/src/Cameras/XR/webXRControllerTeleportation.ts
+++ b/src/Cameras/XR/webXRControllerTeleportation.ts
@@ -18,6 +18,8 @@ export class WebXRControllerTeleportation {
     private _tmpRay = new Ray(new Vector3(), new Vector3());
     private _tmpVector = new Vector3();
 
+    public enabled: boolean = true;
+
     /**
      * Creates a WebXRControllerTeleportation
      * @param input input manager to add teleportation to
@@ -81,7 +83,10 @@ export class WebXRControllerTeleportation {
 
             // Handle user input on every frame
             let renderObserver = scene.onBeforeRenderObservable.add(() => {
-                // Move the teleportationTarget to where the user is targetting to teleport to
+                if (!this.enabled) {
+                    return;
+                }
+                // Move the teleportationTarget to where the user is targeting to teleport to
                 if (forwardReadyToTeleport) {
                     c.getWorldPointerRayToRef(this._tmpRay);
                     let pick = scene.pickWithRay(this._tmpRay, (o) => {
@@ -135,7 +140,7 @@ export class WebXRControllerTeleportation {
                                 });
 
                                 if (pick && pick.pickedPoint) {
-                                    // Teleport the users feet to where they targetted
+                                    // Teleport the users feet to where they targeted
                                     this._tmpVector.copyFrom(pick.pickedPoint);
                                     this._tmpVector.y += input.baseExperience.camera.position.y;
                                     input.baseExperience.setPositionOfCameraUsingContainer(this._tmpVector);

--- a/src/Cameras/XR/webXRControllerTeleportation.ts
+++ b/src/Cameras/XR/webXRControllerTeleportation.ts
@@ -18,6 +18,12 @@ export class WebXRControllerTeleportation {
     private _tmpRay = new Ray(new Vector3(), new Vector3());
     private _tmpVector = new Vector3();
 
+    /**
+     * when set to true (default) teleportation will wait for thumbstick changes.
+     * When set to false teleportation will be disabled.
+     * 
+     * If set to false while teleporting results can be unexpected.
+     */
     public enabled: boolean = true;
 
     /**


### PR DESCRIPTION
closing https://github.com/BabylonJS/Babylon.js/issues/7270

Added an `enabled` flag to the loop. if teleportation.enabled set to false, the teleportation will stop working. Notice that if set enabled WHILE teleporting, results can be unexpected.