### PR TITLE
Put TextureBlock in fragment shader if parent block is in fragment

### DIFF
--- a/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -157,6 +157,10 @@ export class TextureBlock extends NodeMaterialBlock {
             if (parent.target === NodeMaterialBlockTargets.Neutral || parent.target === NodeMaterialBlockTargets.VertexAndFragment) {
                 let parentBlock = parent.ownerBlock;
 
+                if (parentBlock.target === NodeMaterialBlockTargets.Fragment) {
+                    return NodeMaterialBlockTargets.Fragment;
+                }
+
                 parent = null;
                 for (var input of parentBlock.inputs) {
                     if (input.connectedPoint) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/nme-texture-uv-planar-projection/14606/44

I'm not sure of my fix...

The `TextureBlock` `target` getter is currently checking the `target` property of the connection points to choose between vertex or fragment shader, but the new selector that has been added lately allows to choose between vertex and fragment for a block not a connection point... So I have added a check that assigns the `TextureBlock` to the fragment shader if the owner block of a connection point is in the fragment shader (when the target of the connection point is Neutral or VertexAndFragment).