### PR TITLE
Bug Fixes For Exposed Frame Ports

### DIFF
--- a/nodeEditor/src/diagram/nodePort.ts
+++ b/nodeEditor/src/diagram/nodePort.ts
@@ -20,7 +20,6 @@ export class NodePort {
     protected _onCandidateLinkMovedObserver: Nullable<Observer<Nullable<Vector2>>>;
     protected _onSelectionChangedObserver: Nullable<Observer<Nullable<GraphFrame | GraphNode | NodeLink | NodePort | FramePortData>>>;
     protected _exposedOnFrame: boolean;
-    public isExposed = false;
     public delegatedPort: Nullable<FrameNodePort> = null;
 
     public get element(): HTMLDivElement {

--- a/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -470,8 +470,8 @@ export class NodeMaterialConnectionPoint {
             serializationObject.exposedPortPosition = this.exposedPortPosition;
         }
 
-        if (this.isExposedOnFrame) {
-            serializationObject.isExposedOnFrame = this.isExposedOnFrame;
+        if (this.isExposedOnFrame || this.exposedPortPosition >= 0) {
+            serializationObject.isExposedOnFrame = true;
             serializationObject.exposedPortPosition = this.exposedPortPosition;
         }
 


### PR DESCRIPTION
Changes include:

- Removing isExposed variable. This is now tracked through the port position only now. 
- Corrected mistake on port position when a link was deleted.
- Corrected mistake on port position 0 not being added.
- Edges cases where ports were being removed by mistake.

Testing: For this I ran several manual tests using large frames with many nodes, removing and adding nodes with links, and reexporting and importing multiple times. (More testing may be required to find further edge cases).

https://github.com/BabylonJS/Babylon.js/issues/9027
https://github.com/BabylonJS/Babylon.js/issues/9028