### PR TITLE
collision response flag 

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -108,6 +108,7 @@
 
 - Fixed time steps or delta time with sub time step for Oimo.js and Cannon.js ([cedricguillemet](https://github.com/cedricguillemet))
 - Ammo.js collision group and mask supported by impostor parameters ([cedricguillemet](https://github.com/cedricguillemet))
+- `collisionResponse` flag to disable response but still get onCollide events ([cedricguillemet](https://github.com/cedricguillemet))
 - Ammo.js IDL exposed property update and raycast vehicle stablization support ([MackeyK24](https://github.com/MackeyK24))
 - Recast.js plugin nav mesh and crowd agent to ref performance optimizations. ([MackeyK24](https://github.com/MackeyK24))
 - Added `scene.physicsEnabled` boolean ([Deltakosh](https://github.com/deltakosh))

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -368,13 +368,18 @@ export class Collider {
             var distToCollision = t * this._velocity.length();
 
             if (!this.collisionFound || distToCollision < this._nearestDistance) {
-                if (!this.intersectionPoint) {
-                    this.intersectionPoint = this._collisionPoint.clone();
-                } else {
-                    this.intersectionPoint.copyFrom(this._collisionPoint);
+                // if collisionResponse is false, collision is not found but the collidedMesh is set anyway.
+                // onCollide observable are triggered if collideMesh is set
+                // this allow trigger volumes to be created.
+                if (hostMesh.collisionResponse) {
+                    if (!this.intersectionPoint) {
+                        this.intersectionPoint = this._collisionPoint.clone();
+                    } else {
+                        this.intersectionPoint.copyFrom(this._collisionPoint);
+                    }
+                    this._nearestDistance = distToCollision;
+                    this.collisionFound = true;
                 }
-                this._nearestDistance = distToCollision;
-                this.collisionFound = true;
                 this.collidedMesh = hostMesh;
             }
         }

--- a/src/Collisions/meshCollisionData.ts
+++ b/src/Collisions/meshCollisionData.ts
@@ -18,4 +18,5 @@ export class _MeshCollisionData {
     public _diffPositionForCollisions = new Vector3(0, 0, 0);
     public _onCollideObserver: Nullable<Observer<AbstractMesh>>;
     public _onCollisionPositionChangeObserver: Nullable<Observer<Vector3>>;
+    public _collisionResponse = true;
 }

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -558,6 +558,19 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     }
 
     /**
+     * Gets or sets a collision response flag (default is true).
+     * when collisionResponse is false, events are still triggered but colliding entity has no response
+     * This helps creating trigger volume when user wants collision feedback events but not position/velocity
+     * to respond to the collision.
+     */
+    public get collisionResponse(): boolean {
+        return this._meshCollisionData._collisionResponse;
+    }
+
+    public set collisionResponse(response: boolean) {
+        this._meshCollisionData._collisionResponse = response;
+    }
+    /**
      * Gets or sets the current collision group mask (-1 by default).
      * A collision between A and B will happen if A.collisionGroup & b.collisionMask !== 0
      */


### PR DESCRIPTION
Follow up on this thread : https://forum.babylonjs.com/t/mesh-checkcollision-but-pass-thru-other-mesh/13988
Basically, a flag that still triggers onCollide observable but disable collision response on position/velocity

Simple PG to test it when it's merged : https://www.babylonjs-playground.com/#B9NNK2