### PR TITLE
[XR] Do not re-attach a disabled feature

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -181,7 +181,7 @@
 - WebXR hit test can now define different entity type for the results ([#8687](https://github.com/BabylonJS/Babylon.js/issues/8687)) ([RaananW](https://github.com/RaananW))
 - Fixed an issue with stencil not enabled per default ([#8720](https://github.com/BabylonJS/Babylon.js/issues/8720)) ([RaananW](https://github.com/RaananW))
 - Expose the overlay to which the XR Enter/Exit buttons are added to ([#8754](https://github.com/BabylonJS/Babylon.js/issues/8754)) ([RaananW](https://github.com/RaananW))
-- WebXR hand-tracking module is available, able to track hand-joints on selected devices including physics interactions ([RaananW](https://github.com/RaananW))
+- WebXR hand-tracking module is available, able to track hand-joints on selected devices including optional physics interactions ([RaananW](https://github.com/RaananW))
 - Fixed an issue with moving backwards in XR ([#8854](https://github.com/BabylonJS/Babylon.js/issues/8854)) ([RaananW](https://github.com/RaananW))
 ### Collisions
 

--- a/src/XR/features/WebXRAbstractFeature.ts
+++ b/src/XR/features/WebXRAbstractFeature.ts
@@ -16,6 +16,11 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
     }[] = [];
 
     /**
+     * Is this feature disposed?
+     */
+    public isDisposed: boolean = false;
+
+    /**
      * Should auto-attach be disabled?
      */
     public disableAutoAttach: boolean = false;
@@ -23,7 +28,7 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
     /**
      * The name of the native xr feature name (like anchor, hit-test, or hand-tracking)
      */
-    public xrNativeFeatureName: string = '';
+    public xrNativeFeatureName: string = "";
 
     /**
      * Construct a new (abstract) WebXR feature
@@ -45,6 +50,10 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
      * @returns true if successful, false is failed or already attached
      */
     public attach(force?: boolean): boolean {
+        // do not attach a disposed feature
+        if (this.isDisposed) {
+            return false;
+        }
         if (!force) {
             if (this.attached) {
                 return false;
@@ -83,6 +92,7 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
      */
     public dispose(): void {
         this.detach();
+        this.isDisposed = true;
     }
 
     /**

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -330,8 +330,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
      * This is used to remove the selection rays when moving.
      * @param selectionFeature the feature to disable when forward movement is enabled
      */
-    public setSelectionFeature(selectionFeature?: IWebXRFeature) {
-        this._selectionFeature = selectionFeature || null;
+    public setSelectionFeature(selectionFeature: Nullable<IWebXRFeature>) {
+        this._selectionFeature = selectionFeature;
     }
 
     protected _onXRFrame(_xrFrame: XRFrame) {

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -140,7 +140,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
     private _currentTeleportationControllerId: string;
     private _floorMeshes: AbstractMesh[];
     private _quadraticBezierCurve: AbstractMesh;
-    private _selectionFeature: IWebXRFeature;
+    private _selectionFeature: Nullable<IWebXRFeature>;
     private _snapToPositions: Vector3[];
     private _snappedToPoint: boolean = false;
     private _teleportationRingMaterial?: StandardMaterial;
@@ -330,8 +330,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
      * This is used to remove the selection rays when moving.
      * @param selectionFeature the feature to disable when forward movement is enabled
      */
-    public setSelectionFeature(selectionFeature: IWebXRFeature) {
-        this._selectionFeature = selectionFeature;
+    public setSelectionFeature(selectionFeature?: IWebXRFeature) {
+        this._selectionFeature = selectionFeature || null;
     }
 
     protected _onXRFrame(_xrFrame: XRFrame) {

--- a/src/XR/webXRFeaturesManager.ts
+++ b/src/XR/webXRFeaturesManager.ts
@@ -40,6 +40,11 @@ export interface IWebXRFeature extends IDisposable {
     isCompatible(): boolean;
 
     /**
+     * Was this feature disposed;
+     */
+    isDisposed: boolean;
+
+    /**
      * The name of the native xr feature name, if applicable (like anchor, hit-test, or hand-tracking)
      */
     xrNativeFeatureName?: string;


### PR DESCRIPTION
Addressing this - https://forum.babylonjs.com/t/super-hi-poly-mesh-successes-problems-in-vr/13715/9

A disabled feature cannot be attached.

It is also possible to set the selection feature to null.