### PR TITLE
Import refactoring

### DIFF
--- a/Viewer/src/labs/viewerLabs.ts
+++ b/Viewer/src/labs/viewerLabs.ts
@@ -1,10 +1,10 @@
 import { PBREnvironment, EnvironmentDeserializer } from "./environmentSerializer";
 import { Scene } from "babylonjs/scene";
-import { Vector3, Quaternion, Axis, Matrix, TmpVectors } from "babylonjs/Maths/math";
+import { Vector3, Quaternion, Matrix, TmpVectors } from "babylonjs/Maths/math.vector";
 import { SphericalPolynomial } from "babylonjs/Maths/sphericalPolynomial";
 import { ShadowLight } from "babylonjs/Lights/shadowLight";
 import { TextureUtils } from "./texture";
-
+import { Axis } from "babylonjs/Maths/math.axis";
 
 /**
  * The ViewerLabs class will hold functions that are not (!) backwards compatible.

--- a/Viewer/src/model/modelAnimation.ts
+++ b/Viewer/src/model/modelAnimation.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { AnimationGroup, Animatable } from "babylonjs/Animations/index";
 
 /**

--- a/Viewer/src/model/viewerModel.ts
+++ b/Viewer/src/model/viewerModel.ts
@@ -8,7 +8,7 @@ import { SceneLoaderProgressEvent } from "babylonjs/Loading/sceneLoader";
 import { AnimationGroup } from "babylonjs/Animations/animationGroup";
 import { Animation, Animatable, CircleEase, BackEase, BounceEase, CubicEase, ElasticEase, ExponentialEase, PowerEase, QuadraticEase, QuarticEase, QuinticEase, SineEase } from "babylonjs/Animations/index";
 import { Nullable } from "babylonjs/types";
-import { Quaternion, Vector3 } from "babylonjs/Maths/math";
+import { Quaternion, Vector3 } from "babylonjs/Maths/math.vector";
 import { Tags } from "babylonjs/Misc/tags";
 import { Material } from "babylonjs/Materials/material";
 import { PBRMaterial } from "babylonjs/Materials/PBR/pbrMaterial";

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observable, Observer } from "babylonjs/Misc/observable";
-import { Viewport, Color3, Vector2, Vector3, Matrix } from "babylonjs/Maths/math";
+import { Vector2, Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { Tools } from "babylonjs/Misc/tools";
 import { PointerInfoPre, PointerInfo, PointerEventTypes } from 'babylonjs/Events/pointerEvents';
 import { ClipboardEventTypes, ClipboardInfo } from "babylonjs/Events/clipboardEvents";
@@ -19,6 +19,8 @@ import { Control } from "./controls/control";
 import { Style } from "./style";
 import { Measure } from "./measure";
 import { Constants } from 'babylonjs/Engines/constants';
+import { Viewport } from 'babylonjs/Maths/math.viewport';
+import { Color3 } from 'babylonjs/Maths/math.color';
 /**
 * Interface used to define a control that can receive focus
 */

--- a/gui/src/2D/controls/button.ts
+++ b/gui/src/2D/controls/button.ts
@@ -1,5 +1,5 @@
 import { Nullable } from "babylonjs/types";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 import { Rectangle } from "./rectangle";
 import { Control } from "./control";

--- a/gui/src/2D/controls/checkbox.ts
+++ b/gui/src/2D/controls/checkbox.ts
@@ -1,5 +1,5 @@
 import { Observable } from "babylonjs/Misc/observable";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 import { Control } from "./control";
 import { StackPanel } from "./stackPanel";

--- a/gui/src/2D/controls/colorpicker.ts
+++ b/gui/src/2D/controls/colorpicker.ts
@@ -1,5 +1,5 @@
 import { Observable } from "babylonjs/Misc/observable";
