### PR TITLE
NME: Fix redefinition of uniform when it is constant

### DIFF
--- a/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -286,14 +286,6 @@ export class TextureBlock extends NodeMaterialBlock {
         this._defineName = state._getFreeDefineName("UVTRANSFORM");
         this._mainUVDefineName = "VMAIN" + uvInput.associatedVariableName.toUpperCase();
 
-        if (uvInput.connectedPoint!.ownerBlock.isInput) {
-            let uvInputOwnerBlock = uvInput.connectedPoint!.ownerBlock as InputBlock;
-
-            if (!uvInputOwnerBlock.isAttribute) {
-                state._emitUniformFromString(uvInput.associatedVariableName, "vec2");
-            }
-        }
-
         this._mainUVName = "vMain" + uvInput.associatedVariableName;
         this._transformedUVName = state._getFreeVariableName("transformedUV");
         this._textureTransformName = state._getFreeVariableName("textureTransform");


### PR DESCRIPTION
See https://forum.babylonjs.com/t/node-material-not-compiling-on-webgl-1-if-constant-is-used/17883

The block of code I have removed will emit the definition of the uniform linked to the input of the texture, but the `Input.buildBlock` method will already emit the definition. If the uniform is not a constant, we will push two times the definition in the same array and because there is a check that won't push an already existing uniform it does work. But a constant uniform will be pushed in the constant array (by `Input.buildBlock`) and (wrongly) in the std uniform array by `TextureBlock`. As `Input.buildBlock` is doing the job whatever the type of the uniform (attribute or not), I think the right fix is to remove all the code as I did. But if you feel it's safer that I add an additional check to not emit the definition if the input is a constant uniform I can do that instead.