### PR TITLE
Fix typo of EventState.initialize, and 'initialize' in a comment

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -146,3 +146,4 @@
 - Depth renderer: don't render mesh if `infiniteDistance = true` or if `material.disableDepthWrite = true` ([Popov72](https://github.com/Popov72))
 - Mesh.createInstance no longer make a unique Geometry for the Mesh so updating one Geometry can affect more meshes than before. Use Mesh.makeUniqueGeometry for old behaviour. ([breakin](https://github.com/breakin))
 - Ammo.js needs to be initialized before creating the plugin with `await Ammo();` since Ammo introduced an async init in their library. ([sebavan](https://github.com/sebavan))
+- Fixed spelling of EventState.initialize() ([seritools](https://github.com/seritools))

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -230,7 +230,7 @@ export class DeviceInputSystem implements IDisposable {
     private _addPointerDevice(deviceType: DeviceType, deviceSlot: number, currentX: number, currentY: number) {
         this._pointerActive = true;
         this._registerDevice(deviceType, deviceSlot, DeviceInputSystem._MAX_POINTER_INPUTS);
-        const pointer = this._inputs[deviceType][deviceSlot]; /* initalize our pointer position immediately after registration */
+        const pointer = this._inputs[deviceType][deviceSlot]; /* initialize our pointer position immediately after registration */
         pointer[0] = currentX;
         pointer[1] = currentY;
     }

--- a/src/Misc/observable.ts
+++ b/src/Misc/observable.ts
@@ -13,7 +13,7 @@ export class EventState {
      * @param currentTarget defines the current target of the state
      */
     constructor(mask: number, skipNextObservers = false, target?: any, currentTarget?: any) {
-        this.initalize(mask, skipNextObservers, target, currentTarget);
+        this.initialize(mask, skipNextObservers, target, currentTarget);
     }
 
     /**
@@ -24,7 +24,7 @@ export class EventState {
      * @param currentTarget defines the current target of the state
      * @returns the current event state
      */
-    public initalize(mask: number, skipNextObservers = false, target?: any, currentTarget?: any): EventState {
+    public initialize(mask: number, skipNextObservers = false, target?: any, currentTarget?: any): EventState {
         this.mask = mask;
         this.skipNextObservers = skipNextObservers;
         this.target = target;


### PR DESCRIPTION
Fixes #9909 

Also found a comment with the same typo so I just went ahead and fixed that as well.