### PR TITLE
CustomProceduralTexture: No log if texturePath is not a json path

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -27,6 +27,7 @@
 - Added `boundingBoxRenderer.onBeforeBoxRenderingObservable` and `boundingBoxRenderer.onAfterBoxRenderingObservable` ([Deltakosh](https://github.com/deltakosh))
 - Added initial code for user facing DeviceSourceManager ([PolygonalSun](https://github.com/PolygonalSun))
 - Added a Simple and advanced timer, based on observables ([RaananW](https://github.com/RaananW))
+- Don't log a message in `CustomProceduralTexture` if the `texturePath` is not a JSON path ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/src/Materials/Textures/Procedurals/customProceduralTexture.ts
+++ b/src/Materials/Textures/Procedurals/customProceduralTexture.ts
@@ -39,7 +39,6 @@ export class CustomProceduralTexture extends ProceduralTexture {
 
     private _loadJson(jsonUrl: string): void {
         let noConfigFile = () => {
-            Logger.Log("No config file found in " + jsonUrl + " trying to use ShadersStore or DOM element");
             try {
                 this.setFragment(this._texturePath);
             }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-to-stop-json-error-on-procedural-texture/11664/3