### PR TITLE
Fix frame port name bug

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -39,6 +39,7 @@
 - Can now edit Node port names ([belfortk](https://github.com/belfortk))
 - Updated which node ports are shown on frames by default so that only node ports connected to outside nodes are by default exposed on the frame ([belfortk](https://github.com/belfortk))
 - Added a modulo block ([ageneau](https://github.com/ageneau))
+- Fix bug where frame port labels would be the names of incorrect nodes ([belfortk](https://github.com/belfortk))
 
 ### Inspector
 

--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -134,7 +134,7 @@ export class GraphFrame {
                     let portAdded = false;
 
                     for (var link of node.links) {
-                        if (link.portA === port && this.nodes.indexOf(link.nodeB!) === -1 || (link.portA! === port && port.exposedOnFrame)) {
+                        if (link.portA === port && this.nodes.indexOf(link.nodeB!) === -1 || (link.portA === port && port.exposedOnFrame)) {
                             let localPort: FrameNodePort;
 
                             if (!portAdded) {

--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -134,12 +134,12 @@ export class GraphFrame {
                     let portAdded = false;
 
                     for (var link of node.links) {
-                        if (link.portA === port && this.nodes.indexOf(link.nodeB!) === -1 || (link.portA === port && port.exposedOnFrame)) {
+                        if (link.portA === port && this.nodes.indexOf(link.nodeB!) === -1 || (link.portA! === port && port.exposedOnFrame)) {
                             let localPort: FrameNodePort;
 
                             if (!portAdded) {
                                 portAdded = true;
-                                localPort = FrameNodePort.CreateFrameNodePortElement(port.connectionPoint, link.nodeB!, this._outputPortContainer, null, this._ownerCanvas.globalState, false, GraphFrame._FramePortCounter++, this.id);
+                                localPort = FrameNodePort.CreateFrameNodePortElement(port.connectionPoint, link.nodeA!, this._outputPortContainer, null, this._ownerCanvas.globalState, false, GraphFrame._FramePortCounter++, this.id);
                                 this._frameOutPorts.push(localPort);
 
                                 link.isVisible = true;


### PR DESCRIPTION
When generating output frame ports labels for input nodes,
we should use the name of the input node, not the connected node which is
outside the frame.