### PR TITLE
No mip map option added to photo dome

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -51,6 +51,7 @@
 - Changed DeviceSourceManager getInput contract to no longer return nullable values for reals this time. Also added proper cleanup for DeviceSourceManager observables ([Drigax](https://github.com/drigax))
 - Default Loading screen supports any image size and ratio ([#8845](https://github.com/BabylonJS/Babylon.js/issues/8845)) ([RaananW](https://github.com/RaananW))
 - Added optional success and error callbacks for freezeActiveMeshes ([RaananW](https://github.com/RaananW))
+- Added noMipMap option to the photo dome construction process ([#8972](https://github.com/BabylonJS/Babylon.js/issues/8972)) ([RaananW](https://github.com/RaananW))
 
 ### Engine
 

--- a/src/Helpers/photoDome.ts
+++ b/src/Helpers/photoDome.ts
@@ -55,7 +55,7 @@ export class PhotoDome extends TextureDome<Texture> {
     }
 
     protected _initTexture(urlsOrElement: string, scene: Scene, options: any): Texture {
-        return new Texture(urlsOrElement, scene, true, !this._useDirectMapping, undefined, undefined, (message, exception) => {
+        return new Texture(urlsOrElement, scene, options.noMipMap, !this._useDirectMapping, undefined, undefined, (message, exception) => {
             this.onLoadErrorObservable.notifyObservers(message || "Unknown error occured");
 
             if (this.onError) {

--- a/src/Helpers/textureDome.ts
+++ b/src/Helpers/textureDome.ts
@@ -166,6 +166,7 @@ export abstract class TextureDome<T extends Texture> extends TransformNode {
             faceForward?: boolean;
             useDirectMapping?: boolean;
             halfDomeMode?: boolean;
+            noMipMap?: boolean;
         },
         scene: Scene,
         protected onError: Nullable<(message?: string, exception?: any) => void> = null


### PR DESCRIPTION
Fixing #8972 

Was not added to the video texture, as video texture mipmaps can be very expensive.