### PR TITLE
Expose imageWidth and imageHeight

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -66,6 +66,7 @@
 - Added `ToggleButton` GUI control ([kintz09](https://github.com/kintz09))
 - Added shorthand methods which set all padding values at once, named `setPadding` and `setPaddingInPixels`, to the control class  ([kintz09](https://github.com/kintz09))
 - Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
+- Added `imageWidth()` and `imageHeight()` to access the source image dimensions of `Image` ([Queatz](https://github.com/Queatz))
 
 ### WebXR
 

--- a/gui/src/2D/controls/image.ts
+++ b/gui/src/2D/controls/image.ts
@@ -225,6 +225,22 @@ export class Image extends Control {
     }
 
     /**
+     * Gets the image width
+     */
+    @serialize()
+    public get imageWidth(): number {
+        return this._imageWidth;
+    }
+
+    /**
+     * Gets the image height
+     */
+    @serialize()
+    public get imageHeight(): number {
+        return this._imageHeight;
+    }
+
+    /**
     * Gets or sets a boolean indicating if nine patch slices (left, top, right, bottom) should be read from image data
     */
     @serialize()


### PR DESCRIPTION
If there's another way to access the actual image width and height inside of `image.onImageLoadedObservable.add(...)` this may not be needed.