### PR TITLE
Fix gitpod link in contributing.md.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -45,7 +45,7 @@ You can use Gitpod (A free online VS Code like IDE) for contributing online. Wit
 
 so that you can start straight away.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/BabylonJS/Babylon.js)
 
 ## Pull requests
 


### PR DESCRIPTION
Old link: https://gitpod.io/from-referrer
New link: https://gitpod.io/#https://github.com/BabylonJS/Babylon.js

GitHub now sets its Referrer Policy header to 'origin', so gitpod's trick of checking the referer header to see which repo you came from doesn't work.