### PR TITLE
Added support for .glb file loading through a base64 encoded filename

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -102,6 +102,7 @@
 - Improved progress handling in glTF loader. ([bghgary](https://github.com/bghgary))
 - Use min/max values from position accessors (when available) to set the bounding box of meshes ([Popov72](https://github.com/Popov72))
 - Added missing "pluginExtension" parameter to SceneLoader.ImportAnimations. ([phenry20](https://github.com/phenry20))
+- Added support for .glb file loading through a base64 encoded filename ([Popov72](https://github.com/Popov72))
 
 ### Navigation
 

--- a/loaders/src/glTF/glTFFileLoader.ts
+++ b/loaders/src/glTF/glTFFileLoader.ts
@@ -637,13 +637,17 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
 
     /** @hidden */
     public canDirectLoad(data: string): boolean {
-        return (data.indexOf("asset") !== -1 && data.indexOf("version") !== -1) ||
-                StringTools.StartsWith(data, "data:base64," + GLTFFileLoader.magicBase64Encoded);
+        return (data.indexOf("asset") !== -1 && data.indexOf("version") !== -1)
+                || StringTools.StartsWith(data, "data:base64," + GLTFFileLoader.magicBase64Encoded)
+                || StringTools.StartsWith(data, "data:application/octet-stream;base64," + GLTFFileLoader.magicBase64Encoded)
+                || StringTools.StartsWith(data, "data:model/gltf-binary;base64," + GLTFFileLoader.magicBase64Encoded);
     }
 
     /** @hidden */
     public directLoad(scene: Scene, data: string): Promise<any> {
-        if (StringTools.StartsWith(data, "base64," + GLTFFileLoader.magicBase64Encoded)) {
+        if (StringTools.StartsWith(data, "base64," + GLTFFileLoader.magicBase64Encoded) ||
+            StringTools.StartsWith(data, "application/octet-stream;base64," + GLTFFileLoader.magicBase64Encoded) ||
+            StringTools.StartsWith(data, "model/gltf-binary;base64," + GLTFFileLoader.magicBase64Encoded)) {
             const arrayBuffer = Tools.DecodeBase64(data);
 
             this._validate(scene, arrayBuffer);

--- a/src/Loading/sceneLoader.ts
+++ b/src/Loading/sceneLoader.ts
@@ -420,6 +420,8 @@ export class SceneLoader {
             if (plugin.directLoad) {
                 plugin.directLoad(scene, directLoad).then((data) => {
                     onSuccess(plugin, data);
+                }).catch((error) => {
+                    onError("Error in directLoad of _loadData: " + error, error);
                 });
             } else {
                 onSuccess(plugin, directLoad);

--- a/src/Loading/sceneLoader.ts
+++ b/src/Loading/sceneLoader.ts
@@ -123,7 +123,7 @@ export interface ISceneLoaderPluginBase {
      * @param data string containing the data
      * @returns data to pass to the plugin
      */
-    directLoad?(scene: Scene, data: string): any;
+    directLoad?(scene: Scene, data: string): Promise<any>;
 
     /**
      * The callback that allows custom handling of the root url based on the response url.
@@ -417,7 +417,13 @@ export class SceneLoader {
         SceneLoader.OnPluginActivatedObservable.notifyObservers(plugin);
 
         if (directLoad) {
-            onSuccess(plugin, plugin.directLoad ? plugin.directLoad(scene, directLoad) : directLoad);
+            if (plugin.directLoad) {
+                plugin.directLoad(scene, directLoad).then((data) => {
+                    onSuccess(plugin, data);
+                });
+            } else {
+                onSuccess(plugin, directLoad);
+            }
             return plugin;
         }
 


### PR DESCRIPTION
See #5579 

It will make this PG work: https://playground.babylonjs.com/#7F6S08#15

I have checked that the `directLoad` signature change (it now returns a `Promise<any>` instead of a `any`) only impacts the glTF loader (not the .obj / .babylon ones.