### PR TITLE
Fix plane removal callback event

### DIFF
--- a/src/XR/features/WebXRPlaneDetector.ts
+++ b/src/XR/features/WebXRPlaneDetector.ts
@@ -160,7 +160,7 @@ export class WebXRPlaneDetector extends WebXRAbstractFeature {
             toRemove.forEach((index) => {
                 const plane = this._detectedPlanes.splice(index - idxTracker, 1)[0];
                 this.onPlaneRemovedObservable.notifyObservers(plane);
-                idxTracker--;
+                idxTracker++;
             });
             // now check for new ones
             detectedPlanes.forEach((xrPlane) => {


### PR DESCRIPTION
It looks like an index offset isn't being calculated correctly. Without this change, undefined plane objects are obtained and handed to subscribers to onPlaneRemovedObservable. This change fixes the index offset.