### PR TITLE
Depth of field post process

### DIFF
--- a/src/PostProcesses/depthOfFieldEffect.ts
+++ b/src/PostProcesses/depthOfFieldEffect.ts
@@ -122,7 +122,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
         var adjustedKernelSize = kernelSize / Math.pow(2, blurCount - 1);
         var ratio = 1.0;
         for (var i = 0; i < blurCount; i++) {
-            var blurY = new DepthOfFieldBlurPostProcess("verticle blur", scene, new Vector2(0, 1.0), adjustedKernelSize, ratio, null, this._circleOfConfusion, i == 0 ? this._circleOfConfusion : null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, pipelineTextureType, blockCompilation);
+            var blurY = new DepthOfFieldBlurPostProcess("vertical blur", scene, new Vector2(0, 1.0), adjustedKernelSize, ratio, null, this._circleOfConfusion, i == 0 ? this._circleOfConfusion : null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, pipelineTextureType, blockCompilation);
             blurY.autoClear = false;
             ratio = 0.75 / Math.pow(2, i);
             var blurX = new DepthOfFieldBlurPostProcess("horizontal blur", scene, new Vector2(1.0, 0), adjustedKernelSize, ratio, null, this._circleOfConfusion, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, pipelineTextureType, blockCompilation);


### PR DESCRIPTION
Unsure whether this is a breaking change - but suggest changing verticle => vertical as the `name` parameter.

I don't immediately see how this would break something; so, hoping for your expertise here.