### PR TITLE
simplify code contributions by fully automating the dev setup

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,10 @@
+FROM gitpod/workspace-full-vnc
+
+USER gitpod
+
+RUN sudo apt-get update && \
+    sudo apt-get install -yq chromium-browser firefox && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_BIN=/usr/bin/chromium-browser
+ENV BROWSER="Chrome_Without_Sandbox"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - command: gp await-port 1338 && sleep 3 && gp preview $(gp url 1338)/sandbox/index-local.html
+  - before: >
+      cd Tools/Gulp &&
+      npm i typescript gulp@4.0.0 -g &&
+      npm install
+    command: npm run start 
+ports:
+  - port: 1338
+    onOpen: ignore
+  - port: 3000
+    onOpen: ignore

--- a/Viewer/tests/karma.conf.js
+++ b/Viewer/tests/karma.conf.js
@@ -1,3 +1,5 @@
+var baseConfig = require('../../tests/karma-browsers.config')
+
 module.exports = function (config) {
     config.set({
         basePath: '../',
@@ -56,6 +58,6 @@ module.exports = function (config) {
             properties: {} // key value pair of properties to add to the <properties> section of the report
         },
 
-        browsers: ['ChromeHeadless']
+        ...baseConfig
     })
 }

--- a/Viewer/tests/validation/karma.conf.js
+++ b/Viewer/tests/validation/karma.conf.js
@@ -1,3 +1,5 @@
+var baseConfig = require('../../../tests/karma-browsers.config')
+
 module.exports = function (config) {
     'use strict';
     config.set({
@@ -56,7 +58,6 @@ module.exports = function (config) {
             properties: {} // key value pair of properties to add to the <properties> section of the report
         },
 
-        browsers: ['Chrome']
-
+        ...baseConfig
     });
 };

--- a/contributing.md
+++ b/contributing.md
@@ -35,6 +35,12 @@ Please use the Github issues (after discussing them on the forum) **only** for:
 
 We will try to enforce these rules as we consider the forum is a better place for discussions and learnings.
 
+## Online one-click setup for Contributing
+
+Contribute to BabylonJS using a fully featured online development environment; cloned repo, pre-installed dependencies, running web server.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Pull requests
 
 We are not complicated people, but we still have some [coding guidelines](http://doc.babylonjs.com/how_to/approved_naming_conventions)

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -10,6 +10,8 @@
 
 - Scale on one axis for `BoundingBoxGizmo` ([cedricguillemet](https://github.com/cedricguillemet))
 
+- Simplified code contributions by fully automating the dev setup with gitpod ([nisarhassan12](https://github.com/nisarhassan12))
+
 ### Engine
 
 - Allow logging of shader code when a compilation error occurs ([Popov72](https://github.com/Popov72))
@@ -37,3 +39,19 @@
 
 
 ## Breaking changes
+
+My Pr simplifies code contributions by fully automating the dev setup with gitpod, a free online VS Code like IDE with a single click it'll launch a ready-to-code workspace where:
+
+- Babylon.js repo is already cloned.
+- dependencies are pre-installed.
+- `npm run start` running in `Tools/Gulp`
+   
+So that anyone interested in contributing can start straight away without wasting time on the setup.
+
+You can give it a try on my fork of the repo via the following link:
+
+https://gitpod.io/#https://github.com/nisarhassan12/Babylon.js
+
+This is how it looks:
+
+![image](https://user-images.githubusercontent.com/46004116/75895532-9c8eee80-5e57-11ea-93ba-19eade97f08c.png)

--- a/tests/karma-browsers.config.js
+++ b/tests/karma-browsers.config.js
@@ -1,0 +1,11 @@
+var env = process.env
+
+module.exports = {
+    browsers:  env.BROWSER ? env.BROWSER.split(',') : ['ChromeHeadless'],
+    customLaunchers: {
+        Chrome_Without_Sandbox: {
+            base: 'Chrome',
+            flags: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
+    },
+}

--- a/tests/modules/karma.conf.js
+++ b/tests/modules/karma.conf.js
@@ -1,3 +1,5 @@
+var baseConfig = require('../karma-browsers.config')
+
 module.exports = function (config) {
     config.set({
         basePath: '../../',
@@ -55,7 +57,6 @@ module.exports = function (config) {
             classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
             properties: {} // key value pair of properties to add to the <properties> section of the report
         },
-
-        browsers: ['ChromeHeadless']
+        ...baseConfig
     })
 }

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -1,3 +1,5 @@
+var baseConfig = require('../karma-browsers.config')
+
 module.exports = function(config) {
     config.set({
         basePath: '../../',
@@ -74,7 +76,6 @@ module.exports = function(config) {
             classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
             properties: {} // key value pair of properties to add to the <properties> section of the report
         },
-
-        browsers: ['ChromeHeadless']
+        ...baseConfig
     })
 }

--- a/tests/validation/karma.conf.js
+++ b/tests/validation/karma.conf.js
@@ -1,3 +1,5 @@
+var baseConfig = require('../karma-browsers.config')
+
 module.exports = function (config) {
     'use strict';
     config.set({
@@ -63,8 +65,7 @@ module.exports = function (config) {
             classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
             properties: {} // key value pair of properties to add to the <properties> section of the report
         },
-
-        browsers: ['Chrome']
+        ...baseConfig
 
     });
 };


### PR DESCRIPTION
Hi! :slightly_smiling_face:

This Pr simplifies code contributions by fully automating the dev setup with gitpod, a free online VS Code like IDE with a single click it'll launch a ready-to-code workspace where:

- Babylon.js repo is already cloned.
- dependencies are pre-installed.
- `npm run start` running in `Tools/Gulp`
   
So that anyone interested in contributing can start straight away without wasting time on the setup.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/Babylon.js

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/75895532-9c8eee80-5e57-11ea-93ba-19eade97f08c.png)
