### PR TITLE
Make Mesh.bakeCurrentTransformIntoVertices() independent of children

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -308,3 +308,4 @@
 - The glTF2 exporter extension no longer ignores childless empty nodes.([drigax](https://github.com/drigax))
 - Default culling strategy changed to CULLINGSTRATEGY_BOUNDINGSPHERE_ONLY ([Deltakosh](https://github.com/deltakosh/))
 - `MaterialHelper.BindLight` and `MaterialHelper.BindLights` do not need the usePhysicalLight anymore ([Sebavan](https://github.com/sebavan/))
+- `Mesh.bakeTransformIntoVertices` now preserves child world-space transforms([drigax](https://github.com/drigax))

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2151,6 +2151,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * This method returns nothing but really modifies the mesh even if it's originally not set as updatable.
      * Note that, under the hood, this method sets a new VertexBuffer each call.
      * @see http://doc.babylonjs.com/resources/baking_transformations
+     * @param bakeIndependenlyOfChildren indicates whether to preserve all child nodes' World Matrix during baking
      * @returns the current mesh
      */
     public bakeCurrentTransformIntoVertices(bakeIndependenlyOfChildren : boolean = true): Mesh {

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2153,16 +2153,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @see http://doc.babylonjs.com/resources/baking_transformations
      * @returns the current mesh
      */
-    public bakeCurrentTransformIntoVertices(): Mesh {
+    public bakeCurrentTransformIntoVertices(bakeIndependenlyOfChildren : boolean = true): Mesh {
         this.bakeTransformIntoVertices(this.computeWorldMatrix(true));
-        this.scaling.copyFromFloats(1, 1, 1);
-        this.position.copyFromFloats(0, 0, 0);
-        this.rotation.copyFromFloats(0, 0, 0);
-        //only if quaternion is already set
-        if (this.rotationQuaternion) {
-            this.rotationQuaternion = Quaternion.Identity();
-        }
-        this._worldMatrix = Matrix.Identity();
+        this.resetLocalMatrix(bakeIndependenlyOfChildren);
         return this;
     }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -1168,6 +1168,10 @@ export class TransformNode extends Node {
         return this._worldMatrix;
     }
 
+    /**
+     * Resets this nodeTransform's local matrix to Matrix.Identity().
+     * @param independentOfChildren indicates if all child nodeTransform's world-space transform should be preserved.
+     */
     public resetLocalMatrix(independentOfChildren : boolean = true): void
     {
         this.computeWorldMatrix();

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -1175,17 +1175,17 @@ export class TransformNode extends Node {
     public resetLocalMatrix(independentOfChildren : boolean = true): void
     {
         this.computeWorldMatrix();
-        if (independentOfChildren){
+        if (independentOfChildren) {
             let children = this.getChildren();
             for(let i = 0; i < children.length; ++i){
                 let child = children[i] as TransformNode;
-                if (child){
+                if (child) {
                     child.computeWorldMatrix();
                     let bakedMatrix = TmpVectors.Matrix[0];
                     child._localMatrix.multiplyToRef(this._localMatrix, bakedMatrix);
                     let tmpRotationQuaternion = TmpVectors.Quaternion[0];
                     bakedMatrix.decompose(child.scaling, tmpRotationQuaternion, child.position);
-                    if (child.rotationQuaternion){
+                    if (child.rotationQuaternion) {
                         child.rotationQuaternion = tmpRotationQuaternion;
                     } else {
                         tmpRotationQuaternion.toEulerAnglesToRef(child.rotation);

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -1168,6 +1168,38 @@ export class TransformNode extends Node {
         return this._worldMatrix;
     }
 
+    public resetLocalMatrix(independentOfChildren : boolean = true): void
+    {
+        this.computeWorldMatrix();
+        if (independentOfChildren){
+            let children = this.getChildren();
+            for(let i = 0; i < children.length; ++i){
+                let child = children[i] as TransformNode;
+                if (child){
+                    child.computeWorldMatrix();
+                    let bakedMatrix = TmpVectors.Matrix[0];
+                    child._localMatrix.multiplyToRef(this._localMatrix, bakedMatrix);
+                    let tmpRotationQuaternion = TmpVectors.Quaternion[0];
+                    bakedMatrix.decompose(child.scaling, tmpRotationQuaternion, child.position);
+                    if (child.rotationQuaternion){
+                        child.rotationQuaternion = tmpRotationQuaternion;
+                    } else {
+                        tmpRotationQuaternion.toEulerAnglesToRef(child.rotation);
+                    }
+                }
+            }
+        }
+        this.scaling.copyFromFloats(1, 1, 1);
+        this.position.copyFromFloats(0, 0, 0);
+        this.rotation.copyFromFloats(0, 0, 0);
+
+        //only if quaternion is already set
+        if (this.rotationQuaternion) {
+            this.rotationQuaternion = Quaternion.Identity();
+        }
+        this._worldMatrix = Matrix.Identity();
+    }
+
     protected _afterComputeWorldMatrix(): void {
     }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -1177,7 +1177,7 @@ export class TransformNode extends Node {
         this.computeWorldMatrix();
         if (independentOfChildren) {
             let children = this.getChildren();
-            for(let i = 0; i < children.length; ++i){
+            for (let i = 0; i < children.length; ++i) {
                 let child = children[i] as TransformNode;
                 if (child) {
                     child.computeWorldMatrix();


### PR DESCRIPTION
Fix for mesh bakeCurrentTransformIntoVertices() where child transforms are not properly preserved. Added NodeTransform.resetLocalMatrix() method to allow for safe reset of transform independent of child transforms