### PR TITLE
Fix triplanar material when mesh position is not at the origin

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -122,6 +122,7 @@
 - Fix issue when canvas loses focus while holding a pointer button ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix issue where camera controls stay detached if PointerDragBehavior is disabled prematurely ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix uncatchable exception that could be thrown when initializing the environment textures ([CoPrez](https://github.com/CoPrez))
+- Fix the triplanar material when the position of the mesh it is applied to is not (0,0,0) ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -91,9 +91,9 @@ void main(void)
 	vec3 worldBinormal = normalize(xbin * normalizedNormal.x + ybin * normalizedNormal.y + zbin * normalizedNormal.z);
    	vec3 worldTangent = normalize(xtan * normalizedNormal.x + ytan * normalizedNormal.y + ztan * normalizedNormal.z);
 	   
-	worldTangent = (world * vec4(worldTangent, 1.0)).xyz;
-    worldBinormal = (world * vec4(worldBinormal, 1.0)).xyz;
-	vec3 worldNormal = (world * vec4(normalize(normal), 1.0)).xyz;
+	worldTangent = (world * vec4(worldTangent, 0.0)).xyz;
+    worldBinormal = (world * vec4(worldBinormal, 0.0)).xyz;
+	vec3 worldNormal = (world * vec4(normalize(normal), 0.0)).xyz;
 
 	tangentSpace[0] = worldTangent;
     tangentSpace[1] = worldBinormal;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/triplanar-shader-strange-behavior-when-meshs-are-translated-possible-bug/17985