### PR TITLE
Changes to XRAnchor system

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -225,6 +225,7 @@
 - Individual post processing can be applied to the XR rig cameras ([#9038](https://github.com/BabylonJS/Babylon.js/issues/9038)) ([RaananW](https://github.com/RaananW))
 - Pointer selection improvements - single/dual hand selection, max ray distance and more ([#7974](https://github.com/BabylonJS/Babylon.js/issues/7974)) ([RaananW](https://github.com/RaananW))
 - Updated Plane Detection API ([RaananW](https://github.com/RaananW))
+- Updated anchor system's promise resolution and API ([#9258](https://github.com/BabylonJS/Babylon.js/issues/9258)) ([RaananW](https://github.com/RaananW))
 
 ### Collisions
 


### PR DESCRIPTION
Closing WebXR Anchor system should provide full abstraction on top of XRAnchor #9258

Promises are now resolved only when Babylon has created an IWebXRAnchor object, which also means that the system started tracking it.
Also - IWebXRAnchor has a new remove function that is nothing more than a proxy to the native anchor's delete method.

There is now no need to interact with the xrAnchor, but the access to the object is still available.