### PR TITLE
Fix unhandled exception leak in glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -343,7 +343,7 @@ export class GLTFLoader implements IGLTFLoader {
                 return resultFunc();
             });
 
-            resultPromise.then(() => {
+            return resultPromise.then((result) => {
                 this._parent._endPerformanceCounter(loadingToReadyCounterName);
 
                 Tools.SetImmediate(() => {
@@ -365,9 +365,9 @@ export class GLTFLoader implements IGLTFLoader {
                         });
                     }
                 });
-            });
 
-            return resultPromise;
+                return result;
+            });
         }).catch((error) => {
             if (!this._disposed) {
                 this._parent.onErrorObservable.notifyObservers(error);

--- a/src/Loading/sceneLoader.ts
+++ b/src/Loading/sceneLoader.ts
@@ -791,8 +791,7 @@ export class SceneLoader {
                 });
             }, onProgress, (scene, message, exception) => {
                 reject(exception || new Error(message));
-            },
-                pluginExtension);
+            }, pluginExtension);
         });
     }
 


### PR DESCRIPTION
Fixes #9602

The glTF loader was adding a continuation to the final promise without return it and it would result in an unhandled exception in promises to be logged.