### PR TITLE
Small fix for touchMeshButton3D metadata

### DIFF
--- a/gui/src/3D/controls/touchMeshButton3D.ts
+++ b/gui/src/3D/controls/touchMeshButton3D.ts
@@ -70,7 +70,7 @@ export class TouchMeshButton3D extends TouchButton3D {
     // Mesh association
     protected _createNode(scene: Scene): TransformNode {
         this._currentMesh.getChildMeshes().forEach((mesh) => {
-            mesh.metadata = this;
+            this._injectGUI3DMetadata(mesh).control = this;
         });
 
         return this._currentMesh;


### PR DESCRIPTION
Since the touchMeshButton3D was being introduced around the same time that change #9632 went in, it missed the update, and the button did not behave properly once both changes went in.