### PR TITLE
Add a DeviceInputSystem factory function

### DIFF
--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -81,7 +81,7 @@ export class DeviceSourceManager implements IDisposable {
         const numberOfDeviceTypes = Object.keys(DeviceType).length / 2;
         this._devices = new Array<Array<DeviceSource<DeviceType>>>(numberOfDeviceTypes);
         this._firstDevice = new Array<number>(numberOfDeviceTypes);
-        this._deviceInputSystem = new DeviceInputSystem(engine);
+        this._deviceInputSystem = DeviceInputSystem.Create(engine);
 
         this._deviceInputSystem.onDeviceConnected = (deviceType, deviceSlot) => {
             this.onBeforeDeviceConnectedObservable.notifyObservers({ deviceType, deviceSlot });

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -47,10 +47,6 @@ export class DeviceInputSystem implements IDisposable {
     private static _MAX_KEYCODES: number = 255;
     private static _MAX_POINTER_INPUTS: number = 7;
 
-    /**
-     * Default Constructor
-     * @param engine - engine to pull input element from
-     */
     private constructor(engine: Engine) {
         const inputElement = engine.getInputElement();
         if (inputElement) {
@@ -61,6 +57,10 @@ export class DeviceInputSystem implements IDisposable {
         }
     }
 
+    /**
+     * Creates a new DeviceInputSystem instance
+     * @param engine - engine to pull input element from
+     */
     public static Create(engine: Engine): DeviceInputSystem {
         // If running in Babylon Native, then defer to the native input system, which has the same public contract
         if (typeof _native.DeviceInputSystem !== 'undefined') {

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -60,7 +60,8 @@ export class DeviceInputSystem implements IDisposable {
 
     /**
      * Creates a new DeviceInputSystem instance
-     * @param engine - engine to pull input element from
+     * @param engine Engine to pull input element from
+     * @returns The new instance
      */
     public static Create(engine: Engine): DeviceInputSystem {
         // If running in Babylon Native, then defer to the native input system, which has the same public contract

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -3,6 +3,7 @@ import { IDisposable } from '../scene';
 import { Nullable } from '../types';
 import { DeviceType } from './InputDevices/deviceEnums';
 
+/** @hidden */
 declare const _native: any;
 
 /**

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -3,6 +3,8 @@ import { IDisposable } from '../scene';
 import { Nullable } from '../types';
 import { DeviceType } from './InputDevices/deviceEnums';
 
+declare const _native: any;
+
 /**
  * This class will take all inputs from Keyboard, Pointer, and
  * any Gamepads and provide a polling system that all devices
@@ -49,7 +51,7 @@ export class DeviceInputSystem implements IDisposable {
      * Default Constructor
      * @param engine - engine to pull input element from
      */
-    constructor(engine: Engine) {
+    private constructor(engine: Engine) {
         const inputElement = engine.getInputElement();
         if (inputElement) {
             this._elementToAttachTo = inputElement;
@@ -57,6 +59,15 @@ export class DeviceInputSystem implements IDisposable {
             this._handlePointerActions();
             this._handleGamepadActions();
         }
+    }
+
+    public static Create(engine: Engine): DeviceInputSystem {
+        // If running in Babylon Native, then defer to the native input system, which has the same 
+        if (typeof _native.DeviceInputSystem !== 'undefined') {
+            return new _native.DeviceInputSystem(engine);
+        }
+
+        return new DeviceInputSystem(engine);
     }
 
     // Public functions

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -62,7 +62,7 @@ export class DeviceInputSystem implements IDisposable {
     }
 
     public static Create(engine: Engine): DeviceInputSystem {
-        // If running in Babylon Native, then defer to the native input system, which has the same 
+        // If running in Babylon Native, then defer to the native input system, which has the same public contract
         if (typeof _native.DeviceInputSystem !== 'undefined') {
             return new _native.DeviceInputSystem(engine);
         }


### PR DESCRIPTION
This change replaces the `DeviceInputSystem` public constructor with a public static factory function that either creates a native `DeviceInputSystem` or a JS `DeviceInputSystem`. I tried a lot of different ways of handling this, and had hoped we could do it without making any changes to Babylon.js, but it turns out this is hard to do with ES6+modules. This is about the least intrusive change I think I can make in Babylon.js to allow us to transparently swap out a native input system with the DOM based one when running in the context of Babylon Native. I talked at length with @bghgary and @sebavan about this as well, and there are some additional ideas around this, but they are much larger changes. FYI @PolygonalSun 

For the associated Babylon Native change, see https://github.com/BabylonJS/BabylonNative/pull/268