### PR TITLE
Fix spatial sound played reversed in right handed mode

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
+++ b/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
@@ -194,7 +194,6 @@ export class MSFT_audio_emitter implements IGLTFLoaderExtension {
                     sound.maxDistance = emitter.maxDistance || 256;
                     sound.rolloffFactor = emitter.rolloffFactor || 1;
                     sound.distanceModel = emitter.distanceModel || 'exponential';
-                    sound._positionInEmitterSpace = true;
                 }));
             }
 

--- a/src/Audio/audioSceneComponent.ts
+++ b/src/Audio/audioSceneComponent.ts
@@ -249,8 +249,7 @@ Object.defineProperty(Scene.prototype, "audioPositioningRefreshRate", {
  * in a given scene.
  */
 export class AudioSceneComponent implements ISceneSerializableComponent {
-    private static _CameraDirectionLH = new Vector3(0, 0, -1);
-    private static _CameraDirectionRH = new Vector3(0, 0, 1);
+    private static _CameraDirection = new Vector3(0, 0, -1);
 
     /**
      * The component name helpful to identify the component in the list of scene components.
@@ -533,7 +532,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
                         listeningCamera = listeningCamera.rigCameras[0];
                     }
                     var mat = Matrix.Invert(listeningCamera.getViewMatrix());
-                    var cameraDirection = Vector3.TransformNormal(scene.useRightHandedSystem ? AudioSceneComponent._CameraDirectionRH : AudioSceneComponent._CameraDirectionLH, mat);
+                    var cameraDirection = Vector3.TransformNormal(AudioSceneComponent._CameraDirection, mat);
                     cameraDirection.normalize();
                     // To avoid some errors on GearVR
                     if (!isNaN(cameraDirection.x) && !isNaN(cameraDirection.y) && !isNaN(cameraDirection.z)) {

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -1,6 +1,6 @@
 import { Tools } from "../Misc/tools";
 import { Observable } from "../Misc/observable";
-import { Vector3, TmpVectors } from "../Maths/math.vector";
+import { Vector3 } from "../Maths/math.vector";
 import { Nullable } from "../types";
 import { Scene } from "../scene";
 import { Engine } from "../Engines/engine";
@@ -121,8 +121,6 @@ export class Sound {
     private _startTime: number = 0;
     private _startOffset: number = 0;
     private _position: Vector3 = Vector3.Zero();
-    /** @hidden */
-    public _positionInEmitterSpace: boolean = false;
     private _localDirection: Vector3 = new Vector3(1, 0, 0);
     private _volume: number = 1;
     private _isReadyToPlay: boolean = false;
@@ -949,17 +947,12 @@ export class Sound {
     }
 
     private _onRegisterAfterWorldMatrixUpdate(node: TransformNode): void {
-        if (this._positionInEmitterSpace) {
-            node.worldMatrixFromCache.invertToRef(TmpVectors.Matrix[0]);
-            this.setPosition(TmpVectors.Matrix[0].getTranslation());
+        if (!(<any>node).getBoundingInfo) {
+            this.setPosition(node.absolutePosition);
         } else {
-            if (!(<any>node).getBoundingInfo) {
-                this.setPosition(node.absolutePosition);
-            } else {
-                let mesh = node as AbstractMesh;
-                let boundingInfo = mesh.getBoundingInfo();
-                this.setPosition(boundingInfo.boundingSphere.centerWorld);
-            }
+            let mesh = node as AbstractMesh;
+            let boundingInfo = mesh.getBoundingInfo();
+            this.setPosition(boundingInfo.boundingSphere.centerWorld);
         }
         if (Engine.audioEngine.canUseWebAudio && this._isDirectional && this.isPlaying) {
             this._updateDirection();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/spatial-audio-is-reversed-with-userighthandedsystem/17493

This PR reverts back  what was done to fix #8836 as the existing code at that time was ok. The right/left handedness of the scene is taken care in the camera view matrix, so there's no need to use a different camera direction vector when in right handed system.

The problem is in fact with the way the MSFT_audio_emitter extension deals with sounds. It sets `Sound._positionInEmitterSpace = true`, which leads to transforming the origin of the 3D world to the local space of the sound emitter, which does not sound right to me as all sound positions you should be expressed in the same world coordinate for audio engine to work as expected (also, why transforming the origin of the 3D space?).

The code is (first 3 lines):
```typescript
if (this._positionInEmitterSpace) {
    node.worldMatrixFromCache.invertToRef(TmpVectors.Matrix[0]);
    this.setPosition(TmpVectors.Matrix[0].getTranslation());
} else {
    if (!(<any>node).getBoundingInfo) {
        this.setPosition(node.absolutePosition);
    } else {
        let mesh = node as AbstractMesh;
        let boundingInfo = mesh.getBoundingInfo();
        this.setPosition(boundingInfo.boundingSphere.centerWorld);
    }
}
if (Engine.audioEngine.canUseWebAudio && this._isDirectional && this.isPlaying) {
    this._updateDirection();
}
```

Waiting for feedback about this before removing the "Draft" flag.

@najadojo If you are around, could you shed some light on this as you did integrate the MSFT_audio_emitter extension and wrote the code related to `_positionInEmitterSpace`? Thanks in advance!