### PR TITLE
fix: vertically interlaced stereoscopic rendering

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -62,6 +62,7 @@
 - Fix mipmaps creation in the KTX2 decoder for non square textures ([Popov72](https://github.com/Popov72))
 - Fix detail map not working in WebGL1 ([Popov72](https://github.com/Popov72))
 - Fix ArcRotateCamera behaviour when panning is disabled on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
+- Fix vertically interlaced stereoscopic rendering (`RIG_MODE_STEREOSCOPIC_INTERLACED`) not working (follow-up [#7425](https://github.com/BabylonJS/Babylon.js/issues/7425), [#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([foxxyz](https://github.com/foxxyz))
 
 ## Breaking changes
 

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -1,9 +1,20 @@
 import { Camera } from "../camera";
 import { Viewport } from '../../Maths/math.viewport';
+import { PassPostProcess } from '../../PostProcesses/passPostProcess';
+import { StereoscopicInterlacePostProcessI } from '../../PostProcesses/stereoscopicInterlacePostProcess';
 
 Camera._setStereoscopicRigMode = function(camera: Camera) {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
     var isCrossEye = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
-    camera._rigCameras[isCrossEye ? 1 : 0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
-    camera._rigCameras[isCrossEye ? 0 : 1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
+    var isInterlaced = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_INTERLACED;
+    // Use post-processors for interlacing
+    if (isInterlaced) {
+        camera._rigCameras[0]._rigPostProcess = new PassPostProcess(camera.name + "_passthru", 1.0, camera._rigCameras[0]);
+        camera._rigCameras[1]._rigPostProcess = new StereoscopicInterlacePostProcessI(camera.name + "_stereoInterlace", camera._rigCameras, false, true);
+    }
+    // Otherwise, create appropriate viewports
+    else {
+        camera._rigCameras[isCrossEye ? 1 : 0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
+        camera._rigCameras[isCrossEye ? 0 : 1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
+    }
 };


### PR DESCRIPTION
### Background

Rig mode for vertically interlaced stereoscopic rendering `RIG_MODE_STEREOSCOPIC_INTERLACED` was first implemented in #7425 ([forum discussion](https://forum.babylonjs.com/t/stereoscopic-interlaced-camera-rig-mode/7955)), and likely inadvertently removed in #8001 (dc0e816). 

### Current Behavior

`RIG_MODE_STEREOSCOPIC_INTERLACED` currently renders identical to `RIG_MODE_STEREOSCOPIC_OVERUNDER` ([playground link](https://playground.babylonjs.com/#SNXQEI)). Inquiry was made with @RaananW in #8000.

### New Behavior

These changes should preserve the correct behavior of `RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL`,  `RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED`, `RIG_MODE_STEREOSCOPIC_OVERUNDER`, while adding back in support for `RIG_MODE_STEREOSCOPIC_INTERLACED` taken from original commits by @bilkusg (7830702).

Screenshot:
<img width="407" alt="Screen Shot 2020-12-06 at 3 33 45 PM" src="https://user-images.githubusercontent.com/2602605/101297342-62cf8780-37dd-11eb-92eb-2fe7f9251727.png">

Please let me know if any adjustments are required, and thanks for making this fantastic library!