### PR TITLE
Added check for PS5 controller

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -88,6 +88,7 @@
 - Fix PrePass bugs with layers ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix SSAO2 with PrePass sometimes causing colors brighter than they should be ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix PostProcess sharing between cameras/renderTargets, that would create/destroy a texture on every frame ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Fix for DualSense gamepads being incorrectly read as DualShock gamepads
 
 
 ## Breaking changes

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -88,7 +88,7 @@
 - Fix PrePass bugs with layers ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix SSAO2 with PrePass sometimes causing colors brighter than they should be ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix PostProcess sharing between cameras/renderTargets, that would create/destroy a texture on every frame ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Fix for DualSense gamepads being incorrectly read as DualShock gamepads
+- Fix for DualSense gamepads being incorrectly read as DualShock gamepads ([PolygonalSun](https://github.com/PolygonalSun))
 
 
 ## Breaking changes

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -398,7 +398,7 @@ export class DeviceInputSystem implements IDisposable {
      * @returns DeviceType enum value
      */
     private _getGamepadDeviceType(deviceName: string): DeviceType {
-        if (deviceName.indexOf("054c") !== -1) { // DualShock 4 Gamepad
+        if (deviceName.indexOf("054c") !== -1 && deviceName.indexOf("0ce6") === -1) { // DualShock 4 Gamepad
             return DeviceType.DualShock;
         }
         else if (deviceName.indexOf("Xbox One") !== -1 || deviceName.search("Xbox 360") !== -1 || deviceName.search("xinput") !== -1) { // Xbox Gamepad

--- a/src/Gamepads/gamepadManager.ts
+++ b/src/Gamepads/gamepadManager.ts
@@ -170,7 +170,7 @@ export class GamepadManager {
         }
 
         var newGamepad;
-        var dualShock: boolean = ((<string>gamepad.id).search("054c") !== -1);
+        var dualShock: boolean = ((<string>gamepad.id).search("054c") !== -1 && (<string>gamepad.id).search("0ce6") === -1);
         var xboxOne: boolean = ((<string>gamepad.id).search("Xbox One") !== -1);
         if (xboxOne || (<string>gamepad.id).search("Xbox 360") !== -1 || (<string>gamepad.id).search("xinput") !== -1 || (<string>gamepad.id).search("045e") !== -1) {
             newGamepad = new Xbox360Pad(gamepad.id, gamepad.index, gamepad, xboxOne);


### PR DESCRIPTION
As there is no official support for the DualSense controller on PC, this PR is adding a check to make sure that the DualSense controller is not treated as a DualShock controller.  This will not add support for the DualSense yet.