### PR TITLE
Meshes documentation

### DIFF
--- a/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/src/Meshes/Builders/icoSphereBuilder.ts
@@ -226,7 +226,7 @@ VertexData.CreateIcoSphere = function(options: { radius?: number, radiusX?: numb
             normals.push(vertex_normal.x, vertex_normal.y, vertex_normal.z);
             uvs.push(uv_interp.x, uv_interp.y);
             // push each vertex has member of a face
-            // Same vertex can bleong to multiple face, it is pushed multiple time (duplicate vertex are present)
+            // Same vertex can belong to multiple face, it is pushed multiple time (duplicate vertex are present)
             indices.push(current_indice);
             current_indice++;
         };
@@ -273,7 +273,7 @@ export class IcoSphereBuilder {
      * Creates a sphere based upon an icosahedron with 20 triangular faces which can be subdivided
      * * The parameter `radius` sets the radius size (float) of the icosphere (default 1)
      * * You can set some different icosphere dimensions, for instance to build an ellipsoid, by using the parameters `radiusX`, `radiusY` and `radiusZ` (all by default have the same value of `radius`)
-     * * The parameter `subdivisions` sets the number of subdivisions (postive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
+     * * The parameter `subdivisions` sets the number of subdivisions (positive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
      * * The parameter `flat` (boolean, default true) gives each side its own normals. Set it to false to get a smooth continuous light reflection on the surface
      * * You can also set the mesh side orientation with the values : BABYLON.Mesh.FRONTSIDE (default), BABYLON.Mesh.BACKSIDE or BABYLON.Mesh.DOUBLESIDE
      * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation

--- a/src/Meshes/Builders/latheBuilder.ts
+++ b/src/Meshes/Builders/latheBuilder.ts
@@ -22,7 +22,7 @@ Mesh.CreateLathe = (name: string, shape: Vector3[], radius: number, tessellation
 export class LatheBuilder {
     /**
      * Creates lathe mesh.
-     * The lathe is a shape with a symetry axis : a 2D model shape is rotated around this axis to design the lathe
+     * The lathe is a shape with a symmetry axis : a 2D model shape is rotated around this axis to design the lathe
      * * The parameter `shape` is a required array of successive Vector3. This array depicts the shape to be rotated in its local space : the shape must be designed in the xOy plane and will be rotated around the Y axis. It's usually a 2D shape, so the Vector3 z coordinates are often set to zero
      * * The parameter `radius` (positive float, default 1) is the radius value of the lathe
      * * The parameter `tessellation` (positive integer, default 64) is the side number of the lathe

--- a/src/Meshes/Builders/polyhedronBuilder.ts
+++ b/src/Meshes/Builders/polyhedronBuilder.ts
@@ -148,7 +148,7 @@ export class PolyhedronBuilder {
      * * The parameter `type` (positive integer, max 14, default 0) sets the polyhedron type to build among the 15 embbeded types. Please refer to the type sheet in the tutorial to choose the wanted type
      * * The parameter `size` (positive float, default 1) sets the polygon size
      * * You can overwrite the `size` on each dimension bu using the parameters `sizeX`, `sizeY` or `sizeZ` (positive floats, default to `size` value)
-     * * You can build other polyhedron types than the 15 embbeded ones by setting the parameter `custom` (`polyhedronObject`, default null). If you set the parameter `custom`, this overwrittes the parameter `type`
+     * * You can build other polyhedron types than the 15 embbeded ones by setting the parameter `custom` (`polyhedronObject`, default null). If you set the parameter `custom`, this overrides the parameter `type`
      * * A `polyhedronObject` is a formatted javascript object. You'll find a full file with pre-set polyhedra here : https://github.com/BabylonJS/Extensions/tree/master/Polyhedron
      * * You can set the color and the UV of each side of the polyhedron with the parameters `faceColors` (Color4, default `(1, 1, 1, 1)`) and faceUV (Vector4, default `(0, 0, 1, 1)`)
      * * To understand how to set `faceUV` or `faceColors`, please read this by considering the right number of faces of your polyhedron, instead of only 6 for the box : https://doc.babylonjs.com/how_to/createbox_per_face_textures_and_colors

--- a/src/Meshes/Builders/ribbonBuilder.ts
+++ b/src/Meshes/Builders/ribbonBuilder.ts
@@ -25,7 +25,7 @@ VertexData.CreateRibbon = function(options: { pathArray: Vector3[][], closeArray
     var uvs: number[] = [];
 
     var us: number[][] = [];        		// us[path_id] = [uDist1, uDist2, uDist3 ... ] distances between points on path path_id
-    var vs: number[][] = [];        		// vs[i] = [vDist1, vDist2, vDist3, ... ] distances between points i of consecutives paths from pathArray
+    var vs: number[][] = [];        		// vs[i] = [vDist1, vDist2, vDist3, ... ] distances between points i of consecutive paths from pathArray
     var uTotalDistance: number[] = []; 		// uTotalDistance[p] : total distance of path p
     var vTotalDistance: number[] = []; 		//  vTotalDistance[i] : total distance between points i of first and last path from pathArray
     var minlg: number;          	        // minimal length among all paths from pathArray

--- a/src/Meshes/Builders/shapeBuilder.ts
+++ b/src/Meshes/Builders/shapeBuilder.ts
@@ -80,9 +80,9 @@ export class ShapeBuilder {
      * The custom extrusion is a parametric shape. It has no predefined shape. Its final shape will depend on the input parameters.
      * * The parameter `shape` is a required array of successive Vector3. This array depicts the shape to be extruded in its local space : the shape must be designed in the xOy plane and will be extruded along the Z axis.
      * * The parameter `path` is a required array of successive Vector3. This is the axis curve the shape is extruded along.
-     * * The parameter `rotationFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the begining of the path
+     * * The parameter `rotationFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the beginning of the path
      * * It must returns a float value that will be the rotation in radians applied to the shape on each path point.
-     * * The parameter `scaleFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the begining of the path
+     * * The parameter `scaleFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the beginning of the path
      * * It must returns a float value that will be the scale value applied to the shape on each path point
      * * The parameter `ribbonClosePath` (boolean, default false) forces the extrusion underlying ribbon to close all the paths in its `pathArray`
      * * The parameter `ribbonCloseArray` (boolean, default false) forces the extrusion underlying ribbon to close its `pathArray`

--- a/src/Meshes/Builders/torusBuilder.ts
+++ b/src/Meshes/Builders/torusBuilder.ts
@@ -90,7 +90,7 @@ export class TorusBuilder {
      * Creates a torus mesh
      * * The parameter `diameter` sets the diameter size (float) of the torus (default 1)
      * * The parameter `thickness` sets the diameter size of the tube of the torus (float, default 0.5)
-     * * The parameter `tessellation` sets the number of torus sides (postive integer, default 16)
+     * * The parameter `tessellation` sets the number of torus sides (positive integer, default 16)
      * * You can also set the mesh side orientation with the values : BABYLON.Mesh.FRONTSIDE (default), BABYLON.Mesh.BACKSIDE or BABYLON.Mesh.DOUBLESIDE
      * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
      * * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.

--- a/src/Meshes/Builders/tubeBuilder.ts
+++ b/src/Meshes/Builders/tubeBuilder.ts
@@ -30,7 +30,7 @@ export class TubeBuilder {
      * * The parameter `path` is a required array of successive Vector3. It is the curve used as the axis of the tube
      * * The parameter `radius` (positive float, default 1) sets the tube radius size
      * * The parameter `tessellation` (positive float, default 64) is the number of sides on the tubular surface
-     * * The parameter `radiusFunction` (javascript function, default null) is a vanilla javascript function. If it is not null, it overwrittes the parameter `radius`
+     * * The parameter `radiusFunction` (javascript function, default null) is a vanilla javascript function. If it is not null, it overrides the parameter `radius`
      * * This function is called on each point of the tube path and is passed the index `i` of the i-th point and the distance of this point from the first point of the path. It must return a radius value (positive float)
      * * The parameter `arc` (positive float, maximum 1, default 1) is the ratio to apply to the tube circumference : 2 x PI x arc
      * * The parameter `cap` sets the way the extruded shape is capped. Possible values : BABYLON.Mesh.NO_CAP (default), BABYLON.Mesh.CAP_START, BABYLON.Mesh.CAP_END, BABYLON.Mesh.CAP_ALL

--- a/src/Meshes/Compression/dracoCompression.ts
+++ b/src/Meshes/Compression/dracoCompression.ts
@@ -213,7 +213,7 @@ export interface IDracoCompressionConfiguration {
  *     };
  * ```
  *
- * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support Webssembly or only support the JavaScript version.
+ * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
  * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
  * Use `DracoCompression.DecoderAvailable` to determine if the decoder configuration is available for the current context.
  *

--- a/src/Meshes/buffer.ts
+++ b/src/Meshes/buffer.ts
@@ -68,7 +68,7 @@ export class Buffer {
         const byteOffset = useBytes ? offset : offset * Float32Array.BYTES_PER_ELEMENT;
         const byteStride = stride ? (useBytes ? stride : stride * Float32Array.BYTES_PER_ELEMENT) : this.byteStride;
 
-        // a lot of these parameters are ignored as they are overriden by the buffer
+        // a lot of these parameters are ignored as they are overridden by the buffer
         return new VertexBuffer(this._engine, this, kind, this._updatable, true, byteStride, instanced === undefined ? this._instanced : instanced, byteOffset, size, undefined, undefined, true, this._divisor || divisor);
     }
 
@@ -428,7 +428,7 @@ export class VertexBuffer {
                     return result;
                 }
 
-                // Portect against bad data
+                // Protect against bad data
                 let remainder = offset % 4;
 
                 if (remainder) {

--- a/src/Meshes/csg.ts
+++ b/src/Meshes/csg.ts
@@ -569,7 +569,7 @@ export class CSG {
 
     /**
      * Subtracts this CSG with another CSG in place
-     * @param csg The CSG to subtact against this CSG
+     * @param csg The CSG to subtract against this CSG
      */
     public subtractInPlace(csg: CSG): void {
         var a = new Node(this.polygons);

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -113,7 +113,7 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /**
-     * If set to true (false by defaut), the bounding info applied to the meshes sharing this geometry will be the bounding info defined at the class level
+     * If set to true (false by default), the bounding info applied to the meshes sharing this geometry will be the bounding info defined at the class level
      * and won't be computed based on the vertex positions (which is what we get when useBoundingInfoFromGeometry = false)
      */
     public useBoundingInfoFromGeometry = false;
@@ -1010,7 +1010,7 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /**
-     * Serialize all vertices data into a JSON oject
+     * Serialize all vertices data into a JSON object
      * @returns a JSON representation of the current geometry data
      */
     public serializeVerticeData(): any {

--- a/src/Meshes/groundMesh.ts
+++ b/src/Meshes/groundMesh.ts
@@ -8,7 +8,7 @@ Mesh._GroundMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
 };
 
 /**
- * Mesh representing the gorund
+ * Mesh representing the ground
  */
 export class GroundMesh extends Mesh {
     /** If octree should be generated */
@@ -85,7 +85,7 @@ export class GroundMesh extends Mesh {
     }
 
     /**
-     * Returns a height (y) value in the Worl system :
+     * Returns a height (y) value in the World system :
      * the ground altitude at the coordinates (x, z) expressed in the World system.
      * @param x x coordinate
      * @param z z coordinate
@@ -129,7 +129,7 @@ export class GroundMesh extends Mesh {
     /**
      * Updates the Vector3 passed a reference with a normalized vector orthogonal to the ground
      * at the ground coordinates (x, z) expressed in the World system.
-     * Doesn't uptade the reference Vector3 if (x, z) are outside the ground surface.
+     * Doesn't update the reference Vector3 if (x, z) are outside the ground surface.
      * @param x x coordinate
      * @param z z coordinate
      * @param ref vector to store the result
@@ -186,7 +186,7 @@ export class GroundMesh extends Mesh {
 
     //  Creates and populates the heightMap array with "facet" elements :
     // a quad is two triangular facets separated by a slope, so a "facet" element is 1 slope + 2 facets
-    // slope : Vector2(c, h) = 2D diagonal line equation setting appart two triangular facets in a quad : z = cx + h
+    // slope : Vector2(c, h) = 2D diagonal line equation setting apart two triangular facets in a quad : z = cx + h
     // facet1 : Vector4(a, b, c, d) = first facet 3D plane equation : ax + by + cz + d = 0
     // facet2 :  Vector4(a, b, c, d) = second facet 3D plane equation : ax + by + cz + d = 0
     // Returns the GroundMesh.
@@ -204,7 +204,7 @@ export class GroundMesh extends Mesh {
     }
 
     // Compute each quad element values and update the the heightMap array :
-    // slope : Vector2(c, h) = 2D diagonal line equation setting appart two triangular facets in a quad : z = cx + h
+    // slope : Vector2(c, h) = 2D diagonal line equation setting apart two triangular facets in a quad : z = cx + h
     // facet1 : Vector4(a, b, c, d) = first facet 3D plane equation : ax + by + cz + d = 0
     // facet2 :  Vector4(a, b, c, d) = second facet 3D plane equation : ax + by + cz + d = 0
     // Returns the GroundMesh.

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -182,9 +182,9 @@ export class InstancedMesh extends AbstractMesh {
 
     /**
      * Returns an array of integers or a typed array (Int32Array, Uint32Array, Uint16Array) populated with the mesh indices.
-     * @param kind kind of verticies to retreive (eg. positons, normals, uvs, etc.)
+     * @param kind kind of verticies to retrieve (eg. positions, normals, uvs, etc.)
      * @param copyWhenShared If true (default false) and and if the mesh geometry is shared among some other meshes, the returned array is a copy of the internal one.
-     * @returns a float array or a Float32Array of the requested kind of data : positons, normals, uvs, etc.
+     * @returns a float array or a Float32Array of the requested kind of data : positions, normals, uvs, etc.
      */
     public getVerticesData(kind: string, copyWhenShared?: boolean): Nullable<FloatArray> {
         return this._sourceMesh.getVerticesData(kind, copyWhenShared);
@@ -194,7 +194,7 @@ export class InstancedMesh extends AbstractMesh {
      * Sets the vertex data of the mesh geometry for the requested `kind`.
      * If the mesh has no geometry, a new Geometry object is set to the mesh and then passed this vertex data.
      * The `data` are either a numeric array either a Float32Array.
-     * The parameter `updatable` is passed as is to the underlying Geometry object constructor (if initianilly none) or updater.
+     * The parameter `updatable` is passed as is to the underlying Geometry object constructor (if initially none) or updater.
      * The parameter `stride` is an optional positive integer, it is usually automatically deducted from the `kind` (3 for positions or normals, 2 for UV, etc).
      * Note that a new underlying VertexBuffer object is created each call.
      * If the `kind` is the `PositionKind`, the mesh BoundingInfo is renewed, so the bounding box and sphere, and the mesh World Matrix is recomputed.

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -249,7 +249,7 @@ export class InstancedLinesMesh extends InstancedMesh {
     /**
      * The intersection Threshold is the margin applied when intersection a segment of the LinesMesh with a Ray.
      * This margin is expressed in world space coordinates, so its value may vary.
-     * Initilized with the intersectionThreshold value of the source LinesMesh
+     * Initialized with the intersectionThreshold value of the source LinesMesh
      */
     public intersectionThreshold: number;
 

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2051,7 +2051,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             // check for invalid weight and just set it to 1.
             if (t === 0) { matricesWeights[a] = 1; }
             else {
-                // renormalize so everything adds to 1 use reciprical
+                // renormalize so everything adds to 1 use reciprocal
                 let recip = 1 / t;
                 matricesWeights[a] *= recip;
                 matricesWeights[a + 1] *= recip;
@@ -2076,7 +2076,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             // check for invalid weight and just set it to 1.
             if (t === 0) { matricesWeights[a] = 1; }
             else {
-                // renormalize so everything adds to 1 use reciprical
+                // renormalize so everything adds to 1 use reciprocal
                 let recip = 1 / t;
                 matricesWeights[a] *= recip;
                 matricesWeights[a + 1] *= recip;
@@ -2144,7 +2144,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 missingWeights++;
             }
             else {
-                // renormalize so everything adds to 1 use reciprical
+                // renormalize so everything adds to 1 use reciprocal
                 let recip = 1 / t;
                 let tolerance = 0;
                 for (b = 0; b < numInfluences; b++) {
@@ -2155,7 +2155,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                         tolerance += Math.abs(matricesWeightsExtra[a + b - 4] - (matricesWeightsExtra[a + b - 4] * recip));
                     }
                 }
-                // arbitary epsilon value for dicdating not normalized
+                // arbitrary epsilon value for dictating not normalized
                 if (tolerance > toleranceEpsilon) { numberNotNormalized++; }
             }
         }
@@ -3780,7 +3780,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @param name defines the name of the mesh to create
      * @param diameter sets the diameter size (float) of the torus (default 1)
      * @param thickness sets the diameter size of the tube of the torus (float, default 0.5)
-     * @param tessellation sets the number of torus sides (postive integer, default 16)
+     * @param tessellation sets the number of torus sides (positive integer, default 16)
      * @param scene defines the hosting scene
      * @param updatable defines if the mesh must be flagged as updatable
      * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
@@ -3922,7 +3922,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /**
      * Creates lathe mesh.
-     * The lathe is a shape with a symetry axis : a 2D model shape is rotated around this axis to design the lathe.
+     * The lathe is a shape with a symmetry axis : a 2D model shape is rotated around this axis to design the lathe.
      * Please consider using the same method from the MeshBuilder class instead
      * @param name defines the name of the mesh to create
      * @param shape is a required array of successive Vector3. This array depicts the shape to be rotated in its local space : the shape must be designed in the xOy plane and will be rotated around the Y axis. It's usually a 2D shape, so the Vector3 z coordinates are often set to zero
@@ -4014,7 +4014,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @param path is a required array of successive Vector3. It is the curve used as the axis of the tube
      * @param radius sets the tube radius size
      * @param tessellation is the number of sides on the tubular surface
-     * @param radiusFunction is a custom function. If it is not null, it overwrittes the parameter `radius`. This function is called on each point of the tube path and is passed the index `i` of the i-th point and the distance of this point from the first point of the path
+     * @param radiusFunction is a custom function. If it is not null, it overrides the parameter `radius`. This function is called on each point of the tube path and is passed the index `i` of the i-th point and the distance of this point from the first point of the path
      * @param cap sets the way the extruded shape is capped. Possible values : Mesh.NO_CAP (default), Mesh.CAP_START, Mesh.CAP_END, Mesh.CAP_ALL
      * @param scene defines the hosting scene
      * @param updatable defines if the mesh must be flagged as updatable
@@ -4029,7 +4029,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
       * Creates a polyhedron mesh.
       * Please consider using the same method from the MeshBuilder class instead.
-      * * The parameter `type` (positive integer, max 14, default 0) sets the polyhedron type to build among the 15 embbeded types. Please refer to the type sheet in the tutorial to choose the wanted type
+      * * The parameter `type` (positive integer, max 14, default 0) sets the polyhedron type to build among the 15 embedded types. Please refer to the type sheet in the tutorial to choose the wanted type
       * * The parameter `size` (positive float, default 1) sets the polygon size
       * * You can overwrite the `size` on each dimension bu using the parameters `sizeX`, `sizeY` or `sizeZ` (positive floats, default to `size` value)
       * * You can build other polyhedron types than the 15 embbeded ones by setting the parameter `custom` (`polyhedronObject`, default null). If you set the parameter `custom`, this overwrittes the parameter `type`
@@ -4053,7 +4053,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * Creates a sphere based upon an icosahedron with 20 triangular faces which can be subdivided
      * * The parameter `radius` sets the radius size (float) of the icosphere (default 1)
      * * You can set some different icosphere dimensions, for instance to build an ellipsoid, by using the parameters `radiusX`, `radiusY` and `radiusZ` (all by default have the same value than `radius`)
-     * * The parameter `subdivisions` sets the number of subdivisions (postive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
+     * * The parameter `subdivisions` sets the number of subdivisions (positive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
      * * The parameter `flat` (boolean, default true) gives each side its own normals. Set it to false to get a smooth continuous light reflection on the surface
      * * You can also set the mesh side orientation with the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
      * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -689,7 +689,7 @@ export class VertexData {
     /**
      * Extracts the vertexData from the geometry
      * @param geometry the geometry from which to extract the VertexData
-     * @param copyWhenShared defines if the VertexData must be cloned when the geometrty is shared between multiple meshes, optional, default false
+     * @param copyWhenShared defines if the VertexData must be cloned when the geometry is shared between multiple meshes, optional, default false
      * @param forceCopy indicating that the VertexData must be cloned, optional, default false
      * @returns the object VertexData associated to the passed mesh
      */
@@ -1093,7 +1093,7 @@ export class VertexData {
       * * ratio : optional partitioning ratio / bounding box, required for facetPartitioning computation
       * * bInfo : optional bounding info, required for facetPartitioning computation
       * * bbSize : optional bounding box size data, required for facetPartitioning computation
-      * * subDiv : optional partitioning data about subdivsions on  each axis (int), required for facetPartitioning computation
+      * * subDiv : optional partitioning data about subdivisions on  each axis (int), required for facetPartitioning computation
       * * useRightHandedSystem: optional boolean to for right handed system computation
       * * depthSort : optional boolean to enable the facet depth sort computation
       * * distanceTo : optional Vector3 to compute the facet depth from this location
@@ -1156,8 +1156,8 @@ export class VertexData {
         let subSq = 0;
         if (computeFacetPartitioning && options && options.bbSize) {
             var ox = 0;                 // X partitioning index for facet position
-            var oy = 0;                 // Y partinioning index for facet position
-            var oz = 0;                 // Z partinioning index for facet position
+            var oy = 0;                 // Y partitioning index for facet position
+            var oz = 0;                 // Z partitioning index for facet position
             var b1x = 0;                // X partitioning index for facet v1 vertex
             var b1y = 0;                // Y partitioning index for facet v1 vertex
             var b1z = 0;                // z partitioning index for facet v1 vertex

--- a/src/Meshes/meshBuilder.ts
+++ b/src/Meshes/meshBuilder.ts
@@ -108,7 +108,7 @@ export class MeshBuilder {
      * Creates a sphere based upon an icosahedron with 20 triangular faces which can be subdivided
      * * The parameter `radius` sets the radius size (float) of the icosphere (default 1)
      * * You can set some different icosphere dimensions, for instance to build an ellipsoid, by using the parameters `radiusX`, `radiusY` and `radiusZ` (all by default have the same value of `radius`)
-     * * The parameter `subdivisions` sets the number of subdivisions (postive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
+     * * The parameter `subdivisions` sets the number of subdivisions (positive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
      * * The parameter `flat` (boolean, default true) gives each side its own normals. Set it to false to get a smooth continuous light reflection on the surface
      * * You can also set the mesh side orientation with the values : BABYLON.Mesh.FRONTSIDE (default), BABYLON.Mesh.BACKSIDE or BABYLON.Mesh.DOUBLESIDE
      * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
@@ -186,7 +186,7 @@ export class MeshBuilder {
      * Creates a torus mesh
      * * The parameter `diameter` sets the diameter size (float) of the torus (default 1)
      * * The parameter `thickness` sets the diameter size of the tube of the torus (float, default 0.5)
-     * * The parameter `tessellation` sets the number of torus sides (postive integer, default 16)
+     * * The parameter `tessellation` sets the number of torus sides (positive integer, default 16)
      * * You can also set the mesh side orientation with the values : BABYLON.Mesh.FRONTSIDE (default), BABYLON.Mesh.BACKSIDE or BABYLON.Mesh.DOUBLESIDE
      * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
      * * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.
@@ -310,7 +310,7 @@ export class MeshBuilder {
      * The custom extrusion is a parametric shape. It has no predefined shape. Its final shape will depend on the input parameters.
      * * The parameter `shape` is a required array of successive Vector3. This array depicts the shape to be extruded in its local space : the shape must be designed in the xOy plane and will be extruded along the Z axis.
      * * The parameter `path` is a required array of successive Vector3. This is the axis curve the shape is extruded along.
-     * * The parameter `rotationFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the begining of the path
+     * * The parameter `rotationFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the beginning of the path
      * * It must returns a float value that will be the rotation in radians applied to the shape on each path point.
      * * The parameter `scaleFunction` (JS function) is a custom Javascript function called on each path point. This function is passed the position i of the point in the path and the distance of this point from the begining of the path
      * * It must returns a float value that will be the scale value applied to the shape on each path point
@@ -337,7 +337,7 @@ export class MeshBuilder {
 
     /**
      * Creates lathe mesh.
-     * The lathe is a shape with a symetry axis : a 2D model shape is rotated around this axis to design the lathe
+     * The lathe is a shape with a symmetry axis : a 2D model shape is rotated around this axis to design the lathe
      * * The parameter `shape` is a required array of successive Vector3. This array depicts the shape to be rotated in its local space : the shape must be designed in the xOy plane and will be rotated around the Y axis. It's usually a 2D shape, so the Vector3 z coordinates are often set to zero
      * * The parameter `radius` (positive float, default 1) is the radius value of the lathe
      * * The parameter `tessellation` (positive integer, default 64) is the side number of the lathe
@@ -486,7 +486,7 @@ export class MeshBuilder {
      * * The parameter `path` is a required array of successive Vector3. It is the curve used as the axis of the tube
      * * The parameter `radius` (positive float, default 1) sets the tube radius size
      * * The parameter `tessellation` (positive float, default 64) is the number of sides on the tubular surface
-     * * The parameter `radiusFunction` (javascript function, default null) is a vanilla javascript function. If it is not null, it overwrittes the parameter `radius`
+     * * The parameter `radiusFunction` (javascript function, default null) is a vanilla javascript function. If it is not null, it overrides the parameter `radius`
      * * This function is called on each point of the tube path and is passed the index `i` of the i-th point and the distance of this point from the first point of the path. It must return a radius value (positive float)
      * * The parameter `arc` (positive float, maximum 1, default 1) is the ratio to apply to the tube circumference : 2 x PI x arc
      * * The parameter `cap` sets the way the extruded shape is capped. Possible values : BABYLON.Mesh.NO_CAP (default), BABYLON.Mesh.CAP_START, BABYLON.Mesh.CAP_END, BABYLON.Mesh.CAP_ALL

--- a/src/Meshes/meshSimplification.ts
+++ b/src/Meshes/meshSimplification.ts
@@ -309,7 +309,7 @@ export class QuadraticErrorSimplification implements ISimplifier {
 
     private _reconstructedMesh: Mesh;
 
-    /** Gets or sets the number pf sync interations */
+    /** Gets or sets the number pf sync iterations */
     public syncIterations = 5000;
 
     /** Gets or sets the aggressiveness of the simplifier */

--- a/src/Meshes/meshSimplificationSceneComponent.ts
+++ b/src/Meshes/meshSimplificationSceneComponent.ts
@@ -99,7 +99,7 @@ export class SimplicationQueueSceneComponent implements ISceneComponent {
     }
 
     /**
-     * Disposes the component and the associated ressources
+     * Disposes the component and the associated resources
      */
     public dispose(): void {
         // Nothing to do for this component

--- a/src/Meshes/polygonMesh.ts
+++ b/src/Meshes/polygonMesh.ts
@@ -84,7 +84,7 @@ export class Polygon {
      * @param ymin bottom Y coord
      * @param xmax top X coord
      * @param ymax top Y coord
-     * @returns points that make the resulting rectation
+     * @returns points that make the resulting rectangle
      */
     static Rectangle(xmin: number, ymin: number, xmax: number, ymax: number): Vector2[] {
         return [

--- a/src/Meshes/subMesh.ts
+++ b/src/Meshes/subMesh.ts
@@ -181,7 +181,7 @@ export class SubMesh implements ICullable {
     }
 
     /**
-     * Returns the submesh BoudingInfo object
+     * Returns the submesh BoundingInfo object
      * @returns current bounding info (or mesh's one if the submesh is global)
      */
     public getBoundingInfo(): BoundingInfo {

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -475,7 +475,7 @@ export class TransformNode extends Node {
     }
 
     /**
-    * Retuns the mesh absolute position in the World.
+    * Returns the mesh absolute position in the World.
     * @returns a Vector3.
     */
     public getAbsolutePosition(): Vector3 {
@@ -563,7 +563,7 @@ export class TransformNode extends Node {
      * @param yawCor optional yaw (y-axis) correction in radians
      * @param pitchCor optional pitch (x-axis) correction in radians
      * @param rollCor optional roll (z-axis) correction in radians
-     * @param space the choosen space of the target
+     * @param space the chosen space of the target
      * @returns the TransformNode.
      */
     public lookAt(targetPoint: Vector3, yawCor: number = 0, pitchCor: number = 0, rollCor: number = 0, space: Space = Space.LOCAL): TransformNode {
@@ -1314,7 +1314,7 @@ export class TransformNode extends Node {
     /**
      * Returns a new TransformNode object parsed from the source provided.
      * @param parsedTransformNode is the source.
-     * @param scene the scne the object belongs to
+     * @param scene the scene the object belongs to
      * @param rootUrl is a string, it's the root URL to prefix the `delayLoadingFile` property with
      * @returns a new TransformNode object parsed from the source provided.
      */


### PR DESCRIPTION
Minor meshes folder documentation suggested updates:

- accurante => accurate
- appart => apart
- arbitary => arbitrary
- begining => beginning
- bleong => belong
- bouding => bounding
- BoudingInfo => BoundingInfo
- choosen => chosen
- consecutives => consecutive
- defaut => default
- dicdating => dictating
- embbeded => embedded
- facetLocalPartioning => facetLocalPartitioning
- Initilized => Initialized
- initianilly => initially
- interations => iterations
- geometrty => geometry
- gorund => ground
- numner => number
- oject => object
- optimisitic => optimistic
- overriden => overridden
- overwrittes => overrides
- partioning => partitioning
- partinioning => partitioning
- portect => protect
- positons => position
- postive => positive
- reciprical => reciprocal
- rectation => rectangle
- ressources => resources
- retreive => retreive 
- Retuns => Returns
- scne => scene
- skining => skinning
- subdivsions => subdivisions
- subtact => subtract
- symetry => symmetry
- tranform => transform
- unifom => uniform
- uptade => update
- Webssembly => WebAssembly
- Worl => World

