### PR TITLE
Prevent AmmoJS applyForce modifying position param

### DIFF
--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -377,13 +377,14 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             impostor.physicsBody.activate();
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
+            var localContactPoint = new Vector3().copyFrom(contactPoint);
 
             // Convert contactPoint relative to center of mass
             if (impostor.object && impostor.object.getWorldMatrix) {
-                contactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
+                localContactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
             }
 
-            worldPoint.setValue(contactPoint.x, contactPoint.y, contactPoint.z);
+            worldPoint.setValue(localContactPoint.x, localContactPoint.y, localContactPoint.z);
             impulse.setValue(force.x, force.y, force.z);
 
             impostor.physicsBody.applyForce(impulse, worldPoint);

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -377,7 +377,7 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             impostor.physicsBody.activate();
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
-            
+
             worldPoint.setValue(contactPoint.x, contactPoint.y, contactPoint.z);
 
             // Convert contactPoint relative to center of mass

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -377,14 +377,17 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             impostor.physicsBody.activate();
             var worldPoint = this._tmpAmmoVectorA;
             var impulse = this._tmpAmmoVectorB;
-            var localContactPoint = new Vector3().copyFrom(contactPoint);
+            
+            worldPoint.setValue(contactPoint.x, contactPoint.y, contactPoint.z);
 
             // Convert contactPoint relative to center of mass
             if (impostor.object && impostor.object.getWorldMatrix) {
-                localContactPoint.subtractInPlace(impostor.object.getWorldMatrix().getTranslation());
+                var localTranslation = impostor.object.getWorldMatrix().getTranslation();
+                worldPoint.x -= localTranslation.x;
+                worldPoint.y -= localTranslation.y;
+                worldPoint.z -= localTranslation.z;
             }
 
-            worldPoint.setValue(localContactPoint.x, localContactPoint.y, localContactPoint.z);
             impulse.setValue(force.x, force.y, force.z);
 
             impostor.physicsBody.applyForce(impulse, worldPoint);


### PR DESCRIPTION
Took a while for me to work out that the AmmoJS physics plugin's `applyForce()` function was modifying the `contactPoint` parameter for the purposes of converting it to local space; this broke my surrounding code that was relying on using the passed parameter as a cached value.

I've worked around it for now, but I'm guessing it shouldn't be like this? Maybe the physics plugin interfaces need modifying to take a `DeepImmutable<Vector3>` instead of a `Vector3` to enforce good practice?