### PR TITLE
Remove Nullable<Number> from DeviceSourceManager.getInput, add observable cleanup to dispose()

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -45,6 +45,7 @@
 - Photo Dome and Video Dome now use the same abstract class and support the same parameters ([#8771](https://github.com/BabylonJS/Babylon.js/issues/8771)) ([RaananW](https://github.com/RaananW))
 - Added `getTransformNodesByTags` support to `Scene` class ([MackeyK24](https://github.com/MackeyK24))
 - Added support for multi-pointer mesh selection and pointer over/out triggers ([#8820](https://github.com/BabylonJS/Babylon.js/issues/8820)) ([RaananW](https://github.com/RaananW))
+- Changed DeviceSourceManager getInput contract to no longer return nullable values for reals this time. Also added proper cleanup for DeviceSourceManager observables ([Drigax](https://github.com/drigax))
 
 ### Engine
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -297,6 +297,7 @@
 - Fixed issue with Babylon scene export of loaded glTF meshes.([Drigax]/(https://github.com/drigax))
 - Fixed an issue with text block wrap and unicode strings (not working in IE11) ([#8822](https://github.com/BabylonJS/Babylon.js/issues/8822)) ([RaananW](https://github.com/RaananW))
 - Fixed an issue with compound initialization that has rotation ([#8744](https://github.com/BabylonJS/Babylon.js/issues/8744)) ([RaananW](https://github.com/RaananW))
+- Fixed an issue in `DeviceSourceManager.getDeviceSources()` where null devices are returned ([Drigax](https://github.com/drigax))
 
 ## Breaking changes
 - `FollowCamera.target` was renamed to `FollowCamera.meshTarget` to not be in conflict with `TargetCamera.target` ([Deltakosh](https://github.com/deltakosh))

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -130,7 +130,7 @@ export class DeviceSourceManager implements IDisposable {
      * @returns Array of DeviceSource objects
      */
     public getDeviceSources<T extends DeviceType>(deviceType: T): ReadonlyArray<DeviceSource<T>> {
-        return this._devices[deviceType];
+        return this._devices[deviceType].filter(source => !!source);
     }
 
     /**

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -38,7 +38,7 @@ export class DeviceSource<T extends DeviceType> {
      * @param inputIndex index of specific input on device
      * @returns Input value from DeviceInputSystem
      */
-    public getInput(inputIndex: DeviceInput<T>): Nullable<number> {
+    public getInput(inputIndex: DeviceInput<T>): number {
         return this._deviceInputSystem.pollInput(this.deviceType, this.deviceSlot, inputIndex);
     }
 }
@@ -137,6 +137,10 @@ export class DeviceSourceManager implements IDisposable {
      * Dispose of DeviceInputSystem and other parts
      */
     public dispose() {
+        this.onBeforeDeviceConnectedObservable.clear();
+        this.onBeforeDeviceDisconnectedObservable.clear();
+        this.onAfterDeviceConnectedObservable.clear();
+        this.onAfterDeviceDisconnectedObservable.clear();
         this._deviceInputSystem.dispose();
     }
 

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -130,7 +130,7 @@ export class DeviceSourceManager implements IDisposable {
      * @returns Array of DeviceSource objects
      */
     public getDeviceSources<T extends DeviceType>(deviceType: T): ReadonlyArray<DeviceSource<T>> {
-        return this._devices[deviceType].filter(source => !!source);
+        return this._devices[deviceType].filter((source) => { return !!source; });
     }
 
     /**


### PR DESCRIPTION
This PR finalizes changes to the deviceSourceManager contract by via #8721 by removing Nullable<number> from `DeviceSourceManager.getInput`, this also improves the cleanup of DeviceSourceManager by properly cleaning up observables on `dispose()`"

Also, a change was made to `DeviceSourceManager.getDeviceSources()` that filters out null device entries.