### PR TITLE
Fix submaterial cloning when instantiating models

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -223,9 +223,10 @@
 - Fix bug when using `ShadowOnlyMaterial` with Cascaded Shadow Map and `autoCalcDepthBounds` is `true` ([Popov72](https://github.com/Popov72))
 - Fix OBJ serializer default scene scene handedness causing [OBJ Mirror export](https://forum.babylonjs.com/t/obj-export-mirrored/10835/10)
 - Fix bug when using shadows + instances + transparent meshes + `transparencyShadow = false` ([Popov72](https://github.com/Popov72))
-- Incorrect initialization when reattaching XR pointer selection  ([#8227](https://github.com/BabylonJS/Babylon.js/issues/8227)) ([RaananW](https://github.com/RaananW))
+- Incorrect initialization when reattaching XR pointer selection ([#8227](https://github.com/BabylonJS/Babylon.js/issues/8227)) ([RaananW](https://github.com/RaananW))
 - Fixed `DracoCompression` to not load empty data into attributes ([bghgary](https://github.com/bghgary))
-- Fixed `Mesh.subdivide` where one face could be lost depending on the number of subdivision  ([Popov72](https://github.com/Popov72))
+- Fixed `Mesh.subdivide` where one face could be lost depending on the number of subdivision ([Popov72](https://github.com/Popov72))
+- Fixed `AssetContainer.instantiateModelsToScene` with cloneMaterials=true and MultiMaterials to properly set the cloned submaterials ([ghempton](https://github.com/ghempton))
 
 ## Breaking changes
 

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -156,6 +156,8 @@ export class AssetContainer extends AbstractScene {
                                             convertionMap[material.uniqueId] = swap.uniqueId;
                                             storeMap[swap.uniqueId] = swap;
                                         }
+
+                                        multi.subMaterials = multi.subMaterials.map(m => storeMap[convertionMap[m.uniqueId]]);
                                     }
                                 }
 

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -157,7 +157,7 @@ export class AssetContainer extends AbstractScene {
                                             storeMap[swap.uniqueId] = swap;
                                         }
 
-                                        multi.subMaterials = multi.subMaterials.map(m => storeMap[convertionMap[m.uniqueId]]);
+                                        multi.subMaterials = multi.subMaterials.map((m) => m && storeMap[convertionMap[m.uniqueId]]);
                                     }
                                 }
 


### PR DESCRIPTION
The current logic in AssetContainer#instantiateModelsToScene clones
the multimaterial as well as its submaterials, but does not assign the
cloned submaterials.