### PR TITLE
Copy ray origin to first point in _renderPoints

### DIFF
--- a/src/Debug/rayHelper.ts
+++ b/src/Debug/rayHelper.ts
@@ -121,6 +121,8 @@ export class RayHelper {
         point.scaleInPlace(len);
         point.addInPlace(ray.origin);
 
+        this._renderPoints[0].copyFrom(ray.origin);
+
         Mesh.CreateLines("ray", this._renderPoints, this._scene, true, this._renderLine);
 
     }


### PR DESCRIPTION
PR for: [https://forum.babylonjs.com/t/rayhelper-buggy-use-case/15240/3](url)

In rayHelper.ts, copy ray.origin to _renderPoints[0]. This should accommodate reassigning ray.origin to a new vector (if you must). The new origin vector will reproduce correctly in the RayHelper's line mesh.