### PR TITLE
Update RayHelper to Mesh in Physics loop and make renderLine not pickable

### DIFF
--- a/src/Debug/rayHelper.ts
+++ b/src/Debug/rayHelper.ts
@@ -72,6 +72,7 @@ export class RayHelper {
             this._scene = scene;
             this._renderPoints = [ray.origin, ray.origin.add(ray.direction.scale(ray.length))];
             this._renderLine = Mesh.CreateLines("ray", this._renderPoints, scene, true);
+            this._renderLine.isPickable = false;
 
             if (this._renderFunction) {
                 this._scene.registerBeforeRender(this._renderFunction);
@@ -171,6 +172,7 @@ export class RayHelper {
         if (!this._updateToMeshFunction) {
             this._updateToMeshFunction = (<() => void>this._updateToMesh.bind(this));
             this._attachedToMesh.getScene().registerBeforeRender(this._updateToMeshFunction);
+            this._attachedToMesh.getScene().onAfterStepObservable.add(this._updateToMeshFunction);
         }
 
         // force world matrix computation before the first ray helper computation


### PR DESCRIPTION
RayHelper is currently updated to Mesh in scene.registerBeforeRender but not in the physics loop, e.g. onAfterStepObservable. This causes the RayHelper to lag behind the mesh in the physics loop, even if computeWorldMatrix(true) is called on the mesh in the physics loop.

The _renderLine was also made not pickable. Currently, if the RayHelper is showing, its visible line is pickable. In the case of rapid firing bullets with RayHelpers, pick hits will be registered on the RayHelper visible line.

We may also consider adding this line as well:
this._attachedToMesh.getScene().onAfterPhysicsObservable.add(this._updateToMeshFunction);