### PR TITLE
Fix sheen when used with clear coat and no env texture provided

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -348,6 +348,7 @@
 - Fix bug in PBR sheen where the sheen effect could be a little darker than expected when using direct lighting ([Popov72](https://github.com/Popov72)
 - Fix bug in PBR shader when `reflectionTexture.linearSpecularLOD` is `true`  ([Popov72](https://github.com/Popov72))
 - Fix for bug whereResize frame bottom at times will not work for any frame in the graph ([#7377](https://github.com/BabylonJS/Babylon.js/issues/7672))([Kyle Belfort](https://github.com/belfortk))
+- Fix bug in PBR sheen when used with clear coat and no env texture provided ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Shaders/pbr.fragment.fx
+++ b/src/Shaders/pbr.fragment.fx
@@ -935,10 +935,10 @@ void main(void) {
 
             #ifdef REFLECTION
                 environmentIrradiance *= absorption;
-            #endif
 
-            #ifdef SHEEN
-                sheenEnvironmentReflectance *= absorption;
+                #ifdef SHEEN
+                    sheenEnvironmentReflectance *= absorption;
+                #endif
             #endif
 
             specularEnvironmentReflectance *= absorption;
@@ -952,10 +952,10 @@ void main(void) {
 
         #ifdef REFLECTION
             environmentIrradiance *= conservationFactor;
-        #endif
 
-        #ifdef SHEEN
-            sheenEnvironmentReflectance *= conservationFactor;
+            #ifdef SHEEN
+                sheenEnvironmentReflectance *= conservationFactor;
+            #endif
         #endif
 
         specularEnvironmentReflectance *= conservationFactor;


### PR DESCRIPTION
Fix shader compilation error when sheen is used with clear coat enabled and without an environment texture.