### PR TITLE
Add underline and strikethrough to TextBlock

### DIFF
--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -35,10 +35,12 @@ export class TextBlock extends Control {
     private _textVerticalAlignment = Control.VERTICAL_ALIGNMENT_CENTER;
 
     private _lines: any[];
-    private _resizeToFit: boolean = false;
+	private _resizeToFit: boolean = false;
     private _lineSpacing: ValueAndUnit = new ValueAndUnit(0);
     private _outlineWidth: number = 0;
-    private _outlineColor: string = "white";
+	private _outlineColor: string = "white";
+	private _underline: boolean = false;
+	private _strikethrough: boolean = false;
     /**
     * An event triggered after the text is changed
     */
@@ -196,6 +198,42 @@ export class TextBlock extends Control {
     }
 
     /**
+     * Gets or sets an boolean indicating that text must have underline
+     */
+    public get underline(): boolean {
+        return this._underline;
+    }
+
+    /**
+     * Gets or setsan boolean indicating that text must have underline
+     */
+    public set underline(value: boolean) {
+        if (this._underline === value) {
+            return;
+        }
+        this._underline = value;
+        this._markAsDirty();
+	}
+
+	    /**
+     * Gets or sets an boolean indicating that text must have underline
+     */
+    public get strikethrough(): boolean {
+        return this._strikethrough;
+    }
+
+    /**
+     * Gets or setsan boolean indicating that text must be strikethrough
+     */
+    public set strikethrough(value: boolean) {
+        if (this._strikethrough === value) {
+            return;
+        }
+        this._strikethrough = value;
+        this._markAsDirty();
+	}
+	
+	/**
      * Gets or sets outlineColor of the text to display
      */
     public get outlineColor(): string {
@@ -307,8 +345,27 @@ export class TextBlock extends Control {
         if (this.outlineWidth) {
             context.strokeText(text, this._currentMeasure.left + x, y);
         }
-        context.fillText(text, this._currentMeasure.left + x, y);
-    }
+		context.fillText(text, this._currentMeasure.left + x, y);
+	
+
+		if (this._underline) {
+			context.beginPath();
+			context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
+			context.moveTo(this._currentMeasure.left + x, y + 3);
+			context.lineTo(this._currentMeasure.left + x + textWidth, y + 3);
+			context.stroke();
+			context.closePath();
+		}
+
+		if (this._strikethrough) {
+			context.beginPath();
+			context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
+			context.moveTo(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3);
+			context.lineTo(this._currentMeasure.left + x + textWidth, y - this.fontSizeInPixels / 3);
+			context.stroke();
+			context.closePath();
+		}
+	}
 
     /** @hidden */
     public _draw(context: CanvasRenderingContext2D, invalidatedRectangle?: Nullable<Measure>): void {

--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -35,12 +35,12 @@ export class TextBlock extends Control {
     private _textVerticalAlignment = Control.VERTICAL_ALIGNMENT_CENTER;
 
     private _lines: any[];
-	private _resizeToFit: boolean = false;
+    private _resizeToFit: boolean = false;
     private _lineSpacing: ValueAndUnit = new ValueAndUnit(0);
     private _outlineWidth: number = 0;
-	private _outlineColor: string = "white";
-	private _underline: boolean = false;
-	private _strikethrough: boolean = false;
+    private _outlineColor: string = "white";
+    private _underline: boolean = false;
+    private _strikethrough: boolean = false;
     /**
     * An event triggered after the text is changed
     */
@@ -213,9 +213,9 @@ export class TextBlock extends Control {
         }
         this._underline = value;
         this._markAsDirty();
-	}
+    }
 
-	    /**
+        /**
      * Gets or sets an boolean indicating that text must have underline
      */
     public get strikethrough(): boolean {
@@ -231,9 +231,9 @@ export class TextBlock extends Control {
         }
         this._strikethrough = value;
         this._markAsDirty();
-	}
-	
-	/**
+    }
+    
+    /**
      * Gets or sets outlineColor of the text to display
      */
     public get outlineColor(): string {
@@ -345,27 +345,27 @@ export class TextBlock extends Control {
         if (this.outlineWidth) {
             context.strokeText(text, this._currentMeasure.left + x, y);
         }
-		context.fillText(text, this._currentMeasure.left + x, y);
-	
+        context.fillText(text, this._currentMeasure.left + x, y);
+    
 
-		if (this._underline) {
-			context.beginPath();
-			context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
-			context.moveTo(this._currentMeasure.left + x, y + 3);
-			context.lineTo(this._currentMeasure.left + x + textWidth, y + 3);
-			context.stroke();
-			context.closePath();
-		}
+        if (this._underline) {
+            context.beginPath();
+            context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
+            context.moveTo(this._currentMeasure.left + x, y + 3);
+            context.lineTo(this._currentMeasure.left + x + textWidth, y + 3);
+            context.stroke();
+            context.closePath();
+        }
 
-		if (this._strikethrough) {
-			context.beginPath();
-			context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
-			context.moveTo(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3);
-			context.lineTo(this._currentMeasure.left + x + textWidth, y - this.fontSizeInPixels / 3);
-			context.stroke();
-			context.closePath();
-		}
-	}
+        if (this._strikethrough) {
+            context.beginPath();
+            context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
+            context.moveTo(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3);
+            context.lineTo(this._currentMeasure.left + x + textWidth, y - this.fontSizeInPixels / 3);
+            context.stroke();
+            context.closePath();
+        }
+    }
 
     /** @hidden */
     public _draw(context: CanvasRenderingContext2D, invalidatedRectangle?: Nullable<Measure>): void {

--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -198,14 +198,14 @@ export class TextBlock extends Control {
     }
 
     /**
-     * Gets or sets an boolean indicating that text must have underline
+     * Gets or sets a boolean indicating that text must have underline
      */
     public get underline(): boolean {
         return this._underline;
     }
 
     /**
-     * Gets or setsan boolean indicating that text must have underline
+     * Gets or sets a boolean indicating that text must have underline
      */
     public set underline(value: boolean) {
         if (this._underline === value) {
@@ -347,7 +347,6 @@ export class TextBlock extends Control {
         }
         context.fillText(text, this._currentMeasure.left + x, y);
     
-
         if (this._underline) {
             context.beginPath();
             context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);

--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -40,7 +40,7 @@ export class TextBlock extends Control {
     private _outlineWidth: number = 0;
     private _outlineColor: string = "white";
     private _underline: boolean = false;
-    private _strikethrough: boolean = false;
+    private _lineThrough: boolean = false;
     /**
     * An event triggered after the text is changed
     */
@@ -215,21 +215,21 @@ export class TextBlock extends Control {
         this._markAsDirty();
     }
 
-        /**
-     * Gets or sets an boolean indicating that text must have underline
+    /**
+     * Gets or sets an boolean indicating that text must be crossed out
      */
-    public get strikethrough(): boolean {
-        return this._strikethrough;
+    public get lineThrough(): boolean {
+        return this._lineThrough;
     }
 
     /**
-     * Gets or setsan boolean indicating that text must be strikethrough
+     * Gets or sets an boolean indicating that text must be crossed out
      */
-    public set strikethrough(value: boolean) {
-        if (this._strikethrough === value) {
+    public set lineThrough(value: boolean) {
+        if (this._lineThrough === value) {
             return;
         }
-        this._strikethrough = value;
+        this._lineThrough = value;
         this._markAsDirty();
     }
     
@@ -357,7 +357,7 @@ export class TextBlock extends Control {
             context.closePath();
         }
 
-        if (this._strikethrough) {
+        if (this._lineThrough) {
             context.beginPath();
             context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
             context.moveTo(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3);


### PR DESCRIPTION
Adds basic support for underline and strikethrough within TextBlock.
![image](https://user-images.githubusercontent.com/39821509/91308034-fd680580-e7ae-11ea-908e-6fee7131cb2b.png)
