### PR TITLE
homogeneous depth range Native

### DIFF
--- a/src/Engines/Native/nativeShaderProcessors.ts
+++ b/src/Engines/Native/nativeShaderProcessors.ts
@@ -1,0 +1,24 @@
+import { Nullable } from '../../types';
+import { WebGL2ShaderProcessor } from '../WebGL/webGL2ShaderProcessors';
+import { ShaderProcessingContext } from '../Processors/shaderProcessingOptions';
+
+declare type ThinEngine = import("../thinEngine").ThinEngine;
+declare type NativeEngine = import("../nativeEngine").NativeEngine;
+
+/** @hidden */
+export class NativeShaderProcessor extends WebGL2ShaderProcessor {
+    public postProcessor(code: string, defines: string[], isFragment: boolean, processingContext: Nullable<ShaderProcessingContext>, engine: ThinEngine) {
+        code = super.postProcessor(code, defines, isFragment, processingContext, engine);
+
+        // Depending on API, depth range is [-1..1] or [0..1]
+        // This is defined by homogeneousDepth in bgfx caps
+        // Flip Y + convert z range from [-1,1] to [0,1]
+        if (!isFragment && !(<NativeEngine>engine).homogeneousDepth) {
+            const lastClosingCurly = code.lastIndexOf("}");
+            code = code.substring(0, lastClosingCurly);
+            code += "gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0; }";
+        }
+
+        return code;
+    }
+}

--- a/src/Engines/Native/nativeShaderProcessors.ts
+++ b/src/Engines/Native/nativeShaderProcessors.ts
@@ -12,7 +12,6 @@ export class NativeShaderProcessor extends WebGL2ShaderProcessor {
 
         // Depending on API, depth range is [-1..1] or [0..1]
         // This is defined by homogeneousDepth in bgfx caps
-        // Flip Y + convert z range from [-1,1] to [0,1]
         if (!isFragment && !(<NativeEngine>engine).homogeneousDepth) {
             const lastClosingCurly = code.lastIndexOf("}");
             code = code.substring(0, lastClosingCurly);

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -22,7 +22,7 @@ import { ThinEngine, ISceneLike } from './thinEngine';
 import { IWebRequest } from '../Misc/interfaces/iWebRequest';
 import { EngineStore } from './engineStore';
 import { ShaderCodeInliner } from "./Processors/shaderCodeInliner";
-import { WebGL2ShaderProcessor } from '../Engines/WebGL/webGL2ShaderProcessors';
+import { NativeShaderProcessor } from '../Engines/Native/nativeShaderProcessors';
 import { RenderTargetTextureSize } from '../Engines/Extensions/engine.renderTarget';
 import { DepthTextureCreationOptions } from '../Engines/depthTextureCreationOptions';
 
@@ -75,6 +75,8 @@ interface INativeEngine {
     readonly ALPHA_PREMULTIPLIED_PORTERDUFF: number;
     readonly ALPHA_INTERPOLATE: number;
     readonly ALPHA_SCREENMODE: number;
+
+    readonly homogeneousDepth: boolean;
 
     dispose(): void;
 
@@ -747,6 +749,7 @@ export class NativeEngine extends Engine {
     private readonly INVALID_HANDLE = 65535;
     private _boundBuffersVertexArray: any = null;
     private _currentDepthTest: number = this._native.DEPTH_TEST_LEQUAL;
+    public homogeneousDepth: boolean = this._native.homogeneousDepth;
 
     public getHardwareScalingLevel(): number {
         return this._native.getHardwareScalingLevel();
@@ -855,7 +858,7 @@ export class NativeEngine extends Engine {
         }
 
         // Shader processor
-        this._shaderProcessor = new WebGL2ShaderProcessor();
+        this._shaderProcessor = new NativeShaderProcessor();
     }
 
     public dispose(): void {


### PR DESCRIPTION
Viewport depth range is dependant on rendering API.
[-1..1] for webgl and opengl
[0..1] for webgl and d3d

For babylon.js, the fix is done in the shaderprocessor depending on API (webgl vs webgpu).
It has never been fixed for Native, assuming always [-1..1] even on d3d. near plane clipping was happening too soon but no one noticed.

This looks like the inverted UV with the exception we can't use the same trick on native with flipped projection matrix. 
Because all the computations (like shadows) are done assuming a depth range of [-1..1] and the depth range remapping is done at the shader end. 

So, here, the same trick is done as for webgpu with a shader processor.