### PR TITLE
Fix CubeTexture extension detection when rootUrl has a query string

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -104,6 +104,7 @@
 
 ## Bugs
 
+- Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))
 - Fix ArcRotateCamera panning with axis decomposition ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fix an issue with keyboard control (re)attachment. ([#9411](https://github.com/BabylonJS/Babylon.js/issues/9411)) ([RaananW](https://github.com/RaananW))

--- a/src/Materials/Textures/cubeTexture.ts
+++ b/src/Materials/Textures/cubeTexture.ts
@@ -191,8 +191,8 @@ export class CubeTexture extends BaseTexture {
 
         const lastDot = rootUrl.lastIndexOf(".");
         const extension = forcedExtension ? forcedExtension : (lastDot > -1 ? rootUrl.substring(lastDot).toLowerCase() : "");
-        const isDDS = (extension === ".dds");
-        const isEnv = (extension === ".env");
+        const isDDS = (extension.indexOf(".dds") === 0);
+        const isEnv = (extension.indexOf(".env") === 0);
 
         if (isEnv) {
             this.gammaSpace = false;


### PR DESCRIPTION
When a CubeTexture is created with a rootUrl containing a query string, it is considered as part of the extension. 
In this way all urls with query string are interpreted as folder path, searching for the 6 images with the default suffix (_px.jpg, _py.jpg, etc.) even if .env or .dds files path are given.