### PR TITLE
Shadow generator: Fix flash at start when using filtering methods making use of preprocesses

### DIFF
--- a/src/Engines/Extensions/engine.renderTarget.ts
+++ b/src/Engines/Extensions/engine.renderTarget.ts
@@ -100,6 +100,8 @@ ThinEngine.prototype.createRenderTargetTexture = function(this: ThinEngine, size
 
     this._bindTextureDirectly(target, null);
 
+    const currentFrameBuffer = this._currentFramebuffer;
+
     // Create the framebuffer
     const framebuffer = gl.createFramebuffer();
     this._bindUnboundFramebuffer(framebuffer);
@@ -110,7 +112,7 @@ ThinEngine.prototype.createRenderTargetTexture = function(this: ThinEngine, size
         gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture._webGLTexture, 0);
     }
 
-    this._bindUnboundFramebuffer(null);
+    this._bindUnboundFramebuffer(currentFrameBuffer);
 
     texture._framebuffer = framebuffer;
     texture.baseWidth = width;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/cesm-close-exponential-shadow-map-weird-first-render/14603/2