### PR TITLE
Fix for DeviceInputSystem when using non-native implementation

### DIFF
--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -65,7 +65,7 @@ export class DeviceInputSystem implements IDisposable {
      */
     public static Create(engine: Engine): DeviceInputSystem {
         // If running in Babylon Native, then defer to the native input system, which has the same public contract
-        if (typeof _native.DeviceInputSystem !== 'undefined') {
+        if (typeof _native !== 'undefined' && _native.DeviceInputSystem) {
             return new _native.DeviceInputSystem(engine);
         }
 


### PR DESCRIPTION
This is a fix for the DeviceInputSystem.  When the Create function is called, the function will now check if _native is defined before checking for a native implementation of the DeviceInputSystem.