### PR TITLE
Updated enums values in xbox and ds gamepads

### DIFF
--- a/src/Gamepads/dualShockGamepad.ts
+++ b/src/Gamepads/dualShockGamepad.ts
@@ -6,37 +6,37 @@ import { Gamepad } from "./gamepad";
  */
 export enum DualShockButton {
     /** Cross */
-    Cross,
+    Cross = 0,
     /** Circle */
-    Circle,
+    Circle = 1,
     /** Square */
-    Square,
+    Square = 2,
     /** Triangle */
-    Triangle,
-    /** Options */
-    Options,
-    /** Share */
-    Share,
+    Triangle = 3,
     /** L1 */
-    L1,
+    L1 = 4,
     /** R1 */
-    R1,
+    R1 = 5,
+    /** Share */
+    Share = 8,
+    /** Options */
+    Options = 9,
     /** Left stick */
-    LeftStick,
+    LeftStick = 10,
     /** Right stick */
-    RightStick
+    RightStick = 11
 }
 
 /** Defines values for DualShock DPad  */
 export enum DualShockDpad {
     /** Up */
-    Up,
+    Up = 12,
     /** Down */
-    Down,
+    Down = 13,
     /** Left */
-    Left,
+    Left = 14,
     /** Right */
-    Right
+    Right = 15
 }
 
 /**

--- a/src/Gamepads/xboxGamepad.ts
+++ b/src/Gamepads/xboxGamepad.ts
@@ -5,37 +5,37 @@ import { Gamepad } from "../Gamepads/gamepad";
  */
 export enum Xbox360Button {
     /** A */
-    A,
+    A = 0,
     /** B */
-    B,
+    B = 1,
     /** X */
-    X,
+    X = 2,
     /** Y */
-    Y,
-    /** Start */
-    Start,
-    /** Back */
-    Back,
+    Y = 3,
     /** Left button */
-    LB,
+    LB = 4,
     /** Right button */
-    RB,
+    RB = 5,
+    /** Back */
+    Back = 8,
+    /** Start */
+    Start = 9,
     /** Left stick */
-    LeftStick,
+    LeftStick = 10,
     /** Right stick */
-    RightStick
+    RightStick = 11
 }
 
 /** Defines values for XBox360 DPad  */
 export enum Xbox360Dpad {
     /** Up */
-    Up,
+    Up = 12,
     /** Down */
-    Down,
+    Down = 13,
     /** Left */
-    Left,
+    Left = 14,
     /** Right */
-    Right
+    Right = 15
 }
 
 /**


### PR DESCRIPTION
Changed the values of the enums for the xbox and dual shock gamepads to reflect their values, with respect to the Web API.  This does not affect the d-pad or triggers yet.