### PR TITLE
Check if the location object exists before using it

### DIFF
--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -469,7 +469,7 @@ export class FileTools {
      * @returns boolean
      */
     public static IsFileURL(): boolean {
-        return location.protocol === "file:";
+        return typeof location !== "undefined" && location.protocol === "file:";
     }
 }
 


### PR DESCRIPTION
There is no `location` global object in some non-browser environments, such as React Native, so we need to check whether this object exists before using it.