### PR TITLE
Add suport for soft transparent shadows

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -17,6 +17,7 @@
 - Added support for `material.disableColorWrite` ([Deltakosh](https://github.com/deltakosh))
 - The Mesh Asset Task also accepts File as sceneInput ([RaananW](https://github.com/RaananW))
 - Added support preserving vert colors for CSG objects ([PirateJC](https://github.com/PirateJC))
+- Added support in `ShadowGenerator` for fast fake soft transparent shadows ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/materialsLibrary/src/custom/customMaterial.ts
+++ b/materialsLibrary/src/custom/customMaterial.ts
@@ -159,8 +159,11 @@ export class CustomMaterial extends StandardMaterial {
             .replace('#define CUSTOM_FRAGMENT_UPDATE_DIFFUSE', (this.CustomParts.Fragment_Custom_Diffuse ? this.CustomParts.Fragment_Custom_Diffuse : ""))
             .replace('#define CUSTOM_FRAGMENT_UPDATE_ALPHA', (this.CustomParts.Fragment_Custom_Alpha ? this.CustomParts.Fragment_Custom_Alpha : ""))
             .replace('#define CUSTOM_FRAGMENT_BEFORE_LIGHTS', (this.CustomParts.Fragment_Before_Lights ? this.CustomParts.Fragment_Before_Lights : ""))
-            .replace('#define CUSTOM_FRAGMENT_BEFORE_FOG', (this.CustomParts.Fragment_Before_Fog ? this.CustomParts.Fragment_Before_Fog : ""))
             .replace('#define CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR', (this.CustomParts.Fragment_Before_FragColor ? this.CustomParts.Fragment_Before_FragColor : ""));
+
+        if (this.CustomParts.Fragment_Before_Fog) {
+            Effect.ShadersStore[name + "PixelShader"] = Effect.ShadersStore[name + "PixelShader"].replace('#define CUSTOM_FRAGMENT_BEFORE_FOG', this.CustomParts.Fragment_Before_Fog);
+        }
 
         this._isCreatedShader = true;
         this._createdShaderName = name;

--- a/materialsLibrary/src/custom/pbrCustomMaterial.ts
+++ b/materialsLibrary/src/custom/pbrCustomMaterial.ts
@@ -157,8 +157,11 @@ export class PBRCustomMaterial extends PBRMaterial {
             .replace('#define CUSTOM_FRAGMENT_BEFORE_LIGHTS', (this.CustomParts.Fragment_Before_Lights ? this.CustomParts.Fragment_Before_Lights : ""))
             .replace('#define CUSTOM_FRAGMENT_UPDATE_METALLICROUGHNESS', (this.CustomParts.Fragment_Custom_MetallicRoughness ? this.CustomParts.Fragment_Custom_MetallicRoughness : ""))
             .replace('#define CUSTOM_FRAGMENT_UPDATE_MICROSURFACE', (this.CustomParts.Fragment_Custom_MicroSurface ? this.CustomParts.Fragment_Custom_MicroSurface : ""))
-            .replace('#define CUSTOM_FRAGMENT_BEFORE_FOG', (this.CustomParts.Fragment_Before_Fog ? this.CustomParts.Fragment_Before_Fog : ""))
             .replace('#define CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR', (this.CustomParts.Fragment_Before_FragColor ? this.CustomParts.Fragment_Before_FragColor : ""));
+
+        if (this.CustomParts.Fragment_Before_Fog) {
+            Effect.ShadersStore[name + "PixelShader"] = Effect.ShadersStore[name + "PixelShader"].replace('#define CUSTOM_FRAGMENT_BEFORE_FOG', this.CustomParts.Fragment_Before_Fog);
+        }
 
         this._isCreatedShader = true;
         this._createdShaderName = name;

--- a/src/Materials/shadowDepthWrapper.ts
+++ b/src/Materials/shadowDepthWrapper.ts
@@ -203,6 +203,7 @@ export class ShadowDepthWrapper {
 
         const vertexNormalBiasCode = this._options && this._options.remappedVariables ? `#include<shadowMapVertexNormalBias>(${this._options.remappedVariables.join(",")})` : Effect.IncludesShadersStore["shadowMapVertexNormalBias"],
               vertexMetricCode = this._options && this._options.remappedVariables ? `#include<shadowMapVertexMetric>(${this._options.remappedVariables.join(",")})` : Effect.IncludesShadersStore["shadowMapVertexMetric"],
+              fragmentSoftTransparentShadow = this._options && this._options.remappedVariables ? `#include<shadowMapFragmentSoftTransparentShadow>(${this._options.remappedVariables.join(",")})` : Effect.IncludesShadersStore["shadowMapFragmentSoftTransparentShadow"],
               fragmentBlockCode = Effect.IncludesShadersStore["shadowMapFragment"];
 
         vertexCode = vertexCode.replace(/void\s+?main/g, Effect.IncludesShadersStore["shadowMapVertexDeclaration"] + "\r\nvoid main");
@@ -216,6 +217,7 @@ export class ShadowDepthWrapper {
         vertexCode = vertexCode.replace(/#define SHADER_NAME.*?\n|out vec4 glFragColor;\n/g, "");
 
         fragmentCode = fragmentCode.replace(/void\s+?main/g, Effect.IncludesShadersStore["shadowMapFragmentDeclaration"] + "\r\nvoid main");
+        fragmentCode = fragmentCode.replace(/#define SHADOWDEPTH_SOFTTRANSPARENTSHADOW|#define CUSTOM_FRAGMENT_BEFORE_FOG/g, fragmentSoftTransparentShadow);
         if (fragmentCode.indexOf("#define SHADOWDEPTH_FRAGMENT") !== -1) {
             fragmentCode = fragmentCode.replace(/#define SHADOWDEPTH_FRAGMENT/g, fragmentBlockCode);
         } else {
@@ -225,7 +227,7 @@ export class ShadowDepthWrapper {
 
         const uniforms = origEffect.getUniformNames().slice();
 
-        uniforms.push("biasAndScaleSM", "depthValuesSM", "lightDataSM");
+        uniforms.push("biasAndScaleSM", "depthValuesSM", "lightDataSM", "softTransparentShadowSM");
 
         params.depthEffect = this._scene.getEngine().createEffect({
             vertexSource: vertexCode,

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -987,7 +987,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
             if (generator && (!generator.getShadowMap()?.renderList || generator.getShadowMap()?.renderList && generator.getShadowMap()?.renderList?.indexOf(this) !== -1)) {
                 for (var subMesh of this.subMeshes) {
-                    if (!generator.isReady(subMesh, hardwareInstancedRendering)) {
+                    if (!generator.isReady(subMesh, hardwareInstancedRendering, subMesh.getMaterial()?.needAlphaBlendingForMesh(this) ?? false)) {
                         return false;
                     }
                 }

--- a/src/Shaders/ShadersInclude/bayerDitherFunctions.fx
+++ b/src/Shaders/ShadersInclude/bayerDitherFunctions.fx
@@ -1,0 +1,25 @@
+// from https://www.shadertoy.com/view/Mlt3z8
+
+// Generates the basic 2x2 Bayer permutation matrix:
+//  [1 2]
+//  [3 0]
+// Expects _P in [0,1]
+float bayerDither2(vec2 _P) {
+    return mod(2.0 * _P.y + _P.x + 1.0, 4.0);
+}
+
+// Generates the 4x4 matrix
+// Expects _P any pixel coordinate
+float bayerDither4(vec2 _P) {
+    vec2 P1 = mod(_P, 2.0);              // (P >> 0) & 1
+    vec2 P2 = floor(0.5 * mod(_P, 4.0)); // (P >> 1) & 1
+    return 4.0 * bayerDither2(P1) + bayerDither2(P2);
+}
+
+// Generates the 8x8 matrix
+float bayerDither8(vec2 _P) {
+    vec2 P1 = mod(_P, 2.0);	              // (P >> 0) & 1
+    vec2 P2 = floor(0.5  * mod(_P, 4.0)); // (P >> 1) & 1
+    vec2 P4 = floor(0.25 * mod(_P, 8.0)); // (P >> 2) & 1
+    return 4.0 * (4.0 * bayerDither2(P1) + bayerDither2(P2)) + bayerDither2(P4);
+}

--- a/src/Shaders/ShadersInclude/shadowMapFragmentDeclaration.fx
+++ b/src/Shaders/ShadersInclude/shadowMapFragmentDeclaration.fx
@@ -2,6 +2,12 @@
 	#include<packingFunctions>
 #endif
 
+#if SM_SOFTTRANSPARENTSHADOW == 1
+	#include<bayerDitherFunctions>
+
+    uniform float softTransparentShadowSM;
+#endif
+
 varying float vDepthMetricSM;
 
 #if SM_USEDISTANCE == 1

--- a/src/Shaders/ShadersInclude/shadowMapFragmentSoftTransparentShadow.fx
+++ b/src/Shaders/ShadersInclude/shadowMapFragmentSoftTransparentShadow.fx
@@ -1,0 +1,3 @@
+#if SM_SOFTTRANSPARENTSHADOW == 1
+    if ((bayerDither8(floor(mod(gl_FragCoord.xy, 8.0)))) / 64.0 >= softTransparentShadowSM * alpha) discard;
+#endif

--- a/src/Shaders/shadowMap.fragment.fx
+++ b/src/Shaders/shadowMap.fragment.fx
@@ -12,8 +12,17 @@ void main(void)
 #include<clipPlaneFragment>
 
 #ifdef ALPHATEST
-    if (texture2D(diffuseSampler, vUV).a < 0.4)
+    float alphaFromAlphaTexture = texture2D(diffuseSampler, vUV).a;
+    if (alphaFromAlphaTexture < 0.4)
         discard;
+#endif
+
+#if SM_SOFTTRANSPARENTSHADOW == 1
+    #ifdef ALPHATEST
+        if ((bayerDither8(floor(mod(gl_FragCoord.xy, 8.0)))) / 64.0 >= softTransparentShadowSM * alphaFromAlphaTexture) discard;
+    #else
+        if ((bayerDither8(floor(mod(gl_FragCoord.xy, 8.0)))) / 64.0 >= softTransparentShadowSM) discard;
+    #endif
 #endif
 
 #include<shadowMapFragment>


### PR DESCRIPTION
Implement in the engine the technic shown here:
https://forum.babylonjs.com/t/fading-mesh-with-shadow/10085/8

![image](https://user-images.githubusercontent.com/4152247/80501852-38c50580-8970-11ea-883b-eece3496b10f.png)

Based on https://gkjohnson.github.io/threejs-sandbox/screendoor-transparency/ and https://www.shadertoy.com/view/Mlt3z8 for the Bayer fragment code.