### PR TITLE
Remove Array.from references from Core

### DIFF
--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -12,6 +12,7 @@ import { TransformNode } from './transformNode';
 import { Light } from '../Lights/light';
 import { VertexBuffer } from './buffer';
 import { BoundingInfo } from '../Culling/boundingInfo';
+import { Tools } from '../Misc/tools';
 
 Mesh._instancedMeshFactory = (name: string, mesh: Mesh): InstancedMesh => {
     let instance = new InstancedMesh(name, mesh);
@@ -54,8 +55,8 @@ export class InstancedMesh extends AbstractMesh {
             this.rotationQuaternion = source.rotationQuaternion.clone();
         }
 
-        this.animations = Array.from(source.animations);
-        for (var range of source.getAnimationRanges()) {
+        this.animations = Tools.Slice(source.animations);
+        for (let range of source.getAnimationRanges()) {
             if (range != null) {
                 this.createAnimationRange(range.name, range.from, range.to);
             }

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -3179,7 +3179,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         if (this._thinInstanceDataStorage.instancesCount && this._thinInstanceDataStorage.matrixData) {
             serializationObject.thinInstances = {
                 instancesCount: this._thinInstanceDataStorage.instancesCount,
-                matrixData: Array.from(this._thinInstanceDataStorage.matrixData),
+                matrixData: Tools.SliceToArray(this._thinInstanceDataStorage.matrixData),
                 matrixBufferSize: this._thinInstanceDataStorage.matrixBufferSize,
             };
 
@@ -3191,7 +3191,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 };
 
                 for (const kind in this._userThinInstanceBuffersStorage.data) {
-                    userThinInstance.data[kind] = Array.from(this._userThinInstanceBuffersStorage.data[kind]);
+                    userThinInstance.data[kind] = Tools.SliceToArray(this._userThinInstanceBuffersStorage.data[kind]);
                     userThinInstance.sizes[kind] = this._userThinInstanceBuffersStorage.sizes[kind];
                     userThinInstance.strides[kind] = this._userThinInstanceBuffersStorage.strides[kind];
                 }

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -171,6 +171,22 @@ export class Tools {
     }
 
     /**
+     * Provides a slice function that will work even on IE
+     * The difference between this and Slice is that this will force-convert to array
+     * @param data defines the array to slice
+     * @param start defines the start of the data (optional)
+     * @param end defines the end of the data (optional)
+     * @returns the new sliced array
+     */
+    public static SliceToArray<T, P>(data: T, start?: number, end?: number): Array<P> {
+        if (Array.isArray(data)) {
+            return (data as Array<P>).slice(start, end);
+        }
+
+        return Array.prototype.slice.call(data, start, end);
+    }
+
+    /**
      * Polyfill for setImmediate
      * @param action defines the action to execute after the current execution block
      */

--- a/src/Particles/solidParticleSystem.ts
+++ b/src/Particles/solidParticleSystem.ts
@@ -16,6 +16,7 @@ import { Material } from '../Materials/material';
 import { StandardMaterial } from '../Materials/standardMaterial';
 import { MultiMaterial } from '../Materials/multiMaterial';
 import { PickingInfo } from '../Collisions/pickingInfo';
+import { Tools } from '../Misc/tools';
 
 /**
  * The SPS is a single updatable mesh. The solid particles are simply separate parts or faces fo this big mesh.
@@ -365,9 +366,9 @@ export class SolidParticleSystem implements IDisposable {
             var idx: number = this.nbParticles;
             var shape: Vector3[] = this._posToShape(facetPos);
             var shapeUV: number[] = this._uvsToShapeUV(facetUV);
-            var shapeInd = Array.from(facetInd);
-            var shapeCol = Array.from(facetCol);
-            var shapeNor = Array.from(facetNor);
+            var shapeInd = Tools.Slice(facetInd);
+            var shapeCol = Tools.Slice(facetCol);
+            var shapeNor = Tools.Slice(facetNor);
 
             // compute the barycenter of the shape
             barycenter.copyFromFloats(0, 0, 0);
@@ -675,9 +676,9 @@ export class SolidParticleSystem implements IDisposable {
         var meshCol = <FloatArray>mesh.getVerticesData(VertexBuffer.ColorKind);
         var meshNor = <FloatArray>mesh.getVerticesData(VertexBuffer.NormalKind);
         this.recomputeNormals = (meshNor) ? false : true;
-        var indices = Array.from(meshInd);
-        var shapeNormals = Array.from(meshNor);
-        var shapeColors = (meshCol) ? Array.from(meshCol) : [];
+        var indices = Tools.SliceToArray<IndicesArray, number>(meshInd);
+        var shapeNormals = Tools.SliceToArray<number[] | Float32Array, number>(meshNor);
+        var shapeColors = (meshCol) ? Tools.SliceToArray<number[] | Float32Array, number>(meshCol) : [];
         var storage = (options && options.storage) ? options.storage : null;
         var bbInfo: Nullable<BoundingInfo> = null;
         if (this._particlesIntersect) {

--- a/src/Rendering/edgesRenderer.ts
+++ b/src/Rendering/edgesRenderer.ts
@@ -17,6 +17,7 @@ import "../Shaders/line.fragment";
 import "../Shaders/line.vertex";
 import { DataBuffer } from '../Meshes/dataBuffer';
 import { SmartArray } from '../Misc/smartArray';
+import { Tools } from '../Misc/tools';
 
 declare module "../scene" {
     export interface Scene {
@@ -498,7 +499,7 @@ export class EdgesRenderer implements IEdgesRenderer {
         }
 
         if (!Array.isArray(indices)) {
-            indices = Array.from(indices);
+            indices = Tools.SliceToArray(indices);
         }
 
         /**


### PR DESCRIPTION
A new function was introduced - SliceToArray that will force the return of an array instead of a typed array.

Adressing #9122 