### PR TITLE
KHR_materials_transmission: fixes and improvements

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -12,6 +12,7 @@ import { Mesh } from "babylonjs/Meshes/mesh";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { RenderTargetTexture } from "babylonjs/Materials/Textures/renderTargetTexture";
 import { Observable, Observer } from "babylonjs/Misc/observable";
+import { Constants } from "babylonjs/Engines/constants";
 
 interface ITransmissionHelperHolder {
     /**
@@ -40,6 +41,11 @@ interface ITransmissionHelperOptions {
      * Offset to apply when selecting the LOD level to sample the refraction texture (default: -4)
      */
     lodGenerationOffset: number;
+
+    /**
+     * Type of the refraction render target texture (default: TEXTURETYPE_UNSIGNED_INT)
+     */
+    renderTargetTextureType: number;
 }
 
 /**
@@ -56,6 +62,7 @@ class TransmissionHelper {
             samples: 4,
             lodGenerationScale: 1,
             lodGenerationOffset: -4,
+            renderTargetTextureType: Constants.TEXTURETYPE_UNSIGNED_INT
         };
     }
 
@@ -119,7 +126,7 @@ class TransmissionHelper {
         this._options = newOptions;
 
         // If size changes, recreate everything
-        if (newOptions.renderSize !== oldOptions.renderSize || !this._opaqueRenderTarget) {
+        if (newOptions.renderSize !== oldOptions.renderSize || newOptions.renderTargetTextureType !== oldOptions.renderTargetTextureType || !this._opaqueRenderTarget) {
             this._setupRenderTargets();
         } else {
             this._opaqueRenderTarget.samples = newOptions.samples;
@@ -210,7 +217,7 @@ class TransmissionHelper {
      * Setup the render targets according to the specified options.
      */
     private _setupRenderTargets(): void {
-        this._opaqueRenderTarget = new RenderTargetTexture("opaqueSceneTexture", this._options.renderSize, this._scene, true);
+        this._opaqueRenderTarget = new RenderTargetTexture("opaqueSceneTexture", this._options.renderSize, this._scene, true, undefined, this._options.renderTargetTextureType);
         this._opaqueRenderTarget.renderList = this._opaqueMeshesCache;
         // this._opaqueRenderTarget.clearColor = new Color4(0.0, 0.0, 0.0, 0.0);
         this._opaqueRenderTarget.gammaSpace = true;

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -119,8 +119,12 @@ class TransmissionHelper {
         this._options = newOptions;
 
         // If size changes, recreate everything
-        if (newOptions.renderSize !== oldOptions.renderSize || newOptions.samples !== oldOptions.samples) {
+        if (newOptions.renderSize !== oldOptions.renderSize || !this._opaqueRenderTarget) {
             this._setupRenderTargets();
+        } else {
+            this._opaqueRenderTarget.samples = newOptions.samples;
+            this._opaqueRenderTarget.lodGenerationScale = newOptions.lodGenerationScale;
+            this._opaqueRenderTarget.lodGenerationOffset = newOptions.lodGenerationOffset;
         }
     }
 

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -206,7 +206,6 @@ class TransmissionHelper {
      * Setup the render targets according to the specified options.
      */
     private _setupRenderTargets(): void {
-
         this._opaqueRenderTarget = new RenderTargetTexture("opaqueSceneTexture", this._options.renderSize, this._scene, true);
         this._opaqueRenderTarget.renderList = this._opaqueMeshesCache;
         // this._opaqueRenderTarget.clearColor = new Color4(0.0, 0.0, 0.0, 0.0);

--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -205,24 +205,6 @@ class TransmissionHelper {
      */
     private _setupRenderTargets(): void {
 
-        let opaqueRTIndex = -1;
-
-        // Remove any layers rendering to the opaque scene.
-        if (this._scene.layers && this._opaqueRenderTarget) {
-            for (let layer of this._scene.layers) {
-                const idx = layer.renderTargetTextures.indexOf(this._opaqueRenderTarget);
-                if (idx >= 0) {
-                    layer.renderTargetTextures.splice(idx, 1);
-                }
-            }
-        }
-
-        // Remove opaque render target
-        if (this._opaqueRenderTarget) {
-            opaqueRTIndex = this._scene.customRenderTargets.indexOf(this._opaqueRenderTarget);
-            this._opaqueRenderTarget.dispose();
-        }
-
         this._opaqueRenderTarget = new RenderTargetTexture("opaqueSceneTexture", this._options.renderSize, this._scene, true);
         this._opaqueRenderTarget.renderList = this._opaqueMeshesCache;
         // this._opaqueRenderTarget.clearColor = new Color4(0.0, 0.0, 0.0, 0.0);
@@ -232,8 +214,8 @@ class TransmissionHelper {
         this._opaqueRenderTarget.samples = this._options.samples;
 
         this._transparentMeshesCache.forEach((mesh: AbstractMesh) => {
-            if (this.shouldRenderAsTransmission(mesh.material) && mesh.material instanceof PBRMaterial) {
-                mesh.material.refractionTexture = this._opaqueRenderTarget;
+            if (this.shouldRenderAsTransmission(mesh.material)) {
+                (mesh.material as PBRMaterial).refractionTexture = this._opaqueRenderTarget;
             }
         });
     }


### PR DESCRIPTION
* the refraction texture was rendered two times. Setting the `.refractionTexture` of a PBR material is enough to have the RTT generated, so I have removed the push in `scene.customRenderTargets`
* the observer was not removed from `mesh.onMaterialChangedObservable` when a mesh is disposed
* I have removed the layer handling. I don't think we want to have all layers automatically drawn in the refraction texture RTT: it should be a user decision. For eg, if we have a GUI, we get:
![image](https://user-images.githubusercontent.com/4152247/106297606-2bb4aa00-6253-11eb-960f-37577a848ca3.png)
That's not what we want, the button should not be part of the refraction texture. I think it's better to let the user decide if they want to add the refraction texture to the list of RTTs of any layer they can have in their scene => they can access the refraction texture through `scene._transmissionHelper.getOpaqueTarget()`
* made some options configurable (samples, lodGenerationScale and lodGenerationOffset). Those values can be changed by accessing directly the RTT texture, but I think adding theses in the option list make it clear they can/must be changed (and we get their default values in the docs). Notably, lodGenerationScale and lodGenerationOffset will depend on your scene and the size of the opaque objects.

FYI @MiiBond 