### PR TITLE
set touchAction to "none"

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -106,6 +106,7 @@
 - Fixed a rendering issue with GearVR in WebXR mode ([RaananW](https://github.com/RaananW))
 - Fixed error when downloading async createScene function in playground ([#7926](https://github.com/BabylonJS/Babylon.js/issues/7926)) ([RaananW](https://github.com/RaananW))
 - Fix issue where ThinEngine.prototype.createDynamicEngine is undefined when using VideoTexture with es6 packages ([rvadhavk](https://github.com/rvadhavk))
+- Fix [issue](https://forum.babylonjs.com/t/virtualjoystick-needs-to-set-style-touch-action-none-explicitly/9562) that canvas for `VirtualJoystick` does not have `touch-action: "none"` set by default ([joergplewe](https://github.com/joergplewe))
 
 ## Breaking changes
 

--- a/src/Misc/virtualJoystick.ts
+++ b/src/Misc/virtualJoystick.ts
@@ -124,6 +124,7 @@ export class VirtualJoystick {
             VirtualJoystick.Canvas.style.left = "0px";
             VirtualJoystick.Canvas.style.zIndex = "5";
             VirtualJoystick.Canvas.style.msTouchAction = "none";
+            VirtualJoystick.Canvas.style.touchAction = "none";  // fix https://forum.babylonjs.com/t/virtualjoystick-needs-to-set-style-touch-action-none-explicitly/9562
             // Support for jQuery PEP polyfill
             VirtualJoystick.Canvas.setAttribute("touch-action", "none");
             let context = VirtualJoystick.Canvas.getContext('2d');


### PR DESCRIPTION
fix https://forum.babylonjs.com/t/virtualjoystick-needs-to-set-style-touch-action-none-explicitly/9562