### PR TITLE
EXT_mesh_gpu_instancing: Use thin instances when possible

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -8,6 +8,7 @@ import { GLTFLoader, ArrayItem } from "../glTFLoader";
 import { IGLTFLoaderExtension } from "../glTFLoaderExtension";
 import { INode } from "../glTFLoaderInterfaces";
 import { AbstractMesh } from 'babylonjs/Meshes/abstractMesh';
+import { TmpVectors } from 'babylonjs/Maths/math.vector';
 
 const NAME = "EXT_mesh_gpu_instancing";
 
@@ -15,11 +16,6 @@ interface IEXTMeshGpuInstancing {
     mesh?: number;
     attributes: { [name: string]: number };
 }
-
-const T = new Vector3(0, 0, 0);
-const R = new Quaternion(0, 0, 0, 1);
-const S = new Vector3(1, 1, 1);
-const M = new Matrix();
 
 /**
  * [Proposed Specification](https://github.com/KhronosGroup/glTF/pull/1691)
@@ -124,18 +120,18 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
                     const matrices = canUseThinInstances ? new Float32Array(instanceCount * 16) : null;
 
                     if (matrices) {
-                        T.copyFromFloats(0, 0, 0);
-                        R.copyFromFloats(0, 0, 0, 1);
-                        S.copyFromFloats(1, 1, 1);
+                        TmpVectors.Vector3[0].copyFromFloats(0, 0, 0); // translation
+                        TmpVectors.Quaternion[0].copyFromFloats(0, 0, 0, 1); // rotation
+                        TmpVectors.Vector3[1].copyFromFloats(1, 1, 1); // scale
 
                         for (let i = 0; i < instanceCount; ++i) {
-                            translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, T);
-                            rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, R);
-                            scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, S);
+                            translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, TmpVectors.Vector3[0]);
+                            rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, TmpVectors.Quaternion[0]);
+                            scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, TmpVectors.Vector3[1]);
 
-                            Matrix.ComposeToRef(S, R, T, M);
+                            Matrix.ComposeToRef(TmpVectors.Vector3[1], TmpVectors.Quaternion[0], TmpVectors.Vector3[0], TmpVectors.Matrix[0]);
 
-                            M.copyToArray(matrices, i * 16);
+                            TmpVectors.Matrix[0].copyToArray(matrices, i * 16);
                         }
                     }
 

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -1,13 +1,10 @@
 import { Vector3, Quaternion, Matrix } from 'babylonjs/Maths/math.vector';
-import { InstancedMesh } from 'babylonjs/Meshes/instancedMesh';
 import { Mesh } from 'babylonjs/Meshes/mesh';
 import { TransformNode } from "babylonjs/Meshes/transformNode";
-import { StringTools } from 'babylonjs/Misc/stringTools';
 import { Nullable } from "babylonjs/types";
 import { GLTFLoader, ArrayItem } from "../glTFLoader";
 import { IGLTFLoaderExtension } from "../glTFLoaderExtension";
 import { INode } from "../glTFLoaderInterfaces";
-import { AbstractMesh } from 'babylonjs/Meshes/abstractMesh';
 import { TmpVectors } from 'babylonjs/Maths/math.vector';
 
 const NAME = "EXT_mesh_gpu_instancing";
@@ -39,6 +36,9 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
     constructor(loader: GLTFLoader) {
         this._loader = loader;
         this.enabled = this._loader.isExtensionUsed(NAME);
+        if (this.enabled) {
+            loader._disableInstancedMesh = true;
+        }
     }
 
     /** @hidden */
@@ -53,21 +53,6 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
 
             if (!node._primitiveBabylonMeshes) {
                 return promise;
-            }
-
-            let useThinInstancesForAllMeshes = true;
-            let canUseThinInstances = false;
-
-            // Hide the source meshes.
-            for (const babylonMesh of node._primitiveBabylonMeshes) {
-                if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
-                    babylonMesh.isVisible = false;
-                    useThinInstancesForAllMeshes = false;
-                } else {
-                    canUseThinInstances = true;
-                    (babylonMesh as Mesh)._thinInstanceDataStorage.instancesCount = 1;  // make sure mesh.hasThinInstances returns true from now on (else async loading of the thin instance data will lead to problems
-                                                                                        // as the mesh won't be considered as having thin instances until thinInstanceSetBuffer is called)
-                }
             }
 
             const promises = new Array<Promise<Nullable<Float32Array>>>();
