### PR TITLE
Removing log for exception

### DIFF
--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -53,6 +53,7 @@ export class Inspector {
     private static _CopyStyles(sourceDoc: HTMLDocument, targetDoc: HTMLDocument) {
         for (var index = 0; index < sourceDoc.styleSheets.length; index++) {
             var styleSheet: any = sourceDoc.styleSheets[index];
+            
             try {
                 if (styleSheet.cssRules) {
                     // for <style> elements
@@ -73,7 +74,7 @@ export class Inspector {
                     targetDoc.head!.appendChild(newLinkEl);
                 }
             } catch (e) {
-                console.log(e);
+                
             }
         }
     }


### PR DESCRIPTION
Exception is caught and remaining css rules are copied correctly.