### PR TITLE
Force controller profile in WebXR

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -183,6 +183,7 @@
 - New features - Plane detection, Hit Test, Background remover ([RaananW](https://github.com/RaananW/))
 - Camera's API is Babylon-conform (position, rotationQuaternion, world matrix, direction etc') ([#7239](https://github.com/BabylonJS/Babylon.js/issues/7239)) ([RaananW](https://github.com/RaananW/))
 - XR Input now using standard profiles and completely separated from the gamepad class ([#7348](https://github.com/BabylonJS/Babylon.js/issues/7348)) ([RaananW](https://github.com/RaananW/))
+- It is now possible to force a certain profile type for the controllers ([#7348](https://github.com/BabylonJS/Babylon.js/issues/7375)) ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/XR/motionController/webXRMotionControllerManager.ts
+++ b/src/Cameras/XR/motionController/webXRMotionControllerManager.ts
@@ -44,9 +44,18 @@ export class WebXRMotionControllerManager {
      *
      * @param xrInput the xrInput to which a new controller is initialized
      * @param scene the scene to which the model will be added
+     * @param forceProfile force a certain profile for this controller
      * @return the motion controller class for this profile id or the generic standard class if none was found
      */
-    public static GetMotionControllerWithXRInput(xrInput: XRInputSource, scene: Scene): WebXRAbstractMotionController {
+    public static GetMotionControllerWithXRInput(xrInput: XRInputSource, scene: Scene, forceProfile?: string): WebXRAbstractMotionController {
+        //if a type was forced, try creating a controller using it. Continue if not found.
+        if (forceProfile) {
+            const constructionFunction = this._AvailableControllers[forceProfile];
+            if (constructionFunction) {
+                return constructionFunction(xrInput, scene);
+            }
+        }
+
         for (let i = 0; i < xrInput.profiles.length; ++i) {
             const constructionFunction = this._AvailableControllers[xrInput.profiles[i]];
             if (constructionFunction) {

--- a/src/Cameras/XR/webXRController.ts
+++ b/src/Cameras/XR/webXRController.ts
@@ -39,12 +39,13 @@ export class WebXRController {
      * @see https://doc.babylonjs.com/how_to/webxr
      * @param scene the scene which the controller should be associated to
      * @param inputSource the underlying input source for the controller
-     * @param parentContainer parent that the controller meshes should be children of
+     * @param controllerProfile An optional controller profile for this input. This will override the xrInput profile.
      */
     constructor(
         private scene: Scene,
         /** The underlying input source for the controller  */
-        public inputSource: XRInputSource) {
+        public inputSource: XRInputSource,
+        controllerProfile?: string) {
         this.pointer = new AbstractMesh("controllerPointer", scene);
         this.pointer.rotationQuaternion = new Quaternion();
 
@@ -55,7 +56,7 @@ export class WebXRController {
 
         // for now only load motion controllers if gamepad available
         if (this.inputSource.gamepad) {
-            this.gamepadController = WebXRMotionControllerManager.GetMotionControllerWithXRInput(inputSource, scene);
+            this.gamepadController = WebXRMotionControllerManager.GetMotionControllerWithXRInput(inputSource, scene, controllerProfile);
             // if the model is loaded, do your thing
             this.gamepadController.onModelLoadedObservable.addOnce(() => {
                 this.gamepadController!.rootMesh!.parent = this.pointer;

--- a/src/Cameras/XR/webXRInput.ts
+++ b/src/Cameras/XR/webXRInput.ts
@@ -13,6 +13,13 @@ export interface IWebXRInputOptions {
      * If set to true no model will be automatically loaded
      */
     doNotLoadControllerMeshes?: boolean;
+
+    /**
+     * If set, this profile will be used for all controllers loaded (for example "microsoft-mixed-reality")
+     * If not found, the xr input profile data will be used.
+     * Profiles are defined here - https://github.com/immersive-web/webxr-input-profiles/
+     */
+    forceInputProfile?: string;
 }
 /**
  * XR input used to track XR inputs such as controllers/rays
@@ -77,7 +84,7 @@ export class WebXRInput implements IDisposable {
         let sources = this.controllers.map((c) => { return c.inputSource; });
         for (let input of addInputs) {
             if (sources.indexOf(input) === -1) {
-                let controller = new WebXRController(this.xrSessionManager.scene, input);
+                let controller = new WebXRController(this.xrSessionManager.scene, input, this.options.forceInputProfile);
                 this.controllers.push(controller);
                 if (!this.options.doNotLoadControllerMeshes && controller.gamepadController) {
                     controller.gamepadController.loadModel();


### PR DESCRIPTION
As a solutions which dont (hopefully _STILL_ dont) support controller profiles and have already removed the gamepad ID, we introduce a way to force the type of controller when constructing a new motion controller.

Generally addressing #7375 . 

To use, add inputOptions to the options of the default experience helper:

```javascript
const xr = await scene.createDefaultXRExperienceAsync({
    inputOptions: {
        forceInputProfile: "microsoft-mixed-reality"
    }
});
```