### PR TITLE
Mesh instances: Fix missing a call to invalidate vao

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1707,6 +1707,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this._userInstancedBuffersStorage.vertexBuffers["world1"] = instancesBuffer.createVertexBuffer("world1", 4, 4);
             this._userInstancedBuffersStorage.vertexBuffers["world2"] = instancesBuffer.createVertexBuffer("world2", 8, 4);
             this._userInstancedBuffersStorage.vertexBuffers["world3"] = instancesBuffer.createVertexBuffer("world3", 12, 4);
+
+            this._invalidateInstanceVertexArrayObject();
         } else {
             if (!this._instanceDataStorage.isFrozen) {
                 instancesBuffer!.updateDirectly(instanceStorage.instancesData, 0, instancesCount);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/disappearing-and-reappearing-instances/16890