### PR TITLE
clickable light/camera gizmos

### DIFF
--- a/src/Gizmos/cameraGizmo.ts
+++ b/src/Gizmos/cameraGizmo.ts
@@ -39,18 +39,16 @@ export class CameraGizmo extends Gizmo {
         this._material.diffuseColor = new Color3(0.5, 0.5, 0.5);
         this._material.specularColor = new Color3(0.1, 0.1, 0.1);
 
-        if (gizmoLayer) {
-            this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
-                if (!this._camera) {
-                    return;
-                }
+        this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
+            if (!this._camera) {
+                return;
+            }
 
-                var isHovered = pointerInfo.pickInfo && (this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
-                if (isHovered && pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
-                    this.onClickedObservable.notifyObservers(this._camera);
-                }
-            });
-        }
+            var isHovered = pointerInfo.pickInfo && (this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
+            if (isHovered && pointerInfo.event.button === 0) {
+                this.onClickedObservable.notifyObservers(this._camera);
+            }
+        }, PointerEventTypes.POINTERDOWN);
     }
     private _camera: Nullable<Camera> = null;
 
@@ -141,6 +139,7 @@ export class CameraGizmo extends Gizmo {
      * Disposes of the camera gizmo
      */
     public dispose() {
+        this.onClickedObservable.clear();
         this.gizmoLayer.utilityLayerScene.onPointerObservable.remove(this._pointerObserver);
         if (this._cameraMesh) {
             this._cameraMesh.dispose();

--- a/src/Gizmos/lightGizmo.ts
+++ b/src/Gizmos/lightGizmo.ts
@@ -15,6 +15,8 @@ import { SphereBuilder } from '../Meshes/Builders/sphereBuilder';
 import { HemisphereBuilder } from '../Meshes/Builders/hemisphereBuilder';
 import { SpotLight } from '../Lights/spotLight';
 import { TransformNode } from '../Meshes/transformNode';
+import { PointerEventTypes, PointerInfo } from '../Events/pointerEvents';
+import { Observer, Observable } from "../Misc/observable";
 
 /**
  * Gizmo that enables viewing a light
@@ -25,12 +27,18 @@ export class LightGizmo extends Gizmo {
     private _cachedPosition = new Vector3();
     private _cachedForward = new Vector3(0, 0, 1);
     private _attachedMeshParent: TransformNode;
+    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+
+    /**
+     * Event that fires each time the gizmo is clicked
+     */
+    public onClickedObservable = new Observable<Light>();
 
     /**
      * Creates a LightGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
      */
-    constructor(gizmoLayer?: UtilityLayerRenderer) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
         this.attachedMesh = new AbstractMesh("", this.gizmoLayer.utilityLayerScene);
         this._attachedMeshParent = new TransformNode("parent", this.gizmoLayer.utilityLayerScene);
@@ -39,6 +47,19 @@ export class LightGizmo extends Gizmo {
         this._material = new StandardMaterial("light", this.gizmoLayer.utilityLayerScene);
         this._material.diffuseColor = new Color3(0.5, 0.5, 0.5);
         this._material.specularColor = new Color3(0.1, 0.1, 0.1);
+
+        if (gizmoLayer) {
+            this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
+                if (!this._light) {
+                    return;
+                }
+
+                var isHovered = pointerInfo.pickInfo && (this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
+                if (isHovered && pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
+                    this.onClickedObservable.notifyObservers(this._light);
+                }
+            });
+        }
     }
     private _light: Nullable<Light> = null;
 
@@ -218,6 +239,7 @@ export class LightGizmo extends Gizmo {
      * Disposes of the light gizmo
      */
     public dispose() {
+        this.gizmoLayer.utilityLayerScene.onPointerObservable.remove(this._pointerObserver);
         this._material.dispose();
         super.dispose();
         this._attachedMeshParent.dispose();

--- a/src/Gizmos/lightGizmo.ts
+++ b/src/Gizmos/lightGizmo.ts
@@ -48,18 +48,16 @@ export class LightGizmo extends Gizmo {
         this._material.diffuseColor = new Color3(0.5, 0.5, 0.5);
         this._material.specularColor = new Color3(0.1, 0.1, 0.1);
 
-        if (gizmoLayer) {
-            this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
-                if (!this._light) {
-                    return;
-                }
+        this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
+            if (!this._light) {
+                return;
+            }
 
-                var isHovered = pointerInfo.pickInfo && (this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
-                if (isHovered && pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
-                    this.onClickedObservable.notifyObservers(this._light);
-                }
-            });
-        }
+            var isHovered = pointerInfo.pickInfo && (this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
+            if (isHovered && pointerInfo.event.button === 0) {
+                this.onClickedObservable.notifyObservers(this._light);
+            }
+        }, PointerEventTypes.POINTERDOWN);
     }
     private _light: Nullable<Light> = null;
 
@@ -239,6 +237,7 @@ export class LightGizmo extends Gizmo {
      * Disposes of the light gizmo
      */
     public dispose() {
+        this.onClickedObservable.clear();
         this.gizmoLayer.utilityLayerScene.onPointerObservable.remove(this._pointerObserver);
         this._material.dispose();
         super.dispose();


### PR DESCRIPTION
fixes #8737 
Clickable camera and light gizmos.

Example of use:
```
var gizmoManager = new BABYLON.GizmoManager(scene, 3);
gizmoManager.positionGizmoEnabled = true;

var lightGizmo = new BABYLON.LightGizmo();
lightGizmo.light = light;

lightGizmo.onClickedObservable.add((_light) => {
            manager.attachToNode(_light);              
});
```

And in a PG : https://playground.babylonjs.com/#M48IGY