### PR TITLE
[bug] Update texture.ts 

### DIFF
--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -515,7 +515,7 @@ export class Texture extends BaseTexture {
         this._cachedWRotationCenter = this.wRotationCenter;
         this._cachedHomogeneousRotationInUVTransform = this.homogeneousRotationInUVTransform;
 
-        if (!this._cachedTextureMatrix) {
+        if (!this._cachedTextureMatrix || !this._rowGenerationMatrix) {
             this._cachedTextureMatrix = Matrix.Zero();
             this._rowGenerationMatrix = new Matrix();
             this._t0 = Vector3.Zero();

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -515,7 +515,7 @@ export class Texture extends BaseTexture {
         this._cachedWRotationCenter = this.wRotationCenter;
         this._cachedHomogeneousRotationInUVTransform = this.homogeneousRotationInUVTransform;
 
-        if (!this._cachedTextureMatrix || !this._rowGenerationMatrix) {
+        if (!this._rowGenerationMatrix) {
             this._cachedTextureMatrix = Matrix.Zero();
             this._rowGenerationMatrix = new Matrix();
             this._t0 = Vector3.Zero();


### PR DESCRIPTION
Texture._rowGenerationMatrix can be null while Texture._cachedTextureMatrix is not.

If a texture is applied as ReflectionTexture, then applied as another texture type, Texture._rowGenerationMatrix can be null,
throws error in Matrix.RotationYawPitchRollToRef() chain
>Cannot read property '_m' of null

https://www.babylonjs-playground.com/#2FDQT5#564
