### PR TITLE
PointerDragBehavior: Fix potential recursive calls

### DIFF
--- a/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -246,8 +246,8 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      */
     public releaseDrag() {
         if (this.dragging) {
-            this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerID });
             this.dragging = false;
+            this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerID });
         }
 
         this.currentDraggingPointerID = -1;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/mesh-dispose-generates-an-error-when-called-from-pointerdragbehavior-ondragendobservable/13442/5