### PR TITLE
Fix horizon occlusion in PBR materials

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -64,5 +64,7 @@
 - Fixed NME codegen: missing common properties for float-value input block. ([ycw](https://github.com/ycw))
 - Fixed missing options for MeshBuilder.CreateBox. ([ycw](https://github.com/ycw))
 - Fix bug in `Plane.transform` when matrix passed in is not a pure rotation ([Popov72](https://github.com/Popov72)
+- Fix bug in PBR when anisotropy is enabled and no bump texture is provided ([Popov72](https://github.com/Popov72)
+- Fix horizon occlusion in PBR materials ([Popov72](https://github.com/Popov72)
 
 ## Breaking changes

--- a/src/Shaders/ShadersInclude/bumpVertex.fx
+++ b/src/Shaders/ShadersInclude/bumpVertex.fx
@@ -1,4 +1,4 @@
-#if defined(BUMP) || defined(PARALLAX) || defined(CLEARCOAT_BUMP)
+#if defined(BUMP) || defined(PARALLAX) || defined(CLEARCOAT_BUMP) || defined(ANISOTROPIC)
 	#if defined(TANGENT) && defined(NORMAL)
 		vec3 tbnNormal = normalize(normalUpdated);
 		vec3 tbnTangent = normalize(tangentUpdated.xyz);

--- a/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
+++ b/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
@@ -1,4 +1,4 @@
-#if defined(BUMP) || defined(PARALLAX) || defined(CLEARCOAT_BUMP)
+#if defined(BUMP) || defined(PARALLAX) || defined(CLEARCOAT_BUMP) || defined(ANISOTROPIC)
 	#if defined(TANGENT) && defined(NORMAL) 
 		varying mat3 vTBN;
 	#endif

--- a/src/Shaders/ShadersInclude/pbrIBLFunctions.fx
+++ b/src/Shaders/ShadersInclude/pbrIBLFunctions.fx
@@ -21,10 +21,10 @@
 #endif
 
 #if defined(ENVIRONMENTBRDF) && defined(HORIZONOCCLUSION)
-    float environmentHorizonOcclusion(vec3 view, vec3 normal) {
+    float environmentHorizonOcclusion(vec3 view, vec3 normal, vec3 geometricNormal) {
         // http://marmosetco.tumblr.com/post/81245981087
         vec3 reflection = reflect(view, normal);
-        float temp = saturate(1.0 + 1.1 * dot(reflection, normal));
+        float temp = saturate(1.0 + 1.1 * dot(reflection, geometricNormal));
         return square(temp);
     }
 #endif

--- a/src/Shaders/pbr.fragment.fx
+++ b/src/Shaders/pbr.fragment.fx
@@ -66,9 +66,13 @@ void main(void) {
 
     vec3 geometricNormalW = normalW;
 
+#if defined(TWOSIDEDLIGHTING) && defined(NORMAL)
+    geometricNormalW = gl_FrontFacing ? geometricNormalW : -geometricNormalW;
+#endif
+
 #ifdef CLEARCOAT
     // Needs to use the geometric normal before bump for this.
-    vec3 clearCoatNormalW = normalW;
+    vec3 clearCoatNormalW = geometricNormalW;
 #endif
 
 #include<bumpFragment>

--- a/src/Shaders/pbr.fragment.fx
+++ b/src/Shaders/pbr.fragment.fx
@@ -64,6 +64,8 @@ void main(void) {
     vec3 normalW = normalize(cross(dFdx(vPositionW), dFdy(vPositionW))) * vEyePosition.w;
 #endif
 
+    vec3 geometricNormalW = normalW;
+
 #ifdef CLEARCOAT
     // Needs to use the geometric normal before bump for this.
     vec3 clearCoatNormalW = normalW;
@@ -883,7 +885,7 @@ void main(void) {
         #ifdef HORIZONOCCLUSION
             #ifdef BUMP
                 #ifdef REFLECTIONMAP_3D
-                    float eho = environmentHorizonOcclusion(-viewDirectionW, normalW);
+                    float eho = environmentHorizonOcclusion(-viewDirectionW, normalW, geometricNormalW);
                     specularEnvironmentReflectance *= eho;
                 #endif
             #endif
@@ -941,7 +943,7 @@ void main(void) {
             #ifdef HORIZONOCCLUSION
                 #ifdef BUMP
                     #ifdef REFLECTIONMAP_3D
-                        float clearCoatEho = environmentHorizonOcclusion(-viewDirectionW, clearCoatNormalW);
+                        float clearCoatEho = environmentHorizonOcclusion(-viewDirectionW, clearCoatNormalW, geometricNormalW);
                         clearCoatEnvironmentReflectance *= clearCoatEho;
                     #endif
                 #endif


### PR DESCRIPTION
Also fixed a bug (material does not compile) when anisotropy is enabled and no bump texture is provided.

Horizon occlusion before fix:
![image](https://user-images.githubusercontent.com/4152247/76707421-6b33df80-66ef-11ea-84c9-253959bf9526.png)

Horizon occlusion after fix:
![image](https://user-images.githubusercontent.com/4152247/76707427-7d158280-66ef-11ea-8567-46fde80cc237.png)
