### PR TITLE
Remove epsilon check for PolygonPoints.add

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -368,3 +368,4 @@
 - Fix width/height GUI container computation to take into account paddings when `adaptWithToChildren = true` ([Popov72](https://github.com/Popov72))
 - `smoothstep` in NME is now taking any type of parameters for its `value` input. If you use generated code from the NME ("Generate code" button), you may have to move the smoothstep output connection AFTER the input connections ([Popov72](https://github.com/Popov72))
 - `SoundTrack.RemoveSound` and `SoundTrack.AddSound` were renamed to `SoundTrack.removeSound` and `SoundTrack.addSound` ([Deltakosh](https://github.com/deltakosh))
+- `PolygonPoints.add` no longer filters out points that are close to the first point ([bghgary](https://github.com/bghgary))

--- a/src/Meshes/polygonMesh.ts
+++ b/src/Meshes/polygonMesh.ts
@@ -31,11 +31,9 @@ class PolygonPoints {
 
         var result = new Array<IndexedVector2>();
         originalPoints.forEach((point) => {
-            if (result.length === 0 || !point.equalsWithEpsilon(result[0])) {
-                var newPoint = new IndexedVector2(point, this.elements.length);
-                result.push(newPoint);
-                this.elements.push(newPoint);
-            }
+            var newPoint = new IndexedVector2(point, this.elements.length);
+            result.push(newPoint);
+            this.elements.push(newPoint);
         });
 
         return result;


### PR DESCRIPTION
This playground (https://www.babylonjs-playground.com/#MEJFT3#2) is broken because there are two different logic to remove extraneous points in the polygon creation code.

1. https://github.com/BabylonJS/Babylon.js/blob/7fb7f7facaa564bd8cedc88e9ac97c2ca26f6f7d/src/Meshes/polygonMesh.ts#L33-L39
2. https://github.com/BabylonJS/Babylon.js/blob/d1348ad7c27ff8451a13a6229cbba6bcd84e97a7/src/Meshes/Builders/polygonBuilder.ts#L168-L171

The data in the PG has two points at the end that are close with the first point. The first logic removes both points. The second logic removes just the last point. This results in the logic creating extra indices that don't fit into the number of vertices.

I removed the check in 1, but I'm not sure this the right fix.
 