### PR TITLE
Add increment to materials with duplicate id

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -378,3 +378,4 @@
 - `smoothstep` in NME is now taking any type of parameters for its `value` input. If you use generated code from the NME ("Generate code" button), you may have to move the smoothstep output connection AFTER the input connections ([Popov72](https://github.com/Popov72))
 - `SoundTrack.RemoveSound` and `SoundTrack.AddSound` were renamed to `SoundTrack.removeSound` and `SoundTrack.addSound` ([Deltakosh](https://github.com/deltakosh))
 - `PolygonPoints.add` no longer filters out points that are close to the first point ([bghgary](https://github.com/bghgary))
+- `Material` created with matching names now have auto-incrementing IDs.

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -661,6 +661,10 @@ export class Material implements IAnimatable {
     constructor(name: string, scene: Scene, doNotAdd?: boolean) {
         this.name = name;
         this.id = name || Tools.RandomId();
+        let idSubscript = 0;
+        while (scene.getMaterialByID(this.id) != null) {
+            this.id = name + "_" + idSubscript;
+        }
 
         this._scene = scene || EngineStore.LastCreatedScene;
         this.uniqueId = this._scene.getUniqueId();

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -660,13 +660,14 @@ export class Material implements IAnimatable {
      */
     constructor(name: string, scene: Scene, doNotAdd?: boolean) {
         this.name = name;
-        this.id = name || Tools.RandomId();
         let idSubscript = 1;
-        while (scene.getMaterialByID(this.id) !== null) {
+        this._scene = scene || EngineStore.LastCreatedScene;
+
+        this.id = name || Tools.RandomId();
+        while (this._scene.getMaterialByID(this.id) !== null) {
             this.id = name + " " + idSubscript++;
         }
 
-        this._scene = scene || EngineStore.LastCreatedScene;
         this.uniqueId = this._scene.getUniqueId();
 
         if (this._scene.useRightHandedSystem) {

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -661,10 +661,9 @@ export class Material implements IAnimatable {
     constructor(name: string, scene: Scene, doNotAdd?: boolean) {
         this.name = name;
         this.id = name || Tools.RandomId();
-        let idSubscript = 0;
-        while (scene.getMaterialByID(this.id) != null) {
-            idSubscript++;
-            this.id = name + " " + idSubscript;
+        let idSubscript = 1;
+        while (scene.getMaterialByID(this.id) !== null) {
+            this.id = name + " " + idSubscript++;
         }
 
         this._scene = scene || EngineStore.LastCreatedScene;

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -664,7 +664,7 @@ export class Material implements IAnimatable {
         this._scene = scene || EngineStore.LastCreatedScene;
 
         this.id = name || Tools.RandomId();
-        while (this._scene.getMaterialByID(this.id) !== null) {
+        while (this._scene.getMaterialByID(this.id)) {
             this.id = name + " " + idSubscript++;
         }
 

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -663,7 +663,8 @@ export class Material implements IAnimatable {
         this.id = name || Tools.RandomId();
         let idSubscript = 0;
         while (scene.getMaterialByID(this.id) != null) {
-            this.id = name + "_" + idSubscript;
+            idSubscript++;
+            this.id = name + " " + idSubscript;
         }
 
         this._scene = scene || EngineStore.LastCreatedScene;


### PR DESCRIPTION
This PR adds some extra logic to our material creation logic, adding a subscript to any materials created with a duplicate id.

Fixes #9290 