### PR TITLE
CSM Fix shadow bound calculation

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -287,6 +287,7 @@
 - Fixed an infinite clone recursion bug in `InstancedMesh` due to `DeepCopier.DeepCopy` cloning `parent` ([Poolminer](https://github.com/Poolminer/))
 - Fixed an issue with multiview textures ([RaananW](https://github.com/RaananW/))
 - Screenshot height and width is now forced to be integers to prevent mismatch with openGL context ([jekelija](https://github.com/jekelija))
+- Fix shadow bound calculation in CSM shadow technique ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -421,6 +421,21 @@ export class CascadedShadowGenerator implements IShadowGenerator {
                 this._scbiMin.minimizeInPlace(boundingBox.minimumWorld);
                 this._scbiMax.maximizeInPlace(boundingBox.maximumWorld);
             }
+
+            const meshes = this._scene.meshes;
+            for (let meshIndex = 0; meshIndex < meshes.length; meshIndex++) {
+                const mesh = meshes[meshIndex];
+
+                if (!mesh || !mesh.isVisible || !mesh.isEnabled || !mesh.receiveShadows) {
+                    continue;
+                }
+
+                const boundingInfo = mesh.getBoundingInfo(),
+                      boundingBox = boundingInfo.boundingBox;
+
+                this._scbiMin.minimizeInPlace(boundingBox.minimumWorld);
+                this._scbiMax.maximizeInPlace(boundingBox.maximumWorld);
+            }
         }
 
         this._shadowCastersBoundingInfo.reConstruct(this._scbiMin, this._scbiMax);


### PR DESCRIPTION
There are still some rendering artifacts, due to computing the shadow bounding infos without taking into account the shadow receivers:

https://www.babylonjs-playground.com/#IIZ9UU#35

![image](https://user-images.githubusercontent.com/4152247/72158641-01c7e580-33bb-11ea-8880-461550cd6978.png)

So, shadow receivers have to be accounted for in the calculation.

It's an easy fix, but to be optimal we would need to have the list of shadow receivers that are not also shadow casters, to avoid doing the bounding box update twice if the mesh is both shadow caster and receiver. The calculation is not heavy:

```javascript
    this._scbiMin.minimizeInPlace(boundingBox.minimumWorld);
    this._scbiMax.maximizeInPlace(boundingBox.maximumWorld);
```
but it could be avoided with the aforementioned list.

However, I don't know how to maintain this list efficiently...