### PR TITLE
don't add sixDofDrag scene to the last created ones

### DIFF
--- a/src/Behaviors/Meshes/sixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/sixDofDragBehavior.ts
@@ -98,7 +98,7 @@ export class SixDofDragBehavior implements Behavior<Mesh> {
         this._ownerNode = ownerNode;
         this._scene = this._ownerNode.getScene();
         if (!SixDofDragBehavior._virtualScene) {
-            SixDofDragBehavior._virtualScene = new Scene(this._scene.getEngine());
+            SixDofDragBehavior._virtualScene = new Scene(this._scene.getEngine(), {virtual: true});
             SixDofDragBehavior._virtualScene.detachControl();
             this._scene.getEngine().scenes.pop();
         }


### PR DESCRIPTION
Follow up on https://forum.babylonjs.com/t/sixdofdragbehavior-creates-virtual-scene-which-updates-lastcreatedscene/15548
Don't add virtual scene to the lastCreatedScene for sixDofDragBehavior