### PR TITLE
Avoid changing index winding order when fixing coordinate system handedness for WebXRMeshDetector

### DIFF
--- a/src/LibDeclarations/webxr.nativeextensions.d.ts
+++ b/src/LibDeclarations/webxr.nativeextensions.d.ts
@@ -30,7 +30,6 @@ interface XRMesh {
     meshSpace: XRSpace;
     positions: Float32Array;
     indices: Uint32Array;
-    isClockwiseWindingOrder: boolean;
     normals?: Float32Array;
     lastChangedTime: number;
     parentSceneObject?: XRSceneObject;

--- a/src/LibDeclarations/webxr.nativeextensions.d.ts
+++ b/src/LibDeclarations/webxr.nativeextensions.d.ts
@@ -30,6 +30,7 @@ interface XRMesh {
     meshSpace: XRSpace;
     positions: Float32Array;
     indices: Uint32Array;
+    isClockwiseWindingOrder: boolean;
     normals?: Float32Array;
     lastChangedTime: number;
     parentSceneObject?: XRSceneObject;

--- a/src/XR/features/WebXRMeshDetector.ts
+++ b/src/XR/features/WebXRMeshDetector.ts
@@ -55,8 +55,8 @@ export interface IWebXRVertexData {
      */
     positions?: Float32Array;
     /**
-     * An array of indices in babylon space. right/left hand system is taken into account.
-     * Indices will only be calculated if convertCoordinateSystems is set to true in the IWebXRMeshDetectorOptions.
+     * An array of indices in babylon space. Indices have a counterclockwise winding order.
+     * Indices will only be populated if convertCoordinateSystems is set to true in the IWebXRMeshDetectorOptions.
      */
     indices?: Uint32Array;
     /**
@@ -236,17 +236,8 @@ export class WebXRMeshDetector extends WebXRAbstractFeature {
                 mesh.normals = xrMesh.normals;
             }
 
-            if (xrMesh.isClockwiseWindingOrder) {
-                // Babylon.js expects counter clockwise winding order for meshes
-                mesh.indices = new Uint32Array(xrMesh.indices.length);
-                for (let i = 0; i < xrMesh.indices.length; i += 3) {
-                    mesh.indices[i] = xrMesh.indices[i];
-                    mesh.indices[i + 1] = xrMesh.indices[i + 2];
-                    mesh.indices[i + 2] = xrMesh.indices[i + 1];
-                }
-            } else {
-                mesh.indices = xrMesh.indices;
-            }
+            // WebXR should provide indices in a counterclockwise winding order regardless of coordinate system handedness
+            mesh.indices = xrMesh.indices;
 
             // matrix
             const pose = xrFrame.getPose(xrMesh.meshSpace, this._xrSessionManager.referenceSpace);

--- a/src/XR/features/WebXRMeshDetector.ts
+++ b/src/XR/features/WebXRMeshDetector.ts
@@ -223,13 +223,6 @@ export class WebXRMeshDetector extends WebXRAbstractFeature {
                     mesh.positions[i + 2] = -1 * xrMesh.positions[i + 2];
                 }
 
-                mesh.indices = new Uint32Array(xrMesh.indices.length);
-                for (let i = 0; i < xrMesh.indices.length; i += 3) {
-                    mesh.indices[i] = xrMesh.indices[i];
-                    mesh.indices[i + 1] = xrMesh.indices[i + 2];
-                    mesh.indices[i + 2] = xrMesh.indices[i + 1];
-                }
-
                 if (!!xrMesh.normals) {
                     mesh.normals = new Float32Array(xrMesh.normals.length);
                     for (let i = 0; i < xrMesh.normals.length; i += 3) {
@@ -238,11 +231,21 @@ export class WebXRMeshDetector extends WebXRAbstractFeature {
                         mesh.normals[i + 2] = -1 * xrMesh.normals[i + 2];
                     }
                 }
-            }
-            else {
+            } else {
                 mesh.positions = xrMesh.positions;
-                mesh.indices = xrMesh.indices;
                 mesh.normals = xrMesh.normals;
+            }
+
+            if (xrMesh.isClockwiseWindingOrder) {
+                // Babylon.js expects counter clockwise winding order for meshes
+                mesh.indices = new Uint32Array(xrMesh.indices.length);
+                for (let i = 0; i < xrMesh.indices.length; i += 3) {
+                    mesh.indices[i] = xrMesh.indices[i];
+                    mesh.indices[i + 1] = xrMesh.indices[i + 2];
+                    mesh.indices[i + 2] = xrMesh.indices[i + 1];
+                }
+            } else {
+                mesh.indices = xrMesh.indices;
             }
 
             // matrix


### PR DESCRIPTION
There appears to be inconsistency in what winding order is used for left/right handed coordinate systems. WinRT APIs use right handed coordinate systems + clockwise winding. OpenXR uses right handed coordinate systems + counter clockwise winding. Until WebXR has a formalized winding order, we should avoid attempting to fix winding order based on the Babylon.js coordinate system used.