### PR TITLE
fix axis drag gizmo with bones

### DIFF
--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -133,7 +133,7 @@ export class AxisDragGizmo extends Gizmo {
                     }
 
                     // use _worldMatrix to not force a matrix update when calling GetWorldMatrix especialy with Cameras
-                    this.attachedNode._worldMatrix.addTranslationFromFloats(event.delta.x, event.delta.y, event.delta.z);
+                    this.attachedNode.getWorldMatrix().addTranslationFromFloats(event.delta.x, event.delta.y, event.delta.z);
                     this.attachedNode.updateCache();
                 } else {
                     currentSnapDragDistance += event.dragDistance;
@@ -142,7 +142,7 @@ export class AxisDragGizmo extends Gizmo {
                         currentSnapDragDistance = currentSnapDragDistance % this.snapDistance;
                         event.delta.normalizeToRef(tmpVector);
                         tmpVector.scaleInPlace(this.snapDistance * dragSteps);
-                        this.attachedNode._worldMatrix.addTranslationFromFloats(tmpVector.x, tmpVector.y, tmpVector.z);
+                        this.attachedNode.getWorldMatrix().addTranslationFromFloats(tmpVector.x, tmpVector.y, tmpVector.z);
                         this.attachedNode.updateCache();
                         tmpSnapEvent.snapDistance = this.snapDistance * dragSteps;
                         this.onSnapObservable.notifyObservers(tmpSnapEvent);

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -291,8 +291,11 @@ export class Gizmo implements IDisposable {
                 bone.getWorldMatrix().multiplyToRef(invParent, boneLocalMatrix);
                 var lmat = bone.getLocalMatrix();
                 lmat.copyFrom(boneLocalMatrix);
-                bone.markAsDirty();
+            } else {
+                var lmat = bone.getLocalMatrix();
+                lmat.copyFrom(bone.getWorldMatrix());
             }
+            bone.markAsDirty();
         }
     }
 


### PR DESCRIPTION
followup on https://forum.babylonjs.com/t/moving-avatar-with-position-gizmos/15551
_worldMatrix was still used for axisdrag and it was out of sync with bones.