### PR TITLE
Correct query params in pg

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -566,7 +566,7 @@ class Main {
                         exampleList.appendChild(noResultContainer);
                     }
 
-                    if (!location.hash && restoreVersionResult == false && location.pathname === '/') {
+                    if (!location.hash && restoreVersionResult == false && (location.pathname === '/' || !location.pathname)) {
                         // Query string
                         var queryString = window.location.search;
 
@@ -1016,7 +1016,7 @@ class Main {
     };
     checkHash() {
         let pgHash = "";
-        if (location.search && location.pathname === '/' && !location.hash) {
+        if (location.search && (!location.pathname  || location.pathname === '/') && !location.hash) {
             var query = this.parseQuery(location.search);
             if (query.pg) {
                 pgHash = "#" + query.pg + "#" + (query.revision || "0")

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -566,7 +566,7 @@ class Main {
                         exampleList.appendChild(noResultContainer);
                     }
 
-                    if (!location.hash && restoreVersionResult == false) {
+                    if (!location.hash && restoreVersionResult == false && location.pathname === '/') {
                         // Query string
                         var queryString = window.location.search;
 
@@ -1016,12 +1016,11 @@ class Main {
     };
     checkHash() {
         let pgHash = "";
-        if (location.search) {
+        if (location.search && location.pathname === '/' && !location.hash) {
             var query = this.parseQuery(location.search);
             if (query.pg) {
                 pgHash = "#" + query.pg + "#" + (query.revision || "0")
             }
-
         } else if (location.hash) {
             if (this.previousHash !== location.hash) {
                 this.cleanHash();

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -150,6 +150,7 @@
 - Fixed an issue with stereoscopic rendering ([#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([RaananW](https://github.com/RaananW))
 - Fix an error when compiling with the closure compiler ([ageneau](https://github.com/ageneau/))
 - Fix an error in applying texture to sides of `extrudePolygon` using faceUV[1] ([JohnK](https://github.com/BabylonJSGuide/))
+- Playground didn't work if query params were added to the URL ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 


### PR DESCRIPTION
When an external website adds query params to our pg links the PG didn't work.

It now parses the query only under specific terms (pathname should be empty/base)