### PR TITLE
SkeletonViewer: Added new display option: spurFollowsChild.

### DIFF
--- a/src/Debug/ISkeletonViewer.ts
+++ b/src/Debug/ISkeletonViewer.ts
@@ -43,6 +43,9 @@ export interface ISkeletonViewerDisplayOptions{
    /** Ratio for the Sphere Size */
    sphereFactor? : number;
 
+   /** Whether a spur should attach its far end to the child bone position */
+   spurFollowsChild? : boolean;
+
    /** Whether to show local axes or not  */
    showLocalAxes? : boolean;
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -673,6 +673,8 @@ export class SkeletonViewer {
                     for (let i = 0; i < numVertices; i++) {
                         mwk.push(1, 0, 0, 0);
 
+                        // Select verts at end of spur (ie vert 10 to 14) and bind to child
+                        // bone if spurFollowsChild is enabled.
                         if (displayOptions.spurFollowsChild && i > 9) {
                             mik.push(bc.getIndex(), 0, 0, 0);
                         }

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -389,6 +389,7 @@ export class SkeletonViewer {
         options.displayOptions.sphereBaseSize = options.displayOptions.sphereBaseSize ?? 0.15;
         options.displayOptions.sphereScaleUnit = options.displayOptions.sphereScaleUnit ?? 2;
         options.displayOptions.sphereFactor = options.displayOptions.sphereFactor ?? 0.865;
+        options.displayOptions.spurFollowsChild = options.displayOptions.spurFollowsChild ?? false;
         options.displayOptions.showLocalAxes = options.displayOptions.showLocalAxes ?? false;
         options.displayOptions.localAxesSize = options.displayOptions.localAxesSize ?? 0.075;
         options.computeBonesUsingShaders = options.computeBonesUsingShaders ?? true;
@@ -666,19 +667,25 @@ export class SkeletonViewer {
                         updatable: false
                     },  scene);
 
-                    spur.convertToFlatShadedMesh();
-
                     let numVertices = spur.getTotalVertices();
                     let mwk: number[] = [], mik: number[] = [];
 
                     for (let i = 0; i < numVertices; i++) {
                         mwk.push(1, 0, 0, 0);
-                        mik.push(bone.getIndex(), 0, 0, 0);
+
+                        if (displayOptions.spurFollowsChild && i > 9) {
+                            mik.push(bc.getIndex(), 0, 0, 0);
+                        }
+                        else {
+                            mik.push(bone.getIndex(), 0, 0, 0);
+                        }
                     }
+
                     spur.position = anchorPoint.clone();
 
                     spur.setVerticesData(VertexBuffer.MatricesWeightsKind, mwk, false);
                     spur.setVerticesData(VertexBuffer.MatricesIndicesKind, mik, false);
+                    spur.convertToFlatShadedMesh();
 
                     spurs.push(spur);
                 });
@@ -865,16 +872,17 @@ export class SkeletonViewer {
     }
 
     /** Sets a display option of the skeleton viewer
-	 *
-     * | Option          | Type    | Default | Description |
-     * | --------------- | ------- | ------- | ----------- |
-     * | midStep         | float   | 0.235   | A percentage between a bone and its child that determines the widest part of a spur. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
-     * | midStepFactor   | float   | 0.15    | Mid step width expressed as a factor of the length. A value of 0.5 makes the spur width half of the spur length. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
-     * | sphereBaseSize  | float   | 2       | Sphere base size. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
-     * | sphereScaleUnit | float   | 0.865   | Sphere scale factor used to scale spheres in relation to the longest bone. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
-     * | showLocalAxes   | boolean | false   | Displays local axes on all bones. |
-	 * | localAxesSize   | float   | 0.075   | Determines the length of each local axis. |
-	 *
+     *
+     * | Option           | Type    | Default | Description |
+     * | ---------------- | ------- | ------- | ----------- |
+     * | midStep          | float   | 0.235   | A percentage between a bone and its child that determines the widest part of a spur. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
+     * | midStepFactor    | float   | 0.15    | Mid step width expressed as a factor of the length. A value of 0.5 makes the spur width half of the spur length. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
+     * | sphereBaseSize   | float   | 2       | Sphere base size. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
+     * | sphereScaleUnit  | float   | 0.865   | Sphere scale factor used to scale spheres in relation to the longest bone. Only used when `displayMode` is set to `DISPLAY_SPHERE_AND_SPURS`. |
+     * | spurFollowsChild | boolean | false   | Whether a spur should attach its far end to the child bone. |
+     * | showLocalAxes    | boolean | false   | Displays local axes on all bones. |
+     * | localAxesSize    | float   | 0.075   | Determines the length of each local axis. |
+     *
      * @param option String of the option name
      * @param value The numerical option value
      */


### PR DESCRIPTION
When enabling this option (currently disabled by default) the skinning of the spur is altered so that the far end of the spur (the one that's supposed to meet the child bone) is skinned to the child bone rather than the current bone.

In my retargeting use case where bone positions are set explicitly the current behaviour leads to spurs that float around unattached. This solution will not always show a perfectly shaped spur since it can be deformed by the child bone, but it has the advantage of being very fast while still maintaining a debug view of the skeleton that's not blown up.

Related [Playground](https://www.babylonjs-playground.com/#7GM6J3#4).

`spurFollowsChild` disabled (default):
<img width="256" alt="Screenshot 2020-09-22 at 10 05 32" src="https://user-images.githubusercontent.com/83687/93859345-d1f90d80-fcbd-11ea-8dbb-ed9309eb127e.png">

`spurFollowsChild` enabled:
<img width="256" alt="Screenshot 2020-09-22 at 10 05 56" src="https://user-images.githubusercontent.com/83687/93859360-d45b6780-fcbd-11ea-99bf-9a27ebf2d752.png">
