### PR TITLE
[WebXR] Allow disabling default pointer selection

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -70,6 +70,7 @@
 - Added image tracking feature ([RaananW](https://github.com/RaananW))
 - Pointer Events of WebXR controllers have pointerType `xr` ([RaananW](https://github.com/RaananW))
 - better support for custom hand meshes ([RaananW](https://github.com/RaananW))
+- Allow disabling of the WebXRControllerPointerSelection feature as part of the WebXR Default Experience ([rgerd](https://github.com/rgerd))
 
 ### Viewer
 

--- a/src/XR/webXRDefaultExperience.ts
+++ b/src/XR/webXRDefaultExperience.ts
@@ -18,7 +18,13 @@ export class WebXRDefaultExperienceOptions {
      */
     public disableDefaultUI?: boolean;
     /**
-     * Should teleportation not initialize. defaults to false.
+     * Should pointer selection not initialize.
+     * Note that disabling pointer selection also disables teleportation.
+     * Defaults to false.
+     */
+    public disablePointerSelection?: boolean;
+    /**
+     * Should teleportation not initialize. Defaults to false.
      */
     public disableTeleportation?: boolean;
     /**
@@ -116,19 +122,23 @@ export class WebXRDefaultExperience {
                     },
                     ...(options.inputOptions || {}),
                 });
-                result.pointerSelection = <WebXRControllerPointerSelection>result.baseExperience.featuresManager.enableFeature(WebXRControllerPointerSelection.Name, options.useStablePlugins ? "stable" : "latest", <IWebXRControllerPointerSelectionOptions>{
-                    xrInput: result.input,
-                    renderingGroupId: options.renderingGroupId,
-                });
 
-                // Add default teleportation, including rotation
-                if (!options.disableTeleportation) {
-                    result.teleportation = <WebXRMotionControllerTeleportation>result.baseExperience.featuresManager.enableFeature(WebXRMotionControllerTeleportation.Name, options.useStablePlugins ? "stable" : "latest", <IWebXRTeleportationOptions>{
-                        floorMeshes: options.floorMeshes,
+                if (!options.disablePointerSelection) {
+                    // Add default pointer selection
+                    result.pointerSelection = <WebXRControllerPointerSelection>result.baseExperience.featuresManager.enableFeature(WebXRControllerPointerSelection.Name, options.useStablePlugins ? "stable" : "latest", <IWebXRControllerPointerSelectionOptions>{
                         xrInput: result.input,
                         renderingGroupId: options.renderingGroupId,
                     });
-                    result.teleportation.setSelectionFeature(result.pointerSelection);
+
+                    if (!options.disableTeleportation) {
+                        // Add default teleportation, including rotation
+                        result.teleportation = <WebXRMotionControllerTeleportation>result.baseExperience.featuresManager.enableFeature(WebXRMotionControllerTeleportation.Name, options.useStablePlugins ? "stable" : "latest", <IWebXRTeleportationOptions>{
+                            floorMeshes: options.floorMeshes,
+                            xrInput: result.input,
+                            renderingGroupId: options.renderingGroupId,
+                        });
+                        result.teleportation.setSelectionFeature(result.pointerSelection);
+                    }
                 }
 
                 // Create the WebXR output target


### PR DESCRIPTION
This change makes it possible to launch into XR without having the pointer selection feature enabled by default.