### PR TITLE
Fixed time steps/delta time with sub time step for Oimo and Cannon

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -43,6 +43,7 @@
 
 ### Physics
 
+- Fixed time steps or delta time with sub time step for Oimo.js and Cannon.js ([cedricguillemet](https://github.com/cedricguillemet))
 - Ammo.js IDL exposed property update and raycast vehicle stablization support ([MackeyK24](https://github.com/MackeyK24))
 - Recast.js plugin nav mesh and crowd agent to ref performance optimizations. ([MackeyK24](https://github.com/MackeyK24))
 

--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -54,7 +54,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
     }
 
     public executeStep(delta: number): void {
-        this.world.step(this._fixedTimeStep, this._useDeltaForWorldStep ? delta : 0, 3);
+        this.world.step(this._useDeltaForWorldStep ? delta : this._fixedTimeStep);
         this._removeMarkedPhysicsBodiesFromWorld();
     }
 

--- a/src/Physics/Plugins/oimoJSPlugin.ts
+++ b/src/Physics/Plugins/oimoJSPlugin.ts
@@ -17,8 +17,9 @@ export class OimoJSPlugin implements IPhysicsEnginePlugin {
     public name: string = "OimoJSPlugin";
     public BJSOIMO: any;
     private _raycastResult: PhysicsRaycastResult;
+    private _fixedTimeStep: number = 1 / 60;
 
-    constructor(iterations?: number, oimoInjection = OIMO) {
+    constructor(private _useDeltaForWorldStep: boolean = true, iterations?: number, oimoInjection = OIMO) {
         this.BJSOIMO = oimoInjection;
         this.world = new this.BJSOIMO.World({
             iterations: iterations
@@ -47,6 +48,7 @@ export class OimoJSPlugin implements IPhysicsEnginePlugin {
             impostor.beforeStep();
         });
 
+        this.world.timeStep = this._useDeltaForWorldStep ? delta : this._fixedTimeStep;
         this.world.step();
 
         impostors.forEach((impostor) => {


### PR DESCRIPTION
Issue reported on the forum : https://forum.babylonjs.com/t/physics-ammo-cannon-spooky-down-force-in-no-force-scene/9651/11

Basically, for Cannon and Oimo, delta time is not used. So if you want substeps for extra precision, the physics still runs with 1/60s for each steps. And simulation runs faster than expected.
Please note that I added a default constructor parameter for Oimo to be consistent between physics engine. This can be an issue for compatibility. I checked PG using Oimo but didn't find anyone using constructor parameters. So, the impact should be pretty low.

PG for testing is here:
https://playground.babylonjs.com/#QERG1P#4
