### PR TITLE
Add an option to optimize collision detection performance.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -46,6 +46,9 @@
 ### WebXR
 - Added optional ray and mesh selection predicates to `WebXRControllerPointerSelection` ([Exolun](https://github.com/Exolun))
 
+### Collisions
+- Added an option to optimize collision detection performance ([jsdream](https://github.com/jsdream)) - [PR](https://github.com/BabylonJS/Babylon.js/pull/7810)
+
 ## Bugs
 
 - Fix infinite loop in `GlowLayer.unReferenceMeshFromUsingItsOwnMaterial` ([Popov72](https://github.com/Popov72)

--- a/src/Collisions/collisionCoordinator.ts
+++ b/src/Collisions/collisionCoordinator.ts
@@ -57,9 +57,12 @@ export class DefaultCollisionCoordinator implements ICollisionCoordinator {
 
         collider._initialize(position, velocity, closeDistance);
 
-        // Check all meshes
-        for (var index = 0; index < this._scene.meshes.length; index++) {
-            var mesh = this._scene.meshes[index];
+        // Check if collision detection should happen against specified list of meshes or,
+        // if not specified, against all meshes in the scene
+        var meshes = (excludedMesh && excludedMesh.surroundingMeshes) || this._scene.meshes;
+
+        for (var index = 0; index < meshes.length; index++) {
+            var mesh = meshes[index];
             if (mesh.isEnabled() && mesh.checkCollisions && mesh.subMeshes && mesh !== excludedMesh && ((collisionMask & mesh.collisionGroup) !== 0)) {
                 mesh._checkCollision(collider);
             }

--- a/src/Collisions/meshCollisionData.ts
+++ b/src/Collisions/meshCollisionData.ts
@@ -12,6 +12,7 @@ export class _MeshCollisionData {
     public _checkCollisions = false;
     public _collisionMask = -1;
     public _collisionGroup = -1;
+    public _surroundingMeshes: Nullable<AbstractMesh[]> = null;
     public _collider: Nullable<Collider> = null;
     public _oldPositionForCollisions = new Vector3(0, 0, 0);
     public _diffPositionForCollisions = new Vector3(0, 0, 0);

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -559,6 +559,23 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._meshCollisionData._collisionGroup = !isNaN(mask) ? mask : -1;
     }
 
+    /**
+     * Gets or sets current surrounding meshes (null by default).
+     *
+     * By default collision detection is tested against every mesh in the scene.
+     * It is possible to set surroundingMeshes to a defined list of meshes and then only these specified
+     * meshes will be tested for the collision.
+     *
+     * Note: if set to an empty array no collision will happen when this mesh is moved.
+     */
+    public get surroundingMeshes(): Nullable<AbstractMesh[]> {
+        return this._meshCollisionData._surroundingMeshes;
+    }
+
+    public set surroundingMeshes(meshes: Nullable<AbstractMesh[]>) {
+        this._meshCollisionData._surroundingMeshes = meshes;
+    }
+
     // Edges
     /**
      * Defines edge width used when edgesRenderer is enabled


### PR DESCRIPTION
This brings an option to iterate over a defined list of meshes when testing collision detection of a moving mesh, instead of iteration over all meshes in the scene. That gives a significant performance boost in scenarios when there are many meshes in the scene and it is known which exactly meshes are currently close to the moving mesh (e.g. with what meshes collision is theoretically possible). This improvement has shown really good results in the game with a tile-based world.

More details about use case are available in this forum thread: https://forum.babylonjs.com/t/willing-to-extend-movewithcollisions-method/9127/9