### PR TITLE
Gizmo Manager Use Default Utility Layer

### DIFF
--- a/src/Gizmos/gizmoManager.ts
+++ b/src/Gizmos/gizmoManager.ts
@@ -91,10 +91,10 @@ export class GizmoManager implements IDisposable {
      * @param scene the scene to overlay the gizmos on top of
      * @param thickness display gizmo axis thickness
      */
-    constructor(private scene: Scene, thickness: number = 1) {
-        this._defaultKeepDepthUtilityLayer = new UtilityLayerRenderer(scene);
+    constructor(private scene: Scene, thickness: number = 1, utilityLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, keepDepthUtilityLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultKeepDepthUtilityLayer) {
+        this._defaultUtilityLayer = utilityLayer;
+        this._defaultKeepDepthUtilityLayer = keepDepthUtilityLayer;
         this._defaultKeepDepthUtilityLayer.utilityLayerScene.autoClearDepthAndStencil = false;
-        this._defaultUtilityLayer = new UtilityLayerRenderer(scene);
         this._thickness = thickness;
         this.gizmos = { positionGizmo: null, rotationGizmo: null, scaleGizmo: null, boundingBoxGizmo: null };
 

--- a/src/Gizmos/gizmoManager.ts
+++ b/src/Gizmos/gizmoManager.ts
@@ -90,6 +90,8 @@ export class GizmoManager implements IDisposable {
      * Instatiates a gizmo manager
      * @param scene the scene to overlay the gizmos on top of
      * @param thickness display gizmo axis thickness
+     * @param utilityLayer the layer where gizmos are rendered
+     * @param keepDepthUtilityLayer the layer where occluded gizmos are rendered
      */
     constructor(private scene: Scene, thickness: number = 1, utilityLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, keepDepthUtilityLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultKeepDepthUtilityLayer) {
         this._defaultUtilityLayer = utilityLayer;


### PR DESCRIPTION
Please read the comments [here](https://github.com/BabylonJS/Babylon.js/commit/16d106f1d607d20252ea6a6ad7a5f2a79181c5c1)

The purpose of this PR is to ensure `GizmoManager` uses the `UtilityLayerRenderer.DefaultUtilityLayer` by default. 
If an alternate UtilityLayer is desired, it can be input in `GizmoManagers` constructor.

This is critical for applications who want to render utilityLayer outside of the main render loop as seen in [this doc](https://doc.babylonjs.com/how_to/utilitylayerrenderer).