### PR TITLE
Remove Nullable<number> from DeviceSourceManager contracts

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -39,6 +39,7 @@
 - Force compute world matrix of the newly-attached mesh of a ray helper ([RaananW](https://github.com/RaananW))
 - Allow 180 monoscopic videos on top of the video dome ([#8575](https://github.com/BabylonJS/Babylon.js/issues/8575)) ([RaananW](https://github.com/RaananW))
 - Added `AssetContainerTask` support to `AssetsManager` class ([MackeyK24](https://github.com/MackeyK24))
+- Changed DeviceSourceManager getInput contract to no longer return nullable values ([Drigax](https://github.com/drigax))
 
 ### Engine
 

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -29,7 +29,7 @@ export class DeviceInputSystem implements IDisposable {
     public onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>) => void;
 
     // Private Members
-    private _inputs: Array<Array<Array<Nullable<number>>>> = [];
+    private _inputs: Array<Array<Array<number>>> = [];
     private _gamepads: Array<DeviceType>;
     private _keyboardActive: boolean = false;
     private _pointerActive: boolean = false;
@@ -81,13 +81,13 @@ export class DeviceInputSystem implements IDisposable {
      */
 
     /**
-     * Checks for current device input value, given an id and input index
+     * Checks for current device input value, given an id and input index. Throws exception if requested device not initialized.
      * @param deviceType Enum specifiying device type
      * @param deviceSlot "Slot" or index that device is referenced in
      * @param inputIndex Id of input to be checked
      * @returns Current value of input
      */
-    public pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): Nullable<number> {
+    public pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): number {
         const device = this._inputs[deviceType][deviceSlot];
 
         if (!device) {
@@ -138,10 +138,10 @@ export class DeviceInputSystem implements IDisposable {
         }
 
         if (!this._inputs[deviceType][deviceSlot]) {
-            const device = new Array<Nullable<number>>(numberOfInputs);
+            const device = new Array<number>(numberOfInputs);
 
             for (let i = 0; i < numberOfInputs; i++) {
-                device[i] = null;
+                device[i] = 0; /* set device input as unpressed */
             }
 
             this._inputs[deviceType][deviceSlot] = device;

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -209,6 +209,9 @@ export class DeviceInputSystem implements IDisposable {
             if (!this._inputs[deviceType][deviceSlot]) {
                 this._pointerActive = true;
                 this._registerDevice(deviceType, deviceSlot, DeviceInputSystem._MAX_POINTER_INPUTS);
+                const pointer = this._inputs[deviceType][deviceSlot]; /* initalize our pointer position immediately after registration */
+                pointer[0] = evt.clientX;
+                pointer[1] = evt.clientY;
             }
 
             const pointer = this._inputs[deviceType][deviceSlot];
@@ -233,6 +236,9 @@ export class DeviceInputSystem implements IDisposable {
             if (!this._inputs[deviceType][deviceSlot]) {
                 this._pointerActive = true;
                 this._registerDevice(deviceType, deviceSlot, DeviceInputSystem._MAX_POINTER_INPUTS);
+                const pointer = this._inputs[deviceType][deviceSlot]; /* initalize our pointer position immediately after registration */
+                pointer[0] = evt.clientX;
+                pointer[1] = evt.clientY;
             }
 
             const pointer = this._inputs[deviceType][deviceSlot];


### PR DESCRIPTION
This PR follows up on my observations in: 
https://forum.babylonjs.com/t/devicesource-initializes-inputs-to-null/12961/2

In short, for event-driven input devices such as a keyboard, we initialize the inputs of this device as `null` This behavior doesnt seem to make sense, if we consider an input as either expressed or not, `null` would suggest an invalid value.

This PR proposes to remove null from our contract, requesting an input value should now always return a `number` value