### PR TITLE
Handle scales in camera matrices

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -65,6 +65,7 @@
 - handle reattachment of panning button for `ArcRotateCamera` ([cedricguillemet](https://github.com/cedricguillemet))
 - Added flag to TargetCamera to invert rotation direction and multiplier to adjust speed ([Exolun](https://github.com/Exolun))
 - Added upwards and downwards keyboard input to `FreeCamera` ([Pheater](https://github.com/pheater))
+- Handle scales in camera matrices ([Popov72](https://github.com/Popov72))
 
 ### Sprites
 

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -424,22 +424,23 @@ export class TargetCamera extends Camera {
     }
 
     protected _computeViewMatrix(position: Vector3, target: Vector3, up: Vector3): void {
-        if (this.parent) {
-            const parentWorldMatrix = this.parent.getWorldMatrix();
-            Vector3.TransformCoordinatesToRef(position, parentWorldMatrix, this._globalPosition);
-            Vector3.TransformCoordinatesToRef(target, parentWorldMatrix, this._globalCurrentTarget);
-            Vector3.TransformNormalToRef(up, parentWorldMatrix, this._globalCurrentUpVector);
-            this._markSyncedWithParent();
-        } else {
-            this._globalPosition.copyFrom(position);
-            this._globalCurrentTarget.copyFrom(target);
-            this._globalCurrentUpVector.copyFrom(up);
-        }
+        this._globalPosition.copyFrom(position);
+        this._globalCurrentTarget.copyFrom(target);
+        this._globalCurrentUpVector.copyFrom(up);
 
         if (this.getScene().useRightHandedSystem) {
             Matrix.LookAtRHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
         } else {
             Matrix.LookAtLHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
+        }
+
+        if (this.parent) {
+            const parentWorldMatrix = this.parent.getWorldMatrix();
+            this._viewMatrix.invert();
+            this._viewMatrix.multiplyToRef(parentWorldMatrix, this._viewMatrix);
+            this._viewMatrix.getTranslationToRef(this._globalPosition);
+            this._viewMatrix.invert();
+            this._markSyncedWithParent();
         }
     }
 

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -87,9 +87,6 @@ export class TargetCamera extends Camera {
     /** @hidden */
     public _transformedReferencePoint = Vector3.Zero();
 
-    protected _globalCurrentTarget = Vector3.Zero();
-    protected _globalCurrentUpVector = Vector3.Zero();
-
     /** @hidden */
     public _reset: () => void;
 
@@ -424,14 +421,10 @@ export class TargetCamera extends Camera {
     }
 
     protected _computeViewMatrix(position: Vector3, target: Vector3, up: Vector3): void {
-        this._globalPosition.copyFrom(position);
-        this._globalCurrentTarget.copyFrom(target);
-        this._globalCurrentUpVector.copyFrom(up);
-
         if (this.getScene().useRightHandedSystem) {
-            Matrix.LookAtRHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
+            Matrix.LookAtRHToRef(position, target, up, this._viewMatrix);
         } else {
-            Matrix.LookAtLHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
+            Matrix.LookAtLHToRef(position, target, up, this._viewMatrix);
         }
 
         if (this.parent) {
@@ -441,6 +434,8 @@ export class TargetCamera extends Camera {
             this._viewMatrix.getTranslationToRef(this._globalPosition);
             this._viewMatrix.invert();
             this._markSyncedWithParent();
+        } else {
+            this._globalPosition.copyFrom(position);
         }
     }
 


### PR DESCRIPTION
See thorough discussion here: https://forum.babylonjs.com/t/camera-minz-and-maxz-do-not-work-properly-when-camera-parent-is-scaled/11267/13

Here's another PG: https://playground.babylonjs.com/#XTYH95

In this one, the small box is a child of the big box, and the camera is a child of the small box.

When modifying the scale of the small box, you will see that at some time the box disappears: that's when the scale is too low and the box is clipped.

I think it may be strange for a user to have their objects disappear based on their scale, so this PR tries to take into account the scales of the parent matrix to build the camera matrix.

What I did is doing as for transform nodes, meaning creating the camera matrix as being the camera local matrix multiplied by the parent matrix - before, it was constructed by mean of the transformed position/target/up vectors.

The code:
```typescript
this._globalPosition.copyFrom(position);
this._globalCurrentTarget.copyFrom(target);
this._globalCurrentUpVector.copyFrom(up);

if (this.getScene().useRightHandedSystem) {
    Matrix.LookAtRHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
} else {
    Matrix.LookAtLHToRef(this._globalPosition, this._globalCurrentTarget, this._globalCurrentUpVector, this._viewMatrix);
}

if (this.parent) {
    const parentWorldMatrix = this.parent.getWorldMatrix();
    this._viewMatrix.invert();
    this._viewMatrix.multiplyToRef(parentWorldMatrix, this._viewMatrix);
    this._viewMatrix.getTranslationToRef(this._globalPosition);
    this._viewMatrix.invert();
    this._markSyncedWithParent();
}
```
The first `invert` is because the (local) `_viewMatrix` is constructed (by `LookAtLHToRef` / `LookAtRHToRef`) so as to transform world coordinates to view coordinates but we need it the other way around.

After we multiply by the parent matrix, we `invert` it again because `_viewMatrix` is expected to transform world coordinates to view coordinates, not the other way around.

I'm no expert in all those matrix computations and transformations (I did a bit by "try and see if it looks good"), so additional reviews / testing is more than welcome (I did check that the PG from the forum post and the PG linked above do work with the changes)!