### PR TITLE
Add/Fix ArcRotateCamera Pinch to Zoom with new NaturalPinchZoom type

### DIFF
--- a/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
+++ b/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
@@ -59,9 +59,10 @@ export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
     public pinchDeltaPercentage = 0;
 
     /**
-     * useNaturalPinchZoom will be used instead of pinchPrecision if set to true.
-     * Pinch natural zoom is a calculation based off the distance of the
-     * pinch and the camera distance.
+     * When useNaturalPinchZoom is true, multi touch zoom will zoom in such
+     * that any object in the plane at the camera's target point will scale
+     * perfectly with finger motion.
+     * Overrides pinchDeltaPercentage and pinchPrecision.
      */
     @serialize()
     public useNaturalPinchZoom: boolean = false;
@@ -143,13 +144,13 @@ export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
         var direction = this.pinchInwards ? 1 : -1;
 
         if (this.multiTouchPanAndZoom) {
-            if (this.pinchDeltaPercentage) {
+            if (this.useNaturalPinchZoom) {
+                this.camera.radius = this.camera.radius *
+                    Math.sqrt(previousPinchSquaredDistance) / Math.sqrt(pinchSquaredDistance);
+            } else if (this.pinchDeltaPercentage) {
                 this.camera.inertialRadiusOffset +=
                     (pinchSquaredDistance - previousPinchSquaredDistance) * 0.001 *
                     this.camera.radius * this.pinchDeltaPercentage;
-            } else if (this.useNaturalPinchZoom) {
-                this.camera.radius = this.camera.radius *
-                    Math.sqrt(previousPinchSquaredDistance) / Math.sqrt(pinchSquaredDistance);
             }
             else {
                 this.camera.inertialRadiusOffset +=

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -299,8 +299,10 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Gets or Set the pointer use natural pinch zoom to override the pinch precision
-     * and pinch delta percentage. Natural pinch zoom  in uses the distance of the pinch
-     * in relation to the camera distance to determine the zoom.
+     * and pinch delta percentage.
+     * When useNaturalPinchZoom is true, multi touch zoom will zoom in such
+     * that any object in the plane at the camera's target point will scale
+     * perfectly with finger motion.
      */
     public get useNaturalPinchZoom(): boolean {
         var pointers = <ArcRotateCameraPointersInput>this.inputs.attached["pointers"];

--- a/what's new.md
+++ b/what's new.md
@@ -222,6 +222,7 @@
 - Improving visual quality on SSAO2 shader ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fixed a bug where changing the sample count on `PostProcess` would not update the WebGL Texture ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fixed multi camera support in defaultRenderingPipeline depth of field ([sebavan](http://www.github.com/sebavan))
+- Added a new NaturalPinchZoom for the ArcRotateCamera, which adds a new pinch type that is based on the camera and pinch distance. ([rwedoff](https://github.com/rwedoff))
 
 ### Viewer
 


### PR DESCRIPTION
## What Changed
The current pinch to zoom functionality for the ArcRotateCamera is not generic to all models without setting various parameters. Therefore, I added a new pinch type (to support backwards compatibility) that uses the distance of the camera in relation to the pinch distance. As a result, this is a more natural way to zoom in on a model and it generic to any model, without breaking the current pinch to zoom paradigm. 

## Usage
var camera = new BABYLON.ArcRotateCamera(...);
camera.useNaturalPinchZoom = true;
![PinchZoom](https://user-images.githubusercontent.com/6679636/73411075-f4ff2900-42b8-11ea-8571-490f8cc5bb23.gif)