-import { Color3, Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 import { Control } from "./control";
 import { Measure } from "../measure";
@@ -10,6 +10,7 @@ import { Grid } from "./grid";
 import { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import { TextBlock } from "../controls/textBlock";
 import { _TypeStore } from 'babylonjs/Misc/typeStore';
+import { Color3 } from 'babylonjs/Maths/math.color';
 
 /** Class used to create color pickers */
 export class ColorPicker extends Control {

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observable, Observer } from "babylonjs/Misc/observable";
-import { Vector2, Vector3, Matrix } from "babylonjs/Maths/math";
+import { Vector2, Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { PointerEventTypes } from 'babylonjs/Events/pointerEvents';
 import { Logger } from "babylonjs/Misc/logger";
 import { Tools } from "babylonjs/Misc/tools";

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observable, Observer } from "babylonjs/Misc/observable";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { ClipboardEventTypes, ClipboardInfo } from "babylonjs/Events/clipboardEvents";
 import { PointerInfo, PointerEventTypes } from 'babylonjs/Events/pointerEvents';
 

--- a/gui/src/2D/controls/line.ts
+++ b/gui/src/2D/controls/line.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observer } from "babylonjs/Misc/observable";
-import { Vector3, Matrix } from "babylonjs/Maths/math";
+import { Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { Tools } from "babylonjs/Misc/tools";
 import { Scene } from "babylonjs/scene";
 

--- a/gui/src/2D/controls/radioButton.ts
+++ b/gui/src/2D/controls/radioButton.ts
@@ -1,5 +1,5 @@
 import { Observable } from "babylonjs/Misc/observable";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 import { Control } from "./control";
 import { StackPanel } from "./stackPanel";

--- a/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/gui/src/2D/controls/sliders/baseSlider.ts
@@ -1,5 +1,5 @@
 import { Observable } from "babylonjs/Misc/observable";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 import { Control } from "../control";
 import { ValueAndUnit } from "../../valueAndUnit";

--- a/gui/src/2D/controls/sliders/imageScrollBar.ts
+++ b/gui/src/2D/controls/sliders/imageScrollBar.ts
@@ -1,4 +1,4 @@
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { BaseSlider } from "./baseSlider";
 import { Control } from "../control";
 import { Image } from "../image";

--- a/gui/src/2D/controls/sliders/scrollBar.ts
+++ b/gui/src/2D/controls/sliders/scrollBar.ts
@@ -1,4 +1,4 @@
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { BaseSlider } from "./baseSlider";
 import { Control } from "../control";
 import { Measure } from "../../measure";

--- a/gui/src/2D/math2D.ts
+++ b/gui/src/2D/math2D.ts
@@ -1,5 +1,6 @@
 import { Nullable } from "babylonjs/types";
-import { Vector2, Epsilon } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
+import { Epsilon } from 'babylonjs/Maths/math.constants';
 
 /**
  * Class used to transport Vector2 information for pointer events

--- a/gui/src/2D/measure.ts
+++ b/gui/src/2D/measure.ts
@@ -1,5 +1,5 @@
 import { Matrix2D } from "./math2D";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 
 let tmpRect = [
     new Vector2(0, 0),

--- a/gui/src/2D/multiLinePoint.ts
+++ b/gui/src/2D/multiLinePoint.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observer } from "babylonjs/Misc/observable";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { Camera } from "babylonjs/Cameras/camera";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 

--- a/gui/src/3D/controls/button3D.ts
+++ b/gui/src/3D/controls/button3D.ts
@@ -1,5 +1,5 @@
 import { int, Nullable } from "babylonjs/types";
-import { Color3, Vector4 } from "babylonjs/Maths/math";
+import { Vector4 } from "babylonjs/Maths/math.vector";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 import { BoxBuilder } from "babylonjs/Meshes/Builders/boxBuilder";
@@ -11,6 +11,7 @@ import { Scene } from "babylonjs/scene";
 import { AbstractButton3D } from "./abstractButton3D";
 import { AdvancedDynamicTexture } from "../../2D/advancedDynamicTexture";
 import { Control } from "../../2D/controls/control";
+import { Color3 } from 'babylonjs/Maths/math.color';
 
 /**
  * Class used to create a button in 3D

--- a/gui/src/3D/controls/control3D.ts
+++ b/gui/src/3D/controls/control3D.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observable } from "babylonjs/Misc/observable";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { PointerEventTypes } from "babylonjs/Events/pointerEvents";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";

--- a/gui/src/3D/controls/holographicButton.ts
+++ b/gui/src/3D/controls/holographicButton.ts
@@ -2,7 +2,7 @@ import { Button3D } from "./button3D";
 
 import { Nullable } from "babylonjs/types";
 import { Observer } from "babylonjs/Misc/observable";
-import { Color3, Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { StandardMaterial } from "babylonjs/Materials/standardMaterial";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Mesh } from "babylonjs/Meshes/mesh";
@@ -17,6 +17,7 @@ import { Image } from "../../2D/controls/image";
 import { TextBlock } from "../../2D/controls/textBlock";
 import { AdvancedDynamicTexture } from "../../2D/advancedDynamicTexture";
 import { Control3D } from "./control3D";
+import { Color3 } from 'babylonjs/Maths/math.color';
 
 /**
  * Class used to create a holographic button in 3D

--- a/gui/src/3D/controls/planePanel.ts
+++ b/gui/src/3D/controls/planePanel.ts
@@ -1,4 +1,4 @@
-import { TmpVectors, Vector3 } from "babylonjs/Maths/math";
+import { TmpVectors, Vector3 } from "babylonjs/Maths/math.vector";
 
 import { Container3D } from "./container3D";
 import { Control3D } from "./control3D";

--- a/gui/src/3D/controls/scatterPanel.ts
+++ b/gui/src/3D/controls/scatterPanel.ts
@@ -1,5 +1,5 @@
 import { Tools } from "babylonjs/Misc/tools";
-import { TmpVectors, Vector3 } from "babylonjs/Maths/math";
+import { TmpVectors, Vector3 } from "babylonjs/Maths/math.vector";
 import { float } from "babylonjs/types";
 
 import { VolumeBasedPanel } from "./volumeBasedPanel";

--- a/gui/src/3D/controls/spherePanel.ts
+++ b/gui/src/3D/controls/spherePanel.ts
@@ -1,10 +1,11 @@
 import { Tools } from "babylonjs/Misc/tools";
-import { Space, Axis, Matrix, TmpVectors, Vector3 } from "babylonjs/Maths/math";
+import { Matrix, TmpVectors, Vector3 } from "babylonjs/Maths/math.vector";
 import { float } from "babylonjs/types";
 
 import { VolumeBasedPanel } from "./volumeBasedPanel";
 import { Control3D } from "./control3D";
 import { Container3D } from "./container3D";
+import { Axis, Space } from 'babylonjs/Maths/math.axis';
 
 /**
  * Class used to create a container panel deployed on the surface of a sphere

--- a/gui/src/3D/controls/stackPanel3D.ts
+++ b/gui/src/3D/controls/stackPanel3D.ts
@@ -1,5 +1,5 @@
 import { Tools } from "babylonjs/Misc/tools";
-import { Matrix, TmpVectors, Vector3 } from "babylonjs/Maths/math";
+import { Matrix, TmpVectors, Vector3 } from "babylonjs/Maths/math.vector";
 
 import { Container3D } from "./container3D";
 

--- a/gui/src/3D/gui3DManager.ts
+++ b/gui/src/3D/gui3DManager.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { Observable, Observer } from "babylonjs/Misc/observable";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { PointerInfo, PointerEventTypes } from 'babylonjs/Events/pointerEvents';
 import { Material } from "babylonjs/Materials/material";
 import { HemisphericLight } from "babylonjs/Lights/hemisphericLight";

--- a/gui/src/3D/materials/fluentMaterial.ts
+++ b/gui/src/3D/materials/fluentMaterial.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { serializeAsColor4, serializeAsVector3, serializeAsTexture, serialize, expandToProperty, serializeAsColor3, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3, Vector3, Color4, Matrix, TmpVectors } from "babylonjs/Maths/math";
+import { Vector3, Matrix, TmpVectors } from "babylonjs/Maths/math.vector";
 import { BaseTexture } from "babylonjs/Materials/Textures/baseTexture";
 import { MaterialDefines } from "babylonjs/Materials/materialDefines";
 import { IEffectCreationOptions } from "babylonjs/Materials/effect";
@@ -12,6 +12,7 @@ import { SubMesh } from "babylonjs/Meshes/subMesh";
 import { Mesh } from "babylonjs/Meshes/mesh";
 import { Scene } from "babylonjs/scene";
 import { _TypeStore } from 'babylonjs/Misc/typeStore';
+import { Color3, Color4 } from 'babylonjs/Maths/math.color';
 
 import "./shaders/fluent.vertex";
 import "./shaders/fluent.fragment";

--- a/gui/src/3D/vector3WithInfo.ts
+++ b/gui/src/3D/vector3WithInfo.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 
 /**
  * Class used to transport Vector3 information for pointer events

--- a/inspector/src/components/actionTabs/lines/color3LineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/color3LineComponent.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { Observable } from "babylonjs/Misc/observable";
-import { Color3 } from "babylonjs/Maths/math";
 import { PropertyChangedEvent } from "../../propertyChangedEvent";
 import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { Color3 } from 'babylonjs/Maths/math.color';
 
 const copyIcon: string = require("./copy.svg");
 
@@ -124,7 +124,7 @@ export class Color3LineComponent extends React.Component<IColor3LineComponentPro
 
     render() {
 
-        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />
+        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
         const colorAsColor3 = this.state.color.getClassName() === "Color3" ? this.state.color : new Color3(this.state.color.r, this.state.color.g, this.state.color.b);
 
         return (
@@ -146,9 +146,9 @@ export class Color3LineComponent extends React.Component<IColor3LineComponentPro
                 {
                     this.state.isExpanded &&
                     <div className="secondLine">
-                        <NumericInputComponent label="r" value={this.state.color.r} onChange={value => this.updateStateR(value)} />
-                        <NumericInputComponent label="g" value={this.state.color.g} onChange={value => this.updateStateG(value)} />
-                        <NumericInputComponent label="b" value={this.state.color.b} onChange={value => this.updateStateB(value)} />
+                        <NumericInputComponent label="r" value={this.state.color.r} onChange={(value) => this.updateStateR(value)} />
+                        <NumericInputComponent label="g" value={this.state.color.g} onChange={(value) => this.updateStateG(value)} />
+                        <NumericInputComponent label="b" value={this.state.color.b} onChange={(value) => this.updateStateB(value)} />
                     </div>
                 }
             </div>

--- a/inspector/src/components/actionTabs/lines/color4LineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/color4LineComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Observable } from "babylonjs/Misc/observable";
-import { Color3, Color4 } from "babylonjs/Maths/math";
+import { Color3, Color4 } from "babylonjs/Maths/math.color";
 import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";

--- a/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Observable } from "babylonjs/Misc/observable";
-import { Quaternion, Vector3 } from "babylonjs/Maths/math";
+import { Quaternion, Vector3 } from "babylonjs/Maths/math.vector";
 import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";

--- a/inspector/src/components/actionTabs/lines/vector2LineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/vector2LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/inspector/src/components/actionTabs/lines/vector3LineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/vector3LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/inspector/src/components/actionTabs/lines/vector4LineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/vector4LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector4 } from "babylonjs/Maths/math";
+import { Vector4 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 
 import { Observable } from "babylonjs/Misc/observable";
 import { Tools } from "babylonjs/Misc/tools";
-import { Color3, Vector3, TmpVectors } from "babylonjs/Maths/math";
+import { Vector3, TmpVectors } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Mesh } from "babylonjs/Meshes/mesh";
 import { VertexBuffer } from "babylonjs/Meshes/buffer";
 import { LinesBuilder } from "babylonjs/Meshes/Builders/linesBuilder";
@@ -292,12 +293,12 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
             return {
                 label: m.name || "no name",
                 value: i
-            }});
+            };});
 
         materialOptions.splice(0, 0, {
             label: "None",
             value: -1
-        })
+        });
 
         return (
             <div className="pane">
@@ -314,7 +315,7 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
                     {
                         mesh.parent &&
                         <TextLineComponent label="Parent" value={mesh.parent.name} onLink={() => this.props.globalState.onSelectionChangedObservable.notifyObservers(mesh.parent)}/>
-                    }                      
+                    }
                     {
                         mesh.skeleton &&
                         <TextLineComponent label="Skeleton" value={mesh.skeleton.name} onLink={() => this.onSkeletonLink()}/>
@@ -326,8 +327,8 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
                         <TextLineComponent label="Link to material" value={mesh.material.name} onLink={() => this.onMaterialLink()} />
                     }
                     {   !mesh.isAnInstance &&
-                        <OptionsLineComponent label="Active material" options={materialOptions} 
-                            target={mesh} propertyName="material" 
+                        <OptionsLineComponent label="Active material" options={materialOptions}
+                            target={mesh} propertyName="material"
                             noDirectUpdate={true}
                             onSelect={(value: number) => {
                                 if (value < 0) {
@@ -376,7 +377,7 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
                     {
                         mesh.isVerticesDataPresent(VertexBuffer.ColorKind) &&
                         <CheckBoxLineComponent label="Has vertex alpha" target={mesh} propertyName="hasVertexAlpha" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
-                    }                    
+                    }
                     {
                         scene.fogMode !== Scene.FOGMODE_NONE &&
                         <CheckBoxLineComponent label="Apply fog" target={mesh} propertyName="applyFog" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
@@ -393,7 +394,7 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
                             morphTargets.map((mt, i) => {
                                 return (
                                     <SliderLineComponent label={mt.name} target={mt} propertyName="influence" minimum={0} maximum={1} step={0.01} onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
-                                )
+                                );
                             })
                         }
                     </LineContainerComponent>
@@ -430,7 +431,7 @@ export class MeshPropertyGridComponent extends React.Component<IMeshPropertyGrid
                     <OptionsLineComponent label="Algorithm" options={algorithmOptions} target={mesh} propertyName="occlusionQueryAlgorithmType" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
                 </LineContainerComponent>
                 <LineContainerComponent globalState={this.props.globalState} title="EDGE RENDERING" closed={true}>
-                    <CheckBoxLineComponent label="Enable" target={mesh} isSelected={() => mesh.edgesRenderer != null} onSelect={value => {
+                    <CheckBoxLineComponent label="Enable" target={mesh} isSelected={() => mesh.edgesRenderer != null} onSelect={(value) => {
                         if (value) {
                             mesh.enableEdgesRendering();
                         } else {

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/renderGridPropertyGridComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/renderGridPropertyGridComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { Nullable } from "babylonjs/types";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 import { Mesh } from "babylonjs/Meshes/mesh";
 import { Texture } from "babylonjs/Materials/Textures/texture";

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/scenePropertyGridComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/scenePropertyGridComponent.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Nullable } from "babylonjs/types";
 import { Observable } from "babylonjs/Misc/observable";
 import { Tools } from "babylonjs/Misc/tools";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { BaseTexture } from "babylonjs/Materials/Textures/baseTexture";
 import { CubeTexture } from "babylonjs/Materials/Textures/cubeTexture";
 import { ImageProcessingConfiguration } from "babylonjs/Materials/imageProcessingConfiguration";

--- a/loaders/src/OBJ/mtlFileLoader.ts
+++ b/loaders/src/OBJ/mtlFileLoader.ts
@@ -1,5 +1,5 @@
 import { Nullable } from "babylonjs/types";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { StandardMaterial } from "babylonjs/Materials/standardMaterial";
 

--- a/loaders/src/OBJ/objFileLoader.ts
+++ b/loaders/src/OBJ/objFileLoader.ts
@@ -1,5 +1,6 @@
 import { FloatArray, IndicesArray } from "babylonjs/types";
-import { Vector3, Vector2, Color4 } from "babylonjs/Maths/math";
+import { Vector3, Vector2 } from "babylonjs/Maths/math.vector";
+import { Color4 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { VertexData } from "babylonjs/Meshes/mesh.vertexData";
 import { Geometry } from "babylonjs/Meshes/geometry";

--- a/loaders/src/glTF/1.0/glTFLoader.ts
+++ b/loaders/src/glTF/1.0/glTFLoader.ts
@@ -1,7 +1,8 @@
 import { IGLTFRuntime, IGLTFTechniqueParameter, IGLTFAnimation, IGLTFAnimationSampler, IGLTFNode, IGLTFSkins, INodeToRoot, IJointNode, IGLTFMesh, IGLTFAccessor, IGLTFLight, IGLTFAmbienLight, IGLTFDirectionalLight, IGLTFPointLight, IGLTFSpotLight, IGLTFCamera, IGLTFCameraPerspective, IGLTFScene, IGLTFTechnique, IGLTFMaterial, EParameterType, IGLTFProgram, IGLTFBuffer, IGLTFTexture, IGLTFImage, IGLTFSampler, ETextureFilterType, IGLTFShader, IGLTFTechniqueStates, ECullingType, EBlendingFunction, EShaderType } from "./glTFLoaderInterfaces";
 
 import { FloatArray, Nullable } from "babylonjs/types";
-import { Quaternion, Color3, Vector3, Matrix } from "babylonjs/Maths/math";
+import { Quaternion, Vector3, Matrix } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { Camera } from "babylonjs/Cameras/camera";
 import { FreeCamera } from "babylonjs/Cameras/freeCamera";

--- a/loaders/src/glTF/1.0/glTFLoaderUtils.ts
+++ b/loaders/src/glTF/1.0/glTFLoaderUtils.ts
@@ -1,7 +1,8 @@
 ﻿import { IGLTFTechniqueParameter, EParameterType, ETextureWrapMode, IGLTFAccessor, ETextureFilterType, IGLTFRuntime, IGLTFBufferView, EComponentType } from "./glTFLoaderInterfaces";
 
 import { Nullable } from "babylonjs/types";
-import { Vector2, Vector3, Vector4, Color4, Matrix } from "babylonjs/Maths/math";
+import { Vector2, Vector3, Vector4, Matrix } from "babylonjs/Maths/math.vector";
+import { Color4 } from 'babylonjs/Maths/math.color';
 import { Effect } from "babylonjs/Materials/effect";
 import { ShaderMaterial } from "babylonjs/Materials/shaderMaterial";
 import { Texture } from "babylonjs/Materials/Textures/texture";

--- a/loaders/src/glTF/1.0/glTFMaterialsCommonExtension.ts
+++ b/loaders/src/glTF/1.0/glTFMaterialsCommonExtension.ts
@@ -3,7 +3,8 @@ import { GLTFLoaderBase } from "./glTFLoader";
 
 import { IGLTFRuntime, IGLTFMaterial } from "./glTFLoaderInterfaces";
 
-import { Color3, Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { Material } from "babylonjs/Materials/material";
 import { StandardMaterial } from "babylonjs/Materials/standardMaterial";

--- a/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
@@ -1,7 +1,7 @@
 import { Nullable } from "babylonjs/types";
 import { Scalar } from "babylonjs/Maths/math.scalar";
 import { SphericalHarmonics, SphericalPolynomial } from "babylonjs/Maths/sphericalPolynomial";
-import { Quaternion, Matrix } from "babylonjs/Maths/math";
+import { Quaternion, Matrix } from "babylonjs/Maths/math.vector";
 import { BaseTexture } from "babylonjs/Materials/Textures/baseTexture";
 import { RawCubeTexture } from "babylonjs/Materials/Textures/rawCubeTexture";
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -1,5 +1,6 @@
 import { Nullable } from "babylonjs/types";
-import { Color3, Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { DirectionalLight } from "babylonjs/Lights/directionalLight";
 import { PointLight } from "babylonjs/Lights/pointLight";
 import { SpotLight } from "babylonjs/Lights/spotLight";

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -1,5 +1,5 @@
 import { Nullable } from "babylonjs/types";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { PBRMaterial } from "babylonjs/Materials/PBR/pbrMaterial";
 import { Material } from "babylonjs/Materials/material";
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
@@ -1,5 +1,5 @@
 import { Nullable } from "babylonjs/types";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { PBRMaterial } from "babylonjs/Materials/PBR/pbrMaterial";
 import { Material } from "babylonjs/Materials/material";
 

--- a/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
@@ -1,5 +1,5 @@
 import { Nullable } from "babylonjs/types";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { Tools } from "babylonjs/Misc/tools";
 import { AnimationGroup } from "babylonjs/Animations/animationGroup";
 import { AnimationEvent } from "babylonjs/Animations/animationEvent";

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1,6 +1,7 @@
 import { IndicesArray, Nullable } from "babylonjs/types";
 import { Deferred } from "babylonjs/Misc/deferred";
-import { Quaternion, Color3, Vector3, Matrix } from "babylonjs/Maths/math";
+import { Quaternion, Vector3, Matrix } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { IFileRequest } from "babylonjs/Misc/fileRequest";
 import { Camera } from "babylonjs/Cameras/camera";

--- a/nodeEditor/src/sharedComponents/color3LineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/color3LineComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Observable } from "babylonjs/Misc/observable";
-import { Color3, Color4 } from "babylonjs/Maths/math";
+import { Color3, Color4 } from "babylonjs/Maths/math.color";
 import { PropertyChangedEvent } from "./propertyChangedEvent";
 import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -138,7 +138,7 @@ export class Color3LineComponent extends React.Component<IColor3LineComponentPro
 
     render() {
 
-        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />
+        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
         const colorAsColor3 = this.state.color.getClassName() === "Color3" ? this.state.color : new Color3(this.state.color.r, this.state.color.g, this.state.color.b);
 
         return (
@@ -160,9 +160,9 @@ export class Color3LineComponent extends React.Component<IColor3LineComponentPro
                 {
                     this.state.isExpanded &&
                     <div className="secondLine">
-                        <NumericInputComponent globalState={this.props.globalState} label="r" value={this.state.color.r} onChange={value => this.updateStateR(value)} />
-                        <NumericInputComponent globalState={this.props.globalState} label="g" value={this.state.color.g} onChange={value => this.updateStateG(value)} />
-                        <NumericInputComponent globalState={this.props.globalState} label="b" value={this.state.color.b} onChange={value => this.updateStateB(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="r" value={this.state.color.r} onChange={(value) => this.updateStateR(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="g" value={this.state.color.g} onChange={(value) => this.updateStateG(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="b" value={this.state.color.b} onChange={(value) => this.updateStateB(value)} />
                     </div>
                 }
             </div>

--- a/nodeEditor/src/sharedComponents/color4LineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/color4LineComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Observable } from "babylonjs/Misc/observable";
-import { Color3, Color4 } from "babylonjs/Maths/math";
+import { Color3, Color4 } from "babylonjs/Maths/math.color";
 import { PropertyChangedEvent } from "./propertyChangedEvent";
 import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -149,7 +149,7 @@ export class Color4LineComponent extends React.Component<IColor4LineComponentPro
 
     render() {
 
-        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />
+        const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
         const colorAsColor3 = new Color3(this.state.color.r, this.state.color.g, this.state.color.b);
 
         return (
@@ -171,10 +171,10 @@ export class Color4LineComponent extends React.Component<IColor4LineComponentPro
                 {
                     this.state.isExpanded &&
                     <div className="secondLine">
-                        <NumericInputComponent globalState={this.props.globalState} label="r" value={this.state.color.r} onChange={value => this.updateStateR(value)} />
-                        <NumericInputComponent globalState={this.props.globalState} label="g" value={this.state.color.g} onChange={value => this.updateStateG(value)} />
-                        <NumericInputComponent globalState={this.props.globalState} label="b" value={this.state.color.b} onChange={value => this.updateStateB(value)} />
-                        <NumericInputComponent globalState={this.props.globalState} label="a" value={this.state.color.a} onChange={value => this.updateStateA(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="r" value={this.state.color.r} onChange={(value) => this.updateStateR(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="g" value={this.state.color.g} onChange={(value) => this.updateStateG(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="b" value={this.state.color.b} onChange={(value) => this.updateStateB(value)} />
+                        <NumericInputComponent globalState={this.props.globalState} label="a" value={this.state.color.a} onChange={(value) => this.updateStateA(value)} />
                     </div>
                 }
             </div>

--- a/nodeEditor/src/sharedComponents/matrixLineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/matrixLineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector3, Matrix, Vector4, Quaternion } from "babylonjs/Maths/math";
+import { Vector3, Matrix, Vector4, Quaternion } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 import { PropertyChangedEvent } from "./propertyChangedEvent";
 import { Vector4LineComponent } from './vector4LineComponent';

--- a/nodeEditor/src/sharedComponents/vector2LineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/vector2LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector2 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/nodeEditor/src/sharedComponents/vector3LineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/vector3LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/nodeEditor/src/sharedComponents/vector4LineComponent.tsx
+++ b/nodeEditor/src/sharedComponents/vector4LineComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Vector4 } from "babylonjs/Maths/math";
+import { Vector4 } from "babylonjs/Maths/math.vector";
 import { Observable } from "babylonjs/Misc/observable";
 
 import { NumericInputComponent } from "./numericInputComponent";

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "mini-css-extract-plugin": "^0.4.1",
         "minimist": "^1.2.0",
         "mocha": "^5.2.0",
-        "node-sass": "^4.10.0",
+        "node-sass": "^4.13.1",
         "plugin-error": "^1.0.1",
         "prompt": "^1.0.0",
         "re-resizable": "~4.9.1",

--- a/postProcessLibrary/src/digitalRain/digitalRainPostProcess.ts
+++ b/postProcessLibrary/src/digitalRain/digitalRainPostProcess.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "babylonjs/types";
 import { serialize, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Matrix } from "babylonjs/Maths/math";
+import { Matrix } from "babylonjs/Maths/math.vector";
 import { Camera } from "babylonjs/Cameras/camera";
 import { BaseTexture } from "babylonjs/Materials/Textures/baseTexture";
 import { Texture } from "babylonjs/Materials/Textures/texture";

--- a/proceduralTexturesLibrary/src/brick/brickProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/brick/brickProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serialize, serializeAsColor3, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/cloud/cloudProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/cloud/cloudProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serializeAsColor4, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color4 } from "babylonjs/Maths/math";
+import { Color4 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/fire/fireProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/fire/fireProceduralTexture.ts
@@ -1,5 +1,6 @@
 import { serialize, serializeAsVector2, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Vector2, Color3 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/grass/grassProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/grass/grassProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serializeAsColor3, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/marble/marbleProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/marble/marbleProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serialize, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/road/roadProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/road/roadProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serializeAsColor3, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/proceduralTexturesLibrary/src/wood/woodProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/wood/woodProceduralTexture.ts
@@ -1,5 +1,5 @@
 import { serialize, serializeAsColor3, SerializationHelper } from "babylonjs/Misc/decorators";
-import { Color3 } from "babylonjs/Maths/math";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";

--- a/serializers/src/OBJ/objSerializer.ts
+++ b/serializers/src/OBJ/objSerializer.ts
@@ -1,6 +1,6 @@
 
 import { Nullable } from "babylonjs/types";
-import { Matrix } from "babylonjs/Maths/math";
+import { Matrix } from "babylonjs/Maths/math.vector";
 import { Tools } from "babylonjs/Misc/tools";
 import { StandardMaterial } from "babylonjs/Materials/standardMaterial";
 import { Geometry } from "babylonjs/Meshes/geometry";

--- a/serializers/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/serializers/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -1,5 +1,6 @@
 import { SpotLight } from "babylonjs/Lights/spotLight";
-import { Vector3, Color3, Quaternion } from "babylonjs/Maths/math";
+import { Vector3, Quaternion } from "babylonjs/Maths/math.vector";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Light } from "babylonjs/Lights/light";
 import { Node } from "babylonjs/node";
 import { ShadowLight } from "babylonjs/Lights/shadowLight";

--- a/serializers/src/glTF/2.0/glTFAnimation.ts
+++ b/serializers/src/glTF/2.0/glTFAnimation.ts
@@ -1,7 +1,7 @@
 import { AnimationSamplerInterpolation, AnimationChannelTargetPath, AccessorType, IAnimation, INode, IBufferView, IAccessor, IAnimationSampler, IAnimationChannel, AccessorComponentType } from "babylonjs-gltf2interface";
 import { Node } from "babylonjs/node";
 import { Nullable } from "babylonjs/types";
-import { Vector3, Quaternion } from "babylonjs/Maths/math";
+import { Vector3, Quaternion } from "babylonjs/Maths/math.vector";
 import { Tools } from "babylonjs/Misc/tools";
 import { Animation } from "babylonjs/Animations/animation";
 import { TransformNode } from "babylonjs/Meshes/transformNode";

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1,7 +1,8 @@
 import { AccessorType, IBufferView, IAccessor, INode, IScene, IMesh, IMaterial, ITexture, IImage, ISampler, IAnimation, ImageMimeType, IMeshPrimitive, IBuffer, IGLTF, MeshPrimitiveMode, AccessorComponentType, ITextureInfo } from "babylonjs-gltf2interface";
 
 import { FloatArray, Nullable, IndicesArray } from "babylonjs/types";
-import { Viewport, Color3, Vector2, Vector3, Vector4, Quaternion, Epsilon, Matrix } from "babylonjs/Maths/math";
+import { Vector2, Vector3, Vector4, Quaternion, Matrix } from "babylonjs/Maths/math.vector";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Tools } from "babylonjs/Misc/tools";
 import { VertexBuffer } from "babylonjs/Meshes/buffer";
 import { Node } from "babylonjs/node";
@@ -24,6 +25,8 @@ import { IExportOptions } from "./glTFSerializer";
 import { _GLTFUtilities } from "./glTFUtilities";
 import { GLTFData } from "./glTFData";
 import { _GLTFAnimation } from "./glTFAnimation";
+import { Viewport } from 'babylonjs/Maths/math.viewport';
+import { Epsilon } from 'babylonjs/Maths/math.constants';
 
 /**
  * Utility interface for storing vertex attribute data

--- a/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -1,7 +1,8 @@
 import { ITextureInfo, ImageMimeType, IMaterial, IMaterialPbrMetallicRoughness, MaterialAlphaMode, IMaterialOcclusionTextureInfo, ISampler, TextureMagFilter, TextureMinFilter, TextureWrapMode, ITexture, IImage } from "babylonjs-gltf2interface";
 
 import { Nullable } from "babylonjs/types";
-import { Vector2, Color3 } from "babylonjs/Maths/math";
+import { Vector2 } from "babylonjs/Maths/math.vector";
+import { Color3 } from "babylonjs/Maths/math.color";
 import { Scalar } from "babylonjs/Maths/math.scalar";
 import { Tools } from "babylonjs/Misc/tools";
 import { TextureTools } from "babylonjs/Misc/textureTools";

--- a/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -1,7 +1,7 @@
 import { IBufferView, AccessorType, AccessorComponentType, IAccessor } from "babylonjs-gltf2interface";
 
 import { FloatArray, Nullable } from "babylonjs/types";
-import { Vector3, Vector4, Quaternion } from "babylonjs/Maths/math";
+import { Vector3, Vector4, Quaternion } from "babylonjs/Maths/math.vector";
 
 /**
  * @hidden

--- a/serializers/src/stl/stlSerializer.ts
+++ b/serializers/src/stl/stlSerializer.ts
@@ -1,6 +1,6 @@
 import { Mesh } from "babylonjs/Meshes/mesh";
 import { VertexBuffer } from "babylonjs/Meshes/buffer";
-import { Vector3 } from "babylonjs/Maths/math";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 
 /**
 * Class for generating STL data from a Babylon scene.


### PR DESCRIPTION
Not a must, but nice-to-have - converted all imports from `"babylonjs/Maths/math"` to their correct exact path (like `"babylonjs/Maths/math.vector"`).

Also updated package.json to use the latest node-sass (npm was complaining about fixable security issues with the older version)