### PR TITLE
fix linkWithMesh signature to support TransformNode

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -565,7 +565,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 if (!control.isVisible) {
                     continue;
                 }
-                let mesh = control._linkedMesh;
+                let mesh = control._linkedMesh as AbstractMesh;
                 if (!mesh || mesh.isDisposed()) {
                     Tools.SetImmediate(() => {
                         control.linkWithMesh(null);

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -4,7 +4,7 @@ import { Vector2, Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { PointerEventTypes, PointerInfoBase } from 'babylonjs/Events/pointerEvents';
 import { Logger } from "babylonjs/Misc/logger";
 import { Tools } from "babylonjs/Misc/tools";
-import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
+import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Scene } from "babylonjs/scene";
 
 import { Container } from "./container";
@@ -87,7 +87,7 @@ export class Control {
     private _isVisible = true;
     private _isHighlighted = false;
     /** @hidden */
-    public _linkedMesh: Nullable<AbstractMesh>;
+    public _linkedMesh: Nullable<TransformNode>;
     private _fontSet = false;
     private _dummyVector2 = Vector2.Zero();
     private _downCount = 0;
@@ -710,7 +710,7 @@ export class Control {
     /**
      * Gets the current linked mesh (or null if none)
      */
-    public get linkedMesh(): Nullable<AbstractMesh> {
+    public get linkedMesh(): Nullable<TransformNode> {
         return this._linkedMesh;
     }
 
@@ -1145,7 +1145,7 @@ export class Control {
      * @param mesh defines the mesh to link with
      * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
      */
-    public linkWithMesh(mesh: Nullable<AbstractMesh>): void {
+    public linkWithMesh(mesh: Nullable<TransformNode>): void {
         if (!this._host || this.parent && this.parent !== this._host._rootContainer) {
             if (mesh) {
                 Tools.Error("Cannot link a control to a mesh if the control is not at root level");


### PR DESCRIPTION
with 41333fe067eadfa3096a6a249b4b7a1b00e32812 and f8d2898fc42910ec79af62889f62179481ed5fe6 the behavior of `linkWithMesh` was improved to support a plain `TransformNode` instead of `AbstractMesh`, but the signature was not changed so the user may be confused. This simple PR fixes this.
