### PR TITLE
Bones: fix returnToRest + updateMatrix

### DIFF
--- a/src/Bones/bone.ts
+++ b/src/Bones/bone.ts
@@ -244,7 +244,7 @@ export class Bone extends Node {
         if (this._skeleton._numBonesWithLinkedTransformNode > 0) {
             this.updateMatrix(this._restPose.clone(), false, false);
         } else {
-            this.updateMatrix(this._restPose.clone());
+            this.updateMatrix(this._restPose.clone(), false, true);
         }
     }
 
@@ -384,6 +384,7 @@ export class Bone extends Node {
         }
 
         if (updateLocalMatrix) {
+            this._needToCompose = false; // in case there was a pending compose
             this._localMatrix.copyFrom(matrix);
             this._markAsDirtyAndDecompose();
         }

--- a/src/Bones/bone.ts
+++ b/src/Bones/bone.ts
@@ -242,9 +242,9 @@ export class Bone extends Node {
      */
     public returnToRest(): void {
         if (this._skeleton._numBonesWithLinkedTransformNode > 0) {
-            this.updateMatrix(this._restPose.clone(), false, false);
+            this.updateMatrix(this._restPose, false, false);
         } else {
-            this.updateMatrix(this._restPose.clone(), false, true);
+            this.updateMatrix(this._restPose, false, true);
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/bones-freeze-transformations/14036/21

It does fix the problem with `returnToRest` in the PG, but as I don't really understand everything (anything) that's going on with the difference matrix, maybe it's not the right fix...

The fix to `upateMatrix` however is a required fix.