### PR TITLE
[XR] Add support for sessiongranted event

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -87,6 +87,7 @@
 - better support for custom hand meshes ([RaananW](https://github.com/RaananW))
 - Allow disabling of the WebXRControllerPointerSelection feature as part of the WebXR Default Experience ([rgerd](https://github.com/rgerd))
 - Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
+- Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/XR/webXRDefaultExperience.ts
+++ b/src/XR/webXRDefaultExperience.ts
@@ -161,7 +161,7 @@ export class WebXRDefaultExperience {
 
                 if (!options.disableDefaultUI) {
                     // Create ui for entering/exiting xr
-                    return result.enterExitUI.setHelper(result.baseExperience, result.renderTarget);
+                    return result.enterExitUI.setHelperAsync(result.baseExperience, result.renderTarget);
                 } else {
                     return;
                 }

--- a/src/XR/webXRDefaultExperience.ts
+++ b/src/XR/webXRDefaultExperience.ts
@@ -105,6 +105,21 @@ export class WebXRDefaultExperience {
      */
     public static CreateAsync(scene: Scene, options: WebXRDefaultExperienceOptions = {}) {
         var result = new WebXRDefaultExperience();
+        // init the UI right after construction
+        if (!options.disableDefaultUI) {
+            const uiOptions: WebXREnterExitUIOptions = {
+                renderTarget: result.renderTarget,
+                ...(options.uiOptions || {}),
+            };
+            if (options.optionalFeatures) {
+                if (typeof options.optionalFeatures === "boolean") {
+                    uiOptions.optionalFeatures = ["hit-test", "anchors", "plane-detection", "hand-tracking"];
+                } else {
+                    uiOptions.optionalFeatures = options.optionalFeatures;
+                }
+            }
+            result.enterExitUI = new WebXREnterExitUI(scene, uiOptions);
+        }
 
         // Create base experience
         return WebXRExperienceHelper.CreateAsync(scene)
@@ -145,21 +160,8 @@ export class WebXRDefaultExperience {
                 result.renderTarget = result.baseExperience.sessionManager.getWebXRRenderTarget(options.outputCanvasOptions);
 
                 if (!options.disableDefaultUI) {
-                    const uiOptions: WebXREnterExitUIOptions = {
-                        renderTarget: result.renderTarget,
-                        ...(options.uiOptions || {}),
-                    };
-                    if (options.optionalFeatures) {
-                        if (typeof options.optionalFeatures === "boolean") {
-                            uiOptions.optionalFeatures = ["hit-test", "anchors", "plane-detection", "hand-tracking"];
-                        } else {
-                            uiOptions.optionalFeatures = options.optionalFeatures;
-                        }
-                    }
                     // Create ui for entering/exiting xr
-                    return WebXREnterExitUI.CreateAsync(scene, result.baseExperience, uiOptions).then((ui) => {
-                        result.enterExitUI = ui;
-                    });
+                    return result.enterExitUI.setHelper(result.baseExperience, result.renderTarget);
                 } else {
                     return;
                 }

--- a/src/XR/webXREnterExitUI.ts
+++ b/src/XR/webXREnterExitUI.ts
@@ -64,7 +64,7 @@ export class WebXREnterExitUIOptions {
     requiredFeatures?: string[];
 
     /**
-     * If set, the `sessiongranted` event will not be registered. `sessiongranted` is used to move seemingly between WebXR experiences.
+     * If set, the `sessiongranted` event will not be registered. `sessiongranted` is used to move seamlessly between WebXR experiences.
      * If set to true the user will be forced to press the "enter XR" button even if sessiongranted event was triggered.
      * If not set and a sessiongranted event was triggered, the XR session will start automatically.
      */

--- a/src/XR/webXREnterExitUI.ts
+++ b/src/XR/webXREnterExitUI.ts
@@ -98,6 +98,7 @@ export class WebXREnterExitUI implements IDisposable {
     public activeButtonChangedObservable = new Observable<Nullable<WebXREnterExitUIButton>>();
 
     /**
+     * Construct a new EnterExit UI class
      *
      * @param scene babylon scene object to use
      * @param options (read-only) version of the options passed to this UI
@@ -169,8 +170,9 @@ export class WebXREnterExitUI implements IDisposable {
      *
      * @param helper the experience helper to attach
      * @param renderTarget an optional render target (in case it is created outside of the helper scope)
+     * @returns a promise that resolves when the ui is ready
      */
-    public async setHelper(helper: WebXRExperienceHelper, renderTarget?: WebXRRenderTarget) {
+    public async setHelperAsync(helper: WebXRExperienceHelper, renderTarget?: WebXRRenderTarget): Promise<void> {
         this._helper = helper;
         this._renderTarget = renderTarget;
         var supportedPromises = this._buttons.map((btn) => {
@@ -201,7 +203,7 @@ export class WebXREnterExitUI implements IDisposable {
      */
     public static async CreateAsync(scene: Scene, helper: WebXRExperienceHelper, options: WebXREnterExitUIOptions): Promise<WebXREnterExitUI> {
         var ui = new WebXREnterExitUI(scene, options);
-        await ui.setHelper(helper, options.renderTarget || undefined);
+        await ui.setHelperAsync(helper, options.renderTarget || undefined);
         return ui;
     }
 


### PR DESCRIPTION
This allows switching seamlessly between two WebXR experiences

Note that there is no exact definition to the browser state in which the event is triggered. From my tests the playground doesn't work (due to the asynchronous way it loads the components), but self-hosted experiences work well.

Closing #9860