### PR TITLE
Added isRigCamera and rigParent parameters to Camera

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -303,6 +303,7 @@
 - Physics compound calculations were incorrect ([#7407](https://github.com/BabylonJS/Babylon.js/issues/7407)) ([RaananW](https://github.com/RaananW/))
 - Fix bug NME bug where preview area crashes on pop up when NME is opened from playground ([Kyle Belfort](https://github.com/belfortk))
 - Fixed an issue with isSessionSupported return value being ignored ([#7501](https://github.com/BabylonJS/Babylon.js/issues/7501)) ([RaananW](https://github.com/RaananW/))
+- Added isRigCamera to rig cameras so they can be detected. Used to fix a bug with utility layer and WebXR ([#7517](https://github.com/BabylonJS/Babylon.js/issues/7517)) ([RaananW](https://github.com/RaananW/))
 
 ## Breaking changes
 

--- a/src/Cameras/XR/webXRCamera.ts
+++ b/src/Cameras/XR/webXRCamera.ts
@@ -60,10 +60,12 @@ export class WebXRCamera extends FreeCamera {
 
     private _updateNumberOfRigCameras(viewCount = 1) {
         while (this.rigCameras.length < viewCount) {
-            var newCamera = new TargetCamera("view: " + this.rigCameras.length, Vector3.Zero(), this.getScene());
+            var newCamera = new TargetCamera("XR-RigCamera: " + this.rigCameras.length, Vector3.Zero(), this.getScene());
             newCamera.minZ = 0.1;
             newCamera.rotationQuaternion = new Quaternion();
             newCamera.updateUpVectorFromRotation = true;
+            newCamera.isRigCamera = true;
+            newCamera.rigParent = this;
             this.rigCameras.push(newCamera);
         }
         while (this.rigCameras.length > viewCount) {

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -1128,6 +1128,8 @@ export class ArcRotateCamera extends TargetCamera {
         }
         var rigCam = new ArcRotateCamera(name, this.alpha + alphaShift, this.beta, this.radius, this._target, this.getScene());
         rigCam._cameraRigParams = {};
+        rigCam.isRigCamera = true;
+        rigCam.rigParent = this;
         return rigCam;
     }
 

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -266,6 +266,17 @@ export class Camera extends Node {
      */
     public onRestoreStateObservable = new Observable<Camera>();
 
+    /**
+     * Is this camera a part of a rig system?
+     */
+    public isRigCamera: boolean = false;
+
+    /**
+     * If isRigCamera set to true this will be set with the parent camera.
+     * The parent camera is not (!) necessarily the .parent of this camera (like in the case of XR)
+     */
+    public rigParent?: Camera;
+
     /** @hidden */
     public _cameraRigParams: any;
     /** @hidden */

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -432,6 +432,8 @@ export class TargetCamera extends Camera {
     public createRigCamera(name: string, cameraIndex: number): Nullable<Camera> {
         if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
             var rigCamera = new TargetCamera(name, this.position.clone(), this.getScene());
+            rigCamera.isRigCamera = true;
+            rigCamera.rigParent = this;
             if (this.cameraRigMode === Camera.RIG_MODE_VR || this.cameraRigMode === Camera.RIG_MODE_WEBVR) {
                 if (!this.rotationQuaternion) {
                     this.rotationQuaternion = new Quaternion();

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -29,10 +29,14 @@ export class UtilityLayerRenderer implements IDisposable {
     public getRenderCamera() {
         if (this._renderCamera) {
             return this._renderCamera;
-        } else if (this.originalScene.activeCameras.length > 1) {
-            return this.originalScene.activeCameras[this.originalScene.activeCameras.length - 1];
         } else {
-            return this.originalScene.activeCamera;
+            let activeCam: Camera;
+            if (this.originalScene.activeCameras.length > 1) {
+                activeCam = this.originalScene.activeCameras[this.originalScene.activeCameras.length - 1];
+            } else {
+                activeCam = <Camera>(this.originalScene.activeCamera!);
+            }
+            return (activeCam && activeCam.isRigCamera) ? activeCam.rigParent! : activeCam;
         }
     }
     /**


### PR DESCRIPTION
Used to fix a bug with utilityLayerRenderer that was taking the wrong active camera.

The reason we need `rigParent` is that in WebXR the rig cameras don't use the "parent" camera as actual transformation parent. The get their position from the global XR frame. So it is impossible to use `camera.parent` to detect the parent camera of a rig cam.

Closing #7517