### PR TITLE
Added new helper method to abstract mesh class

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -37,6 +37,7 @@
 - Change default camera calculations to only include visible and enabled meshes ([bghgary](https://github.com/bghgary))
 - Optimized frozen instances ([Deltakosh](https://github.com/deltakosh))
 - Add support for detail maps in both the standard and PBR materials ([Popov72](https://github.com/Popov72))
+- Added abstractMesh method to get all particle systems that use the mesh as an emitter ([PirateJC](https://github.com/PirateJC))
 
 ### NME
 

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -29,6 +29,7 @@ import { Color3, Color4 } from '../Maths/math.color';
 import { Epsilon } from '../Maths/math.constants';
 import { Plane } from '../Maths/math.plane';
 import { Axis } from '../Maths/math.axis';
+import { IParticleSystem } from '../Particles/IParticleSystem';
 
 declare type Ray = import("../Culling/ray").Ray;
 declare type Collider = import("../Collisions/collider").Collider;
@@ -2174,6 +2175,14 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
      */
     enableEdgesRendering(epsilon?: number, checkVerticesInsteadOfIndices?: boolean): AbstractMesh {
         throw _DevTools.WarnImport("EdgesRenderer");
+    }
+
+    /**
+     * This function returns all of the particle systems in the scene that use the mesh as an emitter.
+     * @returns an array of particle systems in the scene that use the mesh as an emitter
+     */
+    public getConnectedParticleSystems(): IParticleSystem[] {
+        return this._scene.particleSystems.filter((particleSystem) => particleSystem.emitter === this);
     }
 
 }


### PR DESCRIPTION
Added new method to the abstract mesh class called getConnectedParticleSystems.

This method searches through all particle systems in the scene and returns only those that use the mesh as their emitters.