### PR TITLE
Creating a touchButton subset for togglable buttons and adding steady-state logic for touch

### DIFF
--- a/gui/src/3D/controls/index.ts
+++ b/gui/src/3D/controls/index.ts
@@ -12,4 +12,5 @@ export * from "./stackPanel3D";
 export * from "./touchButton3D";
 export * from "./touchMeshButton3D";
 export * from "./touchHolographicButton";
+export * from "./touchToggleButton3D";
 export * from "./volumeBasedPanel";

--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -329,6 +329,9 @@ export class TouchButton3D extends Button3D {
                         else if (isLower(this._frontOffset)) {
                             this._updateButtonState(uniqueId, ButtonState.Press, pointOnButton);
                         }
+                        else {
+                            this._updateButtonState(uniqueId, ButtonState.Hover, pointOnButton);
+                        }
 
                         break;
                     case ButtonState.Press:
@@ -337,6 +340,9 @@ export class TouchButton3D extends Button3D {
                         }
                         else if (isLower(this._pushThroughBackOffset)) {
                             this._updateButtonState(uniqueId, ButtonState.None, pointOnButton);
+                        }
+                        else {
+                            this._updateButtonState(uniqueId, ButtonState.Press, pointOnButton);
                         }
 
                         break;

--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -13,7 +13,8 @@ import { Button3D } from "./button3D";
 /**
  * Enum for Button States
  */
-enum ButtonState {
+/** @hidden */
+export enum ButtonState {
     /** None */
     None = 0,
     /** Pointer Entered */
@@ -226,8 +227,6 @@ export class TouchButton3D extends Button3D {
 
     // Updates the stored state of the button, and fire pointer events
     private _updateButtonState(id: number, newState: ButtonState, pointOnButton: Vector3) {
-        const dummyPointerId = 0;
-        const buttonIndex = 0; // Left click
         const buttonStateForId = this._activeInteractions.get(id) || ButtonState.None;
 
         // Take into account all inputs interacting with the button to avoid state flickering
@@ -250,30 +249,37 @@ export class TouchButton3D extends Button3D {
             newPushDepth = Math.max(newPushDepth, value);
         });
 
-        if (newPushDepth == ButtonState.Press) {
-            if (previousPushDepth == ButtonState.Hover) {
+        this._firePointerEvents(newPushDepth, previousPushDepth, pointOnButton);
+    }
+
+    protected _firePointerEvents(newButtonState: ButtonState, previousButtonState: ButtonState, pointOnButton: Vector3) {
+        const dummyPointerId = 0;
+        const buttonIndex = 0; // Left click
+
+        if (newButtonState == ButtonState.Press) {
+            if (previousButtonState == ButtonState.Hover) {
                 this._onPointerDown(this, pointOnButton, dummyPointerId, buttonIndex);
             }
-            else if (previousPushDepth == ButtonState.Press) {
+            else if (previousButtonState == ButtonState.Press) {
                 this._onPointerMove(this, pointOnButton);
             }
         }
-        else if (newPushDepth == ButtonState.Hover) {
-            if (previousPushDepth == ButtonState.None) {
+        else if (newButtonState == ButtonState.Hover) {
+            if (previousButtonState == ButtonState.None) {
                 this._onPointerEnter(this);
             }
-            else if (previousPushDepth == ButtonState.Press) {
+            else if (previousButtonState == ButtonState.Press) {
                 this._onPointerUp(this, pointOnButton, dummyPointerId, buttonIndex, false);
             }
             else {
                 this._onPointerMove(this, pointOnButton);
             }
         }
-        else if (newPushDepth == ButtonState.None) {
-            if (previousPushDepth == ButtonState.Hover) {
+        else if (newButtonState == ButtonState.None) {
+            if (previousButtonState == ButtonState.Hover) {
                 this._onPointerOut(this);
             }
-            else if (previousPushDepth == ButtonState.Press) {
+            else if (previousButtonState == ButtonState.Press) {
                 this._onPointerUp(this, pointOnButton, dummyPointerId, buttonIndex, false);
                 this._onPointerOut(this);
             }

--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -230,9 +230,9 @@ export class TouchButton3D extends Button3D {
         const buttonStateForId = this._activeInteractions.get(id) || ButtonState.None;
 
         // Take into account all inputs interacting with the button to avoid state flickering
-        let previousPushDepth = 0;
+        let previousPushState = 0;
         this._activeInteractions.forEach(function(value, key) {
-            previousPushDepth = Math.max(previousPushDepth, value);
+            previousPushState = Math.max(previousPushState, value);
         });
 
         if (buttonStateForId != newState) {
@@ -244,12 +244,12 @@ export class TouchButton3D extends Button3D {
             }
         }
 
-        let newPushDepth = 0;
+        let newPushState = 0;
         this._activeInteractions.forEach(function(value, key) {
-            newPushDepth = Math.max(newPushDepth, value);
+            newPushState = Math.max(newPushState, value);
         });
 
-        this._firePointerEvents(newPushDepth, previousPushDepth, pointOnButton);
+        this._firePointerEvents(newPushState, previousPushState, pointOnButton);
     }
 
     protected _firePointerEvents(newButtonState: ButtonState, previousButtonState: ButtonState, pointOnButton: Vector3) {

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -1,0 +1,60 @@
+import { Observable } from "babylonjs/Misc/observable";
+import { Vector3WithInfo } from "../vector3WithInfo";
+
+import { TouchButton3D, ButtonState } from "./touchButton3D";
+
+export class TouchToggleButton3D extends TouchButton3D {
+    private _isPressed = false;
+
+    /** Callback used to start toggle on animation */
+    public toggleOnAnimation: () => void;
+    /** Callback used to start toggle off animation */
+    public toggleOffAnimation: () => void;
+
+    /**
+     * An event triggered when the button is toggled on
+     */
+    public onToggleOnObservable = new Observable<Vector3WithInfo>();
+
+    /**
+     * An event triggered when the button is toggled off
+     */
+    public onToggleOffObservable = new Observable<Vector3WithInfo>();
+
+    /**
+     * Creates a new button
+     * @param name defines the control name
+     */
+    constructor(name?: string) {
+        super(name);
+    }
+
+    protected _firePointerEvents(newButtonState: ButtonState, previousButtonState: ButtonState, pointOnButton: Vector3) {
+        super._firePointerEvents(newButtonState, previousButtonState, pointOnButton);
+
+        // Remove the chance for strangeness by firing whenever we transition away from a press
+        if (previousButtonState == ButtonState.Press && newButtonState != ButtonState.Press) {
+            this._onToggle(new Vector3WithInfo(pointOnButton, 0));
+        }
+    }
+
+    private _onToggle(position: Vector3WithInfo) {
+        this._isPressed = !this._isPressed;
+
+        if (this._isPressed) {
+            this.onToggleOnObservable.notifyObservers(position);
+            if (this.toggleOnAnimation) {
+                this.toggleOnAnimation();
+            }
+        }
+        else {
+            this.onToggleOffObservable.notifyObservers(position);
+            if (this.toggleOffAnimation) {
+                this.toggleOffAnimation();
+            }
+        }
+    }
+
+    protected _getTypeName(): string {
+        return "TouchToggleButton3D";
+    }

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -8,6 +8,9 @@ import { Vector3WithInfo } from "../vector3WithInfo";
 
 import { TouchButton3D, ButtonState } from "./touchButton3D";
 
+/**
+ * Class used as base class for touch-enabled toggleable buttons
+ */
 export class TouchToggleButton3D extends TouchButton3D {
     private _isPressed = false;
 

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -4,7 +4,6 @@ import { Observable } from "babylonjs/Misc/observable";
 import { Scene } from "babylonjs/scene";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Vector3 } from "babylonjs/Maths/math.vector";
-import { Vector3WithInfo } from "../vector3WithInfo";
 
 import { TouchButton3D, ButtonState } from "./touchButton3D";
 
@@ -22,12 +21,12 @@ export class TouchToggleButton3D extends TouchButton3D {
     /**
      * An event triggered when the button is toggled on
      */
-    public onToggleOnObservable = new Observable<Vector3WithInfo>();
+    public onToggleOnObservable = new Observable<Vector3>();
 
     /**
      * An event triggered when the button is toggled off
      */
-    public onToggleOffObservable = new Observable<Vector3WithInfo>();
+    public onToggleOffObservable = new Observable<Vector3>();
 
     /**
      * Creates a new button
@@ -43,11 +42,11 @@ export class TouchToggleButton3D extends TouchButton3D {
 
         // Remove the chance for strangeness by firing whenever we transition away from a press
         if (previousButtonState == ButtonState.Press && newButtonState != ButtonState.Press) {
-            this._onToggle(new Vector3WithInfo(pointOnButton, 0));
+            this._onToggle(pointOnButton);
         }
     }
 
-    private _onToggle(position: Vector3WithInfo) {
+    private _onToggle(position: Vector3) {
         this._isPressed = !this._isPressed;
 
         if (this._isPressed) {
@@ -75,5 +74,15 @@ export class TouchToggleButton3D extends TouchButton3D {
 
     protected _affectMaterial(mesh: AbstractMesh) {
         super._affectMaterial(mesh);
+    }
+
+    /**
+     * Releases all associated resources
+     */
+    public dispose() {
+        this.onToggleOnObservable.clear();
+        this.onToggleOffObservable.clear();
+
+        super.dispose();
     }
 }

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -1,4 +1,8 @@
+import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
+import { Mesh } from "babylonjs/Meshes/mesh";
 import { Observable } from "babylonjs/Misc/observable";
+import { Scene } from "babylonjs/scene";
+import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Vector3 } from "babylonjs/Maths/math.vector";
 import { Vector3WithInfo } from "../vector3WithInfo";
 
@@ -25,9 +29,10 @@ export class TouchToggleButton3D extends TouchButton3D {
     /**
      * Creates a new button
      * @param name defines the control name
+     * @param collisionMesh defines the mesh to track near interactions with
      */
-    constructor(name?: string) {
-        super(name);
+    constructor(name?: string, collisionMesh?: Mesh) {
+        super(name, collisionMesh);
     }
 
     protected _firePointerEvents(newButtonState: ButtonState, previousButtonState: ButtonState, pointOnButton: Vector3) {
@@ -58,5 +63,14 @@ export class TouchToggleButton3D extends TouchButton3D {
 
     protected _getTypeName(): string {
         return "TouchToggleButton3D";
+    }
+
+    // Mesh association
+    protected _createNode(scene: Scene): TransformNode {
+        return super._createNode(scene);
+    }
+
+    protected _affectMaterial(mesh: AbstractMesh) {
+        super._affectMaterial(mesh);
     }
 }

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -5,18 +5,13 @@ import { Scene } from "babylonjs/scene";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Vector3 } from "babylonjs/Maths/math.vector";
 
-import { TouchButton3D, ButtonState } from "./touchButton3D";
+import { TouchButton3D } from "./touchButton3D";
 
 /**
  * Class used as base class for touch-enabled toggleable buttons
  */
 export class TouchToggleButton3D extends TouchButton3D {
     private _isPressed = false;
-
-    /** Callback used to start toggle on animation */
-    public toggleOnAnimation: () => void;
-    /** Callback used to start toggle off animation */
-    public toggleOffAnimation: () => void;
 
     /**
      * An event triggered when the button is toggled on
@@ -35,15 +30,9 @@ export class TouchToggleButton3D extends TouchButton3D {
      */
     constructor(name?: string, collisionMesh?: Mesh) {
         super(name, collisionMesh);
-    }
-
-    protected _firePointerEvents(newButtonState: ButtonState, previousButtonState: ButtonState, pointOnButton: Vector3) {
-        super._firePointerEvents(newButtonState, previousButtonState, pointOnButton);
-
-        // Remove the chance for strangeness by firing whenever we transition away from a press
-        if (previousButtonState == ButtonState.Press && newButtonState != ButtonState.Press) {
-            this._onToggle(pointOnButton);
-        }
+        this.onPointerUpObservable.add((posVecWithInfo) => {
+            this._onToggle(posVecWithInfo);
+        });
     }
 
     private _onToggle(position: Vector3) {
@@ -51,15 +40,9 @@ export class TouchToggleButton3D extends TouchButton3D {
 
         if (this._isPressed) {
             this.onToggleOnObservable.notifyObservers(position);
-            if (this.toggleOnAnimation) {
-                this.toggleOnAnimation();
-            }
         }
         else {
             this.onToggleOffObservable.notifyObservers(position);
-            if (this.toggleOffAnimation) {
-                this.toggleOffAnimation();
-            }
         }
     }
 

--- a/gui/src/3D/controls/touchToggleButton3D.ts
+++ b/gui/src/3D/controls/touchToggleButton3D.ts
@@ -1,4 +1,5 @@
 import { Observable } from "babylonjs/Misc/observable";
+import { Vector3 } from "babylonjs/Maths/math.vector";
 import { Vector3WithInfo } from "../vector3WithInfo";
 
 import { TouchButton3D, ButtonState } from "./touchButton3D";
@@ -58,3 +59,4 @@ export class TouchToggleButton3D extends TouchButton3D {
     protected _getTypeName(): string {
         return "TouchToggleButton3D";
     }
+}


### PR DESCRIPTION
This change adds a new class intended to make toggle-state buttons easier to manage (when implemented).
This change also adds steady-state logic to the touch button, so we get updated positions for touch interactions every update, rather than once on each state change.