### PR TITLE
Allow override of XMLHttpRequest for Babylon Native

### DIFF
--- a/src/Misc/webRequest.ts
+++ b/src/Misc/webRequest.ts
@@ -1,11 +1,24 @@
 import { IWebRequest } from './interfaces/iWebRequest';
 import { Nullable } from '../types';
 
+/** @hidden */
+declare const _native: any;
+
+/** @hidden */
+function createXMLHttpRequest(): XMLHttpRequest {
+    // If running in Babylon Native, then defer to the native XMLHttpRequest, which has the same public contract
+    if (typeof _native !== 'undefined' && _native.XMLHttpRequest) {
+        return new _native.XMLHttpRequest();
+    } else {
+        return new XMLHttpRequest();
+    }
+}
+
 /**
  * Extended version of XMLHttpRequest with support for customizations (headers, ...)
  */
 export class WebRequest implements IWebRequest {
-    private _xhr = new XMLHttpRequest();
+    private readonly _xhr = createXMLHttpRequest();
 
     /**
      * Custom HTTP Request Headers to be sent with XMLHttpRequests


### PR DESCRIPTION
This change makes it so `WebRequest` uses a custom version of `XMLHttpRequest` when running in the context of Babylon Native. Ideally we'd always just use the globally scoped `XMLHttpRequest` and Babylon Native would always provide that, but in the further context of React Native, React Native itself already provides an `XMLHttpRequest` native polyfill. Unfortunately, the implementation of that native polyfill is *really bad* (e.g. allocates a ton of memory and is extremely slow due to lots of conversions between byte arrays and base64 strings). We don't want Babylon Native to completely override React Native's `XMLHttpRequest` because Babylon Native's implementation (while 3x faster) is not a complete implementation, and we don't want installing Babylon React Native to completely change the underlying `XMLHttpRequest` for the rest of the app (outside the context of Babylon). So, in this scenario, we will hang Babylon Native's custom `XMLHttpRequest` implementation off the `_native` object and `WebRequest` will check and see if it is available before using the default `XMLHttpRequest`.

I built and tested these changes locally for both Babylon.js and Babylon (React) Native.