### PR TITLE
Support "#include <otherShader>" and "#include<otherShader>" (the space character)

### DIFF
--- a/src/Engines/Processors/shaderProcessor.ts
+++ b/src/Engines/Processors/shaderProcessor.ts
@@ -18,6 +18,7 @@ declare type ThinEngine = import("../thinEngine").ThinEngine;
 
 const regexSE = /defined\s*?\((.+?)\)/g;
 const regexSERevert = /defined\s*?\[(.+?)\]/g;
+const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
 
 /** @hidden */
 export class ShaderProcessor {
@@ -301,8 +302,7 @@ export class ShaderProcessor {
     }
 
     private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
-        var regex = /#include<(.+)>(\((.*)\))*(\[(.*)\])*/g;
-        var match = regex.exec(sourceCode);
+        var match = regexShaderInclude.exec(sourceCode);
 
         var returnValue = new String(sourceCode);
         var keepProcessing = false;
@@ -371,7 +371,10 @@ export class ShaderProcessor {
                 // Replace
                 returnValue = returnValue.replace(match[0], includeContent);
 
-                keepProcessing = keepProcessing || includeContent.indexOf("#include<") >= 0;
+                keepProcessing =
+                    keepProcessing ||
+                    includeContent.indexOf("#include<") >= 0 ||
+                    includeContent.indexOf("#include <") >= 0;
             } else {
                 var includeShaderUrl = options.shadersRepository + "ShadersInclude/" + includeFile + ".fx";
 

--- a/src/Engines/Processors/shaderProcessor.ts
+++ b/src/Engines/Processors/shaderProcessor.ts
@@ -18,7 +18,6 @@ declare type ThinEngine = import("../thinEngine").ThinEngine;
 
 const regexSE = /defined\s*?\((.+?)\)/g;
 const regexSERevert = /defined\s*?\[(.+?)\]/g;
-const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
 
 /** @hidden */
 export class ShaderProcessor {
@@ -302,6 +301,7 @@ export class ShaderProcessor {
     }
 
     private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
+        const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
         var match = regexShaderInclude.exec(sourceCode);
 
         var returnValue = new String(sourceCode);
@@ -385,7 +385,7 @@ export class ShaderProcessor {
                 return;
             }
 
-            match = regex.exec(sourceCode);
+            match = regexShaderInclude.exec(sourceCode);
         }
 
         if (keepProcessing) {


### PR DESCRIPTION
Currently, if your shader has a space between `#include` and `<filename>` Babylon.js will throw an error when processing the shader.

This is a little frustrating if you're using `clang-format` to format GLSL for you because it inserts the space automatically, which breaks the shader. 

So I made the regex support an optional space character.

I tested this by manually overriding this function with the diff below in my codebase.

I also wonder if `sourceCode` needs to be copied in `returnValue` on line 307, since strings are immutable.
