### PR TITLE
Updating the feature manager feature usage

### DIFF
--- a/src/XR/webXRFeaturesManager.ts
+++ b/src/XR/webXRFeaturesManager.ts
@@ -337,7 +337,7 @@ export class WebXRFeaturesManager implements IDisposable {
 
             if (attachIfPossible) {
                 // if session started already, request and enable
-                if (this._xrSessionManager.session && !feature.featureImplementation.attached) {
+                if (this._xrSessionManager.session && !this._features[name].featureImplementation.attached) {
                     // enable feature
                     this.attachFeature(name);
                 }


### PR DESCRIPTION
The featureManager had a typo when trying to enable a feature after the session was created, leading to any features created this way not being successfully created. This change corrects that.