### PR TITLE
gltfloader owned buffers are disposed with engine

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1675,8 +1675,17 @@ export class GLTFLoader implements IGLTFLoader {
             const bufferView = ArrayItem.Get(`${context}/bufferView`, this._gltf.bufferViews, accessor.bufferView);
             accessor._babylonVertexBuffer = this._loadVertexBufferViewAsync(bufferView, kind).then((babylonBuffer) => {
                 const size = GLTFLoader._GetNumComponents(context, accessor.type);
-                return new VertexBuffer(this._babylonScene.getEngine(), babylonBuffer, kind, false, false, bufferView.byteStride,
+                var vertexBuffer = new VertexBuffer(this._babylonScene.getEngine(), babylonBuffer, kind, false, false, bufferView.byteStride,
                     false, accessor.byteOffset, size, accessor.componentType, accessor.normalized, true);
+
+                // gltfload owns this buffer and is responsible to dispose it at some point.
+                // for now, it's doing that procedure when the engine is disposed
+                if (babylonBuffer instanceof Buffer) {
+                    this._babylonScene.getEngine().onDispose = () => {
+                        vertexBuffer._buffer.dispose();
+                    };
+                }
+                return vertexBuffer;
             });
         }
 

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -116,6 +116,7 @@ export class GLTFLoader implements IGLTFLoader {
     private _babylonScene: Scene;
     private _rootBabylonMesh: Mesh;
     private _defaultBabylonMaterialData: { [drawMode: number]: Material } = {};
+    private static _buffersToDispose = new Array<VertexBuffer>();
 
     private static _RegisteredExtensions: { [name: string]: IRegisteredExtension } = {};
 
@@ -1681,8 +1682,15 @@ export class GLTFLoader implements IGLTFLoader {
                 // gltfload owns this buffer and is responsible to dispose it at some point.
                 // for now, it's doing that procedure when the engine is disposed
                 if (babylonBuffer instanceof Buffer) {
+                    GLTFLoader._buffersToDispose.push(vertexBuffer);
                     this._babylonScene.getEngine().onDispose = () => {
-                        vertexBuffer._buffer.dispose();
+                        while (GLTFLoader._buffersToDispose.length)
+                        {
+                            var bufferToDispose = GLTFLoader._buffersToDispose.pop();
+                            if (bufferToDispose) {
+                                bufferToDispose._buffer.dispose();
+                            }
+                        }
                     };
                 }
                 return vertexBuffer;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -299,6 +299,22 @@ export class ThinEngine {
     protected _renderingQueueLaunched = false;
     protected _activeRenderLoops = new Array<() => void>();
 
+    /**
+    * An event triggered when the thin engine is disposed.
+    */
+    public onDisposeObservable = new Observable<ThinEngine>();
+
+    private _onDisposeObserver: Nullable<Observer<ThinEngine>> = null;
+    /** Sets a function to be executed when this engine is disposed. 
+     * This callback has been introduced to allow gltf loader to dispose its own buffer.
+    */
+    public set onDispose(callback: () => void) {
+        if (this._onDisposeObserver) {
+            this.onDisposeObservable.remove(this._onDisposeObserver);
+        }
+        this._onDisposeObserver = this.onDisposeObservable.add(callback);
+    }
+
     // Lost context
     /**
      * Observable signaled when a context lost event is raised
@@ -3844,6 +3860,10 @@ export class ThinEngine {
      */
     public dispose(): void {
         this.stopRenderLoop();
+
+        // on dispose event
+        this.onDisposeObservable.notifyObservers(this);
+        this.onDisposeObservable.clear();
 
         // Clear observables
         if (this.onBeforeTextureInitObservable) {

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -305,7 +305,7 @@ export class ThinEngine {
     public onDisposeObservable = new Observable<ThinEngine>();
 
     private _onDisposeObserver: Nullable<Observer<ThinEngine>> = null;
-    /** Sets a function to be executed when this engine is disposed. 
+    /** Sets a function to be executed when this engine is disposed.
      * This callback has been introduced to allow gltf loader to dispose its own buffer.
     */
     public set onDispose(callback: () => void) {


### PR DESCRIPTION
We experienced leaked bgfx resources in babylon native when loading .gltf.
Those leaks are caused by a buffer that is owned by gltfloader and never disposed.
To fix that, I've added an onDisposed callback on thinengine and dispose those buffers when the engine is disposed.
The buffer array to dispose is static because it's possible to load multiple gltf in one engine.