### PR TITLE
Fix submesh recreation when it should not

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -95,4 +95,6 @@
 - Fix texture being inverted on the Y axis by default when using TextureAsset or AssetManager ([broederj](https://github.com/broederj))
 - Fix `TexturePacker` cross-origin image requests, fix falsy default options ([ludevik](https://github.com/ludevik))
 
+- Fix submesh recreation when it should not ([Popov72](https://github.com/Popov72)
+
 ## Breaking changes

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1113,12 +1113,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 needToRecreate = true;
             } else {
                 for (var submesh of this.subMeshes) {
-                    if (submesh.indexStart + submesh.indexCount >= totalIndices) {
+                    if (submesh.indexStart + submesh.indexCount > totalIndices) {
                         needToRecreate = true;
                         break;
                     }
 
-                    if (submesh.verticesStart + submesh.verticesCount >= totalVertices) {
+                    if (submesh.verticesStart + submesh.verticesCount > totalVertices) {
                         needToRecreate = true;
                         break;
                     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/submeshes-disappear-after-merge-meshes-and-markverticesdataasupdatable/9396