### PR TITLE
Add the RenderTargetTexture.getCustomRenderList user function

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -56,6 +56,7 @@
 - Added `CascadedShadowGenerator.autoCalcDepthBounds` to improve the shadow quality rendering ([Popov72](https://github.com/Popov72))
 - Improved cascade blending in CSM shadow technique ([Popov72](https://github.com/Popov72))
 - Speed optimization when cascade blending is not used in CSM shadow technique ([Popov72](https://github.com/Popov72))
+- Added `RenderTargetTexture.getCustomRenderList` to overload the render list at rendering time (and possibly for each layer (2DArray) / face (Cube)) ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -598,10 +598,8 @@ export class CascadedShadowGenerator implements IShadowGenerator {
     private _effect: Effect;
 
     private _cascades: Array<ICascade>;
-    private _cachedPosition: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
     private _cachedDirection: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
     private _cachedDefines: string;
-    private _currentRenderID: Array<number>;
     private _mapSize: number;
     private _currentLayer = 0;
     private _textureType: number;
@@ -723,6 +721,15 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      */
     public getCascadeViewMatrix(cascadeNum: number): Nullable<Matrix> {
         return cascadeNum >= 0 && cascadeNum < this._numCascades ? this._viewMatrices[cascadeNum] : null;
+    }
+
+    /**
+     * Gets the projection matrix corresponding to a given cascade
+     * @param cascadeNum cascade to retrieve the projection matrix from
+     * @returns the cascade projection matrix
+     */
+    public getCascadeProjectionMatrix(cascadeNum: number): Nullable<Matrix> {
+        return cascadeNum >= 0 && cascadeNum < this._numCascades ? this._projectionMatrices[cascadeNum] : null;
     }
 
     private _depthRenderer: Nullable<DepthRenderer>;
@@ -859,21 +866,15 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @returns The transform matrix used to create the CSM shadow map
      */
     public getCSMTransformMatrix(cascadeIndex: number): Matrix {
+        return this._transformMatrices[cascadeIndex];
+    }
+
+    private _computeMatrices(): void {
         var scene = this._scene;
-        if (this._currentRenderID[cascadeIndex] === scene.getRenderId()) {
-            return this._transformMatrices[cascadeIndex];
-        }
 
         let camera = scene.activeCamera;
         if (!camera) {
-            return this._transformMatrices[cascadeIndex];
-        }
-
-        this._currentRenderID[cascadeIndex] = scene.getRenderId();
-
-        var lightPosition = this._light.position;
-        if (this._light.computeTransformedInformation()) {
-            lightPosition = this._light.transformedPosition;
+            return;
         }
 
         Vector3.NormalizeToRef(this._light.getShadowDirection(0), this._lightDirection);
@@ -881,10 +882,9 @@ export class CascadedShadowGenerator implements IShadowGenerator {
             this._lightDirection.z = 0.0000000000001; // Required to avoid perfectly perpendicular light
         }
 
-        if (this._light.needProjectionMatrixCompute() || !this._cachedPosition || !this._cachedDirection || !lightPosition.equals(this._cachedPosition) || !this._lightDirection.equals(this._cachedDirection)) {
-            this._cachedPosition.copyFrom(lightPosition);
-            this._cachedDirection.copyFrom(this._lightDirection);
+        this._cachedDirection.copyFrom(this._lightDirection);
 
+        for (let cascadeIndex = 0; cascadeIndex < this._numCascades; ++cascadeIndex) {
             this._computeFrustumInWorldSpace(cascadeIndex);
             this._computeCascadeFrustum(cascadeIndex);
 
@@ -936,11 +936,9 @@ export class CascadedShadowGenerator implements IShadowGenerator {
 
             this._projectionMatrices[cascadeIndex].multiplyToRef(matrix, this._projectionMatrices[cascadeIndex]);
             this._viewMatrices[cascadeIndex].multiplyToRef(this._projectionMatrices[cascadeIndex], this._transformMatrices[cascadeIndex]);
+
+            this._transformMatrices[cascadeIndex].copyToArray(this._transformMatricesAsArray, cascadeIndex * 16);
         }
-
-        this._transformMatrices[cascadeIndex].copyToArray(this._transformMatricesAsArray, cascadeIndex * 16);
-
-        return this._transformMatrices[cascadeIndex];
     }
 
     // Get the 8 points of the view frustum in world space
@@ -1018,8 +1016,6 @@ export class CascadedShadowGenerator implements IShadowGenerator {
                 this._cascadeMaxExtents[cascadeIndex].maximizeInPlace(tmpv1);
             }
         }
-
-        return;
     }
 
     /** @hidden */
@@ -1090,7 +1086,6 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._transformMatricesAsArray = new Float32Array(this._numCascades * 16);
         this._viewSpaceFrustumsZ = new Array(this._numCascades);
         this._frustumLengths = new Array(this._numCascades);
-        this._currentRenderID = new Array(this._numCascades);
         this._lightSizeUVCorrection = new Array(this._numCascades * 2);
         this._depthCorrection = new Array(this._numCascades);
 
@@ -1145,6 +1140,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
             if (this._breaksAreDirty) {
                 this._splitFrustum();
             }
+            this._computeMatrices();
         });
 
         // Record Face Index before render.


### PR DESCRIPTION
The final goal is to allow the user to perform per cascade culling in CSM if he ever wants to (Babylon.js does not provide per-cascade culling for the time being).

Changes to achieve that:
* `CascadedShadowGenerator`: compute all the matrices at once before the RTT is starting work. It will allow the user to get the view / project / transform / ... matrices by calling the corresponding methods on `CascadedShadowGenerator` when doing the culling and be sure to have up to date matrices
* `RenderTargetTexture`: added a public `getCustomRenderList` function pointer. This method is called before each rendering so that it is possible for the user to return the list of meshes to use for the rendering of the current texture (when in 2DArray mode, the `layer` index is passed, else `face` index is passed).

The expected usage for per-cascade culling is:
```typescript
let rtt = shadowGenerator.getShadowMap()!;

rtt.getCustomRenderList = (layer: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>) : Nullable<Array<AbstractMesh>> => {
    let meshList = [];
    // do the culling for the cascade with index 'layer' by using the
    // getCascadeViewMatrix(layer), getCSMTransformMatrix(layer), getCascadeMinExtents(layer), etc
    return meshList;
};
```

If it's ok for you, I will update the CSM doc with this expected usage.