### PR TITLE
Small tidy up around Camera Inputs Base classes.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -67,6 +67,8 @@
 - Fix detail map not working in WebGL1 ([Popov72](https://github.com/Popov72))
 - Fix ArcRotateCamera behaviour when panning is disabled on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
 - Fix vertically interlaced stereoscopic rendering (`RIG_MODE_STEREOSCOPIC_INTERLACED`) not working (follow-up [#7425](https://github.com/BabylonJS/Babylon.js/issues/7425), [#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([foxxyz](https://github.com/foxxyz))
+- Fix accessibility of BaseCameraMouseWheelInput and BaseCameraPointersInput. They appear in documentation but were not available for include. ([mrdunk](https://github.com/mrdunk))
+- Fix function creation inside regularly called freeCameraMouseWheelInput method leading to excessive GC load. ([mrdunk](https://github.com/mrdunk))
 
 ## Breaking changes
 

--- a/src/Cameras/Inputs/freeCameraMouseWheelInput.ts
+++ b/src/Cameras/Inputs/freeCameraMouseWheelInput.ts
@@ -334,60 +334,60 @@ export class FreeCameraMouseWheelInput extends BaseCameraMouseWheelInput {
      * mouse-wheel axis.
      */
     private _updateCamera(): void {
-        const moveRelative = this._moveRelative;
-        const rotateRelative = this._rotateRelative;
-        const moveScene = this._moveScene;
-
-        let updateCameraProperty = function(/* Mouse-wheel delta. */
-                                            value: number,
-                                            /* Camera property to be changed. */
-                                            cameraProperty: Nullable<_CameraProperty>,
-                                            /* Axis of Camera property to be changed. */
-                                            coordinate: Nullable<Coordinate>): void {
-                if (value === 0) {
-                    // Mouse wheel has not moved.
-                    return;
-                }
-                if (cameraProperty === null || coordinate === null) {
-                    // Mouse wheel axis not configured.
-                    return;
-                }
-
-                let action = null;
-                switch (cameraProperty) {
-                    case _CameraProperty.MoveRelative:
-                        action = moveRelative;
-                        break;
-                    case _CameraProperty.RotateRelative:
-                        action = rotateRelative;
-                        break;
-                    case _CameraProperty.MoveScene:
-                        action = moveScene;
-                        break;
-                }
-
-                switch (coordinate) {
-                    case Coordinate.X:
-                        action.set(value, 0, 0);
-                        break;
-                    case Coordinate.Y:
-                        action.set(0, value, 0);
-                        break;
-                    case Coordinate.Z:
-                        action.set(0, 0, value);
-                        break;
-                }
-            };
-
         // Do the camera updates for each of the 3 touch-wheel axis.
-        updateCameraProperty(
+        this._updateCameraProperty(
             this._wheelDeltaX, this._wheelXAction, this._wheelXActionCoordinate);
-        updateCameraProperty(
+        this._updateCameraProperty(
             this._wheelDeltaY, this._wheelYAction, this._wheelYActionCoordinate);
-        updateCameraProperty(
+        this._updateCameraProperty(
             this._wheelDeltaZ, this._wheelZAction, this._wheelZActionCoordinate);
     }
 
+    /**
+     * Update one property of the camera.
+     */
+    private _updateCameraProperty(
+        /* Mouse-wheel delta. */
+        value: number,
+        /* Camera property to be changed. */
+        cameraProperty: Nullable<_CameraProperty>,
+        /* Axis of Camera property to be changed. */
+        coordinate: Nullable<Coordinate>
+    ): void {
+        if (value === 0) {
+            // Mouse wheel has not moved.
+            return;
+        }
+        if (cameraProperty === null || coordinate === null) {
+            // Mouse wheel axis not configured.
+            return;
+        }
+
+        let action = null;
+        switch (cameraProperty) {
+            case _CameraProperty.MoveRelative:
+                action = this._moveRelative;
+                break;
+            case _CameraProperty.RotateRelative:
+                action = this._rotateRelative;
+                break;
+            case _CameraProperty.MoveScene:
+                action = this._moveScene;
+                break;
+        }
+
+        switch (coordinate) {
+            case Coordinate.X:
+                action.set(value, 0, 0);
+                break;
+            case Coordinate.Y:
+                action.set(0, value, 0);
+                break;
+            case Coordinate.Z:
+                action.set(0, 0, value);
+                break;
+        }
+    };
 }
 
 (<any>CameraInputTypes)["FreeCameraMouseWheelInput"] = FreeCameraMouseWheelInput;

--- a/src/Cameras/Inputs/freeCameraMouseWheelInput.ts
+++ b/src/Cameras/Inputs/freeCameraMouseWheelInput.ts
@@ -387,7 +387,7 @@ export class FreeCameraMouseWheelInput extends BaseCameraMouseWheelInput {
                 action.set(0, 0, value);
                 break;
         }
-    };
+    }
 }
 
 (<any>CameraInputTypes)["FreeCameraMouseWheelInput"] = FreeCameraMouseWheelInput;

--- a/src/Cameras/Inputs/index.ts
+++ b/src/Cameras/Inputs/index.ts
@@ -1,3 +1,5 @@
+export * from "./BaseCameraMouseWheelInput";
+export * from "./BaseCameraPointersInput";
 export * from "./arcRotateCameraGamepadInput";
 export * from "./arcRotateCameraKeyboardMoveInput";
 export * from "./arcRotateCameraMouseWheelInput";


### PR DESCRIPTION
This fixes the following:

1. `BaseCameraMouseWheelInput` and `BaseCameraPointersInput` appear in the API documentation but are not available for include as they are not in `Camera/Inputs/index.ts`.
When i originally created these i presumed they didn't really need to be visible to the outside world but since then i've tried to use `BaseCameraPointersInput`. If i tried, maybe it's of use to others too. Also it's in the API documentation so needs to be available.
2. `FreeCameraMouseWheelInput._updateCamera()` creates the function `updateCameraProperty(...)` every time it is called.
Do i understand the JS GC correctly to say it is not smart enough to re-use the allocation and that this causes unnecessary GC load?