### PR TITLE
Add encapsulate methods to BoundingInfo class

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -13,6 +13,7 @@
 - Added ability to enable/disable ArcRotateCamera zoom on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
 - Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
 - Moving additional components to shared UI folder.([msDestiny14](https://github.com/msDestiny14))
+- Added encapsulate and encapsulateBoundingInfo methods to BoundingInfo. ([Tolo789](https://github.com/Tolo789))
 
 ### Engine
 - Moved all instance data from Geometry to Mesh such that the same Geometry objects can be used by many meshes with instancing. Reduces memory consumption on CPU/GPU. ([breakin](https://github.com/breakin)

--- a/src/Culling/boundingInfo.ts
+++ b/src/Culling/boundingInfo.ts
@@ -141,7 +141,7 @@ export class BoundingInfo implements ICullable {
 
         return this;
     }
-    
+
     /**
      * Grows the bounding info to include the given point.
      * @param point The point that will be included in the current bounding info
@@ -154,7 +154,7 @@ export class BoundingInfo implements ICullable {
 
         return this;
     }
-    
+
     /**
      * Grows the bounding info to encapsulate the given bounding info.
      * @param toEncapsulate The bounding info that will be encapsulated in the current bounding info

--- a/src/Culling/boundingInfo.ts
+++ b/src/Culling/boundingInfo.ts
@@ -141,6 +141,31 @@ export class BoundingInfo implements ICullable {
 
         return this;
     }
+    
+    /**
+     * Grows the bounding info to include the given point.
+     * @param point The point that will be included in the current bounding info
+     * @returns the current bounding info
+     */
+    public encapsulate(point: Vector3): BoundingInfo {
+        const minimum = Vector3.Minimize(this.minimum, point);
+        const maximum = Vector3.Maximize(this.maximum, point);
+        this.reConstruct(minimum, maximum, this.boundingBox.getWorldMatrix());
+
+        return this;
+    }
+    
+    /**
+     * Grows the bounding info to encapsulate the given bounding info.
+     * @param toEncapsulate The bounding info that will be encapsulated in the current bounding info
+     * @returns the current bounding info
+     */
+    public encapsulateBoundingInfo(toEncapsulate: BoundingInfo): BoundingInfo {
+        this.encapsulate(toEncapsulate.boundingBox.centerWorld.subtract(toEncapsulate.boundingBox.extendSizeWorld));
+        this.encapsulate(toEncapsulate.boundingBox.centerWorld.add(toEncapsulate.boundingBox.extendSizeWorld));
+
+        return this;
+    }
 
     /**
      * Scale the current bounding info by applying a scale factor


### PR DESCRIPTION
Add `encapsulate` methods to BoundingInfo class as discussed [here](https://forum.babylonjs.com/t/grow-a-boundinginfo-thanks-to-an-encapsulate-method/16625?u=tolomeo)