### PR TITLE
Cannon.js height and plane impostors fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -210,7 +210,7 @@
 - Make sure bone matrices are up to date when calling `TransformNode.attachToBone` ([Popov72](https://github.com/Popov72))
 - Fix display problem with transparent objects and SSAO2 pipeline (bug in the `GeometryBufferRenderer`) ([Popov72](https://github.com/Popov72))
 - Fixed `Sound` not accepting a `TransformNode` as a source for spatial sound ([Poolminer](https://github.com/Poolminer))
-- Fixed an issue with transformation set after physics body was created using cannon.js ([#7928](https://github.com/BabylonJS/Babylon.js/issues/7928)) ([RaananW](https://github.com/RaananW))
+- Fixed an issue with transformation set after physics body was created using cannon.js (excluding height and plane) ([#7928](https://github.com/BabylonJS/Babylon.js/issues/7928)) ([RaananW](https://github.com/RaananW))
 - Fix bug when using `ShadowOnlyMaterial` with Cascaded Shadow Map and `autoCalcDepthBounds` is `true` ([Popov72](https://github.com/Popov72))
 - Fix OBJ serializer default scene scene handedness causing [OBJ Mirror export](https://forum.babylonjs.com/t/obj-export-mirrored/10835/10)
 - Fix bug when using shadows + instances + transparent meshes + `transparencyShadow = false` ([Popov72](https://github.com/Popov72))

--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -59,7 +59,9 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
         if (this._firstFrame) {
             this._firstFrame = false;
             for (const impostor of impostors) {
-                impostor.beforeStep();
+                if (!(impostor.type == PhysicsImpostor.HeightmapImpostor || impostor.type === PhysicsImpostor.PlaneImpostor)) {
+                    impostor.beforeStep();
+                }
             }
         }
         this.world.step(this._useDeltaForWorldStep ? delta : this._fixedTimeStep);


### PR DESCRIPTION
Due to our plugin architecture and the way cannon before- and after steps work, I have to revert the extra before-step of plane and height maps (due to the 90deg rotation of the X axis).