### PR TITLE
Fix for .babylon exported gltf meshes having improper deformation

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -291,6 +291,7 @@
 - Fix the bounding box of instances that does not match the instance position / rotation / scaling ([Popov72](https://github.com/Popov72))
 - Fix an issue with sound updateOptions not updating the underlying sound buffer/html element ([RaananW](https://github.com/RaananW))
 - Fixed bug in sphereBuilder where top and bottom segments added 6 indices per triangle instead of 3. ([aWeirdo](https://github.com/aWeirdo))
+- Fixed issue with Babylon scene export of loaded glTF meshes.([Drigax]/(https://github.com/drigax))
 
 ## Breaking changes
 - `FollowCamera.target` was renamed to `FollowCamera.meshTarget` to not be in conflict with `TargetCamera.target` ([Deltakosh](https://github.com/deltakosh))

--- a/src/Bones/skeleton.ts
+++ b/src/Bones/skeleton.ts
@@ -770,7 +770,7 @@ export class Skeleton implements IAnimatable {
 
         skeleton.needInitialSkinMatrix = parsedSkeleton.needInitialSkinMatrix;
 
-        if (parsedSkeleton.overrideMeshId){
+        if (parsedSkeleton.overrideMeshId) {
             skeleton._hasWaitingData = true;
             skeleton._waitingOverrideMeshId = parsedSkeleton.overrideMeshId;
         }

--- a/src/Bones/skeleton.ts
+++ b/src/Bones/skeleton.ts
@@ -66,6 +66,9 @@ export class Skeleton implements IAnimatable {
     /** @hidden */
     public _hasWaitingData: Nullable<boolean> = null;
 
+    /** @hidden */
+    public _waitingOverrideMeshId: Nullable<string> = null;
+
     /**
      * Specifies if the skeleton should be serialized
      */
@@ -706,6 +709,7 @@ export class Skeleton implements IAnimatable {
         serializationObject.bones = [];
 
         serializationObject.needInitialSkinMatrix = this.needInitialSkinMatrix;
+        serializationObject.overrideMeshId = this.overrideMesh?.id;
 
         for (var index = 0; index < this.bones.length; index++) {
             var bone = this.bones[index];
@@ -713,9 +717,11 @@ export class Skeleton implements IAnimatable {
 
             var serializedBone: any = {
                 parentBoneIndex: parent ? this.bones.indexOf(parent) : -1,
+                index: bone.getIndex(),
                 name: bone.name,
                 matrix: bone.getBaseMatrix().toArray(),
-                rest: bone.getRestPose().toArray()
+                rest: bone.getRestPose().toArray(),
+                linkedTransformNodeId: bone.getTransformNode()?.id
             };
 
             serializationObject.bones.push(serializedBone);
@@ -764,16 +770,22 @@ export class Skeleton implements IAnimatable {
 
         skeleton.needInitialSkinMatrix = parsedSkeleton.needInitialSkinMatrix;
 
+        if (parsedSkeleton.overrideMeshId){
+            skeleton._hasWaitingData = true;
+            skeleton._waitingOverrideMeshId = parsedSkeleton.overrideMeshId;
+        }
+
         let index: number;
         for (index = 0; index < parsedSkeleton.bones.length; index++) {
             var parsedBone = parsedSkeleton.bones[index];
-
+            var parsedBoneIndex = parsedSkeleton.bones[index].index;
             var parentBone = null;
             if (parsedBone.parentBoneIndex > -1) {
                 parentBone = skeleton.bones[parsedBone.parentBoneIndex];
             }
+
             var rest: Nullable<Matrix> = parsedBone.rest ? Matrix.FromArray(parsedBone.rest) : null;
-            var bone = new Bone(parsedBone.name, skeleton, parentBone, Matrix.FromArray(parsedBone.matrix), rest);
+            var bone = new Bone(parsedBone.name, skeleton, parentBone, Matrix.FromArray(parsedBone.matrix), rest, null, parsedBoneIndex);
 
             if (parsedBone.id !== undefined && parsedBone.id !== null) {
                 bone.id = parsedBone.id;

--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -643,7 +643,7 @@ SceneLoader.RegisterPlugin({
                             skeleton.overrideMesh = scene.getMeshByID(skeleton._waitingOverrideMeshId);
                             skeleton._waitingOverrideMeshId = null;
                         }
-        
+
                         skeleton._hasWaitingData = null;
                     }
                 }

--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -391,6 +391,11 @@ var loadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError?:
                         }
                     });
                 }
+
+                if (skeleton._waitingOverrideMeshId) {
+                    skeleton.overrideMesh = scene.getMeshByID(skeleton._waitingOverrideMeshId);
+                    skeleton._waitingOverrideMeshId = null;
+                }
                 skeleton._hasWaitingData = null;
             }
         }
@@ -633,8 +638,15 @@ SceneLoader.RegisterPlugin({
                                 }
                             });
                         }
+
+                        if (skeleton._waitingOverrideMeshId) {
+                            skeleton.overrideMesh = scene.getMeshByID(skeleton._waitingOverrideMeshId);
+                            skeleton._waitingOverrideMeshId = null;
+                        }
+        
                         skeleton._hasWaitingData = null;
                     }
+                    skeleton.returnToRest();
                 }
 
                 // freeze and compute world matrix application

--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -646,7 +646,6 @@ SceneLoader.RegisterPlugin({
         
                         skeleton._hasWaitingData = null;
                     }
-                    skeleton.returnToRest();
                 }
 
                 // freeze and compute world matrix application

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -3450,12 +3450,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Morph targets
-        if (parsedMesh.morphTargetManagerId) {
+        if (parsedMesh.morphTargetManagerId > -1) {
             mesh.morphTargetManager = scene.getMorphTargetManagerById(parsedMesh.morphTargetManagerId);
         }
 
         // Skeleton
-        if (parsedMesh.skeletonId !== undefined ) {
+        if (parsedMesh.skeletonId !== undefined && parsedMesh.skeletonId !== null) {
             mesh.skeleton = scene.getLastSkeletonByID(parsedMesh.skeletonId);
             if (parsedMesh.numBoneInfluencers) {
                 mesh.numBoneInfluencers = parsedMesh.numBoneInfluencers;

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -3085,6 +3085,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         // Skeleton
         if (this.skeleton) {
             serializationObject.skeletonId = this.skeleton.id;
+            serializationObject.numBoneInfluencers = this.numBoneInfluencers;
         }
 
         // Physics
@@ -3449,12 +3450,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Morph targets
-        if (parsedMesh.morphTargetManagerId > -1) {
+        if (parsedMesh.morphTargetManagerId) {
             mesh.morphTargetManager = scene.getMorphTargetManagerById(parsedMesh.morphTargetManagerId);
         }
 
         // Skeleton
-        if (parsedMesh.skeletonId > -1) {
+        if (parsedMesh.skeletonId) {
             mesh.skeleton = scene.getLastSkeletonByID(parsedMesh.skeletonId);
             if (parsedMesh.numBoneInfluencers) {
                 mesh.numBoneInfluencers = parsedMesh.numBoneInfluencers;

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -3455,7 +3455,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Skeleton
-        if (parsedMesh.skeletonId) {
+        if (parsedMesh.skeletonId !== undefined ) {
             mesh.skeleton = scene.getLastSkeletonByID(parsedMesh.skeletonId);
             if (parsedMesh.numBoneInfluencers) {
                 mesh.numBoneInfluencers = parsedMesh.numBoneInfluencers;


### PR DESCRIPTION
This PR addresses an issue in the babylon scene serialization and deserialization logic for gltf imported meshes. On scene round trip via .babylon format, meshes appear small, improperly oriented and no longer animated by node animation
Issue is caused by helper members `Skeleton.overrideMesh` and `Bone.linkedTransformNode` not being serialized and modified bone serialization indexing logic to match schema used by glTF loader, where glTF coordinate space transform nodes and their associated bones are ignored by the skeleton hierarchy when resolving world transform.

Fixes #7244 