### PR TITLE
Fix order of PBR glTF extensions

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
@@ -36,7 +36,7 @@ export class KHR_materials_clearcoat implements IGLTFLoaderExtension {
     /**
      * Defines a number that determines the order the extensions are applied.
      */
-    public order = 220;
+    public order = 190;
 
     private _loader: GLTFLoader;
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_sheen.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_sheen.ts
@@ -34,7 +34,7 @@ export class KHR_materials_sheen implements IGLTFLoaderExtension {
     /**
      * Defines a number that determines the order the extensions are applied.
      */
-    public order = 240;
+    public order = 190;
 
     private _loader: GLTFLoader;
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -32,7 +32,7 @@ export class KHR_materials_specular implements IGLTFLoaderExtension {
     /**
      * Defines a number that determines the order the extensions are applied.
      */
-    public order = 230;
+    public order = 190;
 
     private _loader: GLTFLoader;
 


### PR DESCRIPTION
Load clearcoat/sheen/specular glTF extension before specGloss.

This fixes an incompatibility when using clearcoat/sheen/specular glTF extension with the specularGlossiness extension.