### PR TITLE
Delete of the root node on GLB export

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -269,6 +269,7 @@
 - Playground will now render the returned scene from createScene() when there are multiple scenes added to engine ([Kyle Belfort](https://github.com/belfortk))
 - Fixed bug so Playground will now download .env texture files to ./textures in .zip  ([Kyle Belfort](https://github.com/belfortk))
 - It was not possible to change the gaze and laser color in VR ([#7323](https://github.com/BabylonJS/Babylon.js/issues/7323)) ([RaananW](https://github.com/RaananW/))
+- Delete the root node on GLB export ([Bloadrick](https://github.com/Bloadrick/))
 
 ## Breaking changes
 


### PR DESCRIPTION
We have fixed this issue:  https://github.com/BabylonJS/Babylon.js/issues/6349

The root node on GLB export is successfuly removed for the export. 

I have 2 things to point out about this implementation:

- We are toggling the coordinate system  (x = !x), would you prefer to set an explicit value  (x=true) in case the user manually edit the 'useRightHandedSystem' ?

- The asynchronous export causes the scene to have its normals inverted during the export, would you prefer we made it synchronous with a loading screen ?

