### PR TITLE
Further fix of updateOptions method of Sound class

### DIFF
--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -459,8 +459,8 @@ export class Sound {
             this.refDistance = options.refDistance ?? this.refDistance;
             this.distanceModel = options.distanceModel ?? this.distanceModel;
             this._playbackRate = options.playbackRate ?? this._playbackRate;
-            this._length = options.length ?? undefined;
-            this._offset = options.offset ?? undefined;
+            this._length = options.length ?? this._length;
+            this._offset = options.offset ?? this._offset;
             this._updateSpatialParameters();
             if (this.isPlaying) {
                 if (this._streaming && this._htmlAudioElement) {


### PR DESCRIPTION
The `updateOptions` method of `Sound` class still has another bug (even after latest fix). If `offset` and/or `length` properties are not set in the `ISoundOptions` parameter, it assigns the private members `_offset` and/or `_length` to undefined. So if they were set in the constructor, their values are lost.

This playground will demonstrate the problem: https://www.babylonjs-playground.com/#DIJA7S#2

Notice that after calling `updateOptions`, the whole track is played, instead of only playing the part defined by `offset` and `length`.

My PR should fix the issue.