### PR TITLE
VideoDome in WebXR

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -255,6 +255,7 @@
 - Fix bug when we call `Mesh.render` twice and the material is still not ready on the second call ([barroij](https://github.com/barroij/))
 - Fixed an issue with pose input in webxr ([RaananW](https://github.com/RaananW/))
 - Fixed bug when parsing animation group without 'to' value ([noalak](https://github.com/noalak/))
+- isRightCamer and isLeftCamera were not set in WebXR ([RaananW](https://github.com/RaananW/))
 
 ## Breaking changes
 

--- a/src/Cameras/XR/webXRCamera.ts
+++ b/src/Cameras/XR/webXRCamera.ts
@@ -92,6 +92,14 @@ export class WebXRCamera extends FreeCamera {
         this._updateNumberOfRigCameras(pose.views.length);
         pose.views.forEach((view: any, i: number) => {
             const currentRig = <TargetCamera>this.rigCameras[i];
+            // update right and left, where applicable
+            if (!currentRig.isLeftCamera && !currentRig.isRightCamera) {
+                if (view.eye === 'right') {
+                    currentRig._isRightCamera = true;
+                } else if (view.eye === 'left') {
+                    currentRig._isLeftCamera = true;
+                }
+            }
             // Update view/projection matrix
             if (view.transform.position && view.transform.orientation) {
                 currentRig.position.copyFrom(view.transform.position);


### PR DESCRIPTION
Fixing https://github.com/BabylonJS/Babylon.js/issues/7264

isRightCamera was never set, which is important for the videoDome