### PR TITLE
Add renderSprites params inside CreateScreenshotUsingRenderTargetAsync

### DIFF
--- a/src/Misc/screenshotTools.ts
+++ b/src/Misc/screenshotTools.ts
@@ -198,10 +198,11 @@ export class ScreenshotTools {
      * @param samples Texture samples (default: 1)
      * @param antialiasing Whether antialiasing should be turned on or not (default: false)
      * @param fileName A name for for the downloaded file.
+     * @param renderSprites Whether the sprites should be rendered or not (default: false)
      * @returns screenshot as a string of base64-encoded characters. This string can be assigned
      * to the src parameter of an <img> to display it
      */
-    public static CreateScreenshotUsingRenderTargetAsync(engine: Engine, camera: Camera, size: any, mimeType: string = "image/png", samples: number = 1, antialiasing: boolean = false, fileName?: string): Promise<string> {
+    public static CreateScreenshotUsingRenderTargetAsync(engine: Engine, camera: Camera, size: any, mimeType: string = "image/png", samples: number = 1, antialiasing: boolean = false, fileName?: string,  renderSprites: boolean = false): Promise<string> {
         return new Promise((resolve, reject) => {
             ScreenshotTools.CreateScreenshotUsingRenderTarget(engine, camera, size, (data) => {
                 if (typeof(data) !== "undefined") {
@@ -209,7 +210,7 @@ export class ScreenshotTools {
                 } else {
                     reject(new Error("Data is undefined"));
                 }
-            }, mimeType, samples, antialiasing, fileName);
+            }, mimeType, samples, antialiasing, fileName, renderSprites);
         });
     }
 


### PR DESCRIPTION
As this [pull request ](https://github.com/BabylonJS/Babylon.js/pull/7621) add a renderSprites param inside the CreateScreenshotUsingRenderTarget, it was necessary to also add it to the Async function for concistency.

It's directly linked to this discussion :  
https://forum.babylonjs.com/t/sprite-and-screenshot-using-render-target/8493/4