### PR TITLE
Decorators switch fallthrough

### DIFF
--- a/src/Misc/decorators.ts
+++ b/src/Misc/decorators.ts
@@ -312,6 +312,7 @@ export class SerializationHelper {
                         break;
                     case 11:    // Camera reference
                         serializationObject[targetPropertyName] = (<Camera>sourceProperty).id;
+                        break;
                     case 12:    // Matrix
                         serializationObject[targetPropertyName] = (<Matrix>sourceProperty).asArray();
                         break;


### PR DESCRIPTION
Is it intentional for case `11` to fallthrough in this switch block?

Presume a `break` is needed there?