### PR TITLE
Add Functionality to retrieve all Meshes affected by a highlight layer 

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -23,7 +23,7 @@
 - Added support preserving vert colors for CSG objects ([PirateJC](https://github.com/PirateJC))
 - Added support in `ShadowGenerator` for fast fake soft transparent shadows ([Popov72](https://github.com/Popov72))
 - Added `boundingBoxRenderer.onBeforeBoxRenderingObservable` and `boundingBoxRenderer.onAfterBoxRenderingObservable` ([Deltakosh](https://github.com/deltakosh))
-
+- Added support to return all affected Meshes by a HighlightLayer ([erik-pilgrim](https://github.com/erik-pilgrim))
 ### Engine
 
 - Allow logging of shader code when a compilation error occurs ([Popov72](https://github.com/Popov72))

--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -623,7 +623,7 @@ export class HighlightLayer extends EffectLayer {
         if (!this._meshes) {
             return;
         }
-        return this._meshes;
+        return [...this._meshes];
     }
     /**
      * Add a mesh in the highlight layer in order to make it glow with the chosen color.

--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -616,7 +616,15 @@ export class HighlightLayer extends EffectLayer {
 
         return this._meshes[mesh.uniqueId] !== undefined && this._meshes[mesh.uniqueId] !== null;
     }
-
+    /**
+     * Retrieve all meshes highlighted by the current HighlightLayer
+     */
+    public getAllMeshes(){
+        if (!this._meshes) {
+            return;
+        }
+        return this._meshes;
+    }
     /**
      * Add a mesh in the highlight layer in order to make it glow with the chosen color.
      * @param mesh The mesh to highlight


### PR DESCRIPTION
Rather than have to keep a list of highlighted elements, we can expose the private property _meshes via a get function to retrieve all affected Meshes. This assists in the selection and de-selection of multiple items within a scene.