### PR TITLE
check dragging state before notifying drag end

### DIFF
--- a/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -245,8 +245,11 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      * Force relase the drag action by code.
      */
     public releaseDrag() {
-        this.dragging = false;
-        this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerID });
+        if (this.dragging) {
+            this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerID });
+            this.dragging = false;
+        }
+
         this.currentDraggingPointerID = -1;
         this._moving = false;
 


### PR DESCRIPTION
Fix for https://forum.babylonjs.com/t/mesh-dispose-triggers-ondragendobservable-behavior/8807