### PR TITLE
Add safety check to deleting textures in nativeEngine

### DIFF
--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1503,7 +1503,9 @@ export class NativeEngine extends Engine {
     }
 
     protected _deleteTexture(texture: Nullable<WebGLTexture>): void {
-        this._native.deleteTexture(texture);
+        if (texture) {
+            this._native.deleteTexture(texture);
+        }
     }
 
     /**


### PR DESCRIPTION
It's possible to call deleteTexture on a null or undefined texture, which is not handled in BabylonNative and results in an access violation.  This adds a check to native engine to check the texture is not null before passing it on to native code.