### PR TITLE
Handle changes in XRWebGLLayer framebuffer size

### DIFF
--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -238,8 +238,21 @@ export class WebXRSessionManager implements IDisposable {
             this._rttProvider = this._xrNavigator.xr.getNativeRenderTargetProvider(this.session, this._createRenderTargetTexture.bind(this));
         } else {
             // Create render target texture from xr's webgl render target
-            const rtt = this._createRenderTargetTexture(this.baseLayer!.framebufferWidth, this.baseLayer!.framebufferHeight, this.baseLayer!.framebuffer);
-            this._rttProvider = { getRenderTargetForEye: () => rtt };
+            let rtt: RenderTargetTexture, framebufferWidth: number, framebufferHeight: number, framebuffer: WebGLFramebuffer;
+            this._rttProvider = {
+                getRenderTargetForEye: () => {
+                    const baseLayer = this.baseLayer!;
+                    if (baseLayer.framebufferWidth !== framebufferWidth ||
+                        baseLayer.framebufferHeight !== framebufferHeight ||
+                        baseLayer.framebuffer !== framebuffer) {
+                        rtt = this._createRenderTargetTexture(baseLayer.framebufferWidth, baseLayer.framebufferHeight, baseLayer.framebuffer);
+                        framebufferWidth = baseLayer.framebufferWidth;
+                        framebufferHeight = baseLayer.framebufferHeight;
+                        framebuffer = baseLayer.framebuffer;
+                    }
+                    return rtt;
+                },
+            };
             engine.framebufferDimensionsObject = this.baseLayer;
         }
 


### PR DESCRIPTION
XRWebGLLayer's framebuffer size (and framebuffer object) are allowed to
change between frames. WebXRSessionManager's IRenderTargetProvider would
create a RenderTargetTexture just once, so it would miss changes coming
from WebXR.

Obviously I have no idea if this is the right fix, but it works :)
Guidance would be appreciated.

I found this bug while working on a personal project:
https://github.com/kainino0x/holoplay-webxr
It is possible to verify this fix by loading the Babylon playground with this browser extension installed, entering XR, then changing the "number of views to render".