### PR TITLE
TransformNode as spatial sound source fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -183,6 +183,7 @@
 - Fixed Path3D `_distances` / length computation ([Poolminer](https://github.com/Poolminer))
 - Make sure bone matrices are up to date when calling `TransformNode.attachToBone` ([Popov72](https://github.com/Popov72))
 - Fix display problem with transparent objects and SSAO2 pipeline (bug in the `GeometryBufferRenderer`) ([Popov72](https://github.com/Popov72))
+- Fixed `Sound` not accepting a `TransformNode` as a source for spatial sound ([Poolminer](https://github.com/Poolminer))
 
 ## Breaking changes
 

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -937,17 +937,18 @@ export class Sound {
     }
 
     private _onRegisterAfterWorldMatrixUpdate(node: TransformNode): void {
-        if (!(<any>node).getBoundingInfo) {
-            return;
-        }
-        let mesh = node as AbstractMesh;
         if (this._positionInEmitterSpace) {
-            mesh.worldMatrixFromCache.invertToRef(TmpVectors.Matrix[0]);
+            node.worldMatrixFromCache.invertToRef(TmpVectors.Matrix[0]);
             this.setPosition(TmpVectors.Matrix[0].getTranslation());
         }
         else {
-            let boundingInfo = mesh.getBoundingInfo();
-            this.setPosition(boundingInfo.boundingSphere.centerWorld);
+            if(!(<any>node).getBoundingInfo){
+                this.setPosition(node.position);
+            } else {
+                let mesh = node as AbstractMesh;
+                let boundingInfo = mesh.getBoundingInfo();
+                this.setPosition(boundingInfo.boundingSphere.centerWorld);
+            }
         }
         if (Engine.audioEngine.canUseWebAudio && this._isDirectional && this.isPlaying) {
             this._updateDirection();

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -943,7 +943,7 @@ export class Sound {
         }
         else {
             if (!(<any>node).getBoundingInfo) {
-                this.setPosition(node.position);
+                this.setPosition(node.absolutePosition);
             } else {
                 let mesh = node as AbstractMesh;
                 let boundingInfo = mesh.getBoundingInfo();

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -942,7 +942,7 @@ export class Sound {
             this.setPosition(TmpVectors.Matrix[0].getTranslation());
         }
         else {
-            if(!(<any>node).getBoundingInfo){
+            if (!(<any>node).getBoundingInfo) {
                 this.setPosition(node.position);
             } else {
                 let mesh = node as AbstractMesh;


### PR DESCRIPTION
https://forum.babylonjs.com/t/spatial-sound-sound-does-not-follow-a-transformnode-but-a-mesh/10717/