### PR TITLE
Fix black skeleton viewer meshes in sandbox

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -336,6 +336,7 @@
 - Fix exporting vertex color of mesh with `StandardMaterial` when exporting to glTF ([Drigax](https://github.com/drigax))
 - Changed use of mousemove to pointermove in freeCameraMouseInput and flyCameraMouseInput to fix issue with Firefox ([PolygonalSun](https://github.com/PolygonalSun))
 - Fixed `TriPlanarMaterial` to compute the right world normals ([julien-moreau](https://github.com/julien-moreau))
+- Fix `SkeletonViewer` to use utillity layer with custom lighting to improve debug mesh visibility ([Drigax](https://github.com/drigax))
 
 ## Breaking changes
 

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -747,7 +747,6 @@ export class SkeletonViewer {
             }
 
             const light = this.utilityLayer!._getSharedGizmoLight();
-            light.includedOnlyMeshes = light.includedOnlyMeshes.concat(this.debugMesh!);
             light.intensity = 0.7;
 
             this._revert(animationState);

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -558,6 +558,7 @@ export class SkeletonViewer {
     private _revert(animationState: boolean): void {
         if (this.options.pauseAnimations) {
             this.scene.animationsEnabled = animationState;
+            this.utilityLayer?.utilityLayerScene!.animationsEnabled = animationState;
         }
     }
 
@@ -583,16 +584,17 @@ export class SkeletonViewer {
         }
 
         this._ready = false;
-        let scene = this.scene;
+        let utilityLayerScene = this.utilityLayer?.utilityLayerScene!;
         let bones: Bone[] = this.skeleton.bones;
         let spheres: Array<[Mesh, Bone]> = [];
         let spurs: Mesh[] = [];
 
-        const animationState = scene.animationsEnabled;
+        const animationState = this.scene.animationsEnabled;
 
         try {
             if (this.options.pauseAnimations) {
-                scene.animationsEnabled = false;
+                this.scene.animationsEnabled = false;
+                utilityLayerScene.animationsEnabled = false;
             }
 
             if (this.options.returnToRest) {
@@ -665,7 +667,7 @@ export class SkeletonViewer {
                                 },
                         sideOrientation: Mesh.DEFAULTSIDE,
                         updatable: false
-                    },  scene);
+                    },  utilityLayerScene);
 
                     let numVertices = spur.getTotalVertices();
                     let mwk: number[] = [], mik: number[] = [];
@@ -698,7 +700,7 @@ export class SkeletonViewer {
                     segments: 6,
                     diameter: sphereBaseSize,
                     updatable: true
-                }, scene);
+                }, utilityLayerScene);
 
                 const numVertices = sphere.getTotalVertices();
 
@@ -743,6 +745,10 @@ export class SkeletonViewer {
                 this.debugMesh.computeBonesUsingShaders = this.options.computeBonesUsingShaders ?? true;
                 this.debugMesh.alwaysSelectAsActiveMesh = true;
             }
+
+            const light = this.utilityLayer!._getSharedGizmoLight();
+            light.includedOnlyMeshes = light.includedOnlyMeshes.concat(this.debugMesh!);
+            light.intensity = 0.7;
 
             this._revert(animationState);
             this.ready = true;

--- a/src/Debug/skeletonViewer.ts
+++ b/src/Debug/skeletonViewer.ts
@@ -558,7 +558,7 @@ export class SkeletonViewer {
     private _revert(animationState: boolean): void {
         if (this.options.pauseAnimations) {
             this.scene.animationsEnabled = animationState;
-            this.utilityLayer?.utilityLayerScene!.animationsEnabled = animationState;
+            this.utilityLayer!.utilityLayerScene!.animationsEnabled = animationState;
         }
     }
 


### PR DESCRIPTION
Fix for issue with skeleton viewer lighting. 
Changed skeleton viewer to use utility layer for mesh creation. 
Added utility layer lighting creation, adjusted light intensity to show surface detail.

Before:
![image](https://user-images.githubusercontent.com/3952729/95132046-fb7d5480-0713-11eb-88d5-133afaea4112.png)

After:
![image](https://user-images.githubusercontent.com/3952729/95132085-0a640700-0714-11eb-9e2c-b7c6ffa37dc3.png)
