### PR TITLE
Mark node materials dirty when texture or reflection texture is changed

### DIFF
--- a/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -76,17 +76,17 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         const scene = texture?.getScene() ?? Engine.LastCreatedScene;
 
         if (!texture && scene) {
-            /*scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+            scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
                 return mat.hasTexture(this._texture!);
-            });*/
+            });
         }
 
         this._texture = texture;
 
         if (texture && scene) {
-            /*scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+            scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
                 return mat.hasTexture(texture);
-            });*/
+            });
         }
     }
 

--- a/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -17,6 +17,7 @@ import { Constants } from '../../../../Engines/constants';
 import "../../../../Shaders/ShadersInclude/reflectionFunction";
 import { CubeTexture } from '../../../Textures/cubeTexture';
 import { Texture } from '../../../Textures/texture';
+import { Engine } from "../../../../Engines/engine";
 
 /**
  * Base block used to read a reflection texture from a sampler
@@ -59,10 +60,35 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
     public _reflectionMatrixName: string;
     protected _reflectionColorName: string;
 
+    protected _texture: Nullable<BaseTexture>;
     /**
      * Gets or sets the texture associated with the node
      */
-    public texture: Nullable<BaseTexture>;
+    public get texture(): Nullable<BaseTexture> {
+        return this._texture;
+    }
+
+    public set texture(texture: Nullable<BaseTexture>) {
+        if (this._texture === texture) {
+            return;
+        }
+
+        const scene = texture?.getScene() ?? Engine.LastCreatedScene;
+
+        if (!texture && scene) {
+            /*scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+                return mat.hasTexture(this._texture!);
+            });*/
+        }
+
+        this._texture = texture;
+
+        if (texture && scene) {
+            /*scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+                return mat.hasTexture(texture);
+            });*/
+        }
+    }
 
     /**
      * Create a new ReflectionTextureBaseBlock

--- a/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -13,6 +13,8 @@ import { _TypeStore } from '../../../../Misc/typeStore';
 import { Texture } from '../../../Textures/texture';
 import { Scene } from '../../../../scene';
 import { NodeMaterialModes } from '../../Enums/nodeMaterialModes';
+import { Engine } from "../../../../Engines/engine";
+import { Constants } from '../../../../Engines/constants';
 
 import "../../../../Shaders/ShadersInclude/helperFunctions";
 
@@ -32,10 +34,35 @@ export class TextureBlock extends NodeMaterialBlock {
     private _mainUVDefineName: string;
     private _fragmentOnly: boolean;
 
+    protected _texture: Nullable<Texture>;
     /**
      * Gets or sets the texture associated with the node
      */
-    public texture: Nullable<Texture>;
+    public get texture(): Nullable<Texture> {
+        return this._texture;
+    }
+
+    public set texture(texture: Nullable<Texture>) {
+        if (this._texture === texture) {
+            return;
+        }
+
+        const scene = texture?.getScene() ?? Engine.LastCreatedScene;
+
+        if (!texture && scene) {
+            scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+                return mat.hasTexture(this._texture!);
+            });
+        }
+
+        this._texture = texture;
+
+        if (texture && scene) {
+            scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag, (mat) => {
+                return mat.hasTexture(texture);
+            });
+        }
+    }
 
     /**
      * Gets or sets a boolean indicating if content needs to be converted to gamma space


### PR DESCRIPTION
Hoping that replacing the `texture` property by getter/setter does not break anything...