### PR TITLE
Materials documentation

### DIFF
--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -174,7 +174,7 @@ class BackgroundMaterialDefines extends MaterialDefines implements IImageProcess
 }
 
 /**
- * Background material used to create an efficient environement around your scene.
+ * Background material used to create an efficient environment around your scene.
  */
 export class BackgroundMaterial extends PushMaterial {
 
@@ -191,7 +191,7 @@ export class BackgroundMaterial extends PushMaterial {
     @serializeAsColor3()
     protected _primaryColor: Color3;
     /**
-     * Key light Color (multiply against the environement texture)
+     * Key light Color (multiply against the environment texture)
      */
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public primaryColor = Color3.White();
@@ -235,7 +235,7 @@ export class BackgroundMaterial extends PushMaterial {
     @serialize()
     protected _primaryColorHighlightLevel: float = 0;
     /**
-     * Defines the level of the highliights (highlight area of the reflection map) in order to help scaling the colors.
+     * Defines the level of the highlights (highlight area of the reflection map) in order to help scaling the colors.
      * The primary color is used at the level chosen to define what the white area would look.
      */
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
@@ -487,39 +487,39 @@ export class BackgroundMaterial extends PushMaterial {
     }
 
     /**
-     * Gets wether the color curves effect is enabled.
+     * Gets whether the color curves effect is enabled.
      */
     public get cameraColorCurvesEnabled(): boolean {
         return (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorCurvesEnabled;
     }
     /**
-     * Sets wether the color curves effect is enabled.
+     * Sets whether the color curves effect is enabled.
      */
     public set cameraColorCurvesEnabled(value: boolean) {
         (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorCurvesEnabled = value;
     }
 
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public get cameraColorGradingEnabled(): boolean {
         return (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorGradingEnabled;
     }
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public set cameraColorGradingEnabled(value: boolean) {
         (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorGradingEnabled = value;
     }
 
     /**
-     * Gets wether tonemapping is enabled or not.
+     * Gets whether tonemapping is enabled or not.
      */
     public get cameraToneMappingEnabled(): boolean {
         return this._imageProcessingConfiguration.toneMappingEnabled;
     }
     /**
-     * Sets wether tonemapping is enabled or not
+     * Sets whether tonemapping is enabled or not
      */
     public set cameraToneMappingEnabled(value: boolean) {
         this._imageProcessingConfiguration.toneMappingEnabled = value;
@@ -570,7 +570,7 @@ export class BackgroundMaterial extends PushMaterial {
     }
 
     /**
-     * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+     * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
      * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
      * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
      * corresponding to low luminance, medium luminance, and high luminance areas respectively.
@@ -579,7 +579,7 @@ export class BackgroundMaterial extends PushMaterial {
         return (<ImageProcessingConfiguration>this.imageProcessingConfiguration).colorCurves;
     }
     /**
-     * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+     * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
      * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
      * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
      * corresponding to low luminance, medium luminance, and high luminance areas respectively.
@@ -659,7 +659,7 @@ export class BackgroundMaterial extends PushMaterial {
     }
 
     /**
-     * Checks wether the material is ready to be rendered for a given mesh.
+     * Checks whether the material is ready to be rendered for a given mesh.
      * @param mesh The mesh to render
      * @param subMesh The submesh to check against
      * @param useInstances Specify wether or not the material is used with instances

--- a/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -96,7 +96,7 @@ export class LightBlock extends NodeMaterialBlock {
     }
 
     /**
-    * Gets the glossinness power component
+    * Gets the glossiness power component
     */
     public get glossPower(): NodeMaterialConnectionPoint {
         return this._inputs[4];

--- a/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -17,7 +17,7 @@ import "../../../../Shaders/ShadersInclude/bumpFragmentFunctions";
 import "../../../../Shaders/ShadersInclude/bumpFragment";
 
 /**
- * Block used to pertub normals based on a normal map
+ * Block used to perturb normals based on a normal map
  */
 export class PerturbNormalBlock extends NodeMaterialBlock {
     private _tangentSpaceParameterName = "";

--- a/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -121,7 +121,7 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
 
     /**
      * Intensity of the environment e.g. how much the environment will light the object
-     * either through harmonics for rough material or through the refelction for shiny ones.
+     * either through harmonics for rough material or through the reflection for shiny ones.
      */
     @editableInPropertyPage("Environment lights", PropertyTypeForEdition.Float, "INTENSITY", { min: 0, max: 1, "notifiers": { "update": true }})
     public environmentIntensity: number = 1.0;
@@ -164,14 +164,14 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
 
     /**
      * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most luminous ones).
-     * A car glass is a good exemple of that. When the street lights reflects on it you can not see what is behind.
+     * A car glass is a good example of that. When the street lights reflects on it you can not see what is behind.
      */
     @editableInPropertyPage("Radiance over alpha", PropertyTypeForEdition.Boolean, "RENDERING", { "notifiers": { "update": true }})
     public useRadianceOverAlpha: boolean = true;
 
     /**
      * Specifies that the material will keeps the specular highlights over a transparent surface (only the most luminous ones).
-     * A car glass is a good exemple of that. When sun reflects on it you can not see what is behind.
+     * A car glass is a good example of that. When sun reflects on it you can not see what is behind.
      */
     @editableInPropertyPage("Specular over alpha", PropertyTypeForEdition.Boolean, "RENDERING", { "notifiers": { "update": true }})
     public useSpecularOverAlpha: boolean = true;

--- a/src/Materials/Node/Blocks/PBR/refractionBlock.ts
+++ b/src/Materials/Node/Blocks/PBR/refractionBlock.ts
@@ -61,7 +61,7 @@ export class RefractionBlock extends NodeMaterialBlock {
     public indexOfRefractionConnectionPoint: NodeMaterialConnectionPoint;
 
     /**
-     * This parameters will make the material used its opacity to control how much it is refracting aginst not.
+     * This parameters will make the material used its opacity to control how much it is refracting against not.
      * Materials half opaque for instance using refraction could benefit from this control.
      */
     @editableInPropertyPage("Link refraction to transparency", PropertyTypeForEdition.Boolean, "ADVANCED", { "notifiers": { "update": true }})

--- a/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
+++ b/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
@@ -83,7 +83,7 @@ export class InstancesBlock extends NodeMaterialBlock {
     }
 
     /**
-     * Gets the isntanceID component
+     * Gets the instanceID component
      */
     public get instanceID(): NodeMaterialConnectionPoint {
         return this._outputs[1];

--- a/src/Materials/Node/Blocks/worleyNoise3DBlock.ts
+++ b/src/Materials/Node/Blocks/worleyNoise3DBlock.ts
@@ -240,7 +240,7 @@ export class WorleyNoise3DBlock extends NodeMaterialBlock {
         return codeString;
     }
     /**
-     * Exposes the properties to the Seralize?
+     * Exposes the properties to the Serialize?
      */
     public serialize(): any {
         let serializationObject = super.serialize();
@@ -250,7 +250,7 @@ export class WorleyNoise3DBlock extends NodeMaterialBlock {
         return serializationObject;
     }
     /**
-     * Exposes the properties to the deseralize?
+     * Exposes the properties to the deserialize?
      */
     public _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
         super._deserialize(serializationObject, scene, rootUrl);

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -1579,7 +1579,7 @@ export class NodeMaterial extends PushMaterial {
     /**
      * Loads the current Node Material from a url pointing to a file save by the Node Material Editor
      * @param url defines the url to load from
-     * @returns a promise that will fullfil when the material is fully loaded
+     * @returns a promise that will fulfil when the material is fully loaded
      */
     public loadAsync(url: string) {
         return this.getScene()._loadFileAsync(url).then((data) => {

--- a/src/Materials/Node/nodeMaterialBlock.ts
+++ b/src/Materials/Node/nodeMaterialBlock.ts
@@ -146,7 +146,7 @@ export class NodeMaterialBlock {
 
     /**
      * Find an output by its name
-     * @param name defines the name of the outputto look for
+     * @param name defines the name of the output to look for
      * @returns the output or null if not found
      */
     public getOutputByName(name: string) {

--- a/src/Materials/PBR/pbrAnisotropicConfiguration.ts
+++ b/src/Materials/PBR/pbrAnisotropicConfiguration.ts
@@ -45,7 +45,7 @@ export class PBRAnisotropicConfiguration {
 
     /**
      * Defines if the effect is along the tangents, bitangents or in between.
-     * By default, the effect is "strectching" the highlights along the tangents.
+     * By default, the effect is "stretching" the highlights along the tangents.
      */
     @serializeAsVector2()
     public direction = new Vector2(1, 0);
@@ -69,7 +69,7 @@ export class PBRAnisotropicConfiguration {
     }
 
     /**
-     * Instantiate a new istance of anisotropy configuration.
+     * Instantiate a new instance of anisotropy configuration.
      * @param markAllSubMeshesAsTexturesDirty Callback to flag the material to dirty
      */
     constructor(markAllSubMeshesAsTexturesDirty: () => void) {
@@ -130,7 +130,7 @@ export class PBRAnisotropicConfiguration {
      * Binds the material data.
      * @param uniformBuffer defines the Uniform buffer to fill in.
      * @param scene defines the scene the material belongs to.
-     * @param isFrozen defines wether the material is frozen or not.
+     * @param isFrozen defines whether the material is frozen or not.
      */
     public bindForSubMesh(uniformBuffer: UniformBuffer, scene: Scene, isFrozen: boolean): void {
         if (!uniformBuffer.useUbo || !isFrozen || !uniformBuffer.isSync) {

--- a/src/Materials/PBR/pbrBRDFConfiguration.ts
+++ b/src/Materials/PBR/pbrBRDFConfiguration.ts
@@ -98,7 +98,7 @@ export class PBRBRDFConfiguration {
     }
 
     /**
-     * Instantiate a new istance of clear coat configuration.
+     * Instantiate a new instance of clear coat configuration.
      * @param markAllSubMeshesAsMiscDirty Callback to flag the material to dirty
      */
     constructor(markAllSubMeshesAsMiscDirty: () => void) {

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -368,7 +368,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
     /**
      * Intensity of the environment e.g. how much the environment will light the object
-     * either through harmonics for rough material or through the refelction for shiny ones.
+     * either through harmonics for rough material or through the reflection for shiny ones.
      */
     protected _environmentIntensity: number = 1.0;
 
@@ -544,8 +544,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     protected _useAlphaFromAlbedoTexture = false;
 
     /**
-     * Specifies that the material will keeps the specular highlights over a transparent surface (only the most limunous ones).
-     * A car glass is a good exemple of that. When sun reflects on it you can not see what is behind.
+     * Specifies that the material will keeps the specular highlights over a transparent surface (only the most luminous ones).
+     * A car glass is a good example of that. When sun reflects on it you can not see what is behind.
      */
     protected _useSpecularOverAlpha = true;
 
@@ -592,8 +592,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     protected _lightFalloff = PBRBaseMaterial.LIGHTFALLOFF_PHYSICAL;
 
     /**
-     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most limunous ones).
-     * A car glass is a good exemple of that. When the street lights reflects on it you can not see what is behind.
+     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most luminous ones).
+     * A car glass is a good example of that. When the street lights reflects on it you can not see what is behind.
      */
     protected _useRadianceOverAlpha = true;
 
@@ -665,8 +665,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     protected _useLinearAlphaFresnel = false;
 
     /**
-     * Specifies the environment BRDF texture used to comput the scale and offset roughness values
-     * from cos thetav and roughness:
+     * Specifies the environment BRDF texture used to compute the scale and offset roughness values
+     * from cos theta and roughness:
      * http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf
      */
     protected _environmentBRDFTexture: Nullable<BaseTexture> = null;
@@ -834,7 +834,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     public readonly subSurface: PBRSubSurfaceConfiguration;
 
     /**
-     * Defines additionnal PrePass parameters for the material.
+     * Defines additional PrePass parameters for the material.
      */
     public readonly prePassConfiguration: PrePassConfiguration;
 
@@ -1133,7 +1133,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
     /**
      * Specifies if the material uses metallic roughness workflow.
-     * @returns boolean specifiying if the material uses metallic roughness workflow.
+     * @returns boolean specifying if the material uses metallic roughness workflow.
     */
     public isMetallicWorkflow(): boolean {
         if (this._metallic != null || this._roughness != null || this._metallicTexture) {
@@ -1953,7 +1953,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                     ubo.updateColor4("vReflectivityColor", TmpColors.Color3[0], 1);
 
                     const ior = this.subSurface.indexOfRefraction;
-                    const outside_ior = 1; // consider air as clear coat and other layaers would remap in the shader.
+                    const outside_ior = 1; // consider air as clear coat and other layers would remap in the shader.
 
                     // We are here deriving our default reflectance from a common value for none metallic surface.
                     // Based of the schlick fresnel approximation model

--- a/src/Materials/PBR/pbrBaseSimpleMaterial.ts
+++ b/src/Materials/PBR/pbrBaseSimpleMaterial.ts
@@ -69,7 +69,7 @@ export abstract class PBRBaseSimpleMaterial extends PBRBaseMaterial {
     public emissiveTexture: BaseTexture;
 
     /**
-     * Occlusion Channel Strenght.
+     * Occlusion Channel Strength.
      */
     @serialize()
     @expandToProperty("_markAllSubMeshesAsTexturesDirty", "_ambientTextureStrength")

--- a/src/Materials/PBR/pbrClearCoatConfiguration.ts
+++ b/src/Materials/PBR/pbrClearCoatConfiguration.ts
@@ -171,7 +171,7 @@ export class PBRClearCoatConfiguration {
     }
 
     /**
-     * Instantiate a new istance of clear coat configuration.
+     * Instantiate a new instance of clear coat configuration.
      * @param markAllSubMeshesAsTexturesDirty Callback to flag the material to dirty
      */
     constructor(markAllSubMeshesAsTexturesDirty: () => void) {
@@ -179,11 +179,11 @@ export class PBRClearCoatConfiguration {
     }
 
     /**
-     * Gets wehter the submesh is ready to be used or not.
+     * Gets whether the submesh is ready to be used or not.
      * @param defines the list of "defines" to update.
      * @param scene defines the scene the material belongs to.
      * @param engine defines the engine the material belongs to.
-     * @param disableBumpMap defines wether the material disables bump or not.
+     * @param disableBumpMap defines whether the material disables bump or not.
      * @returns - boolean indicating that the submesh is ready or not.
      */
     public isReadyForSubMesh(defines: IMaterialClearCoatDefines, scene: Scene, engine: Engine, disableBumpMap: boolean): boolean {
@@ -286,8 +286,8 @@ export class PBRClearCoatConfiguration {
      * @param uniformBuffer defines the Uniform buffer to fill in.
      * @param scene defines the scene the material belongs to.
      * @param engine defines the engine the material belongs to.
-     * @param disableBumpMap defines wether the material disables bump or not.
-     * @param isFrozen defines wether the material is frozen or not.
+     * @param disableBumpMap defines whether the material disables bump or not.
+     * @param isFrozen defines whether the material is frozen or not.
      * @param invertNormalMapX If sets to true, x component of normal map value will be inverted (x = 1.0 - x).
      * @param invertNormalMapY If sets to true, y component of normal map value will be inverted (y = 1.0 - y).
      * @param subMesh the submesh to bind data for

--- a/src/Materials/PBR/pbrMaterial.ts
+++ b/src/Materials/PBR/pbrMaterial.ts
@@ -62,7 +62,7 @@ export class PBRMaterial extends PBRBaseMaterial {
 
     /**
      * Intensity of the environment e.g. how much the environment will light the object
-     * either through harmonics for rough material or through the refelction for shiny ones.
+     * either through harmonics for rough material or through the reflection for shiny ones.
      */
     @serialize()
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -304,7 +304,7 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * This parameters will make the material used its opacity to control how much it is refracting aginst not.
+     * This parameters will make the material used its opacity to control how much it is refracting against not.
      * Materials half opaque for instance using refraction could benefit from this control.
      */
     public get linkRefractionWithTransparency(): boolean {
@@ -346,8 +346,8 @@ export class PBRMaterial extends PBRBaseMaterial {
     public alphaCutOff = 0.4;
 
     /**
-     * Specifies that the material will keep the specular highlights over a transparent surface (only the most limunous ones).
-     * A car glass is a good exemple of that. When sun reflects on it you can not see what is behind.
+     * Specifies that the material will keep the specular highlights over a transparent surface (only the most luminous ones).
+     * A car glass is a good example of that. When sun reflects on it you can not see what is behind.
      */
     @serialize()
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -404,8 +404,8 @@ export class PBRMaterial extends PBRBaseMaterial {
     public useAutoMicroSurfaceFromReflectivityMap = false;
 
     /**
-     * BJS is using an harcoded light falloff based on a manually sets up range.
-     * In PBR, one way to represents the fallof is to use the inverse squared root algorythm.
+     * BJS is using an hardcoded light falloff based on a manually sets up range.
+     * In PBR, one way to represents the falloff is to use the inverse squared root algorithm.
      * This parameter can help you switch back to the BJS mode in order to create scenes using both materials.
      */
     @serialize()
@@ -414,8 +414,8 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * BJS is using an harcoded light falloff based on a manually sets up range.
-     * In PBR, one way to represents the fallof is to use the inverse squared root algorythm.
+     * BJS is using an hardcoded light falloff based on a manually sets up range.
+     * In PBR, one way to represents the falloff is to use the inverse squared root algorithm.
      * This parameter can help you switch back to the BJS mode in order to create scenes using both materials.
      */
     public set usePhysicalLightFalloff(value: boolean) {
@@ -460,8 +460,8 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most limunous ones).
-     * A car glass is a good exemple of that. When the street lights reflects on it you can not see what is behind.
+     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most luminous ones).
+     * A car glass is a good example of that. When the street lights reflects on it you can not see what is behind.
      */
     @serialize()
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -624,39 +624,39 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * Gets wether the color curves effect is enabled.
+     * Gets whether the color curves effect is enabled.
      */
     public get cameraColorCurvesEnabled(): boolean {
         return this.imageProcessingConfiguration.colorCurvesEnabled;
     }
     /**
-     * Sets wether the color curves effect is enabled.
+     * Sets whether the color curves effect is enabled.
      */
     public set cameraColorCurvesEnabled(value: boolean) {
         this.imageProcessingConfiguration.colorCurvesEnabled = value;
     }
 
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public get cameraColorGradingEnabled(): boolean {
         return this.imageProcessingConfiguration.colorGradingEnabled;
     }
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public set cameraColorGradingEnabled(value: boolean) {
         this.imageProcessingConfiguration.colorGradingEnabled = value;
     }
 
     /**
-     * Gets wether tonemapping is enabled or not.
+     * Gets whether tonemapping is enabled or not.
      */
     public get cameraToneMappingEnabled(): boolean {
         return this._imageProcessingConfiguration.toneMappingEnabled;
     }
     /**
-     * Sets wether tonemapping is enabled or not
+     * Sets whether tonemapping is enabled or not
      */
     public set cameraToneMappingEnabled(value: boolean) {
         this._imageProcessingConfiguration.toneMappingEnabled = value;
@@ -707,7 +707,7 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+     * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
      * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
      * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
      * corresponding to low luminance, medium luminance, and high luminance areas respectively.
@@ -716,7 +716,7 @@ export class PBRMaterial extends PBRBaseMaterial {
         return this._imageProcessingConfiguration.colorCurves;
     }
     /**
-     * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+     * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
      * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
      * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
      * corresponding to low luminance, medium luminance, and high luminance areas respectively.

--- a/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
+++ b/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
@@ -71,7 +71,7 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
     }
 
     /**
-     * Return the currrent class name of the material.
+     * Return the current class name of the material.
      */
     public getClassName(): string {
         return "PBRMetallicRoughnessMaterial";
@@ -113,7 +113,7 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
     }
 
     /**
-     * Parses a JSON object correponding to the serialize function.
+     * Parses a JSON object corresponding to the serialize function.
      */
     public static Parse(source: any, scene: Scene, rootUrl: string): PBRMetallicRoughnessMaterial {
         const material = SerializationHelper.Parse(() => new PBRMetallicRoughnessMaterial(source.name, scene), source, scene, rootUrl);

--- a/src/Materials/PBR/pbrSheenConfiguration.ts
+++ b/src/Materials/PBR/pbrSheenConfiguration.ts
@@ -120,7 +120,7 @@ export class PBRSheenConfiguration {
     }
 
     /**
-     * Instantiate a new istance of clear coat configuration.
+     * Instantiate a new instance of clear coat configuration.
      * @param markAllSubMeshesAsTexturesDirty Callback to flag the material to dirty
      */
     constructor(markAllSubMeshesAsTexturesDirty: () => void) {
@@ -199,7 +199,7 @@ export class PBRSheenConfiguration {
      * Binds the material data.
      * @param uniformBuffer defines the Uniform buffer to fill in.
      * @param scene defines the scene the material belongs to.
-     * @param isFrozen defines wether the material is frozen or not.
+     * @param isFrozen defines whether the material is frozen or not.
      * @param subMesh the submesh to bind data for
      */
     public bindForSubMesh(uniformBuffer: UniformBuffer, scene: Scene, isFrozen: boolean, subMesh?: SubMesh): void {

--- a/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
+++ b/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
@@ -21,7 +21,7 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
     public diffuseColor: Color3;
 
     /**
-     * Specifies the diffuse texture of the material. This can also contains the opcity value in its alpha
+     * Specifies the diffuse texture of the material. This can also contains the opacity value in its alpha
      * channel.
      */
     @serializeAsTexture()
@@ -68,7 +68,7 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
     }
 
     /**
-     * Return the currrent class name of the material.
+     * Return the current class name of the material.
      */
     public getClassName(): string {
         return "PBRSpecularGlossinessMaterial";
@@ -110,7 +110,7 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
     }
 
     /**
-     * Parses a JSON object correponding to the serialize function.
+     * Parses a JSON object corresponding to the serialize function.
      */
     public static Parse(source: any, scene: Scene, rootUrl: string): PBRSpecularGlossinessMaterial {
         const material = SerializationHelper.Parse(() => new PBRSpecularGlossinessMaterial(source.name, scene), source, scene, rootUrl);

--- a/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
+++ b/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
@@ -103,7 +103,7 @@ export class PBRSubSurfaceConfiguration {
     /**
      * Defines the refraction intensity of the material.
      * The refraction when enabled replaces the Diffuse part of the material.
-     * The intensity helps transitionning between diffuse and refraction.
+     * The intensity helps transitioning between diffuse and refraction.
      */
     @serialize()
     public refractionIntensity: number = 1;
@@ -111,7 +111,7 @@ export class PBRSubSurfaceConfiguration {
     /**
      * Defines the translucency intensity of the material.
      * When translucency has been enabled, this defines how much of the "translucency"
-     * is addded to the diffuse part of the material.
+     * is added to the diffuse part of the material.
      */
     @serialize()
     public translucencyIntensity: number = 1;
@@ -190,7 +190,7 @@ export class PBRSubSurfaceConfiguration {
 
     private _linkRefractionWithTransparency = false;
     /**
-     * This parameters will make the material used its opacity to control how much it is refracting aginst not.
+     * This parameters will make the material used its opacity to control how much it is refracting against not.
      * Materials half opaque for instance using refraction could benefit from this control.
      */
     @serialize()
@@ -269,7 +269,7 @@ export class PBRSubSurfaceConfiguration {
     }
 
     /**
-     * Instantiate a new istance of sub surface configuration.
+     * Instantiate a new instance of sub surface configuration.
      * @param markAllSubMeshesAsTexturesDirty Callback to flag the material to dirty
      * @param markScenePrePassDirty Callback to flag the scene as prepass dirty
      * @param scene The scene
@@ -281,7 +281,7 @@ export class PBRSubSurfaceConfiguration {
     }
 
     /**
-     * Gets wehter the submesh is ready to be used or not.
+     * Gets whether the submesh is ready to be used or not.
      * @param defines the list of "defines" to update.
      * @param scene defines the scene the material belongs to.
      * @returns - boolean indicating that the submesh is ready or not.

--- a/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -11,7 +11,7 @@ import { StringTools } from '../../../Misc/stringTools';
  */
 export class _DDSTextureLoader implements IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     public readonly supportCascades = true;
 

--- a/src/Materials/Textures/Loaders/envTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/envTextureLoader.ts
@@ -11,7 +11,7 @@ import { StringTools } from '../../../Misc/stringTools';
  */
 export class _ENVTextureLoader implements IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     public readonly supportCascades = false;
 

--- a/src/Materials/Textures/Loaders/hdrTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/hdrTextureLoader.ts
@@ -12,7 +12,7 @@ import { Constants } from "../../../Engines/constants";
  */
 export class _HDRTextureLoader implements IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     public readonly supportCascades = false;
 

--- a/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -13,7 +13,7 @@ import { Logger } from '../../../Misc/logger';
  */
 export class _KTXTextureLoader implements IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     public readonly supportCascades = false;
 

--- a/src/Materials/Textures/Loaders/tgaTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/tgaTextureLoader.ts
@@ -11,7 +11,7 @@ import { StringTools } from '../../../Misc/stringTools';
  */
 export class _TGATextureLoader implements IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     public readonly supportCascades = false;
 

--- a/src/Materials/Textures/Procedurals/customProceduralTexture.ts
+++ b/src/Materials/Textures/Procedurals/customProceduralTexture.ts
@@ -22,7 +22,7 @@ export class CustomProceduralTexture extends ProceduralTexture {
      * Custom Procedural textures are the easiest way to create your own procedural in your application.
      * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures#creating-custom-procedural-textures
      * @param name Define the name of the texture
-     * @param texturePath Define the folder path containing all the cutom texture related files (config, shaders...)
+     * @param texturePath Define the folder path containing all the custom texture related files (config, shaders...)
      * @param size Define the size of the texture to create
      * @param scene Define the scene the texture belongs to
      * @param fallbackTexture Define a fallback texture in case there were issues to create the custom texture

--- a/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -645,7 +645,7 @@ export class ProceduralTexture extends Texture {
     }
 
     /**
-     * Dispose the texture and release its asoociated resources.
+     * Dispose the texture and release its associated resources.
      */
     public dispose(): void {
         let scene = this.getScene();

--- a/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
+++ b/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
@@ -19,7 +19,7 @@ declare module "../../../abstractScene" {
  */
 export class ProceduralTextureSceneComponent implements ISceneComponent {
     /**
-     * The component name helpfull to identify the component in the list of scene components.
+     * The component name helpful to identify the component in the list of scene components.
      */
     public readonly name = SceneComponentConstants.NAME_PROCEDURALTEXTURE;
 
@@ -53,7 +53,7 @@ export class ProceduralTextureSceneComponent implements ISceneComponent {
     }
 
     /**
-     * Disposes the component and the associated ressources.
+     * Disposes the component and the associated resources.
      */
     public dispose(): void {
         // Nothing to do here.

--- a/src/Materials/Textures/baseTexture.ts
+++ b/src/Materials/Textures/baseTexture.ts
@@ -83,7 +83,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
     public level = 1;
 
     /**
-     * Define the UV chanel to use starting from 0 and defaulting to 0.
+     * Define the UV channel to use starting from 0 and defaulting to 0.
      * This is part of the texture as textures usually maps to one uv set.
      */
     @serialize()
@@ -415,7 +415,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
     private _uid: Nullable<string> = null;
 
     /**
-     * Define if the texture is preventinga material to render or not.
+     * Define if the texture is preventing a material to render or not.
      * If not and the texture is not ready, the engine will use a default black texture instead.
      */
     public get isBlocking(): boolean {
@@ -427,7 +427,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
      * Base class of all the textures in babylon.
      * It groups all the common properties the materials, post process, lights... might need
      * in order to make a correct use of the texture.
-     * @param sceneOrEngine Define the scene or engine the texture blongs to
+     * @param sceneOrEngine Define the scene or engine the texture belongs to
      */
     constructor(sceneOrEngine: Nullable<Scene | ThinEngine>) {
         super(null);
@@ -476,7 +476,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
     }
 
     /**
-     * Get the texture transform matrix used to offset tile the texture for istance.
+     * Get the texture transform matrix used to offset tile the texture for instance.
      * @returns the transformation matrix
      */
     public getTextureMatrix(): Matrix {

--- a/src/Materials/Textures/colorGradingTexture.ts
+++ b/src/Materials/Textures/colorGradingTexture.ts
@@ -35,7 +35,7 @@ export class ColorGradingTexture extends BaseTexture {
     /**
      * Instantiates a ColorGradingTexture from the following parameters.
      *
-     * @param url The location of the color gradind data (currently only supporting 3dl)
+     * @param url The location of the color grading data (currently only supporting 3dl)
      * @param sceneOrEngine The scene or engine the texture will be used in
      * @param onLoad defines a callback triggered when the texture has been loaded
      */
@@ -231,7 +231,7 @@ export class ColorGradingTexture extends BaseTexture {
     }
 
     /**
-     * Clones the color gradind texture.
+     * Clones the color grading texture.
      */
     public clone(): ColorGradingTexture {
         var newTexture = new ColorGradingTexture(this.url, this.getScene() || this._getEngine()!);
@@ -263,7 +263,7 @@ export class ColorGradingTexture extends BaseTexture {
      * @param parsedTexture The texture information being parsedTexture
      * @param scene The scene to load the texture in
      * @param rootUrl The root url of the data assets to load
-     * @return A color gradind texture
+     * @return A color grading texture
      */
     public static Parse(parsedTexture: any, scene: Scene): Nullable<ColorGradingTexture> {
         var texture = null;

--- a/src/Materials/Textures/cubeTexture.ts
+++ b/src/Materials/Textures/cubeTexture.ts
@@ -147,7 +147,7 @@ export class CubeTexture extends BaseTexture {
      * @param extensions defines the suffixes add to the picture name in case six images are in use like _px.jpg...
      * @param noMipmap defines if mipmaps should be created or not
      * @param files defines the six files to load for the different faces in that order: px, py, pz, nx, ny, nz
-     * @param onLoad defines a callback triggered at the end of the file load if no errors occured
+     * @param onLoad defines a callback triggered at the end of the file load if no errors occurred
      * @param onError defines a callback triggered in case of error during load
      * @param format defines the internal format to use for the texture once loaded
      * @param prefiltered defines whether or not the texture is created from prefiltered data

--- a/src/Materials/Textures/hdrCubeTexture.ts
+++ b/src/Materials/Textures/hdrCubeTexture.ts
@@ -46,13 +46,13 @@ export class HDRCubeTexture extends BaseTexture {
 
     protected _isBlocking: boolean = true;
     /**
-     * Sets wether or not the texture is blocking during loading.
+     * Sets whether or not the texture is blocking during loading.
      */
     public set isBlocking(value: boolean) {
         this._isBlocking = value;
     }
     /**
-     * Gets wether or not the texture is blocking during loading.
+     * Gets whether or not the texture is blocking during loading.
      */
     public get isBlocking(): boolean {
         return this._isBlocking;

--- a/src/Materials/Textures/htmlElementTexture.ts
+++ b/src/Materials/Textures/htmlElementTexture.ts
@@ -14,7 +14,7 @@ declare type Scene = import("../../scene").Scene;
  */
 export interface IHtmlElementTextureOptions {
     /**
-     * Defines wether mip maps should be created or not.
+     * Defines whether mip maps should be created or not.
      */
     generateMipMaps?: boolean;
     /**
@@ -124,7 +124,7 @@ export class HtmlElementTexture extends BaseTexture {
 
     /**
      * Updates the content of the texture.
-     * @param invertY Defines wether the texture should be inverted on Y (false by default on video and true on canvas)
+     * @param invertY Defines whether the texture should be inverted on Y (false by default on video and true on canvas)
      */
     public update(invertY: Nullable<boolean> = null): void {
         const engine = this._getEngine();

--- a/src/Materials/Textures/internalTextureLoader.ts
+++ b/src/Materials/Textures/internalTextureLoader.ts
@@ -6,7 +6,7 @@ import { InternalTexture } from "../../Materials/Textures/internalTexture";
  */
 export interface IInternalTextureLoader {
     /**
-     * Defines wether the loader supports cascade loading the different faces.
+     * Defines whether the loader supports cascade loading the different faces.
      */
     supportCascades: boolean;
 

--- a/src/Materials/Textures/rawCubeTexture.ts
+++ b/src/Materials/Textures/rawCubeTexture.ts
@@ -53,7 +53,7 @@ export class RawCubeTexture extends CubeTexture {
      * @param sphericalPolynomial defines the spherical polynomial for irradiance
      * @param lodScale defines the scale applied to environment texture. This manages the range of LOD level used for IBL according to the roughness
      * @param lodOffset defines the offset applied to environment texture. This manages first LOD level used for IBL according to the roughness
-     * @returns a promsie that resolves when the operation is complete
+     * @returns a promise that resolves when the operation is complete
      */
     public updateRGBDAsync(data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial> = null, lodScale: number = 0.8, lodOffset: number = 0): Promise<void> {
         return RawCubeTexture._UpdateRGBDAsync(this._texture!, data, sphericalPolynomial, lodScale, lodOffset);

--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -31,7 +31,7 @@ export class RenderTargetTexture extends Texture {
      */
     public static readonly REFRESHRATE_RENDER_ONCE: number = 0;
     /**
-     * The texture will only be rendered rendered every frame and is recomended for dynamic contents.
+     * The texture will only be rendered rendered every frame and is recommended for dynamic contents.
      */
     public static readonly REFRESHRATE_RENDER_ONEVERYFRAME: number = 1;
     /**
@@ -64,7 +64,7 @@ export class RenderTargetTexture extends Texture {
 
     /**
      * Use this function to overload the renderList array at rendering time.
-     * Return null to render with the curent renderList, else return the list of meshes to use for rendering.
+     * Return null to render with the current renderList, else return the list of meshes to use for rendering.
      * For 2DArray RTT, layerOrFace is the index of the layer that is going to be rendered, else it is the faceIndex of
      * the cube (if the RTT is a cube, else layerOrFace=0).
      * The renderList passed to the function is the current render list (the one that will be used if the function returns null).
@@ -283,7 +283,7 @@ export class RenderTargetTexture extends Texture {
     }
 
     /**
-     * Instantiate a render target texture. This is mainly used to render of screen the scene to for instance apply post processse
+     * Instantiate a render target texture. This is mainly used to render of screen the scene to for instance apply post process
      * or used a shadow, depth texture...
      * @param name The friendly name of the texture
      * @param size The size of the RTT (number if square, or {width: number, height:number} or {ratio:} to define a ratio from the main scene)
@@ -460,7 +460,7 @@ export class RenderTargetTexture extends Texture {
 
     /**
      * Clear all the post processes attached to the render target
-     * @param dispose define if the cleared post processesshould also be disposed (false by default)
+     * @param dispose define if the cleared post processes should also be disposed (false by default)
      */
     public clearPostProcesses(dispose: boolean = false): void {
         if (!this._postProcesses) {
@@ -590,7 +590,7 @@ export class RenderTargetTexture extends Texture {
 
     /**
      * Resize the texture to a new desired size.
-     * Be carrefull as it will recreate all the data in the new texture.
+     * Be careful as it will recreate all the data in the new texture.
      * @param size Define the new size. It can be:
      *   - a number for squared texture,
      *   - an object containing { width: number, height: number }
@@ -959,8 +959,8 @@ export class RenderTargetTexture extends Texture {
     }
 
     /**
-     * Overrides the default sort function applied in the renderging group to prepare the meshes.
-     * This allowed control for front to back rendering or reversly depending of the special needs.
+     * Overrides the default sort function applied in the rendering group to prepare the meshes.
+     * This allowed control for front to back rendering or reversely depending of the special needs.
      *
      * @param renderingGroupId The rendering group id corresponding to its index
      * @param opaqueSortCompareFn The opaque queue comparison function use to sort.
@@ -1026,7 +1026,7 @@ export class RenderTargetTexture extends Texture {
     }
 
     /**
-     * Serialize the texture to a JSON representation we can easily use in the resepective Parse function.
+     * Serialize the texture to a JSON representation we can easily use in the respective Parse function.
      * @returns The JSON representation of the texture
      */
     public serialize(): any {

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -292,7 +292,7 @@ export class Texture extends BaseTexture {
      * @param sceneOrEngine defines the scene or engine the texture will belong to
      * @param noMipmap defines if the texture will require mip maps or not
      * @param invertY defines if the texture needs to be inverted on the y axis during loading
-     * @param samplingMode defines the sampling mode we want for the texture while fectching from it (Texture.NEAREST_SAMPLINGMODE...)
+     * @param samplingMode defines the sampling mode we want for the texture while fetching from it (Texture.NEAREST_SAMPLINGMODE...)
      * @param onLoad defines a callback triggered when the texture has been loaded
      * @param onError defines a callback triggered when an error occurred during the loading session
      * @param buffer defines the buffer to load the texture from in case the texture is loaded from a buffer representation
@@ -335,7 +335,7 @@ export class Texture extends BaseTexture {
                     this.vOffset += 1;
                 }
 
-                // Update texutre to match internal texture's wrapping
+                // Update texture to match internal texture's wrapping
                 if (this._texture._cachedWrapU !== null) {
                     this.wrapU = this._texture._cachedWrapU;
                     this._texture._cachedWrapU = null;
@@ -652,7 +652,7 @@ export class Texture extends BaseTexture {
     }
 
     /**
-     * Serialize the texture to a JSON representation we can easily use in the resepective Parse function.
+     * Serialize the texture to a JSON representation we can easily use in the respective Parse function.
      * @returns The JSON representation of the texture
      */
     public serialize(): any {
@@ -830,7 +830,7 @@ export class Texture extends BaseTexture {
      * @param scene Define the scene the texture should belong to
      * @param noMipmap Forces the texture to not create mip map information if true
      * @param invertY define if the texture needs to be inverted on the y axis during loading
-     * @param samplingMode define the sampling mode we want for the texture while fectching from it (Texture.NEAREST_SAMPLINGMODE...)
+     * @param samplingMode define the sampling mode we want for the texture while fetching from it (Texture.NEAREST_SAMPLINGMODE...)
      * @param onLoad define a callback triggered when the texture has been loaded
      * @param onError define a callback triggered when an error occurred during the loading session
      * @param format define the format of the texture we are trying to load (Engine.TEXTUREFORMAT_RGBA...)
@@ -850,7 +850,7 @@ export class Texture extends BaseTexture {
      * @param deleteBuffer define if the buffer we are loading the texture from should be deleted after load
      * @param noMipmap Forces the texture to not create mip map information if true
      * @param invertY define if the texture needs to be inverted on the y axis during loading
-     * @param samplingMode define the sampling mode we want for the texture while fectching from it (Texture.NEAREST_SAMPLINGMODE...)
+     * @param samplingMode define the sampling mode we want for the texture while fetching from it (Texture.NEAREST_SAMPLINGMODE...)
      * @param onLoad define a callback triggered when the texture has been loaded
      * @param onError define a callback triggered when an error occurred during the loading session
      * @param format define the format of the texture we are trying to load (Engine.TEXTUREFORMAT_RGBA...)

--- a/src/Materials/Textures/thinTexture.ts
+++ b/src/Materials/Textures/thinTexture.ts
@@ -183,7 +183,7 @@ export class ThinTexture {
 
     /**
      * Get the underlying lower level texture from Babylon.
-     * @returns the insternal texture
+     * @returns the internal texture
      */
     public getInternalTexture(): Nullable<InternalTexture> {
         return this._texture;

--- a/src/Materials/Textures/videoTexture.ts
+++ b/src/Materials/Textures/videoTexture.ts
@@ -57,7 +57,7 @@ export class VideoTexture extends Texture {
     private _onUserActionRequestedObservable: Nullable<Observable<Texture>> = null;
 
     /**
-     * Event triggerd when a dom action is required by the user to play the video.
+     * Event triggered when a dom action is required by the user to play the video.
      * This happens due to recent changes in browser policies preventing video to auto start.
      */
     public get onUserActionRequestedObservable(): Observable<Texture> {
@@ -285,7 +285,7 @@ export class VideoTexture extends Texture {
 
     /**
      * Update Texture in `manual` mode. Does not do anything if not visible or paused.
-     * @param isVisible Visibility state, detected by user using `scene.getActiveMeshes()` or othervise.
+     * @param isVisible Visibility state, detected by user using `scene.getActiveMeshes()` or otherwise.
      */
     public updateTexture(isVisible: boolean): void {
         if (!isVisible) {

--- a/src/Materials/colorCurves.ts
+++ b/src/Materials/colorCurves.ts
@@ -3,7 +3,7 @@ import { Color4 } from '../Maths/math.color';
 import { Effect } from "../Materials/effect";
 
 /**
- * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+ * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
  * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
  * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
  * corresponding to low luminance, medium luminance, and high luminance areas respectively.

--- a/src/Materials/effect.ts
+++ b/src/Materials/effect.ts
@@ -23,11 +23,11 @@ declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
  */
 export interface IEffectCreationOptions {
     /**
-     * Atrributes that will be used in the shader.
+     * Attributes that will be used in the shader.
      */
     attributes: string[];
     /**
-     * Uniform varible names that will be set in the shader.
+     * Uniform variable names that will be set in the shader.
      */
     uniformsNames: string[];
     /**
@@ -423,7 +423,7 @@ export class Effect implements IDisposable {
 
     /**
      * The number of attributes.
-     * @returns the numnber of attributes.
+     * @returns the number of attributes.
      */
     public getAttributesCount(): number {
         return this._attributes.length;
@@ -496,7 +496,7 @@ export class Effect implements IDisposable {
     }
 
     /**
-     * Adds a callback to the onCompiled observable and call the callback imediatly if already ready.
+     * Adds a callback to the onCompiled observable and call the callback immediately if already ready.
      * @param func The callback to be used.
      */
     public executeWhenCompiled(func: (effect: Effect) => void): void {
@@ -903,7 +903,7 @@ export class Effect implements IDisposable {
     }
 
     /**
-     * Sets an interger value on a uniform variable.
+     * Sets an integer value on a uniform variable.
      * @param uniformName Name of the variable.
      * @param value Value to be set.
      * @returns this effect.
@@ -1107,7 +1107,7 @@ export class Effect implements IDisposable {
     }
 
     /**
-     * Sets a 3x3 matrix on a uniform variable. (Speicified as [1,2,3,4,5,6,7,8,9] will result in [1,2,3][4,5,6][7,8,9] matrix)
+     * Sets a 3x3 matrix on a uniform variable. (Specified as [1,2,3,4,5,6,7,8,9] will result in [1,2,3][4,5,6][7,8,9] matrix)
      * @param uniformName Name of the variable.
      * @param matrix matrix to be set.
      * @returns this effect.
@@ -1119,7 +1119,7 @@ export class Effect implements IDisposable {
     }
 
     /**
-     * Sets a 2x2 matrix on a uniform variable. (Speicified as [1,2,3,4] will result in [1,2][3,4] matrix)
+     * Sets a 2x2 matrix on a uniform variable. (Specified as [1,2,3,4] will result in [1,2][3,4] matrix)
      * @param uniformName Name of the variable.
      * @param matrix matrix to be set.
      * @returns this effect.

--- a/src/Materials/effectFallbacks.ts
+++ b/src/Materials/effectFallbacks.ts
@@ -61,7 +61,7 @@ export class EffectFallbacks implements IEffectFallbacks {
     }
 
     /**
-     * Checks to see if more fallbacks are still availible.
+     * Checks to see if more fallbacks are still available.
      */
     public get hasMoreFallbacks(): boolean {
         return this._currentRank <= this._maxRank;

--- a/src/Materials/fresnelParameters.ts
+++ b/src/Materials/fresnelParameters.ts
@@ -122,7 +122,7 @@ export class FresnelParameters {
     }
 
     /**
-     * Clones the current fresnel and its valuues
+     * Clones the current fresnel and its values
      * @returns a clone fresnel configuration
      */
     public clone(): FresnelParameters {

--- a/src/Materials/iEffectFallbacks.ts
+++ b/src/Materials/iEffectFallbacks.ts
@@ -18,7 +18,7 @@ export interface IEffectFallbacks {
     unBindMesh(): void;
 
     /**
-     * Checks to see if more fallbacks are still availible.
+     * Checks to see if more fallbacks are still available.
      */
     hasMoreFallbacks: boolean;
 }

--- a/src/Materials/imageProcessingConfiguration.ts
+++ b/src/Materials/imageProcessingConfiguration.ts
@@ -10,7 +10,7 @@ import { ColorCurves } from "../Materials/colorCurves";
 
 /**
  * Interface to follow in your material defines to integrate easily the
- * Image proccessing functions.
+ * Image processing functions.
  * @hidden
  */
 export interface IImageProcessingConfigurationDefines {
@@ -82,13 +82,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _colorCurvesEnabled = false;
     /**
-     * Gets wether the color curves effect is enabled.
+     * Gets whether the color curves effect is enabled.
      */
     public get colorCurvesEnabled(): boolean {
         return this._colorCurvesEnabled;
     }
     /**
-     * Sets wether the color curves effect is enabled.
+     * Sets whether the color curves effect is enabled.
      */
     public set colorCurvesEnabled(value: boolean) {
         if (this._colorCurvesEnabled === value) {
@@ -122,13 +122,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _colorGradingEnabled = false;
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public get colorGradingEnabled(): boolean {
         return this._colorGradingEnabled;
     }
     /**
-     * Sets wether the color grading effect is enabled.
+     * Sets whether the color grading effect is enabled.
      */
     public set colorGradingEnabled(value: boolean) {
         if (this._colorGradingEnabled === value) {
@@ -142,13 +142,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _colorGradingWithGreenDepth = true;
     /**
-     * Gets wether the color grading effect is using a green depth for the 3d Texture.
+     * Gets whether the color grading effect is using a green depth for the 3d Texture.
      */
     public get colorGradingWithGreenDepth(): boolean {
         return this._colorGradingWithGreenDepth;
     }
     /**
-     * Sets wether the color grading effect is using a green depth for the 3d Texture.
+     * Sets whether the color grading effect is using a green depth for the 3d Texture.
      */
     public set colorGradingWithGreenDepth(value: boolean) {
         if (this._colorGradingWithGreenDepth === value) {
@@ -162,13 +162,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _colorGradingBGR = true;
     /**
-     * Gets wether the color grading texture contains BGR values.
+     * Gets whether the color grading texture contains BGR values.
      */
     public get colorGradingBGR(): boolean {
         return this._colorGradingBGR;
     }
     /**
-     * Sets wether the color grading texture contains BGR values.
+     * Sets whether the color grading texture contains BGR values.
      */
     public set colorGradingBGR(value: boolean) {
         if (this._colorGradingBGR === value) {
@@ -203,13 +203,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _toneMappingEnabled = false;
     /**
-     * Gets wether the tone mapping effect is enabled.
+     * Gets whether the tone mapping effect is enabled.
      */
     public get toneMappingEnabled(): boolean {
         return this._toneMappingEnabled;
     }
     /**
-     * Sets wether the tone mapping effect is enabled.
+     * Sets whether the tone mapping effect is enabled.
      */
     public set toneMappingEnabled(value: boolean) {
         if (this._toneMappingEnabled === value) {
@@ -320,13 +320,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _vignetteEnabled = false;
     /**
-     * Gets wether the vignette effect is enabled.
+     * Gets whether the vignette effect is enabled.
      */
     public get vignetteEnabled(): boolean {
         return this._vignetteEnabled;
     }
     /**
-     * Sets wether the vignette effect is enabled.
+     * Sets whether the vignette effect is enabled.
      */
     public set vignetteEnabled(value: boolean) {
         if (this._vignetteEnabled === value) {
@@ -340,13 +340,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _applyByPostProcess = false;
     /**
-     * Gets wether the image processing is applied through a post process or not.
+     * Gets whether the image processing is applied through a post process or not.
      */
     public get applyByPostProcess(): boolean {
         return this._applyByPostProcess;
     }
     /**
-     * Sets wether the image processing is applied through a post process or not.
+     * Sets whether the image processing is applied through a post process or not.
      */
     public set applyByPostProcess(value: boolean) {
         if (this._applyByPostProcess === value) {
@@ -360,13 +360,13 @@ export class ImageProcessingConfiguration {
     @serialize()
     private _isEnabled = true;
     /**
-     * Gets wether the image processing is enabled or not.
+     * Gets whether the image processing is enabled or not.
      */
     public get isEnabled(): boolean {
         return this._isEnabled;
     }
     /**
-     * Sets wether the image processing is enabled or not.
+     * Sets whether the image processing is enabled or not.
      */
     public set isEnabled(value: boolean) {
         if (this._isEnabled === value) {
@@ -487,7 +487,7 @@ export class ImageProcessingConfiguration {
      * @returns True if ready, otherwise, false
      */
     public isReady() {
-        // Color Grading texure can not be none blocking.
+        // Color Grading texture can not be none blocking.
         return !this.colorGradingEnabled || !this.colorGradingTexture || this.colorGradingTexture.isReady();
     }
 

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -511,7 +511,7 @@ export class Material implements IAnimatable {
     public separateCullingPass = false;
 
     /**
-     * Stores the state specifing if fog should be enabled
+     * Stores the state specifying if fog should be enabled
      */
     @serialize("fogEnabled")
     private _fogEnabled = true;

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -61,7 +61,7 @@ export class MaterialHelper {
 
     /**
      * Helps preparing the defines values about the UVs in used in the effect.
-     * UVs are shared as much as we can accross channels in the shaders.
+     * UVs are shared as much as we can across channels in the shaders.
      * @param texture The texture we are preparing the UVs for
      * @param defines The defines to update
      * @param key The channel key "diffuse", "specular"... used in the shader
@@ -82,9 +82,9 @@ export class MaterialHelper {
     }
 
     /**
-     * Binds a texture matrix value to its corrsponding uniform
+     * Binds a texture matrix value to its corresponding uniform
      * @param texture The texture to bind the matrix for
-     * @param uniformBuffer The uniform buffer receivin the data
+     * @param uniformBuffer The uniform buffer receiving the data
      * @param key The channel key "diffuse", "specular"... used in the shader
      */
     public static BindTextureMatrix(texture: BaseTexture, uniformBuffer: UniformBuffer, key: string): void {
@@ -486,7 +486,7 @@ export class MaterialHelper {
      * @param mesh The mesh the effect is compiling for
      * @param defines The defines to update
      * @param specularSupported Specifies whether specular is supported or not (override lights data)
-     * @param maxSimultaneousLights Specfies how manuy lights can be added to the effect at max
+     * @param maxSimultaneousLights Specifies how manuy lights can be added to the effect at max
      * @param disableLighting Specifies whether the lighting is disabled (override scene and light)
      * @returns true if normals will be required for the rest of the effect
      */
@@ -614,10 +614,10 @@ export class MaterialHelper {
 
     /**
      * Prepares the uniforms and samplers list to be used in the effect
-     * @param uniformsListOrOptions The uniform names to prepare or an EffectCreationOptions containing the liist and extra information
+     * @param uniformsListOrOptions The uniform names to prepare or an EffectCreationOptions containing the list and extra information
      * @param samplersList The sampler list
      * @param defines The defines helping in the list generation
-     * @param maxSimultaneousLights The maximum number of simultanous light allowed in the effect
+     * @param maxSimultaneousLights The maximum number of simultaneous light allowed in the effect
      */
     public static PrepareUniformsAndSamplersList(uniformsListOrOptions: string[] | IEffectCreationOptions, samplersList?: string[], defines?: any, maxSimultaneousLights = 4): void {
         let uniformsList: string[];
@@ -752,7 +752,7 @@ export class MaterialHelper {
      * @param attribs The current list of supported attribs
      * @param mesh The mesh to prepare the bones attributes for
      * @param defines The current Defines of the effect
-     * @param fallbacks The current efffect fallback strategy
+     * @param fallbacks The current effect fallback strategy
      */
     public static PrepareAttributesForBones(attribs: string[], mesh: AbstractMesh, defines: any, fallbacks: EffectFallbacks): void {
         if (defines["NUM_BONE_INFLUENCERS"] > 0) {

--- a/src/Materials/multiMaterial.ts
+++ b/src/Materials/multiMaterial.ts
@@ -132,7 +132,7 @@ export class MultiMaterial extends Material {
     /**
      * Checks if the material is ready to render the requested sub mesh
      * @param mesh Define the mesh the submesh belongs to
-     * @param subMesh Define the sub mesh to look readyness for
+     * @param subMesh Define the sub mesh to look readiness for
      * @param useInstances Define whether or not the material is used with instances
      * @returns true if ready, otherwise false
      */

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -39,7 +39,7 @@ export interface IShaderMaterialOptions {
     attributes: string[];
 
     /**
-     * The list of unifrom names used in the shader
+     * The list of uniform names used in the shader
      */
     uniforms: string[];
 
@@ -1111,7 +1111,7 @@ export class ShaderMaterial extends Material {
 
     /**
      * Creates a shader material from parsed shader material data
-     * @param source defines the JSON represnetation of the material
+     * @param source defines the JSON representation of the material
      * @param scene defines the hosting scene
      * @param rootUrl defines the root URL to use to load textures and relative dependencies
      * @returns a new material

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -341,7 +341,7 @@ export class StandardMaterial extends PushMaterial {
     @serialize("useSpecularOverAlpha")
     private _useSpecularOverAlpha = false;
     /**
-     * Specifies that the material will keep the specular highlights over a transparent surface (only the most limunous ones).
+     * Specifies that the material will keep the specular highlights over a transparent surface (only the most luminous ones).
      * A car glass is a good exemple of that. When sun reflects on it you can not see what is behind.
      */
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -350,7 +350,7 @@ export class StandardMaterial extends PushMaterial {
     @serialize("useReflectionOverAlpha")
     private _useReflectionOverAlpha = false;
     /**
-     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most limunous ones).
+     * Specifies that the material will keeps the reflection highlights over a transparent surface (only the most luminous ones).
      * A car glass is a good exemple of that. When the street lights reflects on it you can not see what is behind.
      */
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -590,44 +590,44 @@ export class StandardMaterial extends PushMaterial {
     }
 
     /**
-     * Defines additionnal PrePass parameters for the material.
+     * Defines additional PrePass parameters for the material.
      */
     public readonly prePassConfiguration: PrePassConfiguration;
 
     /**
-     * Gets wether the color curves effect is enabled.
+     * Gets whether the color curves effect is enabled.
      */
     public get cameraColorCurvesEnabled(): boolean {
         return this.imageProcessingConfiguration.colorCurvesEnabled;
     }
     /**
-     * Sets wether the color curves effect is enabled.
+     * Sets whether the color curves effect is enabled.
      */
     public set cameraColorCurvesEnabled(value: boolean) {
         this.imageProcessingConfiguration.colorCurvesEnabled = value;
     }
 
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public get cameraColorGradingEnabled(): boolean {
         return this.imageProcessingConfiguration.colorGradingEnabled;
     }
     /**
-     * Gets wether the color grading effect is enabled.
+     * Gets whether the color grading effect is enabled.
      */
     public set cameraColorGradingEnabled(value: boolean) {
         this.imageProcessingConfiguration.colorGradingEnabled = value;
     }
 
     /**
-     * Gets wether tonemapping is enabled or not.
+     * Gets whether tonemapping is enabled or not.
      */
     public get cameraToneMappingEnabled(): boolean {
         return this._imageProcessingConfiguration.toneMappingEnabled;
     }
     /**
-     * Sets wether tonemapping is enabled or not
+     * Sets whether tonemapping is enabled or not
      */
     public set cameraToneMappingEnabled(value: boolean) {
         this._imageProcessingConfiguration.toneMappingEnabled = value;
@@ -687,7 +687,7 @@ export class StandardMaterial extends PushMaterial {
         return this._imageProcessingConfiguration.colorCurves;
     }
     /**
-     * The color grading curves provide additional color adjustmnent that is applied after any color grading transform (3D LUT).
+     * The color grading curves provide additional color adjustment that is applied after any color grading transform (3D LUT).
      * They allow basic adjustment of saturation and small exposure adjustments, along with color filter tinting to provide white balance adjustment or more stylistic effects.
      * These are similar to controls found in many professional imaging or colorist software. The global controls are applied to the entire image. For advanced tuning, extra controls are provided to adjust the shadow, midtone and highlight areas of the image;
      * corresponding to low luminance, medium luminance, and high luminance areas respectively.
@@ -990,7 +990,7 @@ export class StandardMaterial extends PushMaterial {
                 }
 
                 if (scene.getEngine().getCaps().standardDerivatives && this._bumpTexture && StandardMaterial.BumpTextureEnabled) {
-                    // Bump texure can not be not blocking.
+                    // Bump texture can not be not blocking.
                     if (!this._bumpTexture.isReady()) {
                         return false;
                     } else {

--- a/src/Materials/uniformBuffer.ts
+++ b/src/Materials/uniformBuffer.ts
@@ -15,7 +15,7 @@ import "../Engines/Extensions/engine.uniformBuffer";
  *
  * Handles blocks of uniform on the GPU.
  *
- * If WebGL 2 is not available, this class falls back on traditionnal setUniformXXX calls.
+ * If WebGL 2 is not available, this class falls back on traditional setUniformXXX calls.
  *
  * For more information, please refer to :
  * https://www.khronos.org/opengl/wiki/Uniform_Buffer_Object
@@ -189,7 +189,7 @@ export class UniformBuffer {
      *
      * Handles blocks of uniform on the GPU.
      *
-     * If WebGL 2 is not available, this class falls back on traditionnal setUniformXXX calls.
+     * If WebGL 2 is not available, this class falls back on traditional setUniformXXX calls.
      *
      * For more information, please refer to :
      * @see https://www.khronos.org/opengl/wiki/Uniform_Buffer_Object


### PR DESCRIPTION
Minor `Materials` folder documentation suggested updates:

- accross => across
- addded => added
- additionnal => additional
- adjustmnent => adjustment
- aginst => against
- algorythm => algorithm
- asoociated => associated
- Atrributes => Attributes
- availible => available
- blongs => belongs
- carrefull => careful
- chanel => channel
- comput => compute
- correponding => corresponding
- currrent => current
- cutom => custom
- deseralize => deserialize
- efffect => effect
- environement => environment
- exemple => example
- fallof => falloff
- fullfil => fulfil
- fectching => fetching
- glossinness => glossiness
- gradind => grading
- harcoded => hardcoded
- helpfull => helpful
- highliights => highlights
- imediatly => immediately
- insternal => internal
- interger => integer
- isntanceID => instanceID
- istance => instance
- layaers => layers
- liist => list
- limunous => luminous
- numnber => number
- occured => occurred
- opcity => opacity
- othervise => otherwise
- outputto => output to
- pertub => perturb
- preventinga => preventing a
- processse => process
- processesshould => processes should
- promsie => promise
- readyness => readiness
- receivin => receiving
- recomended => recommended
- refelction => reflection
- renderging => rendering
- resepective => respective
- represnetation => representation
- resso => resources
- reversly => reversely
- Seralize => Serialize
- simultanous => simultaneous
- Speicified => Specified
- specifiying => specifying
- strectching => stretching
- Strenght => Strength
- texure => texture
- texutre => texture
- thetav => theta
- traditionnal => traditional
- transitionning => transitioning
- triggerd => triggered
- unifrom => uniform
- valuues => values
- varible => variable
- wether => whether