### PR TITLE
Bind frame buffer and clear all rigCameras for XR

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3683,15 +3683,15 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.setTransformMatrix(this.activeCamera.getViewMatrix(), this.activeCamera.getProjectionMatrix(force));
     }
 
-    private _bindFrameBuffer() {
-        if (this.activeCamera && this.activeCamera._multiviewTexture) {
-            this.activeCamera._multiviewTexture._bindFrameBuffer();
-        } else if (this.activeCamera && this.activeCamera.outputRenderTarget) {
-            var useMultiview = this.getEngine().getCaps().multiview && this.activeCamera.outputRenderTarget && this.activeCamera.outputRenderTarget.getViewCount() > 1;
+    private _bindFrameBuffer(camera: Nullable<Camera>) {
+        if (camera && camera._multiviewTexture) {
+            camera._multiviewTexture._bindFrameBuffer();
+        } else if (camera && camera.outputRenderTarget) {
+            var useMultiview = this.getEngine().getCaps().multiview && camera.outputRenderTarget && camera.outputRenderTarget.getViewCount() > 1;
             if (useMultiview) {
-                this.activeCamera.outputRenderTarget._bindFrameBuffer();
+                camera.outputRenderTarget._bindFrameBuffer();
             } else {
-                var internalTexture = this.activeCamera.outputRenderTarget.getInternalTexture();
+                var internalTexture = camera.outputRenderTarget.getInternalTexture();
                 if (internalTexture) {
                     this.getEngine().bindFramebuffer(internalTexture);
                 } else {
@@ -3702,6 +3702,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             this.getEngine().restoreDefaultFramebuffer(); // Restore back buffer if needed
         }
     }
+
     /** @hidden */
     public _allowPostProcessClearColor = true;
     /** @hidden */
@@ -3795,7 +3796,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         // Restore framebuffer after rendering to targets
         if (needRebind && !this.prePass) {
-            this._bindFrameBuffer();
+            this._bindFrameBuffer(this._activeCamera);
         }
 
         this.onAfterRenderTargetsRenderObservable.notifyObservers(this);
@@ -3972,6 +3973,15 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
     }
 
+    private _clear(): void {
+        if (this.autoClearDepthAndStencil || this.autoClear) {
+            this._engine.clear(this.clearColor,
+                this.autoClear || this.forceWireframe || this.forcePointsCloud,
+                this.autoClearDepthAndStencil,
+                this.autoClearDepthAndStencil);
+        }
+    }
+
     /**
      * Render the scene
      * @param updateCameras defines a boolean indicating if cameras must update according to their inputs (true by default)
@@ -4110,8 +4120,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         // Restore back buffer
         this.activeCamera = currentActiveCamera;
+        let frameBufferBound = false;
         if (this._activeCamera && this._activeCamera.cameraRigMode !== Camera.RIG_MODE_CUSTOM && !this.prePass) {
-            this._bindFrameBuffer();
+            this._bindFrameBuffer(this._activeCamera);
+            frameBufferBound = true;
         }
         this.onAfterRenderTargetsRenderObservable.notifyObservers(this);
 
@@ -4120,11 +4132,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         // Clear
-        if (this.autoClearDepthAndStencil || this.autoClear) {
-            this._engine.clear(this.clearColor,
-                this.autoClear || this.forceWireframe || this.forcePointsCloud,
-                this.autoClearDepthAndStencil,
-                this.autoClearDepthAndStencil);
+        if (!frameBufferBound && this.activeCamera && this.activeCamera._rigCameras.length > 0) {
+            for (const rigCamera of this.activeCamera._rigCameras) {
+                this._bindFrameBuffer(rigCamera);
+                this._clear();
+            }
+        } else {
+            this._clear();
         }
 
         // Collects render targets from external components.


### PR DESCRIPTION
This is a patch fix for clearing both eyes when using XR in Babylon Native. The code is currently getting lucky and is clearing whatever is the last bound framebuffer for XR. This happens to work in a browser since the frame buffer of either eye is the same frame buffer. This is not true for Babylon Native and thus it only clears one eye which ever is the last one bound. Ideally, this code needs to be refactored so that it's not full of these specific branches for XR.