### PR TITLE
Add Support to Auto-Update Inspector when Switching Scenes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -40,6 +40,7 @@
 - Added right click options to create PBR and Standard Materials ([Deltakosh](https://github.com/deltakosh))
 - Added support for recording GIF ([Deltakosh](https://github.com/deltakosh))
 - Popup Window available (To be used in Curve Editor) ([pixelspace](https://github.com/devpixelspace))
+- Add support to update inspector when switching to new scene ([belfortk](https://github.com/belfortk))
 
 ### Cameras
 

--- a/inspector/src/components/globalState.ts
+++ b/inspector/src/components/globalState.ts
@@ -20,7 +20,7 @@ export class GlobalState {
     public onTabChangedObservable = new Observable<number>();
     public onSelectionRenamedObservable = new Observable<void>();
     public onPluginActivatedObserver: Nullable<Observer<ISceneLoaderPlugin | ISceneLoaderPluginAsync>>;
-
+    public onNewSceneObservable = new Observable<Scene>();
     public sceneImportDefaults: { [key: string]: any } = {};
 
     public validationResults: Nullable<IGLTFValidationResults> = null;

--- a/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -63,6 +63,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
     private _onSelectionChangeObserver: Nullable<Observer<any>>;
     private _onSelectionRenamedObserver: Nullable<Observer<void>>;
     private _onNewSceneAddedObserver: Nullable<Observer<Scene>>;
+    private _onNewSceneObserver: Nullable<Observer<Scene>>;
     private sceneExplorerRef: React.RefObject<Resizable>;
 
 
@@ -79,6 +80,12 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
         this.sceneMutationFunc = this.processMutation.bind(this);
 
         this.sceneExplorerRef = React.createRef();
+        this._onNewSceneObserver = this.props.globalState.onNewSceneObservable.add((scene: Scene) => {
+            this.setState({
+                ...this.state,
+                scene
+            });
+        })
     }
 
     processMutation() {
@@ -112,6 +119,10 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
 
         if (this._onNewSceneAddedObserver) {
             EngineStore.LastCreatedEngine!.onNewSceneAddedObservable.remove(this._onNewSceneAddedObserver);
+        }
+
+        if(this._onNewSceneObserver){
+            this.props.globalState.onNewSceneObservable.remove(this._onNewSceneObserver);
         }
 
         const scene = this.state.scene;

--- a/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -82,7 +82,6 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
         this.sceneExplorerRef = React.createRef();
         this._onNewSceneObserver = this.props.globalState.onNewSceneObservable.add((scene: Scene) => {
             this.setState({
-                ...this.state,
                 scene
             });
         })

--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -417,6 +417,11 @@ export class Inspector {
         }
     }
 
+    public static _SetNewScene(scene: Scene) {
+        this._Scene = scene;
+        this._GlobalState.onNewSceneObservable.notifyObservers(scene);
+    }
+
     public static _CreateCanvasContainer(parentControl: HTMLElement) {
         // Create a container for previous elements
         this._NewCanvasContainer = parentControl.ownerDocument!.createElement("div");

--- a/src/Debug/debugLayer.ts
+++ b/src/Debug/debugLayer.ts
@@ -262,6 +262,16 @@ export class DebugLayer {
         }
     }
 
+
+    /**
+     * Update the scene in the inspector 
+     */
+    public setAsActiveScene(){
+        if (this.BJSINSPECTOR) {
+            this.BJSINSPECTOR.Inspector._SetNewScene(this._scene);
+        }
+    }
+
     /**
       * Launch the debugLayer.
       * @param config Define the configuration of the inspector


### PR DESCRIPTION
Previously, the Inspector would not update when switching scenes. You would have to close it and re-open it.

With this PR, you can call `debugLayer.setAsActiveScene()` to smoothly update the scene in the inspector.