### PR TITLE
Add optional predicates to WebXR laser pointer selection

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -29,6 +29,9 @@
 ### Materials
 - Added the `roughness` and `albedoScaling` parameters to PBR sheen ([Popov72](https://github.com/Popov72))
 
+### WebXR
+- Added optional ray and mesh selection predicates to `WebXRControllerPointerSelection` ([Exolun](https://github.com/Exolun))
+
 ## Bugs
 
 - Fix infinite loop in `GlowLayer.unReferenceMeshFromUsingItsOwnMaterial` ([Popov72](https://github.com/Popov72)

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -163,11 +163,6 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     public selectionMeshPickedColor: Color3 = new Color3(0.3, 0.3, 1.0);
 
     /**
-     * To be optionaly changed by user to define custom selection logic (after ray selection)
-     */
-    public meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
-
-    /**
      * To be optionaly changed by user to define custom ray selection
      */
     public raySelectionPredicate: (mesh: AbstractMesh) => boolean;
@@ -283,11 +278,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                     controllerData.selectionMesh.position.addInPlace(pickNormal.scale(deltaFighting));
                 }
                 controllerData.selectionMesh.isVisible = true && this.displaySelectionMesh;
-                if (this.meshSelectionPredicate && pick.pickedMesh && this.meshSelectionPredicate(pick.pickedMesh)) {
-                    controllerData.meshUnderPointer = pick.pickedMesh;
-                } else {
-                    controllerData.meshUnderPointer = pick.pickedMesh;
-                }
+                controllerData.meshUnderPointer = pick.pickedMesh;
             } else {
                 controllerData.selectionMesh.isVisible = false;
                 controllerData.meshUnderPointer = null;

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -163,7 +163,8 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     public selectionMeshPickedColor: Color3 = new Color3(0.3, 0.3, 1.0);
 
     /**
-     * To be optionaly changed by user to define custom ray selection
+     * Optional filter to be used for ray selection.  This predicate shares behavior with
+     * scene.pointerMovePredicate which takes priority if it is also assigned.
      */
     public raySelectionPredicate: (mesh: AbstractMesh) => boolean;
 
@@ -253,7 +254,8 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
 
             // Every frame check collisions/input
             controllerData.xrController.getWorldPointerRayToRef(controllerData.tmpRay);
-            controllerData.pick = this._scene.pickWithRay(controllerData.tmpRay, this.raySelectionPredicate);
+            controllerData.pick = this._scene.pickWithRay(controllerData.tmpRay,
+                this._scene.pointerMovePredicate || this.raySelectionPredicate);
 
             const pick = controllerData.pick;
 

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -163,6 +163,16 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     public selectionMeshPickedColor: Color3 = new Color3(0.3, 0.3, 1.0);
 
     /**
+     * To be optionaly changed by user to define custom selection logic (after ray selection)
+     */
+    public meshSelectionPredicate: (mesh: AbstractMesh) => boolean;
+
+    /**
+     * To be optionaly changed by user to define custom ray selection
+     */
+    public raySelectionPredicate: (mesh: AbstractMesh) => boolean;
+
+    /**
      * constructs a new background remover module
      * @param _xrSessionManager the session manager for this module
      * @param _options read-only options to be used in this module
@@ -248,7 +258,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
 
             // Every frame check collisions/input
             controllerData.xrController.getWorldPointerRayToRef(controllerData.tmpRay);
-            controllerData.pick = this._scene.pickWithRay(controllerData.tmpRay);
+            controllerData.pick = this._scene.pickWithRay(controllerData.tmpRay, this.raySelectionPredicate);
 
             const pick = controllerData.pick;
 
@@ -273,7 +283,11 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                     controllerData.selectionMesh.position.addInPlace(pickNormal.scale(deltaFighting));
                 }
                 controllerData.selectionMesh.isVisible = true && this.displaySelectionMesh;
-                controllerData.meshUnderPointer = pick.pickedMesh;
+                if (this.meshSelectionPredicate && pick.pickedMesh && this.meshSelectionPredicate(pick.pickedMesh)) {
+                    controllerData.meshUnderPointer = pick.pickedMesh;
+                } else {
+                    controllerData.meshUnderPointer = pick.pickedMesh;
+                }
             } else {
                 controllerData.selectionMesh.isVisible = false;
                 controllerData.meshUnderPointer = null;


### PR DESCRIPTION
VR implementation had predicates available for filtering ray and mesh hits, so I pulled over pretty much the same thing into the `WebXRControllerPointerSelection` class.