### PR TITLE
[PG] createEngine fails silently and default engine is created on error

### DIFF
--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -106,6 +106,7 @@ var engine;
 try {
     engine = ${createEngineFunction}();
 } catch(e) {
+    console.log("the available createEngine function failed. Creating the default engine instead");
     engine = createDefaultEngine();
 }`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";

--- a/Playground/js/main.js
+++ b/Playground/js/main.js
@@ -101,7 +101,13 @@ compileAndRun = function (parent, fpsLabel) {
 
                 parent.zipTool.ZipCode = zipVariables + defaultEngineZip + "var engine = createDefaultEngine();" + ";\r\nvar scene = new BABYLON.Scene(engine);\r\n\r\n" + code;
             } else {
-                code += "\r\n\r\nengine = " + createEngineFunction + "();";
+                code += `
+var engine;
+try {
+    engine = ${createEngineFunction}();
+} catch(e) {
+    engine = createDefaultEngine();
+}`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";
 
                 if (parent.settingsPG.ScriptLanguage == "JS") {

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -135,6 +135,7 @@
 ### Playground
 
 - Added support for code templates in the playground ([sailro](http://www.github.com/sailro))
+- If createEngine fails, a default engine will be created ([#8084](https://github.com/BabylonJS/Babylon.js/issues/8084)) ([RaananW](https://github.com/RaananW))
 
 ## Bugs
 


### PR DESCRIPTION
closing #8084

Instead of analyzing the code for commented-out functions, we check if the creageEngine function failed. If it did, the default engine is created and the error is logged.