### PR TITLE
Improvements for playground

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -1073,6 +1073,11 @@ class Main {
             }
         }
         if (pgHash) {
+            var match = pgHash.match(/^(#[A-Z\d]*)(%23)([\d]+)$/);
+            if (match){
+                pgHash = match[1]+'#'+match[3];
+                parent.location.hash = pgHash;
+            }
             this.previousHash = pgHash;
             this.loadPlayground(pgHash.substr(1))
         }

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -1142,16 +1142,27 @@ class Main {
         }
     }
     updateMetadata() {
+        var selection;
+
         if (this.currentSnippetTitle) {
-            document.querySelector('title').innerText = (this.currentSnippetTitle + " | Babylon.js Playground");
+            selection = document.querySelector('title');
+            if(selection){
+                selection.innerText = (this.currentSnippetTitle + " | Babylon.js Playground");
+            }
         }
 
         if (this.currentSnippetDescription) {
-            document.querySelector('meta[name="description"]').setAttribute("content", this.currentSnippetDescription + " - Babylon.js Playground");
+            selection = document.querySelector('meta[name="description"]');
+            if(selection){
+                selection.setAttribute("content", this.currentSnippetDescription + " - Babylon.js Playground");
+            }
         }
 
         if (this.currentSnippetTags) {
-            document.querySelector('meta[name="keywords"]').setAttribute("content", "babylon.js, game engine, webgl, 3d," + this.currentSnippetTags);
+            selection = document.querySelector('meta[name="keywords"]');
+            if(selection){
+                selection.setAttribute("content", "babylon.js, game engine, webgl, 3d," + this.currentSnippetTags);
+            }
         }
     }
     parseQuery(queryString) {

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -1073,7 +1073,7 @@ class Main {
             }
         }
         if (pgHash) {
-            var match = pgHash.match(/^(#[A-Z\d]*)(%23)([\d]+)$/);
+            var match = pgHash.match(/^(#[A-Za-z\d]*)(%23)([\d]+)$/);
             if (match){
                 pgHash = match[1]+'#'+match[3];
                 parent.location.hash = pgHash;

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -291,7 +291,7 @@ class Main {
             this.parent.menuPG.removeAllOptions();
             this.createNewScript.call(this);
         }.bind(this));
-        // Clear 
+        // Clear
         this.parent.utils.setToMultipleID("clearButton", "click", function () {
             this.parent.menuPG.removeAllOptions();
             this.clear.call(this);
@@ -460,7 +460,7 @@ class Main {
 
     /**
      * Check if we're in the correct language for the selected script
-     * @param {*} xhr 
+     * @param {*} xhr
      */
     checkTypescriptSupport(xhr) {
         // If we're loading TS content and it's JS page
@@ -482,8 +482,8 @@ class Main {
 
     /**
      * Load a script in the database
-     * @param {*} scriptURL 
-     * @param {*} title 
+     * @param {*} scriptURL
+     * @param {*} title
      */
     loadScript(scriptURL, title) {
         var xhr = new XMLHttpRequest();


### PR DESCRIPTION
Some apps (for ex. `Telegram`) and services convert second hash symbol in Babylon Playground links from `#` to `%23` and these links become unreachable for playground. This PR solves this problem
`#UYS16D%236` --> `#UYS16D#6`

`+` plus make small fix for unreachable selectors error