### PR TITLE
Added ImageScrollBar.num90RotationInVerticalMode property

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -224,6 +224,7 @@
 - Added `_getSVGAttribs` functionality for loading multiple svg icons from an external svg file via icon id. Fixed bug for Chrome. Strip icon id from image url for firefox.([lockphase](https://github.com/lockphase/))
 - Scroll Viewer extended to include the use of images in the scroll bars([JohnK](https://github.com/BabylonJSGuide/))
 - Added `ScrollViewer.freezeControls` property to speed up rendering ([Popov72](https://github.com/Popov72))
+- Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user rotate the pictures when in vertical mode ([Popov72](https://github.com/Popov72))
 
 ### Particles
 

--- a/gui/src/2D/controls/sliders/imageScrollBar.ts
+++ b/gui/src/2D/controls/sliders/imageScrollBar.ts
@@ -17,6 +17,9 @@ export class ImageScrollBar extends BaseSlider {
     private _barImageHeight: number = 1;
     private _tempMeasure = new Measure(0, 0, 0, 0);
 
+    /** Number of 90° rotation to apply on the images when in vertical mode */
+    public num90RotationInVerticalMode = 1;
+
     /**
      * Gets or sets the image used to render the background for horizontal bar
      */
@@ -31,10 +34,10 @@ export class ImageScrollBar extends BaseSlider {
 
         this._backgroundBaseImage = value;
 
-        if (this.isVertical) {
+        if (this.isVertical && this.num90RotationInVerticalMode !== 0) {
             if (!value.isLoaded) {
                 value.onImageLoadedObservable.addOnce(() => {
-                    const rotatedValue = value._rotate90(1, true);
+                    const rotatedValue = value._rotate90(this.num90RotationInVerticalMode, true);
                     this._backgroundImage = rotatedValue;
                     if (!rotatedValue.isLoaded) {
                         rotatedValue.onImageLoadedObservable.addOnce(() => {
@@ -44,7 +47,7 @@ export class ImageScrollBar extends BaseSlider {
                     this._markAsDirty();
                 });
             } else {
-                this._backgroundImage = value._rotate90(1, true);
+                this._backgroundImage = value._rotate90(this.num90RotationInVerticalMode, true);
                 this._markAsDirty();
             }
         }
@@ -74,10 +77,10 @@ export class ImageScrollBar extends BaseSlider {
 
         this._thumbBaseImage = value;
 
-        if (this.isVertical) {
+        if (this.isVertical && this.num90RotationInVerticalMode !== 0) {
             if (!value.isLoaded) {
                 value.onImageLoadedObservable.addOnce(() => {
-                    var rotatedValue = value._rotate90(-1, true);
+                    var rotatedValue = value._rotate90(-this.num90RotationInVerticalMode, true);
                     this._thumbImage = rotatedValue;
                     if (!rotatedValue.isLoaded) {
                         rotatedValue.onImageLoadedObservable.addOnce(() => {
@@ -87,7 +90,7 @@ export class ImageScrollBar extends BaseSlider {
                     this._markAsDirty();
                 });
             } else {
-                this._thumbImage = value._rotate90(-1, true);
+                this._thumbImage = value._rotate90(-this.num90RotationInVerticalMode, true);
                 this._markAsDirty();
             }
         }


### PR DESCRIPTION
Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user freely rotate the pictures (background / thumb) when in vertical mode.

This property is equal to 1 by default to stay backward compatible.

I noticed the thumb image is rotated -90° whereas it is 90° for the background picture. I left it as is to no break compatibility but was there a reason for this? It may seem awkward for the user to have a different rotation for the background and for the thumb.

Should we have two `num90RotationInVerticalMode` properties, one for the background and one for the thumb image?