### PR TITLE
Increase transmission render target default size to 1024x1024

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -12,6 +12,7 @@
 ### Loaders
 
 - Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))
+- Increased transmission render target texture default size. ([Drigax](https://github.com/drigax))
 
 ### Navigation
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -12,7 +12,7 @@
 ### Loaders
 
 - Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))
-- Increased transmission render target texture default size. ([Drigax](https://github.com/drigax))
+- Increased KHR_materials_transmission render target texture default size. ([Drigax](https://github.com/drigax))
 
 ### Navigation
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -37,7 +37,7 @@ class TransmissionHelper {
      */
     private static _getDefaultOptions(): ITransmissionHelperOptions {
         return {
-            renderSize: 512
+            renderSize: 1024
         };
     }
 


### PR DESCRIPTION
Increasing the default render target size to hopefully improve OOB experience with KHR_materials_transmission assets