### PR TITLE
Changed the way the detail map and base material roughness are blended

### DIFF
--- a/src/Materials/material.detailMapConfiguration.ts
+++ b/src/Materials/material.detailMapConfiguration.ts
@@ -44,14 +44,14 @@ export class DetailMapConfiguration {
      * Bigger values mean stronger blending
      */
     @serialize()
-    public diffuseBlendLevel = 0.5;
+    public diffuseBlendLevel = 1;
 
     /**
      * Defines how strongly the detail roughness channel is blended with the regular roughness value
      * Bigger values mean stronger blending. Only used with PBR materials
      */
     @serialize()
-    public roughnessBlendLevel = 0.5;
+    public roughnessBlendLevel = 1;
 
     /**
      * Defines how strong the bump effect from the detail map is

--- a/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
@@ -73,8 +73,10 @@ void reflectivityBlock(
         #endif
 
         #ifdef DETAIL
-            float detailRoughness = 2.0 * mix(0.5, detailColor.b, vDetailInfos.w);
-            metallicRoughness.g = saturate(metallicRoughness.g * detailRoughness);
+            float detailRoughness = mix(0.5, detailColor.b, vDetailInfos.w);
+            float loLerp = mix(0., metallicRoughness.g, detailRoughness * 2.);
+            float hiLerp = mix(metallicRoughness.g, 1., (detailRoughness - 0.5) * 2.);
+            metallicRoughness.g = mix(loLerp, hiLerp, step(detailRoughness, 0.5));
         #endif
 
         #ifdef MICROSURFACEMAP


### PR DESCRIPTION
After some discussions with @PatrickRyanMS, I changed the way the detail map and base material roughness are blended according to:

https://nme.babylonjs.com/#UQJGP8#1