@@ -93,61 +78,26 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
             loadAttribute("ROTATION");
             loadAttribute("SCALE");
 
-            if (instanceCount == 0) {
-                for (const babylonMesh of node._primitiveBabylonMeshes) {
-                    if ((babylonMesh as any).thinInstanceSetBuffer) {
-                        (babylonMesh as Mesh)._thinInstanceDataStorage.instancesCount = 0;
-                    }
-                }
-                return promise;
-            }
-
-            if (!useThinInstancesForAllMeshes) {
-                const digitLength = instanceCount.toString().length;
-                for (let i = 0; i < instanceCount; ++i) {
-                    for (const babylonMesh of node._primitiveBabylonMeshes!) {
-                        if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
-                            const instanceName = `${babylonMesh.name || babylonMesh.id}_${StringTools.PadNumber(i, digitLength)}`;
-                            const babylonInstancedMesh = (babylonMesh as (InstancedMesh | Mesh)).createInstance(instanceName);
-                            babylonInstancedMesh.setParent(babylonMesh);
-                        }
-                    }
-                }
-            }
-
             return promise.then((babylonTransformNode) => {
                 return Promise.all(promises).then(([translationBuffer, rotationBuffer, scaleBuffer]) => {
-                    const matrices = canUseThinInstances ? new Float32Array(instanceCount * 16) : null;
+                    const matrices = new Float32Array(instanceCount * 16);
 
-                    if (matrices) {
-                        TmpVectors.Vector3[0].copyFromFloats(0, 0, 0); // translation
-                        TmpVectors.Quaternion[0].copyFromFloats(0, 0, 0, 1); // rotation
-                        TmpVectors.Vector3[1].copyFromFloats(1, 1, 1); // scale
+                    TmpVectors.Vector3[0].copyFromFloats(0, 0, 0); // translation
+                    TmpVectors.Quaternion[0].copyFromFloats(0, 0, 0, 1); // rotation
+                    TmpVectors.Vector3[1].copyFromFloats(1, 1, 1); // scale
 
-                        for (let i = 0; i < instanceCount; ++i) {
-                            translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, TmpVectors.Vector3[0]);
-                            rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, TmpVectors.Quaternion[0]);
-                            scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, TmpVectors.Vector3[1]);
+                    for (let i = 0; i < instanceCount; ++i) {
+                        translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, TmpVectors.Vector3[0]);
+                        rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, TmpVectors.Quaternion[0]);
+                        scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, TmpVectors.Vector3[1]);
 
-                            Matrix.ComposeToRef(TmpVectors.Vector3[1], TmpVectors.Quaternion[0], TmpVectors.Vector3[0], TmpVectors.Matrix[0]);
+                        Matrix.ComposeToRef(TmpVectors.Vector3[1], TmpVectors.Quaternion[0], TmpVectors.Vector3[0], TmpVectors.Matrix[0]);
 
-                            TmpVectors.Matrix[0].copyToArray(matrices, i * 16);
-                        }
+                        TmpVectors.Matrix[0].copyToArray(matrices, i * 16);
                     }
 
                     for (const babylonMesh of node._primitiveBabylonMeshes!) {
-                        if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
-                            const babylonInstancedMeshes = babylonMesh.getChildMeshes(true, (node) => (node as AbstractMesh).isAnInstance);
-                            for (let i = 0; i < instanceCount; ++i) {
-                                const babylonInstancedMesh = babylonInstancedMeshes[i];
-                                translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, babylonInstancedMesh.position);
-                                rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, babylonInstancedMesh.rotationQuaternion!);
-                                scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, babylonInstancedMesh.scaling);
-                                babylonInstancedMesh.refreshBoundingInfo();
-                            }
-                        } else {
                             (babylonMesh as Mesh).thinInstanceSetBuffer("matrix", matrices, 16, true);
-                        }
                     }
 
                     return babylonTransformNode;

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -36,9 +36,6 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
     constructor(loader: GLTFLoader) {
         this._loader = loader;
         this.enabled = this._loader.isExtensionUsed(NAME);
-        if (this.enabled) {
-            loader._disableInstancedMesh = true;
-        }
     }
 
     /** @hidden */
