### PR TITLE
Fix bug in Plane.transform when matrix passed in is not a pure rotation

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -58,5 +58,6 @@
 - Fix improper baking of transformed textures in `KHR_texture_transform` serializer. ([drigax](https://github.com/Drigax))
 - Fixed NME codegen: missing common properties for float-value input block. ([ycw](https://github.com/ycw))
 - Fixed missing options for MeshBuilder.CreateBox. ([ycw](https://github.com/ycw))
+- Fix bug in `Plane.transform` when matrix passed in is not a pure rotation ([Popov72](https://github.com/Popov72)
 
 ## Breaking changes

--- a/src/Maths/math.plane.ts
+++ b/src/Maths/math.plane.ts
@@ -78,9 +78,9 @@ export class Plane {
      * @returns a new Plane as the result of the transformation of the current Plane by the given matrix.
      */
     public transform(transformation: DeepImmutable<Matrix>): Plane {
-        const transposedMatrix = Plane._TmpMatrix;
-        Matrix.TransposeToRef(transformation, transposedMatrix);
-        const m = transposedMatrix.m;
+        const invertedMatrix = Plane._TmpMatrix;
+        transformation.invertToRef(invertedMatrix);
+        const m = invertedMatrix.m;
         var x = this.normal.x;
         var y = this.normal.y;
         var z = this.normal.z;


### PR DESCRIPTION
There's  no impact in the engine itself as this function is not called by any other code.