### PR TITLE
Fix for light gizmo changing light transforms on activation.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -328,6 +328,7 @@
 - Fix wrong import of _TimeToken ([Sebavan](https://github.com/sebavan/)
 - Fix shadows not rendered correctly when using point lights ([Popov72](https://github.com/Popov72))
 - Prevent depth buffer clear in shadow maps ([Sebavan](https://github.com/sebavan/)
+- Fix for bug where the light gizmo causes lights to flip orientation ([#7603](https://github.com/BabylonJS/Babylon.js/issues/7603)) ([drigax](https://github.com/drigax))
 
 ## Breaking changes
 

--- a/src/Gizmos/lightGizmo.ts
+++ b/src/Gizmos/lightGizmo.ts
@@ -85,9 +85,13 @@ export class LightGizmo extends Gizmo {
             // Get update position and direction if the light has it
             if ((light as any).position) {
                 this.attachedMesh!.position.copyFrom((light as any).position);
+                this.attachedMesh!.computeWorldMatrix(true);
+                this._cachedPosition.copyFrom(this.attachedMesh!.position);
             }
             if ((light as any).direction) {
                 this.attachedMesh!.setDirection((light as any).direction);
+                this.attachedMesh!.computeWorldMatrix(true);
+                this._cachedForward.copyFrom(this.attachedMesh!.forward);
             }
 
             this._update();
@@ -127,6 +131,8 @@ export class LightGizmo extends Gizmo {
             } else {
                 // update gizmo to match light
                 this.attachedMesh!.position.copyFrom((this._light as any).position);
+                this.attachedMesh!.computeWorldMatrix(true);
+                this._cachedPosition.copyFrom(this.attachedMesh!.position);
             }
 
         }
@@ -139,7 +145,8 @@ export class LightGizmo extends Gizmo {
             } else if (Vector3.DistanceSquared(this.attachedMesh!.forward, (this._light as any).direction) > 0.0001) {
                 // update gizmo to match light
                 this.attachedMesh!.setDirection((this._light as any).direction);
-                this._cachedForward.copyFrom(this._lightMesh.forward);
+                this.attachedMesh!.computeWorldMatrix(true);
+                this._cachedForward.copyFrom(this.attachedMesh!.forward);
             }
         }
         if (!this._light.isEnabled()) {


### PR DESCRIPTION
This PR addresses an issue in the lights gizmo where activating the gizmo causes the light to invert direction.

This appears caused by us not properly setting and recalculating the cached light orientation and direction after creating the gizmo, causing the light's transform to be improperly updated on the next BeforeRender tick, using the stale world matrix of the gizmo. This appears to cause a toggling behavior, as the gizmo is removed and recreated.

My proposed fix forces a world matrix recalculation, and sets the cached value appropriately.