### PR TITLE
WebXR - Other Ray Modes in Select and Trigger teleportation

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -189,6 +189,7 @@
 - Teleportation allows selecting direction before teleporting when using thumbstick/touchpad. ([#7290](https://github.com/BabylonJS/Babylon.js/issues/7290)) ([RaananW](https://github.com/RaananW/))
 - It is now possible to force a certain profile type for the controllers ([#7348](https://github.com/BabylonJS/Babylon.js/issues/7375)) ([RaananW](https://github.com/RaananW/))
 - WebXR camera is initialized on the first frame ([#7389](https://github.com/BabylonJS/Babylon.js/issues/7389)) ([RaananW](https://github.com/RaananW/))
+- Selection has forcable gaze mode and touch-screen support ([#7395](https://github.com/BabylonJS/Babylon.js/issues/7395)) ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
@@ -300,16 +300,15 @@ export class WebXRControllerPointerSelection implements IWebXRFeature {
                         downTriggered = true;
                         // pointer up right after down, if disable on touch out
                         if (this._options.disablePointerUpOnTouchOut) {
-                            discMesh.isVisible = false;
                             this._scene.simulatePointerUp(controllerData.pick, { pointerId: controllerData.id });
                         } else {
-                            discMesh.isVisible = false;
                             this._scene.simulatePointerMove(controllerData.pick, { pointerId: controllerData.id });
                         }
-                        // timer = 0;
+                        discMesh.isVisible = false;
+                    } else {
+                        const scaleFactor = 1 - (timer / timeToSelect);
+                        discMesh.scaling.set(scaleFactor, scaleFactor, scaleFactor);
                     }
-                    const scaleFactor = 1 - (timer / timeToSelect);
-                    discMesh.scaling.set(scaleFactor, scaleFactor, scaleFactor);
                 } else {
                     if (downTriggered) {
                         if (!this._options.disablePointerUpOnTouchOut) {

--- a/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
@@ -422,7 +422,6 @@ export class WebXRControllerPointerSelection implements IWebXRFeature {
     private _updatePointerDistance(_laserPointer: AbstractMesh, distance: number = 100) {
         _laserPointer.scaling.y = distance;
         _laserPointer.position.z = distance / 2;
-        console.log(distance, _laserPointer.position);
     }
 
     /**

--- a/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
@@ -210,6 +210,7 @@ export class WebXRControllerPointerSelection implements IWebXRFeature {
      * Get the xr controller that correlates to the pointer id in the pointer event
      *
      * @param id the pointer id to search for
+     * @returns the controller that correlates to this id or null if not found
      */
     public getXRControllerByPointerId(id: number): Nullable<WebXRController> {
         const keys = Object.keys(this._controllers);


### PR DESCRIPTION
Closes #7395 and #7397 

* It is now possible to use trigger to teleport (with N ms delay, set in the options, defaults to 3 seconds)
* Selection now supports Touch mode (for ar on touchscreens) and gaze mode. 

Gaze mode will focus on a specific mesh, wait for a specific timeout (configurable, defaults to 3 seconds) and will trigger a pointer down after this time interval, unless the pointer moved more then a configurable delta.

It is possible to force gaze mode on normal controllers as well