### PR TITLE
Added WSAD keys to freeCameraKeyboardMoveInput.ts 

### DIFF
--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -128,6 +128,7 @@
 - Added upwards and downwards keyboard input to `FreeCamera` ([Pheater](https://github.com/pheater))
 - Handle scales in camera matrices ([Popov72](https://github.com/Popov72))
 - Added mouse wheel controls to FreeCamera. ([mrdunk](https://github.com/mrdunk))
+- Added WASD movement to FreeCamera. ([geonom](https://github.com/geonom))
 
 ### Debug
 - Added new view modes to the `SkeletonViewer` class. ([Pryme8](https://github.com/Pryme8))

--- a/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
+++ b/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
@@ -22,7 +22,7 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
      * Gets or Set the list of keyboard keys used to control the forward move of the camera.
      */
     @serialize()
-    public keysUp = [38];
+    public keysUp = [38, 87];
 
     /**
      * Gets or Set the list of keyboard keys used to control the upward move of the camera.
@@ -34,7 +34,7 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
      * Gets or Set the list of keyboard keys used to control the backward move of the camera.
      */
     @serialize()
-    public keysDown = [40];
+    public keysDown = [40, 83];
 
     /**
      * Gets or Set the list of keyboard keys used to control the downward move of the camera.
@@ -46,13 +46,13 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
      * Gets or Set the list of keyboard keys used to control the left strafe move of the camera.
      */
     @serialize()
-    public keysLeft = [37];
+    public keysLeft = [37, 65];
 
     /**
      * Gets or Set the list of keyboard keys used to control the right strafe move of the camera.
      */
     @serialize()
-    public keysRight = [39];
+    public keysRight = [39, 68];
 
     private _keys = new Array<number>();
     private _onCanvasBlurObserver: Nullable<Observer<Engine>>;


### PR DESCRIPTION
Added WSAD for movement in addition to the arrow keys to support default ego perspective movement as commonly used in first person games.

Would help usability and be more friendly to newbies like me, so I do not have to add dozens of lines of code just to get the standard WSAD movement going :smile:

I think, it does none of these:

    You cannot add code that will break backward compatibility
    You cannot add code that will slow down the rendering process
    You cannot add code that will make things complex to use
