### PR TITLE
Force worldmatrix to be updated before baking vertices

### DIFF
--- a/src/Navigation/Plugins/recastJSPlugin.ts
+++ b/src/Navigation/Plugins/recastJSPlugin.ts
@@ -92,7 +92,7 @@ export class RecastJSPlugin implements INavigationEnginePlugin {
                     continue;
                 }
 
-                const wm = mesh.computeWorldMatrix(false);
+                const wm = mesh.computeWorldMatrix(true);
 
                 for (tri = 0; tri < meshIndices.length; tri++) {
                     indices.push(meshIndices[tri] + offset);


### PR DESCRIPTION
Followup on https://forum.babylonjs.com/t/navmesh-parenting/14329/3

World matrix was not properly updated when creating a navmesh. Forcing its update before baking vertices.
