### PR TITLE
Fix bug in WebXRHit test due to directly casting to Babylon types

### DIFF
--- a/src/XR/features/WebXRHitTest.ts
+++ b/src/XR/features/WebXRHitTest.ts
@@ -226,8 +226,10 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
             if (!pose) {
                 return;
             }
-            this._tmpPos.copyFrom(pose.transform.position as unknown as Vector3);
-            this._tmpQuat.copyFrom(pose.transform.orientation as unknown as Quaternion);
+            const pos = pose.transform.position;
+            const quat = pose.transform.orientation;
+            this._tmpPos.set(pos.x, pos.y, pos.z);
+            this._tmpQuat.set(quat.x, quat.y, quat.z, quat.w);
             Matrix.FromFloat32ArrayToRefScaled(pose.transform.matrix, 0, 1, this._tmpMat);
             if (!this._xrSessionManager.scene.useRightHandedSystem) {
                 this._tmpPos.z *= -1;


### PR DESCRIPTION
This is fixing a regression in the WebXR Hit Test implementation caused by a change to the Babylon implementation of Vector3 and Quaternion.  This code was incorrectly casting the a WebXR Transform's position and orientation properties directly to Babylon types, which do not fulfill the same class contract as the underlying member variables are named differently.  This used to work as the variables had identical naming. 

To fix this I'm simply changing the call from "copyFrom" to "set" and referencing the transform properties directly without casting.  I have tested this in the BabylonNative project and verified the fix works.  @RaananW If you could help me test this out in the web playground either by giving me some pointers for how to do this properly, or validating for me that would be great!