### PR TITLE
Transparent meshes are not displayed when calling geometryBufferRenderer customRenderFunction before rendering the scene

### DIFF
--- a/src/Rendering/geometryBufferRenderer.ts
+++ b/src/Rendering/geometryBufferRenderer.ts
@@ -431,6 +431,10 @@ export class GeometryBufferRenderer {
             for (index = 0; index < alphaTestSubMeshes.length; index++) {
                 renderSubMesh(alphaTestSubMeshes.data[index]);
             }
+
+            for (index = 0; index < transparentSubMeshes.length; index++) {
+                renderSubMesh(transparentSubMeshes.data[index]);
+            }
         };
     }
 


### PR DESCRIPTION
In my project since babylon 4.1 my transparent instances were not
rendered.

After some investigation if found that i was using a rendertarget that
renders my submeshes with this function.

As this function doesn't render the transparent meshes, those meshes
`_internalAbstractMeshDataInfo._isActiveIntermediate` property keep
containing true.

So when rendering the next frame, during `Scene._evaluteActiveMeshes`
those transparent instances are considered as style active when calling
`InstancedMesh._activate`.

This cause the meshes to not being dispatched in `RenderingGroups` and not
being rendered.

This fix work but you may take a closer look at the reason why only
alpha and opaque meshes were initially rendered.

If this solution is not optimal, it is also possible to do that, it is also possible to check and disable each active states in `Mesh.render` but that will set the mesh as inactive the first time the scene is rendered through the rendertarget.

```JS
if (this._internalAbstractMeshDataInfo._isActiveIntermediate) {
    this._internalAbstractMeshDataInfo._isActiveIntermediate = false;
}
if (this._internalAbstractMeshDataInfo._isActive) {
    this._internalAbstractMeshDataInfo._isActive = false;
}
```