### PR TITLE
Check length of XR input sources

### DIFF
--- a/src/Cameras/XR/webXRInput.ts
+++ b/src/Cameras/XR/webXRInput.ts
@@ -47,7 +47,7 @@ export class WebXRInput implements IDisposable {
             }
 
             // Start listing to input add/remove event
-            if (this.controllers.length == 0 && baseExperience.sessionManager.session.inputSources) {
+            if (this.controllers.length == 0 && baseExperience.sessionManager.session.inputSources && baseExperience.sessionManager.session.inputSources.length > 0) {
                 this._addAndRemoveControllers(baseExperience.sessionManager.session.inputSources, []);
                 baseExperience.sessionManager.session.addEventListener("inputsourceschange", this._onInputSourcesChange);
             }


### PR DESCRIPTION
If length is not checked, then if the `XRSession` returns a valid empty array for `inputSources`, a new event listener will be added to the session manager every XR frame. According to [the spec](https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources), it appears that this valid-but-empty scenario can (and perhaps must) occur.