### PR TITLE
[physics]Removed irrelevant check on shape extrusion

### DIFF
--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -796,10 +796,6 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 Logger.Warn("No shape available for extruded mesh");
                 return new this.bjsAMMO.btCompoundShape();
             }
-            if ((vertexPositions!.length % (3 * pathVectors.length)) !== 0) {
-                Logger.Warn("Path does not match extrusion");
-                return new this.bjsAMMO.btCompoundShape();
-            }
             len = pathVectors.length;
             segments = len - 1;
             this._tmpAmmoVectorA.setValue(pathVectors[0].x, pathVectors[0].y, pathVectors[0].z);


### PR DESCRIPTION
followup on https://forum.babylonjs.com/t/ropeimpostor-with-extrudeshape-error/17570

The check was failing for capped extruded meshes because vertex count doesn't match uncapped extrusion.
I don't see a better solution than removing this check :/