### PR TITLE
Fix width/height GUI container computation to take into account paddi…

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -237,6 +237,7 @@
 - Fixed wrong display when setting `DefaultRenderingPipeline.imageProcessingEnabled` to `false` ([Popov72](https://github.com/Popov72))
 - Fix crash when loading a .obj file with vertex colors ([Popov72](https://github.com/Popov72))
 - Fix skeleton viewer still visible when `isEnabled = false` ([Popov72](https://github.com/Popov72))
+- Fix width/height GUI container computation to take into account paddings when `adapWithToChildren = true` ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -237,7 +237,6 @@
 - Fixed wrong display when setting `DefaultRenderingPipeline.imageProcessingEnabled` to `false` ([Popov72](https://github.com/Popov72))
 - Fix crash when loading a .obj file with vertex colors ([Popov72](https://github.com/Popov72))
 - Fix skeleton viewer still visible when `isEnabled = false` ([Popov72](https://github.com/Popov72))
-- Fix width/height GUI container computation to take into account paddings when `adapWithToChildren = true` ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 
@@ -247,3 +246,4 @@
 - PBRMaterial index of refraction is now defined as index of refraction and not the inverse of it ([Sebavan](https://github.com/sebavan/))
 - `SceneLoaderProgress` class is now `ISceneLoaderProgress` interface ([bghgary](https://github.com/bghgary))
 - Rendering of transparent meshes: stencil state is now set to the value registered in the engine instead of being set to `false` unconditionally ([Popov72](https://github.com/Popov72))
+- Fix width/height GUI container computation to take into account paddings when `adapWithToChildren = true` ([Popov72](https://github.com/Popov72))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -246,4 +246,4 @@
 - PBRMaterial index of refraction is now defined as index of refraction and not the inverse of it ([Sebavan](https://github.com/sebavan/))
 - `SceneLoaderProgress` class is now `ISceneLoaderProgress` interface ([bghgary](https://github.com/bghgary))
 - Rendering of transparent meshes: stencil state is now set to the value registered in the engine instead of being set to `false` unconditionally ([Popov72](https://github.com/Popov72))
-- Fix width/height GUI container computation to take into account paddings when `adapWithToChildren = true` ([Popov72](https://github.com/Popov72))
+- Fix width/height GUI container computation to take into account paddings when `adaptWithToChildren = true` ([Popov72](https://github.com/Popov72))

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -331,10 +331,10 @@ export class Container extends Control {
                     if (child._layout(this._measureForChildren, context)) {
 
                         if (this.adaptWidthToChildren && child._width.isPixel) {
-                            computedWidth = Math.max(computedWidth, child._currentMeasure.width);
+                            computedWidth = Math.max(computedWidth, child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels);
                         }
                         if (this.adaptHeightToChildren && child._height.isPixel) {
-                            computedHeight = Math.max(computedHeight, child._currentMeasure.height);
+                            computedHeight = Math.max(computedHeight, child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels);
                         }
                     }
                 }


### PR DESCRIPTION
…ngs when `adapWithToChildren = true`

See https://forum.babylonjs.com/t/gui-container-adaptwidthtochildren-doesnt-respect-child-horizontal-padding/11890/5