### PR TITLE
InputManager: Fix writing to the pointerId readonly property when it exists

### DIFF
--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -608,7 +608,9 @@ export class InputManager {
 
         this._onPointerMove = (evt: PointerEvent) => {
             // preserve compatibility with Safari when pointerId is not present
-            (evt as any).pointerId = evt.pointerId ?? 0;
+            if ((evt as any).pointerId === undefined) {
+                (evt as any).pointerId = 0;
+            }
 
             this._updatePointerPosition(evt);
 
@@ -637,7 +639,9 @@ export class InputManager {
             this._meshPickProceed = false;
 
             // preserve compatibility with Safari when pointerId is not present
-            (evt as any).pointerId = evt.pointerId ?? 0;
+            if ((evt as any).pointerId === undefined) {
+                (evt as any).pointerId = 0;
+            }
 
             this._updatePointerPosition(evt);
 
@@ -684,7 +688,9 @@ export class InputManager {
             this._meshPickProceed = false;
 
             // preserve compatibility with Safari when pointerId is not present
-            (evt as any).pointerId = evt.pointerId ?? 0;
+            if ((evt as any).pointerId === undefined) {
+                (evt as any).pointerId = 0;
+            }
 
             this._updatePointerPosition(evt);
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/event-has-no-pointerid-in-4-2-0-alpha-27/12971/12