### PR TITLE
[Enhancement] Observable-based timer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -27,6 +27,7 @@
 - Added support in `ShadowGenerator` for fast fake soft transparent shadows ([Popov72](https://github.com/Popov72))
 - Added `boundingBoxRenderer.onBeforeBoxRenderingObservable` and `boundingBoxRenderer.onAfterBoxRenderingObservable` ([Deltakosh](https://github.com/deltakosh))
 - Added initial code for user facing DeviceSourceManager ([PolygonalSun](https://github.com/PolygonalSun))
+- Added a Simple and advanced timer, based on observables ([RaananW](https://github.com/RaananW))
 
 ### Engine
 

--- a/src/Misc/timer.ts
+++ b/src/Misc/timer.ts
@@ -69,17 +69,26 @@ export interface ITimerData<T> {
  * The current state of the timer
  */
 export enum TimerState {
+    /**
+     * Timer initialized, not yet started
+     */
     INIT,
+    /**
+     * Timer started and counting
+     */
     STARTED,
+    /**
+     * Timer ended (whether aborted or time reached)
+     */
     ENDED
 }
 
 /**
  * A simple version of the timer. Will take options and start the timer immediately after calling it
  *
- * @param options options to initialize this timer
+ * @param options options with which to initialize this timer
  */
-export const SetAndStartTimer = (options: ITimerOptions<any>): Nullable<Observer<any>> => {
+export function SetAndStartTimer(options: ITimerOptions<any>): Nullable<Observer<any>> {
     let timer = 0;
     const startTime = Date.now();
     options.observableParameters = options.observableParameters ?? {};
@@ -103,7 +112,7 @@ export const SetAndStartTimer = (options: ITimerOptions<any>): Nullable<Observer
         }
     }, options.observableParameters.mask, options.observableParameters.insertFirst, options.observableParameters.scope);
     return observer;
-};
+}
 
 /**
  * An advanced implementation of a timer class

--- a/src/Misc/timer.ts
+++ b/src/Misc/timer.ts
@@ -1,0 +1,232 @@
+import { Observable, Observer } from '../Misc/observable';
+import { Nullable } from '../types';
+import { IDisposable } from '../scene';
+
+/**
+ * Construction options for a timer
+ */
+export interface ITimerOptions<T> {
+    /**
+     * Time-to-end
+     */
+    time: number;
+    /**
+     * What is the counting observable. Will usually be OnBeforeRenderObservable.
+     * Time calculation is done ONLY when the observable is notifying, meaning that if
+     * you choose an observable that doesn't trigger too often, the wait time might extend further than the requested max time
+     */
+    countingObservable: Observable<T>;
+    /**
+     * An optional break condition that will stop the times prematurely. In this case onEnded will not be triggered!
+     */
+    breakCondition?: (data?: ITimerData<T>) => boolean;
+    /**
+     * Will be triggered when the time condition has met
+     */
+    onEnded?: (data: ITimerData<any>) => void;
+    /**
+     * Optional function to execute on each tick (or count)
+     */
+    onTick?: (data: ITimerData<any>) => void;
+}
+
+/**
+ * An interface defining the data sent by the timer
+ */
+export interface ITimerData<T> {
+    /**
+     * When did it start
+     */
+    startTime: number;
+    /**
+     * Time now
+     */
+    currentTime: number;
+    /**
+     * Time passed since started
+     */
+    deltaTime: number;
+    /**
+     * How much was completed, in [0.0...1.0].
+     * Note that this CAN be higher than 1due to the fact that we don't actually measure time but observable calls
+     */
+    completeRate: number;
+    /**
+     * What the registered observable sent in the last count
+     */
+    payload: T;
+}
+
+/**
+ * The current state of the timer
+ */
+export enum TimerState {
+    INIT,
+    STARTED,
+    ENDED
+}
+
+/**
+ * A simple version of the timer. Will take options and start the timer immediately after calling it
+ *
+ * @param options options to initialize this timer
+ */
+export const SetAndStartTimer = (options: ITimerOptions<any>): Nullable<Observer<any>> => {
+    let timer = 0;
+    const startTime = Date.now();
+    const observer = options.countingObservable.add((payload: any) => {
+        const now = Date.now();
+        timer = now - startTime;
+        const data: ITimerData<any> = {
+            startTime,
+            currentTime: now,
+            deltaTime: timer,
+            completeRate: timer / options.time,
+            payload
+        };
+        options.onTick && options.onTick(data);
+        if (options.breakCondition && options.breakCondition()) {
+            options.countingObservable.remove(observer);
+        }
+        if (timer >= options.time) {
+            options.countingObservable.remove(observer);
+            options.onEnded && options.onEnded(data);
+        }
+    });
+    return observer;
+};
+
+/**
+ * An advanced implementation of a timer class
+ */
+export class AdvancedTimer<T = any> implements IDisposable {
+
+    /**
+     * Will notify each time the timer calculates the remaining time
+     */
+    public onEachCountObservable: Observable<ITimerData<T>> = new Observable();
+    /**
+     * Will trigger when the timer was aborted due to the break condition
+     */
+    public onTimerAbortedObservable: Observable<ITimerData<T>> = new Observable();
+    /**
+     * Will trigger when the timer ended successfully
+     */
+    public onTimerEndedObservable: Observable<ITimerData<T>> = new Observable();
+    /**
+     * Will trigger when the timer state has changed
+     */
+    public onStateChangedObservable: Observable<TimerState> = new Observable();
+
+    private _observer: Nullable<Observer<T>> = null;
+    private _countingObservable: Observable<T>;
+    private _startTime: number;
+    private _timer: number;
+    private _state: TimerState;
+    private _breakCondition: (data: ITimerData<T>) => boolean;
+    private _timeToEnd: number;
+    private _breakOnNextTick: boolean = false;
+
+    /**
+     * Will construct a new advanced timer based on the options provided. Timer will not start until start() is called.
+     * @param options construction options for this advanced timer
+     */
+    constructor(options: ITimerOptions<T>) {
+        this._setState(TimerState.INIT);
+        this._countingObservable = options.countingObservable;
+        this._breakCondition = options.breakCondition ?? (() => false);
+        if (options.onEnded) {
+            this.onTimerEndedObservable.add(options.onEnded);
+        }
+        if (options.onTick) {
+            this.onEachCountObservable.add(options.onTick);
+        }
+    }
+
+    /**
+     * set a breaking condition for this timer. Default is to never break during count
+     * @param predicate the new break condition. Returns true to break, false otherwise
+     */
+    public set breakCondition(predicate: (data: ITimerData<T>) => boolean) {
+        this._breakCondition = predicate;
+    }
+
+    /**
+     * Reset ALL associated observables in this advanced timer
+     */
+    public clearObservables() {
+        this.onEachCountObservable.clear();
+        this.onTimerAbortedObservable.clear();
+        this.onTimerEndedObservable.clear();
+        this.onStateChangedObservable.clear();
+    }
+
+    /**
+     * Will start a new iteration of this timer. Only one instance of this timer can run at a time.
+     *
+     * @param timeToEnd how much time to measure until timer ended
+     */
+    public start(timeToEnd: number = this._timeToEnd) {
+        if (this._state === TimerState.STARTED) {
+            throw new Error('Timer already started. Please stop it before starting again');
+        }
+        this._timeToEnd = timeToEnd;
+        this._startTime = Date.now();
+        this._timer = 0;
+        this._observer = this._countingObservable.add(this._tick);
+        this._setState(TimerState.STARTED);
+    }
+
+    /**
+     * Will force a stop on the next tick.
+     */
+    public stop() {
+        if (this._state !== TimerState.STARTED) {
+            return;
+        }
+        this._breakOnNextTick = true;
+    }
+
+    /**
+     * Dispose this timer, clearing all resources
+     */
+    public dispose() {
+        if (this._observer) {
+            this._countingObservable.remove(this._observer);
+        }
+        this.clearObservables();
+    }
+
+    private _setState(newState: TimerState) {
+        this._state = newState;
+        this.onStateChangedObservable.notifyObservers(this._state);
+    }
+
+    private _tick = (payload: T) => {
+        const now = Date.now();
+        this._timer = now - this._startTime;
+        const data: ITimerData<T> = {
+            startTime: this._startTime,
+            currentTime: now,
+            deltaTime: this._timer,
+            completeRate: this._timer / this._timeToEnd,
+            payload
+        };
+        const shouldBreak = this._breakOnNextTick || this._breakCondition(data);
+        if (shouldBreak || this._timer >= this._timeToEnd) {
+            this._stop(data, shouldBreak);
+        } else {
+            this.onEachCountObservable.notifyObservers(data);
+        }
+    }
+
+    private _stop(data: ITimerData<T>, aborted: boolean = false) {
+        this._countingObservable.remove(this._observer);
+        this._setState(TimerState.ENDED);
+        if (aborted) {
+            this.onTimerAbortedObservable.notifyObservers(data);
+        } else {
+            this.onTimerEndedObservable.notifyObservers(data);
+        }
+    }
+}

--- a/src/Misc/timer.ts
+++ b/src/Misc/timer.ts
@@ -33,6 +33,10 @@ export interface ITimerOptions<T> {
      */
     onEnded?: (data: ITimerData<any>) => void;
     /**
+     * Will be triggered when the break condition has met (prematurely ended)
+     */
+    onAborted?: (data: ITimerData<any>) => void;
+    /**
      * Optional function to execute on each tick (or count)
      */
     onTick?: (data: ITimerData<any>) => void;
@@ -105,6 +109,7 @@ export function setAndStartTimer(options: ITimerOptions<any>): Nullable<Observer
         options.onTick && options.onTick(data);
         if (options.breakCondition && options.breakCondition()) {
             options.contextObservable.remove(observer);
+            options.onAborted && options.onAborted(data);
         }
         if (timer >= options.timeout) {
             options.contextObservable.remove(observer);
@@ -164,6 +169,9 @@ export class AdvancedTimer<T = any> implements IDisposable {
         }
         if (options.onTick) {
             this.onEachCountObservable.add(options.onTick);
+        }
+        if (options.onAborted) {
+            this.onTimerAbortedObservable.add(options.onAborted);
         }
     }
 

--- a/src/Misc/timer.ts
+++ b/src/Misc/timer.ts
@@ -88,7 +88,7 @@ export enum TimerState {
  *
  * @param options options with which to initialize this timer
  */
-export function SetAndStartTimer(options: ITimerOptions<any>): Nullable<Observer<any>> {
+export function setAndStartTimer(options: ITimerOptions<any>): Nullable<Observer<any>> {
     let timer = 0;
     const startTime = Date.now();
     options.observableParameters = options.observableParameters ?? {};

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -431,8 +431,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                                     controllerData.teleportationState.currentRotation = 0;
                                     const timeToSelect = this._options.timeToTeleport || 3000;
                                     setAndStartTimer({
-                                        time: timeToSelect,
-                                        countingObservable: this._xrSessionManager.onXRFrameObservable,
+                                        timeout: timeToSelect,
+                                        contextObservable: this._xrSessionManager.onXRFrameObservable,
                                         breakCondition: () => !mainComponent.pressed,
                                         onEnded: () => {
                                             if (this._currentTeleportationControllerId === controllerData.xrController.uniqueId && controllerData.teleportationState.forward) {
@@ -522,8 +522,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     controllerData.teleportationState.currentRotation = 0;
                     const timeToSelect = this._options.timeToTeleport || 3000;
                     setAndStartTimer({
-                        time: timeToSelect,
-                        countingObservable: this._xrSessionManager.onXRFrameObservable,
+                        timeout: timeToSelect,
+                        contextObservable: this._xrSessionManager.onXRFrameObservable,
                         onEnded: () => {
                             if (this._currentTeleportationControllerId === controllerData.xrController.uniqueId && controllerData.teleportationState.forward) {
                                 this._teleportForward(xrController.uniqueId);

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -25,7 +25,7 @@ import { Color3 } from '../../Maths/math.color';
 import { Scene } from '../../scene';
 import { UtilityLayerRenderer } from '../../Rendering/utilityLayerRenderer';
 import { PointerEventTypes } from '../../Events/pointerEvents';
-import { SetAndStartTimer } from '../../Misc/timer';
+import { setAndStartTimer } from '../../Misc/timer';
 
 /**
  * The options container for the teleportation module
@@ -430,7 +430,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                                     controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
                                     controllerData.teleportationState.currentRotation = 0;
                                     const timeToSelect = this._options.timeToTeleport || 3000;
-                                    SetAndStartTimer({
+                                    setAndStartTimer({
                                         time: timeToSelect,
                                         countingObservable: this._xrSessionManager.onXRFrameObservable,
                                         breakCondition: () => !mainComponent.pressed,
@@ -521,7 +521,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
                     controllerData.teleportationState.currentRotation = 0;
                     const timeToSelect = this._options.timeToTeleport || 3000;
-                    SetAndStartTimer({
+                    setAndStartTimer({
                         time: timeToSelect,
                         countingObservable: this._xrSessionManager.onXRFrameObservable,
                         onEnded: () => {


### PR DESCRIPTION
When implementing timed functions in XR i noticed I used this pattern quite a lot - set time-to-end, measure time using the onXRFrameObservable, and clear the observer after the timer has ended.

I then thought - this might be needed globally, and can actually be used with any observable. So - introducing the Simple and Advanced timers.

The timers count time on each call of the observable attached to them. meaning that they can also be used as a form of "debounce" for pointer events. 

The simplest example - notify me in 2 seconds:

```javascript
SetAndStartTimer({
        time: 2000,
        countingObservable: scene.onBeforeRenderObservable, 
        onEnded: () => { alert("Huzza!!!"); }
    });
```

Advantage here is that we are not using setTimeout. the onEnded function is guaranteed to be triggered inside the render loop (better yet - inside the beforeRender loop)

hold pointer down for 3 seconds:

```javascript
let blackMaterial = ..... // create a material with black diffuse color
let pointerDown = false;
scene.onPointerDown = () => {
    pointerDown = true;
    SetAndStartTimer({
        time: 3000,
        countingObservable: scene.onBeforeRenderObservable, 
        onEnded: () => { alert("Huzza!!!"); },
        breakCondition: () => !pointerDown,
        onTick: (data) => {
            // turn the material to green for visualization
            blackMaterial.diffuseColor.set(0, data.completeRate, 0);
        }
    });
}
scene.onPointerUp = () => {
    pointerDown = false;
}
```

Any observable can be used, if it makes sense. For example - draw on a mesh for 5 seconds:

```javascript
scene.onPointerDown = () => {
    pointerDown = true;
    SetAndStartTimer({
        time: 3000,
        countingObservable: scene.onPointerObservable,  // use the onPointer observable for the ticks
        observableParameters: { mask: PointerEventTypes.POINTERMOVE } // filter to pointer move only
        onEnded: () => { commitPainting() },
        onTick: (data) => {
            if(data.payload.pickInfo.pickedPoint) { /* paint on the mesh with the pick info */ }
        }
    });
}
```

The advanced timer has a lot more options (like the options to manually stop and restart the timer), a state machine and a lot of available observables, when needed. But essentially, it works the same.

Disadvantage is that it is never 100% exact. Even when using the beforeRenderObservable, there will always be a few extra milliseconds on the timer.