### PR TITLE
Update sphereBuilder.ts

### DIFF
--- a/src/Meshes/Builders/sphereBuilder.ts
+++ b/src/Meshes/Builders/sphereBuilder.ts
@@ -53,7 +53,7 @@ VertexData.CreateSphere = function(options: { segments?: number, diameter?: numb
                     indices.push((firstIndex + 1));
                     indices.push(firstIndex + totalYRotationSteps + 1);
                 }
-                if (zRotationStep < totalZRotationSteps) {
+                if (zRotationStep < totalZRotationSteps || slice < 1.0) {
                     indices.push((firstIndex + totalYRotationSteps + 1));
                     indices.push((firstIndex + 1));
                     indices.push((firstIndex + totalYRotationSteps + 2));


### PR DESCRIPTION
Fix bug introduced by https://github.com/BabylonJS/Babylon.js/pull/8750 
when slice is being used, sliced edge only have 1 triangle per yRotationStep.

https://playground.babylonjs.com/#XLQWA7


Also tested Arc just in case, but found no issues so far.
