### PR TITLE
[XR] View Matrix calculations

### DIFF
--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -118,6 +118,8 @@ export class WebXRCamera extends FreeCamera {
         return this._computedViewMatrix;
     }
 
+    private _rotate180 = new Quaternion(0, 1, 0, 0);
+
     private _updateFromXRSession() {
         const pose = this._xrSessionManager.currentFrame && this._xrSessionManager.currentFrame.getViewerPose(this._xrSessionManager.referenceSpace);
 
@@ -188,15 +190,8 @@ export class WebXRCamera extends FreeCamera {
                 currentRig.position.z *= -1;
                 currentRig.rotationQuaternion.z *= -1;
                 currentRig.rotationQuaternion.w *= -1;
-            }
-            if (view.transform.inverse) {
-                Matrix.FromFloat32ArrayToRefScaled(view.transform.inverse.matrix, 0, 1, currentRig._computedViewMatrix);
             } else {
-                Matrix.FromFloat32ArrayToRefScaled(view.transform.matrix, 0, 1, currentRig._computedViewMatrix);
-                currentRig._computedViewMatrix.invert();
-            }
-            if (!this._scene.useRightHandedSystem) {
-                currentRig._computedViewMatrix.toggleModelMatrixHandInPlace();
+                currentRig.rotationQuaternion.multiplyInPlace(this._rotate180);
             }
             Matrix.FromFloat32ArrayToRefScaled(view.projectionMatrix, 0, 1, currentRig._projectionMatrix);
 
@@ -230,10 +225,6 @@ export class WebXRCamera extends FreeCamera {
             newCamera.rigParent = this;
             // do not compute projection matrix, provided by XR
             newCamera.freezeProjectionMatrix();
-            // use the view matrix provided by XR
-            newCamera._getViewMatrix = function(): Matrix {
-                return this._computedViewMatrix;
-            };
             this.rigCameras.push(newCamera);
         }
         while (this.rigCameras.length > viewCount) {

--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -179,8 +179,11 @@ export class WebXRCamera extends FreeCamera {
                 }
             }
             // Update view/projection matrix
-            currentRig.position.copyFrom(view.transform.position);
-            currentRig.rotationQuaternion.copyFrom(view.transform.orientation);
+            const pos = view.transform.position;
+            const orientation = view.transform.orientation;
+
+            currentRig.position.set(pos.x, pos.y, pos.z);
+            currentRig.rotationQuaternion.set(orientation.x, orientation.y, orientation.z, orientation.w);
             if (!this._scene.useRightHandedSystem) {
                 currentRig.position.z *= -1;
                 currentRig.rotationQuaternion.z *= -1;


### PR DESCRIPTION
Addressing #8424 

When we calculate the view matrix we are doing some extra calculations (like the global position and the current target) that prevents us from using the WebXR view matrix directly.

To get right handed system to work I had to rotate the quaternion sent from the device Math.PI rads. 

Checked on Espilit using A windows MR device and the webxr emulator.

There might be a slight performance hit going back to calculating the view matrix on our own, but this is needed, as global position and target (the the _viewMatrix itself) are needed to correctly render the scene.  

I am leaving a TODO for me to see if we can change the targetcamera's architecture to fit XR needs, or maybe create a controlled rig camera type that only takes view matrix and projection matrix (coming from the XR frame itself).