### PR TITLE
Make Geometry shareable by sourceMeshes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -14,6 +14,9 @@
 - Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
 - Moving additional components to shared UI folder.([msDestiny14](https://github.com/msDestiny14))
 
+### Engine
+- Moved all sourceMesh data from Geometry to Mesh such that one Geometry can be used by many source meshes without making the geometry unique. ([AndersLindqvist](https://github.com/breakin)
+
 ### Loaders
 
 - Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -15,7 +15,7 @@
 - Moving additional components to shared UI folder.([msDestiny14](https://github.com/msDestiny14))
 
 ### Engine
-- Moved all sourceMesh data from Geometry to Mesh such that one Geometry can be used by many source meshes without making the geometry unique. ([AndersLindqvist](https://github.com/breakin)
+- Moved all instance data from Geometry to Mesh such that the same Geometry objects can be used by many meshes with instancing. Reduces memory consumption on CPU/GPU. ([breakin](https://github.com/breakin)
 
 ### Loaders
 
@@ -84,3 +84,4 @@
     - [Shader support differences](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#shader-code-differences)
 - Use both `mesh.visibility` and `material.alpha` values to compute the global alpha value used by the soft transparent shadow rendering code. Formerly was only using `mesh.visibility` ([Popov72](https://github.com/Popov72))
 - Depth renderer: don't render mesh if `infiniteDistance = true` or if `material.disableDepthWrite = true` ([Popov72](https://github.com/Popov72))
+- Mesh.createInstance no longer make a unique Geometry for the Mesh so updating one Geometry can affect more meshes than before. Use Mesh.makeUniqueGeometry for old behaviour. ([breakin](https://github.com/breakin))

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1766,7 +1766,7 @@ export class ThinEngine {
         }
     }
 
-    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect, extraVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): void {
+    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): void {
         var attributes = effect.getAttributesNames();
 
         if (!this._vaoRecordInProgress) {
@@ -1782,8 +1782,8 @@ export class ThinEngine {
                 var ai = attributes[index];
                 var vertexBuffer: Nullable<VertexBuffer> = null;
 
-                if (extraVertexBuffers) {
-                    vertexBuffer = extraVertexBuffers[ai];
+                if (overrideVertexBuffers) {
+                    vertexBuffer = overrideVertexBuffers[ai];
                 }
 
                 if (!vertexBuffer) {
@@ -1821,9 +1821,10 @@ export class ThinEngine {
      * @param vertexBuffers defines the list of vertex buffers to store
      * @param indexBuffer defines the index buffer to store
      * @param effect defines the effect to store
+     * @param overrideVertexBuffers defines optional list of avertex buffers that overrides the entries in vertexBuffers
      * @returns the new vertex array object
      */
-    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect, extraVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): WebGLVertexArrayObject {
+    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): WebGLVertexArrayObject {
         var vao = this._gl.createVertexArray();
 
         this._vaoRecordInProgress = true;
@@ -1831,7 +1832,7 @@ export class ThinEngine {
         this._gl.bindVertexArray(vao);
 
         this._mustWipeVertexAttributes = true;
-        this._bindVertexBuffersAttributes(vertexBuffers, effect, extraVertexBuffers);
+        this._bindVertexBuffersAttributes(vertexBuffers, effect, overrideVertexBuffers);
 
         this.bindIndexBuffer(indexBuffer);
 
@@ -1913,13 +1914,14 @@ export class ThinEngine {
      * @param vertexBuffers defines the list of vertex buffers to bind
      * @param indexBuffer defines the index buffer to bind
      * @param effect defines the effect associated with the vertex buffers
+     * @param overrideVertexBuffers defines optional list of avertex buffers that overrides the entries in vertexBuffers
      */
-    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect, extraVertexBuffers?: {[kind: string]: Nullable<VertexBuffer>}): void {
+    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: {[kind: string]: Nullable<VertexBuffer>}): void {
         if (this._cachedVertexBuffers !== vertexBuffers || this._cachedEffectForVertexBuffers !== effect) {
             this._cachedVertexBuffers = vertexBuffers;
             this._cachedEffectForVertexBuffers = effect;
 
-            this._bindVertexBuffersAttributes(vertexBuffers, effect, extraVertexBuffers);
+            this._bindVertexBuffersAttributes(vertexBuffers, effect, overrideVertexBuffers);
         }
 
         this._bindIndexBufferWithCache(indexBuffer);

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1780,10 +1780,14 @@ export class ThinEngine {
 
             if (order >= 0) {
                 var ai = attributes[index];
-                var vertexBuffer = vertexBuffers[ai];
+                var vertexBuffer: Nullable<VertexBuffer> = null;
 
-                if (!vertexBuffer && extraVertexBuffers) {
+                if (extraVertexBuffers) {
                     vertexBuffer = extraVertexBuffers[ai];
+                }
+
+                if (!vertexBuffer) {
+                    vertexBuffer = vertexBuffers[ai];
                 }
 
                 if (!vertexBuffer) {

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1766,7 +1766,7 @@ export class ThinEngine {
         }
     }
 
-    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect): void {
+    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect, extraVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): void {
         var attributes = effect.getAttributesNames();
 
         if (!this._vaoRecordInProgress) {
@@ -1779,7 +1779,12 @@ export class ThinEngine {
             var order = effect.getAttributeLocation(index);
 
             if (order >= 0) {
-                var vertexBuffer = vertexBuffers[attributes[index]];
+                var ai = attributes[index];
+                var vertexBuffer = vertexBuffers[ai];
+
+                if (!vertexBuffer && extraVertexBuffers) {
+                    vertexBuffer = extraVertexBuffers[ai];
+                }
 
                 if (!vertexBuffer) {
                     continue;
@@ -1814,7 +1819,7 @@ export class ThinEngine {
      * @param effect defines the effect to store
      * @returns the new vertex array object
      */
-    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect): WebGLVertexArrayObject {
+    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect, extraVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): WebGLVertexArrayObject {
         var vao = this._gl.createVertexArray();
 
         this._vaoRecordInProgress = true;
@@ -1822,7 +1827,7 @@ export class ThinEngine {
         this._gl.bindVertexArray(vao);
 
         this._mustWipeVertexAttributes = true;
-        this._bindVertexBuffersAttributes(vertexBuffers, effect);
+        this._bindVertexBuffersAttributes(vertexBuffers, effect, extraVertexBuffers);
 
         this.bindIndexBuffer(indexBuffer);
 
@@ -1905,12 +1910,12 @@ export class ThinEngine {
      * @param indexBuffer defines the index buffer to bind
      * @param effect defines the effect associated with the vertex buffers
      */
-    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect): void {
+    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect, extraVertexBuffers?: {[kind: string]: Nullable<VertexBuffer>}): void {
         if (this._cachedVertexBuffers !== vertexBuffers || this._cachedEffectForVertexBuffers !== effect) {
             this._cachedVertexBuffers = vertexBuffers;
             this._cachedEffectForVertexBuffers = effect;
 
-            this._bindVertexBuffersAttributes(vertexBuffers, effect);
+            this._bindVertexBuffersAttributes(vertexBuffers, effect, extraVertexBuffers);
         }
 
         this._bindIndexBufferWithCache(indexBuffer);

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -293,14 +293,14 @@ export class Geometry implements IGetSetVerticesData {
 
         this.notifyUpdate(kind);
 
-        var meshes = this._meshes;
-        for (var index = 0; index < numOfMeshes; index++) {
-            meshes[index].invalidateInstanceVertexArrayObject(false);
-        }
-
         if (this._vertexArrayObjects) {
             this._disposeVertexArrayObjects();
             this._vertexArrayObjects = {}; // Will trigger a rebuild of the VAO if supported
+
+            var meshes = this._meshes;
+            for (var index = 0; index < numOfMeshes; index++) {
+                meshes[index].invalidateInstanceVertexArrayObject();
+            }
         }
     }
 
@@ -680,6 +680,10 @@ export class Geometry implements IGetSetVerticesData {
 
         meshes.splice(index, 1);
 
+        if (this._vertexArrayObjects) {
+            mesh.invalidateInstanceVertexArrayObject();
+        }
+
         mesh._geometry = null;
 
         if (meshes.length === 0 && shouldDispose) {
@@ -701,11 +705,14 @@ export class Geometry implements IGetSetVerticesData {
             previousGeometry.releaseForMesh(mesh);
         }
 
+        if (this._vertexArrayObjects) {
+            mesh.invalidateInstanceVertexArrayObject();
+        }
+
         var meshes = this._meshes;
 
         // must be done before setting vertexBuffers because of mesh._createGlobalSubMesh()
         mesh._geometry = this;
-        mesh.invalidateVAO(false);
 
         this._scene.pushGeometry(this);
 
@@ -923,12 +930,6 @@ export class Geometry implements IGetSetVerticesData {
                 this._engine.releaseVertexArrayObject(this._vertexArrayObjects[kind]);
             }
             this._vertexArrayObjects = {};
-
-            const meshes = this.meshes
-            const numMeshes = meshes.length
-            for (let i = 0; i < numMeshes; i++) {
-                meshes[i].invalidateInstanceVertexArrayObject(true);
-            }
         }
     }
 

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -253,6 +253,10 @@ export class Geometry implements IGetSetVerticesData {
             this._vertexBuffers[kind].dispose();
             delete this._vertexBuffers[kind];
         }
+
+        if (this._vertexArrayObjects) {
+            this._disposeVertexArrayObjects();
+        }
     }
 
     /**
@@ -295,12 +299,6 @@ export class Geometry implements IGetSetVerticesData {
 
         if (this._vertexArrayObjects) {
             this._disposeVertexArrayObjects();
-            this._vertexArrayObjects = {}; // Will trigger a rebuild of the VAO if supported
-
-            var meshes = this._meshes;
-            for (var index = 0; index < numOfMeshes; index++) {
-                meshes[index]._invalidateInstanceVertexArrayObject();
-            }
         }
     }
 
@@ -585,8 +583,6 @@ export class Geometry implements IGetSetVerticesData {
         if (this._indexBuffer) {
             this._engine._releaseBuffer(this._indexBuffer);
         }
-
-        this._disposeVertexArrayObjects();
 
         this._indices = indices;
         this._indexBufferIsUpdatable = updatable;
@@ -927,7 +923,13 @@ export class Geometry implements IGetSetVerticesData {
             for (var kind in this._vertexArrayObjects) {
                 this._engine.releaseVertexArrayObject(this._vertexArrayObjects[kind]);
             }
-            this._vertexArrayObjects = {};
+            this._vertexArrayObjects = {}; // Will trigger a rebuild of the VAO if supported
+
+            var meshes = this._meshes;
+            var numOfMeshes = meshes.length;
+            for (var index = 0; index < numOfMeshes; index++) {
+                meshes[index]._invalidateInstanceVertexArrayObject();
+            }
         }
     }
 

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -299,7 +299,7 @@ export class Geometry implements IGetSetVerticesData {
 
             var meshes = this._meshes;
             for (var index = 0; index < numOfMeshes; index++) {
-                meshes[index].invalidateInstanceVertexArrayObject();
+                meshes[index]._invalidateInstanceVertexArrayObject();
             }
         }
     }
@@ -679,7 +679,7 @@ export class Geometry implements IGetSetVerticesData {
         meshes.splice(index, 1);
 
         if (this._vertexArrayObjects) {
-            mesh.invalidateInstanceVertexArrayObject();
+            mesh._invalidateInstanceVertexArrayObject();
         }
 
         mesh._geometry = null;
@@ -704,7 +704,7 @@ export class Geometry implements IGetSetVerticesData {
         }
 
         if (this._vertexArrayObjects) {
-            mesh.invalidateInstanceVertexArrayObject();
+            mesh._invalidateInstanceVertexArrayObject();
         }
 
         var meshes = this._meshes;

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -216,13 +216,6 @@ export class Geometry implements IGetSetVerticesData {
             let vertexBuffer = <VertexBuffer>this._vertexBuffers[key];
             vertexBuffer._rebuild();
         }
-
-        // Invalidate MESH VAO
-        const meshes = this.meshes
-        const numMeshes = meshes.length
-        for (let i = 0; i < numMeshes; i++) {
-            meshes[i].invalidateVAO(true);
-        }
     }
 
     /**
@@ -302,7 +295,7 @@ export class Geometry implements IGetSetVerticesData {
 
         var meshes = this._meshes;
         for (var index = 0; index < numOfMeshes; index++) {
-            meshes[index].invalidateVAO(false);
+            meshes[index].invalidateInstanceVertexArrayObject(false);
         }
 
         if (this._vertexArrayObjects) {
@@ -930,9 +923,13 @@ export class Geometry implements IGetSetVerticesData {
                 this._engine.releaseVertexArrayObject(this._vertexArrayObjects[kind]);
             }
             this._vertexArrayObjects = {};
-        }
 
-        // TODO: Do the meshes too?
+            const meshes = this.meshes
+            const numMeshes = meshes.length
+            for (let i = 0; i < numMeshes; i++) {
+                meshes[i].invalidateInstanceVertexArrayObject(true);
+            }
+        }
     }
 
     /**

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -371,7 +371,7 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /** @hidden */
-    public _bind(effect: Nullable<Effect>, indexToBind?: Nullable<DataBuffer>, extraVertexBuffers?: { [kind:string]: Nullable<VertexBuffer>}, overrideVAO?: {[key: string]: WebGLVertexArrayObject}): void {
+    public _bind(effect: Nullable<Effect>, indexToBind?: Nullable<DataBuffer>, overrideVertexBuffers?: { [kind:string]: Nullable<VertexBuffer>}, overrideVertexArrayObjects?: {[key: string]: WebGLVertexArrayObject}): void {
         if (!effect) {
             return;
         }
@@ -385,18 +385,16 @@ export class Geometry implements IGetSetVerticesData {
             return;
         }
 
-        // TODO: It could be the case that all vertex bufferas are in extraVertexBuffers but lets ignore that for now
-
-        if (indexToBind != this._indexBuffer || (!this._vertexArrayObjects && !overrideVAO)) {
-            this._engine.bindBuffers(vbs, indexToBind, effect, extraVertexBuffers);
+        if (indexToBind != this._indexBuffer || (!this._vertexArrayObjects && !overrideVertexArrayObjects)) {
+            this._engine.bindBuffers(vbs, indexToBind, effect, overrideVertexBuffers);
             return;
         }
 
-        var vaos = overrideVAO ? overrideVAO : this._vertexArrayObjects;
+        var vaos = overrideVertexArrayObjects ? overrideVertexArrayObjects : this._vertexArrayObjects;
 
         // Using VAO
         if (!vaos[effect.key]) {
-            vaos[effect.key] = this._engine.recordVertexArrayObject(vbs, indexToBind, effect, extraVertexBuffers);
+            vaos[effect.key] = this._engine.recordVertexArrayObject(vbs, indexToBind, effect, overrideVertexBuffers);
         }
 
         this._engine.bindVertexArrayObject(vaos[effect.key], indexToBind);

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -371,7 +371,7 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /** @hidden */
-    public _bind(effect: Nullable<Effect>, indexToBind?: Nullable<DataBuffer>, overrideVertexBuffers?: { [kind:string]: Nullable<VertexBuffer>}, overrideVertexArrayObjects?: {[key: string]: WebGLVertexArrayObject}): void {
+    public _bind(effect: Nullable<Effect>, indexToBind?: Nullable<DataBuffer>, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}, overrideVertexArrayObjects?: {[key: string]: WebGLVertexArrayObject}): void {
         if (!effect) {
             return;
         }

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -490,6 +490,9 @@ declare module "./mesh" {
          */
         registerInstancedBuffer(kind: string, stride: number): void;
 
+        /**
+         * Invalidate VertexArrayObjects belonging to the mesh (but not to the Geometry of the mesh).
+         */
         invalidateInstanceVertexArrayObject(): void;
 
         /**

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -493,7 +493,7 @@ declare module "./mesh" {
         /**
          * Invalidate VertexArrayObjects belonging to the mesh (but not to the Geometry of the mesh).
          */
-        invalidateInstanceVertexArrayObject(): void;
+        _invalidateInstanceVertexArrayObject(): void;
 
         /**
          * true to use the edge renderer for all instances of this mesh
@@ -524,11 +524,6 @@ declare module "./abstractMesh" {
 Mesh.prototype.edgesShareWithInstances = false;
 
 Mesh.prototype.registerInstancedBuffer = function(kind: string, stride: number): void {
-    if (this.geometry?._vertexBuffers[kind] !== undefined) {
-        console.error('Mesh.registerInstancedBuffer; ignored', kind, ' since geometry already specifies it!');
-        return;
-    }
-
     // Creates the instancedBuffer field if not present
     if (!this.instancedBuffers) {
         this.instancedBuffers = {};
@@ -558,7 +553,7 @@ Mesh.prototype.registerInstancedBuffer = function(kind: string, stride: number):
         instance.instancedBuffers[kind] = null;
     }
 
-    this.invalidateInstanceVertexArrayObject();
+    this._invalidateInstanceVertexArrayObject();
 };
 
 Mesh.prototype._processInstancedBuffers = function(visibleInstances: InstancedMesh[], renderSelf: boolean) {
@@ -617,14 +612,14 @@ Mesh.prototype._processInstancedBuffers = function(visibleInstances: InstancedMe
         // Update vertex buffer
         if (!this._userInstancedBuffersStorage.vertexBuffers[kind]) {
             this._userInstancedBuffersStorage.vertexBuffers[kind] = new VertexBuffer(this.getEngine(), this._userInstancedBuffersStorage.data[kind], kind, true, false, stride, true);
-            this.invalidateInstanceVertexArrayObject();
+            this._invalidateInstanceVertexArrayObject();
         } else {
             this._userInstancedBuffersStorage.vertexBuffers[kind]!.updateDirectly(data, 0);
         }
     }
 };
 
-Mesh.prototype.invalidateInstanceVertexArrayObject = function() {
+Mesh.prototype._invalidateInstanceVertexArrayObject = function() {
     if (!this._userInstancedBuffersStorage || this._userInstancedBuffersStorage.vertexArrayObjects === undefined) {
         return;
     }
@@ -652,7 +647,7 @@ Mesh.prototype._disposeInstanceSpecificData = function() {
         }
     }
 
-    this.invalidateInstanceVertexArrayObject();
+    this._invalidateInstanceVertexArrayObject();
 
     this.instancedBuffers = {};
 };

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -633,8 +633,8 @@ Mesh.prototype.invalidateInstanceVertexArrayObject = function() {
         this.getEngine().releaseVertexArrayObject(this._userInstancedBuffersStorage.vertexArrayObjects[kind]);
     }
 
-    this._userInstancedBuffersStorage.vertexArrayObjects = {}
-}
+    this._userInstancedBuffersStorage.vertexArrayObjects = {};
+};
 
 Mesh.prototype._disposeInstanceSpecificData = function() {
     if (this._instanceDataStorage.instancesBuffer) {
@@ -651,6 +651,8 @@ Mesh.prototype._disposeInstanceSpecificData = function() {
             this._userInstancedBuffersStorage.vertexBuffers[kind]!.dispose();
         }
     }
+
+    this.invalidateInstanceVertexArrayObject();
 
     this.instancedBuffers = {};
 };

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2435,6 +2435,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         // Do nothing
     }
 
+    /** @hidden */
+    public _invalidateInstanceVertexArrayObject() {
+        // Do nothing
+    }
+
     /**
      * Modifies the mesh geometry according to a displacement map.
      * A displacement map is a colored image. Each pixel color value (actually a gradient computed from red, green, blue values) will give the displacement to apply to each mesh vertex.

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1522,7 +1522,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         // VBOs
         if (!this._userInstancedBuffersStorage) {
-            this._geometry._bind(effect, indexToBind)
+            this._geometry._bind(effect, indexToBind);
         } else {
             this._geometry._bind(effect, indexToBind, this._userInstancedBuffersStorage.vertexBuffers, this._userInstancedBuffersStorage.vertexArrayObjects);
         }
@@ -1692,10 +1692,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 };
             }
 
-            this._userInstancedBuffersStorage.vertexBuffers["world0"] = instancesBuffer.createVertexBuffer("world0", 0, 4)
-            this._userInstancedBuffersStorage.vertexBuffers["world1"] = instancesBuffer.createVertexBuffer("world0", 4, 4)
-            this._userInstancedBuffersStorage.vertexBuffers["world2"] = instancesBuffer.createVertexBuffer("world0", 8, 4)
-            this._userInstancedBuffersStorage.vertexBuffers["world3"] = instancesBuffer.createVertexBuffer("world0", 12, 4)
+            this._userInstancedBuffersStorage.vertexBuffers["world0"] = instancesBuffer.createVertexBuffer("world0", 0, 4);
+            this._userInstancedBuffersStorage.vertexBuffers["world1"] = instancesBuffer.createVertexBuffer("world0", 4, 4);
+            this._userInstancedBuffersStorage.vertexBuffers["world2"] = instancesBuffer.createVertexBuffer("world0", 8, 4);
+            this._userInstancedBuffersStorage.vertexBuffers["world3"] = instancesBuffer.createVertexBuffer("world0", 12, 4);
         } else {
             if (!this._instanceDataStorage.isFrozen) {
                 instancesBuffer!.updateDirectly(instanceStorage.instancesData, 0, instancesCount);
@@ -1802,7 +1802,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 }
             }
             if (this._userInstancedBuffersStorage.vertexArrayObjects) {
-                this._userInstancedBuffersStorage.vertexArrayObjects = {}
+                this._userInstancedBuffersStorage.vertexArrayObjects = {};
             }
         }
         super._rebuild();

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1688,7 +1688,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                     vertexBuffers: {},
                     strides: {},
                     sizes: {},
-                    vertexArrayObjects: {}
+                    vertexArrayObjects: (this.getEngine().getCaps().vertexArrayObject) ? {} : undefined
                 };
             }
 
@@ -1791,6 +1791,19 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             // Dispose instance buffer to be recreated in _renderWithInstances when rendered
             this._instanceDataStorage.instancesBuffer.dispose();
             this._instanceDataStorage.instancesBuffer = null;
+        }
+        if (this._userInstancedBuffersStorage) {
+            for (var kind in this._userInstancedBuffersStorage.vertexBuffers) {
+                var buffer = this._userInstancedBuffersStorage.vertexBuffers[kind];
+                if (buffer) {
+                    // Dispose instance buffer to be recreated in _renderWithInstances when rendered
+                    buffer.dispose();
+                    this._userInstancedBuffersStorage.vertexBuffers[kind] = null;
+                }
+            }
+            if (this._userInstancedBuffersStorage.vertexArrayObjects) {
+                this._userInstancedBuffersStorage.vertexArrayObjects = {}
+            }
         }
         super._rebuild();
     }


### PR DESCRIPTION
This PR hope to be a better alternative than the approach tried in #9214 .
It can use the same Geometry object with many meshes that has instances (or not).
The VertexArrayObject and per-instance VertexBuffers are handled by the Mesh itself.

The goal is the not have to copy the entire geometry (increases CPU/GPU storage) whenever we want to create instances from it (as otherwise it will destroy the other users).

```
var createScene = function () {
    var scene = new BABYLON.Scene(engine);
    var camera = new BABYLON.FreeCamera("camera1", new BABYLON.Vector3(0, 5, -10), scene);
    camera.setTarget(BABYLON.Vector3.Zero());
    camera.attachControl(canvas, true);
    camera.minZ = 0.1;
    camera.maxZ = 100.0;
    var light = new BABYLON.HemisphericLight("light", new BABYLON.Vector3(0, 1, 0), scene);
    light.intensity = 0.7;

    BABYLON.Effect.ShadersStore["myVertexShader"] = `
		#ifdef GL_ES
		precision highp float;
		#endif
		// Attributes
		attribute vec3 position;
		attribute vec2 uv;
		#ifdef INSTANCES
			attribute vec4 world0;
			attribute vec4 world1;
			attribute vec4 world2;
			attribute vec4 world3;
			attribute vec3 per_instance_data;
		#endif
		uniform mat4 world;
        uniform vec3 albedoColor;
		uniform mat4 viewProjection;
		varying vec3 color;
		varying vec2 vUV;
		void main(void) {
			vec3 positionUpdated = position;

            #ifdef INSTANCES
            	positionUpdated.xz *= per_instance_data.x;
            #endif

            #include<instancesVertex>

            vec4 worldPos = finalWorld * vec4(positionUpdated, 1.0);
            gl_Position = viewProjection * worldPos;
			color = albedoColor;
			vUV = uv;
		}	        
    `;

    BABYLON.Effect.ShadersStore["myFragmentShader"] = `
		#ifdef GL_ES
		precision highp float;
		#endif
		varying vec2 vUV;
		varying vec3 color;
		void main(void) {
            vec3 c = color * vUV.x;
			gl_FragColor = vec4(c, 1.0);
		}    
    `;

    var sett = {needAlphaBlending: false, attributes: ["position", "uv", "per_instance_data"], uniforms: ["world", "viewProjection", "albedoColor"] };
    var m1 = new BABYLON.ShaderMaterial("my1", scene, {vertexElement: "my", fragmentElement: "my"}, sett );
    var m2 = new BABYLON.ShaderMaterial("my2", scene, {vertexElement: "my", fragmentElement: "my"}, sett );
    var m3 = new BABYLON.ShaderMaterial("my3", scene, {vertexElement: "my", fragmentElement: "my"}, sett );

    m1.metallic = 0.0
    m2.metallic = 0.0
    m3.metallic = 0.0
    m1.setVector3("albedoColor", new BABYLON.Vector3(1.0, 0.0, 0.0));
    m2.setVector3("albedoColor", new BABYLON.Vector3(0.0, 1.0, 0.0));
    m3.setVector3("albedoColor", new BABYLON.Vector3(0.0, 0.0, 1.0));

    var sphere = BABYLON.MeshBuilder.CreateSphere("sphere", {diameter: 1, segments: 32}, scene);
    sphere.setEnabled(false)

    var s1 = sphere.clone('s1')
    var s2 = sphere.clone('s2')
    var s3 = sphere.clone('s3')
    s1.material = m1
    s2.material = m2
    s3.material = m3

    s1.registerInstancedBuffer('per_instance_data', 3);
    s2.registerInstancedBuffer('per_instance_data', 3);
    s3.registerInstancedBuffer('per_instance_data', 3); // This one will not be used for instances, lets see how it goes

    const instances = []

    for (let i=0; i<20; i++) {
        // Instances using material 1
        instances.push(s1.createInstance())
    }
    for (let i=0; i<20; i++) {
        // Instances using material 2
        instances.push(s2.createInstance())
    }
    for (let i=0; i<20; i++) {
        // Not instances at all
        instances.push(s3.clone())
    }


    var xp = -3.0, zp = 0.0;
    for (let idx=0; idx<instances.length; idx++) {
        const i = instances[idx]
        var s = 1.0
        if (i instanceof BABYLON.InstancedMesh) {
        	s = Math.random()*0.3+0.7;
        	i.instancedBuffers.per_instance_data = new BABYLON.Vector3(s, 0, 0);
        }

        i.position.x = xp;
        xp += s*1.1;

        
        i.position.z = zp
        i.position.y = 0.5;

        if (xp > 8.0) {
        	xp = -3.0;
        	zp += 1.1;
        }
        i.setEnabled(true);
    }

    var test = -1;

    // Here are some tests to see if things propagate
    setTimeout(() => {
        if (test === 0) { // Dispose
            for (let idx=0; idx<instances.length; idx++) {
                instances[idx].dispose();
            }
            s1.dispose();
            s2.dispose();
            s3.dispose();
        } else if (test === 1) { // Dispose
            s1.dispose();
            s2.dispose();
            s3.dispose();
        } else if (test === 2) { // Turn all spheres into a box by modifying geometry of one of them
	        var vertexData = BABYLON.VertexData.CreateBox({});
    	    vertexData.applyToMesh(sphere, false);
        } else if (test === 3) { // Turn all spheres into a box by modifying geometry of one of them
	        var vertexData = BABYLON.VertexData.CreateBox({});
    	    vertexData.applyToMesh(s1, false);
            // NOTE: Clicking on objects give an error right now, see https://forum.babylonjs.com/t/applying-vertexdata-to-mesh-used-as-instancedmesh-source/16670
        } else if (test === 4) { // Make sure the VAO of the instances are notified when geometry buffers are modified
            // Add a new Vertex channel, see if all objects get it
            var num = sphere.geometry.getTotalVertices() * 2;
            var uv = new Float32Array(num);
            for (let i = 0; i<num; i++) {
                uv[i] = Math.random();
            }
            // Make sure the VAO of the instances are notified that they need to be rebuilt
            sphere.setVerticesData("uv", uv, false)
        } else if (test === 5) { // Make sure the VAO of the instances are notified when geometry buffers are modified
            // Add a new Vertex channel, see if all objects get it
            var num = sphere.geometry.getTotalVertices() * 2;
            var uv = new Float32Array(num);

            setInterval(() => {
                for (let i = 0; i<num; i++) {
                    uv[i] = Math.random();
                }
                // Make sure the VAO of the instances are notified that they need to be rebuilt
                sphere.setVerticesData("uv", uv, true)

            }, 500)
        }
    }, 500);

    // Our built-in 'ground' shape.
    var ground = BABYLON.MeshBuilder.CreateGround("ground", {width: 12, height: 12}, scene);
    ground.receiveShadows = true

    return scene;
};
```