### PR TITLE
Fix for bug where NME would crash if frames did not have comments

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -315,6 +315,7 @@
 - Fixed bug in the `ScrollViewer` GUI class when setting a `idealWidth` or `idealHeight` on the ADT ([Popov72](https://github.com/Popov72))
 - Fixed bug in the `Image` GUI class where some properties were lost after a rotation by n x 90° ([Popov72](https://github.com/Popov72))
 - Fixed bug in the `Image` GUI class when rotating a SVG picture ([Popov72](https://github.com/Popov72))
+- Fix for bug where NME would crash if frames did not have comments ([Kyle Belfort](https://github.com/belfortk))
 
 ## Breaking changes
 

--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -256,6 +256,7 @@ export class GraphFrame {
             this._commentsElement.style.gridRow = "2";
             this._commentsElement.style.gridColumn = "1";
             this._commentsElement.style.paddingLeft = "10px";
+            this._commentsElement.style.fontStyle = "italic";
             this._commentsElement.innerText = comments;
         }
         this._comments = comments;

--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -248,7 +248,7 @@ export class GraphFrame {
     }
 
     public set comments(comments: string) {
-        if (comments.length > 0) {
+        if (comments && comments.length > 0) {
             this.element.style.gridTemplateRows = "40px 40px calc(100% - 80px)";
             this._borderElement.style.gridRow = "1 / span 3";
             this._portContainer.style.gridRow = "3";
@@ -256,10 +256,9 @@ export class GraphFrame {
             this._commentsElement.style.gridRow = "2";
             this._commentsElement.style.gridColumn = "1";
             this._commentsElement.style.paddingLeft = "10px";
-            this._commentsElement.style.fontStyle = "italic";
+            this._commentsElement.innerText = comments;
         }
         this._comments = comments;
-        this._commentsElement.innerText = comments;
     }
 
     public constructor(candidate: Nullable<HTMLDivElement>, canvas: GraphCanvasComponent, doNotCaptureNodes = false) {


### PR DESCRIPTION
Updated the if guard in graphFrames.[set comments] to handle if comments is undefined.