### PR TITLE
Fix error handling and KTX/Basis loading issues

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -356,7 +356,7 @@ export class GLTFLoader implements IGLTFLoader {
             });
 
             return resultPromise;
-        }, (error) => {
+        }).catch((error) => {
             if (!this._disposed) {
                 this._parent.onErrorObservable.notifyObservers(error);
                 this._parent.onErrorObservable.clear();

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -2797,7 +2797,7 @@ export class ThinEngine {
         let loader: Nullable<IInternalTextureLoader> = null;
 
         for (const availableLoader of ThinEngine._TextureLoaders) {
-            if (availableLoader.canLoad(extension)) {
+            if (availableLoader.canLoad(extension, mimeType)) {
                 loader = availableLoader;
                 break;
             }

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -2796,7 +2796,7 @@ export class ThinEngine {
         const extension = forcedExtension ? forcedExtension : (lastDot > -1 ? url.substring(lastDot).toLowerCase() : "");
         let loader: Nullable<IInternalTextureLoader> = null;
 
-        for (let availableLoader of ThinEngine._TextureLoaders) {
+        for (const availableLoader of ThinEngine._TextureLoaders) {
             if (availableLoader.canLoad(extension)) {
                 loader = availableLoader;
                 break;

--- a/src/Materials/Textures/Loaders/basisTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/basisTextureLoader.ts
@@ -13,7 +13,7 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
     /**
      * Defines whether the loader supports cascade loading the different faces.
      */
-    public readonly supportCascades = true;
+    public readonly supportCascades = false;
 
     /**
      * This returns if the loader support the current file information.

--- a/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -20,11 +20,12 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
     /**
      * This returns if the loader support the current file information.
      * @param extension defines the file extension of the file being loaded
+     * @param mimeType defines the optional mime type of the file being loaded
      * @returns true if the loader can load the specified file
      */
-    public canLoad(extension: string): boolean {
+    public canLoad(extension: string, mimeType?: string): boolean {
         // The ".ktx2" file extension is still up for debate: https://github.com/KhronosGroup/KTX-Specification/issues/18
-        return StringTools.EndsWith(extension, ".ktx") || StringTools.EndsWith(extension, ".ktx2");
+        return StringTools.EndsWith(extension, ".ktx") || StringTools.EndsWith(extension, ".ktx2") || mimeType === "image/ktx" || mimeType === "image/ktx2";
     }
 
     /**

--- a/src/Materials/Textures/internalTextureLoader.ts
+++ b/src/Materials/Textures/internalTextureLoader.ts
@@ -16,7 +16,7 @@ export interface IInternalTextureLoader {
      * @param mimeType defines the optional mime type of the file being loaded
      * @returns true if the loader can load the specified file
      */
-    canLoad(extension: string, mimetype?: string): boolean;
+    canLoad(extension: string, mimeType?: string): boolean;
 
     /**
      * Uploads the cube texture data to the WebGL texture. It has already been bound.

--- a/src/Materials/Textures/internalTextureLoader.ts
+++ b/src/Materials/Textures/internalTextureLoader.ts
@@ -13,9 +13,10 @@ export interface IInternalTextureLoader {
     /**
      * This returns if the loader support the current file information.
      * @param extension defines the file extension of the file being loaded
+     * @param mimeType defines the optional mime type of the file being loaded
      * @returns true if the loader can load the specified file
      */
-    canLoad(extension: string): boolean;
+    canLoad(extension: string, mimetype?: string): boolean;
 
     /**
      * Uploads the cube texture data to the WebGL texture. It has already been bound.

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -197,7 +197,8 @@ export class FileTools {
             img.removeEventListener("error", errorHandler);
 
             if (onError) {
-                onError("Error while trying to load image: " + input, err);
+                const inputText = input.toString();
+                onError("Error while trying to load image: " + (inputText.length < 32 ? inputText : inputText.slice(0, 32) + "..."), err);
             }
 
             if (usingObjectURL && img.src) {

--- a/src/Misc/filesInput.ts
+++ b/src/Misc/filesInput.ts
@@ -289,6 +289,7 @@ export class FilesInput {
                     });
                 });
             }).catch((error) => {
+                this._engine.hideLoadingUI();
                 if (this._errorCallback) {
                     this._errorCallback(this._sceneFileToLoad, this._currentScene, error.message);
                 }


### PR DESCRIPTION
Fixes #8394

* Update Basis flag to disallow loose cubemaps as it's not supported in the texture loader right now.
* Fix issue with error handling such that errors show up in the sandbox again.
* Truncate the error message if it's too long.
* Use mime type in internal texture loaders.