### PR TITLE
Fix issue when compiling with closure compiler.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -138,6 +138,7 @@
 - Fix bug in `ShaderMaterial` when using morph targets ([Popov72](https://github.com/Popov72)
 - Fix bug in playground where child NME windows would not close before page unload events ([belfortk](https://github.com/belfortk)
 - Fixed an issue with stereoscopic rendering ([#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([RaananW](https://github.com/RaananW))
+- Fix an error when compiling with the closure compiler ([ageneau](https://github.com/ageneau/))
 
 ## Breaking changes
 

--- a/src/Misc/depthReducer.ts
+++ b/src/Misc/depthReducer.ts
@@ -98,7 +98,10 @@ export class DepthReducer extends MinMaxReducer {
         super.dispose(disposeAll);
 
         if (this._depthRenderer && disposeAll) {
-            delete this._depthRenderer.getDepthMap().getScene()?._depthRenderer[this._depthRendererId];
+            const scene = this._depthRenderer.getDepthMap().getScene();
+            if (scene) {
+                delete scene._depthRenderer[this._depthRendererId];
+            }
 
             this._depthRenderer.dispose();
             this._depthRenderer = null;


### PR DESCRIPTION
Fixes "Invalid delete operand. Only properties can be deleted." when compiling
with the closure compiler.
See https://forum.babylonjs.com/t/possible-bug-when-compiling-babylonjs-with-the-closure-compiler/9923