### PR TITLE
Check Event Type Touch input Camera

### DIFF
--- a/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -54,7 +54,8 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             this._pointerInput = (p) => {
                 var evt = <PointerEvent>p.event;
 
-                if (evt.pointerType === "mouse") {
+                let isMouseEvent = evt instanceof MouseEvent;
+                if (evt.pointerType === "mouse" || isMouseEvent) {
                     return;
                 }
 


### PR DESCRIPTION
This is a fix for https://forum.babylonjs.com/t/move-forward-in-universal-camera-not-working-in-chrome/13121/6
On Safari with a Universal Camera, mouse event are treated like touch input. So when you click and drag, instead of rotating the camera, il also translates the camera.
I fixed it by checking the instance type of the event. It worked for me but this is typically the kind of fix that breaks multiple things down the line.
