### PR TITLE
Playground will now render the returned scene from createScene() when there are multiple scenes added to engine

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -138,8 +138,17 @@ compileAndRun = function(parent, fpsLabel) {
             }
 
             engine = engine;
+            var sceneToRender;
+            if(scene.then) {
+                scene.then(s => {
+                    sceneToRender = s;
+                });
+            } else {
+                sceneToRender = scene;
+            }
+
             engine.runRenderLoop(function () {
-                if (engine.scenes.length === 0) {
+                if (!sceneToRender) {
                     return;
                 }
 
@@ -147,10 +156,9 @@ compileAndRun = function(parent, fpsLabel) {
                     engine.resize();
                 }
 
-                var scene = engine.scenes[0];
 
-                if (scene.activeCamera || scene.activeCameras.length > 0) {
-                    scene.render();
+                if (sceneToRender.activeCamera || sceneToRender.activeCameras.length > 0) {
+                    sceneToRender.render();
                 }
 
                 fpsLabel.innerHTML = engine.getFps().toFixed() + " fps";

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -265,6 +265,7 @@
 - Fixed bug when parsing animation group without 'to' value ([noalak](https://github.com/noalak/))
 - isRightCamera and isLeftCamera were not set in WebXR ([RaananW](https://github.com/RaananW/))
 - Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
+- Playground will now render the returned scene from createScene() when there are multiple scenes added to engine([Kyle Belfort](https://github.com/belfortk))
 
 ## Breaking changes
 


### PR DESCRIPTION
Fix for #7295.

update the scene used in engine.runRenderLoop callback from engine.scenes[0] to the one returned from createScene() in the playground script.