### PR TITLE
[XR] Babylon calculates the view matrix of the main camera

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -144,6 +144,7 @@
 - Full support for right handed scenes ([#8132](https://github.com/BabylonJS/Babylon.js/issues/8132)) ([RaananW](https://github.com/RaananW))
 - WebXR anchors feature implemented ([#7917](https://github.com/BabylonJS/Babylon.js/issues/7917)) ([RaananW](https://github.com/RaananW))
 - Canvas is being resized when entering XR ([RaananW](https://github.com/RaananW))
+- All camera view matrices are now calculated by Babylon to support left and right handed systems ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -111,13 +111,6 @@ export class WebXRCamera extends FreeCamera {
         return "WebXRCamera";
     }
 
-    /**
-     * Overriding the _getViewMatrix function, as it is computed by WebXR
-     */
-    public _getViewMatrix(): Matrix {
-        return this._computedViewMatrix;
-    }
-
     private _rotate180 = new Quaternion(0, 1, 0, 0);
 
     private _updateFromXRSession() {
@@ -153,15 +146,6 @@ export class WebXRCamera extends FreeCamera {
                 // update position and rotation as reference
                 this.rotationQuaternion.copyFrom(this._referenceQuaternion);
                 this.position.copyFrom(this._referencedPosition);
-                if (pose.transform.inverse) {
-                    Matrix.FromFloat32ArrayToRefScaled(pose.transform.inverse.matrix, 0, 1, this._computedViewMatrix);
-                } else {
-                    Matrix.FromFloat32ArrayToRefScaled(pose.transform.matrix, 0, 1, this._computedViewMatrix);
-                    this._computedViewMatrix.invert();
-                }
-                if (!this._scene.useRightHandedSystem) {
-                    this._computedViewMatrix.toggleModelMatrixHandInPlace();
-                }
             }
         }
 


### PR DESCRIPTION
Starting now, Babylon will calculate all view matrices for the 3 WebXR cameras (main and two rendering cameras).

I will further investigate how we can use the view matrices provided by the browser directly to save the few computations done. For the time being it will stay like this.