### PR TITLE
Add more exclusions when deep copying mesh

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -407,13 +407,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             }
 
             // Deep copy
-            DeepCopier.DeepCopy(source, this, ["name", "material", "skeleton", "instances", "parent", "uniqueId",
-                "source", "metadata", "hasLODLevels", "geometry", "isBlocked", "areNormalsFrozen",
-                "onBeforeDrawObservable", "onBeforeRenderObservable", "onAfterRenderObservable", "onBeforeDraw",
-                "onAfterWorldMatrixUpdateObservable", "onCollideObservable", "onCollisionPositionChangeObservable", "onRebuildObservable",
-                "onDisposeObservable", "lightSources", "morphTargetManager"
-            ],
-                ["_poseMatrix"]);
+            DeepCopier.DeepCopy(source, this, [
+                "name", "material", "skeleton", "instances", "parent", "uniqueId", "source", "metadata", "morphTargetManager",
+                "hasInstances", "source", "worldMatrixInstancedBuffer", "hasLODLevels", "geometry", "isBlocked", "areNormalsFrozen",
+                "facetNb", "isFacetDataEnabled", "lightSources", "useBones", "isAnInstance", "collider", "edgesRenderer", "forward",
+                "up", "right", "absolutePosition", "absoluteScaling", "absoluteRotationQuaternion", "isWorldMatrixFrozen",
+                "nonUniformScaling", "behaviors", "worldMatrixFromCache"
+            ], ["_poseMatrix"]);
 
             // Source mesh
             this._internalMeshDataInfo._source = source;

--- a/src/Misc/deepCopier.ts
+++ b/src/Misc/deepCopier.ts
@@ -1,4 +1,5 @@
 import { StringTools } from './stringTools';
+import { Logger } from './logger';
 
 var cloneValue = (source: any, destinationObject: any) => {
     if (!source) {
@@ -76,7 +77,8 @@ export class DeepCopier {
                 }
             }
             catch (e) {
-                // Just ignore error (it could be because of a read-only property)
+                // Log a warning (it could be because of a read-only property)
+                Logger.Warn(e.message);
             }
         }
     }


### PR DESCRIPTION
NOTE: This is not for 4.1

The reason for this change is avoid a lot of spewing of exceptions when running in Babylon Native. The DeepCopy method throws exceptions if it tries to set a read-only property. The JS exception is caught but on the native side (for Chakra) a C++ exception is thrown which causes spewing in the debug output.