### PR TITLE
Add a property to the EffectLayer class to render the bounding boxes unaffected by the effect

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -53,6 +53,7 @@
 - Added optional success and error callbacks for freezeActiveMeshes ([RaananW](https://github.com/RaananW))
 - Allow cross-eye mode in photo and video dome ([#8897](https://github.com/BabylonJS/Babylon.js/issues/8897)) ([RaananW](https://github.com/RaananW))
 - Added noMipMap option to the photo dome construction process ([#8972](https://github.com/BabylonJS/Babylon.js/issues/8972)) ([RaananW](https://github.com/RaananW))
+- Add a `disableBoundingBoxesFromEffectLayer` property to the `EffectLayer` class to render the bounding boxes unaffected by the effect ([Popov72](https://github.com/Popov72))
 
 ### Engine
 

--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -125,6 +125,12 @@ export abstract class EffectLayer {
     }
 
     /**
+     * Specifies if the bounding boxes should be rendered normally or if they should undergo the effect of the layer
+     */
+    @serialize()
+    public disableBoundingBoxesFromEffectLayer = false;
+
+    /**
      * An event triggered when the effect layer has been disposed.
      */
     public onDisposeObservable = new Observable<EffectLayer>();
@@ -373,6 +379,16 @@ export abstract class EffectLayer {
 
         this._mainTexture.onClearObservable.add((engine: Engine) => {
             engine.clear(this.neutralColor, true, true, true);
+        });
+
+        const boundingBoxRendererDisabled = this._scene.getBoundingBoxRenderer().disabled;
+
+        this._mainTexture.onBeforeBindObservable.add(() => {
+            this._scene.getBoundingBoxRenderer().disabled = this.disableBoundingBoxesFromEffectLayer || boundingBoxRendererDisabled;
+        });
+
+        this._mainTexture.onAfterUnbindObservable.add(() => {
+            this._scene.getBoundingBoxRenderer().disabled = boundingBoxRendererDisabled;
         });
     }
 

--- a/src/Rendering/boundingBoxRenderer.ts
+++ b/src/Rendering/boundingBoxRenderer.ts
@@ -131,6 +131,11 @@ export class BoundingBoxRenderer implements ISceneComponent {
     public onAfterBoxRenderingObservable = new Observable<BoundingBox>();
 
     /**
+     * When true, no bounding boxes will be rendered
+     */
+    public disabled = false;
+
+    /**
      * @hidden
      */
     public renderList = new SmartArray<BoundingBox>(32);
@@ -231,7 +236,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
      * @param renderingGroupId defines the rendering group to render
      */
     public render(renderingGroupId: number): void {
-        if (this.renderList.length === 0) {
+        if (this.renderList.length === 0 || this.disabled) {
             return;
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/strange-bloom-effect-on-bounding-boxes-when-a-highlight-layer-is-added/14737

Property added: `disableBoundingBoxesFromEffectLayer`