### PR TITLE
Add groundBuilder's import

### DIFF
--- a/readme-es6.md
+++ b/readme-es6.md
@@ -55,6 +55,7 @@ import "@babylonjs/core/Materials/standardMaterial";
 // Side-effects only imports allowing Mesh to create default shapes (to enhance tree shaking, the construction methods on mesh are not available if the meshbuilder has not been imported).
 import "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import "@babylonjs/core/Meshes/Builders/boxBuilder";
+import "@babylonjs/core/Meshes/Builders/groundBuilder";
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 const engine = new Engine(canvas);


### PR DESCRIPTION
If we just copy&run the example without import the groundBuilder that will throw MeshBuilder exception.