### PR TITLE
Sound switch fallthrough

### DIFF
--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -245,6 +245,7 @@ export class Sound {
                             break;
                         case "String":
                             urls.push(urlOrArrayBuffer);
+                            break;
                         case "Array":
                             if (urls.length === 0) {
                                 urls = urlOrArrayBuffer;


### PR DESCRIPTION
Is it intentional for case `String` to fallthrough to `Array` here?

Presume a `break` is needed?