### PR TITLE
Sandbox will now load assets relatively path-ed to same folder

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -257,6 +257,7 @@
 - Fixed an issue with pose input in webxr ([RaananW](https://github.com/RaananW/))
 - Fixed bug when parsing animation group without 'to' value ([noalak](https://github.com/noalak/))
 - isRightCamer and isLeftCamera were not set in WebXR ([RaananW](https://github.com/RaananW/))
+- Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
 
 ## Breaking changes
 

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -87,7 +87,11 @@ export class FileTools {
      * Gets or sets a function used to pre-process url before using them to load assets
      */
     public static PreprocessUrl = (url: string) => {
-        return url;
+        let processedURL = url.substring(5).toLowerCase();
+        if (processedURL.indexOf('./') === 0) {
+            processedURL = processedURL.substring(2);
+          }
+        return processedURL;
     }
 
     /**
@@ -150,7 +154,6 @@ export class FileTools {
         }
         else {
             url = this._CleanUrl(input);
-            url = this.PreprocessUrl(input);
         }
 
         if (typeof Image === "undefined") {
@@ -301,7 +304,8 @@ export class FileTools {
     public static LoadFile(url: string, onSuccess: (data: string | ArrayBuffer, responseURL?: string) => void, onProgress?: (ev: ProgressEvent) => void, offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (request?: WebRequest, exception?: LoadFileError) => void): IFileRequest {
         // If file and file input are set
         if (url.indexOf("file:") !== -1) {
-            const fileName = decodeURIComponent(url.substring(5).toLowerCase());
+            const processedUrl = this.PreprocessUrl(url);
+            const fileName = decodeURIComponent(processedUrl);
             const file = FilesInputStore.FilesToLoad[fileName];
             if (file) {
                 return this.ReadFile(file, onSuccess, onProgress, useArrayBuffer, onError ? (error) => onError(undefined, new LoadFileError(error.message, error.file)) : undefined);
@@ -327,7 +331,6 @@ export class FileTools {
      */
     public static RequestFile(url: string, onSuccess: (data: string | ArrayBuffer, request?: WebRequest) => void, onProgress?: (event: ProgressEvent) => void, offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (error: RequestFileError) => void, onOpened?: (request: WebRequest) => void): IFileRequest {
         url = this._CleanUrl(url);
-        url = this.PreprocessUrl(url);
 
         const loadUrl = this.BaseUrl + url;
 

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -87,11 +87,7 @@ export class FileTools {
      * Gets or sets a function used to pre-process url before using them to load assets
      */
     public static PreprocessUrl = (url: string) => {
-        let processedURL = url.substring(5).toLowerCase();
-        if (processedURL.indexOf('./') === 0) {
-            processedURL = processedURL.substring(2);
-          }
-        return processedURL;
+       return url;
     }
 
     /**
@@ -154,6 +150,7 @@ export class FileTools {
         }
         else {
             url = this._CleanUrl(input);
+            url = this.PreprocessUrl(input);
         }
 
         if (typeof Image === "undefined") {
@@ -304,8 +301,10 @@ export class FileTools {
     public static LoadFile(url: string, onSuccess: (data: string | ArrayBuffer, responseURL?: string) => void, onProgress?: (ev: ProgressEvent) => void, offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (request?: WebRequest, exception?: LoadFileError) => void): IFileRequest {
         // If file and file input are set
         if (url.indexOf("file:") !== -1) {
-            const processedUrl = this.PreprocessUrl(url);
-            const fileName = decodeURIComponent(processedUrl);
+            let fileName = decodeURIComponent(url.substring(5).toLowerCase());
+            if (fileName.indexOf('./') === 0) {
+                fileName = fileName.substring(2);
+            }
             const file = FilesInputStore.FilesToLoad[fileName];
             if (file) {
                 return this.ReadFile(file, onSuccess, onProgress, useArrayBuffer, onError ? (error) => onError(undefined, new LoadFileError(error.message, error.file)) : undefined);
@@ -331,6 +330,7 @@ export class FileTools {
      */
     public static RequestFile(url: string, onSuccess: (data: string | ArrayBuffer, request?: WebRequest) => void, onProgress?: (event: ProgressEvent) => void, offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (error: RequestFileError) => void, onOpened?: (request: WebRequest) => void): IFileRequest {
         url = this._CleanUrl(url);
+        url = this.PreprocessUrl(url);
 
         const loadUrl = this.BaseUrl + url;
 

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -87,7 +87,7 @@ export class FileTools {
      * Gets or sets a function used to pre-process url before using them to load assets
      */
     public static PreprocessUrl = (url: string) => {
-       return url;
+        return url;
     }
 
     /**

--- a/what's new.md
+++ b/what's new.md
@@ -205,6 +205,7 @@
 - Sometimes duplicate controller models are loaded in VR ([TrevorDev](https://github.com/TrevorDev))
 - Particle emit rate and start size over time do not reset on every particle system start ([TrevorDev](https://github.com/TrevorDev))
 - SSAO2 now correctly takes diffuse texture alpha value into account ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
 
 ### Core Engine
 

--- a/what's new.md
+++ b/what's new.md
@@ -205,7 +205,6 @@
 - Sometimes duplicate controller models are loaded in VR ([TrevorDev](https://github.com/TrevorDev))
 - Particle emit rate and start size over time do not reset on every particle system start ([TrevorDev](https://github.com/TrevorDev))
 - SSAO2 now correctly takes diffuse texture alpha value into account ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
 
 ### Core Engine
 


### PR DESCRIPTION
Fix for [#7210](https://github.com/BabylonJS/Babylon.js/issues/7210). Updated FileTools.LoadFiles to preprocess the url string before decoding. This pre-processing removes the "file:/" prefix from the file URL and handles the case when the files are relatively path-ed to the same folder.