### PR TITLE
[XR] Tracking state for the WebXR Camera

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -206,6 +206,7 @@
 - Fixed an issue with moving backwards in XR ([#8854](https://github.com/BabylonJS/Babylon.js/issues/8854)) ([RaananW](https://github.com/RaananW))
 - Hit-Test results can be an empty array ([#8887](https://github.com/BabylonJS/Babylon.js/issues/8887)) ([RaananW](https://github.com/RaananW))
 - XR's main camera uses the first eye's projection matrix ([#8944](https://github.com/BabylonJS/Babylon.js/issues/8944)) ([RaananW](https://github.com/RaananW))
+- XR tracking state was added to the camera ([#9076](https://github.com/BabylonJS/Babylon.js/issues/9076)) ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/XR/webXRTypes.ts
+++ b/src/XR/webXRTypes.ts
@@ -24,6 +24,24 @@ export enum WebXRState {
 }
 
 /**
+ * The state of the XR camera's tracking
+ */
+export enum WebXRTrackingState {
+    /**
+     * No transformation received, device is not being tracked
+     */
+    NOT_TRACKING,
+    /**
+     * Tracking lost - using emulated position
+     */
+    TRACKING_LOST,
+    /**
+     * Transformation tracking works normally
+     */
+    TRACKING
+}
+
+/**
  * Abstraction of the XR render target
  */
 export interface WebXRRenderTarget extends IDisposable {


### PR DESCRIPTION
A new observable and a tracking state member was added to the camera. The observable is being triggered when the state has changed.

@ryantrem - please let me know if you need anything else

closing #9076 