### PR TITLE
SkeletonViewer: Added option to show local rotation axis on each bone.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -105,6 +105,7 @@
 ### Debug
 - Added new view modes to the `SkeletonViewer` class. ([Pryme8](https://github.com/Pryme8))
 - Added static methods to create debug shaders materials for a mesh with a skeleton. ([Pryme8](https://github.com/Pryme8))
+- Added ability to view local rotation axes of bones using new `displayOptions`: `showLocalAxes` and `localAxesSize` ([reimund](https://github.com/reimund))
 
 ### Sprites
 

--- a/src/Debug/ISkeletonViewer.ts
+++ b/src/Debug/ISkeletonViewer.ts
@@ -42,6 +42,12 @@ export interface ISkeletonViewerDisplayOptions{
 
    /** Ratio for the Sphere Size */
    sphereFactor? : number;
+
+   /** Whether to show local axes or not  */
+   showLocalAxes? : boolean;
+
+   /** Length of each local axis */
+   localAxesSize? : number;
 }
 
 /**

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -743,14 +743,11 @@ export class SkeletonViewer {
     }
 
     private _buildLocalAxes(): void {
-        if (this._localAxes) {
-            for (let axisMesh of this._localAxes) {
-                axisMesh.dispose();
-            }
-
-            this._localAxes = [];
+        for (let axisMesh of this._localAxes) {
+            axisMesh.dispose();
         }
 
+        this._localAxes = [];
         let displayOptions = this.options.displayOptions || {};
 
         if (!displayOptions.showLocalAxes) {
@@ -761,26 +758,24 @@ export class SkeletonViewer {
             const targetScene = this._utilityLayer.utilityLayerScene;
             const size = displayOptions.localAxesSize || 0.075;
 
-            if (targetScene) {
-                for (let b of this.skeleton.bones) {
-                    if (b._index === -1 || (!this._boneIndices.has(b.getIndex()) && !this.options.useAllBones)) {
-                        continue;
-                    }
-                
-                    let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
-                    let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
-                    let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
-
-                    axisX.color = new Color3(1, 0, 0);
-                    axisY.color = new Color3(0, 1, 0);
-                    axisZ.color = new Color3(0, 0, 1);
-
-                    axisX.parent = axisY.parent = axisZ.parent = b;
-                    axisX.renderingGroupId = axisY.renderingGroupId = axisZ.renderingGroupId = this.renderingGroupId;
-
-                    this._localAxes.push(axisX, axisY, axisZ);
+            for (let b of this.skeleton.bones) {
+                if (b._index === -1 || (!this._boneIndices.has(b.getIndex()) && !this.options.useAllBones)) {
+                    continue;
                 }
-            }    
+            
+                let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
+                let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
+                let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
+
+                axisX.color = new Color3(1, 0, 0);
+                axisY.color = new Color3(0, 1, 0);
+                axisZ.color = new Color3(0, 0, 1);
+
+                axisX.parent = axisY.parent = axisZ.parent = b;
+                axisX.renderingGroupId = axisY.renderingGroupId = axisZ.renderingGroupId = this.renderingGroupId;
+
+                this._localAxes.push(axisX, axisY, axisZ);
+            }	
         }
     }
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -299,7 +299,7 @@ export class SkeletonViewer {
 
     /** The SkeletonViewers Mesh. */
     private _debugMesh: Nullable<LinesMesh>;
-    
+
     /** The local axes Meshes. */
     private _localAxes: LinesMesh[] = [];
 
@@ -753,7 +753,7 @@ export class SkeletonViewer {
         if (!displayOptions.showLocalAxes) {
             return;
         }
-        
+
         const targetScene = this._utilityLayer!.utilityLayerScene;
         const size = displayOptions.localAxesSize || 0.075;
 
@@ -761,13 +761,13 @@ export class SkeletonViewer {
             if (b._index === -1 || (!this._boneIndices.has(b.getIndex()) && !this.options.useAllBones)) {
                 continue;
             }
-        
+
             let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
             let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
             let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
-            
+
             if (this.displayMode === SkeletonViewer.DISPLAY_LINES) {
-                // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its 
+                // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its
                 // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
                 axisX.skeleton = this.skeleton;
             }

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -765,6 +765,12 @@ export class SkeletonViewer {
             let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
             let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
             let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
+            
+            if (this.displayMode === SkeletonViewer.DISPLAY_LINES) {
+                // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its 
+                // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
+                axisX.skeleton = this.skeleton;
+            }
 
             axisX.color = new Color3(1, 0, 0);
             axisY.color = new Color3(0, 1, 0);

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -302,7 +302,7 @@ export class SkeletonViewer {
     private _debugMesh: Nullable<LinesMesh>;
 
     /** The local axes Meshes. */
-    private _localAxes: Nullable<LinesMesh> = null;
+    private _localAxes: LinesMesh[] = [];
 
     /** If SkeletonViewer is enabled. */
     private _isEnabled = false;
@@ -744,11 +744,11 @@ export class SkeletonViewer {
     }
 
     private _buildLocalAxes(): void {
-        if (this._localAxes) {
-            this._localAxes.dispose();
+        for (let axisMesh of this._localAxes) {
+            axisMesh.dispose();
         }
         
-        this._localAxes = null;
+        this._localAxes = [];
         let displayOptions = this.options.displayOptions || {};
 
         if (!displayOptions.showLocalAxes) {
@@ -772,17 +772,18 @@ export class SkeletonViewer {
             let green = new Color4(0, 1, 0, 1);
             let blue = new Color4(0, 0, 1, 1);
             let colors = [[red, red], [green, green], [blue, blue]];
+            let axes = MeshBuilder.CreateLineSystem('localAxes', { lines: lines, colors: colors, updatable: true }, targetScene);
+            
+            axes.parent = b;
+            axes.renderingGroupId = this.renderingGroupId;
 
-            this._localAxes = MeshBuilder.CreateLineSystem('localAxes', { lines: lines, colors: colors, updatable: true }, targetScene);
+            this._localAxes.push(axes);
+        }
 
-            if (this.displayMode === SkeletonViewer.DISPLAY_LINES && !this._localAxes.skeleton) {
-                // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its
-                // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
-                this._localAxes.skeleton = this.skeleton;
-            }
-
-            this._localAxes.parent = b;
-            this._localAxes.renderingGroupId = this.renderingGroupId;
+        if (this.displayMode === SkeletonViewer.DISPLAY_LINES && !this._localAxes[0].skeleton) {
+            // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its
+            // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
+            this._localAxes[0].skeleton = this.skeleton;
         }
     }
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -754,28 +754,26 @@ export class SkeletonViewer {
             return;
         }
         
-        if (this._utilityLayer) {
-            const targetScene = this._utilityLayer.utilityLayerScene;
-            const size = displayOptions.localAxesSize || 0.075;
+        const targetScene = this._utilityLayer!.utilityLayerScene;
+        const size = displayOptions.localAxesSize || 0.075;
 
-            for (let b of this.skeleton.bones) {
-                if (b._index === -1 || (!this._boneIndices.has(b.getIndex()) && !this.options.useAllBones)) {
-                    continue;
-                }
-            
-                let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
-                let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
-                let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
+        for (let b of this.skeleton.bones) {
+            if (b._index === -1 || (!this._boneIndices.has(b.getIndex()) && !this.options.useAllBones)) {
+                continue;
+            }
+        
+            let axisX = Mesh.CreateLines('axisX', [Vector3.Zero(), new Vector3(size, 0, 0)], targetScene, true);
+            let axisY = Mesh.CreateLines('axisY', [Vector3.Zero(), new Vector3(0, size, 0)], targetScene, true);
+            let axisZ = Mesh.CreateLines('axisZ', [Vector3.Zero(), new Vector3(0, 0, size)], targetScene, true);
 
-                axisX.color = new Color3(1, 0, 0);
-                axisY.color = new Color3(0, 1, 0);
-                axisZ.color = new Color3(0, 0, 1);
+            axisX.color = new Color3(1, 0, 0);
+            axisY.color = new Color3(0, 1, 0);
+            axisZ.color = new Color3(0, 0, 1);
 
-                axisX.parent = axisY.parent = axisZ.parent = b;
-                axisX.renderingGroupId = axisY.renderingGroupId = axisZ.renderingGroupId = this.renderingGroupId;
+            axisX.parent = axisY.parent = axisZ.parent = b;
+            axisX.renderingGroupId = axisY.renderingGroupId = axisZ.renderingGroupId = this.renderingGroupId;
 
-                this._localAxes.push(axisX, axisY, axisZ);
-            }	
+            this._localAxes.push(axisX, axisY, axisZ);
         }
     }
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -20,7 +20,6 @@ import { Observer } from '../Misc/observable';
 
 import { SphereBuilder } from '../Meshes/Builders/sphereBuilder';
 import { ShapeBuilder } from '../Meshes/Builders/shapeBuilder';
-import { MeshBuilder } from '../Meshes/meshBuilder';
 
 /**
  * Class used to render a debug view of a given skeleton
@@ -772,7 +771,7 @@ export class SkeletonViewer {
             let green = new Color4(0, 1, 0, 1);
             let blue = new Color4(0, 0, 1, 1);
             let colors = [[red, red], [green, green], [blue, blue]];
-            let axes = MeshBuilder.CreateLineSystem('localAxes', { lines: lines, colors: colors, updatable: true }, targetScene);
+            let axes = LinesBuilder.CreateLineSystem('localAxes', { lines: lines, colors: colors, updatable: true }, targetScene);
 
             axes.parent = b;
             axes.renderingGroupId = this.renderingGroupId;

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -776,13 +776,13 @@ export class SkeletonViewer {
             axes.parent = b;
             axes.renderingGroupId = this.renderingGroupId;
 
-            this._localAxes.push(axes);
-        }
+            if (this.displayMode === SkeletonViewer.DISPLAY_LINES) {
+                // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its
+                // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
+                axes.skeleton = this.skeleton;
+            }
 
-        if (this.displayMode === SkeletonViewer.DISPLAY_LINES && !this._localAxes[0].skeleton) {
-            // The local axes needs a mesh. Since the world matrix of a bone is not recalculated unless its
-            // skeleton is applied to at least one mesh. For the other display mode we don't have this issue.
-            this._localAxes[0].skeleton = this.skeleton;
+            this._localAxes.push(axes);
         }
     }
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -863,7 +863,13 @@ export class SkeletonViewer {
         }
     }
 
-    /** Changes the displayMode of the skeleton viewer
+    /** Sets a display option of the skeleton viewer
+     *
+     * | Option          | Type    | Default | Description |
+     * | --------------- | ------- | ------- | ----------- |
+     * | showLocalAxes   | boolean | false   | Displays local axes on all bones. |
+     * | localAxesSize   | float   | 0.075   | Determines the length of each local axis. |
+     *
      * @param option String of the option name
      * @param value The numerical option value
      */

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -747,7 +747,7 @@ export class SkeletonViewer {
         for (let axisMesh of this._localAxes) {
             axisMesh.dispose();
         }
-        
+
         this._localAxes = [];
         let displayOptions = this.options.displayOptions || {};
 
@@ -773,7 +773,7 @@ export class SkeletonViewer {
             let blue = new Color4(0, 0, 1, 1);
             let colors = [[red, red], [green, green], [blue, blue]];
             let axes = MeshBuilder.CreateLineSystem('localAxes', { lines: lines, colors: colors, updatable: true }, targetScene);
-            
+
             axes.parent = b;
             axes.renderingGroupId = this.renderingGroupId;
 


### PR DESCRIPTION
Added support for new displayOptions: `showLocalAxes` and `localAxesSize`.

The new option `showLocalAxes` defaults to false but when enabled it lets you debug the rotations of a skeleton:

<img width="615" alt="Screenshot 2020-09-13 at 23 05 31" src="https://user-images.githubusercontent.com/83687/93028695-c77fa980-f615-11ea-97cf-3d07546e82c6.png">
