### PR TITLE
[PG] location.hash update on load

### DIFF
--- a/Playground/src/tools/loadManager.ts
+++ b/Playground/src/tools/loadManager.ts
@@ -11,7 +11,7 @@ export class LoadManager {
 
         globalState.onLoadRequiredObservable.add((id) => {
             globalState.onDisplayWaitRingObservable.notifyObservers(true);
-            this._loadPlayground(id);
+            window.location.hash = id;
         });
     }
 

--- a/Playground/src/tools/loadManager.ts
+++ b/Playground/src/tools/loadManager.ts
@@ -11,8 +11,13 @@ export class LoadManager {
 
         globalState.onLoadRequiredObservable.add((id) => {
             globalState.onDisplayWaitRingObservable.notifyObservers(true);
+
+            let prevHash = location.hash;
             location.hash = id;
-            this._loadPlayground(id);
+
+            if(location.hash === prevHash){
+                this._loadPlayground(id);
+            }
         });
     }
 

--- a/Playground/src/tools/loadManager.ts
+++ b/Playground/src/tools/loadManager.ts
@@ -7,7 +7,7 @@ export class LoadManager {
     public constructor(public globalState: GlobalState) {
         // Check the url to prepopulate data
         this._checkHash();
-        window.addEventListener("hashchange", () => globalState.onLoadRequiredObservable.notifyObservers(location.hash));
+        window.addEventListener("hashchange", () => this._checkHash());
 
         globalState.onLoadRequiredObservable.add((id) => {
             globalState.onDisplayWaitRingObservable.notifyObservers(true);

--- a/Playground/src/tools/loadManager.ts
+++ b/Playground/src/tools/loadManager.ts
@@ -7,11 +7,12 @@ export class LoadManager {
     public constructor(public globalState: GlobalState) {
         // Check the url to prepopulate data
         this._checkHash();
-        window.addEventListener("hashchange", () => this._checkHash());
+        window.addEventListener("hashchange", () => globalState.onLoadRequiredObservable.notifyObservers(location.hash));
 
         globalState.onLoadRequiredObservable.add((id) => {
             globalState.onDisplayWaitRingObservable.notifyObservers(true);
-            window.location.hash = id;
+            location.hash = id;
+            this._loadPlayground(id);
         });
     }
 


### PR DESCRIPTION
This sets `location.hash` to the new PG id (when clicking on an example from the list). It checks to see if the hash has actually been updated by the browser (with/without '#' prefix), if so, the `_checkHash` function will call `_loadPlayground`, and if not, it will still call `_loadPlayground` itself.