### PR TITLE
Fix dragging when a pivot point is set

### DIFF
--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -158,7 +158,8 @@ export class TransformNode extends Node {
     private _absoluteRotationQuaternion = Quaternion.Identity();
     private _pivotMatrix = Matrix.Identity();
     private _pivotMatrixInverse: Matrix;
-    protected _postMultiplyPivotMatrix = false;
+    /** @hidden */
+    public _postMultiplyPivotMatrix = false;
 
     protected _isWorldMatrixFrozen = false;
 

--- a/src/Misc/pivotTools.ts
+++ b/src/Misc/pivotTools.ts
@@ -12,11 +12,13 @@ export class PivotTools {
     private static _OldPivotPoint = new Vector3();
     private static _PivotTranslation = new Vector3();
     private static _PivotTmpVector = new Vector3();
+    private static _PivotPostMultiplyPivotMatrix = false;
     /** @hidden */
     public static _RemoveAndStorePivotPoint(mesh: AbstractMesh) {
         if (mesh && PivotTools._PivotCached === 0) {
             // Save old pivot and set pivot to 0,0,0
             mesh.getPivotPointToRef(PivotTools._OldPivotPoint);
+            PivotTools._PivotPostMultiplyPivotMatrix = mesh._postMultiplyPivotMatrix;
             if (!PivotTools._OldPivotPoint.equalsToFloats(0, 0, 0)) {
                 mesh.setPivotMatrix(Matrix.IdentityReadOnly);
                 PivotTools._OldPivotPoint.subtractToRef(mesh.getPivotPoint(), PivotTools._PivotTranslation);
@@ -32,6 +34,7 @@ export class PivotTools {
     public static _RestorePivotPoint(mesh: AbstractMesh) {
         if (mesh && !PivotTools._OldPivotPoint.equalsToFloats(0, 0, 0) && PivotTools._PivotCached === 1) {
             mesh.setPivotPoint(PivotTools._OldPivotPoint);
+            mesh._postMultiplyPivotMatrix = PivotTools._PivotPostMultiplyPivotMatrix;
             PivotTools._PivotTmpVector.copyFromFloats(1, 1, 1);
             PivotTools._PivotTmpVector.subtractInPlace(mesh.scaling);
             PivotTools._PivotTmpVector.multiplyInPlace(PivotTools._PivotTranslation);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/set-origin-of-mesh-pivot-matrix-unexpected-behavior-in-pointerdragbehavior/13907