### PR TITLE
Fix typo in comment: "messh" -> "mesh"

### DIFF
--- a/src/Cameras/followCamera.ts
+++ b/src/Cameras/followCamera.ts
@@ -263,7 +263,7 @@ export class ArcFollowCamera extends TargetCamera {
         public beta: number,
         /** The radius of the camera from its target */
         public radius: number,
-        /** Define the camera target (the messh it should follow) */
+        /** Define the camera target (the mesh it should follow) */
         public target: Nullable<AbstractMesh>,
         scene: Scene) {
         super(name, Vector3.Zero(), scene);


### PR DESCRIPTION
I noticed this typo when reading the docs for `FollowCamera` and figured it'd be quick to fix if I just searched the github repo for the string