### PR TITLE
Fix issue(s) with bone map

### DIFF
--- a/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -383,10 +383,10 @@ export class MeshPropertyGridComponent extends React.Component<
             value: -1,
         });
 
-        const targetBoneOptions: ListLineOption[] = mesh.skeleton ? mesh.skeleton.bones.map((bone, idx) => {
+        const targetBoneOptions: ListLineOption[] = mesh.skeleton ? mesh.skeleton.bones.filter((bone) => bone.getIndex() >= 0).sort((bone1, bone2) => bone1.getIndex() - bone2.getIndex()).map((bone, idx) => {
             return {
                 label: bone.name,
-                value: idx,
+                value: bone.getIndex(),
             };
         }) : [];
 
@@ -548,7 +548,7 @@ export class MeshPropertyGridComponent extends React.Component<
                             target={mesh.reservedDataStore}
                             propertyName="displayBoneIndex"
                             minimum={0}
-                            maximum={mesh.skeleton.bones.length - 1 || 0}
+                            maximum={targetBoneOptions.length - 1 || 0}
                             step={1}
                             onChange={(value) => {
                                 this.onBoneDisplayIndexChange(value);


### PR DESCRIPTION
Using the bones array is not enough - some bones have a negative index and should not be displayed.

This fixes two issues - the name of the bones were displayed incorrectly (because of a difference between index in the array and the actualy index of the bone), and the length of the sliders was fixed (now according to the length of active bones).