### PR TITLE
PlayAnimationAction documentation match function signature

### DIFF
--- a/src/Actions/directActions.ts
+++ b/src/Actions/directActions.ts
@@ -281,7 +281,7 @@ export class PlayAnimationAction extends Action {
      * @param triggerOptions defines the trigger options
      * @param target defines the target animation or animation name
      * @param from defines from where the animation should start (animation frame)
-     * @param end defines where the animation should stop (animation frame)
+     * @param to defines where the animation should stop (animation frame)
      * @param loop defines if the animation should loop or stop after the first play
      * @param condition defines the trigger related conditions
      */


### PR DESCRIPTION
Documentation references `end`, but I believe this should be `to` to match function signature.

```js
/**
 * Instantiate the action
 * @param triggerOptions defines the trigger options
 * @param target defines the target animation or animation name
 * @param from defines from where the animation should start (animation frame)
 * @param end defines where the animation should stop (animation frame)
 * @param loop defines if the animation should loop or stop after the first play
 * @param condition defines the trigger related conditions
 */
constructor(triggerOptions: any, target: any, from: number, to: number, loop?: boolean, condition?: Condition) {{
```

Recommending:

```js
/**
 * @param to defines where the animation should stop (animation frame)
 */
constructor(... to: number ...) {
```