### PR TITLE
[XR] make teleportation and physics work automatically for non-gamepad-enabled controllers 

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -133,8 +133,6 @@
 - Fix bugs in NME that were causing inconsistent behavior displaying Move Node Up and Down buttons on frame ports ([belfortk](https://github.com/belfortk))
 - Fix bug in `ShaderMaterial` when using morph targets ([Popov72](https://github.com/Popov72)
 - Fix bug in playground where child NME windows would not close before page unload events ([belfortk](https://github.com/belfortk)
-- Fixed an issue with stereoscopic rendering ([#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([RaananW](https://github.com/RaananW))
-
 
 ## Breaking changes
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -133,6 +133,8 @@
 - Fix bugs in NME that were causing inconsistent behavior displaying Move Node Up and Down buttons on frame ports ([belfortk](https://github.com/belfortk))
 - Fix bug in `ShaderMaterial` when using morph targets ([Popov72](https://github.com/Popov72)
 - Fix bug in playground where child NME windows would not close before page unload events ([belfortk](https://github.com/belfortk)
+- Fixed an issue with stereoscopic rendering ([#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([RaananW](https://github.com/RaananW))
+
 
 ## Breaking changes
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -81,7 +81,7 @@
 - AR reference space type recommendation changed to 'unbounded' ([#7959](https://github.com/BabylonJS/Babylon.js/issues/7959)) ([RaananW](https://github.com/RaananW))
 - Teleportation plugin doesn't use the touched to finish teleportation ([#7916](https://github.com/BabylonJS/Babylon.js/issues/7916)) ([RaananW](https://github.com/RaananW))
 - Support for pointer selection and teleportation in right handed systems ([#7967](https://github.com/BabylonJS/Babylon.js/issues/7967)) ([RaananW](https://github.com/RaananW))
-- Pointer Selection feature now uses `selectstart` and `selectend` events when gamepad is not present ([#7989](https://github.com/BabylonJS/Babylon.js/issues/7989)) ([RaananW](https://github.com/RaananW))
+- Pointer Selection feature now uses `selectstart` and `selectend` events when gamepad and motion controller are not present ([#7989](https://github.com/BabylonJS/Babylon.js/issues/7989)) ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -1,10 +1,9 @@
 import { Camera } from "../camera";
-import { PassPostProcess } from "../../PostProcesses/passPostProcess";
-import { StereoscopicInterlacePostProcessI } from "../../PostProcesses/stereoscopicInterlacePostProcess";
+import { Viewport } from '../../Maths/math.viewport';
 
 Camera._setStereoscopicRigMode = function(camera: Camera) {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
-    var isStereoscopicInterlaced = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_INTERLACED;
-    camera._rigCameras[0]._rigPostProcess = new PassPostProcess(camera.name + "_passthru", 1.0, camera._rigCameras[0]);
-    camera._rigCameras[1]._rigPostProcess = new StereoscopicInterlacePostProcessI(camera.name + "_stereoInterlace", camera._rigCameras, isStereoscopicHoriz, isStereoscopicInterlaced);
+    camera._rigCameras[0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5: 1.0, isStereoscopicHoriz ? 1.0: 0.5);
+    camera._rigCameras[1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5: 1.0, isStereoscopicHoriz ? 1.0: 0.5);
+
 };

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -1,9 +1,10 @@
 import { Camera } from "../camera";
-import { Viewport } from '../../Maths/math.viewport';
+import { PassPostProcess } from "../../PostProcesses/passPostProcess";
+import { StereoscopicInterlacePostProcessI } from "../../PostProcesses/stereoscopicInterlacePostProcess";
 
 Camera._setStereoscopicRigMode = function(camera: Camera) {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
-    var isCrossEye = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
-    camera._rigCameras[isCrossEye ? 1 : 0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
-    camera._rigCameras[isCrossEye ? 0 : 1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
+    var isStereoscopicInterlaced = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_INTERLACED;
+    camera._rigCameras[0]._rigPostProcess = new PassPostProcess(camera.name + "_passthru", 1.0, camera._rigCameras[0]);
+    camera._rigCameras[1]._rigPostProcess = new StereoscopicInterlacePostProcessI(camera.name + "_stereoInterlace", camera._rigCameras, isStereoscopicHoriz, isStereoscopicInterlaced);
 };

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -3,7 +3,7 @@ import { Viewport } from '../../Maths/math.viewport';
 
 Camera._setStereoscopicRigMode = function(camera: Camera) {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
-    camera._rigCameras[0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5: 1.0, isStereoscopicHoriz ? 1.0: 0.5);
-    camera._rigCameras[1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5: 1.0, isStereoscopicHoriz ? 1.0: 0.5);
-
+    var isCrossEye = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
+    camera._rigCameras[isCrossEye ? 1 : 0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
+    camera._rigCameras[isCrossEye ? 0 : 1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
 };

--- a/src/XR/features/WebXRControllerPhysics.ts
+++ b/src/XR/features/WebXRControllerPhysics.ts
@@ -85,7 +85,8 @@ export class WebXRControllerPhysics extends WebXRAbstractFeature {
         if (!this._xrSessionManager.scene.isPhysicsEnabled()) {
             Logger.Warn("physics engine not enabled, skipped. Please add this controller manually.");
         }
-        if (this._options.physicsProperties!.useControllerMesh) {
+        // if no motion controller available, create impostors!
+        if (this._options.physicsProperties!.useControllerMesh && xrController.inputSource.gamepad) {
             xrController.onMotionControllerInitObservable.addOnce((motionController) => {
                 motionController.onModelLoadedObservable.addOnce(() => {
                     const impostor = new PhysicsImpostor(motionController.rootMesh!, PhysicsImpostor.MeshImpostor, {

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -406,7 +406,9 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
             }
         };
         const controllerData = this._controllers[xrController.uniqueId];
-        if (controllerData.xrController.inputSource.targetRayMode === 'tracked-pointer') {
+        // motion controller only available to gamepad-enabled input sources.
+        if (controllerData.xrController.inputSource.targetRayMode === 'tracked-pointer'
+            && controllerData.xrController.inputSource.gamepad) {
             // motion controller support
             xrController.onMotionControllerInitObservable.addOnce(() => {
                 if (xrController.motionController) {
@@ -520,21 +522,21 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
             this._xrSessionManager.scene.onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
                     controllerData.teleportationState.forward = true;
-                        this._currentTeleportationControllerId = controllerData.xrController.uniqueId;
-                        controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
-                        controllerData.teleportationState.currentRotation = 0;
-                        const timeToSelect = this._options.timeToTeleport || 3000;
-                        let timer = 0;
-                        const observer = this._xrSessionManager.onXRFrameObservable.add(() => {
-                            timer += this._xrSessionManager.scene.getEngine().getDeltaTime();
-                            if (timer >= timeToSelect && this._currentTeleportationControllerId === controllerData.xrController.uniqueId && controllerData.teleportationState.forward) {
-                                this._teleportForward(xrController.uniqueId);
-                            }
+                    this._currentTeleportationControllerId = controllerData.xrController.uniqueId;
+                    controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
+                    controllerData.teleportationState.currentRotation = 0;
+                    const timeToSelect = this._options.timeToTeleport || 3000;
+                    let timer = 0;
+                    const observer = this._xrSessionManager.onXRFrameObservable.add(() => {
+                        timer += this._xrSessionManager.scene.getEngine().getDeltaTime();
+                        if (timer >= timeToSelect && this._currentTeleportationControllerId === controllerData.xrController.uniqueId && controllerData.teleportationState.forward) {
+                            this._teleportForward(xrController.uniqueId);
+                        }
 
-                            if (timer >= timeToSelect) {
-                                this._xrSessionManager.onXRFrameObservable.remove(observer);
-                            }
-                        });
+                        if (timer >= timeToSelect) {
+                            this._xrSessionManager.onXRFrameObservable.remove(observer);
+                        }
+                    });
                 } else if (pointerInfo.type === PointerEventTypes.POINTERUP) {
                     controllerData.teleportationState.forward = false;
                     this._currentTeleportationControllerId = "";


### PR DESCRIPTION
Teleportation and physics have support for controllers with no motion controllers, but till now it was optional ( in the case of physics) and implemented for other types of controllers (in the case of teleportation). 
This will enable those features automatically when a motion controller is not present in tracked-pointer input sources.