### PR TITLE
Fix collision squared distance computation

### DIFF
--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -373,7 +373,7 @@ export class Collider {
         }
 
         if (found) {
-            var distToCollisionSquared = (t * Math.sqrt(this._velocitySquaredLength)) ** 2;
+            var distToCollisionSquared = t * t * this._velocitySquaredLength;
 
             if (!this.collisionFound || distToCollisionSquared < this._nearestDistanceSquared) {
                 // if collisionResponse is false, collision is not found but the collidedMesh is set anyway.

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -260,6 +260,7 @@ export class Collider {
         if (!embeddedInPlane) {
             this._basePoint.subtractToRef(trianglePlane.normal, this._planeIntersectionPoint);
             this._velocity.scaleToRef(t0, this._tempVector);
+            this._velocitySquaredLength = this._velocity.lengthSquared();
             this._planeIntersectionPoint.addInPlace(this._tempVector);
 
             if (this._checkPointInTriangle(this._planeIntersectionPoint, p1, p2, p3, trianglePlane.normal)) {
@@ -270,7 +271,6 @@ export class Collider {
         }
 
         if (!found) {
-
             var a = this._velocitySquaredLength;
 
             this._basePoint.subtractToRef(p1, this._tempVector);
@@ -373,7 +373,7 @@ export class Collider {
         }
 
         if (found) {
-            var distToCollisionSquared = t * this._velocitySquaredLength;
+            var distToCollisionSquared = (t * Math.sqrt(this._velocitySquaredLength)) ** 2;
 
             if (!this.collisionFound || distToCollisionSquared < this._nearestDistanceSquared) {
                 // if collisionResponse is false, collision is not found but the collidedMesh is set anyway.

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -260,7 +260,6 @@ export class Collider {
         if (!embeddedInPlane) {
             this._basePoint.subtractToRef(trianglePlane.normal, this._planeIntersectionPoint);
             this._velocity.scaleToRef(t0, this._tempVector);
-            this._velocitySquaredLength = this._velocity.lengthSquared();
             this._planeIntersectionPoint.addInPlace(this._tempVector);
 
             if (this._checkPointInTriangle(this._planeIntersectionPoint, p1, p2, p3, trianglePlane.normal)) {


### PR DESCRIPTION
Followup on https://forum.babylonjs.com/t/jumping-camera-movement/18352
Fixes issues introduced with https://github.com/BabylonJS/Babylon.js/pull/9873

Side note: a PR claiming 'optimize something ... ' shall not be merged unless there are metrics clearly showing a performance improvement. I doubt a significant improvement can benefit from that PR. Moreover, adding more states for the same value (here, velocity) almost always make the work more difficult as values must be properly synced.

- `distToCollisionSquared` is not `t * this._velocitySquaredLength` but `(t * velocityLength) * (t * velocityLength)` which is `t2 * _velocitySquaredLength`

