### PR TITLE
Allow post processes on cameras with output render targets

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -212,6 +212,7 @@
 - XR's main camera uses the first eye's projection matrix ([#8944](https://github.com/BabylonJS/Babylon.js/issues/8944)) ([RaananW](https://github.com/RaananW))
 - pointerX and pointerY of the scene are now updated when using the pointer selection feature ([#8879](https://github.com/BabylonJS/Babylon.js/issues/8879)) ([RaananW](https://github.com/RaananW))
 - XR tracking state was added to the camera ([#9076](https://github.com/BabylonJS/Babylon.js/issues/9076)) ([RaananW](https://github.com/RaananW))
+- Individual post processing can be applied to the XR rig cameras ([#9038](https://github.com/BabylonJS/Babylon.js/issues/9038)) ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3789,10 +3789,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         // Finalize frame
         if (this.postProcessManager && !camera._multiviewTexture) {
-            // When in XR the outputRenderTarget should be the one the post process is rendered to
-            // To keep the current behavior, I am checking for rigCamera AND that there is an outputRenderTarget defined.
-            // If there isn't, the previous behavior is kept.
-            const texture = camera.isRigCamera && camera.outputRenderTarget ? camera.outputRenderTarget.getInternalTexture()! : undefined;
+            // if the camera has an output render target, render the post process to the render target
+            const texture = camera.outputRenderTarget ? camera.outputRenderTarget.getInternalTexture()! : undefined;
             this.postProcessManager._finalizeFrame(camera.isIntermediate, texture);
         }
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3789,7 +3789,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         // Finalize frame
         if (this.postProcessManager && !camera._multiviewTexture) {
-            this.postProcessManager._finalizeFrame(camera.isIntermediate);
+            // When in XR the outputRenderTarget should be the one the post process is rendered to
+            // To keep the current behavior, I am checking for rigCamera AND that there is an outputRenderTarget defined.
+            // If there isn't, the previous behavior is kept.
+            const texture = camera.isRigCamera && camera.outputRenderTarget ? camera.outputRenderTarget.getInternalTexture()! : undefined;
+            this.postProcessManager._finalizeFrame(camera.isIntermediate, texture);
         }
 
         // Reset some special arrays


### PR DESCRIPTION
XR renders the renderOutputTarget of the camera directly to the device. This was ignored when the post process manager finalized the frame on the XR camera.

To avoid back-compat issues, only rig cameras that have renderOutputTarget defined (i.e. XR cameras) will have the output set to its internal texture..

My recommendation, however, will be to apply this to each camera with a renderOutputTarget. unless I am missing something, this should be the default behavior.

Closing #9038 