### PR TITLE
Delete Objects in Scene Explorer with the Delete Key

### DIFF
--- a/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -215,7 +215,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
             }
             keyEvent.preventDefault();
             return;
-        } else if(keyEvent.keyCode === 46) { // delete
+        } else if (keyEvent.keyCode === 46) { // delete
             this.state.selectedEntity.dispose();
         }
 

--- a/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -453,7 +453,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
     render() {
         if (this.props.popupMode) {
             return (
-                <div id="sceneExplorer">
+                <div id="sceneExplorer" tabIndex={0} onKeyDown={(keyEvent) => this.processKeys(keyEvent)}>
                     {
                         !this.props.noHeader &&
                         <HeaderComponent title="SCENE EXPLORER" noClose={this.props.noClose} noExpand={this.props.noExpand} noCommands={this.props.noCommands} onClose={() => this.onClose()} onPopup={() => this.onPopup()} />

--- a/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -215,6 +215,8 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
             }
             keyEvent.preventDefault();
             return;
+        } else if(keyEvent.keyCode === 46) { // delete
+            this.state.selectedEntity.dispose();
         }
 
         if (!search) {


### PR DESCRIPTION
Be able to delete an object in the scene explorer with the delete key when it is focused. Also fixed a bug relating to the key input not registering in the inspector in playground.

https://github.com/BabylonJS/Babylon.js/issues/8646#issue-669201642