### PR TITLE
AssetContainer: fix cloning material when mesh is an instanced mesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -103,6 +103,7 @@
 - Fix SSAO2 with PrePass sometimes causing colors brighter than they should be ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix PostProcess sharing between cameras/renderTargets, that would create/destroy a texture on every frame ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix for DualSense gamepads being incorrectly read as DualShock gamepads ([PolygonalSun](https://github.com/PolygonalSun))
+- Fix crash when cloning material in `AssetContainer.instantiateModelsToScene` when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -161,7 +161,9 @@ export class AssetContainer extends AbstractScene {
                                     }
                                 }
 
-                                mesh.material = storeMap[convertionMap[sourceMaterial.uniqueId]];
+                                if (mesh.getClassName() !== "InstancedMesh") {
+                                    mesh.material = storeMap[convertionMap[sourceMaterial.uniqueId]];
+                                }
                             } else {
                                 if (mesh.material.getClassName() === "MultiMaterial") {
                                     if (this.scene.multiMaterials.indexOf(mesh.material as MultiMaterial) === -1) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/cannot-set-property-material-of-object-object-which-has-only-a-getter/17398