### PR TITLE
[XR] XRHand as interface

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -182,7 +182,7 @@
 - Fixed an issue with stencil not enabled per default ([#8720](https://github.com/BabylonJS/Babylon.js/issues/8720)) ([RaananW](https://github.com/RaananW))
 - Expose the overlay to which the XR Enter/Exit buttons are added to ([#8754](https://github.com/BabylonJS/Babylon.js/issues/8754)) ([RaananW](https://github.com/RaananW))
 - WebXR hand-tracking module is available, able to track hand-joints on selected devices including physics interactions ([RaananW](https://github.com/RaananW))
-- Fixed an issue with backwards movement in XR ([#8854](https://github.com/BabylonJS/Babylon.js/issues/8854)) ([RaananW](https://github.com/RaananW))
+- Fixed an issue with moving backwards in XR ([#8854](https://github.com/BabylonJS/Babylon.js/issues/8854)) ([RaananW](https://github.com/RaananW))
 ### Collisions
 
 - Added an option to optimize collision detection performance ([jsdream](https://github.com/jsdream)) - [PR](https://github.com/BabylonJS/Babylon.js/pull/7810)

--- a/src/LibDeclarations/webxr.d.ts
+++ b/src/LibDeclarations/webxr.d.ts
@@ -207,37 +207,41 @@ interface XRJointPose extends XRPose {
     radius: number | undefined;
 }
 
-declare class XRHand extends Array<XRJointSpace> {
+interface XRHand /*extends Iterablele<XRJointSpace>*/ {
     readonly length: number;
 
-    static readonly WRIST = 0;
+    [index: number]: XRJointSpace;
 
-    static readonly THUMB_METACARPAL = 1;
-    static readonly THUMB_PHALANX_PROXIMAL = 2;
-    static readonly THUMB_PHALANX_DISTAL = 3;
-    static readonly THUMB_PHALANX_TIP = 4;
+    // Specs have the function 'joint(idx: number)', but chrome doesn't support it yet.
 
-    static readonly INDEX_METACARPAL = 5;
-    static readonly INDEX_PHALANX_PROXIMAL = 6;
-    static readonly INDEX_PHALANX_INTERMEDIATE = 7;
-    static readonly INDEX_PHALANX_DISTAL = 8;
-    static readonly INDEX_PHALANX_TIP = 9;
+    readonly WRIST: number;
 
-    static readonly MIDDLE_METACARPAL = 10;
-    static readonly MIDDLE_PHALANX_PROXIMAL = 11;
-    static readonly MIDDLE_PHALANX_INTERMEDIATE = 12;
-    static readonly MIDDLE_PHALANX_DISTAL = 13;
-    static readonly MIDDLE_PHALANX_TIP = 14;
+    readonly THUMB_METACARPAL: number;
+    readonly THUMB_PHALANX_PROXIMAL: number;
+    readonly THUMB_PHALANX_DISTAL: number;
+    readonly THUMB_PHALANX_TIP: number;
 
-    static readonly RING_METACARPAL = 15;
-    static readonly RING_PHALANX_PROXIMAL = 16;
-    static readonly RING_PHALANX_INTERMEDIATE = 17;
-    static readonly RING_PHALANX_DISTAL = 18;
-    static readonly RING_PHALANX_TIP = 19;
+    readonly INDEX_METACARPAL: number;
+    readonly INDEX_PHALANX_PROXIMAL: number;
+    readonly INDEX_PHALANX_INTERMEDIATE: number;
+    readonly INDEX_PHALANX_DISTAL: number;
+    readonly INDEX_PHALANX_TIP: number;
 
-    static readonly LITTLE_METACARPAL = 20;
-    static readonly LITTLE_PHALANX_PROXIMAL = 21;
-    static readonly LITTLE_PHALANX_INTERMEDIATE = 22;
-    static readonly LITTLE_PHALANX_DISTAL = 23;
-    static readonly LITTLE_PHALANX_TIP = 24;
+    readonly MIDDLE_METACARPAL: number;
+    readonly MIDDLE_PHALANX_PROXIMAL: number;
+    readonly MIDDLE_PHALANX_INTERMEDIATE: number;
+    readonly MIDDLE_PHALANX_DISTAL: number;
+    readonly MIDDLE_PHALANX_TIP: number;
+
+    readonly RING_METACARPAL: number;
+    readonly RING_PHALANX_PROXIMAL: number;
+    readonly RING_PHALANX_INTERMEDIATE: number;
+    readonly RING_PHALANX_DISTAL: number;
+    readonly RING_PHALANX_TIP: number;
+
+    readonly LITTLE_METACARPAL: number;
+    readonly LITTLE_PHALANX_PROXIMAL: number;
+    readonly LITTLE_PHALANX_INTERMEDIATE: number;
+    readonly LITTLE_PHALANX_DISTAL: number;
+    readonly LITTLE_PHALANX_TIP: number;
 }


### PR DESCRIPTION
To allow further implementation of XRHand (mainly in native), i define the XRHand object as an interface instead of a class.

This does have the downside of not having the static members on XRHand, but since they are not 100% a part of the spects, it is actually better not to use them.