### PR TITLE
NME: Fix crash when updating post process material in nme while a PG is running

### DIFF
--- a/nodeEditor/src/components/preview/previewManager.ts
+++ b/nodeEditor/src/components/preview/previewManager.ts
@@ -425,7 +425,7 @@ export class PreviewManager {
 
                     const currentScreen = tempMaterial.getBlockByPredicate((block) => block instanceof CurrentScreenBlock);
                     if (currentScreen) {
-                        this._postprocess!.onApplyObservable.add((effect) => {
+                        this._postprocess.onApplyObservable.add((effect) => {
                             effect.setTexture("textureSampler", (currentScreen as CurrentScreenBlock).texture);
                         });
                     }
@@ -449,6 +449,11 @@ export class PreviewManager {
                         }
                     });
                     tempMaterial.createEffectForParticles(this._particleSystem!);
+
+                    if (this._material) {
+                        this._material.dispose();
+                    }
+                    this._material = tempMaterial;
                     break;
                 }
 

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -46,6 +46,7 @@ import { Texture } from '../Textures/texture';
 import { IParticleSystem } from '../../Particles/IParticleSystem';
 import { BaseParticleSystem } from '../../Particles/baseParticleSystem';
 import { ColorSplitterBlock } from './Blocks/colorSplitterBlock';
+import { TimingTools } from '../../Misc/timingTools';
 
 const onCreatedEffectParameters = { effect: null as unknown as Effect, subMesh: null as unknown as Nullable<SubMesh> };
 
@@ -784,7 +785,9 @@ export class NodeMaterial extends PushMaterial {
             if (result) {
                 Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString);
 
-                postProcess.updateEffect(defines.toString(), this._fragmentCompilationState.uniforms, this._fragmentCompilationState.samplers, { maxSimultaneousLights: this.maxSimultaneousLights }, undefined, undefined, tempName, tempName);
+                TimingTools.SetImmediate(() =>
+                    postProcess!.updateEffect(defines.toString(), this._fragmentCompilationState.uniforms, this._fragmentCompilationState.samplers, { maxSimultaneousLights: this.maxSimultaneousLights }, undefined, undefined, tempName, tempName)
+                );
             }
 
             // Animated blocks


### PR DESCRIPTION
Also added `NodeMaterial.createEffectForPostProcess` to create the effect for an existing post process.