### PR TITLE
Use mesh.visibility and material.alpha for global alpha value in soft transparent shadow rendering

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -9,3 +9,5 @@
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))
 
 ## Breaking changes
+
+- Use both `mesh.visibility` and `material.alpha` values to compute the global alpha value used by the soft transparent shadow rendering code. Formerly was only using `mesh.visibility` ([Popov72](https://github.com/Popov72))

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1110,7 +1110,7 @@ export class ShadowGenerator implements IShadowGenerator {
         if (this.isReady(subMesh, hardwareInstancedRendering, isTransparent)) {
             subMesh._renderId = scene.getRenderId();
 
-            const shadowDepthWrapper = renderingMesh.material?.shadowDepthWrapper;
+            const shadowDepthWrapper = material.shadowDepthWrapper;
 
             let effect = shadowDepthWrapper?.getEffect(subMesh, this) ?? this._effect;
 

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1134,7 +1134,7 @@ export class ShadowGenerator implements IShadowGenerator {
             }
 
             if (isTransparent && this.enableSoftTransparentShadow) {
-                effect.setFloat("softTransparentShadowSM", effectiveMesh.visibility);
+                effect.setFloat("softTransparentShadowSM", effectiveMesh.visibility * material.alpha);
             }
 
             if (shadowDepthWrapper) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/soft-transparent-shadows-not-working-for-materials-without-textures/15681/3