### PR TITLE
KTX2 decoder: Fix mipmaps creation for non square textures

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -48,6 +48,7 @@
 - Fix crash of some node materials using instances on iOS ([Popov72](https://github.com/Popov72))
 - Fix the code generated for the NME gradient block ([Popov72](https://github.com/Popov72))
 - Fix ssao2RenderingPipeline for orthographic cameras ([Kesshi](https://github.com/Kesshi))
+- Fix mipmaps creation in the KTX2 decoder for non square textures ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/ktx2Decoder/src/ktx2Decoder.ts
+++ b/ktx2Decoder/src/ktx2Decoder.ts
@@ -175,8 +175,8 @@ export class KTX2Decoder {
                 firstImageDescIndex += Math.max(kfr.header.layerCount, 1) * kfr.header.faceCount * Math.max(kfr.header.pixelDepth >> (level - 1), 1);
             }
 
-            const levelWidth = Math.floor(width / (1 << level));
-            const levelHeight = Math.floor(height / (1 << level));
+            const levelWidth = Math.floor(width / (1 << level)) || 1;
+            const levelHeight = Math.floor(height / (1 << level)) || 1;
 
             const numImagesInLevel = kfr.header.faceCount; // note that cubemap are not supported yet (see KTX2FileReader), so faceCount == 1
             const levelImageByteLength = ((levelWidth + 3) >> 2) * ((levelHeight + 3) >> 2) * kfr.dfdBlock.bytesPlane[0];


### PR DESCRIPTION
Fix #9503 