### PR TITLE
Ensure integer values for height and width when taking screenshots

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -285,6 +285,7 @@
 - Fix a bug when resizing a MRT ([Popov72](https://github.com/Popov72))
 - Fixed an infinite clone recursion bug in `InstancedMesh` due to `DeepCopier.DeepCopy` cloning `parent` ([Poolminer](https://github.com/Poolminer/))
 - Fixed an issue with multiview textures ([RaananW](https://github.com/RaananW/))
+- Screenshot height and width is now forced to be integers to prevent mismatch with openGL context ([jekelija](https://github.com/jekelija))
 
 ## Breaking changes
 

--- a/src/Misc/screenshotTools.ts
+++ b/src/Misc/screenshotTools.ts
@@ -251,6 +251,17 @@ export class ScreenshotTools {
             width = size;
         }
 
+        // When creating the image data from the CanvasRenderingContext2D, the width and height is clamped to the size of the _gl context
+        // On certain GPUs, it seems as if the _gl context truncates to an integer automatically. Therefore, if a user tries to pass the width of their canvas element
+        // and it happens to be a float (1000.5 x 600.5 px), the engine.readPixels will return a different size array than context.createImageData
+        // to resolve this, we truncate the floats here to ensure the same size
+        if (width) {
+            width = Math.floor(width);
+        }
+        if (height) {
+            height = Math.floor(height);
+        }
+
         return { height: height | 0, width: width | 0 };
     }
 }

--- a/what's new.md
+++ b/what's new.md
@@ -205,7 +205,6 @@
 - Sometimes duplicate controller models are loaded in VR ([TrevorDev](https://github.com/TrevorDev))
 - Particle emit rate and start size over time do not reset on every particle system start ([TrevorDev](https://github.com/TrevorDev))
 - SSAO2 now correctly takes diffuse texture alpha value into account ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Screenshot height and width is now forced to be integers to prevent mismatch with openGL context ([jekelija](https://github.com/jekelija))
 
 ### Core Engine
 

--- a/what's new.md
+++ b/what's new.md
@@ -205,6 +205,7 @@
 - Sometimes duplicate controller models are loaded in VR ([TrevorDev](https://github.com/TrevorDev))
 - Particle emit rate and start size over time do not reset on every particle system start ([TrevorDev](https://github.com/TrevorDev))
 - SSAO2 now correctly takes diffuse texture alpha value into account ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Screenshot height and width is now forced to be integers to prevent mismatch with openGL context ([jekelija](https://github.com/jekelija))
 
 ### Core Engine
 


### PR DESCRIPTION
When creating the image data from the CanvasRenderingContext2D, the width and height is clamped to the size of the _gl context
On certain GPUs, it seems as if the _gl context truncates to an integer automatically. Therefore, if a user tries to pass the width of their canvas element and it happens to be a float (1000.5 x 600.5 px), the engine.readPixels will return a different size array than context.createImageData to resolve this, we truncate the floats here to ensure the same size