### PR TITLE
Hiding Contrast/Exposure tool from Texture Inspector

### DIFF
--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/defaultTools.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/defaultTools.ts
@@ -1,7 +1,6 @@
 import { Paintbrush } from './paintbrush';
 import { Eyedropper } from './eyedropper';
 import { Floodfill } from './floodfill';
-import { Contrast } from './contrast';
 import { RectangleSelect } from './rectangleSelect';
 
-export default [RectangleSelect, Paintbrush, Eyedropper, Floodfill, Contrast];
+export default [RectangleSelect, Paintbrush, Eyedropper, Floodfill];


### PR DESCRIPTION
Tool is still there just not loaded in. 

https://github.com/BabylonJS/Babylon.js/issues/8907