### PR TITLE
Fix parsing the camera upVector from serialization

### DIFF
--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1303,6 +1303,8 @@ export class Camera extends Node {
             camera._setupInputs();
         }
 
+        camera.upVector = Vector3.FromArray(parsedCamera.upVector); // need to force the upVector
+
         if ((<any>camera).setPosition) { // need to force position
             camera.position.copyFromFloats(0, 0, 0);
             (<any>camera).setPosition(Vector3.FromArray(parsedCamera.position));

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1303,7 +1303,9 @@ export class Camera extends Node {
             camera._setupInputs();
         }
 
-        camera.upVector = Vector3.FromArray(parsedCamera.upVector); // need to force the upVector
+        if (parsedCamera.upVector) {
+            camera.upVector = Vector3.FromArray(parsedCamera.upVector); // need to force the upVector
+        }
 
         if ((<any>camera).setPosition) { // need to force position
             camera.position.copyFromFloats(0, 0, 0);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/sceneloader-fails-to-load-data-if-upvector-of-a-camera-is-different-than-0-1-0/15433