### PR TITLE
Ammo.js collision group and mask supported by impostor parameters

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -50,6 +50,7 @@
 ### Physics
 
 - Fixed time steps or delta time with sub time step for Oimo.js and Cannon.js ([cedricguillemet](https://github.com/cedricguillemet))
+- Ammo.js collision group and mask supported by impostor parameters ([cedricguillemet](https://github.com/cedricguillemet))
 - Ammo.js IDL exposed property update and raycast vehicle stablization support ([MackeyK24](https://github.com/MackeyK24))
 - Recast.js plugin nav mesh and crowd agent to ref performance optimizations. ([MackeyK24](https://github.com/MackeyK24))
 - Added `scene.physicsEnabled` boolean ([Deltakosh](https://github.com/deltakosh))

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -447,7 +447,13 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                     body.setCollisionFlags(body.getCollisionFlags() | AmmoJSPlugin.DISABLE_COLLISION_FLAG);
                 }
 
-                this.world.addRigidBody(body);
+                let group = impostor.getParam("group");
+                let mask = impostor.getParam("mask");
+                if (group && mask) {
+                    this.world.addRigidBody(body, group, mask);
+                } else {
+                    this.world.addRigidBody(body);
+                }
                 impostor.physicsBody = body;
                 impostor._pluginData.toDispose = impostor._pluginData.toDispose.concat([body, rbInfo, myMotionState, startTransform, localInertia, colShape]);
             }


### PR DESCRIPTION
followup on this thread:
https://forum.babylonjs.com/t/how-i-can-disable-collision-between-some-group-meshes/10029