@@ -49,7 +46,11 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
     /** @hidden */
     public loadNodeAsync(context: string, node: INode, assign: (babylonTransformNode: TransformNode) => void): Nullable<Promise<TransformNode>> {
         return GLTFLoader.LoadExtensionAsync<IEXTMeshGpuInstancing, TransformNode>(context, node, this.name, (extensionContext, extension) => {
+            this._loader._disableInstancedMesh++;
+
             const promise = this._loader.loadNodeAsync(`#/nodes/${node.index}`, node, assign);
+
+            this._loader._disableInstancedMesh--;
 
             if (!node._primitiveBabylonMeshes) {
                 return promise;

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -146,7 +146,6 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
                                 babylonInstancedMesh.refreshBoundingInfo();
                             }
                         } else {
-                            (babylonMesh as Mesh).refreshBoundingInfo();
                             (babylonMesh as Mesh).thinInstanceSetBuffer("matrix", matrices, 16, true);
                         }
                     }

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -99,7 +99,7 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
 
             if (instanceCount == 0) {
                 for (const babylonMesh of node._primitiveBabylonMeshes) {
-                    if ((babylonMesh as Mesh).thinInstanceSetBuffer) {
+                    if ((babylonMesh as any).thinInstanceSetBuffer) {
                         (babylonMesh as Mesh).thinInstanceCount = 0;
                     }
                 }

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -1,4 +1,4 @@
-import { Vector3, Quaternion } from 'babylonjs/Maths/math.vector';
+import { Vector3, Quaternion, Matrix } from 'babylonjs/Maths/math.vector';
 import { InstancedMesh } from 'babylonjs/Meshes/instancedMesh';
 import { Mesh } from 'babylonjs/Meshes/mesh';
 import { TransformNode } from "babylonjs/Meshes/transformNode";
@@ -15,6 +15,11 @@ interface IEXTMeshGpuInstancing {
     mesh?: number;
     attributes: { [name: string]: number };
 }
+
+const T = new Vector3(0, 0, 0);
+const R = new Quaternion(0, 0, 0, 1);
+const S = new Vector3(1, 1, 1);
+const M = new Matrix();
 
 /**
  * [Proposed Specification](https://github.com/KhronosGroup/glTF/pull/1691)
@@ -54,9 +59,19 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
                 return promise;
             }
 
+            let useThinInstancesForAllMeshes = true;
+            let canUseThinInstances = false;
+
             // Hide the source meshes.
             for (const babylonMesh of node._primitiveBabylonMeshes) {
-                babylonMesh.isVisible = false;
+                if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
+                    babylonMesh.isVisible = false;
+                    useThinInstancesForAllMeshes = false;
+                } else {
+                    canUseThinInstances = true;
+                    (babylonMesh as Mesh).thinInstanceCount = 1;    // make sure mesh.hasThinInstances returns true from now on (else async loading of the thin instance data will lead to problems
+                                                                    // as the mesh won't be considered as having thin instances until thinInstanceSetBuffer is called)
+                }
             }
 
             const promises = new Array<Promise<Nullable<Float32Array>>>();
@@ -83,28 +98,60 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
             loadAttribute("SCALE");
 
             if (instanceCount == 0) {
+                for (const babylonMesh of node._primitiveBabylonMeshes) {
+                    if ((babylonMesh as Mesh).thinInstanceSetBuffer) {
+                        (babylonMesh as Mesh).thinInstanceCount = 0;
+                    }
+                }
                 return promise;
             }
 
-            const digitLength = instanceCount.toString().length;
-            for (let i = 0; i < instanceCount; ++i) {
-                for (const babylonMesh of node._primitiveBabylonMeshes!) {
-                    const instanceName = `${babylonMesh.name || babylonMesh.id}_${StringTools.PadNumber(i, digitLength)}`;
-                    const babylonInstancedMesh = (babylonMesh as (InstancedMesh | Mesh)).createInstance(instanceName);
-                    babylonInstancedMesh.setParent(babylonMesh);
+            if (!useThinInstancesForAllMeshes) {
+                const digitLength = instanceCount.toString().length;
+                for (let i = 0; i < instanceCount; ++i) {
+                    for (const babylonMesh of node._primitiveBabylonMeshes!) {
+                        if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
+                            const instanceName = `${babylonMesh.name || babylonMesh.id}_${StringTools.PadNumber(i, digitLength)}`;
+                            const babylonInstancedMesh = (babylonMesh as (InstancedMesh | Mesh)).createInstance(instanceName);
+                            babylonInstancedMesh.setParent(babylonMesh);
+                        }
+                    }
                 }
             }
 
             return promise.then((babylonTransformNode) => {
                 return Promise.all(promises).then(([translationBuffer, rotationBuffer, scaleBuffer]) => {
-                    for (const babylonMesh of node._primitiveBabylonMeshes!) {
-                        const babylonInstancedMeshes = babylonMesh.getChildMeshes(true, (node) => (node as AbstractMesh).isAnInstance);
+                    const matrices = canUseThinInstances ? new Float32Array(instanceCount * 16) : null;
+
+                    if (matrices) {
+                        T.copyFromFloats(0, 0, 0);
+                        R.copyFromFloats(0, 0, 0, 1);
+                        S.copyFromFloats(1, 1, 1);
+
                         for (let i = 0; i < instanceCount; ++i) {
-                            const babylonInstancedMesh = babylonInstancedMeshes[i];
-                            translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, babylonInstancedMesh.position);
-                            rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, babylonInstancedMesh.rotationQuaternion!);
-                            scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, babylonInstancedMesh.scaling);
-                            babylonInstancedMesh.refreshBoundingInfo();
+                            translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, T);
+                            rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, R);
+                            scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, S);
+
+                            Matrix.ComposeToRef(S, R, T, M);
+
+                            M.copyToArray(matrices, i * 16);
+                        }
+                    }
+
+                    for (const babylonMesh of node._primitiveBabylonMeshes!) {
+                        if (!(babylonMesh as Mesh).thinInstanceSetBuffer) {
+                            const babylonInstancedMeshes = babylonMesh.getChildMeshes(true, (node) => (node as AbstractMesh).isAnInstance);
+                            for (let i = 0; i < instanceCount; ++i) {
+                                const babylonInstancedMesh = babylonInstancedMeshes[i];
+                                translationBuffer && Vector3.FromArrayToRef(translationBuffer, i * 3, babylonInstancedMesh.position);
+                                rotationBuffer && Quaternion.FromArrayToRef(rotationBuffer, i * 4, babylonInstancedMesh.rotationQuaternion!);
+                                scaleBuffer && Vector3.FromArrayToRef(scaleBuffer, i * 3, babylonInstancedMesh.scaling);
+                                babylonInstancedMesh.refreshBoundingInfo();
+                            }
+                        } else {
+                            (babylonMesh as Mesh).refreshBoundingInfo();
+                            (babylonMesh as Mesh).thinInstanceSetBuffer("matrix", matrices, 16, true);
                         }
                     }
 

--- a/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -69,8 +69,8 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
                     useThinInstancesForAllMeshes = false;
                 } else {
                     canUseThinInstances = true;
-                    (babylonMesh as Mesh).thinInstanceCount = 1;    // make sure mesh.hasThinInstances returns true from now on (else async loading of the thin instance data will lead to problems
-                                                                    // as the mesh won't be considered as having thin instances until thinInstanceSetBuffer is called)
+                    (babylonMesh as Mesh)._thinInstanceDataStorage.instancesCount = 1;  // make sure mesh.hasThinInstances returns true from now on (else async loading of the thin instance data will lead to problems
+                                                                                        // as the mesh won't be considered as having thin instances until thinInstanceSetBuffer is called)
                 }
             }
 
@@ -100,7 +100,7 @@ export class EXT_mesh_gpu_instancing implements IGLTFLoaderExtension {
             if (instanceCount == 0) {
                 for (const babylonMesh of node._primitiveBabylonMeshes) {
                     if ((babylonMesh as any).thinInstanceSetBuffer) {
-                        (babylonMesh as Mesh).thinInstanceCount = 0;
+                        (babylonMesh as Mesh)._thinInstanceDataStorage.instancesCount = 0;
                     }
                 }
                 return promise;

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -106,6 +106,9 @@ export class GLTFLoader implements IGLTFLoader {
     /** Storage */
     public _babylonLights: Light[] = [];
 
+    /** @hidden */
+    public _disableInstancedMesh = false;
+
     private _disposed = false;
     private _parent: GLTFFileLoader;
     private _state: Nullable<GLTFLoaderState> = null;
@@ -777,7 +780,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         this.logOpen(`${context}`);
 
-        const shouldInstance = this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets) && (!primitive._instanceData || !primitive._instanceData.babylonSourceMesh.hasThinInstances);
+        const shouldInstance = !this._disableInstancedMesh && this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets);
 
         let babylonAbstractMesh: AbstractMesh;
         let promise: Promise<any>;

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -107,7 +107,7 @@ export class GLTFLoader implements IGLTFLoader {
     public _babylonLights: Light[] = [];
 
     /** @hidden */
-    public _disableInstancedMesh = false;
+    public _disableInstancedMesh = 0;
 
     private _disposed = false;
     private _parent: GLTFFileLoader;
@@ -780,7 +780,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         this.logOpen(`${context}`);
 
-        const shouldInstance = !this._disableInstancedMesh && this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets);
+        const shouldInstance = (this._disableInstancedMesh === 0) && this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets);
 
         let babylonAbstractMesh: AbstractMesh;
         let promise: Promise<any>;

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -702,11 +702,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         return Promise.all(promises).then(() => {
             this._forEachPrimitive(node, (babylonMesh) => {
-                if ((babylonMesh as Mesh).hasThinInstances) {
-                    // refresh already done
-                } else {
-                    babylonMesh.refreshBoundingInfo(true);
-                }
+                babylonMesh.refreshBoundingInfo(true);
             });
 
             return node._babylonTransformNode!;

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -702,7 +702,11 @@ export class GLTFLoader implements IGLTFLoader {
 
         return Promise.all(promises).then(() => {
             this._forEachPrimitive(node, (babylonMesh) => {
-                babylonMesh.refreshBoundingInfo(true);
+                if ((babylonMesh as Mesh).hasThinInstances) {
+                    // refresh already done
+                } else {
+                    babylonMesh.refreshBoundingInfo(true);
+                }
             });
 
             return node._babylonTransformNode!;
@@ -777,7 +781,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         this.logOpen(`${context}`);
 
-        const shouldInstance = this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets);
+        const shouldInstance = this._parent.createInstances && (node.skin == undefined && !mesh.primitives[0].targets) && (!primitive._instanceData || !primitive._instanceData.babylonSourceMesh.hasThinInstances);
 
         let babylonAbstractMesh: AbstractMesh;
         let promise: Promise<any>;

--- a/src/Meshes/thinInstanceMesh.ts
+++ b/src/Meshes/thinInstanceMesh.ts
@@ -343,3 +343,8 @@ Mesh.prototype._disposeThinInstanceSpecificData = function() {
         this._thinInstanceDataStorage.matrixBuffer = null;
     }
 };
+
+/**
+ * @hidden
+ */
+export var _IDoNeedToBeInTheBuild2 = 42;

--- a/src/Meshes/thinInstanceMesh.ts
+++ b/src/Meshes/thinInstanceMesh.ts
@@ -250,8 +250,10 @@ Mesh.prototype.thinInstanceRefreshBoundingInfo = function(forceRefreshParentInfo
     const matrixData = this._thinInstanceDataStorage.matrixData;
 
     if (vectors.length === 0) {
+        const worldMatrix = this.getWorldMatrix();
         for (let v = 0; v < boundingInfo.boundingBox.vectors.length; ++v) {
             vectors.push(boundingInfo.boundingBox.vectors[v].clone());
+            Vector3.TransformCoordinatesToRef(vectors[v], worldMatrix, vectors[v]);
         }
     }
 


### PR DESCRIPTION
If the node we must create instances for is an `InstancedMesh`, thin instances can't be used because the features are mutually exclusive (and `InstancedMesh` subclass `AbstractMesh` whereas thin instances pertain to `Mesh`, anyway).

That's why there are several checks `if (!(babylonMesh as Mesh).thinInstanceSetBuffer) ...` in the code, to deal with both cases.