### PR TITLE
Texture: Add a property to avoid deformations when rotating the texture and us…

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -225,6 +225,7 @@
 ### Textures
 
 - .HDR environment files will now give accurate PBR reflections ([CraigFeldpsar](https://github.com/craigfeldspar))
+- Added a `homogeneousRotationInUVTransform` property in the `Texture` to avoid deformations when rotating the texture with non-uniform scaling ([Popov72](https://github.com/Popov72))
 
 ### Audio
 

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -500,10 +500,12 @@ export class Texture extends BaseTexture {
             Matrix.TranslationToRef(-this.uRotationCenter, -this.vRotationCenter, -this.wRotationCenter, TmpVectors.Matrix[0]);
             Matrix.TranslationToRef(this.uRotationCenter, this.vRotationCenter, this.wRotationCenter, TmpVectors.Matrix[1]);
             Matrix.ScalingToRef(this._cachedUScale, this._cachedVScale, 0, TmpVectors.Matrix[2]);
+            Matrix.TranslationToRef(this._cachedUOffset, this._cachedVOffset, 0, TmpVectors.Matrix[3]);
 
             TmpVectors.Matrix[0].multiplyToRef(this._rowGenerationMatrix!, this._cachedTextureMatrix);
             this._cachedTextureMatrix.multiplyToRef(TmpVectors.Matrix[1], this._cachedTextureMatrix);
             this._cachedTextureMatrix.multiplyToRef(TmpVectors.Matrix[2], this._cachedTextureMatrix);
+            this._cachedTextureMatrix.multiplyToRef(TmpVectors.Matrix[3], this._cachedTextureMatrix);
 
             // copy the translation row to the 3rd row of the matrix so that we don't need to update the shaders (which expects the translation to be on the 3rd row)
             this._cachedTextureMatrix.setRowFromFloats(2, this._cachedTextureMatrix.m[12], this._cachedTextureMatrix.m[13], this._cachedTextureMatrix.m[14], 1);

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -497,8 +497,8 @@ export class Texture extends BaseTexture {
         Matrix.RotationYawPitchRollToRef(this.vAng, this.uAng, this.wAng, this._rowGenerationMatrix!);
 
         if (this.homogeneousRotationInUVTransform) {
-            Matrix.TranslationToRef(-this.uRotationCenter, -this.vRotationCenter, -this.wRotationCenter, TmpVectors.Matrix[0]);
-            Matrix.TranslationToRef(this.uRotationCenter, this.vRotationCenter, this.wRotationCenter, TmpVectors.Matrix[1]);
+            Matrix.TranslationToRef(-this._cachedURotationCenter, -this._cachedVRotationCenter, -this._cachedWRotationCenter, TmpVectors.Matrix[0]);
+            Matrix.TranslationToRef(this._cachedURotationCenter, this._cachedVRotationCenter, this._cachedWRotationCenter, TmpVectors.Matrix[1]);
             Matrix.ScalingToRef(this._cachedUScale, this._cachedVScale, 0, TmpVectors.Matrix[2]);
             Matrix.TranslationToRef(this._cachedUOffset, this._cachedVOffset, 0, TmpVectors.Matrix[3]);
 


### PR DESCRIPTION
…ing non-uniform scaling.

See https://forum.babylonjs.com/t/texture-rotation-not-working-for-non-square-images/14482

PG: https://www.babylonjs-playground.com/#T32V41#22