### PR TITLE
Fix error where this._engine.createDynamicTexture is undefined in VideoTexture

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -105,6 +105,7 @@
 - Fix mesh winding order inversion when merging meshes with overridden side orientation ([drigax](https://github.com/Drigax))
 - Fixed a rendering issue with GearVR in WebXR mode ([RaananW](https://github.com/RaananW))
 - Fixed error when downloading async createScene function in playground ([#7926](https://github.com/BabylonJS/Babylon.js/issues/7926)) ([RaananW](https://github.com/RaananW))
+- Fix issue where ThinEngine.prototype.createDynamicEngine is undefined when using VideoTexture with es6 packages ([rvadhavk](https://github.com/rvadhavk))
 
 ## Breaking changes
 

--- a/src/Materials/Textures/videoTexture.ts
+++ b/src/Materials/Textures/videoTexture.ts
@@ -7,6 +7,7 @@ import { Engine } from "../../Engines/engine";
 import { Texture } from "../../Materials/Textures/texture";
 
 import "../../Engines/Extensions/engine.videoTexture";
+import "../../Engines/Extensions/engine.dynamicTexture";
 
 /**
  * Settings for finer control over video usage


### PR DESCRIPTION
This occurs when using VideoTexture via es6 packages (see https://doc.babylonjs.com/features/es6_support), because
VideoTexture relies on Engine/Extensions/engine.dynamicTexture to add the createDynamicTexture method to ThinEngine.