### PR TITLE
Make it possible to move an instance from one source mesh to another

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -57,6 +57,7 @@
 - Removed all references to HTML element from cameras' attach and detach control functions ([RaananW](https://github.com/RaananW))
 - Added `boundingBoxRenderer.onResourcesReadyObservable` ([aWeirdo](https://github.com/aWeirdo))
 - Added `copyTools.GenerateBase64StringFromTexture` ([aWeirdo](https://github.com/aWeirdo))
+- Added `instancedMesh.changeSourceMesh` ([breakin](https://github.com/breakin))
 
 ### Engine
 

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -172,6 +172,30 @@ export class InstancedMesh extends AbstractMesh {
     }
 
     /**
+     * Changes the source mesh for this instance
+     * Animations are not affected by this (they are not copied from the new source mesh)
+     * Note that the result might be unexpected if the source meshes are different
+     * @see https://doc.babylonjs.com/how_to/how_to_use_instances
+     * @param newSourceMesh defines the new source mesh for the instance
+     */
+    public changeSourceMesh(newSourceMesh: Mesh): void {
+        if (this.sourceMesh.uniqueId === newSourceMesh.uniqueId) {
+            return;
+        }
+        this.sourceMesh.removeInstance(this);
+        newSourceMesh.addInstance(this);
+        this._sourceMesh = newSourceMesh;
+        this._currentLOD = newSourceMesh; // TODO: ?
+
+        this._unIndexed = newSourceMesh._unIndexed;
+
+        this.infiniteDistance = newSourceMesh.infiniteDistance;
+
+        this.refreshBoundingInfo();
+        this._syncSubMeshes();
+    }
+
+    /**
      * Is this node ready to be used/rendered
      * @param completeCheck defines if a complete check (including materials and lights) has to be done (false by default)
      * @return {boolean} is it ready


### PR DESCRIPTION
Afaict the animations doesn't explicitly mention the source node in any form so it should be saft to leave them as is.

The use-case I see is that we have two source meshes that are the same except for having different materials (or some other per-sourceMesh property). Now we want to change material on one instance and then we change the source mesh.

Possibly this entire method could be replaced with some other general methods on instanceMesh such that the client can move it themselves. This includes:
* Changing soruceMesh attribute (in typescript)