### PR TITLE
Add DirectionalLight.autoCalcShadowZBounds property

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -51,6 +51,7 @@
 - Allow setting of `BABYLON.Basis.JSModuleURL` and `BABYLON.Basis.WasmModuleURL`, for hosting the Basis transcoder locally ([JasonAyre])(https://github.com/jasonyre))
 - PNG support for browsers not supporting SVG ([RaananW](https://github.com/RaananW/))
 - Device orientation event permissions for iOS 13+ ([RaananW](https://github.com/RaananW/))
+- Added `DirectionalLight.autoCalcShadowZBounds` to automatically compute the `shadowMinZ` and `shadowMaxZ` values ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/src/Lights/directionalLight.ts
+++ b/src/Lights/directionalLight.ts
@@ -67,6 +67,7 @@ export class DirectionalLight extends ShadowLight {
      * Automatically compute the shadowMinZ and shadowMaxZ for the projection matrix to best fit (including all the casters)
      * on each frame. autoUpdateExtends must be set to true for this to work
      */
+    @serialize()
     public autoCalcShadowZBounds = false;
 
     // Cache

--- a/src/Lights/directionalLight.ts
+++ b/src/Lights/directionalLight.ts
@@ -63,6 +63,12 @@ export class DirectionalLight extends ShadowLight {
     @serialize()
     public autoUpdateExtends = true;
 
+    /**
+     * Automatically compute the shadowMinZ and shadowMaxZ for the projection matrix to best fit (including all the casters)
+     * on each frame. autoUpdateExtends must be set to true for this to work
+     */
+    public autoCalcShadowZBounds = false;
+
     // Cache
     private _orthoLeft = Number.MAX_VALUE;
     private _orthoRight = Number.MIN_VALUE;
@@ -148,6 +154,9 @@ export class DirectionalLight extends ShadowLight {
             this._orthoTop = Number.MIN_VALUE;
             this._orthoBottom = Number.MAX_VALUE;
 
+            var shadowMinZ = Number.MAX_VALUE;
+            var shadowMaxZ = Number.MIN_VALUE;
+
             for (var meshIndex = 0; meshIndex < renderList.length; meshIndex++) {
                 var mesh = renderList[meshIndex];
 
@@ -174,7 +183,20 @@ export class DirectionalLight extends ShadowLight {
                     if (tempVector3.y > this._orthoTop) {
                         this._orthoTop = tempVector3.y;
                     }
+                    if (this.autoCalcShadowZBounds) {
+                        if (tempVector3.z < shadowMinZ) {
+                            shadowMinZ = tempVector3.z;
+                        }
+                        if (tempVector3.z > shadowMaxZ) {
+                            shadowMaxZ = tempVector3.z;
+                        }
+                    }
                 }
+            }
+
+            if (this.autoCalcShadowZBounds) {
+                this._shadowMinZ = shadowMinZ;
+                this._shadowMaxZ = shadowMaxZ;
             }
         }
 

--- a/src/Lights/shadowLight.ts
+++ b/src/Lights/shadowLight.ts
@@ -165,7 +165,7 @@ export abstract class ShadowLight extends Light implements IShadowLight {
         this._setDirection(value);
     }
 
-    private _shadowMinZ: number;
+    protected _shadowMinZ: number;
     /**
      * Gets the shadow projection clipping minimum z value.
      */
@@ -181,7 +181,7 @@ export abstract class ShadowLight extends Light implements IShadowLight {
         this.forceProjectionMatrixCompute();
     }
 
-    private _shadowMaxZ: number;
+    protected _shadowMaxZ: number;
     /**
      * Sets the shadow projection clipping maximum z value.
      */


### PR DESCRIPTION
The min/max X/Y best fit bounds are calculated when `autoUpdateExtends` is `true` but not the min/max Z.

When `autoCalcShadowZBounds` is set to `true`, min/max Z best fit will also be calculated (the values being set to `shadowMinZ` / `shadowMaxZ`).

Note I had to switch `private` to `protected` for the `ShadowLight.shadowMin/MaxZ` properties because calling their setter leads to the projection matrix being recomputed, something we don't want because we are already in the function that computes this matrix when we set those properties!

This auto calculation allows better fit in Z, so better precision in the shadow map:

![image](https://user-images.githubusercontent.com/4152247/71029992-d7af3a80-2110-11ea-8ebc-858a21d16ce3.png) ![image](https://user-images.githubusercontent.com/4152247/71030026-e72e8380-2110-11ea-8aae-e6b7895de7cc.png)

Left: depth map with zmin/zmax values I set manually (that I thought were good...)
Right: depth map with auto-calculated zmin/zmax. You can see there's a better range of Z values

Also, maybe more importantly, it frees the user from setting the `shadowMinZ` / `shadowMaxZ` manually. Generally, those properties are left untouched, and so the camera near / far Z values are used instead (which is generally awful). When they are set, setting the best values can be difficult and will change when objects / light move.