### PR TITLE
Handle missing cloned properties

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -142,6 +142,7 @@
 - Fixed delay calculation in Animatable.goToFrame when speedRatio != 1 ([Reimund Järnfors](https://github.com/reimund))
 - Fix bug in PBR when translucency is enabled and an irradiance texture is provided ([Popov72](https://github.com/Popov72))
 - Fix bug in PBR with translucency when irradiance texture is 2D ([Popov72](https://github.com/Popov72))
+- Fix parenting and enabled state of cloned lights ([cedricguillemet](https://github.com/cedricguillemet))
 - Fix bug in PBR when specific combinations of parameters are used ([Popov72](https://github.com/Popov72))
 - Fix texture being inverted on the Y axis by default when using TextureAsset or AssetManager ([broederj](https://github.com/broederj))
 - Fix `TexturePacker` cross-origin image requests, fix falsy default options ([ludevik](https://github.com/ludevik))

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -586,15 +586,21 @@ export abstract class Light extends Node {
     /**
      * Returns a new Light object, named "name", from the current one.
      * @param name The name of the cloned light
+     * @param newParent The parent of this light, if it has one
      * @returns the new created light
      */
-    public clone(name: string): Nullable<Light> {
+    public clone(name: string, newParent: Nullable<Node> = null): Nullable<Light> {
         let constructor = Light.GetConstructorFromName(this.getTypeID(), name, this.getScene());
 
         if (!constructor) {
             return null;
         }
-        return SerializationHelper.Clone(constructor, this);
+        let clonedLight = SerializationHelper.Clone(constructor, this);
+        if (newParent) {
+            clonedLight.parent = newParent;
+        }
+        clonedLight.setEnabled(this.isEnabled());
+        return clonedLight;
     }
 
     /**

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -457,6 +457,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 Tags.AddTagsTo(this, Tags.GetTags(source, true));
             }
 
+            // Enabled
+            this.setEnabled(source.isEnabled());
+
             // Parent
             this.parent = source.parent;
 


### PR DESCRIPTION
- clone enabled state for lights and meshes
- handle parent for cloned light

Followup on this thread : https://forum.babylonjs.com/t/possible-bug-cloning-lights-imported-via-sceneloader-loadassetcontainer/10547/3