### PR TITLE
Shadow generators code refactoring

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -59,6 +59,7 @@
 - Added `RenderTargetTexture.getCustomRenderList` to overload the render list at rendering time (and possibly for each layer (2DArray) / face (Cube)) ([Popov72](https://github.com/Popov72))
 - Make sure all properties of CascadedShadowMap class are serialized/parsed ([Popov72](https://github.com/Popov72))
 - Added `textures/opacity.png` file to the Playground ([Popov72](https://github.com/Popov72))
+- Refactored the shadow generators code ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -1,16 +1,10 @@
-import { SmartArray } from "../../Misc/smartArray";
 import { Nullable } from "../../types";
 import { Scene } from "../../scene";
 import { Matrix, Vector3 } from "../../Maths/math.vector";
-import { Color4 } from "../../Maths/math.color";
-import { VertexBuffer } from "../../Meshes/buffer";
 import { SubMesh } from "../../Meshes/subMesh";
-import { AbstractMesh } from "../../Meshes/abstractMesh";
-import { Mesh } from "../../Meshes/mesh";
 
-import { MaterialHelper } from "../../Materials/materialHelper";
+import { IShadowLight } from "../../Lights/shadowLight";
 import { Effect } from "../../Materials/effect";
-import { Texture } from "../../Materials/Textures/texture";
 import { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
 
 import { _TimeToken } from "../../Instrumentation/timeToken";
@@ -19,10 +13,9 @@ import { Constants } from "../../Engines/constants";
 import "../../Shaders/shadowMap.fragment";
 import "../../Shaders/shadowMap.vertex";
 import "../../Shaders/depthBoxBlur.fragment";
-import { Observable, Observer } from '../../Misc/observable';
+import { Observer } from '../../Misc/observable';
 import { _DevTools } from '../../Misc/devTools';
-import { EffectFallbacks } from '../../Materials/effectFallbacks';
-import { IShadowGenerator } from './shadowGenerator';
+import { ShadowGenerator } from './shadowGenerator';
 import { DirectionalLight } from '../directionalLight';
 
 import { BoundingInfo } from '../../Culling/boundingInfo';
@@ -46,7 +39,7 @@ let tmpv1 = new Vector3(),
  * Documentation : https://doc.babylonjs.com/babylon101/cascadedShadows
  * Based on: https://github.com/TheRealMJP/Shadows and https://johanmedestrom.wordpress.com/2016/03/18/opengl-cascaded-shadow-maps/
  */
-export class CascadedShadowGenerator implements IShadowGenerator {
+export class CascadedShadowGenerator extends ShadowGenerator {
 
     private static readonly frustumCornersNDCSpace = [
         new Vector3(-1.0, +1.0, -1.0),
@@ -62,7 +55,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
     /**
      * Name of the CSM class
      */
-    public static readonly CLASSNAME = "CascadedShadowGenerator";
+    public static CLASSNAME = "CascadedShadowGenerator";
 
     /**
      * Defines the default number of cascades used by the CSM.
@@ -77,270 +70,25 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      */
     public static readonly MAX_CASCADES_COUNT = 4;
 
-    /**
-     * Shadow generator mode None: no filtering applied.
-     */
-    public static readonly FILTER_NONE = 0;
-    /**
-     * Shadow generator mode PCF: Percentage Closer Filtering
-     * benefits from Webgl 2 shadow samplers. Fallback to Poisson Sampling in Webgl 1
-     * (https://developer.nvidia.com/gpugems/GPUGems/gpugems_ch11.html)
-     */
-    public static readonly FILTER_PCF = 6;
-    /**
-     * Shadow generator mode PCSS: Percentage Closering Soft Shadow.
-     * benefits from Webgl 2 shadow samplers. Fallback to Poisson Sampling in Webgl 1
-     * Contact Hardening
-     */
-    public static readonly FILTER_PCSS = 7;
-
-    /**
-     * Reserved for PCF and PCSS
-     * Highest Quality.
-     *
-     * Execute PCF on a 5*5 kernel improving a lot the shadow aliasing artifacts.
-     *
-     * Execute PCSS with 32 taps blocker search and 64 taps PCF.
-     */
-    public static readonly QUALITY_HIGH = 0;
-    /**
-     * Reserved for PCF and PCSS
-     * Good tradeoff for quality/perf cross devices
-     *
-     * Execute PCF on a 3*3 kernel.
-     *
-     * Execute PCSS with 16 taps blocker search and 32 taps PCF.
-     */
-    public static readonly QUALITY_MEDIUM = 1;
-    /**
-     * Reserved for PCF and PCSS
-     * The lowest quality but the fastest.
-     *
-     * Execute PCF on a 1*1 kernel.
-     *
-     * Execute PCSS with 16 taps blocker search and 16 taps PCF.
-     */
-    public static readonly QUALITY_LOW = 2;
-
-    private static readonly _CLEARONE = new Color4(1.0, 1.0, 1.0, 1.0);
-
-    /**
-     * Observable triggered before the shadow is rendered. Can be used to update internal effect state
-     */
-    public onBeforeShadowMapRenderObservable = new Observable<Effect>();
-
-    /**
-     * Observable triggered after the shadow is rendered. Can be used to restore internal effect state
-     */
-    public onAfterShadowMapRenderObservable = new Observable<Effect>();
-
-    /**
-     * Observable triggered before a mesh is rendered in the shadow map.
-     * Can be used to update internal effect state (that you can get from the onBeforeShadowMapRenderObservable)
-     */
-    public onBeforeShadowMapRenderMeshObservable = new Observable<Mesh>();
-
-    /**
-     * Observable triggered after a mesh is rendered in the shadow map.
-     * Can be used to update internal effect state (that you can get from the onAfterShadowMapRenderObservable)
-     */
-    public onAfterShadowMapRenderMeshObservable = new Observable<Mesh>();
-
-    private _bias = 0.00005;
-    /**
-     * Gets the bias: offset applied on the depth preventing acnea (in light direction).
-     */
-    public get bias(): number {
-        return this._bias;
-    }
-    /**
-     * Sets the bias: offset applied on the depth preventing acnea (in light direction).
-     */
-    public set bias(bias: number) {
-        this._bias = bias;
-    }
-
-    private _normalBias = 0;
-    /**
-     * Gets the normalBias: offset applied on the depth preventing acnea (along side the normal direction and proportinal to the light/normal angle).
-     */
-    public get normalBias(): number {
-        return this._normalBias;
-    }
-    /**
-     * Sets the normalBias: offset applied on the depth preventing acnea (along side the normal direction and proportinal to the light/normal angle).
-     */
-    public set normalBias(normalBias: number) {
-        this._normalBias = normalBias;
-    }
-
-    private _filter = CascadedShadowGenerator.FILTER_PCF;
-    /**
-     * Gets the current mode of the shadow generator (normal, PCF, PCSS...).
-     * The returned value is a number equal to one of the available mode defined in ShadowMap.FILTER_x like _FILTER_NONE
-     */
-    public get filter(): number {
-        return this._filter;
-    }
-    /**
-     * Sets the current mode of the shadow generator (normal, PCF, PCSS...).
-     * The returned value is a number equal to one of the available mode defined in ShadowMap.FILTER_x like _FILTER_NONE
-     */
-    public set filter(value: number) {
-        if (this._filter === value) {
-            return;
+    protected _validateFilter(filter: number): number {
+        if (filter === ShadowGenerator.FILTER_NONE ||
+            filter === ShadowGenerator.FILTER_PCF ||
+            filter === ShadowGenerator.FILTER_PCSS)
+        {
+            return filter;
         }
 
-        this._filter = value;
-        this._applyFilterValues();
-        this._light._markMeshesAsLightDirty();
-    }
+        console.error('Unsupported filter "' + filter + '"!');
 
-    /**
-     * Gets if the current filter is set to "PCF" (percentage closer filtering).
-     */
-    public get usePercentageCloserFiltering(): boolean {
-        return this.filter === CascadedShadowGenerator.FILTER_PCF;
-    }
-    /**
-     * Sets the current filter to "PCF" (percentage closer filtering).
-     */
-    public set usePercentageCloserFiltering(value: boolean) {
-        if (!value && this.filter !== CascadedShadowGenerator.FILTER_PCF) {
-            return;
-        }
-        this.filter = (value ? CascadedShadowGenerator.FILTER_PCF : CascadedShadowGenerator.FILTER_NONE);
-    }
-
-    private _filteringQuality = CascadedShadowGenerator.QUALITY_HIGH;
-    /**
-     * Gets the PCF or PCSS Quality.
-     * Only valid if usePercentageCloserFiltering or usePercentageCloserFiltering is true.
-     */
-    public get filteringQuality(): number {
-        return this._filteringQuality;
-    }
-    /**
-     * Sets the PCF or PCSS Quality.
-     * Only valid if usePercentageCloserFiltering or usePercentageCloserFiltering is true.
-     */
-    public set filteringQuality(filteringQuality: number) {
-        if (this._filteringQuality === filteringQuality) {
-            return;
-        }
-
-        this._filteringQuality = filteringQuality;
-
-        this._applyFilterValues();
-        this._light._markMeshesAsLightDirty();
-    }
-
-    /**
-     * Gets if the current filter is set to "PCSS" (contact hardening).
-     */
-    public get useContactHardeningShadow(): boolean {
-        return this.filter === CascadedShadowGenerator.FILTER_PCSS;
-    }
-    /**
-     * Sets the current filter to "PCSS" (contact hardening).
-     */
-    public set useContactHardeningShadow(value: boolean) {
-        if (!value && this.filter !== CascadedShadowGenerator.FILTER_PCSS) {
-            return;
-        }
-        this.filter = (value ? CascadedShadowGenerator.FILTER_PCSS : CascadedShadowGenerator.FILTER_NONE);
-    }
-
-    private _contactHardeningLightSizeUVRatio = 0.1;
-    /**
-     * Gets the Light Size (in shadow map uv unit) used in PCSS to determine the blocker search area and the penumbra size.
-     * Using a ratio helps keeping shape stability independently of the map size.
-     *
-     * It does not account for the light projection as it was having too much
-     * instability during the light setup or during light position changes.
-     *
-     * Only valid if useContactHardeningShadow is true.
-     */
-    public get contactHardeningLightSizeUVRatio(): number {
-        return this._contactHardeningLightSizeUVRatio;
-    }
-    /**
-     * Sets the Light Size (in shadow map uv unit) used in PCSS to determine the blocker search area and the penumbra size.
-     * Using a ratio helps keeping shape stability independently of the map size.
-     *
-     * It does not account for the light projection as it was having too much
-     * instability during the light setup or during light position changes.
-     *
-     * Only valid if useContactHardeningShadow is true.
-     */
-    public set contactHardeningLightSizeUVRatio(contactHardeningLightSizeUVRatio: number) {
-        this._contactHardeningLightSizeUVRatio = contactHardeningLightSizeUVRatio;
-    }
-
-    private _darkness = 0;
-
-    /** Gets or sets the actual darkness of a shadow */
-    public get darkness() {
-        return this._darkness;
-    }
-
-    public set darkness(value: number) {
-        this.setDarkness(value);
-    }
-
-    /**
-     * Returns the darkness value (float). This can only decrease the actual darkness of a shadow.
-     * 0 means strongest and 1 would means no shadow.
-     * @returns the darkness.
-     */
-    public getDarkness(): number {
-        return this._darkness;
-    }
-    /**
-     * Sets the darkness value (float). This can only decrease the actual darkness of a shadow.
-     * @param darkness The darkness value 0 means strongest and 1 would means no shadow.
-     * @returns the shadow generator allowing fluent coding.
-     */
-    public setDarkness(darkness: number): CascadedShadowGenerator {
-        if (darkness >= 1.0) {
-            this._darkness = 1.0;
-        }
-        else if (darkness <= 0.0) {
-            this._darkness = 0.0;
-        }
-        else {
-            this._darkness = darkness;
-        }
-        return this;
+        return ShadowGenerator.FILTER_NONE;
     }
 
     /**
      * Gets or sets the actual darkness of the soft shadows while using PCSS filtering (value between 0. and 1.)
      */
-    public penumbraDarkness: number = 1.0;
+    public penumbraDarkness: number;
 
-    private _transparencyShadow = false;
-
-    /** Gets or sets the ability to have transparent shadow  */
-    public get transparencyShadow() {
-        return this._transparencyShadow;
-    }
-
-    public set transparencyShadow(value: boolean) {
-        this.setTransparencyShadow(value);
-    }
-
-    /**
-     * Sets the ability to have transparent shadow (boolean).
-     * @param transparent True if transparent else False
-     * @returns the shadow generator allowing fluent coding
-     */
-    public setTransparencyShadow(transparent: boolean): CascadedShadowGenerator {
-        this._transparencyShadow = transparent;
-        return this;
-    }
-
-    private _numCascades = CascadedShadowGenerator.DEFAULT_CASCADES_COUNT;
+    private _numCascades: number;
 
     /**
      * Gets or set the number of cascades used by the CSM.
@@ -363,19 +111,10 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * Sets this to true if you want that the edges of the shadows don't "swimm" / "shimmer" when rotating the camera.
      * The trade off is that you loose some precision in the shadow rendering when enabling this setting.
      */
-    public stabilizeCascades: boolean = false;
+    public stabilizeCascades: boolean;
 
-    private _shadowMap: Nullable<RenderTargetTexture>;
-    /**
-     * Gets the main RTT containing the shadow map (usually storing depth from the light point of view).
-     * @returns The render target texture if present otherwise, null
-     */
-    public getShadowMap(): Nullable<RenderTargetTexture> {
-        return this._shadowMap;
-    }
-
-    protected _freezeShadowCastersBoundingInfo: boolean = false;
-    private _freezeShadowCastersBoundingInfoObservable: Nullable<Observer<Scene>> = null;
+    private _freezeShadowCastersBoundingInfo: boolean;
+    private _freezeShadowCastersBoundingInfoObservable: Nullable<Observer<Scene>>;
 
     /**
      * Enables or disables the shadow casters bounding info computation.
@@ -403,8 +142,8 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         }
     }
 
-    private _scbiMin = new Vector3(0, 0, 0);
-    private _scbiMax = new Vector3(0, 0, 0);
+    private _scbiMin: Vector3;
+    private _scbiMax: Vector3;
 
     protected _computeShadowCastersBoundingInfo(): void {
         this._scbiMin.copyFromFloats(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
@@ -460,10 +199,10 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._shadowCastersBoundingInfo = boundingInfo;
     }
 
-    protected _breaksAreDirty: boolean = true;
+    protected _breaksAreDirty: boolean;
 
-    protected _minDistance: number = 0;
-    protected _maxDistance: number = 1;
+    protected _minDistance: number;
+    protected _maxDistance: number;
 
     /**
      * Sets the minimal and maximal distances to use when computing the cascade breaks.
@@ -508,82 +247,11 @@ export class CascadedShadowGenerator implements IShadowGenerator {
 
     /**
      * Gets the class name of that object
-     * @returns "ShadowGenerator"
+     * @returns "CascadedShadowGenerator"
      */
     public getClassName(): string {
         return CascadedShadowGenerator.CLASSNAME;
     }
-
-    /**
-     * Helper function to add a mesh and its descendants to the list of shadow casters.
-     * @param mesh Mesh to add
-     * @param includeDescendants boolean indicating if the descendants should be added. Default to true
-     * @returns the Shadow Generator itself
-     */
-    public addShadowCaster(mesh: AbstractMesh, includeDescendants = true): CascadedShadowGenerator {
-        if (!this._shadowMap) {
-            return this;
-        }
-
-        if (!this._shadowMap.renderList) {
-            this._shadowMap.renderList = [];
-        }
-
-        this._shadowMap.renderList.push(mesh);
-
-        if (includeDescendants) {
-            this._shadowMap.renderList.push(...mesh.getChildMeshes());
-        }
-
-        return this;
-    }
-
-    /**
-     * Helper function to remove a mesh and its descendants from the list of shadow casters
-     * @param mesh Mesh to remove
-     * @param includeDescendants boolean indicating if the descendants should be removed. Default to true
-     * @returns the Shadow Generator itself
-     */
-    public removeShadowCaster(mesh: AbstractMesh, includeDescendants = true): CascadedShadowGenerator {
-        if (!this._shadowMap || !this._shadowMap.renderList) {
-            return this;
-        }
-
-        var index = this._shadowMap.renderList.indexOf(mesh);
-
-        if (index !== -1) {
-            this._shadowMap.renderList.splice(index, 1);
-        }
-
-        if (includeDescendants) {
-            for (var child of mesh.getChildren()) {
-                this.removeShadowCaster(<any>child);
-            }
-        }
-
-        return this;
-    }
-
-    /**
-     * Controls the extent to which the shadows fade out at the edge of the frustum
-     */
-    public frustumEdgeFalloff = 0;
-
-    private _light: DirectionalLight;
-    /**
-     * Returns the associated light object.
-     * @returns the light generating the shadow
-     */
-    public getLight(): DirectionalLight {
-        return this._light;
-    }
-
-    /**
-     * If true the shadow map is generated by rendering the back face of the mesh instead of the front face.
-     * This can help with self-shadowing as the geometry making up the back of objects is slightly offset.
-     * It might on the other hand introduce peter panning.
-     */
-    public forceBackFacesOnly = false;
 
     private _cascadeMinExtents: Array<Vector3>;
     private _cascadeMaxExtents: Array<Vector3>;
@@ -606,20 +274,8 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         return cascadeIndex >= 0 && cascadeIndex < this._numCascades ? this._cascadeMaxExtents[cascadeIndex] : null;
     }
 
-    private _scene: Scene;
-    private _lightDirection = Vector3.Zero();
-
-    private _effect: Effect;
-
     private _cascades: Array<ICascade>;
-    private _cachedDirection: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-    private _cachedDefines: string;
-    private _mapSize: number;
-    private _currentLayer = 0;
-    private _textureType: number;
-    private _defaultTextureMatrix = Matrix.Identity();
-    private _storedUniqueId: Nullable<number>;
-
+    private _currentLayer: number;
     private _viewSpaceFrustumsZ: Array<number>;
     private _viewMatrices: Array<Matrix>;
     private _projectionMatrices: Array<Matrix>;
@@ -659,7 +315,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._breaksAreDirty = true;
     }
 
-    protected _debug = false;
+    protected _debug: boolean;
 
     /**
      * Gets or sets the debug flag.
@@ -674,7 +330,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._light._markMeshesAsLightDirty();
     }
 
-    private _depthClamp = true;
+    private _depthClamp: boolean;
 
     /**
      * Gets or sets the depth clamping value.
@@ -692,7 +348,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._depthClamp = value;
     }
 
-    private _cascadeBlendPercentage: number = 0.1;
+    private _cascadeBlendPercentage: number;
 
     /**
      * Gets or sets the percentage of blending between two cascades (value between 0. and 1.).
@@ -707,7 +363,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._light._markMeshesAsLightDirty();
     }
 
-    private _lambda = 0.5;
+    private _lambda: number;
 
     /**
      * Gets or set the lambda parameter.
@@ -746,6 +402,15 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         return cascadeNum >= 0 && cascadeNum < this._numCascades ? this._projectionMatrices[cascadeNum] : null;
     }
 
+    /**
+     * Gets the transformation matrix corresponding to a given cascade
+     * @param cascadeNum cascade to retrieve the transformation matrix from
+     * @returns the cascade transformation matrix
+     */
+    public getCascadeTransformMatrix(cascadeNum: number): Nullable<Matrix> {
+        return cascadeNum >= 0 && cascadeNum < this._numCascades ? this._transformMatrices[cascadeNum] : null;
+    }
+
     private _depthRenderer: Nullable<DepthRenderer>;
     /**
      * Sets the depth renderer to use when autoCalcDepthBounds is enabled.
@@ -765,7 +430,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
     }
 
     private _depthReducer: Nullable<DepthReducer>;
-    private _autoCalcDepthBounds = false;
+    private _autoCalcDepthBounds: boolean;
 
     /**
      * Gets or sets the autoCalcDepthBounds property.
@@ -875,16 +540,6 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         this._breaksAreDirty = false;
     }
 
-    /**
-     * Gets the CSM transformation matrix used to project the meshes into the map from the light point of view.
-     * (eq to view projection * shadow projection matrices)
-	 * @param cascadeIndex index number of the cascaded shadow map
-     * @returns The transform matrix used to create the CSM shadow map
-     */
-    public getCSMTransformMatrix(cascadeIndex: number): Matrix {
-        return this._transformMatrices[cascadeIndex];
-    }
-
     private _computeMatrices(): void {
         var scene = this._scene;
 
@@ -921,7 +576,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
 
             maxZ = Math.min(maxZ, boundingInfo.boundingBox.maximumWorld.z);
 
-            if (!this._depthClamp || this.filter === CascadedShadowGenerator.FILTER_PCSS) {
+            if (!this._depthClamp || this.filter === ShadowGenerator.FILTER_PCSS) {
                 // If we don't use depth clamping, we must set minZ so that all shadow casters are in the light frustum
                 minZ = Math.min(minZ, boundingInfo.boundingBox.minimumWorld.z);
             } else {
@@ -1049,56 +704,51 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @param usefulFloatFirst By default the generator will try to use half float textures but if you need precision (for self shadowing for instance), you can use this option to enforce full float texture.
      */
     constructor(mapSize: number, light: DirectionalLight, usefulFloatFirst?: boolean) {
-        this._scene = light.getScene();
+        super(mapSize, light, usefulFloatFirst);
+
         if (this._scene.getEngine().webGLVersion == 1) {
             throw "CSM can only be used in WebGL2";
         }
 
-        this._light = light;
-        this._mapSize = mapSize;
-        light._shadowGenerator = this;
-        this._shadowMaxZ = this._scene.activeCamera?.maxZ ?? 10000;
-        this._shadowCastersBoundingInfo = new BoundingInfo(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
-        this.freezeShadowCastersBoundingInfo = false;
+        this.usePercentageCloserFiltering = true;
+    }
 
-        CascadedShadowGenerator._SceneComponentInitialization(this._scene);
+    protected _initializeGenerator(): void {
+        this.penumbraDarkness = this.penumbraDarkness ?? 1.0;
+        this._numCascades = this._numCascades ?? CascadedShadowGenerator.DEFAULT_CASCADES_COUNT;
+        this.stabilizeCascades = this.stabilizeCascades ?? false;
+        this._freezeShadowCastersBoundingInfoObservable = this._freezeShadowCastersBoundingInfoObservable ?? null;
+        this.freezeShadowCastersBoundingInfo = this.freezeShadowCastersBoundingInfo ?? false;
+        this._scbiMin = this._scbiMin ?? new Vector3(0, 0, 0);
+        this._scbiMax = this._scbiMax ?? new Vector3(0, 0, 0);
+        this._shadowCastersBoundingInfo = this._shadowCastersBoundingInfo ?? new BoundingInfo(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
+        this._breaksAreDirty = this._breaksAreDirty ?? true;
+        this._minDistance = this._minDistance ?? 0;
+        this._maxDistance = this._maxDistance ?? 1;
+        this._currentLayer = this._currentLayer ?? 0;
+        this._shadowMaxZ = this._shadowMaxZ ?? this._scene.activeCamera?.maxZ ?? 10000;
+        this._debug = this._debug ?? false;
+        this._depthClamp = this._depthClamp ?? true;
+        this._cascadeBlendPercentage = this._cascadeBlendPercentage ?? 0.1;
+        this._lambda = this._lambda ?? 0.5;
+        this._autoCalcDepthBounds = this._autoCalcDepthBounds ?? false;
 
-        // Texture type fallback from float to int if not supported.
-        var caps = this._scene.getEngine().getCaps();
+        super._initializeGenerator();
+    }
 
-        if (!usefulFloatFirst) {
-            if (caps.textureHalfFloatRender && caps.textureHalfFloatLinearFiltering) {
-                this._textureType = Constants.TEXTURETYPE_HALF_FLOAT;
-            }
-            else if (caps.textureFloatRender && caps.textureFloatLinearFiltering) {
-                this._textureType = Constants.TEXTURETYPE_FLOAT;
-            }
-            else {
-                this._textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
-            }
-        } else {
-            if (caps.textureFloatRender && caps.textureFloatLinearFiltering) {
-                this._textureType = Constants.TEXTURETYPE_FLOAT;
-            }
-            else if (caps.textureHalfFloatRender && caps.textureHalfFloatLinearFiltering) {
-                this._textureType = Constants.TEXTURETYPE_HALF_FLOAT;
-            }
-            else {
-                this._textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
-            }
+    protected _createTargetRenderTexture(): void {
+        const size = { width: this._mapSize, height: this._mapSize, layers: this.numCascades };
+        this._shadowMap = new RenderTargetTexture(this._light.name + "_shadowMap", size, this._scene, false, true, this._textureType, false, undefined, false, false, undefined/*, Constants.TEXTUREFORMAT_RED*/);
+        this._shadowMap.createDepthStencilTexture(Constants.LESS, true);
+    }
+
+    protected _initializeShadowMap(): void {
+        super._initializeShadowMap();
+
+        if (this._shadowMap === null) {
+            return;
         }
 
-        this._initializeGenerator();
-        this._applyFilterValues();
-    }
-
-    private _initializeGenerator(): void {
-        this._light._markMeshesAsLightDirty();
-        this._initializeShadowMap();
-    }
-
-    private _initializeShadowMap(): void {
-        // CSM
         this._transformMatricesAsArray = new Float32Array(this._numCascades * 16);
         this._viewSpaceFrustumsZ = new Array(this._numCascades);
         this._frustumLengths = new Array(this._numCascades);
@@ -1135,22 +785,9 @@ export class CascadedShadowGenerator implements IShadowGenerator {
             }
         }
 
-        // Render target
-        let engine = this._scene.getEngine();
-
-        const size = { width: this._mapSize, height: this._mapSize, layers: this.numCascades };
-        this._shadowMap = new RenderTargetTexture(this._light.name + "_shadowMap", size, this._scene, false, true, this._textureType, false, undefined, false, false, undefined, Constants.TEXTUREFORMAT_RED);
-        this._shadowMap.createDepthStencilTexture(Constants.LESS, true);
-
-        this._shadowMap.wrapU = Texture.CLAMP_ADDRESSMODE;
-        this._shadowMap.wrapV = Texture.CLAMP_ADDRESSMODE;
-        this._shadowMap.anisotropicFilteringLevel = 4;
-        this._shadowMap.updateSamplingMode(Texture.BILINEAR_SAMPLINGMODE);
-        this._shadowMap.renderParticles = false;
-        this._shadowMap.ignoreCameraViewport = true;
-        if (this._storedUniqueId) {
-            this._shadowMap.uniqueId = this._storedUniqueId;
-        }
+        this._shadowMap.onBeforeRenderObservable.add((layer: number) => {
+            this._currentLayer = layer;
+        });
 
         this._shadowMap.onBeforeBindObservable.add(() => {
             if (this._breaksAreDirty) {
@@ -1159,363 +796,17 @@ export class CascadedShadowGenerator implements IShadowGenerator {
             this._computeMatrices();
         });
 
-        // Record Face Index before render.
-        this._shadowMap.onBeforeRenderObservable.add((layer: number) => {
-            this._currentLayer = layer;
-            if (this._filter === CascadedShadowGenerator.FILTER_PCF) {
-                engine.setColorWrite(this.debug);
-            }
-        });
-
-        // Custom render function.
-        this._shadowMap.customRenderFunction = this._renderForShadowMap.bind(this);
-
-        // Restore state after bind.
-        this._shadowMap.onAfterUnbindObservable.add(() => {
-            if (this._filter === CascadedShadowGenerator.FILTER_PCF) {
-                engine.setColorWrite(true);
-            }
-        });
-
-        // Clear according to the chosen filter.
-        this._shadowMap.onClearObservable.add((engine) => {
-            if (this._filter === CascadedShadowGenerator.FILTER_PCF) {
-                engine.clear(CascadedShadowGenerator._CLEARONE, this.debug, true, false);
-            }
-            else {
-                engine.clear(CascadedShadowGenerator._CLEARONE, true, true, false);
-            }
-        });
-
-        // Recreate on resize.
-        this._shadowMap.onResizeObservable.add((RTT) => {
-            this._storedUniqueId = this._shadowMap!.uniqueId;
-            this._mapSize = RTT.getRenderSize();
-            this._light._markMeshesAsLightDirty();
-            this.recreateShadowMap();
-        });
-
         this._splitFrustum();
     }
 
-    private _renderForShadowMap(opaqueSubMeshes: SmartArray<SubMesh>, alphaTestSubMeshes: SmartArray<SubMesh>, transparentSubMeshes: SmartArray<SubMesh>, depthOnlySubMeshes: SmartArray<SubMesh>): void {
-        var index: number;
-        let engine = this._scene.getEngine();
-
-        const colorWrite = engine.getColorWrite();
-        if (depthOnlySubMeshes.length) {
-            engine.setColorWrite(false);
-            for (index = 0; index < depthOnlySubMeshes.length; index++) {
-                this._renderSubMeshForShadowMap(depthOnlySubMeshes.data[index]);
-            }
-            engine.setColorWrite(colorWrite);
-        }
-
-        for (index = 0; index < opaqueSubMeshes.length; index++) {
-            this._renderSubMeshForShadowMap(opaqueSubMeshes.data[index]);
-        }
-
-        for (index = 0; index < alphaTestSubMeshes.length; index++) {
-            this._renderSubMeshForShadowMap(alphaTestSubMeshes.data[index]);
-        }
-
-        if (this._transparencyShadow) {
-            for (index = 0; index < transparentSubMeshes.length; index++) {
-                this._renderSubMeshForShadowMap(transparentSubMeshes.data[index]);
-            }
-        }
+    protected _bindCustomEffectForRenderSubMeshForShadowMap(subMesh: SubMesh, effect: Effect): void {
+        effect.setMatrix("viewProjection", this.getCascadeTransformMatrix(this._currentLayer)!);
     }
 
-    private _renderSubMeshForShadowMap(subMesh: SubMesh): void {
-        var mesh = subMesh.getRenderingMesh();
-        var scene = this._scene;
-        var engine = scene.getEngine();
-        let material = subMesh.getMaterial();
-
-        mesh._internalAbstractMeshDataInfo._isActiveIntermediate = false;
-
-        if (!material || subMesh.verticesCount === 0) {
-            return;
-        }
-
-        // Culling
-        engine.setState(material.backFaceCulling);
-
-        // Managing instances
-        var batch = mesh._getInstancesRenderList(subMesh._id);
-        if (batch.mustReturn) {
-            return;
-        }
-
-        var hardwareInstancedRendering = (engine.getCaps().instancedArrays) && (batch.visibleInstances[subMesh._id] !== null) && (batch.visibleInstances[subMesh._id] !== undefined);
-        if (this.isReady(subMesh, hardwareInstancedRendering)) {
-            engine.enableEffect(this._effect);
-            mesh._bind(subMesh, this._effect, material.fillMode);
-
-            this._effect.setFloat3("biasAndScale", this.bias, this.normalBias, 0);
-
-            this._effect.setMatrix("viewProjection", this.getCSMTransformMatrix(this._currentLayer));
-            this._effect.setVector3("lightData", this._cachedDirection);
-
-            if (scene.activeCamera) {
-                this._effect.setFloat2("depthValues", this.getLight().getDepthMinZ(scene.activeCamera), this.getLight().getDepthMinZ(scene.activeCamera) + this.getLight().getDepthMaxZ(scene.activeCamera));
-            }
-
-            // Alpha test
-            if (material && material.needAlphaTesting()) {
-                var alphaTexture = material.getAlphaTestTexture();
-                if (alphaTexture) {
-                    this._effect.setTexture("diffuseSampler", alphaTexture);
-                    this._effect.setMatrix("diffuseMatrix", alphaTexture.getTextureMatrix() || this._defaultTextureMatrix);
-                }
-            }
-
-            // Bones
-            if (mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
-                const skeleton = mesh.skeleton;
-
-                if (skeleton.isUsingTextureForMatrices) {
-                    const boneTexture = skeleton.getTransformMatrixTexture(mesh);
-
-                    if (!boneTexture) {
-                        return;
-                    }
-
-                    this._effect.setTexture("boneSampler", boneTexture);
-                    this._effect.setFloat("boneTextureWidth", 4.0 * (skeleton.bones.length + 1));
-                } else {
-                    this._effect.setMatrices("mBones", skeleton.getTransformMatrices((mesh)));
-                }
-            }
-
-            // Morph targets
-            MaterialHelper.BindMorphTargetParameters(mesh, this._effect);
-
-            if (this.forceBackFacesOnly) {
-                engine.setState(true, 0, false, true);
-            }
-
-            // Observables
-            this.onBeforeShadowMapRenderMeshObservable.notifyObservers(mesh);
-            this.onBeforeShadowMapRenderObservable.notifyObservers(this._effect);
-
-            // Draw
-            mesh._processRendering(subMesh, this._effect, material.fillMode, batch, hardwareInstancedRendering,
-                (isInstance, world) => this._effect.setMatrix("world", world));
-
-            if (this.forceBackFacesOnly) {
-                engine.setState(true, 0, false, false);
-            }
-
-            // Observables
-            this.onAfterShadowMapRenderObservable.notifyObservers(this._effect);
-            this.onAfterShadowMapRenderMeshObservable.notifyObservers(mesh);
-
-        } else {
-            // Need to reset refresh rate of the shadowMap
-            if (this._shadowMap) {
-                this._shadowMap.resetRefreshCounter();
-            }
-        }
-    }
-
-    private _applyFilterValues(): void {
-        if (!this._shadowMap) {
-            return;
-        }
-
-        if (this.filter === CascadedShadowGenerator.FILTER_PCSS) {
-            this._shadowMap.updateSamplingMode(Texture.NEAREST_SAMPLINGMODE);
-        } else {
-            this._shadowMap.updateSamplingMode(Texture.BILINEAR_SAMPLINGMODE);
-        }
-    }
-
-    /**
-     * Forces all the attached effect to compile to enable rendering only once ready vs. lazyly compiling effects.
-     * @param onCompiled Callback triggered at the and of the effects compilation
-     * @param options Sets of optional options forcing the compilation with different modes
-     */
-    public forceCompilation(onCompiled?: (generator: IShadowGenerator) => void, options?: Partial<{ useInstances: boolean }>): void {
-        let localOptions = {
-            useInstances: false,
-            ...options
-        };
-
-        let shadowMap = this.getShadowMap();
-        if (!shadowMap) {
-            if (onCompiled) {
-                onCompiled(this);
-            }
-            return;
-        }
-
-        let renderList = shadowMap.renderList;
-        if (!renderList) {
-            if (onCompiled) {
-                onCompiled(this);
-            }
-            return;
-        }
-
-        var subMeshes = new Array<SubMesh>();
-        for (var mesh of renderList) {
-            subMeshes.push(...mesh.subMeshes);
-        }
-        if (subMeshes.length === 0) {
-            if (onCompiled) {
-                onCompiled(this);
-            }
-            return;
-        }
-
-        var currentIndex = 0;
-
-        var checkReady = () => {
-            if (!this._scene || !this._scene.getEngine()) {
-                return;
-            }
-
-            while (this.isReady(subMeshes[currentIndex], localOptions.useInstances)) {
-                currentIndex++;
-                if (currentIndex >= subMeshes.length) {
-                    if (onCompiled) {
-                        onCompiled(this);
-                    }
-                    return;
-                }
-            }
-            setTimeout(checkReady, 16);
-        };
-
-        checkReady();
-    }
-
-    /**
-     * Forces all the attached effect to compile to enable rendering only once ready vs. lazyly compiling effects.
-     * @param options Sets of optional options forcing the compilation with different modes
-     * @returns A promise that resolves when the compilation completes
-     */
-    public forceCompilationAsync(options?: Partial<{ useInstances: boolean }>): Promise<void> {
-        return new Promise((resolve) => {
-            this.forceCompilation(() => {
-                resolve();
-            }, options);
-        });
-    }
-
-    /**
-     * Determine wheter the shadow generator is ready or not (mainly all effects and related post processes needs to be ready).
-     * @param subMesh The submesh we want to render in the shadow map
-     * @param useInstances Defines wether will draw in the map using instances
-     * @returns true if ready otherwise, false
-     */
-    public isReady(subMesh: SubMesh, useInstances: boolean): boolean {
-        var defines = [];
-
-        if (this._textureType !== Constants.TEXTURETYPE_UNSIGNED_INT) {
-            defines.push("#define FLOAT");
-        }
-
-        defines.push("#define DEPTHTEXTURE");
-
-        if (this._depthClamp && this._filter !== CascadedShadowGenerator.FILTER_PCSS) {
+    protected _isReadyCustomDefines(defines: any, subMesh: SubMesh, useInstances: boolean): void {
+        if (this._depthClamp && this._filter !== ShadowGenerator.FILTER_PCSS) {
             defines.push("#define DEPTHCLAMP");
         }
-
-        var attribs = [VertexBuffer.PositionKind];
-
-        var mesh = subMesh.getMesh();
-        var material = subMesh.getMaterial();
-
-        // Normal bias.
-        if (this.normalBias && mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {
-            attribs.push(VertexBuffer.NormalKind);
-            defines.push("#define NORMAL");
-            defines.push("#define DIRECTIONINLIGHTDATA");
-        }
-
-        // Alpha test
-        if (material && material.needAlphaTesting()) {
-            var alphaTexture = material.getAlphaTestTexture();
-            if (alphaTexture) {
-                defines.push("#define ALPHATEST");
-                if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
-                    attribs.push(VertexBuffer.UVKind);
-                    defines.push("#define UV1");
-                }
-                if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
-                    if (alphaTexture.coordinatesIndex === 1) {
-                        attribs.push(VertexBuffer.UV2Kind);
-                        defines.push("#define UV2");
-                    }
-                }
-            }
-        }
-
-        // Bones
-        const fallbacks = new EffectFallbacks();
-        if (mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
-            attribs.push(VertexBuffer.MatricesIndicesKind);
-            attribs.push(VertexBuffer.MatricesWeightsKind);
-            if (mesh.numBoneInfluencers > 4) {
-                attribs.push(VertexBuffer.MatricesIndicesExtraKind);
-                attribs.push(VertexBuffer.MatricesWeightsExtraKind);
-            }
-            const skeleton = mesh.skeleton;
-            defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
-            if (mesh.numBoneInfluencers > 0) {
-                fallbacks.addCPUSkinningFallback(0, mesh);
-            }
-
-            if (skeleton.isUsingTextureForMatrices) {
-                defines.push("#define BONETEXTURE");
-            } else {
-                defines.push("#define BonesPerMesh " + (skeleton.bones.length + 1));
-            }
-
-        } else {
-            defines.push("#define NUM_BONE_INFLUENCERS 0");
-        }
-
-        // Morph targets
-        var manager = (<Mesh>mesh).morphTargetManager;
-        let morphInfluencers = 0;
-        if (manager) {
-            if (manager.numInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-                morphInfluencers = manager.numInfluencers;
-                defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
-                MaterialHelper.PrepareAttributesForMorphTargetsInfluencers(attribs, mesh, morphInfluencers);
-            }
-        }
-
-        // Instances
-        if (useInstances) {
-            defines.push("#define INSTANCES");
-            MaterialHelper.PushAttributesForInstances(attribs);
-        }
-
-        // Get correct effect
-        var join = defines.join("\n");
-        if (this._cachedDefines !== join) {
-            this._cachedDefines = join;
-
-            let shaderName = "shadowMap";
-            let uniforms = ["world", "mBones", "viewProjection", "diffuseMatrix", "lightData", "depthValues", "biasAndScale", "morphTargetInfluences", "boneTextureWidth"];
-            let samplers = ["diffuseSampler", "boneSampler"];
-
-            this._effect = this._scene.getEngine().createEffect(shaderName,
-                attribs, uniforms,
-                samplers, join,
-                fallbacks, undefined, undefined, { maxSimultaneousMorphTargets: morphInfluencers });
-        }
-
-        if (!this._effect.isReady()) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -1524,14 +815,14 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @param lightIndex Index of the light in the enabled light list of the material
      */
     public prepareDefines(defines: any, lightIndex: number): void {
+        super.prepareDefines(defines, lightIndex);
+
         var scene = this._scene;
         var light = this._light;
 
         if (!scene.shadowsEnabled || !light.shadowEnabled) {
             return;
         }
-
-        defines["SHADOW" + lightIndex] = true;
 
         defines["SHADOWCSM" + lightIndex] = true;
         defines["SHADOWCSMDEBUG" + lightIndex] = this.debug;
@@ -1545,27 +836,6 @@ export class CascadedShadowGenerator implements IShadowGenerator {
 
         if (this.cascadeBlendPercentage === 0) {
             defines["SHADOWCSMNOBLEND" + lightIndex] = true;
-        }
-
-        if (this.useContactHardeningShadow) {
-            defines["SHADOWPCSS" + lightIndex] = true;
-            if (this._filteringQuality === CascadedShadowGenerator.QUALITY_LOW) {
-                defines["SHADOWLOWQUALITY" + lightIndex] = true;
-            }
-            else if (this._filteringQuality === CascadedShadowGenerator.QUALITY_MEDIUM) {
-                defines["SHADOWMEDIUMQUALITY" + lightIndex] = true;
-            }
-            // else default to high.
-        }
-        else if (this.usePercentageCloserFiltering) {
-            defines["SHADOWPCF" + lightIndex] = true;
-            if (this._filteringQuality === CascadedShadowGenerator.QUALITY_LOW) {
-                defines["SHADOWLOWQUALITY" + lightIndex] = true;
-            }
-            else if (this._filteringQuality === CascadedShadowGenerator.QUALITY_MEDIUM) {
-                defines["SHADOWMEDIUMQUALITY" + lightIndex] = true;
-            }
-            // else default to high.
         }
     }
 
@@ -1601,10 +871,10 @@ export class CascadedShadowGenerator implements IShadowGenerator {
         effect.setArray("frustumLengths" + lightIndex, this._frustumLengths);
 
         // Only PCF uses depth stencil texture.
-        if (this._filter === CascadedShadowGenerator.FILTER_PCF) {
+        if (this._filter === ShadowGenerator.FILTER_PCF) {
             effect.setDepthStencilTexture("shadowSampler" + lightIndex, shadowMap);
             light._uniformBuffer.updateFloat4("shadowsInfo", this.getDarkness(), width, 1 / width, this.frustumEdgeFalloff, lightIndex);
-        } else if (this._filter === CascadedShadowGenerator.FILTER_PCSS) {
+        } else if (this._filter === ShadowGenerator.FILTER_PCSS) {
             for (let cascadeIndex = 0; cascadeIndex < this._numCascades; ++cascadeIndex) {
                 this._lightSizeUVCorrection[cascadeIndex * 2 + 0] = cascadeIndex === 0 ? 1 : (this._cascadeMaxExtents[0].x - this._cascadeMinExtents[0].x) / (this._cascadeMaxExtents[cascadeIndex].x - this._cascadeMinExtents[cascadeIndex].x); // x correction
                 this._lightSizeUVCorrection[cascadeIndex * 2 + 1] = cascadeIndex === 0 ? 1 : (this._cascadeMaxExtents[0].y - this._cascadeMinExtents[0].y) / (this._cascadeMaxExtents[cascadeIndex].y - this._cascadeMinExtents[cascadeIndex].y); // y correction
@@ -1631,38 +901,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @returns The transform matrix used to create the shadow map
      */
     public getTransformMatrix(): Matrix {
-        return this.getCSMTransformMatrix(0);
-    }
-
-    /**
-     * Recreates the shadow map dependencies like RTT and post processes. This can be used during the switch between
-     * Cube and 2D textures for instance.
-     */
-    public recreateShadowMap(): void {
-        let shadowMap = this._shadowMap;
-        if (!shadowMap) {
-            return;
-        }
-
-        // Track render list.
-        var renderList = shadowMap.renderList;
-        // Clean up existing data.
-        this._disposeRTT();
-        // Reinitializes.
-        this._initializeGenerator();
-        // Reaffect the filter to ensure a correct fallback if necessary.
-        this.filter = this.filter;
-        // Reaffect the filter.
-        this._applyFilterValues();
-        // Reaffect Render List.
-        this._shadowMap!.renderList = renderList;
-    }
-
-    private _disposeRTT(): void {
-        if (this._shadowMap) {
-            this._shadowMap.dispose();
-            this._shadowMap = null;
-        }
+        return this.getCascadeTransformMatrix(0)!;
     }
 
     /**
@@ -1670,17 +909,7 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * Returns nothing.
      */
     public dispose(): void {
-        this._disposeRTT();
-
-        if (this._light) {
-            this._light._shadowGenerator = null;
-            this._light._markMeshesAsLightDirty();
-        }
-
-        this.onBeforeShadowMapRenderMeshObservable.clear();
-        this.onBeforeShadowMapRenderObservable.clear();
-        this.onAfterShadowMapRenderMeshObservable.clear();
-        this.onAfterShadowMapRenderObservable.clear();
+        super.dispose();
 
         if (this._freezeShadowCastersBoundingInfoObservable) {
             this._scene.onBeforeRenderObservable.remove(this._freezeShadowCastersBoundingInfoObservable);
@@ -1698,26 +927,12 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @returns The serialized JSON object
      */
     public serialize(): any {
-        var serializationObject: any = {};
+        var serializationObject: any = super.serialize();
         var shadowMap = this.getShadowMap();
 
         if (!shadowMap) {
             return serializationObject;
         }
-
-        serializationObject.className = this.getClassName();
-        serializationObject.lightId = this._light.id;
-        serializationObject.mapSize = shadowMap.getRenderSize();
-        serializationObject.forceBackFacesOnly = this.forceBackFacesOnly;
-        serializationObject.darkness = this.getDarkness();
-        serializationObject.transparencyShadow = this._transparencyShadow;
-        serializationObject.frustumEdgeFalloff = this.frustumEdgeFalloff;
-        serializationObject.bias = this.bias;
-        serializationObject.normalBias = this.normalBias;
-        serializationObject.usePercentageCloserFiltering = this.usePercentageCloserFiltering;
-        serializationObject.useContactHardeningShadow = this.useContactHardeningShadow;
-        serializationObject.contactHardeningLightSizeUVRatio = this.contactHardeningLightSizeUVRatio;
-        serializationObject.filteringQuality = this.filteringQuality;
 
         serializationObject.numCascades = this._numCascades;
         serializationObject.debug = this._debug;
@@ -1751,59 +966,8 @@ export class CascadedShadowGenerator implements IShadowGenerator {
      * @param scene The scene to create the shadow map for
      * @returns The parsed shadow generator
      */
-    public static Parse(parsedShadowGenerator: any, scene: Scene): CascadedShadowGenerator {
-        var light = <DirectionalLight>scene.getLightByID(parsedShadowGenerator.lightId);
-        var shadowGenerator = new CascadedShadowGenerator(parsedShadowGenerator.mapSize, light);
-        var shadowMap = shadowGenerator.getShadowMap();
-
-        for (var meshIndex = 0; meshIndex < parsedShadowGenerator.renderList.length; meshIndex++) {
-            var meshes = scene.getMeshesByID(parsedShadowGenerator.renderList[meshIndex]);
-            meshes.forEach(function(mesh) {
-                if (!shadowMap) {
-                    return;
-                }
-                if (!shadowMap.renderList) {
-                    shadowMap.renderList = [];
-                }
-                shadowMap.renderList.push(mesh);
-            });
-        }
-
-        shadowGenerator.forceBackFacesOnly = !!parsedShadowGenerator.forceBackFacesOnly;
-
-        if (parsedShadowGenerator.darkness !== undefined) {
-            shadowGenerator.setDarkness(parsedShadowGenerator.darkness);
-        }
-
-        if (parsedShadowGenerator.transparencyShadow) {
-            shadowGenerator.setTransparencyShadow(true);
-        }
-
-        if (parsedShadowGenerator.frustumEdgeFalloff !== undefined) {
-            shadowGenerator.frustumEdgeFalloff = parsedShadowGenerator.frustumEdgeFalloff;
-        }
-
-        if (parsedShadowGenerator.bias !== undefined) {
-            shadowGenerator.bias = parsedShadowGenerator.bias;
-        }
-
-        if (parsedShadowGenerator.normalBias !== undefined) {
-            shadowGenerator.normalBias = parsedShadowGenerator.normalBias;
-        }
-
-        if (parsedShadowGenerator.usePercentageCloserFiltering) {
-            shadowGenerator.usePercentageCloserFiltering = true;
-        } else if (parsedShadowGenerator.useContactHardeningShadow) {
-            shadowGenerator.useContactHardeningShadow = true;
-        }
-
-        if (parsedShadowGenerator.contactHardeningLightSizeUVRatio !== undefined) {
-            shadowGenerator.contactHardeningLightSizeUVRatio = parsedShadowGenerator.contactHardeningLightSizeUVRatio;
-        }
-
-        if (parsedShadowGenerator.filteringQuality !== undefined) {
-            shadowGenerator.filteringQuality = parsedShadowGenerator.filteringQuality;
-        }
+    public static Parse(parsedShadowGenerator: any, scene: Scene): ShadowGenerator {
+        var shadowGenerator = ShadowGenerator.Parse(parsedShadowGenerator, scene, (mapSize: number, light: IShadowLight) => new CascadedShadowGenerator(mapSize, <DirectionalLight>light)) as CascadedShadowGenerator;
 
         if (parsedShadowGenerator.numCascades !== undefined) {
             shadowGenerator.numCascades = parsedShadowGenerator.numCascades;

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -135,6 +135,12 @@ export interface IShadowGenerator {
  * Documentation: https://doc.babylonjs.com/babylon101/shadows
  */
 export class ShadowGenerator implements IShadowGenerator {
+
+    /**
+     * Name of the shadow generator class
+     */
+    public static CLASSNAME = "ShadowGenerator";
+
     /**
      * Shadow generator mode None: no filtering applied.
      */
@@ -232,7 +238,7 @@ export class ShadowGenerator implements IShadowGenerator {
      */
     public onAfterShadowMapRenderMeshObservable = new Observable<Mesh>();
 
-    private _bias = 0.00005;
+    protected _bias = 0.00005;
     /**
      * Gets the bias: offset applied on the depth preventing acnea (in light direction).
      */
@@ -246,7 +252,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._bias = bias;
     }
 
-    private _normalBias = 0;
+    protected _normalBias = 0;
     /**
      * Gets the normalBias: offset applied on the depth preventing acnea (along side the normal direction and proportinal to the light/normal angle).
      */
@@ -260,7 +266,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._normalBias = normalBias;
     }
 
-    private _blurBoxOffset = 1;
+    protected _blurBoxOffset = 1;
     /**
      * Gets the blur box offset: offset applied during the blur pass.
      * Only useful if useKernelBlur = false
@@ -281,7 +287,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._disposeBlurPostProcesses();
     }
 
-    private _blurScale = 2;
+    protected _blurScale = 2;
     /**
      * Gets the blur scale: scale of the blurred texture compared to the main shadow map.
      * 2 means half of the size.
@@ -302,7 +308,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._disposeBlurPostProcesses();
     }
 
-    private _blurKernel = 1;
+    protected _blurKernel = 1;
     /**
      * Gets the blur kernel: kernel size of the blur pass.
      * Only useful if useKernelBlur = true
@@ -323,7 +329,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._disposeBlurPostProcesses();
     }
 
-    private _useKernelBlur = false;
+    protected _useKernelBlur = false;
     /**
      * Gets whether the blur pass is a kernel blur (if true) or box blur.
      * Only useful in filtered mode (useBlurExponentialShadowMap...)
@@ -344,7 +350,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._disposeBlurPostProcesses();
     }
 
-    private _depthScale: number;
+    protected _depthScale: number;
     /**
      * Gets the depth scale used in ESM mode.
      */
@@ -359,7 +365,11 @@ export class ShadowGenerator implements IShadowGenerator {
         this._depthScale = value;
     }
 
-    private _filter = ShadowGenerator.FILTER_NONE;
+    protected _validateFilter(filter: number): number {
+        return filter;
+    }
+
+    protected _filter = ShadowGenerator.FILTER_NONE;
     /**
      * Gets the current mode of the shadow generator (normal, PCF, ESM...).
      * The returned value is a number equal to one of the available mode defined in ShadowMap.FILTER_x like _FILTER_NONE
@@ -372,6 +382,8 @@ export class ShadowGenerator implements IShadowGenerator {
      * The returned value is a number equal to one of the available mode defined in ShadowMap.FILTER_x like _FILTER_NONE
      */
     public set filter(value: number) {
+        value = this._validateFilter(value);
+
         // Blurring the cubemap is going to be too expensive. Reverting to unblurred version
         if (this._light.needCube()) {
             if (value === ShadowGenerator.FILTER_BLUREXPONENTIALSHADOWMAP) {
@@ -417,11 +429,13 @@ export class ShadowGenerator implements IShadowGenerator {
      * Sets the current filter to Poisson Sampling.
      */
     public set usePoissonSampling(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_POISSONSAMPLING);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_POISSONSAMPLING) {
             return;
         }
 
-        this.filter = (value ? ShadowGenerator.FILTER_POISSONSAMPLING : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
     /**
@@ -434,10 +448,12 @@ export class ShadowGenerator implements IShadowGenerator {
      * Sets the current filter is to ESM.
      */
     public set useExponentialShadowMap(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_EXPONENTIALSHADOWMAP);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_EXPONENTIALSHADOWMAP) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_EXPONENTIALSHADOWMAP : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
     /**
@@ -450,10 +466,12 @@ export class ShadowGenerator implements IShadowGenerator {
      * Gets if the current filter is set to filtered  ESM.
      */
     public set useBlurExponentialShadowMap(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_BLUREXPONENTIALSHADOWMAP);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_BLUREXPONENTIALSHADOWMAP) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_BLUREXPONENTIALSHADOWMAP : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
     /**
@@ -468,10 +486,12 @@ export class ShadowGenerator implements IShadowGenerator {
      * exponential to prevent steep falloff artifacts).
      */
     public set useCloseExponentialShadowMap(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_CLOSEEXPONENTIALSHADOWMAP);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_CLOSEEXPONENTIALSHADOWMAP) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_CLOSEEXPONENTIALSHADOWMAP : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
     /**
@@ -486,10 +506,12 @@ export class ShadowGenerator implements IShadowGenerator {
      * exponential to prevent steep falloff artifacts).
      */
     public set useBlurCloseExponentialShadowMap(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_BLURCLOSEEXPONENTIALSHADOWMAP);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_BLURCLOSEEXPONENTIALSHADOWMAP) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_BLURCLOSEEXPONENTIALSHADOWMAP : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
     /**
@@ -502,13 +524,15 @@ export class ShadowGenerator implements IShadowGenerator {
      * Sets the current filter to "PCF" (percentage closer filtering).
      */
     public set usePercentageCloserFiltering(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_PCF);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_PCF) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_PCF : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
-    private _filteringQuality = ShadowGenerator.QUALITY_HIGH;
+    protected _filteringQuality = ShadowGenerator.QUALITY_HIGH;
     /**
      * Gets the PCF or PCSS Quality.
      * Only valid if usePercentageCloserFiltering or usePercentageCloserFiltering is true.
@@ -542,13 +566,15 @@ export class ShadowGenerator implements IShadowGenerator {
      * Sets the current filter to "PCSS" (contact hardening).
      */
     public set useContactHardeningShadow(value: boolean) {
+        let filter = this._validateFilter(ShadowGenerator.FILTER_PCSS);
+
         if (!value && this.filter !== ShadowGenerator.FILTER_PCSS) {
             return;
         }
-        this.filter = (value ? ShadowGenerator.FILTER_PCSS : ShadowGenerator.FILTER_NONE);
+        this.filter = (value ? filter : ShadowGenerator.FILTER_NONE);
     }
 
-    private _contactHardeningLightSizeUVRatio = 0.1;
+    protected _contactHardeningLightSizeUVRatio = 0.1;
     /**
      * Gets the Light Size (in shadow map uv unit) used in PCSS to determine the blocker search area and the penumbra size.
      * Using a ratio helps keeping shape stability independently of the map size.
@@ -574,7 +600,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._contactHardeningLightSizeUVRatio = contactHardeningLightSizeUVRatio;
     }
 
-    private _darkness = 0;
+    protected _darkness = 0;
 
     /** Gets or sets the actual darkness of a shadow */
     public get darkness() {
@@ -611,7 +637,7 @@ export class ShadowGenerator implements IShadowGenerator {
         return this;
     }
 
-    private _transparencyShadow = false;
+    protected _transparencyShadow = false;
 
     /** Gets or sets the ability to have transparent shadow  */
     public get transparencyShadow() {
@@ -632,8 +658,9 @@ export class ShadowGenerator implements IShadowGenerator {
         return this;
     }
 
-    private _shadowMap: Nullable<RenderTargetTexture>;
-    private _shadowMap2: Nullable<RenderTargetTexture>;
+    protected _shadowMap: Nullable<RenderTargetTexture>;
+    protected _shadowMap2: Nullable<RenderTargetTexture>;
+
     /**
      * Gets the main RTT containing the shadow map (usually storing depth from the light point of view).
      * @returns The render target texture if present otherwise, null
@@ -641,6 +668,7 @@ export class ShadowGenerator implements IShadowGenerator {
     public getShadowMap(): Nullable<RenderTargetTexture> {
         return this._shadowMap;
     }
+
     /**
      * Gets the RTT used during rendering (can be a blurred version of the shadow map or the shadow map itself).
      * @returns The render target texture if the shadow map is present otherwise, null
@@ -658,7 +686,7 @@ export class ShadowGenerator implements IShadowGenerator {
      * @returns "ShadowGenerator"
      */
     public getClassName(): string {
-        return "ShadowGenerator";
+        return ShadowGenerator.CLASSNAME;
     }
 
     /**
@@ -713,11 +741,10 @@ export class ShadowGenerator implements IShadowGenerator {
 
     /**
      * Controls the extent to which the shadows fade out at the edge of the frustum
-     * Used only by directionals and spots
      */
     public frustumEdgeFalloff = 0;
 
-    private _light: IShadowLight;
+    protected _light: IShadowLight;
     /**
      * Returns the associated light object.
      * @returns the light generating the shadow
@@ -733,28 +760,28 @@ export class ShadowGenerator implements IShadowGenerator {
      */
     public forceBackFacesOnly = false;
 
-    private _scene: Scene;
-    private _lightDirection = Vector3.Zero();
+    protected _scene: Scene;
+    protected _lightDirection = Vector3.Zero();
 
-    private _effect: Effect;
+    protected _effect: Effect;
 
-    private _viewMatrix = Matrix.Zero();
-    private _projectionMatrix = Matrix.Zero();
-    private _transformMatrix = Matrix.Zero();
-    private _cachedPosition: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-    private _cachedDirection: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-    private _cachedDefines: string;
-    private _currentRenderID: number;
-    private _boxBlurPostprocess: Nullable<PostProcess>;
-    private _kernelBlurXPostprocess: Nullable<PostProcess>;
-    private _kernelBlurYPostprocess: Nullable<PostProcess>;
-    private _blurPostProcesses: PostProcess[];
-    private _mapSize: number;
-    private _currentFaceIndex = 0;
-    private _currentFaceIndexCache = 0;
-    private _textureType: number;
-    private _defaultTextureMatrix = Matrix.Identity();
-    private _storedUniqueId: Nullable<number>;
+    protected _viewMatrix = Matrix.Zero();
+    protected _projectionMatrix = Matrix.Zero();
+    protected _transformMatrix = Matrix.Zero();
+    protected _cachedPosition: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
+    protected _cachedDirection: Vector3 = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
+    protected _cachedDefines: string;
+    protected _currentRenderID: number;
+    protected _boxBlurPostprocess: Nullable<PostProcess>;
+    protected _kernelBlurXPostprocess: Nullable<PostProcess>;
+    protected _kernelBlurYPostprocess: Nullable<PostProcess>;
+    protected _blurPostProcesses: PostProcess[];
+    protected _mapSize: number;
+    protected _currentFaceIndex = 0;
+    protected _currentFaceIndexCache = 0;
+    protected _textureType: number;
+    protected _defaultTextureMatrix = Matrix.Identity();
+    protected _storedUniqueId: Nullable<number>;
 
     /** @hidden */
     public static _SceneComponentInitialization: (scene: Scene) => void = (_) => {
@@ -807,13 +834,12 @@ export class ShadowGenerator implements IShadowGenerator {
         this._applyFilterValues();
     }
 
-    private _initializeGenerator(): void {
+    protected _initializeGenerator(): void {
         this._light._markMeshesAsLightDirty();
         this._initializeShadowMap();
     }
 
-    private _initializeShadowMap(): void {
-        // Render target
+    protected _createTargetRenderTexture(): void {
         let engine = this._scene.getEngine();
         if (engine.webGLVersion > 1) {
             this._shadowMap = new RenderTargetTexture(this._light.name + "_shadowMap", this._mapSize, this._scene, false, true, this._textureType, this._light.needCube(), undefined, false, false);
@@ -822,6 +848,15 @@ export class ShadowGenerator implements IShadowGenerator {
         else {
             this._shadowMap = new RenderTargetTexture(this._light.name + "_shadowMap", this._mapSize, this._scene, false, true, this._textureType, this._light.needCube());
         }
+    }
+
+    protected _initializeShadowMap(): void {
+        this._createTargetRenderTexture();
+
+        if (this._shadowMap === null) {
+            return;
+        }
+
         this._shadowMap.wrapU = Texture.CLAMP_ADDRESSMODE;
         this._shadowMap.wrapV = Texture.CLAMP_ADDRESSMODE;
         this._shadowMap.anisotropicFilteringLevel = 1;
@@ -832,6 +867,11 @@ export class ShadowGenerator implements IShadowGenerator {
             this._shadowMap.uniqueId = this._storedUniqueId;
         }
 
+        // Custom render function.
+        this._shadowMap.customRenderFunction = this._renderForShadowMap.bind(this);
+
+        let engine = this._scene.getEngine();
+
         // Record Face Index before render.
         this._shadowMap.onBeforeRenderObservable.add((faceIndex: number) => {
             this._currentFaceIndex = faceIndex;
@@ -839,9 +879,6 @@ export class ShadowGenerator implements IShadowGenerator {
                 engine.setColorWrite(false);
             }
         });
-
-        // Custom render function.
-        this._shadowMap.customRenderFunction = this._renderForShadowMap.bind(this);
 
         // Blur if required afer render.
         this._shadowMap.onAfterUnbindObservable.add(() => {
@@ -873,6 +910,7 @@ export class ShadowGenerator implements IShadowGenerator {
             }
         });
 
+        // Recreate on resize.
         this._shadowMap.onResizeObservable.add((RTT) => {
             this._storedUniqueId = this._shadowMap!.uniqueId;
             this._mapSize = RTT.getRenderSize();
@@ -881,7 +919,7 @@ export class ShadowGenerator implements IShadowGenerator {
         });
     }
 
-    private _initializeBlurRTTAndPostProcesses(): void {
+    protected _initializeBlurRTTAndPostProcesses(): void {
         var engine = this._scene.getEngine();
         var targetSize = this._mapSize / this.blurScale;
 
@@ -925,7 +963,7 @@ export class ShadowGenerator implements IShadowGenerator {
         }
     }
 
-    private _renderForShadowMap(opaqueSubMeshes: SmartArray<SubMesh>, alphaTestSubMeshes: SmartArray<SubMesh>, transparentSubMeshes: SmartArray<SubMesh>, depthOnlySubMeshes: SmartArray<SubMesh>): void {
+    protected _renderForShadowMap(opaqueSubMeshes: SmartArray<SubMesh>, alphaTestSubMeshes: SmartArray<SubMesh>, transparentSubMeshes: SmartArray<SubMesh>, depthOnlySubMeshes: SmartArray<SubMesh>): void {
         var index: number;
         let engine = this._scene.getEngine();
 
@@ -953,7 +991,10 @@ export class ShadowGenerator implements IShadowGenerator {
         }
     }
 
-    private _renderSubMeshForShadowMap(subMesh: SubMesh): void {
+    protected _bindCustomEffectForRenderSubMeshForShadowMap(subMesh: SubMesh, effect: Effect): void {
+    }
+
+    protected _renderSubMeshForShadowMap(subMesh: SubMesh): void {
         var mesh = subMesh.getRenderingMesh();
         var scene = this._scene;
         var engine = scene.getEngine();
@@ -1023,6 +1064,8 @@ export class ShadowGenerator implements IShadowGenerator {
             // Morph targets
             MaterialHelper.BindMorphTargetParameters(mesh, this._effect);
 
+            this._bindCustomEffectForRenderSubMeshForShadowMap(subMesh, this._effect);
+
             if (this.forceBackFacesOnly) {
                 engine.setState(true, 0, false, true);
             }
@@ -1051,7 +1094,7 @@ export class ShadowGenerator implements IShadowGenerator {
         }
     }
 
-    private _applyFilterValues(): void {
+    protected _applyFilterValues(): void {
         if (!this._shadowMap) {
             return;
         }
@@ -1134,6 +1177,9 @@ export class ShadowGenerator implements IShadowGenerator {
                 resolve();
             }, options);
         });
+    }
+
+    protected _isReadyCustomDefines(defines: any, subMesh: SubMesh, useInstances: boolean): void {
     }
 
     /**
@@ -1244,6 +1290,8 @@ export class ShadowGenerator implements IShadowGenerator {
             }
         }
 
+        this._isReadyCustomDefines(defines, subMesh, useInstances);
+
         // Get correct effect
         var join = defines.join("\n");
         if (this._cachedDefines !== join) {
@@ -1336,7 +1384,7 @@ export class ShadowGenerator implements IShadowGenerator {
             }
             // else default to high.
         }
-        if (this.usePercentageCloserFiltering) {
+        else if (this.usePercentageCloserFiltering) {
             defines["SHADOWPCF" + lightIndex] = true;
             if (this._filteringQuality === ShadowGenerator.QUALITY_LOW) {
                 defines["SHADOWLOWQUALITY" + lightIndex] = true;
@@ -1368,19 +1416,19 @@ export class ShadowGenerator implements IShadowGenerator {
      * @param effect The effect we are binfing the information for
      */
     public bindShadowLight(lightIndex: string, effect: Effect): void {
-        var light = this._light;
-        var scene = this._scene;
+        const light = this._light;
+        const scene = this._scene;
 
         if (!scene.shadowsEnabled || !light.shadowEnabled) {
             return;
         }
 
-        let camera = scene.activeCamera;
+        const camera = scene.activeCamera;
         if (!camera) {
             return;
         }
 
-        let shadowMap = this.getShadowMap();
+        const shadowMap = this.getShadowMap();
 
         if (!shadowMap) {
             return;
@@ -1479,7 +1527,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._shadowMap!.renderList = renderList;
     }
 
-    private _disposeBlurPostProcesses(): void {
+    protected _disposeBlurPostProcesses(): void {
         if (this._shadowMap2) {
             this._shadowMap2.dispose();
             this._shadowMap2 = null;
@@ -1503,7 +1551,7 @@ export class ShadowGenerator implements IShadowGenerator {
         this._blurPostProcesses = [];
     }
 
-    private _disposeRTTandPostProcesses(): void {
+    protected _disposeRTTandPostProcesses(): void {
         if (this._shadowMap) {
             this._shadowMap.dispose();
             this._shadowMap = null;
@@ -1542,30 +1590,29 @@ export class ShadowGenerator implements IShadowGenerator {
             return serializationObject;
         }
 
+        serializationObject.className = this.getClassName();
         serializationObject.lightId = this._light.id;
         serializationObject.mapSize = shadowMap.getRenderSize();
+        serializationObject.forceBackFacesOnly = this.forceBackFacesOnly;
+        serializationObject.darkness = this.getDarkness();
+        serializationObject.transparencyShadow = this._transparencyShadow;
+        serializationObject.frustumEdgeFalloff = this.frustumEdgeFalloff;
+        serializationObject.bias = this.bias;
+        serializationObject.normalBias = this.normalBias;
+        serializationObject.usePercentageCloserFiltering = this.usePercentageCloserFiltering;
+        serializationObject.useContactHardeningShadow = this.useContactHardeningShadow;
+        serializationObject.contactHardeningLightSizeUVRatio = this.contactHardeningLightSizeUVRatio;
+        serializationObject.filteringQuality = this.filteringQuality;
         serializationObject.useExponentialShadowMap = this.useExponentialShadowMap;
         serializationObject.useBlurExponentialShadowMap = this.useBlurExponentialShadowMap;
         serializationObject.useCloseExponentialShadowMap = this.useBlurExponentialShadowMap;
         serializationObject.useBlurCloseExponentialShadowMap = this.useBlurExponentialShadowMap;
         serializationObject.usePoissonSampling = this.usePoissonSampling;
-        serializationObject.forceBackFacesOnly = this.forceBackFacesOnly;
         serializationObject.depthScale = this.depthScale;
-        serializationObject.darkness = this.getDarkness();
         serializationObject.blurBoxOffset = this.blurBoxOffset;
         serializationObject.blurKernel = this.blurKernel;
         serializationObject.blurScale = this.blurScale;
         serializationObject.useKernelBlur = this.useKernelBlur;
-        serializationObject.transparencyShadow = this._transparencyShadow;
-        serializationObject.frustumEdgeFalloff = this.frustumEdgeFalloff;
-
-        serializationObject.bias = this.bias;
-        serializationObject.normalBias = this.normalBias;
-
-        serializationObject.usePercentageCloserFiltering = this.usePercentageCloserFiltering;
-        serializationObject.useContactHardeningShadow = this.useContactHardeningShadow;
-        serializationObject.filteringQuality = this.filteringQuality;
-        serializationObject.contactHardeningLightSizeUVRatio = this.contactHardeningLightSizeUVRatio;
 
         serializationObject.renderList = [];
         if (shadowMap.renderList) {
@@ -1583,11 +1630,12 @@ export class ShadowGenerator implements IShadowGenerator {
      * Parses a serialized ShadowGenerator and returns a new ShadowGenerator.
      * @param parsedShadowGenerator The JSON object to parse
      * @param scene The scene to create the shadow map for
+     * @param constr A function that builds a shadow generator or undefined to create an instance of the default shadow generator
      * @returns The parsed shadow generator
      */
-    public static Parse(parsedShadowGenerator: any, scene: Scene): ShadowGenerator {
+    public static Parse(parsedShadowGenerator: any, scene: Scene, constr?: (mapSize: number, light: IShadowLight) => ShadowGenerator): ShadowGenerator {
         var light = <IShadowLight>scene.getLightByID(parsedShadowGenerator.lightId);
-        var shadowGenerator = new ShadowGenerator(parsedShadowGenerator.mapSize, light);
+        var shadowGenerator = constr ? constr(parsedShadowGenerator.mapSize, light) : new ShadowGenerator(parsedShadowGenerator.mapSize, light);
         var shadowMap = shadowGenerator.getShadowMap();
 
         for (var meshIndex = 0; meshIndex < parsedShadowGenerator.renderList.length; meshIndex++) {
@@ -1603,42 +1651,56 @@ export class ShadowGenerator implements IShadowGenerator {
             });
         }
 
-        if (parsedShadowGenerator.usePoissonSampling) {
+        shadowGenerator.forceBackFacesOnly = !!parsedShadowGenerator.forceBackFacesOnly;
+
+        if (parsedShadowGenerator.darkness !== undefined) {
+            shadowGenerator.setDarkness(parsedShadowGenerator.darkness);
+        }
+
+        if (parsedShadowGenerator.transparencyShadow) {
+            shadowGenerator.setTransparencyShadow(true);
+        }
+
+        if (parsedShadowGenerator.frustumEdgeFalloff !== undefined) {
+            shadowGenerator.frustumEdgeFalloff = parsedShadowGenerator.frustumEdgeFalloff;
+        }
+
+        if (parsedShadowGenerator.bias !== undefined) {
+            shadowGenerator.bias = parsedShadowGenerator.bias;
+        }
+
+        if (parsedShadowGenerator.normalBias !== undefined) {
+            shadowGenerator.normalBias = parsedShadowGenerator.normalBias;
+        }
+
+        if (parsedShadowGenerator.usePercentageCloserFiltering) {
+            shadowGenerator.usePercentageCloserFiltering = true;
+        } else if (parsedShadowGenerator.useContactHardeningShadow) {
+            shadowGenerator.useContactHardeningShadow = true;
+        } else if (parsedShadowGenerator.usePoissonSampling) {
             shadowGenerator.usePoissonSampling = true;
-        }
-        else if (parsedShadowGenerator.useExponentialShadowMap) {
+        } else if (parsedShadowGenerator.useExponentialShadowMap) {
             shadowGenerator.useExponentialShadowMap = true;
-        }
-        else if (parsedShadowGenerator.useBlurExponentialShadowMap) {
+        } else if (parsedShadowGenerator.useBlurExponentialShadowMap) {
+            shadowGenerator.useBlurExponentialShadowMap = true;
+        } else if (parsedShadowGenerator.useCloseExponentialShadowMap) {
+            shadowGenerator.useCloseExponentialShadowMap = true;
+        } else if (parsedShadowGenerator.useBlurCloseExponentialShadowMap) {
+            shadowGenerator.useBlurCloseExponentialShadowMap = true;
+        } else
+        // Backward compat
+        if (parsedShadowGenerator.useVarianceShadowMap) {
+            shadowGenerator.useExponentialShadowMap = true;
+        } else if (parsedShadowGenerator.useBlurVarianceShadowMap) {
             shadowGenerator.useBlurExponentialShadowMap = true;
         }
-        else if (parsedShadowGenerator.useCloseExponentialShadowMap) {
-            shadowGenerator.useCloseExponentialShadowMap = true;
-        }
-        else if (parsedShadowGenerator.useBlurCloseExponentialShadowMap) {
-            shadowGenerator.useBlurCloseExponentialShadowMap = true;
-        }
-        else if (parsedShadowGenerator.usePercentageCloserFiltering) {
-            shadowGenerator.usePercentageCloserFiltering = true;
-        }
-        else if (parsedShadowGenerator.useContactHardeningShadow) {
-            shadowGenerator.useContactHardeningShadow = true;
-        }
 
-        if (parsedShadowGenerator.filteringQuality) {
-            shadowGenerator.filteringQuality = parsedShadowGenerator.filteringQuality;
-        }
-
-        if (parsedShadowGenerator.contactHardeningLightSizeUVRatio) {
+        if (parsedShadowGenerator.contactHardeningLightSizeUVRatio !== undefined) {
             shadowGenerator.contactHardeningLightSizeUVRatio = parsedShadowGenerator.contactHardeningLightSizeUVRatio;
         }
 
-        // Backward compat
-        else if (parsedShadowGenerator.useVarianceShadowMap) {
-            shadowGenerator.useExponentialShadowMap = true;
-        }
-        else if (parsedShadowGenerator.useBlurVarianceShadowMap) {
-            shadowGenerator.useBlurExponentialShadowMap = true;
+        if (parsedShadowGenerator.filteringQuality !== undefined) {
+            shadowGenerator.filteringQuality = parsedShadowGenerator.filteringQuality;
         }
 
         if (parsedShadowGenerator.depthScale) {
@@ -1660,28 +1722,6 @@ export class ShadowGenerator implements IShadowGenerator {
         if (parsedShadowGenerator.blurKernel) {
             shadowGenerator.blurKernel = parsedShadowGenerator.blurKernel;
         }
-
-        if (parsedShadowGenerator.bias !== undefined) {
-            shadowGenerator.bias = parsedShadowGenerator.bias;
-        }
-
-        if (parsedShadowGenerator.normalBias !== undefined) {
-            shadowGenerator.normalBias = parsedShadowGenerator.normalBias;
-        }
-
-        if (parsedShadowGenerator.frustumEdgeFalloff !== undefined) {
-            shadowGenerator.frustumEdgeFalloff = parsedShadowGenerator.frustumEdgeFalloff;
-        }
-
-        if (parsedShadowGenerator.darkness) {
-            shadowGenerator.setDarkness(parsedShadowGenerator.darkness);
-        }
-
-        if (parsedShadowGenerator.transparencyShadow) {
-            shadowGenerator.setTransparencyShadow(true);
-        }
-
-        shadowGenerator.forceBackFacesOnly = parsedShadowGenerator.forceBackFacesOnly;
 
         return shadowGenerator;
     }

--- a/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
+++ b/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
@@ -127,11 +127,3 @@ ShadowGenerator._SceneComponentInitialization = (scene: Scene) => {
         scene._addComponent(component);
     }
 };
-
-CascadedShadowGenerator._SceneComponentInitialization = (scene: Scene) => {
-    let component = scene._getComponent(SceneComponentConstants.NAME_SHADOWGENERATOR);
-    if (!component) {
-        component = new ShadowGeneratorSceneComponent(scene);
-        scene._addComponent(component);
-    }
-};


### PR DESCRIPTION
Refactoring of `ShadowGenerator` and `CascadedShadowGenerator` classes.

`CascadedShadowGenerator` now extends `ShadowGenerator` and add specific methods to handle CSM.

For `CascadedShadowGenerator`, if the user tries to use a filtering method other than none / PCF / PCSS, an error is logged to the console and the filter is set to none.

There's a breaking change: `getCSMTransformMatrix` has been renamed to `getCascadeTransformMatrix` to follow the naming convention used for `getCascadeViewMatrix` and `getCascadeProjectionMatrix`.

I don't think it's too much a problem, as I doubt someone has used `getCSMTransformMatrix` yet and because we are still in beta for 4.1 and not in production stage.

Let me know if it's ok, I performed a lot of checks for both `ShadowGenerator` and `CascadedShadowGenerator` after refactoring, so I hope I didn't break anything...