### PR TITLE
glTF loader: rework for the loadAllMaterials property

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -194,7 +194,7 @@ export class MSFT_lod implements IGLTFLoaderExtension {
     }
 
     /** @hidden */
-    public _loadMaterialAsync(context: string, material: IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
+    public _loadMaterialAsync(context: string, material: IMaterial, babylonMesh: Nullable<Mesh>, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>> {
         // Don't load material LODs if already loading a node LOD.
         if (this._nodeIndexLOD) {
             return null;

--- a/loaders/src/glTF/2.0/glTFLoaderExtension.ts
+++ b/loaders/src/glTF/2.0/glTFLoaderExtension.ts
@@ -82,7 +82,7 @@ export interface IGLTFLoaderExtension extends IGLTFBaseLoaderExtension, IDisposa
      * @param assign A function called synchronously after parsing the glTF properties
      * @returns A promise that resolves with the loaded Babylon material when the load is complete or null if not handled
      */
-    _loadMaterialAsync?(context: string, material: IMaterial, babylonMesh: Mesh, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>>;
+    _loadMaterialAsync?(context: string, material: IMaterial, babylonMesh: Nullable<Mesh>, babylonDrawMode: number, assign: (babylonMaterial: Material) => void): Nullable<Promise<Material>>;
 
     /**
      * Define this method to modify the default behavior when creating materials.


### PR DESCRIPTION
See #8680 

Following discussion with @bghgary, I have factorized the code.

Also, I have tested with a gltf file using the MSFT_load extension and I think the behaviour when the extension is applied to a standalone material (meaning not used by any mesh) is ok: all the lods are created at first, but because they are successively removed by the lod extension, only the highest lod remains in the end.