### PR TITLE
Add NativeEngine Babylon.js entry points for get and setHardwareScalingLevel

### DIFF
--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -747,7 +747,11 @@ export class NativeEngine extends Engine {
     private _currentDepthTest: number = this._native.DEPTH_TEST_LEQUAL;
 
     public getHardwareScalingLevel(): number {
-        return 1.0;
+        return _native.getHardwareScalingLevel();
+    }
+
+    public setHardwareScalingLevel(level: number): void {
+        _native.setHardwareScalingLevel(level);
     }
 
     public constructor() {

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -154,6 +154,8 @@ interface INativeEngine {
 
     getRenderWidth(): number;
     getRenderHeight(): number;
+    getHardwareScalingLevel(): number;
+    setHardwareScalingLevel(level: number): void;
 
     setViewPort(x: number, y: number, width: number, height: number): void;
 }
@@ -747,11 +749,11 @@ export class NativeEngine extends Engine {
     private _currentDepthTest: number = this._native.DEPTH_TEST_LEQUAL;
 
     public getHardwareScalingLevel(): number {
-        return _native.getHardwareScalingLevel();
+        return this._native.getHardwareScalingLevel();
     }
 
     public setHardwareScalingLevel(level: number): void {
-        _native.setHardwareScalingLevel(level);
+        this._native.setHardwareScalingLevel(level);
     }
 
     public constructor() {


### PR DESCRIPTION
This PR exposes get and setHardwareScalingLevel to the javascript nativeEngine entry points.

Related to the corresponding BabylonNative PR: https://github.com/BabylonJS/BabylonNative/pull/566