### PR TITLE
react types as peer dependency

### DIFF
--- a/dist/preview release/inspector/package.json
+++ b/dist/preview release/inspector/package.json
@@ -34,9 +34,11 @@
         "babylonjs-loaders": "4.2.0-alpha.19",
         "babylonjs-materials": "4.2.0-alpha.19",
         "babylonjs-serializers": "4.2.0-alpha.19",
-        "babylonjs-gltf2interface": "4.2.0-alpha.19",
-        "@types/react": "~16.7.3",
-        "@types/react-dom": "~16.0.9"
+        "babylonjs-gltf2interface": "4.2.0-alpha.19"
+    },
+    "peerDependencies": {
+        "@types/react": ">=16.7.3",
+        "@types/react-dom": ">=16.0.9"
     },
     "engines": {
         "node": "*"


### PR DESCRIPTION
i used the initial version defined as the base for the dependency semver. Anything higher than this (we are already using the 16.9.x branch) will be accepted. 