### PR TITLE
impulse and force applied relative to center of mass

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -89,6 +89,7 @@
 - Fix bug in `Plane.transform` when matrix passed in is not a pure rotation ([Popov72](https://github.com/Popov72)
 - Fix bug in PBR when anisotropy is enabled and no bump texture is provided ([Popov72](https://github.com/Popov72)
 - Fix horizon occlusion in PBR materials ([Popov72](https://github.com/Popov72)
+- Fix wrong relative position in applyImpulse/applyForce for ammojs plugin ([cedricguillemet](https://github.com/cedricguillemet))
 - Fixed delay calculation in Animatable.goToFrame when speedRatio != 1 ([Reimund Järnfors](https://github.com/reimund)
 - Fix bug in PBR when translucency is enabled and an irradiance texture is provided ([Popov72](https://github.com/Popov72)
 - Fix bug in PBR with translucency when irradiance texture is 2D ([Popov72](https://github.com/Popov72)

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -341,7 +341,7 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
 
-            // Convert contactPoint relative to body position
+            // Convert contactPoint relative to center of mass
             if (impostor.object && impostor.object.getWorldMatrix) {
                 contactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
             }
@@ -368,7 +368,7 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
 
-            // Convert contactPoint relative to body position
+            // Convert contactPoint relative to center of mass
             if (impostor.object && impostor.object.getWorldMatrix) {
                 contactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
             }

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -328,7 +328,6 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
         vertex_data.applyToMesh(<Mesh>object);
     }
 
-    private _tmpVector = new Vector3();
     private _tmpMatrix = new Matrix();
     /**
      * Applies an impulse on the imposter
@@ -342,11 +341,9 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
 
-            // Convert contactPoint into world space
+            // Convert contactPoint relative to body position
             if (impostor.object && impostor.object.getWorldMatrix) {
-                impostor.object.getWorldMatrix().invertToRef(this._tmpMatrix);
-                Vector3.TransformCoordinatesToRef(contactPoint, this._tmpMatrix, this._tmpVector);
-                contactPoint = this._tmpVector;
+                contactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
             }
 
             worldPoint.setValue(contactPoint.x, contactPoint.y, contactPoint.z);
@@ -371,11 +368,9 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
 
-            // Convert contactPoint into world space
+            // Convert contactPoint relative to body position
             if (impostor.object && impostor.object.getWorldMatrix) {
-                impostor.object.getWorldMatrix().invertToRef(this._tmpMatrix);
-                Vector3.TransformCoordinatesToRef(contactPoint, this._tmpMatrix, this._tmpVector);
-                contactPoint = this._tmpVector;
+                contactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
             }
 
             worldPoint.setValue(contactPoint.x, contactPoint.y, contactPoint.z);


### PR DESCRIPTION
This is a fix for https://forum.babylonjs.com/t/contact-point-in-impostor-applyforce-is-handled-differently-with-ammo-and-cannon-plugin/9422/6

In this PR: https://playground.babylonjs.com/#FD65RR#35
You can clearly see the difference between ammojs and Cannon. Cannon performs correctly a torque while rotation in ammo stops after a while.

After some research, it looks like 'relative' in BulletPhysics for applyImpulse doesn't mean relative to the object matrix but relative to the center of mass.
See this topic:
https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=8219
And this code in BulletPhysics :
https://github.com/kripken/ammo.js/blob/00506d296df957d80bd192d27ff8a3ef2aa9f176/bullet/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp#L1096

With my fix, the behavior is consistent between Bullet and Cannon. As this fix is a good candidate for breaking everything for users using ammojs, thanks for taking extra care reviewing it :)