### PR TITLE
Arcrotatecamera rebuild angles fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -368,6 +368,7 @@
 - Fix issue when taking a screenshot with multi-cameras using method `CreateScreenshotUsingRenderTarget` ([#9201](https://github.com/BabylonJS/Babylon.js/issues/9201)) ([gabrielheming](https://github.com/gabrielheming))
 - Fix inTangent in animationGroup ([dad72](https://github.com/dad72))
 - Fixed bug in `QuadraticErrorSimplification` not correctly optimizing mesh. ([aWeirdo](https://github.com/aWeirdo))
+- Fixed bug in `ArcRotateCamera` where setting the position would recalculate the alpha value to a value outside the current limits. ([nilss0n](https://github.com/nilss0n))
 
 ## Breaking changes
 

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -985,7 +985,7 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         // Alpha
-        const previousAlpha = this.alpha
+        const previousAlpha = this.alpha;
         if (this._computationVector.x === 0 && this._computationVector.z === 0) {
             this.alpha = Math.PI / 2; // avoid division by zero when looking along up axis, and set to acos(0)
         } else {
@@ -997,9 +997,9 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         // Calculate the number of revolutions between the new and old alpha values.
-        const alphaCorrectionTurns = Math.round((previousAlpha - this.alpha) / (2.0 * Math.PI))
+        const alphaCorrectionTurns = Math.round((previousAlpha - this.alpha) / (2.0 * Math.PI));
         // Adjust alpha so that its numerical representation is the closest one to the old value.
-        this.alpha += alphaCorrectionTurns * 2.0 * Math.PI
+        this.alpha += alphaCorrectionTurns * 2.0 * Math.PI;
 
         // Beta
         this.beta = Math.acos(this._computationVector.y / this.radius);

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -985,6 +985,7 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         // Alpha
+        const previousAlpha = this.alpha
         if (this._computationVector.x === 0 && this._computationVector.z === 0) {
             this.alpha = Math.PI / 2; // avoid division by zero when looking along up axis, and set to acos(0)
         } else {
@@ -994,6 +995,11 @@ export class ArcRotateCamera extends TargetCamera {
         if (this._computationVector.z < 0) {
             this.alpha = 2 * Math.PI - this.alpha;
         }
+
+        // Calculate the number of revolutions between the new and old alpha values.
+        const alphaCorrectionTurns = Math.round((previousAlpha - this.alpha) / (2.0 * Math.PI))
+        // Adjust alpha so that its numerical representation is the closest one to the old value.
+        this.alpha += alphaCorrectionTurns * 2.0 * Math.PI
 
         // Beta
         this.beta = Math.acos(this._computationVector.y / this.radius);


### PR DESCRIPTION
Fix for the following issue: https://forum.babylonjs.com/t/issue-involving-arcrotatecamera-collisions-and-angular-limits/15397

ArcRotateCamera.rebuildAnglesAndRadius calculates alpha in the range [0, 2*Pi]. If the previous alpha value was outside this range (e.g. < 0) it could cause the new value to  be outside the alpha limits, causing the camera to jump to the closest limit. 

This fix adds a correction to the alpha value such that the resulting numerical value is the closest one to the old value. 

