### PR TITLE
Make the outline renderer work for thin instances

### DIFF
--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -185,7 +185,6 @@ export class OutlineRenderer implements ISceneComponent {
         this._effect.setMatrix("viewProjection", scene.getTransformMatrix());
         this._effect.setMatrix("world", effectiveMesh.getWorldMatrix());
 
-
         // Bones
         if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {
             this._effect.setMatrices("mBones", renderingMesh.skeleton.getTransformMatrices(renderingMesh));

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -183,6 +183,8 @@ export class OutlineRenderer implements ISceneComponent {
         this._effect.setFloat("offset", useOverlay ? 0 : renderingMesh.outlineWidth);
         this._effect.setColor4("color", useOverlay ? renderingMesh.overlayColor : renderingMesh.outlineColor, useOverlay ? renderingMesh.overlayAlpha : material.alpha);
         this._effect.setMatrix("viewProjection", scene.getTransformMatrix());
+        this._effect.setMatrix("world", effectiveMesh.getWorldMatrix());
+
 
         // Bones
         if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/weekly-video-faster-scenes-and-smaller-scene-graphs-with-thin-instances/12825/6