### PR TITLE
Keeping frame state for node material saving

### DIFF
--- a/nodeEditor/src/diagram/graphCanvas.tsx
+++ b/nodeEditor/src/diagram/graphCanvas.tsx
@@ -234,13 +234,13 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
         this.props.globalState.storeEditorData = (editorData, graphFrame) => {
             editorData.frames = [];
             if (graphFrame) {
-                editorData.frames.push(graphFrame!.serialize());
+                editorData.frames.push(graphFrame!.serialize(false));
             } else {
                 editorData.x = this.x;
                 editorData.y = this.y;
                 editorData.zoom = this.zoom;
                 for (var frame of this._frames) {
-                    editorData.frames.push(frame.serialize());
+                    editorData.frames.push(frame.serialize(true));
                 }
             }
         }

--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -1415,7 +1415,7 @@ export class GraphFrame {
         }
     }
 
-    public serialize(): IFrameData {
+    public serialize(saveCollapsedState: boolean): IFrameData {
         this.serializePortData(this._exposedInPorts);
         this.serializePortData(this._exposedOutPorts);
         return {
@@ -1425,7 +1425,7 @@ export class GraphFrame {
             height: this._height,
             color: this._color.asArray(),
             name: this.name,
-            isCollapsed: true, //keeping closed to make reimporting cleaner
+            isCollapsed: saveCollapsedState ? this.isCollapsed: true, //keeping closed for stand along exporting.
             blocks: this.nodes.map(n => n.block.uniqueId),
             comments: this._comments
         }


### PR DESCRIPTION
When frames were exported they were saved with the state closed so they would be reimported close. However, when the node material itself is saved the frame closed state is now preserved.