### PR TITLE
fix: Web Workers have no window

### DIFF
--- a/src/Offline/database.ts
+++ b/src/Offline/database.ts
@@ -92,7 +92,7 @@ export class Database implements IOfflineProvider {
     }
 
     private static _ReturnFullUrlLocation = (url: string): string => {
-        if (url.indexOf("http:/") === -1 && url.indexOf("https:/") === -1) {
+        if (url.indexOf("http:/") === -1 && url.indexOf("https:/") === -1 && typeof window !== "undefined") {
             return (Database._ParseURL(window.location.href) + url);
         }
         else {


### PR DESCRIPTION
This is to allow Web Workers to perform things like `SceneLoader.ImportMesh` without having to switch engine to offline (`enableOfflineSupport = false`).