### PR TITLE
exposed collision retry count

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -14,6 +14,7 @@
 - Added support for infinite perspective cameras ([Deltakosh](https://github.com/deltakosh))
 - Added ability to enable/disable ArcRotateCamera zoom on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
 - Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
+- Added `collisionRetryCount` to improved collision detection ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Moved sharedUI component to shared UI folder. ([msDestiny14](https://github.com/msDestiny14))
 - Added encapsulate and encapsulateBoundingInfo methods to BoundingInfo. ([Tolo789](https://github.com/Tolo789))
 - Added onLoadObservable to the textureDome class(es) ([RaananW](https://github.com/RaananW))

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -90,6 +90,7 @@ class _InternalAbstractMeshDataInfo {
     public _actAsRegularMesh = false;
     public _currentLOD: Nullable<AbstractMesh> = null;
     public _currentLODIsUpToDate: boolean = false;
+    public _collisionRetryCount: number = 3;
 }
 
 /**
@@ -245,6 +246,13 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._internalAbstractMeshDataInfo._facetData.facetDepthSortFrom = location;
     }
 
+    /** number of collision detection tries. Change this value if not all colisions are detected and handled properly. */
+    public get collisionRetryCount(): number {
+        return this._internalAbstractMeshDataInfo._collisionRetryCount;
+    }
+    public set collisionRetryCount(retryCount: number) {
+        this._internalAbstractMeshDataInfo._collisionRetryCount = retryCount;
+    }
     /**
      * gets a boolean indicating if facetData is enabled
      * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#what-is-a-mesh-facet
@@ -501,8 +509,6 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     public useOctreeForPicking = true;
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes collision (true by default) */
     public useOctreeForCollisions = true;
-    /** number of collision detection tries. Change this value if not all colisions are detected and handled properly. */
-    public collisionRetryCount: number = 3;
 
     /**
      * Gets or sets the current layer mask (default is 0x0FFFFFFF)

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -501,6 +501,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     public useOctreeForPicking = true;
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes collision (true by default) */
     public useOctreeForCollisions = true;
+    /** number of collision detection tries. Change this value if not all colisions are detected and handled properly. */
+    public collisionRetryCount: number = 3;
 
     /**
      * Gets or sets the current layer mask (default is 0x0FFFFFFF)
@@ -1458,7 +1460,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
 
         this._meshCollisionData._collider._radius = this.ellipsoid;
 
-        coordinator.getNewPosition(this._meshCollisionData._oldPositionForCollisions, displacement, this._meshCollisionData._collider, 3, this, this._onCollisionPositionChange, this.uniqueId);
+        coordinator.getNewPosition(this._meshCollisionData._oldPositionForCollisions, displacement, this._meshCollisionData._collider, this.collisionRetryCount, this, this._onCollisionPositionChange, this.uniqueId);
         return this;
     }
 


### PR DESCRIPTION
follow up on https://forum.babylonjs.com/t/internal-collision-system-acting-weird-after-calling-mesh-dispose/17700 and maybe https://forum.babylonjs.com/t/collision-problem/17751/2

by default, stops collision detection after 3 retries which might not be enough in some cases. I exposed the value so it can be tweaked .