### PR TITLE
Changed glTF loader to remove empty animation groups

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -13,6 +13,7 @@
 
 - Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))
 - Increased KHR_materials_transmission render target texture default size. ([Drigax](https://github.com/drigax))
+- Changed glTF loader to remove empty animation groups if there are no animation channels loaded with the given options. ([bghgary](https://github.com/bghgary))
 
 ### Navigation
 

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1243,11 +1243,16 @@ export class GLTFLoader implements IGLTFLoader {
             return Promise.resolve();
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<void>>();
 
         for (let index = 0; index < animations.length; index++) {
             const animation = animations[index];
-            promises.push(this.loadAnimationAsync(`/animations/${animation.index}`, animation));
+            promises.push(this.loadAnimationAsync(`/animations/${animation.index}`, animation).then((animationGroup) => {
+                // Delete the animation group if it ended up not having any animations in it.
+                if (animationGroup.targetedAnimations.length === 0) {
+                    animationGroup.dispose();
+                }
+            }));
         }
 
         return Promise.all(promises).then(() => { });


### PR DESCRIPTION
See https://forum.babylonjs.com/t/importing-animation-corrupt-animation-data-3dsmax-creating-animationgroups/16115.