### PR TITLE
Add muted setting to VideoTexture, fix autoplay in Chrome

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -164,6 +164,7 @@
 - Added the possibility to update the shader code before being compiled ([Popov72](https://github.com/Popov72))
 - Added the `shadowOnly` property to the `BackgroundMaterial` class ([Popov72](https://github.com/Popov72))
 - Added support for lightmaps in unlit PBR materials ([Popov72](https://github.com/Popov72))
+- Added `muted` setting to `VideoTexture`, fix autoplay in Chrome ([simonihmig](https://github.com/simonihmig))
 
 ### Meshes
 

--- a/src/Materials/Textures/videoTexture.ts
+++ b/src/Materials/Textures/videoTexture.ts
@@ -18,6 +18,11 @@ export interface VideoTextureSettings {
     autoPlay?: boolean;
 
     /**
+     * Applies `muted` to video, if specified
+     */
+    muted?: boolean;
+
+    /**
      * Applies `loop` to video, if specified
      */
     loop?: boolean;
@@ -110,12 +115,14 @@ export class VideoTexture extends Texture {
         if (settings.poster) {
             this.video.poster = settings.poster;
         }
-
         if (settings.autoPlay !== undefined) {
             this.video.autoplay = settings.autoPlay;
         }
         if (settings.loop !== undefined) {
             this.video.loop = settings.loop;
+        }
+        if (settings.muted !== undefined) {
+            this.video.muted = settings.muted;
         }
 
         this.video.setAttribute("playsinline", "");
@@ -125,6 +132,10 @@ export class VideoTexture extends Texture {
         this.video.addEventListener("emptied", this.reset);
         this._createInternalTextureOnEvent = (settings.poster && !settings.autoPlay) ? "play" : "canplay";
         this.video.addEventListener(this._createInternalTextureOnEvent, this._createInternalTexture);
+
+        if (settings.autoPlay) {
+            this.video.play();
+        }
 
         const videoHasEnoughData = (this.video.readyState >= this.video.HAVE_CURRENT_DATA);
         if (settings.poster &&


### PR DESCRIPTION
Auto-playing a VideoTexture in Chrome failed to work. According to their [autoplay policy](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes) muted autoplay is allowed, so this adds support for a `muted` setting.

But this still seems to be not enough for Chrome, as a video element detached from DOM seems still to not autoplay. See this reproduction: https://jsfiddle.net/6105nLzr/4/ - when line 13 is commented out, the video does *not* start to play (see console output). So calling `play()` programmatically which fixed this for me.