### PR TITLE
Check that 'document' exists before trying to unregister events

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1885,19 +1885,23 @@ export class Engine extends ThinEngine {
         if (DomManagement.IsWindowObjectExist()) {
             window.removeEventListener("blur", this._onBlur);
             window.removeEventListener("focus", this._onFocus);
+
             if (this._renderingCanvas) {
                 this._renderingCanvas.removeEventListener("focus", this._onCanvasFocus);
                 this._renderingCanvas.removeEventListener("blur", this._onCanvasBlur);
                 this._renderingCanvas.removeEventListener("pointerout", this._onCanvasPointerOut);
             }
-            document.removeEventListener("fullscreenchange", this._onFullscreenChange);
-            document.removeEventListener("mozfullscreenchange", this._onFullscreenChange);
-            document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
-            document.removeEventListener("msfullscreenchange", this._onFullscreenChange);
-            document.removeEventListener("pointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("mspointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("mozpointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("webkitpointerlockchange", this._onPointerLockChange);
+
+            if (DomManagement.IsDocumentAvailable()) {
+                document.removeEventListener("fullscreenchange", this._onFullscreenChange);
+                document.removeEventListener("mozfullscreenchange", this._onFullscreenChange);
+                document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
+                document.removeEventListener("msfullscreenchange", this._onFullscreenChange);
+                document.removeEventListener("pointerlockchange", this._onPointerLockChange);
+                document.removeEventListener("mspointerlockchange", this._onPointerLockChange);
+                document.removeEventListener("mozpointerlockchange", this._onPointerLockChange);
+                document.removeEventListener("webkitpointerlockchange", this._onPointerLockChange);
+            }
         }
 
         super.dispose();

--- a/src/Misc/domManagement.ts
+++ b/src/Misc/domManagement.ts
@@ -20,6 +20,14 @@ export class DomManagement {
     }
 
     /**
+     * Check if the document object exists
+     * @returns true if the document object exists
+     */
+    public static IsDocumentAvailable(): boolean {
+        return (typeof document) !== "undefined";
+    }
+
+    /**
      * Extracts text content from a DOM element hierarchy
      * @param element defines the root element
      * @returns a string


### PR DESCRIPTION
The code currently assumes that if `window` exists then `document` does too, but this isn't the case with Babylon Native, so disposing the engine throws. This adds an explicit check that `document` exists before trying to unregister events.
@bghgary 