### PR TITLE
Fix Safari inverting exported textures

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -269,6 +269,7 @@
 - Playground will now render the returned scene from createScene() when there are multiple scenes added to engine ([Kyle Belfort](https://github.com/belfortk))
 - Fixed bug so Playground will now download .env texture files to ./textures in .zip  ([Kyle Belfort](https://github.com/belfortk))
 - It was not possible to change the gaze and laser color in VR ([#7323](https://github.com/BabylonJS/Babylon.js/issues/7323)) ([RaananW](https://github.com/RaananW/))
+- Fixed issue where textures exported using Safari web browser are Y mirrored. ([#7352](https://github.com/BabylonJS/Babylon.js/issues/7352)) ([Drigax](https://github.com/drigax))
 
 ## Breaking changes
 

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -327,7 +327,7 @@ export class _Exporter {
     }
 
     /**
-     * Lazy load a local engine with premultiplied alpha set to false
+     * Lazy load a local engine
      */
     public _getLocalEngine(): Engine {
         if (!this._localEngine) {
@@ -335,11 +335,7 @@ export class _Exporter {
             localCanvas.id = "WriteCanvas";
             localCanvas.width = 2048;
             localCanvas.height = 2048;
-            if (Tools.IsSafari()) {
-                this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: true, preserveDrawingBuffer: true });
-            } else {
-                this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: false, preserveDrawingBuffer: true });
-            }
+            this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: Tools.IsSafari(), preserveDrawingBuffer: true });
             this._localEngine.setViewport(new Viewport(0, 0, 1, 1));
         }
 

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -335,7 +335,11 @@ export class _Exporter {
             localCanvas.id = "WriteCanvas";
             localCanvas.width = 2048;
             localCanvas.height = 2048;
-            this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: false, preserveDrawingBuffer: true });
+            if (Tools.IsSafari()) {
+                this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: true, preserveDrawingBuffer: true });
+            } else {
+                this._localEngine = new Engine(localCanvas, true, { premultipliedAlpha: false, preserveDrawingBuffer: true });
+            }
             this._localEngine.setViewport(new Viewport(0, 0, 1, 1));
         }
 

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -1215,6 +1215,14 @@ export class AsyncLoop {
             }
         }, callback);
     }
+
+    /**
+     * Utility function to detect if the current user agent is Safari
+     * @returns whether or not the current user agent is safari
+     */
+    public static IsSafari() : boolean {
+        return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    }
 }
 
 // Will only be define if Tools is imported freeing up some space when only engine is required

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -1098,6 +1098,14 @@ export class Tools {
             }, delay);
         });
     }
+
+    /**
+     * Utility function to detect if the current user agent is Safari
+     * @returns whether or not the current user agent is safari
+     */
+    public static IsSafari() : boolean {
+        return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    }
 }
 
 /**
@@ -1214,14 +1222,6 @@ export class AsyncLoop {
                 }, timeout);
             }
         }, callback);
-    }
-
-    /**
-     * Utility function to detect if the current user agent is Safari
-     * @returns whether or not the current user agent is safari
-     */
-    public static IsSafari() : boolean {
-        return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     }
 }
 


### PR DESCRIPTION
Fix for issue where Safari canvas is drawn Y down, workaround was discovered where premultiplying alpha causes correct canvas orientation. Added utility method to detect Safari browser to use this alternate engine initializing path.

Addressing #7352 