### PR TITLE
Update meshSimplification.ts

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -364,6 +364,7 @@
 - Fixed bug in `Mesh.IncreaseVertices` assuming null value if a property didn't exist. ([aWeirdo](https://github.com/aWeirdo))
 - Fix issue when taking a screenshot with multi-cameras using method `CreateScreenshotUsingRenderTarget` ([#9201](https://github.com/BabylonJS/Babylon.js/issues/9201)) ([gabrielheming](https://github.com/gabrielheming))
 - Fix inTangent in animationGroup ([dad72](https://github.com/dad72))
+- Fixed bug in `QuadraticErrorSimplification` not correctly optimizing mesh. ([aWeirdo](https://github.com/aWeirdo))
 
 ## Breaking changes
 

--- a/src/Meshes/meshSimplification.ts
+++ b/src/Meshes/meshSimplification.ts
@@ -473,7 +473,7 @@ export class QuadraticErrorSimplification implements ISimplifier {
         var findInVertices = (positionToSearch: Vector3) => {
             if (optimizeMesh) {
                 for (var ii = 0; ii < this.vertices.length; ++ii) {
-                    if (this.vertices[ii].position.equals(positionToSearch)) {
+                    if (this.vertices[ii].position.equalsWithEpsilon(positionToSearch, 0.0001)) {
                         return this.vertices[ii];
                     }
                 }

--- a/src/Meshes/meshSimplification.ts
+++ b/src/Meshes/meshSimplification.ts
@@ -582,21 +582,20 @@ export class QuadraticErrorSimplification implements ISimplifier {
             vertex.id = vertexCount;
             if (vertex.triangleCount) {
                 vertex.originalOffsets.forEach((originalOffset) => {
-                    if (!normalData) {
-                        return;
-                    }
 
                     newPositionData.push(vertex.position.x);
                     newPositionData.push(vertex.position.y);
                     newPositionData.push(vertex.position.z);
-                    newNormalData.push(normalData[originalOffset * 3]);
-                    newNormalData.push(normalData[(originalOffset * 3) + 1]);
-                    newNormalData.push(normalData[(originalOffset * 3) + 2]);
+
+                    if (normalData && normalData.length) {
+                        newNormalData.push(normalData[originalOffset * 3]);
+                        newNormalData.push(normalData[(originalOffset * 3) + 1]);
+                        newNormalData.push(normalData[(originalOffset * 3) + 2]);
+                    }
                     if (uvs && uvs.length) {
                         newUVsData.push(uvs[(originalOffset * 2)]);
                         newUVsData.push(uvs[(originalOffset * 2) + 1]);
                     }
-
                     if (colorsData && colorsData.length) {
                         newColorsData.push(colorsData[(originalOffset * 4)]);
                         newColorsData.push(colorsData[(originalOffset * 4) + 1]);
@@ -630,7 +629,9 @@ export class QuadraticErrorSimplification implements ISimplifier {
 
         this._reconstructedMesh.setIndices(newIndicesArray);
         this._reconstructedMesh.setVerticesData(VertexBuffer.PositionKind, newPositionData);
-        this._reconstructedMesh.setVerticesData(VertexBuffer.NormalKind, newNormalData);
+        if (newNormalData.length > 0) {
+            this._reconstructedMesh.setVerticesData(VertexBuffer.NormalKind, newNormalData);
+        }
         if (newUVsData.length > 0) {
             this._reconstructedMesh.setVerticesData(VertexBuffer.UVKind, newUVsData);
         }


### PR DESCRIPTION
- Fixes https://forum.babylonjs.com/t/make-mesh-simplify-affect-mesh-evenly/15113 when optimizeMesh option is enabled.
- & Allow meshes without normals

![a3e2ce9f91977a74833fc7fd0072d2dc04823113 1](https://user-images.githubusercontent.com/4191201/97812370-227e6600-1c81-11eb-80c3-dbecf177e9ec.png)
