### PR TITLE
check zero buffer update, reformat pipeline layout, parallel shader loading

### DIFF
--- a/src/Engines/WebGPU/webgpuPipelineContext.ts
+++ b/src/Engines/WebGPU/webgpuPipelineContext.ts
@@ -63,7 +63,7 @@ export class WebGPUPipelineContext implements IPipelineContext {
 
     public vertexInputs: IWebGPUPipelineContextVertexInputsCache;
 
-    public bindGroupLayouts: (GPUBindGroupLayout | undefined)[];
+    public bindGroupLayouts: GPUBindGroupLayout[];
     public bindGroups: GPUBindGroup[];
 
     public renderPipeline: GPURenderPipeline;

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -519,7 +519,7 @@ export class WebGPUEngine extends Engine {
     //------------------------------------------------------------------------------
     private _createBuffer(view: ArrayBufferView, flags: GPUBufferUsageFlags): DataBuffer {
         if (view.byteLength == 0) {
-            throw new Error("Unable to create WebGPU buffer"); // Zero size buffer would kill the tab in chrome
+            throw new Error("Unable to create WebGPU buffer: cannot create zero-sized buffer"); // Zero size buffer would kill the tab in chrome
         }
         const padding = view.byteLength % 4;
 
@@ -580,7 +580,7 @@ export class WebGPUEngine extends Engine {
             for (let offset = 0; offset < src.byteLength; offset += this._maxBufferChunk) {
                 const uploadCount = Math.min(src.byteLength - offset, this._maxBufferChunk);
                 if (uploadCount == 0) {
-                    throw new Error("Unable to create WebGPU buffer"); // Zero size buffer would kill the tab in chrome
+                    throw new Error("Cannot create zero-sized buffer"); // Zero size buffer would kill the tab in chrome
                 }
                 const [uploadBuffer, uploadMapping] = this._device.createBufferMapped({
                     usage: WebGPUConstants.GPUBufferUsage_TRANSFER_SRC,
@@ -596,7 +596,7 @@ export class WebGPUEngine extends Engine {
             }
             this._device.defaultQueue.submit([commandEncoder.finish()]);
         } catch (e) {
-            Logger.Error(e);
+            Logger.Error('Unable to update WebGPU buffer: ' + e);
         } finally {
             tempBuffers.forEach((buff) => buff.destroy());
         }

--- a/src/LibDeclarations/webgpu.d.ts
+++ b/src/LibDeclarations/webgpu.d.ts
@@ -223,7 +223,7 @@ interface GPUBindGroupBinding {
 
 interface GPUBindGroupDescriptor extends GPUObjectDescriptorBase {
   layout: GPUBindGroupLayout;
-  bindings: GPUBindGroupBinding[];
+  entries: GPUBindGroupBinding[];
 }
 
 interface GPUBindGroupLayoutBinding {
@@ -802,8 +802,9 @@ interface GPURenderBundleEncoderDescriptor
   sampleCount?: number;
 }
 
-class GPURenderPipeline implements GPUObjectBase {
+declare class GPURenderPipeline implements GPUObjectBase {
   label: string | undefined;
+  getBindGroupLayout: (number) => GPUBindGroupLayout;
 }
 
 class GPUSampler implements GPUObjectBase {

--- a/src/Materials/effect.ts
+++ b/src/Materials/effect.ts
@@ -289,16 +289,27 @@ export class Effect implements IDisposable {
             processingContext: this._processingContext
         };
 
-        this._loadShader(vertexSource, "Vertex", "", (vertexCode) => {
-            this._loadShader(fragmentSource, "Fragment", "Pixel", (fragmentCode) => {
-                ShaderProcessor.Process(vertexCode, processorOptions, (migratedVertexCode) => {
-                    processorOptions.isFragment = true;
-                    ShaderProcessor.Process(fragmentCode, processorOptions, (migratedFragmentCode) => {
-                        const finalShaders = ShaderProcessor.Finalize(migratedVertexCode, migratedFragmentCode, processorOptions);
-                        this._useFinalCode(finalShaders.vertexCode, finalShaders.fragmentCode, baseName);
-                    });
+        let shaderCodes : [string | undefined, string | undefined] = [undefined, undefined];
+        let shadersLoaded = () => {
+            if (shaderCodes[0] && shaderCodes[1]) {
+                processorOptions.isFragment = true;
+                let [migratedVertexCode, fragmentCode] = shaderCodes;
+                ShaderProcessor.Process(fragmentCode, processorOptions, (migratedFragmentCode) => {
+                    const finalShaders = ShaderProcessor.Finalize(migratedVertexCode, migratedFragmentCode, processorOptions);
+                    this._useFinalCode(finalShaders.vertexCode, finalShaders.fragmentCode, baseName);
                 });
+            }
+
+        }
+        this._loadShader(vertexSource, "Vertex", "", (vertexCode) => {
+            ShaderProcessor.Process(vertexCode, processorOptions, (migratedVertexCode) => {
+                shaderCodes[0] = migratedVertexCode;
+                shadersLoaded();
             });
+        });
+        this._loadShader(fragmentSource, "Fragment", "Pixel", (fragmentCode) => {
+            shaderCodes[1] = fragmentCode;
+            shadersLoaded();
         });
     }
 

--- a/src/Materials/effect.ts
+++ b/src/Materials/effect.ts
@@ -11,9 +11,6 @@ import { ProcessingOptions, ShaderProcessingContext } from '../Engines/Processor
 import { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like, IColor4Like } from '../Maths/math.like';
 import { ThinEngine } from '../Engines/thinEngine';
 import { IEffectFallbacks } from './iEffectFallbacks';
-import { WebGPUPipelineContext } from '../Engines/WebGPU/webgpuPipelineContext';
-import type { WebGPUEngine } from '../Engines/webgpuEngine';
-import { WebGPUConstants } from '../Engines/WebGPU/webgpuConstants';
 
 declare type Engine = import("../Engines/engine").Engine;
 declare type InternalTexture = import("../Materials/Textures/internalTexture").InternalTexture;
@@ -300,7 +297,7 @@ export class Effect implements IDisposable {
                 });
             }
 
-        }
+        };
         this._loadShader(vertexSource, "Vertex", "", (vertexCode) => {
             ShaderProcessor.Process(vertexCode, processorOptions, (migratedVertexCode) => {
                 shaderCodes[0] = migratedVertexCode;
@@ -681,65 +678,6 @@ export class Effect implements IDisposable {
         } else {
             this._allFallbacksProcessed = true;
         }
-    }
-
-    public getPipelineLayout(): GPUPipelineLayout {
-        const bindGroupLayouts: GPUBindGroupLayout[] = [];
-        const webgpuPipelineContext = this._pipelineContext as WebGPUPipelineContext;
-
-        for (let i = 0; i < webgpuPipelineContext.orderedUBOsAndSamplers.length; i++) {
-            const setDefinition = webgpuPipelineContext.orderedUBOsAndSamplers[i];
-            if (setDefinition === undefined) {
-                const bindings: GPUBindGroupLayoutBinding[] = [];
-                const uniformsBindGroupLayout = (this._engine as WebGPUEngine).getDevice().createBindGroupLayout({
-                    bindings,
-                });
-                bindGroupLayouts[i] = uniformsBindGroupLayout;
-                continue;
-            }
-
-            const bindings: GPUBindGroupLayoutBinding[] = [];
-            for (let j = 0; j < setDefinition.length; j++) {
-                const bindingDefinition = webgpuPipelineContext.orderedUBOsAndSamplers[i][j];
-                if (bindingDefinition === undefined) {
-                    continue;
-                }
-
-                // TODO WEBGPU. Optimize shared samplers visibility for vertex/framgent.
-                if (bindingDefinition.isSampler) {
-                    bindings.push({
-                        binding: j,
-                        visibility: WebGPUConstants.GPUShaderStageBit_VERTEX | WebGPUConstants.GPUShaderStageBit_FRAGMENT,
-                        type: WebGPUConstants.GPUBindingType_sampledTexture,
-                        textureDimension: bindingDefinition.textureDimension,
-                        // TODO WEBGPU. Handle texture component type properly.
-                        // textureComponentType?: GPUTextureComponentType,
-                    }, {
-                        // TODO WEBGPU. No Magic + 1 (coming from current 1 texture 1 sampler startegy).
-                        binding: j + 1,
-                        visibility: WebGPUConstants.GPUShaderStageBit_VERTEX | WebGPUConstants.GPUShaderStageBit_FRAGMENT,
-                        type: WebGPUConstants.GPUBindingType_sampler
-                    });
-                }
-                else {
-                    bindings.push({
-                        binding: j,
-                        visibility: WebGPUConstants.GPUShaderStageBit_VERTEX | WebGPUConstants.GPUShaderStageBit_FRAGMENT,
-                        type: WebGPUConstants.GPUBindingType_uniformBuffer,
-                    });
-                }
-            }
-
-            if (bindings.length > 0) {
-                const uniformsBindGroupLayout = (this._engine as WebGPUEngine).getDevice().createBindGroupLayout({
-                    bindings,
-                });
-                bindGroupLayouts[i] = uniformsBindGroupLayout;
-            }
-        }
-
-        webgpuPipelineContext.bindGroupLayouts = bindGroupLayouts;
-        return (this._engine as WebGPUEngine).getDevice().createPipelineLayout({ bindGroupLayouts });
     }
 
     /**


### PR DESCRIPTION
- Fix unnecessary mapped buffer on buffer creation in certain cases
- Do not kill tab in chrome if updating buffer with 0 size data
- Use getBindGroupLayout to create a layout if necessary.
- Load fragment shader while vertex shader is being processing.