### PR TITLE
NME - Saving Expose Port on Frame

### DIFF
--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -1299,7 +1299,7 @@ export class GraphFrame {
             height: this._height,
             color: this._color.asArray(),
             name: this.name,
-            isCollapsed: this.isCollapsed,
+            isCollapsed: false, //keeping closed to make reimporting cleaner
             blocks: this.nodes.map(n => n.block.uniqueId),
             comments: this._comments
         }

--- a/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -461,6 +461,7 @@ export class NodeMaterialConnectionPoint {
             serializationObject.inputName = this.name;
             serializationObject.targetBlockId = this.connectedPoint.ownerBlock.uniqueId;
             serializationObject.targetConnectionName = this.connectedPoint.name;
+            serializationObject.isExposedOnFrame = true;
         }
 
         if (this.isExposedOnFrame) {


### PR DESCRIPTION
Exposed port on frame should now be exported correctly. In addition frames will not be exported collapsed in order to make the importing cleaner for the user.

https://github.com/BabylonJS/Babylon.js/issues/8799