### PR TITLE
Fix callback of FilesInput sometimes not called

### DIFF
--- a/src/Misc/filesInput.ts
+++ b/src/Misc/filesInput.ts
@@ -157,7 +157,7 @@ export class FilesInput {
                 }
             }
 
-            if (--remaining.count) {
+            if (--remaining.count === 0) {
                 callback();
             }
         });


### PR DESCRIPTION
See https://forum.babylonjs.com/t/filesinput-wont-complete-load-on-folder-drop-with-an-empty-folder-at-end-of-parse/14290/5