### PR TITLE
GUI image: fix cache issue with "contains" method

### DIFF
--- a/gui/src/2D/controls/image.ts
+++ b/gui/src/2D/controls/image.ts
@@ -384,6 +384,7 @@ export class Image extends Control {
     }
 
     private _onImageLoaded(): void {
+        this._imageDataCache.data = null;
         this._imageWidth = this._domImage.width;
         this._imageHeight = this._domImage.height;
         this._loaded = true;
@@ -470,7 +471,6 @@ export class Image extends Control {
         this._domImage = document.createElement("img");
 
         this._domImage.onload = () => {
-            this._imageDataCache.data = null;
             this._onImageLoaded();
         };
         if (value) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/image-class-has-poor-performance-when-transparent-parts-of-image-should-be-ignored-detectpointeronopaqueonly/13018/6