### PR TITLE
Fix ortographic camera bug

### DIFF
--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -752,18 +752,18 @@ export class Camera extends Node {
             var halfWidth = engine.getRenderWidth() / 2.0;
             var halfHeight = engine.getRenderHeight() / 2.0;
             if (scene.useRightHandedSystem) {
-                Matrix.OrthoOffCenterRHToRef(this.orthoLeft || -halfWidth,
-                    this.orthoRight || halfWidth,
-                    this.orthoBottom || -halfHeight,
-                    this.orthoTop || halfHeight,
+                Matrix.OrthoOffCenterRHToRef(this.orthoLeft ?? -halfWidth,
+                    this.orthoRight ?? halfWidth,
+                    this.orthoBottom ?? -halfHeight,
+                    this.orthoTop ?? halfHeight,
                     this.minZ,
                     this.maxZ,
                     this._projectionMatrix);
             } else {
-                Matrix.OrthoOffCenterLHToRef(this.orthoLeft || -halfWidth,
-                    this.orthoRight || halfWidth,
-                    this.orthoBottom || -halfHeight,
-                    this.orthoTop || halfHeight,
+                Matrix.OrthoOffCenterLHToRef(this.orthoLeft ?? -halfWidth,
+                    this.orthoRight ?? halfWidth,
+                    this.orthoBottom ?? -halfHeight,
+                    this.orthoTop ?? halfHeight,
                     this.minZ,
                     this.maxZ,
                     this._projectionMatrix);


### PR DESCRIPTION
If the values of (orthoLeft, orthoRight, orthoBottom, orthoTop) are explicitly set to 0, they are ignored currently.
This fix changes the logical OR (||) operator to the Nullish Coalescing coalescing operator (??), so 0 values are allowed.

Discussed originally here:
https://forum.babylonjs.com/t/camera-orthographic-projection/9385