### PR TITLE
freeCameraTouchInput bug: Uneven panning on touch.

### DIFF
--- a/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -163,19 +163,24 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
      * This is a dynamically created lambda to avoid the performance penalty of looping for inputs in the render loop.
      */
     public checkInputs(): void {
-        if (this._offsetX && this._offsetY) {
-            var camera = this.camera;
-            camera.cameraRotation.y += this._offsetX / this.touchAngularSensibility;
+        if (this._offsetX === null || this._offsetY === null) {
+            return;
+        }
+        if (this._offsetX === 0 && this._offsetY === 0) {
+            return;
+        }
 
-            if (this._pointerPressed.length > 1) {
-                camera.cameraRotation.x += -this._offsetY / this.touchAngularSensibility;
-            } else {
-                var speed = camera._computeLocalCameraSpeed();
-                var direction = new Vector3(0, 0, speed * this._offsetY / this.touchMoveSensibility);
+        var camera = this.camera;
+        camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
 
-                Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, camera._cameraRotationMatrix);
-                camera.cameraDirection.addInPlace(Vector3.TransformCoordinates(direction, camera._cameraRotationMatrix));
-            }
+        if (this._pointerPressed.length > 1) {
+            camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
+        } else {
+            var speed = camera._computeLocalCameraSpeed();
+            var direction = new Vector3(0, 0, speed * this._offsetY / this.touchMoveSensibility);
+
+            Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, camera._cameraRotationMatrix);
+            camera.cameraDirection.addInPlace(Vector3.TransformCoordinates(direction, camera._cameraRotationMatrix));
         }
     }
 


### PR DESCRIPTION
Well this is fascinating.
Please close if it's a known issue.
I'm not sure words will explain it very well so here's a playground:

https://playground.babylonjs.com/#WPLZCD#5
I've disabled mouse and forced on touch so you can see the issue on your workstation.

Click and drag left and right.
Notice the step change in pan speed at a repeatable but arbitrary point.

it's caused by a surprising interaction between the `camera.cameraRotation` values and `this.cameraRotation.scaleInPlace(this.inertia);` in `targetCamera.ts`.

The workaround is to set `camera.inertia = 0;`.
If you decide not to merge this change, this badly needs documenting. 

When i was playing with Babylon the last time around i presumed this was annoying but intended behavior.
After looking at the code i'm convinced it's a bug.

My diff:
Simply assigning `camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility` instead of adding fixes this.
On my setup the pan speed after the fix is similar to the average of the 2 speeds before.
This does change the behavior but IMO, the current implementation is verging on unusable.

My diff does a small bit of extra tidy-up too. Blame my OCD:
`if (this._offsetX && this._offsetY) {` does not take into account the case where one of the axis equal zero but the other has a valid value.