### PR TITLE
[XR] Major changes to pointer selection

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -212,6 +212,7 @@
 - XR's main camera uses the first eye's projection matrix ([#8944](https://github.com/BabylonJS/Babylon.js/issues/8944)) ([RaananW](https://github.com/RaananW))
 - pointerX and pointerY of the scene are now updated when using the pointer selection feature ([#8879](https://github.com/BabylonJS/Babylon.js/issues/8879)) ([RaananW](https://github.com/RaananW))
 - XR tracking state was added to the camera ([#9076](https://github.com/BabylonJS/Babylon.js/issues/9076)) ([RaananW](https://github.com/RaananW))
+- Pointer selection improvements - single/dual hand selection, max ray distance and more ([#7974](https://github.com/BabylonJS/Babylon.js/issues/7974)) ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 


### PR DESCRIPTION
- Only one controller will have pointer selection enabled per default
- it is possible to enable pointer selection to all attached controllers
- dev can set the preferred handedness for the initial pointer selection controller
- if more than one controller is available, the pointer selection will switch between then when using the main button
- the switch feature can be disabled
- It is now possible to limit the distance of the pointer selection ray

Closing #7974