### PR TITLE
createImageBitmap Abstraction

### DIFF
--- a/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -27,6 +27,7 @@ import { HardwareTextureWrapper } from '../../Materials/Textures/hardwareTexture
 import { BaseTexture } from '../../Materials/Textures/baseTexture';
 import { WebGPUHardwareTexture } from './webgpuHardwareTexture';
 import { IColor4Like } from '../../Maths/math.like';
+import { EngineStore } from '../engineStore';
 
 // TODO WEBGPU improve mipmap generation by not using the OutputAttachment flag
 // see https://github.com/toji/web-texture-tool/tree/main/src
@@ -1056,7 +1057,8 @@ export class WebGPUTextureHelper {
             imageBitmap = imageBitmap as ImageBitmap;
 
             if (invertY || premultiplyAlpha) {
-                createImageBitmap(imageBitmap, { imageOrientation: invertY ? "flipY" : "none", premultiplyAlpha: premultiplyAlpha ? "premultiply" : "none" }).then((imageBitmap) => {
+                const engine = EngineStore.LastCreatedEngine;
+                engine && engine.createImageBitmap(imageBitmap, { imageOrientation: invertY ? "flipY" : "none", premultiplyAlpha: premultiplyAlpha ? "premultiply" : "none" }).then((imageBitmap) => {
                     this._device.defaultQueue.copyImageBitmapToTexture({ imageBitmap }, textureCopyView, textureExtent);
                 });
             } else {

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -25,6 +25,7 @@ import "./Extensions/engine.readTexture";
 import "./Extensions/engine.dynamicBuffer";
 import { IAudioEngine } from '../Audio/Interfaces/IAudioEngine';
 import { IPointerEvent } from "../Events/deviceInputEvents";
+import { CanvasGenerator } from '../Misc/canvasGenerator';
 
 declare type Material = import("../Materials/material").Material;
 declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
@@ -295,10 +296,30 @@ export class Engine extends ThinEngine {
      */
     public createImageBitmap(...args: any[]): Promise<ImageBitmap> //image: ImageBitmapSource, options?: ImageBitmapOptions
     {
-        if (args.length <= 2) {
-            return createImageBitmap(args[0], args[1]);
+        return createImageBitmap.apply(null, args);
+    }
+
+    /**
+     * Resize an image and returns the image data as an uint8array
+     * @param image image to resize
+     * @param bufferWidth destination buffer width
+     * @param bufferHeight destination buffer height
+     * @returns an uint8array containing RGBA values of bufferWidth * bufferHeight size
+     */
+    public resizeImageBitmap(image: HTMLImageElement | ImageBitmap, bufferWidth: number, bufferHeight: number): Uint8Array {
+        var canvas = CanvasGenerator.CreateCanvas(bufferWidth, bufferHeight);
+        var context = canvas.getContext("2d");
+
+        if (!context) {
+            throw new Error("Unable to get 2d context for resizeImageBitmap");
         }
-        return createImageBitmap(args[0], args[1], args[2], args[3], args[4], args[5]);
+
+        context.drawImage(image, 0, 0);
+
+        // Create VertexData from map data
+        // Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949
+        var buffer = <Uint8Array>(<any>context.getImageData(0, 0, bufferWidth, bufferHeight).data);
+        return buffer;
     }
 
     /**

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -291,6 +291,17 @@ export class Engine extends ThinEngine {
     }
 
     /**
+     * Engine abstraction for createImageBitmap
+     */
+    public createImageBitmap(...args: any[]): Promise<ImageBitmap> //image: ImageBitmapSource, options?: ImageBitmapOptions
+    {
+        if (args.length <= 2) {
+            return createImageBitmap(args[0], args[1]);
+        }
+        return createImageBitmap(args[0], args[1], args[2], args[3], args[4], args[5]);
+    }
+
+    /**
      * Will flag all materials in all scenes in all engines as dirty to trigger new shader compilation
      * @param flag defines which part of the materials must be marked as dirty
      * @param predicate defines a predicate used to filter which materials should be affected

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -293,12 +293,12 @@ export class Engine extends ThinEngine {
 
     /**
      * Engine abstraction for createImageBitmap
-     * @param args parameters for createImageBitmap implementation
+     * @param image source for image
+     * @param options An object that sets options for the image's extraction.
      * @returns ImageBitmap
      */
-    public createImageBitmap(...args: any[]): Promise<ImageBitmap>
-    {
-        return createImageBitmap.apply(null, args);
+    public createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap> {
+        return createImageBitmap(image, options);
     }
 
     /**

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -293,8 +293,10 @@ export class Engine extends ThinEngine {
 
     /**
      * Engine abstraction for createImageBitmap
+     * @param args parameters for createImageBitmap implementation
+     * @returns ImageBitmap
      */
-    public createImageBitmap(...args: any[]): Promise<ImageBitmap> //image: ImageBitmapSource, options?: ImageBitmapOptions
+    public createImageBitmap(...args: any[]): Promise<ImageBitmap>
     {
         return createImageBitmap.apply(null, args);
     }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1775,6 +1775,8 @@ export class NativeEngine extends Engine {
 
     /**
      * Engine abstraction for createImageBitmap with Native implementation
+     * @param args parameters for createImageBitmap implementation
+     * @returns ImageBitmap
      */
     public createImageBitmap(...args: any[]): Promise<ImageBitmap>
     {

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1774,18 +1774,21 @@ export class NativeEngine extends Engine {
     }
 
     /**
-     * Engine abstraction for createImageBitmap with Native implementation
-     * @param args parameters for createImageBitmap implementation
+     * Engine abstraction for createImageBitmap
+     * @param image source for image
+     * @param options An object that sets options for the image's extraction.
      * @returns ImageBitmap
      */
-    public createImageBitmap(...args: any[]): Promise<ImageBitmap>
-    {
+    public createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap> {
         return new Promise((resolve, reject) => {
-            if (args.length && Array.isArray(args[0]) && args[0].length) {
-                const image = this._native.createImageBitmap(args[0][0]);
-                if (image) {
-                    resolve(image);
-                    return;
+            if (Array.isArray(image)) {
+                const arr = <Array<ArrayBufferView>>image;
+                if (arr.length) {
+                    const image = this._native.createImageBitmap(arr[0]);
+                    if (image) {
+                        resolve(image);
+                        return;
+                    }
                 }
             }
             reject(`Unsupported data for createImageBitmap.`);

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1781,14 +1781,16 @@ export class NativeEngine extends Engine {
     public createImageBitmap(...args: any[]): Promise<ImageBitmap>
     {
         return new Promise((resolve, reject) => {
-            const image = this._native.createImageBitmap(args);
-            if (image) {
-                resolve(image);
-            } else if (reject) {
-                reject();
-            } else {
-                throw new Error(`Unsupported data for createImageBitmap.`);
+            if (args.length && Array.isArray(args[0]) && args[0].length) {
+                const image = this._native.createImageBitmap(args[0][0]);
+                if (image) {
+                    resolve(image);
+                } else if (reject) {
+                    reject();
+                }
+                return;
             }
+            throw new Error(`Unsupported data for createImageBitmap.`);
         });
     }
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -143,6 +143,7 @@ interface INativeEngine {
     setTextureAnisotropicLevel(texture: WebGLTexture, value: number): void;
     setTexture(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
+    createImageBitmap(image: any , sx: any, sy: any, sw: any, sh: any, options: Nullable<any>): ImageBitmap ;
 
     createFramebuffer(texture: WebGLTexture, width: number, height: number, format: number, samplingMode: number, generateStencilBuffer: boolean, generateDepthBuffer: boolean, generateMips: boolean): WebGLFramebuffer;
     deleteFramebuffer(framebuffer: WebGLFramebuffer): void;
@@ -1769,6 +1770,20 @@ export class NativeEngine extends Engine {
             this._native.deleteFramebuffer(texture._framebuffer);
             texture._framebuffer = null;
         }
+    }
+
+    /**
+     * Engine abstraction for createImageBitmap with Native implementation
+     */
+    public createImageBitmap(...args: any[]): Promise<ImageBitmap>
+    {
+        return new Promise((resolve, reject) => {
+            if (args.length <= 2) {
+                resolve(this._native.createImageBitmap(args[0], args[1], undefined, undefined, undefined, undefined));
+            } else {
+                resolve(this._native.createImageBitmap(args[0], args[1], args[2], args[3], args[4], args[5]));
+            }
+        });
     }
 
     /**

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -143,7 +143,7 @@ interface INativeEngine {
     setTextureAnisotropicLevel(texture: WebGLTexture, value: number): void;
     setTexture(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
-    createImageBitmap(parameters: any): ImageBitmap;
+    createImageBitmap(data: ArrayBufferView): ImageBitmap;
     resizeImageBitmap(image: ImageBitmap, bufferWidth: number, bufferHeight: number) : Uint8Array;
 
     createFramebuffer(texture: WebGLTexture, width: number, height: number, format: number, samplingMode: number, generateStencilBuffer: boolean, generateDepthBuffer: boolean, generateMips: boolean): WebGLFramebuffer;
@@ -1785,12 +1785,10 @@ export class NativeEngine extends Engine {
                 const image = this._native.createImageBitmap(args[0][0]);
                 if (image) {
                     resolve(image);
-                } else if (reject) {
-                    reject();
+                    return;
                 }
-                return;
             }
-            throw new Error(`Unsupported data for createImageBitmap.`);
+            reject(`Unsupported data for createImageBitmap.`);
         });
     }
 

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -39,6 +39,7 @@ import { WebGPUCacheRenderPipeline } from "./WebGPU/webgpuCacheRenderPipeline";
 import { WebGPUCacheRenderPipelineTree } from "./WebGPU/webgpuCacheRenderPipelineTree";
 import { WebGPUStencilState } from "./WebGPU/webgpuStencilState";
 import { WebGPUDepthCullingState } from "./WebGPU/webgpuDepthCullingState";
+import { EngineStore } from '../Engines/engineStore';
 
 import "../Shaders/clearQuad.vertex";
 import "../Shaders/clearQuad.fragment";
@@ -2030,7 +2031,8 @@ export class WebGPUEngine extends Engine {
             gpuTextureWrapper = this._textureHelper.createGPUTextureForInternalTexture(texture, width, height);
         }
 
-        createImageBitmap(canvas).then((bitmap) => {
+        const engine = EngineStore.LastCreatedEngine;
+        engine && engine.createImageBitmap(canvas).then((bitmap) => {
             this._textureHelper.updateTexture(bitmap, gpuTextureWrapper.underlyingResource!, width, height, texture.depth, gpuTextureWrapper.format, 0, 0, invertY, premulAlpha, 0, 0, this._uploadEncoder);
             if (texture.generateMipMaps) {
                 this._generateMipmaps(texture, this._uploadEncoder);
@@ -2084,7 +2086,8 @@ export class WebGPUEngine extends Engine {
             gpuTextureWrapper = this._textureHelper.createGPUTextureForInternalTexture(texture);
         }
 
-        createImageBitmap(video).then((bitmap) => {
+        const engine = EngineStore.LastCreatedEngine;
+        engine && engine.createImageBitmap(video).then((bitmap) => {
             this._textureHelper.updateTexture(bitmap, gpuTextureWrapper.underlyingResource!, texture.width, texture.height, texture.depth, gpuTextureWrapper.format, 0, 0, !invertY, false, 0, 0, this._uploadEncoder);
             if (texture.generateMipMaps) {
                 this._generateMipmaps(texture, this._uploadEncoder);

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -39,7 +39,6 @@ import { WebGPUCacheRenderPipeline } from "./WebGPU/webgpuCacheRenderPipeline";
 import { WebGPUCacheRenderPipelineTree } from "./WebGPU/webgpuCacheRenderPipelineTree";
 import { WebGPUStencilState } from "./WebGPU/webgpuStencilState";
 import { WebGPUDepthCullingState } from "./WebGPU/webgpuDepthCullingState";
-import { EngineStore } from '../Engines/engineStore';
 
 import "../Shaders/clearQuad.vertex";
 import "../Shaders/clearQuad.fragment";
@@ -2031,8 +2030,7 @@ export class WebGPUEngine extends Engine {
             gpuTextureWrapper = this._textureHelper.createGPUTextureForInternalTexture(texture, width, height);
         }
 
-        const engine = EngineStore.LastCreatedEngine;
-        engine && engine.createImageBitmap(canvas).then((bitmap) => {
+        this.createImageBitmap(canvas).then((bitmap) => {
             this._textureHelper.updateTexture(bitmap, gpuTextureWrapper.underlyingResource!, width, height, texture.depth, gpuTextureWrapper.format, 0, 0, invertY, premulAlpha, 0, 0, this._uploadEncoder);
             if (texture.generateMipMaps) {
                 this._generateMipmaps(texture, this._uploadEncoder);
@@ -2086,8 +2084,7 @@ export class WebGPUEngine extends Engine {
             gpuTextureWrapper = this._textureHelper.createGPUTextureForInternalTexture(texture);
         }
 
-        const engine = EngineStore.LastCreatedEngine;
-        engine && engine.createImageBitmap(video).then((bitmap) => {
+        this.createImageBitmap(video).then((bitmap) => {
             this._textureHelper.updateTexture(bitmap, gpuTextureWrapper.underlyingResource!, texture.width, texture.height, texture.depth, gpuTextureWrapper.format, 0, 0, !invertY, false, 0, 0, this._uploadEncoder);
             if (texture.generateMipMaps) {
                 this._generateMipmaps(texture, this._uploadEncoder);

--- a/src/Meshes/Builders/groundBuilder.ts
+++ b/src/Meshes/Builders/groundBuilder.ts
@@ -8,7 +8,6 @@ import { Tools } from "../../Misc/tools";
 import { Nullable } from '../../types';
 import { EngineStore } from '../../Engines/engineStore';
 import { Epsilon } from '../../Maths/math.constants';
-import { CanvasGenerator } from '../../Misc/canvasGenerator';
 
 VertexData.CreateGround = function(options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsY?: number }): VertexData {
     var indices = [];
@@ -387,23 +386,12 @@ export class GroundBuilder {
             var bufferWidth = img.width;
             var bufferHeight = img.height;
 
-            // Getting height map data
-            var canvas = CanvasGenerator.CreateCanvas(bufferWidth, bufferHeight);
-            var context = canvas.getContext("2d");
-
-            if (!context) {
-                throw new Error("Unable to get 2d context for CreateGroundFromHeightMap");
-            }
-
             if (scene!.isDisposed) {
                 return;
             }
 
-            context.drawImage(img, 0, 0);
+            var buffer = <Uint8Array>(scene?.getEngine().resizeImageBitmap(img, bufferWidth, bufferHeight));
 
-            // Create VertexData from map data
-            // Cast is due to wrong definition in lib.d.ts from ts 1.3 - https://github.com/Microsoft/TypeScript/issues/949
-            var buffer = <Uint8Array>(<any>context.getImageData(0, 0, bufferWidth, bufferHeight).data);
             var vertexData = VertexData.CreateGroundFromHeightMap({
                 width: width, height: height,
                 subdivisions: subdivisions,

--- a/src/Misc/environmentTextureTools.ts
+++ b/src/Misc/environmentTextureTools.ts
@@ -532,7 +532,7 @@ export class EnvironmentTextureTools {
                 let promise: Promise<void>;
 
                 if (typeof Image === "undefined" || engine._features.forceBitmapOverHTMLImageElement) {
-                    promise = createImageBitmap(blob, { premultiplyAlpha: "none" }).then((img) => {
+                    promise = engine.createImageBitmap(blob, { premultiplyAlpha: "none" }).then((img) => {
                         return this._OnImageReadyAsync(img, engine, expandTexture, rgbdPostProcess, url, face, i, generateNonLODTextures, lodTextures, cubeRtt, texture);
                     });
                 } else {

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -160,7 +160,7 @@ export class FileTools {
 
         if (typeof Image === "undefined" || (engine?._features.forceBitmapOverHTMLImageElement ?? false)) {
             FileTools.LoadFile(url, (data) => {
-                createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none" }).then((imgBmp) => {
+                engine?.createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none" }).then((imgBmp) => {
                     onLoad(imgBmp);
                     if (usingObjectURL) {
                         URL.revokeObjectURL(url);

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -160,7 +160,7 @@ export class FileTools {
 
         if (typeof Image === "undefined" || (engine?._features.forceBitmapOverHTMLImageElement ?? false)) {
             FileTools.LoadFile(url, (data) => {
-                engine?.createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none" }).then((imgBmp) => {
+                engine!.createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none" }).then((imgBmp) => {
                     onLoad(imgBmp);
                     if (usingObjectURL) {
                         URL.revokeObjectURL(url);

--- a/src/XR/features/WebXRImageTracking.ts
+++ b/src/XR/features/WebXRImageTracking.ts
@@ -5,7 +5,6 @@ import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import { Matrix } from "../../Maths/math.vector";
 import { Tools } from "../../Misc/tools";
 import { Nullable } from "../../types";
-import { EngineStore } from '../../Engines/engineStore';
 
 declare const XRImageTrackingResult: XRImageTrackingResult;
 
@@ -191,8 +190,7 @@ export class WebXRImageTracking extends WebXRAbstractFeature {
                         img.src = image.src;
                         img.onload = () => {
                             img.decode().then(() => {
-                                const engine = EngineStore.LastCreatedEngine;
-                                engine?.createImageBitmap(img).then((imageBitmap) => {
+                                this._xrSessionManager.scene.getEngine().createImageBitmap(img).then((imageBitmap) => {
                                     resolve(imageBitmap);
                                 });
                             });

--- a/src/XR/features/WebXRImageTracking.ts
+++ b/src/XR/features/WebXRImageTracking.ts
@@ -5,6 +5,7 @@ import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import { Matrix } from "../../Maths/math.vector";
 import { Tools } from "../../Misc/tools";
 import { Nullable } from "../../types";
+import { EngineStore } from '../../Engines/engineStore';
 
 declare const XRImageTrackingResult: XRImageTrackingResult;
 
@@ -190,7 +191,8 @@ export class WebXRImageTracking extends WebXRAbstractFeature {
                         img.src = image.src;
                         img.onload = () => {
                             img.decode().then(() => {
-                                createImageBitmap(img).then((imageBitmap) => {
+                                const engine = EngineStore.LastCreatedEngine;
+                                engine?.createImageBitmap(img).then((imageBitmap) => {
                                     resolve(imageBitmap);
                                 });
                             });


### PR DESCRIPTION
Followup for https://forum.babylonjs.com/t/babylon-native-on-ubuntu/15615/21
createImageBitmap is used for `CreateGroundFromHeightMap` . This PR is the JS part. Native part will be done once this is OK.

The goal here is also for me to learn how to properly wrap JS function as the same work will be needed for the Canvas/GUI.