### PR TITLE
Fixed up vector not correctly handled with stereoscopic rig

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -36,6 +36,7 @@
 
 ### Cameras
 
+- Fixed up vector not correctly handled with stereoscopic rig ([cedricguillemet](https://github.com/cedricguillemet))
 - Added flag to TargetCamera to invert rotation direction and multiplier to adjust speed ([Exolun](https://github.com/Exolun))
 - Added upwards and downwards keyboard input to `FreeCamera` ([Pheater](https://github.com/pheater))
 

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -1153,6 +1153,7 @@ export class ArcRotateCamera extends TargetCamera {
         rigCam._cameraRigParams = {};
         rigCam.isRigCamera = true;
         rigCam.rigParent = this;
+        rigCam.upVector = this.upVector;
         return rigCam;
     }
 

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -504,7 +504,7 @@ export class TargetCamera extends Camera {
         var newFocalTarget = TargetCamera._TargetFocalPoint.addInPlace(this.position);
 
         Matrix.TranslationToRef(-newFocalTarget.x, -newFocalTarget.y, -newFocalTarget.z, TargetCamera._TargetTransformMatrix);
-        TargetCamera._TargetTransformMatrix.multiplyToRef(Matrix.RotationY(halfSpace), TargetCamera._RigCamTransformMatrix);
+        TargetCamera._TargetTransformMatrix.multiplyToRef(Matrix.RotationAxis(rigCamera.upVector, halfSpace), TargetCamera._RigCamTransformMatrix);
         Matrix.TranslationToRef(newFocalTarget.x, newFocalTarget.y, newFocalTarget.z, TargetCamera._TargetTransformMatrix);
 
         TargetCamera._RigCamTransformMatrix.multiplyToRef(TargetCamera._TargetTransformMatrix, TargetCamera._RigCamTransformMatrix);


### PR DESCRIPTION
Quick fix for this issue https://forum.babylonjs.com/t/physics-w-o-global-gravity-cannon-js-ignores-friction-ammo-js-totally-broken/9754
Up vector was not correctly handled for stereo rig