### PR TITLE
fixed missing options for `MeshBuilder.CreateBox`

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -51,5 +51,6 @@
 - Fix: when using instances, master mesh (if displayed) does not have correct instance buffer values ([Popov72](https://github.com/Popov72)
 - Fix improper baking of transformed textures in `KHR_texture_transform` serializer. ([drigax](https://github.com/Drigax))
 - Fixed NME codegen: missing common properties for float-value input block. ([ycw](https://github.com/ycw))
+- Fixed missing options for MeshBuilder.CreateBox. ([ycw](https://github.com/ycw))
 
 ## Breaking changes

--- a/src/Meshes/meshBuilder.ts
+++ b/src/Meshes/meshBuilder.ts
@@ -49,7 +49,7 @@ export class MeshBuilder {
      * @param scene defines the hosting scene
      * @returns the box mesh
      */
-    public static CreateBox(name: string, options: { size?: number, width?: number, height?: number, depth?: number, faceUV?: Vector4[], faceColors?: Color4[], sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean }, scene: Nullable<Scene> = null): Mesh {
+    public static CreateBox(name: string, options: { size?: number, width?: number, height?: number, depth?: number, faceUV?: Vector4[], faceColors?: Color4[], sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, wrap?: boolean, topBaseAt?: number, bottomBaseAt?: number, updatable?: boolean }, scene: Nullable<Scene> = null): Mesh {
         return BoxBuilder.CreateBox(name, options, scene);
     }
 


### PR DESCRIPTION
sync facade `MeshBuilder.CreateBox` with actual `BoxBuilder.CreateBox` 