### PR TITLE
load babylon.serializers.js when using the debug playground page

### DIFF
--- a/Playground/debug.html
+++ b/Playground/debug.html
@@ -94,7 +94,7 @@
 
 
 
-    <script src="https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js"></script>
+    <script src="https://preview.babylonjs.com/serializers/babylonjs.serializers.js"></script>
 
     <!-- Monaco -->
     <script src="node_modules/monaco-editor/dev/vs/loader.js"></script>


### PR DESCRIPTION
as titled, the debug Playgrounds page loads in the minified babylonjs.serializers.js script, this changes this to load the non-minimized script instead.