### PR TITLE
Implement Quaternion.FromLookDirectionLH/RH and Matrix LookDirectionLH/RH

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -21,6 +21,7 @@
 - Modified InputManager to use DeviceInputSystem ([PolygonalSun](https://github.com/PolygonalSun))
 - Added a [helper class](https://doc.babylonjs.com/typedoc/classes/babylon.debug.directionallightfrustumviewer) to display the frustum of a directional light ([Popov72](https://github.com/Popov72))
 - Improved collision detection performance ([ottoville](https://github.com/ottoville/))
+- Added new helper functions for Quaternion.FromLookDirection and Matrix.LookDirection ([Alex-MSFT](https://github.com/Alex-MSFT))
 
 ### Engine
 

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3597,6 +3597,7 @@ export class Quaternion {
      * This function works in left handed mode
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
+     * @param ref defines the target quaternion.
      */
     public static FromLookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
         var rotMat = MathTmp.Matrix[0];
@@ -3621,7 +3622,7 @@ export class Quaternion {
      * This function works in right handed mode
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
-     * @returns A new quaternion oriented toward the specified forward and up.
+     * @param ref defines the target quaternion.
      */
     public static FromLookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
         var rotMat = MathTmp.Matrix[0];

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3583,7 +3583,7 @@ export class Quaternion {
      * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in left handed mode
      * @param forward Defines the forward direction of the desired quaternion.
-     * @param up  Defines the up direction of the desired quaternion.
+     * @param up Defines the up direction of the desired quaternion.
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
@@ -3594,7 +3594,7 @@ export class Quaternion {
      * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in right handed mode
      * @param forward Defines the forward direction of the desired quaternion.
-     * @param up  Defines the up direction of the desired quaternion.
+     * @param up Defines the up direction of the desired quaternion.
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3580,6 +3580,28 @@ export class Quaternion {
     }
 
     /**
+     * Creates a new rotation value to orient an object to look at the given forward and up vectors.
+     * This function works in left handed mode
+     * @param forward Defines the forward direction of the desired quaternion.
+     * @param up  Defines the up direction of the desired quaternion.
+     * @returns A new quaternion oriented toward the specified forward and up.
+     */
+    public static FromLookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
+        return Quaternion.FromRotationMatrix(Matrix.LookDirectionLH(forward, up));
+    }
+
+    /**
+     * Creates a new rotation value to orient an object to look at the given forward and up vectors.
+     * This function works in right handed mode
+     * @param forward Defines the forward direction of the desired quaternion.
+     * @param up  Defines the up direction of the desired quaternion.
+     * @returns A new quaternion oriented toward the specified forward and up.
+     */
+    public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
+        return Quaternion.FromRotationMatrix(Matrix.LookDirectionRH(forward, up));
+    }
+
+    /**
      * Interpolates between two quaternions
      * @param left defines first quaternion
      * @param right defines second quaternion
@@ -5130,6 +5152,97 @@ export class Matrix {
             xAxis._y, yAxis._y, zAxis._y, 0.0,
             xAxis._z, yAxis._z, zAxis._z, 0.0,
             ex, ey, ez, 1.0,
+            result
+        );
+    }
+
+    /**
+     * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up Vector3 being oriented like "up".
+     * This function works in left handed mode
+     * @param forward defines the forward direction
+     * @param up defines the up vector for the entity
+     * @returns the new matrix
+     */
+    public static LookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Matrix {
+        var result = new Matrix();
+        Matrix.LookDirectionLHToRef(forward, up, result);
+        return result;
+    }
+
+    /**
+     * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up vector3 being oriented like "up".
+     * This function works in left handed mode
+     * @param forward defines the forward direction
+     * @param up defines the up vector for the entity
+     * @param result defines the target matrix
+     */
+    public static LookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
+        // First ensure that two vectors are valid and approximately orthogonal.
+        if (forward.length() < Epsilon || up.length() < Epsilon || Math.abs(Vector3.Dot(forward, up)) >= Epsilon) {
+            result.copyFrom(Matrix.IdentityReadOnly);
+        }
+
+        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector (left) that defines the rotation.
+        const forwardNorm = MathTmp.Vector3[0];
+        const upNorm = MathTmp.Vector3[1];
+        const right = MathTmp.Vector3[2];
+        forward.normalizeToRef(forwardNorm);
+        up.normalizeToRef(upNorm);
+        Vector3.CrossToRef(upNorm, forwardNorm, right);
+        right.normalize();
+
+        // Generate the rotation matrix.
+        Matrix.FromValuesToRef(
+            right._x, right._y, right._z, 0.0,
+            upNorm._x, upNorm._y, upNorm._z, 0.0,
+            forwardNorm._x, forwardNorm._y, forwardNorm._z, 0.0,
+            0, 0, 0, 1.0,
+            result
+        );
+    }
+
+     /**
+     * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up Vector3 being oriented like "up".
+     * This function works in right handed mode
+     * @param forward defines the forward direction
+     * @param up defines the up vector for the entity
+     * @returns the new matrix
+     */
+    public static LookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Matrix {
+        var result = new Matrix();
+        Matrix.LookDirectionRHToRef(forward, up, result);
+        return result;
+    }
+
+    /**
+     * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up vector3 being oriented like "up".
+     * This function works in right handed mode
+     * @param forward defines the forward direction
+     * @param up defines the up vector for the entity
+     * @param result defines the target matrix
+     */
+    public static LookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
+        // First ensure that two vectors are valid and approximately orthogonal.
+        if (forward.length() < Epsilon || up.length() < Epsilon || Math.abs(Vector3.Dot(forward, up)) >= Epsilon) {
+            result.copyFrom(Matrix.IdentityReadOnly);
+        }
+
+        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector (left) that defines the rotation.
+        const forwardNorm = MathTmp.Vector3[0];
+        const upNorm = MathTmp.Vector3[1];
+        const right = MathTmp.Vector3[2];
+        forward.normalizeToRef(forwardNorm);
+        forwardNorm.scale(-1);
+        up.normalizeToRef(upNorm);
+        Vector3.CrossToRef(upNorm, forwardNorm, right);
+        right.normalize();
+
+        // Generate the rotation matrix.
+        Matrix.FromValuesToRef(
+            right._x, right._y, right._z, 0.0,
+            upNorm._x, upNorm._y, upNorm._z, 0.0,
+            forwardNorm._x, forwardNorm._y, forwardNorm._z, 0.0,
+            0, 0, 0, 1.0,
             result
         );
     }

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3597,7 +3597,6 @@ export class Quaternion {
      * This function works in left handed mode
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
-     * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
         var rotMat = MathTmp.Matrix[0];
@@ -3610,7 +3609,6 @@ export class Quaternion {
      * This function works in right handed mode
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
-     * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
         var quat = new Quaternion();

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3582,8 +3582,8 @@ export class Quaternion {
     /**
      * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in left handed mode
-     * @param forward Defines the forward direction of the desired quaternion.
-     * @param up Defines the up direction of the desired quaternion.
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
@@ -3593,8 +3593,8 @@ export class Quaternion {
     /**
      * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in right handed mode
-     * @param forward Defines the forward direction of the desired quaternion.
-     * @param up Defines the up direction of the desired quaternion.
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
@@ -5159,8 +5159,8 @@ export class Matrix {
     /**
      * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up direction being oriented like "up".
      * This function works in left handed mode
-     * @param forward defines the forward direction
-     * @param up defines the up vector for the entity
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @returns the new matrix
      */
     public static LookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Matrix {
@@ -5172,31 +5172,22 @@ export class Matrix {
     /**
      * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up direction being oriented like "up".
      * This function works in left handed mode
-     * @param forward defines the forward direction
-     * @param up defines the up vector for the entity
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param result defines the target matrix
      */
     public static LookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
-        // First ensure that two vectors are valid and approximately orthogonal.
-        if (forward.length() < Epsilon || up.length() < Epsilon || Math.abs(Vector3.Dot(forward, up)) >= Epsilon) {
-            result.copyFrom(Matrix.IdentityReadOnly);
-        }
-
-        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
-        const forwardNorm = MathTmp.Vector3[0];
-        const upNorm = MathTmp.Vector3[1];
-        const left = MathTmp.Vector3[2];
-        forward.normalizeToRef(forwardNorm);
-        forwardNorm.scaleInPlace(-1);
-        up.normalizeToRef(upNorm);
-        Vector3.CrossToRef(upNorm, forwardNorm, left);
-        left.normalize();
+        const back = MathTmp.Vector3[0];
+        back.copyFrom(forward);
+        back.scaleInPlace(-1);
+        const left = MathTmp.Vector3[1];
+        Vector3.CrossToRef(up, back, left);
 
         // Generate the rotation matrix.
         Matrix.FromValuesToRef(
             left._x, left._y, left._z, 0.0,
-            upNorm._x, upNorm._y, upNorm._z, 0.0,
-            forwardNorm._x, forwardNorm._y, forwardNorm._z, 0.0,
+            up._x, up._y, up._z, 0.0,
+            back._x, back._y, back._z, 0.0,
             0, 0, 0, 1.0,
             result
         );
@@ -5205,8 +5196,8 @@ export class Matrix {
      /**
      * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up Vector3 being oriented like "up".
      * This function works in right handed mode
-     * @param forward defines the forward direction
-     * @param up defines the up vector for the entity
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @returns the new matrix
      */
     public static LookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Matrix {
@@ -5218,30 +5209,19 @@ export class Matrix {
     /**
      * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up vector3 being oriented like "up".
      * This function works in right handed mode
-     * @param forward defines the forward direction
-     * @param up defines the up vector for the entity
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param result defines the target matrix
      */
     public static LookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
-        // First ensure that two vectors are valid and approximately orthogonal.
-        if (forward.length() < Epsilon || up.length() < Epsilon || Math.abs(Vector3.Dot(forward, up)) >= Epsilon) {
-            result.copyFrom(Matrix.IdentityReadOnly);
-        }
-
-        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
-        const forwardNorm = MathTmp.Vector3[0];
-        const upNorm = MathTmp.Vector3[1];
         const right = MathTmp.Vector3[2];
-        forward.normalizeToRef(forwardNorm);
-        up.normalizeToRef(upNorm);
-        Vector3.CrossToRef(upNorm, forwardNorm, right);
-        right.normalize();
+        Vector3.CrossToRef(up, forward, right);
 
         // Generate the rotation matrix.
         Matrix.FromValuesToRef(
             right._x, right._y, right._z, 0.0,
-            upNorm._x, upNorm._y, upNorm._z, 0.0,
-            forwardNorm._x, forwardNorm._y, forwardNorm._z, 0.0,
+            up._x, up._y, up._z, 0.0,
+            forward._x, forward._y, forward._z, 0.0,
             0, 0, 0, 1.0,
             result
         );

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3587,7 +3587,22 @@ export class Quaternion {
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionLH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
-        return Quaternion.FromRotationMatrix(Matrix.LookDirectionLH(forward, up));
+        var quat = new Quaternion();
+        Quaternion.FromLookDirectionLHToRef(forward, up, quat);
+        return quat;
+    }
+
+     /**
+     * Creates a new rotation value to orient an object to look towards the given forward direction with the up direction being oriented like "up", and stores it in the target quaternion.
+     * This function works in left handed mode
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
+     * @returns A new quaternion oriented toward the specified forward and up.
+     */
+    public static FromLookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
+        var rotMat = MathTmp.Matrix[0];
+        Matrix.LookDirectionLHToRef(forward, up, rotMat);
+        Quaternion.FromRotationMatrixToRef(rotMat, ref);
     }
 
     /**
@@ -3598,7 +3613,22 @@ export class Quaternion {
      * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
-        return Quaternion.FromRotationMatrix(Matrix.LookDirectionRH(forward, up));
+        var quat = new Quaternion();
+        Quaternion.FromLookDirectionRHToRef(forward, up, quat);
+        return quat;
+    }
+
+    /**
+     * Creates a new rotation value to orient an object to look towards the given forward direction with the up direction being oriented like "up", and stores it in the target quaternion.
+     * This function works in right handed mode
+     * @param forward defines the forward direction - Must be normalized and orthogonal to up.
+     * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
+     * @returns A new quaternion oriented toward the specified forward and up.
+     */
+    public static FromLookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
+        var rotMat = MathTmp.Matrix[0];
+        Matrix.LookDirectionRHToRef(forward, up, rotMat);
+        return Quaternion.FromRotationMatrixToRef(rotMat, ref);
     }
 
     /**

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -5185,16 +5185,16 @@ export class Matrix {
         // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
         const forwardNorm = MathTmp.Vector3[0];
         const upNorm = MathTmp.Vector3[1];
-        const right = MathTmp.Vector3[2];
+        const left = MathTmp.Vector3[2];
         forward.normalizeToRef(forwardNorm);
         forwardNorm.scaleInPlace(-1);
         up.normalizeToRef(upNorm);
-        Vector3.CrossToRef(upNorm, forwardNorm, right);
-        right.normalize();
+        Vector3.CrossToRef(upNorm, forwardNorm, left);
+        left.normalize();
 
         // Generate the rotation matrix.
         Matrix.FromValuesToRef(
-            right._x, right._y, right._z, 0.0,
+            left._x, left._y, left._z, 0.0,
             upNorm._x, upNorm._y, upNorm._z, 0.0,
             forwardNorm._x, forwardNorm._y, forwardNorm._z, 0.0,
             0, 0, 0, 1.0,

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3580,7 +3580,7 @@ export class Quaternion {
     }
 
     /**
-     * Creates a new rotation value to orient an object to look at the given forward and up vectors.
+     * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in left handed mode
      * @param forward Defines the forward direction of the desired quaternion.
      * @param up  Defines the up direction of the desired quaternion.
@@ -3591,7 +3591,7 @@ export class Quaternion {
     }
 
     /**
-     * Creates a new rotation value to orient an object to look at the given forward and up vectors.
+     * Creates a new rotation value to orient an object to look towards the given forward direction, the up direction being oriented like "up".
      * This function works in right handed mode
      * @param forward Defines the forward direction of the desired quaternion.
      * @param up  Defines the up direction of the desired quaternion.
@@ -5157,7 +5157,7 @@ export class Matrix {
     }
 
     /**
-     * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up Vector3 being oriented like "up".
+     * Gets a new rotation matrix used to rotate an entity so as it looks in the direction specified by forward from the eye position, the up direction being oriented like "up".
      * This function works in left handed mode
      * @param forward defines the forward direction
      * @param up defines the up vector for the entity
@@ -5170,7 +5170,7 @@ export class Matrix {
     }
 
     /**
-     * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up vector3 being oriented like "up".
+     * Sets the given "result" Matrix to a rotation matrix used to rotate an entity so that it looks in the direction of forward, the up direction being oriented like "up".
      * This function works in left handed mode
      * @param forward defines the forward direction
      * @param up defines the up vector for the entity
@@ -5182,7 +5182,7 @@ export class Matrix {
             result.copyFrom(Matrix.IdentityReadOnly);
         }
 
-        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector (left) that defines the rotation.
+        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
         const forwardNorm = MathTmp.Vector3[0];
         const upNorm = MathTmp.Vector3[1];
         const right = MathTmp.Vector3[2];
@@ -5227,12 +5227,12 @@ export class Matrix {
             result.copyFrom(Matrix.IdentityReadOnly);
         }
 
-        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector (left) that defines the rotation.
+        // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
         const forwardNorm = MathTmp.Vector3[0];
+        forwardNorm.scaleInPlace(-1);
         const upNorm = MathTmp.Vector3[1];
         const right = MathTmp.Vector3[2];
         forward.normalizeToRef(forwardNorm);
-        forwardNorm.scale(-1);
         up.normalizeToRef(upNorm);
         Vector3.CrossToRef(upNorm, forwardNorm, right);
         right.normalize();

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -5187,6 +5187,7 @@ export class Matrix {
         const upNorm = MathTmp.Vector3[1];
         const right = MathTmp.Vector3[2];
         forward.normalizeToRef(forwardNorm);
+        forwardNorm.scaleInPlace(-1);
         up.normalizeToRef(upNorm);
         Vector3.CrossToRef(upNorm, forwardNorm, right);
         right.normalize();
@@ -5229,7 +5230,6 @@ export class Matrix {
 
         // Next normalize the two inputted vectors and take the cross product to find the third orthonormal vector that defines the rotation.
         const forwardNorm = MathTmp.Vector3[0];
-        forwardNorm.scaleInPlace(-1);
         const upNorm = MathTmp.Vector3[1];
         const right = MathTmp.Vector3[2];
         forward.normalizeToRef(forwardNorm);

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -3610,6 +3610,7 @@ export class Quaternion {
      * This function works in right handed mode
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
+     * @returns A new quaternion oriented toward the specified forward and up.
      */
     public static FromLookDirectionRH(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>): Quaternion {
         var quat = new Quaternion();


### PR DESCRIPTION
This PR adds new helper functions for Quaternion and Matrices which allow creation of a rotation specifying just a direction and up vector as discussed in #9293.

These utilities are similar to LookAtLH/RH, however differ in that they do not take into account the eye orientation, and are based only on two orthogonal direction vectors for up and forward.  This will generate a rotation in an upright position that is facing in the same direction as the forward direction vector.

Here are some examples:
![LookRotation_1](https://user-images.githubusercontent.com/27031140/106964913-bd129900-66f7-11eb-9fe6-1c4417cbc415.gif)

![LookRotation_2](https://user-images.githubusercontent.com/27031140/106964917-bedc5c80-66f7-11eb-9393-e7248daef716.gif)