### PR TITLE
DX and UX improvements for Gizmos

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -11,6 +11,7 @@
 - Added Curve editor to create and view selected entity's animations in the Inspector ([pixelspace](https://github.com/devpixelspace))
 - Added support in `ShadowGenerator` for fast fake soft transparent shadows ([Popov72](https://github.com/Popov72))
 - Added support for **thin instances** for faster mesh instances. [Doc](https://doc.babylonjs.com/how_to/how_to_use_thininstances) ([Popov72](https://github.com/Popov72))
+- Gizmo updates - dragging state, easier customization ([edzis](https://github.com/edzis))
 
 ## Updates
 

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -16,7 +16,7 @@ export class AxisDragGizmo extends DraggableGizmo {
     private _arrow: TransformNode;
 
     /** @hidden */
-    public static _CreateArrow(scene: Scene, material?: StandardMaterial): TransformNode {
+    public static _CreateArrow(scene: Scene, material: Nullable<StandardMaterial> = null): TransformNode {
         var arrow = new TransformNode("arrow", scene);
         var cylinder = CylinderBuilder.CreateCylinder("cylinder", { diameterTop: 0, height: 0.075, diameterBottom: 0.0375, tessellation: 96 }, scene);
         var line = CylinderBuilder.CreateCylinder("cylinder", { diameterTop: 0.005, height: 0.275, diameterBottom: 0.005, tessellation: 96 }, scene);
@@ -24,7 +24,7 @@ export class AxisDragGizmo extends DraggableGizmo {
         line.parent = arrow;
 
         // Position arrow pointing in its drag axis
-        cylinder.material = material ?? null;
+        cylinder.material = material;
         cylinder.rotation.x = Math.PI / 2;
         cylinder.position.z += 0.3;
         line.position.z += 0.275 / 2;

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -44,9 +44,9 @@ export class AxisDragGizmo extends DraggableGizmo {
 
     /**
      * Creates an AxisDragGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param dragAxis The axis which the gizmo will be able to drag on
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      */
     constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, parent: Nullable<PositionGizmo> = null) {
         super({ dragAxis }, color, gizmoLayer, parent);

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -25,9 +25,9 @@ export class AxisScaleGizmo extends DraggableGizmo {
 
     /**
      * Creates an AxisScaleGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param dragAxis The axis which the gizmo will be able to scale on
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      */
     constructor(dragAxis: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, parent: Nullable<ScaleGizmo> = null) {
         super({ dragAxis }, color, gizmoLayer, parent);

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -12,6 +12,9 @@ import { ScaleGizmo } from "./scaleGizmo";
  * Single axis scale gizmo
  */
 export class AxisScaleGizmo extends DraggableGizmo {
+    /**
+     * Scale proportionally
+     */
     public uniformScaling = false;
     /**
      * Custom sensitivity value for the drag strength

--- a/src/Gizmos/boundingBoxGizmo.ts
+++ b/src/Gizmos/boundingBoxGizmo.ts
@@ -115,8 +115,8 @@ export class BoundingBoxGizmo extends Gizmo {
     }
     /**
      * Creates an BoundingBoxGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      */
     constructor(color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultKeepDepthUtilityLayer) {
         super(gizmoLayer);

--- a/src/Gizmos/draggableGizmo.ts
+++ b/src/Gizmos/draggableGizmo.ts
@@ -1,0 +1,122 @@
+import { PointerDragBehavior } from "../Behaviors/Meshes/pointerDragBehavior";
+import { PointerInfo } from "../Events/pointerEvents";
+import { Color3 } from "../Maths/math.color";
+import { Vector3 } from "../Maths/math.vector";
+import { AbstractMesh } from "../Meshes/abstractMesh";
+import { Mesh } from "../Meshes/mesh";
+import { Observable, Observer } from "../Misc/observable";
+import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
+import { Nullable } from "../types";
+import { Gizmo } from "./gizmo";
+import { GizmoMaterialSwitcher } from "./gizmoMaterialSwitcher";
+/**
+ * Common base for several draggable gizmos
+ */
+export class DraggableGizmo extends Gizmo {
+    /**
+     * Drag behavior responsible for the gizmos dragging interactions
+     */
+    public dragBehavior: PointerDragBehavior;
+    /**
+     * Drag distance in babylon units that the gizmo will snap to when dragged (Default: 0)
+     */
+    public snapDistance = 0;
+    /**
+     * Event that fires each time the gizmo snaps to a new location.
+     * * snapDistance is the the change in distance
+     */
+    public onSnapObservable = new Observable<{ snapDistance: number }>();
+
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _materialSwitcher: GizmoMaterialSwitcher;
+
+    protected _isEnabled: boolean = true;
+    protected _parent: Nullable<Gizmo> = null;
+
+    /**
+     * Creates an InteractableGizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
+     * @param color The color of the gizmo
+     */
+    constructor(
+        dragOptions: { dragAxis?: Vector3; dragPlaneNormal?: Vector3 },
+        color: Color3,
+        gizmoLayer: UtilityLayerRenderer,
+        parent: Nullable<Gizmo>
+    ) {
+        super(gizmoLayer);
+        this._parent = parent;
+
+        // Add drag behavior to handle events when the gizmo is dragged
+        this.dragBehavior = new PointerDragBehavior(dragOptions);
+        this.dragBehavior.moveAttached = false;
+        this._rootMesh.addBehavior(this.dragBehavior);
+
+        // Create Material Switcher
+        this._materialSwitcher = new GizmoMaterialSwitcher(
+            color,
+            this.dragBehavior,
+            gizmoLayer._getSharedGizmoLight(),
+            gizmoLayer.utilityLayerScene
+        );
+    }
+
+    protected _attachedMeshChanged(value: Nullable<AbstractMesh>) {
+        if (this.dragBehavior) {
+            this.dragBehavior.enabled = value ? true : false;
+        }
+    }
+
+    /**
+     * If the gizmo is enabled
+     */
+    public set isEnabled(value: boolean) {
+        this._isEnabled = value;
+        if (!value) {
+            this.attachedMesh = null;
+        } else {
+            if (this._parent) {
+                this.attachedMesh = this._parent.attachedMesh;
+            }
+        }
+    }
+    public get isEnabled(): boolean {
+        return this._isEnabled;
+    }
+
+    public get materialSwitcher() {
+        return this._materialSwitcher;
+    }
+
+    /**
+     * Disposes of the gizmo
+     */
+    public dispose() {
+        this.onSnapObservable.clear();
+        this.gizmoLayer.utilityLayerScene.onPointerObservable.remove(
+            this._pointerObserver
+        );
+        this.dragBehavior.detach();
+        this._materialSwitcher.dispose();
+        super.dispose();
+    }
+
+    /**
+     * Disposes and replaces the current meshes in the gizmo with the specified mesh
+     * @param mesh The mesh to replace the default mesh of the gizmo
+     * @param useGizmoMaterials If the gizmo's default materials should be used (default: false)
+     */
+    public setCustomMesh(mesh: Mesh, useGizmoMaterials: boolean = false) {
+        this._materialSwitcher.unregisterMeshes(
+            this._rootMesh.getChildMeshes()
+        );
+
+        super.setCustomMesh(mesh);
+
+        if (useGizmoMaterials) {
+            this._materialSwitcher.registerMeshes(
+                this._rootMesh.getChildMeshes()
+            );
+        }
+    }
+}

--- a/src/Gizmos/draggableGizmo.ts
+++ b/src/Gizmos/draggableGizmo.ts
@@ -84,6 +84,9 @@ export class DraggableGizmo extends Gizmo {
         return this._isEnabled;
     }
 
+    /**
+     * Instance of GizmoMaterialSwitcher
+     */
     public get materialSwitcher() {
         return this._materialSwitcher;
     }

--- a/src/Gizmos/draggableGizmo.ts
+++ b/src/Gizmos/draggableGizmo.ts
@@ -34,9 +34,10 @@ export class DraggableGizmo extends Gizmo {
     protected _parent: Nullable<Gizmo> = null;
 
     /**
-     * Creates an InteractableGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
+     * Creates an instance of a DraggableGizmo
+     * @param dragOptions  Input for PointerDragBehavior
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      */
     constructor(
         dragOptions: { dragAxis?: Vector3; dragPlaneNormal?: Vector3 },

--- a/src/Gizmos/gizmoMaterialSwitcher.ts
+++ b/src/Gizmos/gizmoMaterialSwitcher.ts
@@ -167,15 +167,30 @@ export class GizmoMaterialSwitcher {
         });
     }
 
+    /**
+     * Material applied in resting state
+     */
     public get defaultMaterial() {
         return this._defaultMaterial;
     }
+
+    /**
+     * Material applied in hover state
+     */
     public get hoverMaterial() {
         return this._hoverMaterial;
     }
+
+    /**
+     * Material applied in dragging state
+     */
     public get dragMaterial() {
         return this._dragMaterial;
     }
+
+    /**
+     * Currently applied material
+     */
     public get material() {
         return this._material;
     }

--- a/src/Gizmos/gizmoMaterialSwitcher.ts
+++ b/src/Gizmos/gizmoMaterialSwitcher.ts
@@ -1,0 +1,169 @@
+import { PointerDragBehavior } from "../Behaviors/Meshes/pointerDragBehavior";
+import { PointerInfo } from "../Events/pointerEvents";
+import { HemisphericLight } from "../Lights/hemisphericLight";
+import { StandardMaterial } from "../Materials/standardMaterial";
+import { Color3 } from "../Maths/math.color";
+import { AbstractMesh } from "../Meshes/abstractMesh";
+import { Scene } from "../scene";
+
+/**
+ * Tracks interactivity state of a Gizmo and switches materials of it's meshes
+ */
+export class GizmoMaterialSwitcher {
+    private _dragBehavior: PointerDragBehavior;
+    private _sharedGizmoLight: HemisphericLight;
+    private _scene: Scene;
+
+    private _defaultMaterial: StandardMaterial;
+    private _hoverMaterial: StandardMaterial;
+    private _dragMaterial: StandardMaterial;
+
+    private _isHover: boolean = false;
+    private _isDrag: boolean = false;
+    private _material: StandardMaterial;
+
+    private _meshes: AbstractMesh[];
+
+    /**
+     * Creates a GizmoMaterialSwitcher
+     * @param color The color of the gizmo
+     * @param dragBehavior PointerDragBehavior of the Gizmo
+     * @param sharedGizmoLight The Light from gizmoLayer._getSharedGizmoLight()
+     * @param scene Scene from gizmoLayer.utilityLayerScene
+     */
+    constructor(
+        color: Color3,
+        dragBehavior: PointerDragBehavior,
+        sharedGizmoLight: HemisphericLight,
+        scene: Scene
+    ) {
+        this._dragBehavior = dragBehavior;
+        this._sharedGizmoLight = sharedGizmoLight;
+        this._scene = scene;
+
+        // Create Materials
+        this._defaultMaterial = new StandardMaterial("_defaultMaterial", scene);
+        this._defaultMaterial.diffuseColor = color;
+        this._defaultMaterial.specularColor = color.subtract(
+            new Color3(0.1, 0.1, 0.1)
+        );
+
+        this._hoverMaterial = new StandardMaterial("_hoverMaterial", scene);
+        this._hoverMaterial.diffuseColor = color.add(new Color3(0.3, 0.3, 0.3));
+
+        this._dragMaterial = new StandardMaterial("_dragMaterial", scene);
+        this._dragMaterial.diffuseColor = color.add(
+            new Color3(0.15, 0.15, 0.15)
+        );
+
+        // Add interactivity
+        this._dragBehavior.onDragStartObservable.add(this._onDragStart);
+        this._dragBehavior.onDragEndObservable.add(this._onDragEnd);
+        this._scene.onPointerObservable.add(this._onPointer);
+
+        // Update state
+        this._meshes = [];
+        this._updateMaterial();
+    }
+
+    // ========================================================================
+    // PRIVATE
+    // ========================================================================
+    private _applyMaterial() {
+        this._meshes.forEach((m) => {
+            m.material = this._material;
+        });
+    }
+
+    private _updateMaterial() {
+        const material = this._isDrag
+            ? this._dragMaterial
+            : this._isHover
+                ? this._hoverMaterial
+                : this._defaultMaterial;
+        if (this._material === material) {
+            return;
+        }
+        this._material = material;
+        this._applyMaterial();
+    }
+
+    private _onDragStart = () => {
+        this._isDrag = true;
+        this._updateMaterial();
+    }
+
+    private _onDragEnd = () => {
+        this._isDrag = false;
+        this._updateMaterial();
+    }
+
+    private _onPointer = (pointerInfo: PointerInfo) => {
+        this._isHover = pointerInfo.pickInfo
+            ? this._meshes.indexOf(
+                <AbstractMesh>pointerInfo.pickInfo.pickedMesh
+            ) != -1
+            : false;
+        this._updateMaterial();
+    }
+
+    // ========================================================================
+    // PUBLIC
+    // ========================================================================
+    /**
+     * Start tracking and updating materials for meshes
+     * @param newMeshes The meshes to add to internal list
+     */
+    public registerMeshes(newMeshes: AbstractMesh[]) {
+        this._meshes = this._meshes.concat(newMeshes);
+        this._sharedGizmoLight.includedOnlyMeshes = this._sharedGizmoLight.includedOnlyMeshes.concat(
+            newMeshes
+        );
+        this._applyMaterial();
+    }
+
+    /**
+     * Stop tracking and updating materials for meshes
+     * @param oldMeshes The meshes to remove from internal list
+     */
+    public unregisterMeshes(oldMeshes: AbstractMesh[]) {
+        const notOldMesh = (mesh: AbstractMesh) =>
+            oldMeshes.indexOf(mesh) === -1;
+        this._meshes = this._meshes.filter(notOldMesh);
+        this._sharedGizmoLight.includedOnlyMeshes = this._sharedGizmoLight.includedOnlyMeshes.filter(
+            notOldMesh
+        );
+    }
+
+    /**
+     * Disposes of the gizmo
+     */
+    public dispose() {
+        this._dragBehavior.onDragStartObservable.removeCallback(
+            this._onDragStart
+        );
+        this._dragBehavior.onDragEndObservable.removeCallback(this._onDragEnd);
+        this._scene.onPointerObservable.removeCallback(this._onPointer);
+
+        [
+            this._defaultMaterial,
+            this._hoverMaterial,
+            this._dragMaterial,
+        ].forEach((material) => {
+            material.dispose();
+        });
+    }
+
+    public get defaultMaterial() {
+        return this._defaultMaterial;
+    }
+    public get hoverMaterial() {
+        return this._hoverMaterial;
+    }
+    public get dragMaterial() {
+        return this._dragMaterial;
+    }
+    public get material() {
+        return this._material;
+    }
+}

--- a/src/Gizmos/gizmoMaterialSwitcher.ts
+++ b/src/Gizmos/gizmoMaterialSwitcher.ts
@@ -10,6 +10,13 @@ import { Scene } from "../scene";
  * Tracks interactivity state of a Gizmo and switches materials of it's meshes
  */
 export class GizmoMaterialSwitcher {
+    /** @hidden */
+    /**
+     * Tracks Scenes that have an active Gizmo drag interaction.
+     * Assumes only one Gizmo can be dragged at a time per Scene
+     */
+    public static _ScenesWithActiveDrag: Scene[] = [];
+
     private _dragBehavior: PointerDragBehavior;
     private _sharedGizmoLight: HemisphericLight;
     private _scene: Scene;
@@ -91,14 +98,20 @@ export class GizmoMaterialSwitcher {
     private _onDragStart = () => {
         this._isDrag = true;
         this._updateMaterial();
+        GizmoMaterialSwitcher._ScenesWithActiveDrag = [...GizmoMaterialSwitcher._ScenesWithActiveDrag, this._scene];
     }
 
     private _onDragEnd = () => {
         this._isDrag = false;
         this._updateMaterial();
+        GizmoMaterialSwitcher._ScenesWithActiveDrag = GizmoMaterialSwitcher._ScenesWithActiveDrag.filter((scene) => scene !== this._scene);
     }
 
     private _onPointer = (pointerInfo: PointerInfo) => {
+        const isDragActive = GizmoMaterialSwitcher._ScenesWithActiveDrag.indexOf(this._scene) != -1;
+        if (isDragActive) {
+            return;
+        }
         this._isHover = pointerInfo.pickInfo
             ? this._meshes.indexOf(
                 <AbstractMesh>pointerInfo.pickInfo.pickedMesh

--- a/src/Gizmos/gizmoMaterialSwitcher.ts
+++ b/src/Gizmos/gizmoMaterialSwitcher.ts
@@ -53,7 +53,7 @@ export class GizmoMaterialSwitcher {
 
         this._dragMaterial = new StandardMaterial("_dragMaterial", scene);
         this._dragMaterial.diffuseColor = color.add(
-            new Color3(0.15, 0.15, 0.15)
+            new Color3(0.2, 0.2, 0.2)
         );
 
         // Add interactivity

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -53,16 +53,6 @@ export class PlaneDragGizmo extends Gizmo {
         return plane;
     }
 
-    /** @hidden */
-    public static _CreateArrowInstance(scene: Scene, arrow: TransformNode): TransformNode {
-        const instance = new TransformNode("arrow", scene);
-        for (const mesh of arrow.getChildMeshes()) {
-            const childInstance = (mesh as Mesh).createInstance(mesh.name);
-            childInstance.parent = instance;
-        }
-        return instance;
-    }
-
     /**
      * Creates a PlaneDragGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -25,9 +25,9 @@ export class PlaneDragGizmo extends DraggableGizmo {
 
     /**
      * Creates a PlaneDragGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param dragPlaneNormal The axis normal to which the gizmo will be able to drag on
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      */
     constructor(dragPlaneNormal: Vector3, color: Color3 = Color3.Gray(), gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, parent: Nullable<PositionGizmo> = null) {
         super({ dragPlaneNormal }, color, gizmoLayer, parent);

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -14,9 +14,9 @@ import { RotationGizmo } from "./rotationGizmo";
 export class PlaneRotationGizmo extends DraggableGizmo {
     /**
      * Creates a PlaneRotationGizmo
-     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param dragPlaneNormal The normal of the plane which the gizmo will be able to rotate on
      * @param color The color of the gizmo
+     * @param gizmoLayer The utility layer the gizmo will be added to
      * @param tessellation Amount of tessellation to be used when creating rotation circles
      * @param useEulerRotation Use and update Euler angle instead of quaternion
      */


### PR DESCRIPTION
Done:
- Show a different material while gizmo is being dragged
- Expose gizmo materials for color changes
- Optionally apply the same materials  to custom meshes based on state changes
- Less code through generalization
- Do not apply hover material to other meshes while one is being dragged
- What's new

TODO:
- Show Pointer cursor on hover - not sure how
- Apply also to BoundingBoxGizmo - current setup too complex
- Usage examples in documentation

Tested via https://gist.github.com/edzis/461dd1f6036509ea942088dbb1a43130