### PR TITLE
double click support in utilityLayerRenderer

### DIFF
--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -150,7 +150,8 @@ export class UtilityLayerRenderer implements IDisposable {
                 if (!this.processAllEvents) {
                     if (prePointerInfo.type !== PointerEventTypes.POINTERMOVE
                         && prePointerInfo.type !== PointerEventTypes.POINTERUP
-                        && prePointerInfo.type !== PointerEventTypes.POINTERDOWN) {
+                        && prePointerInfo.type !== PointerEventTypes.POINTERDOWN
+                        && prePointerInfo.type !== PointerEventTypes.POINTERDOUBLETAP) {
                         return;
                     }
                 }


### PR DESCRIPTION
Fix for https://forum.babylonjs.com/t/pointerdoubletap-not-working-on-gizmo-utility-layer/9223/3
