### PR TITLE
Deactive sliders when canvas loses focus

### DIFF
--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -236,7 +236,7 @@
 - Added `ScrollViewer.freezeControls` property to speed up rendering ([Popov72](https://github.com/Popov72))
 - Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user rotate the pictures when in vertical mode ([Popov72](https://github.com/Popov72))
 - Modified isPointerBlocker to block mouse wheel scroll events. ScrollViewer mouse scroll no longer dependent on scene. ([lockphase](https://github.com/lockphase/))
-- Added `_onCanvasBlur` event for controls to detect when the canvas loses focus. Fixes bug where sliders would become stuck when canvas lost focus. ([DarraghBurkeMS](https://github.com/DarraghBurkeMS))
+- Added `_onCanvasBlur` event for controls to detect when the canvas loses focus. Fixes bug where sliders and color pickers would become stuck when canvas lost focus. ([DarraghBurkeMS](https://github.com/DarraghBurkeMS))
 
 ### Particles
 

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -236,6 +236,7 @@
 - Added `ScrollViewer.freezeControls` property to speed up rendering ([Popov72](https://github.com/Popov72))
 - Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user rotate the pictures when in vertical mode ([Popov72](https://github.com/Popov72))
 - Modified isPointerBlocker to block mouse wheel scroll events. ScrollViewer mouse scroll no longer dependent on scene. ([lockphase](https://github.com/lockphase/))
+- Added `_onCanvasBlur` event for GUI controls to detect when the canvas has lost focus ([DarraghBurkeMS](https://github.com/DarraghBurkeMS))
 
 ### Particles
 

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -236,7 +236,7 @@
 - Added `ScrollViewer.freezeControls` property to speed up rendering ([Popov72](https://github.com/Popov72))
 - Added `ImageScrollBar.num90RotationInVerticalMode` property to let the user rotate the pictures when in vertical mode ([Popov72](https://github.com/Popov72))
 - Modified isPointerBlocker to block mouse wheel scroll events. ScrollViewer mouse scroll no longer dependent on scene. ([lockphase](https://github.com/lockphase/))
-- Added `_onCanvasBlur` event for GUI controls to detect when the canvas has lost focus ([DarraghBurkeMS](https://github.com/DarraghBurkeMS))
+- Added `_onCanvasBlur` event for controls to detect when the canvas loses focus. Fixes bug where sliders would become stuck when canvas lost focus. ([DarraghBurkeMS](https://github.com/DarraghBurkeMS))
 
 ### Particles
 

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -56,6 +56,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _pointerMoveObserver: Nullable<Observer<PointerInfoPre>>;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _canvasPointerOutObserver: Nullable<Observer<PointerEvent>>;
+    private _canvasBlurObserver: Nullable<Observer<Engine>>;
     private _background: string;
     /** @hidden */
     public _rootContainer = new Container("root");
@@ -480,6 +481,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (this._canvasPointerOutObserver) {
             scene.getEngine().onCanvasPointerOutObservable.remove(this._canvasPointerOutObserver);
         }
+        if (this._canvasBlurObserver) {
+            scene.getEngine().onCanvasBlurObservable.remove(this._canvasBlurObserver);
+        }
         if (this._layerToDispose) {
             this._layerToDispose.texture = null;
             this._layerToDispose.dispose();
@@ -741,6 +745,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             }
         });
         this._attachToOnPointerOut(scene);
+        this._attachToOnBlur(scene);
     }
     /** @hidden */
     private onClipboardCopy = (rawEvt: Event) => {
@@ -838,6 +843,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         });
         mesh.enablePointerMoveEvents = supportPointerMove;
         this._attachToOnPointerOut(scene);
+        this._attachToOnBlur(scene);
     }
     /**
     * Move the focus to a specific control
@@ -875,6 +881,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 delete this._lastControlDown[pointerEvent.pointerId];
             }
         });
+    }
+    private _attachToOnBlur(scene: Scene): void {
+        this._canvasBlurObserver = scene.getEngine().onCanvasBlurObservable.add((pointerEvent) => {
+            this._lastPickedControl._onCanvasBlur();
+        })
     }
     // Statics
     /**

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -884,7 +884,10 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     }
     private _attachToOnBlur(scene: Scene): void {
         this._canvasBlurObserver = scene.getEngine().onCanvasBlurObservable.add((pointerEvent) => {
-            this._lastPickedControl._onCanvasBlur();
+            Object.entries(this._lastControlDown).forEach(([key, value]) => {
+                value._onCanvasBlur();
+            });
+            this._lastControlDown = {};
         });
     }
     // Statics

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -885,7 +885,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _attachToOnBlur(scene: Scene): void {
         this._canvasBlurObserver = scene.getEngine().onCanvasBlurObservable.add((pointerEvent) => {
             this._lastPickedControl._onCanvasBlur();
-        })
+        });
     }
     // Statics
     /**

--- a/gui/src/2D/controls/colorpicker.ts
+++ b/gui/src/2D/controls/colorpicker.ts
@@ -434,6 +434,11 @@ export class ColorPicker extends Control {
         super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
     }
 
+    public _onCanvasBlur() {
+        this._forcePointerUp();
+        super._onCanvasBlur();
+    }
+
     /**
      * This function expands the color picker by creating a color picker dialog with manual
      * color value input and the ability to save colors into an array to be used later in

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1854,14 +1854,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _onCanvasBlur(): void {
-        if (!this._isEnabled) {
-            return;
-        }
-        this._downCount = 0;
-
-        this._downPointerIds = {};
-    }
+    public _onCanvasBlur(): void {}
 
     /** @hidden */
     public _processObservables(type: number, x: number, y: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1854,6 +1854,16 @@ export class Control {
     }
 
     /** @hidden */
+    public _onCanvasBlur(): void {
+        if (!this._isEnabled) {
+            return;
+        }
+        this._downCount = 0;
+
+        this._downPointerIds = {};
+    }
+
+    /** @hidden */
     public _processObservables(type: number, x: number, y: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
         if (!this._isEnabled) {
             return false;

--- a/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/gui/src/2D/controls/sliders/baseSlider.ts
@@ -326,4 +326,11 @@ export class BaseSlider extends Control {
         delete this._host._capturingControl[pointerId];
         super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
     }
+
+    public _onCanvasBlur(): void {
+        this._pointerIsDown = false;
+        this._host._capturingControl = {};
+        super._onCanvasBlur();
+    }
+
 }

--- a/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/gui/src/2D/controls/sliders/baseSlider.ts
@@ -328,8 +328,7 @@ export class BaseSlider extends Control {
     }
 
     public _onCanvasBlur(): void {
-        this._pointerIsDown = false;
-        this._host._capturingControl = {};
+        this._forcePointerUp();
         super._onCanvasBlur();
     }
 


### PR DESCRIPTION
Adds an _onCanvasBlur() function that GUI controls can override, which handles canvas blurring events. For all controls, it sets downCount to 0, since no control should think the pointer is still down if the canvas has lost focus. Fixes #8719 by deactivating a slider when the canvas is blurred.