### PR TITLE
Render transparent meshes with the same stencil state than the opaque…

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -235,3 +235,4 @@
 - HDRCubeTexture default rotation is now similar to the industry one. You might need to add a rotation on y of 90 degrees if you scene changes ([Sebavan](https://github.com/sebavan/))
 - PBRMaterial index of refraction is now defined as index of refraction and not the inverse of it ([Sebavan](https://github.com/sebavan/))
 - `SceneLoaderProgress` class is now `ISceneLoaderProgress` interface ([bghgary](https://github.com/bghgary))
+- Rendering of transparent meshes: stencil state is now set to the value registered in the engine instead of being set to `false` unconditionally ([Popov72](https://github.com/Popov72))

--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -513,6 +513,17 @@ export class HighlightLayer extends EffectLayer {
     }
 
     /**
+     * Returns true if the mesh can be rendered, otherwise false.
+     * @param mesh The mesh to render
+     * @param material The material used on the mesh
+     * @returns true if it can be rendered otherwise false
+     */
+    protected _canRenderMesh(mesh: AbstractMesh, material: Material): boolean {
+        // all meshes can be rendered in the highlight layer, even transparent ones
+        return true;
+    }
+
+    /**
      * Adds specific effects defines.
      * @param defines The defines to add specifics to.
      */

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -299,7 +299,7 @@ export class OutlineRenderer implements ISceneComponent {
         this._savedDepthWrite = this._engine.getDepthWrite();
         if (mesh.renderOutline) {
             var material = subMesh.getMaterial();
-            if (material && material.needAlphaBlending()) {
+            if (material && material.needAlphaBlendingForMesh(mesh)) {
                 this._engine.cacheStencilState();
                 // Draw only to stencil buffer for the original mesh
                 // The resulting stencil buffer will be used so the outline is not visible inside the mesh when the mesh is transparent
@@ -321,7 +321,7 @@ export class OutlineRenderer implements ISceneComponent {
             this.render(subMesh, batch);
             this._engine.setDepthWrite(this._savedDepthWrite);
 
-            if (material && material.needAlphaBlending()) {
+            if (material && material.needAlphaBlendingForMesh(mesh)) {
                 this._engine.restoreStencilState();
             }
         }

--- a/src/Rendering/renderingGroup.ts
+++ b/src/Rendering/renderingGroup.ts
@@ -149,6 +149,7 @@ export class RenderingGroup {
 
         // Transparent
         if (this._transparentSubMeshes.length !== 0) {
+            engine.setStencilBuffer(stencilState);
             this._renderTransparent(this._transparentSubMeshes);
             engine.setAlphaMode(Constants.ALPHA_DISABLE);
         }


### PR DESCRIPTION
… ones

In `RenderingGroup.render`, there's a `engine.setStencilBuffer(false);` issued before rendering sprites / particles / transparent meshes.

Regarding sprites and particles I can understand we want to control the rendering and not be bothered with the stencil buffer (albeit now that you can have custom shaders - at least for particles - it may be questionable), but for transparent meshes it's a bit strange to reset the stencil buffer to `false`.

I had been working with the stencil buffer in a PG and everything was working well until I added some transparency to my material, making it switch from the opaque to the transparent queue, making my PG suddenly fail.

This PR simply sets the stencil buffer state to the same value than the one used to render the opaque/alpha test meshes.

As it is possibly a breaking change, I have updated the corresponding section of the What's new file.