### PR TITLE
added setters for laser and gaze colors

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -267,6 +267,7 @@
 - isRightCamera and isLeftCamera were not set in WebXR ([RaananW](https://github.com/RaananW/))
 - Sandbox will now load assets relatively path-ed to same folder([Kyle Belfort](https://github.com/belfortk))
 - Playground will now render the returned scene from createScene() when there are multiple scenes added to engine([Kyle Belfort](https://github.com/belfortk))
+- It was not possible to change the gaze and laser color in VR ([#7323](https://github.com/BabylonJS/Babylon.js/issues/7323)) ([RaananW](https://github.com/RaananW/))
 
 ## Breaking changes
 

--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -429,6 +429,11 @@ export class VRExperienceHelper {
     private _leftController: Nullable<VRExperienceHelperControllerGazer> = null;
     private _rightController: Nullable<VRExperienceHelperControllerGazer> = null;
 
+    private _gazeColor: Color3 = new Color3(0.7, 0.7, 0.7);
+    private _laserColor: Color3 = new Color3(0.7, 0.7, 0.7);
+    private _pickedLaserColor: Color3 = new Color3(0.2, 0.2, 1);
+    private _pickedGazeColor: Color3 = new Color3(0, 0, 1);
+
     /**
      * Observable raised when a new mesh is selected based on meshSelectionPredicate
      */
@@ -2193,13 +2198,13 @@ export class VRExperienceHelper {
                     this.onNewMeshPicked.notifyObservers(hit);
                     gazer._currentMeshSelected = hit.pickedMesh;
                     if (hit.pickedMesh.isPickable && hit.pickedMesh.actionManager) {
-                        this.changeGazeColor(new Color3(0, 0, 1));
-                        this.changeLaserColor(new Color3(0.2, 0.2, 1));
+                        this.changeGazeColor(this._pickedGazeColor);
+                        this.changeLaserColor(this._pickedLaserColor);
                         gazer._isActionableMesh = true;
                     }
                     else {
-                        this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
-                        this.changeLaserColor(new Color3(0.7, 0.7, 0.7));
+                        this.changeGazeColor(this._gazeColor);
+                        this.changeLaserColor(this._laserColor);
                         gazer._isActionableMesh = false;
                     }
                     try {
@@ -2216,8 +2221,8 @@ export class VRExperienceHelper {
                 else {
                     this._notifySelectedMeshUnselected(gazer._currentMeshSelected);
                     gazer._currentMeshSelected = null;
-                    this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
-                    this.changeLaserColor(new Color3(0.7, 0.7, 0.7));
+                    this.changeGazeColor(this._gazeColor);
+                    this.changeLaserColor(this._laserColor);
                 }
             }
         }
@@ -2225,8 +2230,8 @@ export class VRExperienceHelper {
             this._notifySelectedMeshUnselected(gazer._currentMeshSelected);
             gazer._currentMeshSelected = null;
             //this._teleportationAllowed = false;
-            this.changeGazeColor(new Color3(0.7, 0.7, 0.7));
-            this.changeLaserColor(new Color3(0.7, 0.7, 0.7));
+            this.changeGazeColor(this._gazeColor);
+            this.changeLaserColor(this._laserColor);
         }
     }
 
@@ -2234,6 +2239,26 @@ export class VRExperienceHelper {
         if (mesh) {
             this.onSelectedMeshUnselected.notifyObservers(mesh);
         }
+    }
+
+    /**
+     * Permanently set new colors for the laser pointer
+     * @param color the new laser color
+     * @param pickedColor the new laser color when picked mesh detected
+     */
+    public setLaserColor(color: Color3, pickedColor: Color3 = this._pickedLaserColor) {
+        this._laserColor = color;
+        this._pickedLaserColor = pickedColor;
+    }
+
+    /**
+     * Permanently set new colors for the gaze pointer
+     * @param color the new gaze color
+     * @param pickedColor the new gaze color when picked mesh detected
+     */
+    public setGazeColor(color: Color3, pickedColor: Color3 = this._pickedGazeColor) {
+        this._gazeColor = color;
+        this._pickedGazeColor = pickedColor;
     }
 
     /**


### PR DESCRIPTION
Addressing https://github.com/BabylonJS/Babylon.js/issues/7323

Using the new setLaserColor and setGazeColor you can permanently change the color that will be set by the `_castRayAndSelectObject` function

New signature:

```
/**
 * Permanently set new colors for the laser pointer
 * @param color the new laser color
 * @param pickedColor the new laser color when picked mesh detected
 */
setLaserColor(color: Color3, pickedColor?: Color3);
```