### PR TITLE
Comment clarification

### DIFF
--- a/src/Maths/math.path.ts
+++ b/src/Maths/math.path.ts
@@ -84,9 +84,9 @@ export class Angle {
     }
 
     /**
-     * Gets a new Angle object valued with the angle value in radians between the two given vectors
-     * @param a defines first vector
-     * @param b defines second vector
+     * Gets a new Angle object valued with the gradient angle, in radians, of the line joining two points
+     * @param a defines first point as the origin
+     * @param b defines point
      * @returns a new Angle
      */
     public static BetweenTwoPoints(a: DeepImmutable<Vector2>, b: DeepImmutable<Vector2>): Angle {


### PR DESCRIPTION
The comment, as it stands, referring to _between the two given vectors_ does not describe correctly the purpose of the method. It has, and does, cause confusion, for example https://www.babylonjs-playground.com/#0RYA8I#4 from https://forum.babylonjs.com/t/rotation-of-connected-object/12043/11?u=johnk

After discussion that led to me clearing up my own confusion, https://forum.babylonjs.com/t/angle-object-anglebetweentwopoints-is-wrong/12348/9?u=johnk I suggest the PR to change the comment only.

