### PR TITLE
Camera fixes for glTF loader and sandbox

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -4,7 +4,7 @@ import { Quaternion, Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { Color3 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { Camera } from "babylonjs/Cameras/camera";
-import { TargetCamera } from "babylonjs/Cameras/targetCamera";
+import { FreeCamera } from "babylonjs/Cameras/freeCamera";
 import { AnimationGroup } from "babylonjs/Animations/animationGroup";
 import { Animation } from "babylonjs/Animations/animation";
 import { Bone } from "babylonjs/Bones/bone";
@@ -1189,7 +1189,7 @@ export class GLTFLoader implements IGLTFLoader {
         this.logOpen(`${context} ${camera.name || ""}`);
 
         this._babylonScene._blockEntityCollection = this._forAssetContainer;
-        const babylonCamera = new TargetCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
+        const babylonCamera = new FreeCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
         this._babylonScene._blockEntityCollection = false;
         babylonCamera.ignoreParentScaling = true;
 

--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -4,7 +4,7 @@ import { Quaternion, Vector3, Matrix } from "babylonjs/Maths/math.vector";
 import { Color3 } from 'babylonjs/Maths/math.color';
 import { Tools } from "babylonjs/Misc/tools";
 import { Camera } from "babylonjs/Cameras/camera";
-import { FreeCamera } from "babylonjs/Cameras/freeCamera";
+import { TargetCamera } from "babylonjs/Cameras/targetCamera";
 import { AnimationGroup } from "babylonjs/Animations/animationGroup";
 import { Animation } from "babylonjs/Animations/animation";
 import { Bone } from "babylonjs/Bones/bone";
@@ -1189,7 +1189,7 @@ export class GLTFLoader implements IGLTFLoader {
         this.logOpen(`${context} ${camera.name || ""}`);
 
         this._babylonScene._blockEntityCollection = this._forAssetContainer;
-        const babylonCamera = new FreeCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
+        const babylonCamera = new TargetCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
         this._babylonScene._blockEntityCollection = false;
         babylonCamera.ignoreParentScaling = true;
 
@@ -1204,7 +1204,7 @@ export class GLTFLoader implements IGLTFLoader {
 
                 babylonCamera.fov = perspective.yfov;
                 babylonCamera.minZ = perspective.znear;
-                babylonCamera.maxZ = perspective.zfar || Number.MAX_VALUE;
+                babylonCamera.maxZ = perspective.zfar || 0;
                 break;
             }
             case CameraType.ORTHOGRAPHIC: {

--- a/sandbox/src/components/renderingZone.tsx
+++ b/sandbox/src/components/renderingZone.tsx
@@ -142,13 +142,11 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
     }
 
     prepareCamera() {
-        let camera: ArcRotateCamera;
-
         // Attach camera to canvas inputs
-        if (!this._scene.activeCamera || this._scene.lights.length === 0) {
+        if (!this._scene.activeCamera) {
             this._scene.createDefaultCamera(true);
 
-            camera = this._scene.activeCamera! as ArcRotateCamera;
+            const camera = this._scene.activeCamera! as ArcRotateCamera;
 
             if (this._currentPluginName === "gltf") {
                 // glTF assets use a +Z forward convention while the default camera faces +Z. Rotate the camera to look at the front of the asset.

--- a/src/Helpers/sceneHelpers.ts
+++ b/src/Helpers/sceneHelpers.ts
@@ -168,9 +168,9 @@ Scene.prototype.createDefaultSkybox = function(environmentTexture?: BaseTexture,
     }
 
     // Skybox
-    var hdrSkybox = Mesh.CreateBox("hdrSkyBox", scale, this);
+    const hdrSkybox = Mesh.CreateBox("hdrSkyBox", scale, this);
     if (pbr) {
-        let hdrSkyboxMaterial = new PBRMaterial("skyBox", this);
+        const hdrSkyboxMaterial = new PBRMaterial("skyBox", this);
         hdrSkyboxMaterial.backFaceCulling = false;
         hdrSkyboxMaterial.reflectionTexture = environmentTexture.clone();
         if (hdrSkyboxMaterial.reflectionTexture) {
@@ -179,21 +179,21 @@ Scene.prototype.createDefaultSkybox = function(environmentTexture?: BaseTexture,
         hdrSkyboxMaterial.microSurface = 1.0 - blur;
         hdrSkyboxMaterial.disableLighting = true;
         hdrSkyboxMaterial.twoSidedLighting = true;
-        hdrSkybox.infiniteDistance = true;
         hdrSkybox.material = hdrSkyboxMaterial;
     }
     else {
-        let skyboxMaterial = new StandardMaterial("skyBox", this);
+        const skyboxMaterial = new StandardMaterial("skyBox", this);
         skyboxMaterial.backFaceCulling = false;
         skyboxMaterial.reflectionTexture = environmentTexture.clone();
         if (skyboxMaterial.reflectionTexture) {
             skyboxMaterial.reflectionTexture.coordinatesMode = Texture.SKYBOX_MODE;
         }
         skyboxMaterial.disableLighting = true;
-        hdrSkybox.infiniteDistance = true;
         hdrSkybox.material = skyboxMaterial;
     }
     hdrSkybox.isPickable = false;
+    hdrSkybox.infiniteDistance = true;
+    hdrSkybox.ignoreCameraMaxZ = true;
     return hdrSkybox;
 };
 

--- a/src/Loading/sceneLoader.ts
+++ b/src/Loading/sceneLoader.ts
@@ -1056,7 +1056,7 @@ export class SceneLoader {
      * @param pluginExtension the extension used to determine the plugin
      * @returns The loaded asset container
      */
-    public static LoadAssetContainerAsync(rootUrl: string, sceneFilename: string = "", scene: Nullable<Scene> = EngineStore.LastCreatedScene, onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null, pluginExtension: Nullable<string> = null): Promise<AssetContainer> {
+    public static LoadAssetContainerAsync(rootUrl: string, sceneFilename: string | File = "", scene: Nullable<Scene> = EngineStore.LastCreatedScene, onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null, pluginExtension: Nullable<string> = null): Promise<AssetContainer> {
         return new Promise((resolve, reject) => {
             SceneLoader.LoadAssetContainer(rootUrl, sceneFilename, scene, (assetContainer) => {
                 resolve(assetContainer);

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -391,6 +391,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     public overrideMaterialSideOrientation: Nullable<number> = null;
 
     /**
+     * Gets or sets a boolean indicating whether to render ignoring the active camera's max z setting. (false by default)
+     * Note this will reduce performance when set to true.
+     */
+    public ignoreCameraMaxZ = false;
+
+    /**
      * Gets the source mesh (the one used to clone this one from)
      */
     public get source(): Nullable<Mesh> {
@@ -1829,6 +1835,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             return this;
         }
 
+        let oldCameraMaxZ = 0;
+        if (this.ignoreCameraMaxZ && scene.activeCamera && !scene._isInIntermediateRendering()) {
+            oldCameraMaxZ = scene.activeCamera.maxZ;
+            scene.activeCamera.maxZ = 0;
+            scene.updateTransformMatrix(true);
+        }
+
         if (this._internalMeshDataInfo._onBeforeRenderObservable) {
             this._internalMeshDataInfo._onBeforeRenderObservable.notifyObservers(this);
         }
@@ -1938,6 +1951,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         if (this._internalMeshDataInfo._onAfterRenderObservable) {
             this._internalMeshDataInfo._onAfterRenderObservable.notifyObservers(this);
         }
+
+        if (this.ignoreCameraMaxZ && scene.activeCamera && !scene._isInIntermediateRendering()) {
+            scene.activeCamera.maxZ = oldCameraMaxZ;
+            scene.updateTransformMatrix(true);
+        }
+
         return this;
     }
 


### PR DESCRIPTION
This fixes a couple of issues with camera handling in glTF loader.

- glTF cameras with [infinite projection](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#infinite-perspective-projection) now works correctly.
- The skybox will now render even if the camera's maxZ is smaller than the size of the skybox.