### PR TITLE
Fix crash when using "AO from red channel" in the Reflectivity block

### DIFF
--- a/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
@@ -54,7 +54,7 @@ void reflectivityBlock(
 
             #ifdef AOSTOREINMETALMAPRED
                 vec3 aoStoreInMetalMap = vec3(surfaceMetallicOrReflectivityColorMap.r, surfaceMetallicOrReflectivityColorMap.r, surfaceMetallicOrReflectivityColorMap.r);
-                outParams.ambientOcclusionColor = mix(ambientOcclusionColorIn, aoStoreInMetalMap, vReflectivityInfos.z);
+                outParams.ambientOcclusionColor = mix(ambientOcclusionColorIn, aoStoreInMetalMap, reflectivityInfos.z);
             #endif
 
             #ifdef METALLNESSSTOREINMETALMAPBLUE


### PR DESCRIPTION
Fix #9165 