### PR TITLE
Disallow window.requestAnimationFrame for Babylon Native

### DIFF
--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -282,7 +282,8 @@ export class NativeEngine extends Engine {
      * @hidden
      */
     protected _queueNewFrame(bindedRenderFunction: any, requester?: any): number {
-        if (requester.requestAnimationFrame) {
+        // Use the provided requestAnimationFrame, unless the requester is the window. In that case, we will default to the Babylon Native version of requestAnimationFrame.
+        if (requester.requestAnimationFrame && requester !== window) {
             requester.requestAnimationFrame(bindedRenderFunction);
         } else {
             this._native.requestAnimationFrame(bindedRenderFunction);


### PR DESCRIPTION
The way the code was written, it assumes that `window.requestAnimationFrame` doesn't exist. In some cases (such as with React Native) it may exist in the hosted JavaScript runtime. However, Babylon.js should *always* be redirected to Babylon Native's `requestAnimationFrame`, even if one exists (e.g. via a polyfill) on `window`.