### PR TITLE
Allowing disable lighting on laser pointers

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -196,6 +196,7 @@
 - It is now possible to force a certain profile type for the controllers ([#7348](https://github.com/BabylonJS/Babylon.js/issues/7375)) ([RaananW](https://github.com/RaananW/))
 - WebXR camera is initialized on the first frame ([#7389](https://github.com/BabylonJS/Babylon.js/issues/7389)) ([RaananW](https://github.com/RaananW/))
 - Selection has gaze mode (which can be forced) and touch-screen support ([#7395](https://github.com/BabylonJS/Babylon.js/issues/7395)) ([RaananW](https://github.com/RaananW/))
+- Laser pointers can be excluded from lighting influence so that they are always visible in both WebXR and WebVR ([#7323](https://github.com/BabylonJS/Babylon.js/issues/7323)) ([RaananW](https://github.com/RaananW/))
 
 ### Ray
 

--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -254,6 +254,11 @@ class VRExperienceHelperControllerGazer extends VRExperienceHelperGazer {
     }
 
     /** @hidden */
+    public _setLaserPointerLightingDisabled(disabled: boolean) {
+        (<StandardMaterial>this._laserPointer.material).disableLighting = disabled;
+    }
+
+    /** @hidden */
     public _setLaserPointerParent(mesh: AbstractMesh) {
         var makeNotPick = (root: AbstractMesh) => {
             root.isPickable = false;
@@ -2225,6 +2230,16 @@ export class VRExperienceHelper {
     public setLaserColor(color: Color3, pickedColor: Color3 = this._pickedLaserColor) {
         this._laserColor = color;
         this._pickedLaserColor = pickedColor;
+    }
+
+    public setLaserLightingState(enabled: boolean = true) {
+        if (this._leftController) {
+            this._leftController._setLaserPointerLightingDisabled(!enabled);
+
+        }
+        if (this._rightController) {
+            this._rightController._setLaserPointerLightingDisabled(!enabled);
+        }
     }
 
     /**

--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -2232,6 +2232,10 @@ export class VRExperienceHelper {
         this._pickedLaserColor = pickedColor;
     }
 
+    /**
+     * Set lighting enabled / disabled on the laser pointer of both controllers
+     * @param enabled should the lighting be enabled on the laser pointer
+     */
     public setLaserLightingState(enabled: boolean = true) {
         if (this._leftController) {
             this._leftController._setLaserPointerLightingDisabled(!enabled);

--- a/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/Cameras/XR/features/WebXRControllerPointerSelection.ts
@@ -78,19 +78,19 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature implem
     /**
      * This color will be set to the laser pointer when selection is triggered
      */
-    public laserPointerPickedColor: Color3 = new Color3(0.7, 0.7, 0.7);
+    public laserPointerPickedColor: Color3 = new Color3(0.9, 0.9, 0.9);
     /**
      * This color will be applied to the selection ring when selection is triggered
      */
-    public selectionMeshPickedColor: Color3 = new Color3(0.7, 0.7, 0.7);
+    public selectionMeshPickedColor: Color3 = new Color3(0.3, 0.3, 1.0);
     /**
      * default color of the selection ring
      */
-    public selectionMeshDefaultColor: Color3 = new Color3(0.5, 0.5, 0.5);
+    public selectionMeshDefaultColor: Color3 = new Color3(0.8, 0.8, 0.8);
     /**
      * Default color of the laser pointer
      */
-    public lasterPointerDefaultColor: Color3 = new Color3(0.5, 0.5, 0.5);
+    public lasterPointerDefaultColor: Color3 = new Color3(0.7, 0.7, 0.7);
 
     /**
      * Should the laser pointer be displayed
@@ -100,6 +100,16 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature implem
      * Should the selection mesh be displayed (The ring at the end of the laser pointer)
      */
     public displaySelectionMesh: boolean = true;
+
+    /**
+     * Disable lighting on the laser pointer (so it will always be visible)
+     */
+    public disablePointerLighting: boolean = true;
+
+    /**
+     * Disable lighting on the selection mesh (so it will always be visible)
+     */
+    public disableSelectionMeshLighting: boolean = true;
 
     private static _idCounter = 0;
 
@@ -376,6 +386,8 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature implem
             }
 
             controllerData.laserPointer.isVisible = this.displayLaserPointer;
+            (<StandardMaterial>controllerData.laserPointer.material).disableLighting = this.disablePointerLighting;
+            (<StandardMaterial>controllerData.selectionMesh.material).disableLighting = this.disableSelectionMeshLighting;
 
             if (controllerData.pick) {
                 this._scene.simulatePointerMove(controllerData.pick, { pointerId: controllerData.id });
@@ -424,7 +436,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature implem
         laserPointer.parent = xrController.pointer;
         let laserPointerMaterial = new StandardMaterial("laserPointerMat", this._scene);
         laserPointerMaterial.emissiveColor = this.lasterPointerDefaultColor;
-        laserPointerMaterial.alpha = 0.6;
+        laserPointerMaterial.alpha = 0.7;
         laserPointer.material = laserPointerMaterial;
         laserPointer.rotation.x = Math.PI / 2;
         this._updatePointerDistance(laserPointer, 1);


### PR DESCRIPTION
Laser pointers should always be visible. 

In XR laser pointer and selection mesh now have `disableLighting` on per default (configurable), in WebVR, the VR Helper has a new function `setLaserLightingState`.

Note that the `setLaserLightingState` will work only after the controllers were initialized