### PR TITLE
Update TS args for scene.createDefaultXRExprienceAsync

### DIFF
--- a/src/Helpers/sceneHelpers.ts
+++ b/src/Helpers/sceneHelpers.ts
@@ -208,7 +208,7 @@ Scene.prototype.createDefaultVRExperience = function(webVROptions: VRExperienceH
     return new VRExperienceHelper(this, webVROptions);
 };
 
-Scene.prototype.createDefaultXRExperienceAsync = function(options: WebXRDefaultExperienceOptions): Promise<WebXRDefaultExperience> {
+Scene.prototype.createDefaultXRExperienceAsync = function(options: WebXRDefaultExperienceOptions = {}): Promise<WebXRDefaultExperience> {
     return WebXRDefaultExperience.CreateAsync(this, options).then((helper) => {
         return helper;
     });


### PR DESCRIPTION
One small TS type fix for you!

When calling `WebXRDefaultExperience.CreateAsync()`, you can omit the second argument for the options object if you don't need to change any options. Similarly, the documentation for `Scene.createDefaultXRExperienceAsync()` suggests you can omit the options argument as well.

However, the TS type signature for the scene helper currently requires you to pass in a valid `WebXRDefaultExperienceOptions` object. A JS user can currently call `someScene.createDefaultXRExperienceAsync()` with no argument to get the default options, but a TS user gets a compiler error. This PR should have no practical effect other than to remove that compiler error.

An alternate solution would be to make it an optional parameter (`function(options?: WebXRDefaultExperienceOptions)`), but setting a default value of the empty object is what you do both for `Scene.prototype.createDefaultVRExperience` and in `WebXRDefaultExperience.CreateAsync`, so it seemed more stylistically appropriate.