### PR TITLE
Immediately set the _sessionEnded to guard against multiple calls to dispose

### DIFF
--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -109,8 +109,9 @@ export class WebXRSessionManager implements IDisposable {
      */
     public exitXRAsync() {
         if (this.session && !this._sessionEnded) {
+            this._sessionEnded = true;
             return this.session.end().catch((e) => {
-                Logger.Warn("could not end XR session. It has ended already.");
+                Logger.Warn("Could not end XR session.");
             });
         }
         return Promise.resolve();


### PR DESCRIPTION
One part of my code manages the lifetime of an `Engine` instance, and another part of my code manages lifetimes of `WebXRDefaultExperience` instances. When I leave the "page" (testing in a React Native app), both the `Engine` and the `WebXRDefaultExperience` get disposed, but disposing the `Engine` ultimately leads to the `WebXRDefaultExperience` also getting disposed, so its `dispose` method gets called twice. Since `_sessionEnded` does not get set synchronously (it is only set on the `ended` event from the XR session), it ends up calling `end` twice on the session. To prevent this, the change I'm making here is to just set `_sessionEnded` synchronously in the `exitXRAsync` method. Since really what I'm trying to prevent here is a double dispose, I could also add a `disposed` private property, but I was hesitant to add more state to the class if it can be avoided (more state == more opportunity for bugs!). I also changed the warning message if the `end` function throws an exception since before it assumed a failure meant calling `end` after a session has already ended.