### PR TITLE
Particle error messages

### DIFF
--- a/src/Particles/particleHelper.ts
+++ b/src/Particles/particleHelper.ts
@@ -94,7 +94,7 @@ export class ParticleHelper {
                 return resolve(ParticleSystemSet.Parse(newData, scene!, gpu));
             }, undefined, undefined, undefined, () => {
                 scene!._removePendingData(token);
-                return reject(`An error occured while the creation of your particle system. Check if your type '${type}' exists.`);
+                return reject(`An error occurred with the creation of your particle system. Check if your type '${type}' exists.`);
             });
 
         });

--- a/src/Particles/pointsCloudSystem.ts
+++ b/src/Particles/pointsCloudSystem.ts
@@ -462,7 +462,7 @@ export class PointsCloudSystem implements IDisposable {
         var mat = mesh.material;
         let textureList: BaseTexture[] = mat.getActiveTextures();
         if (textureList.length === 0) {
-            Logger.Warn(mesh.name + "has no useable texture.");
+            Logger.Warn(mesh.name + "has no usable texture.");
             pointsGroup._groupImageData = null;
             this._setPointsColorOrUV(mesh, pointsGroup, isVolume, true, false);
             return;


### PR DESCRIPTION
Put these two as separate as they are error messages, and not documentation

- occured => occurred
- useable => usable

Also with the statement: "An error occured while the creation of your particle system."

Suggesting this read: "An error occurred with the creation of your particle system."

Alternatively: 
- "An error occurred during the creation of your particle system."
- "An error occurred while creating your particle system."