### PR TITLE
Loud error handling

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -144,6 +144,7 @@
 - Full support for right handed scenes ([#8132](https://github.com/BabylonJS/Babylon.js/issues/8132)) ([RaananW](https://github.com/RaananW))
 - WebXR anchors feature implemented ([#7917](https://github.com/BabylonJS/Babylon.js/issues/7917)) ([RaananW](https://github.com/RaananW))
 - Canvas is being resized when entering XR ([RaananW](https://github.com/RaananW))
+- Added error alerts when XR fails ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/XR/features/WebXRAnchorSystem.ts
+++ b/src/XR/features/WebXRAnchorSystem.ts
@@ -340,7 +340,11 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
                 throw new Error(error);
             }
         } else {
-            throw new Error('Anchors are not enabled in your browser');
+            const error = 'Anchors not enabled in this browser. Enable it in chrome://flags';
+            if (!this._options.disableUserErrorAlerts) {
+                alert(error);
+            }
+            throw new Error(error);
         }
     }
 }

--- a/src/XR/features/WebXRAnchorSystem.ts
+++ b/src/XR/features/WebXRAnchorSystem.ts
@@ -21,6 +21,12 @@ export interface IWebXRAnchorSystemOptions {
      * If not defined, anchors will be removed from the array when the feature is detached or the session ended.
      */
     doNotRemoveAnchorsOnSessionEnded?: boolean;
+
+    /**
+     * Should alerts that something wrong has happened be disabled.
+     * This feature is using the alert() function! Disable it to error silently
+     */
+    disableUserErrorAlerts?: boolean;
 }
 
 /**
@@ -155,7 +161,11 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         const m = new XRRigidTransform({x: this._tmpVector.x, y: this._tmpVector.y, z: this._tmpVector.z},
                                        {x: this._tmpQuaternion.x, y: this._tmpQuaternion.y, z: this._tmpQuaternion.z, w: this._tmpQuaternion.w});
         if (!hitTestResult.xrHitResult.createAnchor) {
-            throw new Error('Anchors not enabled in this browsed. Add "anchors" to optional features');
+            const error = 'Anchors not enabled in this browser. Enable it in chrome://flags';
+            if (!this._options.disableUserErrorAlerts) {
+                alert(error);
+            }
+            throw new Error(error + ' and make sure to add it in the optionalFeatures of the xr session');
         } else {
             try {
                 return hitTestResult.xrHitResult.createAnchor(m);

--- a/src/XR/features/WebXRHitTest.ts
+++ b/src/XR/features/WebXRHitTest.ts
@@ -32,6 +32,12 @@ export interface IWebXRHitTestOptions extends IWebXRLegacyHitTestOptions {
      * Instead of using viewer space for hit tests, use the reference space defined in the session manager
      */
     useReferenceSpace?: boolean;
+
+    /**
+     * Should alerts that something wrong has happened be disabled.
+     * This feature is using the alert() function! Disable it to error silently
+     */
+    disableUserErrorAlerts?: boolean;
 }
 
 /**
@@ -88,6 +94,9 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
             Tools.Warn('waiting for viewer reference space to initialize');
             return;
         }
+        if (!this.options.disableUserErrorAlerts && !this._xrSessionManager.session.requestHitTestSource) {
+            alert('hit-tests are not available in this browser.');
+        }
         this._xrSessionManager.session.requestHitTestSource(options).then((hitTestSource) => {
             if (this._xrHitTestSource) {
                 this._xrHitTestSource.cancel();
@@ -133,7 +142,7 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
          */
         public readonly options: IWebXRHitTestOptions = {}) {
         super(_xrSessionManager);
-        Tools.Warn('Hit test is an experimental and unstable feature. make sure you enable optionalFeatures when creating the XR session');
+        Tools.Warn('Hit test is an experimental feature. make sure you enable optionalFeatures when creating the XR session');
     }
 
     /**

--- a/src/XR/webXREnterExitUI.ts
+++ b/src/XR/webXREnterExitUI.ts
@@ -58,6 +58,12 @@ export class WebXREnterExitUIOptions {
      * A list of optional features to init the session with
      */
     optionalFeatures?: string[];
+
+    /**
+     * An alert using the alert() function will be displayed for the user when XR or this session mode is not available.
+     * Use this to error silently
+     */
+    disableUserErrorAlerts?: boolean;
 }
 /**
  * UI to allow the user to enter/exit XR mode
@@ -164,14 +170,22 @@ export class WebXREnterExitUI implements IDisposable {
                                     ui._updateButtons(null);
                                     const element = ui._buttons[i].element;
                                     const prevTitle = element.title;
-                                    element.title = "Error entering XR session : " + prevTitle;
+                                    const error = "Error entering WebXR session : " + prevTitle;
+                                    if (!options.disableUserErrorAlerts) {
+                                        alert(error);
+                                    }
+                                    element.title = error;
                                     element.classList.add("xr-error");
                                 }
                             }
                         }
                     };
                 } else {
-                    Tools.Warn(`Session mode "${ui._buttons[i].sessionMode}" not supported in browser`);
+                    const error = `WebXR Session mode "${ui._buttons[i].sessionMode}" is not supported in this browser`;
+                    if (!options.disableUserErrorAlerts) {
+                        alert(error);
+                    }
+                    Tools.Warn(error);
                 }
             });
             return ui;

--- a/src/XR/webXREnterExitUI.ts
+++ b/src/XR/webXREnterExitUI.ts
@@ -163,6 +163,9 @@ export class WebXREnterExitUI implements IDisposable {
                         } else if (helper.state == WebXRState.NOT_IN_XR) {
                             if (options.renderTarget) {
                                 try {
+                                    const element = ui._buttons[i].element;
+                                    element.title = `${ui._buttons[i].sessionMode} - ${ui._buttons[i].referenceSpaceType}`;
+                                    element.classList.remove("xr-error");
                                     await helper.enterXRAsync(ui._buttons[i].sessionMode, ui._buttons[i].referenceSpaceType, options.renderTarget, {optionalFeatures: options.optionalFeatures});
                                     ui._updateButtons(ui._buttons[i]);
                                 } catch (e) {
@@ -172,7 +175,7 @@ export class WebXREnterExitUI implements IDisposable {
                                     const prevTitle = element.title;
                                     const error = "Error entering WebXR session : " + prevTitle;
                                     if (!options.disableUserErrorAlerts) {
-                                        alert(error);
+                                        alert(error + '. Please make sure your browser supports WebXR.');
                                     }
                                     element.title = error;
                                     element.classList.add("xr-error");

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -61,16 +61,18 @@ export class WebXRExperienceHelper implements IDisposable {
      * @param scene the scene to attach the experience helper to
      * @returns a promise for the experience helper
      */
-    public static CreateAsync(scene: Scene): Promise<WebXRExperienceHelper> {
+    public static async CreateAsync(scene: Scene): Promise<WebXRExperienceHelper> {
         var helper = new WebXRExperienceHelper(scene);
-        return helper.sessionManager.initializeAsync().then(() => {
+        try {
+            await helper.sessionManager.initializeAsync();
             helper._supported = true;
             return helper;
-        }).catch((e) => {
+        }
+        catch (e) {
             helper._setState(WebXRState.NOT_IN_XR);
             helper.dispose();
             throw e;
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
Browser alerts will be shown on major XR errors (like missing features or when XR cannot be initialized).

This can be disabled during initialization (on per default).