### PR TITLE
If indices are empty use unindexed intersection

### DIFF
--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1590,7 +1590,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             if (!material) {
                 continue;
             }
-            if (this.getIndices()?.length && (material.fillMode == Constants.MATERIAL_TriangleStripDrawMode ||
+            if (this.getIndices() && (material.fillMode == Constants.MATERIAL_TriangleStripDrawMode ||
                     material.fillMode == Constants.MATERIAL_TriangleFillMode ||
                     material.fillMode == Constants.MATERIAL_WireFrameFillMode ||
                     material.fillMode == Constants.MATERIAL_PointFillMode)) {


### PR DESCRIPTION
Unindexed meshes are now supported when being picked.