### PR TITLE
Stop animation and other bugs

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -9,7 +9,7 @@
 - Reflection probes can now be used to give accurate shading with PBR ([CraigFeldpsar](https://github.com/craigfeldspar) and ([Sebavan](https://github.com/sebavan/)))
 - Added SubSurfaceScattering on PBR materials ([CraigFeldpsar](https://github.com/craigfeldspar) and ([Sebavan](https://github.com/sebavan/)))
 - Added editing of PBR materials, Post processes and Particle fragment shaders in the node material editor ([Popov72](https://github.com/Popov72))
-- Added Curve editor to manage entity's animations and edit animation groups in Inspector ([pixelspace](https://github.com/devpixelspace))
+- Added Curve editor to manage selected entity's animations and edit animation groups in Inspector ([pixelspace](https://github.com/devpixelspace))
 - Added support in `ShadowGenerator` for fast fake soft transparent shadows ([Popov72](https://github.com/Popov72))
 - Added support for **thin instances** for faster mesh instances. [Doc](https://doc.babylonjs.com/how_to/how_to_use_thininstances) ([Popov72](https://github.com/Popov72))
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/addAnimation.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/addAnimation.tsx
@@ -376,15 +376,14 @@ export class AddAnimation extends React.Component<
                 onChange={(e) => this.handleTypeChange(e)}
                 value={this.state.animationType}
               >
+                <option value={Animation.ANIMATIONTYPE_COLOR3}>Color3</option>
+                <option value={Animation.ANIMATIONTYPE_COLOR4}>Color4</option>
                 <option value={Animation.ANIMATIONTYPE_FLOAT}>Float</option>
                 <option value={Animation.ANIMATIONTYPE_VECTOR3}>Vector3</option>
                 <option value={Animation.ANIMATIONTYPE_VECTOR2}>Vector2</option>
                 <option value={Animation.ANIMATIONTYPE_QUATERNION}>
                   Quaternion
                 </option>
-                <option value={Animation.ANIMATIONTYPE_COLOR3}>Color3</option>
-                <option value={Animation.ANIMATIONTYPE_COLOR4}>Color4</option>
-                <option value={Animation.ANIMATIONTYPE_SIZE}>Size</option>
               </select>
             </div>
           )}

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationCurveEditorComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationCurveEditorComponent.tsx
@@ -715,8 +715,8 @@ export class AnimationCurveEditorComponent extends React.Component<
 
       if (currentAnimation.dataType === Animation.ANIMATIONTYPE_FLOAT) {
         let keys = currentAnimation.getKeys();
-        let x = this.state.currentFrame;
-        let y = this.state.currentValue;
+        let x = this.state.actionableKeyframe.frame;
+        let y = this.state.actionableKeyframe.value;
 
         keys.push({ frame: x, value: y, inTangent: 0, outTangent: 0 });
         keys.sort((a, b) => a.frame - b.frame);
@@ -1104,18 +1104,6 @@ export class AnimationCurveEditorComponent extends React.Component<
           : this.getValueAsArray(type, key.outTangent)[coordinate];
 
       let y = this._heightScale - keyframe_valueAsArray * middle;
-
-      let nextKeyframe = keyframes[i + 1];
-      let prevKeyframe = keyframes[i - 1];
-      if (nextKeyframe !== undefined) {
-        let distance = keyframes[i + 1].frame - key.frame;
-        defaultWeight = distance * 1; // Adjust for scaled
-      }
-
-      if (prevKeyframe !== undefined) {
-        let distance = key.frame - keyframes[i - 1].frame;
-        defaultWeight = distance * 1; // Adjust for scaled
-      }
 
       if (inT !== null) {
         let valueIn = y * inT + y;

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor.scss
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor.scss
@@ -497,18 +497,6 @@
           outline: solid 1px #ccc;
         }
       }
-      &.frame-input {
-        input::-webkit-outer-spin-button,
-        input::-webkit-inner-spin-button {
-          -webkit-appearance: none;
-          margin: 0;
-        }
-
-        /* Firefox */
-        input[type='number'] {
-          -moz-appearance: textfield;
-        }
-      }
     }
   }
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/graphActionsBar.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/graphActionsBar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { IconButtonLineComponent } from '../../../lines/iconButtonLineComponent';
+import { IActionableKeyFrame } from './animationCurveEditorComponent';
 
 interface IGraphActionsBarProps {
   addKeyframe: () => void;
@@ -11,8 +12,7 @@ interface IGraphActionsBarProps {
   setLerpMode: () => void;
   brokenMode: boolean;
   lerpMode: boolean;
-  currentValue: number;
-  currentFrame: number;
+  actionableKeyframe: IActionableKeyFrame;
   title: string;
   close: (event: any) => void;
   enabled: boolean;
@@ -37,17 +37,17 @@ export class GraphActionsBar extends React.Component<IGraphActionsBarProps> {
           <div className='action-input frame-input'>
             <input
               type='number'
-              readOnly
-              value={this.props.currentFrame}
+              onChange={this.props.handleFrameChange}
+              value={this.props.actionableKeyframe.frame}
               step='1'
             />
           </div>
           <div className='action-input'>
             <input
               type='number'
-              value={this.props.currentValue}
+              value={this.props.actionableKeyframe.value}
               onChange={this.props.handleValueChange}
-              step='0.1'
+              step='0.01'
             />
           </div>
           <IconButtonLineComponent


### PR DESCRIPTION
Hi! 😃 

This PR addresses the following bugs in issue #8478 

1. Frame Input should not reposition Playhead. (The input now indicates the frame to put a keyframe or edit the value)
2. Connect the value box to Playhead change. (When value changes in value input the keyframe updates its value)

The following even though they stop the animation because the bug on playing the animation still feels weird. So I think the best option is to fix the play animation bug in the next PR.

3. Stop animation on Loop button click (The animation stops on clicking the loop button or changing frames per second. 
The weird play animation bug is still there.
4. Stop animation after clicking Playhead. (The weird play animation bug is still there)

These we low hanging fruits to solve.

5. Remove Size animation type on "create a new animation". (Also reorder the list alphabetically)
6. Graph action controls hide sometimes. Should be visible all times (Used to be hidden, now only disabled if there is not animation selected)
