### PR TITLE
Playground will add .env files to textures in .zip folder on download

### DIFF
--- a/Playground/js/zipTool.js
+++ b/Playground/js/zipTool.js
@@ -67,7 +67,7 @@ class ZipTool {
         }
 
         if (textures[index].isCube) {
-            if (textures[index].name.indexOf("dds") === -1) {
+            if (textures[index].name.indexOf("dds") === -1 && textures[index].name.indexOf(".env") === -1) {
                 if (textures[index]._extensions) {
                     for (var i = 0; i < 6; i++) {
                         textures.push({ name: textures[index].name + textures[index]._extensions[i] });

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -265,8 +265,9 @@
 - Fixed an issue with pose input in webxr ([RaananW](https://github.com/RaananW/))
 - Fixed bug when parsing animation group without 'to' value ([noalak](https://github.com/noalak/))
 - isRightCamera and isLeftCamera were not set in WebXR ([RaananW](https://github.com/RaananW/))
-- Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
-- Playground will now render the returned scene from createScene() when there are multiple scenes added to engine([Kyle Belfort](https://github.com/belfortk))
+- Sandbox will now load assets relatively path-ed to same folder ([Kyle Belfort](https://github.com/belfortk))
+- Playground will now render the returned scene from createScene() when there are multiple scenes added to engine ([Kyle Belfort](https://github.com/belfortk))
+- Fixed bug so Playground will now download .env texture files to ./textures in .zip  ([Kyle Belfort](https://github.com/belfortk))
 
 ## Breaking changes
 


### PR DESCRIPTION
In reference to bug @sebavan assigned to me for this [comment](https://github.com/BabylonJS/Babylon.js/pull/7302#issuecomment-564914373).

When downloading PG contents, .env textures weren't downloaded.  I updated the zipTools.addTexturesToZip() function to added .env files to the textures folder.