### PR TITLE
Fixed delay calculation in Animatable.goToFrame when speedRatio != 1.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -79,5 +79,6 @@
 - Fix bug in `Plane.transform` when matrix passed in is not a pure rotation ([Popov72](https://github.com/Popov72)
 - Fix bug in PBR when anisotropy is enabled and no bump texture is provided ([Popov72](https://github.com/Popov72)
 - Fix horizon occlusion in PBR materials ([Popov72](https://github.com/Popov72)
+- Fixed delay calculation in Animatable.goToFrame when speedRatio != 1 ([Reimund Järnfors](https://github.com/reimund)
 
 ## Breaking changes

--- a/src/Animations/animatable.ts
+++ b/src/Animations/animatable.ts
@@ -269,8 +269,7 @@ export class Animatable {
         if (runtimeAnimations[0]) {
             var fps = runtimeAnimations[0].animation.framePerSecond;
             var currentFrame = runtimeAnimations[0].currentFrame;
-            var adjustTime = frame - currentFrame;
-            var delay = this.speedRatio !== 0 ? adjustTime * 1000 / (fps / this.speedRatio) : 0;
+            var delay = this.speedRatio === 0 ? 0 : ((frame - currentFrame) / fps * 1000) / this.speedRatio;
             if (this._localDelayOffset === null) {
                 this._localDelayOffset = 0;
             }


### PR DESCRIPTION
Related discussion: https://forum.babylonjs.com/t/problem-with-gotoframe-and-speed-ratio/9249