### PR TITLE
Update windowsMotionController.ts

### DIFF
--- a/src/Gamepads/Controllers/windowsMotionController.ts
+++ b/src/Gamepads/Controllers/windowsMotionController.ts
@@ -269,7 +269,7 @@ export class WindowsMotionController extends WebVRController {
 
         var meshInfo = this._loadedMeshInfo.buttonMeshes[buttonName];
 
-        if (!meshInfo.unpressed.rotationQuaternion || !meshInfo.pressed.rotationQuaternion || !meshInfo.value.rotationQuaternion) {
+        if (!meshInfo || !meshInfo.unpressed.rotationQuaternion || !meshInfo.pressed.rotationQuaternion || !meshInfo.value.rotationQuaternion) {
             return;
         }
 


### PR DESCRIPTION
Since the motion controller is the default controller it leads to  problems when used with other generic controllers like the mozilla xr emulator. 

Make sure the mesh info exists before checking other variables