### PR TITLE
[XR] Enable XR experimental features during session init

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -93,6 +93,7 @@
 - Added a warning that WebXR can only be served over HTTPS ([RaananW](https://github.com/RaananW))
 - Default (XR-global) rendering group ID can be defined when initializing a default experience ([RaananW](https://github.com/RaananW))
 - Added support for (experimental) haptic actuators ([#8068](https://github.com/BabylonJS/Babylon.js/issues/8068)) ([RaananW](https://github.com/RaananW))
+- It is now possible to enable experimental (AR) features using the options of the default xr helper ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/LibDeclarations/webxr.d.ts
+++ b/src/LibDeclarations/webxr.d.ts
@@ -69,8 +69,8 @@ interface XRInputSource {
 }
 
 interface XRSessionInit {
-    optionalFeatures?: XRReferenceSpaceType[];
-    requiredFeatures?: XRReferenceSpaceType[];
+    optionalFeatures?: string[];
+    requiredFeatures?: string[];
 }
 
 interface XRSession extends XRAnchorCreator {

--- a/src/XR/webXRDefaultExperience.ts
+++ b/src/XR/webXRDefaultExperience.ts
@@ -52,6 +52,12 @@ export class WebXRDefaultExperienceOptions {
      * An optional rendering group id that will be set globally for teleportation, pointer selection and default controller meshes
      */
     public renderingGroupId?: number;
+
+    /**
+     * A list of optional features to init the session with
+     * If set to true, all features we support will be added
+     */
+    optionalFeatures?: boolean | string[];
 }
 
 /**
@@ -131,11 +137,20 @@ export class WebXRDefaultExperience {
             result.renderTarget = result.baseExperience.sessionManager.getWebXRRenderTarget(options.outputCanvasOptions);
 
             if (!options.disableDefaultUI) {
-                if (options.uiOptions) {
-                    options.uiOptions.renderTarget = options.uiOptions.renderTarget || result.renderTarget;
+
+                const uiOptions: WebXREnterExitUIOptions = {
+                    renderTarget: result.renderTarget,
+                    ...(options.uiOptions || {})
+                };
+                if (options.optionalFeatures) {
+                    if (typeof options.optionalFeatures === 'boolean') {
+                        uiOptions.optionalFeatures = ['hit-test', 'anchors'/*, 'hand-tracking'*/];
+                    } else {
+                        uiOptions.optionalFeatures = options.optionalFeatures;
+                    }
                 }
                 // Create ui for entering/exiting xr
-                return WebXREnterExitUI.CreateAsync(scene, result.baseExperience, options.uiOptions || { renderTarget: result.renderTarget }).then((ui) => {
+                return WebXREnterExitUI.CreateAsync(scene, result.baseExperience, uiOptions).then((ui) => {
                     result.enterExitUI = ui;
                 });
             } else {

--- a/src/XR/webXREnterExitUI.ts
+++ b/src/XR/webXREnterExitUI.ts
@@ -53,6 +53,11 @@ export class WebXREnterExitUIOptions {
      * Default is immersive-vr
      */
     sessionMode?: XRSessionMode;
+
+    /**
+     * A list of optional features to init the session with
+     */
+    optionalFeatures?: string[];
 }
 /**
  * UI to allow the user to enter/exit XR mode
@@ -152,7 +157,7 @@ export class WebXREnterExitUI implements IDisposable {
                         } else if (helper.state == WebXRState.NOT_IN_XR) {
                             if (options.renderTarget) {
                                 try {
-                                    await helper.enterXRAsync(ui._buttons[i].sessionMode, ui._buttons[i].referenceSpaceType, options.renderTarget);
+                                    await helper.enterXRAsync(ui._buttons[i].sessionMode, ui._buttons[i].referenceSpaceType, options.renderTarget, {optionalFeatures: options.optionalFeatures});
                                     ui._updateButtons(ui._buttons[i]);
                                 } catch (e) {
                                     // make sure button is visible

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -91,16 +91,18 @@ export class WebXRExperienceHelper implements IDisposable {
      * @param sessionMode options for the XR session
      * @param referenceSpaceType frame of reference of the XR session
      * @param renderTarget the output canvas that will be used to enter XR mode
+     * @param sessionCreationOptions optional XRSessionInit object to init the session with
      * @returns promise that resolves after xr mode has entered
      */
-    public enterXRAsync(sessionMode: XRSessionMode, referenceSpaceType: XRReferenceSpaceType, renderTarget: WebXRRenderTarget = this.sessionManager.getWebXRRenderTarget()): Promise<WebXRSessionManager> {
+    public enterXRAsync(sessionMode: XRSessionMode, referenceSpaceType: XRReferenceSpaceType, renderTarget: WebXRRenderTarget = this.sessionManager.getWebXRRenderTarget(), sessionCreationOptions: XRSessionInit = {}): Promise<WebXRSessionManager> {
         if (!this._supported) {
             throw "WebXR not supported in this browser or environment";
         }
         this._setState(WebXRState.ENTERING_XR);
-        let sessionCreationOptions: XRSessionInit = {
-            optionalFeatures: (referenceSpaceType !== "viewer" && referenceSpaceType !== "local") ? [referenceSpaceType] : []
-        };
+        if (referenceSpaceType !== "viewer" && referenceSpaceType !== "local") {
+            sessionCreationOptions.optionalFeatures = sessionCreationOptions.optionalFeatures || [];
+            sessionCreationOptions.optionalFeatures.push(referenceSpaceType);
+        }
         // we currently recommend "unbounded" space in AR (#7959)
         if (sessionMode === "immersive-ar" && referenceSpaceType !== "unbounded") {
             Logger.Warn("We recommend using 'unbounded' reference space type when using 'immersive-ar' session mode");

--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -267,12 +267,14 @@ export class WebXRSessionManager implements IDisposable {
                 throw "XR initialization failed: required \"viewer\" reference space type not supported.";
             });
         }).then((referenceSpace) => {
+            // create viewer reference space before setting the first reference space
+            return this.session.requestReferenceSpace("viewer").then((viewerReferenceSpace: XRReferenceSpace) => {
+                this.viewerReferenceSpace = viewerReferenceSpace;
+                return referenceSpace;
+            });
+        }).then((referenceSpace) => {
             // initialize the base and offset (currently the same)
             this.referenceSpace = this.baseReferenceSpace = referenceSpace;
-
-            this.session.requestReferenceSpace("viewer").then((referenceSpace: XRReferenceSpace) => {
-                this.viewerReferenceSpace = referenceSpace;
-            });
             return this.referenceSpace;
         });
     }


### PR DESCRIPTION
Latest chrome canary requires to request the initialization of certain features (incubation features) such as hit test and anchors.

This PR enables the developer to set the requested optional parameters, or let us load everything we support :

```javascript
const xr = await scene.createDefaultXRExperienceHelper({optionalFeatures: true}); // enable all!
const xr = await scene.createDefaultXRExperienceHelper({optionalFeatures: ['hit-test']}); // enable just hit test
```