### PR TITLE
[XR] Support the emulator

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -19,6 +19,10 @@
 
 - Added an `OcclusionMaterial` to simplify depth-only rendering of geometry ([rgerd](https://github.com/rgerd))
 
+### WebXR
+
+- A browser error preventing the emulator to render scene is now correctly dealt with ([RaananW](https://github.com/RaananW))
+
 ## Bugs
 
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))

--- a/src/XR/webXRManagedOutputCanvas.ts
+++ b/src/XR/webXRManagedOutputCanvas.ts
@@ -3,6 +3,7 @@ import { ThinEngine } from "../Engines/thinEngine";
 import { WebXRRenderTarget } from "./webXRTypes";
 import { WebXRSessionManager } from "./webXRSessionManager";
 import { Observable } from "../Misc/observable";
+import { Tools } from "../Misc/tools";
 
 /**
  * COnfiguration object for WebXR output canvas
@@ -118,10 +119,20 @@ export class WebXRManagedOutputCanvas implements WebXRRenderTarget {
             return Promise.resolve(this.xrLayer);
         }
 
-        return (this.canvasContext as any).makeXRCompatible().then(() => {
-            this.xrLayer = createLayer();
-            return this.xrLayer;
-        });
+        return (this.canvasContext as any)
+            .makeXRCompatible()
+            .then(
+                // catch any error and continue. When using the emulator is throws this error for no apparent reason.
+                () => {},
+                () => {
+                    // log the error, continue nonetheless!
+                    Tools.Warn("Error executing makeXRCompatible. This does not mean that the session will work incorrectly.");
+                }
+            )
+            .then(() => {
+                this.xrLayer = createLayer();
+                return this.xrLayer;
+            });
     }
 
     private _addCanvas() {


### PR DESCRIPTION
It seems like the emulator cannot execute the makeXRCompatible function corectly, which results in DOM exception.

This will log the error but will still continue and not throw any error further up. XR-enabled browsers still work the same.