### PR TITLE
fixing xr framebuffer size issue

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -237,7 +237,6 @@
 - Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user rotate the pictures when in vertical mode ([Popov72](https://github.com/Popov72))
 - Modified isPointerBlocker to block mouse wheel scroll events. ScrollViewer mouse scroll no longer dependent on scene. ([lockphase](https://github.com/lockphase/))
 
-
 ### Particles
 
 - Added `particleSystem.isLocal` for CPU particles to let the particles live in emitter local space. [Doc](https://doc.babylonjs.com/babylon101/particles#local-space) ([Deltakosh](https://github.com/deltakosh/))
@@ -353,6 +352,7 @@
 - Fix for bug where Preview Area pop up does not change background color across windows ([#7377](https://github.com/BabylonJS/Babylon.js/issues/7684))([Kyle Belfort](https://github.com/belfortk))
 - Fix for bug where comments would break out of frames and break resizing of frames ([Kyle Belfort](https://github.com/belfortk))
 - Fix for bug where frames without comments would display undefined at the bottom right corner ([Kyle Belfort](https://github.com/belfortk))
+- Fixed an issue in XR where one of the cameras used for rendering got the wrong framebuffer dimensions ([RaananW](https://github.com/RaananW/))
 
 ## Breaking changes
 

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -390,6 +390,17 @@ export class ThinEngine {
         return false;
     }
 
+    private _glLayerDimensionsObject: Nullable<{framebufferWidth: number, framebufferHeight: number}>;
+
+    /**
+     * sets the object from which width and height will be taken from when getting render width and height
+     * Will fallback to the gl object
+     * @param dimensions the framebuffer width and height that will be used.
+     */
+    public set glLayerDimensionsObject(dimensions: Nullable<{framebufferWidth: number, framebufferHeight: number}>) {
+      this._glLayerDimensionsObject = dimensions;
+    }
+
     /**
      * Gets the list of texture formats supported
      */
@@ -1099,7 +1110,7 @@ export class ThinEngine {
             return this._currentRenderTarget.width;
         }
 
-        return this._gl.drawingBufferWidth;
+        return this._glLayerDimensionsObject ? this._glLayerDimensionsObject.framebufferWidth : this._gl.drawingBufferWidth;
     }
 
     /**
@@ -1112,7 +1123,7 @@ export class ThinEngine {
             return this._currentRenderTarget.height;
         }
 
-        return this._gl.drawingBufferHeight;
+        return this._glLayerDimensionsObject ? this._glLayerDimensionsObject.framebufferHeight : this._gl.drawingBufferHeight;
     }
 
     /**

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -318,7 +318,7 @@ export class UtilityLayerRenderer implements IDisposable {
     }
 
     private _updateCamera() {
-        this.utilityLayerScene.cameraToUseForPointers = this.getRenderCamera(true);
-        this.utilityLayerScene.activeCamera = this.getRenderCamera(true);
+        this.utilityLayerScene.cameraToUseForPointers = this.getRenderCamera();
+        this.utilityLayerScene.activeCamera = this.getRenderCamera();
     }
 }

--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -176,6 +176,8 @@ export class WebXRSessionManager implements IDisposable {
                 this._sessionEnded = true;
                 // Remove render target texture and notify frame observers
                 this._rttProvider = null;
+                // make sure dimensions object is restored
+                engine.glLayerDimensionsObject = null;
 
                 // Restore frame buffer to avoid clear on xr framebuffer after session end
                 engine.restoreDefaultFramebuffer();
@@ -223,7 +225,9 @@ export class WebXRSessionManager implements IDisposable {
                 if (xrFrame) {
                     this.onXRFrameObservable.notifyObservers(xrFrame);
                     // only run the render loop if a frame exists
+                    engine.glLayerDimensionsObject = this.baseLayer!;
                     engine._renderLoop();
+                    engine.glLayerDimensionsObject = null;
                 }
             }
         };
@@ -234,6 +238,7 @@ export class WebXRSessionManager implements IDisposable {
             // Create render target texture from xr's webgl render target
             const rtt = this._createRenderTargetTexture(this.baseLayer!.framebufferWidth, this.baseLayer!.framebufferHeight, this.baseLayer!.framebuffer);
             this._rttProvider = { getRenderTargetForEye: () => rtt };
+            engine.glLayerDimensionsObject = this.baseLayer;
         }
 
         // Stop window's animation frame and trigger sessions animation frame


### PR DESCRIPTION
there was an issue when rendering an XR scene - the first camera always got initially the wrong framebuffer width and height, leading to incorrect rendering when using utility layer.

This probably caused issues with some webxr-polyfill scenes.