### PR TITLE
Fix preview version number and various links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,13 +102,13 @@ window.addEventListener('resize', function(){
 
 ## Preview release
 
-Preview version of **4.1** can be found [here](https://github.com/BabylonJS/Babylon.js/tree/master/dist/preview%20release).
+Preview version of **5.0** can be found [here](https://github.com/BabylonJS/Babylon.js/tree/master/dist/preview%20release).
 If you want to contribute, please read our [contribution guidelines](https://github.com/BabylonJS/Babylon.js/blob/master/contributing.md) first.
 
 ## Documentation
 
 - [Documentation](https://doc.babylonjs.com)
-- [Examples](https://doc.babylonjs.com/examples)
+- [Demos](https://www.babylonjs.com/community/)
 
 ## Contributing
 Please see the [Contributing Guidelines](./contributing.md).
@@ -118,17 +118,17 @@ Please see the [Contributing Guidelines](./contributing.md).
 - Official web site: [www.babylonjs.com](https://www.babylonjs.com/)
 - Online [playground](https://playground.babylonjs.com/) to learn by experimentating
 - Online [sandbox](https://www.babylonjs.com/sandbox) where you can test your .babylon and glTF scenes with a simple drag'n'drop
-- Online [shader creation tool](https://www.babylonjs.com/cyos/) where you can learn how to create GLSL shaders
+- Online [shader creation tool](https://cyos.babylonjs.com/) where you can learn how to create GLSL shaders
 - 3DS Max [exporter](https://github.com/BabylonJS/Exporters/tree/master/3ds%20Max) can be used to generate a .babylon file from 3DS Max
 - Maya [exporter](https://github.com/BabylonJS/Exporters/tree/master/Maya) can be used to generate a .babylon file from Maya
-- Blender [exporter](https://github.com/BabylonJS/Exporters/tree/master/Blender) can be used to generate a .babylon file from Blender 3d
+- Blender [exporter](https://github.com/BabylonJS/BlenderExporter) can be used to generate a .babylon file from Blender 3d
 - Unity 5[ (deprecated) exporter](https://github.com/BabylonJS/Exporters/tree/master/Unity) can be used to export your geometries from Unity 5 scene editor(animations are supported)
 - [glTF Tools](https://github.com/KhronosGroup/glTF#gltf-tools) by KhronosGroup
 
 ## Features
 
-To get a complete list of supported features, please visit our [website](https://www.babylonjs.com/#specifications).
+To get a complete list of supported features, please visit our [website](https://www.babylonjs.com/specifications/).
 
 ## Build
 
-Babylon.js is automatically built using [Gulp](https://gulpjs.com/). Further instructions can be found in [the documentation](https://doc.babylonjs.com/how_to/how_to_start#the-build) or in the readme at [/Tools/Gulp](https://github.com/BabylonJS/Babylon.js/tree/master/Tools/Gulp).
+Babylon.js is automatically built using [Gulp](https://gulpjs.com/). Further instructions can be found in [the documentation](https://doc.babylonjs.com/divingDeeper/developWithBjs/howToStart#the-build) or in the readme at [/Tools/Gulp](https://github.com/BabylonJS/Babylon.js/tree/master/Tools/Gulp).


### PR DESCRIPTION
This README was still referring to 4.1 in the future tense.
Fixed old hash-based link;
Fixed cyos link;
Swapped broken "Examples" link for community demos;
Updated build instructions link;
Updated Blender exporter link