### PR TITLE
added support for orthographic cameras to ssao2RenderingPipeline

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -45,6 +45,7 @@
 - Fix an issue with keyboard control (re)attachment. ([#9411](https://github.com/BabylonJS/Babylon.js/issues/9411)) ([RaananW](https://github.com/RaananW))
 - Fix issue where PBRSpecularGlossiness materials were excluded from export [#9423](https://github.com/BabylonJS/Babylon.js/issues/9423)([Drigax](https://github.com/drigax))
 - Fix direct loading of a glTF string that has base64-encoded URI. ([bghgary](https://github.com/bghgary))
+- Fix ssao2RenderingPipeline for orthographic cameras ([Kesshi](https://github.com/Kesshi))
 
 ## Breaking changes
 

--- a/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -385,6 +385,16 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
         return defines;
     }
 
+    private static readonly ORTHO_DEPTH_PROJECTION = [
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1];
+
+    private static readonly PERSPECTIVE_DEPTH_PROJECTION = [
+        0, 0, 0,
+        0, 0, 0,
+        1, 1, 1];
+
     private _createSSAOPostProcess(ratio: number): void {
         this._sampleSphere = this._generateHemisphere();
 
@@ -401,7 +411,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             [
                 "sampleSphere", "samplesFactor", "randTextureTiles", "totalStrength", "radius",
                 "base", "range", "projection", "near", "far", "texelSize",
-                "xViewport", "yViewport", "maxZ", "minZAspect", "orthoProjection"
+                "xViewport", "yViewport", "maxZ", "minZAspect", "depthProjection"
             ],
             samplers,
             ratio, null, Texture.BILINEAR_SAMPLINGMODE,
@@ -425,7 +435,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             effect.setFloat("near", this._scene.activeCamera.minZ);
             effect.setFloat("far", this._scene.activeCamera.maxZ);
             if (this._scene.activeCamera.mode === Camera.PERSPECTIVE_CAMERA) {
-                effect.setInt("orthoProjection", 0);
+                effect.setMatrix3x3("depthProjection", SSAO2RenderingPipeline.PERSPECTIVE_DEPTH_PROJECTION);
                 effect.setFloat("xViewport", Math.tan(this._scene.activeCamera.fov / 2) * this._scene.getEngine().getAspectRatio(this._scene.activeCamera, true));
                 effect.setFloat("yViewport", Math.tan(this._scene.activeCamera.fov / 2));
             } else {
@@ -435,7 +445,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 const orthoRight = this._scene.activeCamera.orthoRight ?? halfWidth;
                 const orthoBottom = this._scene.activeCamera.orthoBottom ?? -halfHeight;
                 const orthoTop = this._scene.activeCamera.orthoTop ?? halfHeight;
-                effect.setInt("orthoProjection", 1);
+                effect.setMatrix3x3("depthProjection", SSAO2RenderingPipeline.ORTHO_DEPTH_PROJECTION);
                 effect.setFloat("xViewport", (orthoRight - orthoLeft) * 0.5);
                 effect.setFloat("yViewport", (orthoTop - orthoBottom) * 0.5);
             }

--- a/src/Shaders/ssao2.fragment.fx
+++ b/src/Shaders/ssao2.fragment.fx
@@ -56,7 +56,7 @@ float viewZToOrthographicDepth( const in float viewZ, const in float near, const
 	uniform float base;
 	uniform float xViewport;
 	uniform float yViewport;
-	uniform int orthoProjection;
+	uniform mat3 depthProjection;
 	uniform float maxZ;
 	uniform float minZAspect;
 	uniform vec2 texelSize;
@@ -82,7 +82,8 @@ float viewZToOrthographicDepth( const in float viewZ, const in float near, const
 		float correctedRadius = min(radius, minZAspect * depth / near);
 
 		vec3 vViewRay = vec3((vUV.x * 2.0 - 1.0)*xViewport, (vUV.y * 2.0 - 1.0)*yViewport, depthSign);
-		vec3 origin = orthoProjection > 0 ? vec3(vViewRay.x, vViewRay.y, vViewRay.z * depth) : vViewRay * depth;
+		vec3 vDepthFactor = depthProjection * vec3(1.0, 1.0, depth); 
+		vec3 origin = vViewRay * vDepthFactor;
 		vec3 rvec = random * 2.0 - 1.0;
 		rvec.z = 0.0;
 

--- a/src/Shaders/ssao2.fragment.fx
+++ b/src/Shaders/ssao2.fragment.fx
@@ -56,6 +56,7 @@ float viewZToOrthographicDepth( const in float viewZ, const in float near, const
 	uniform float base;
 	uniform float xViewport;
 	uniform float yViewport;
+	uniform int orthoProjection;
 	uniform float maxZ;
 	uniform float minZAspect;
 	uniform vec2 texelSize;
@@ -81,7 +82,7 @@ float viewZToOrthographicDepth( const in float viewZ, const in float near, const
 		float correctedRadius = min(radius, minZAspect * depth / near);
 
 		vec3 vViewRay = vec3((vUV.x * 2.0 - 1.0)*xViewport, (vUV.y * 2.0 - 1.0)*yViewport, depthSign);
-		vec3 origin = vViewRay * depth;
+		vec3 origin = orthoProjection > 0 ? vec3(vViewRay.x, vViewRay.y, vViewRay.z * depth) : vViewRay * depth;
 		vec3 rvec = random * 2.0 - 1.0;
 		rvec.z = 0.0;
 


### PR DESCRIPTION
With the help of @CraigFeldspar i was able to fix this issue: https://forum.babylonjs.com/t/ssao-bug-with-othographic-cameras/12350