### PR TITLE
Custom shader material for line mesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -2,168 +2,169 @@
 
 ## Major updates
 
-- Infinite Morph Targets: When supported (WebGL2+) you are no more limited to 4 morph targets per mesh ([Deltakosh](https://github.com/deltakosh))
+-   Infinite Morph Targets: When supported (WebGL2+) you are no more limited to 4 morph targets per mesh ([Deltakosh](https://github.com/deltakosh))
 
 ## Updates
 
 ### General
 
-- Added static CenterToRef for vectors 2/3/4  ([aWeirdo](https://github.com/aWeirdo))
-- Added ability to view images (ktx2, png, jpg) to the sandbox. ([bghgary](https://github.com/bghgary))
-- Added optional smoothed normals for extruded procedural polygons. ([snagy](https://github.com/snagy))
-- Added support for infinite perspective cameras ([Deltakosh](https://github.com/deltakosh))
-- Added ability to enable/disable ArcRotateCamera zoom on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
-- Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
-- Added `collisionRetryCount` to improved collision detection ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Moved sharedUI component to shared UI folder. ([msDestiny14](https://github.com/msDestiny14))
-- Added encapsulate and encapsulateBoundingInfo methods to BoundingInfo. ([Tolo789](https://github.com/Tolo789))
-- Added onLoadObservable to the textureDome class(es) ([RaananW](https://github.com/RaananW))
-- Modified InputManager to use DeviceInputSystem ([PolygonalSun](https://github.com/PolygonalSun))
-- Added a [helper class](https://doc.babylonjs.com/typedoc/classes/babylon.debug.directionallightfrustumviewer) to display the frustum of a directional light ([Popov72](https://github.com/Popov72))
-- Improved collision detection performance ([ottoville](https://github.com/ottoville/))
-- Added new helper functions for Quaternion.FromLookDirection and Matrix.LookDirection ([Alex-MSFT](https://github.com/Alex-MSFT))
+-   Added static CenterToRef for vectors 2/3/4 ([aWeirdo](https://github.com/aWeirdo))
+-   Added ability to view images (ktx2, png, jpg) to the sandbox. ([bghgary](https://github.com/bghgary))
+-   Added optional smoothed normals for extruded procedural polygons. ([snagy](https://github.com/snagy))
+-   Added support for infinite perspective cameras ([Deltakosh](https://github.com/deltakosh))
+-   Added ability to enable/disable ArcRotateCamera zoom on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
+-   Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
+-   Added `collisionRetryCount` to improved collision detection ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Moved sharedUI component to shared UI folder. ([msDestiny14](https://github.com/msDestiny14))
+-   Added encapsulate and encapsulateBoundingInfo methods to BoundingInfo. ([Tolo789](https://github.com/Tolo789))
+-   Added onLoadObservable to the textureDome class(es) ([RaananW](https://github.com/RaananW))
+-   Modified InputManager to use DeviceInputSystem ([PolygonalSun](https://github.com/PolygonalSun))
+-   Added a [helper class](https://doc.babylonjs.com/typedoc/classes/babylon.debug.directionallightfrustumviewer) to display the frustum of a directional light ([Popov72](https://github.com/Popov72))
+-   Improved collision detection performance ([ottoville](https://github.com/ottoville/))
+-   Added new helper functions for Quaternion.FromLookDirection and Matrix.LookDirection ([Alex-MSFT](https://github.com/Alex-MSFT))
 
 ### Engine
 
-- Moved all instance data from Geometry to Mesh such that the same Geometry objects can be used by many meshes with instancing. Reduces memory consumption on CPU/GPU. ([breakin](https://github.com/breakin)
-- Added NativeEngine configuration object parameter. ([drigax](https://github.com/drigax))
+-   Moved all instance data from Geometry to Mesh such that the same Geometry objects can be used by many meshes with instancing. Reduces memory consumption on CPU/GPU. ([breakin](https://github.com/breakin)
+-   Added NativeEngine configuration object parameter. ([drigax](https://github.com/drigax))
 
 ### Loaders
 
-- Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))
-- Increased KHR_materials_transmission render target texture default size. ([Drigax](https://github.com/drigax))
-- Changed glTF loader to remove empty animation groups if there are no animation channels loaded with the given options. ([bghgary](https://github.com/bghgary))
-- Update glTF validator to `2.0.0-dev.3.3`. ([bghgary](https://github.com/bghgary))
-- Added support for KHR_xmp_json_ld for glTF loader. ([Sebavan](https://github.com/sebavan/), [bghgary](https://github.com/bghgary))
-- Added a `OptimizeNormals` option to the OBJ loader to smooth lighting ([Popov72](https://github.com/Popov72))
-- Added a `Prefiltered` option to the CubeTextureAssetTask ([MackeyK24](https://github.com/MackeyK24))
+-   Added support for EXT_meshopt_compression for glTF loader. ([zeux](https://github.com/zeux))
+-   Increased KHR_materials_transmission render target texture default size. ([Drigax](https://github.com/drigax))
+-   Changed glTF loader to remove empty animation groups if there are no animation channels loaded with the given options. ([bghgary](https://github.com/bghgary))
+-   Update glTF validator to `2.0.0-dev.3.3`. ([bghgary](https://github.com/bghgary))
+-   Added support for KHR_xmp_json_ld for glTF loader. ([Sebavan](https://github.com/sebavan/), [bghgary](https://github.com/bghgary))
+-   Added a `OptimizeNormals` option to the OBJ loader to smooth lighting ([Popov72](https://github.com/Popov72))
+-   Added a `Prefiltered` option to the CubeTextureAssetTask ([MackeyK24](https://github.com/MackeyK24))
 
 ### Navigation
 
-- Added support for thin instances in navigation mesh creation ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Added recast.d.ts definition file for recast.js ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Added obstacle support ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Added support for thin instances in navigation mesh creation ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Added recast.d.ts definition file for recast.js ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Added obstacle support ([CedricGuillemet](https://github.com/CedricGuillemet))
 
 ### Materials
 
-- Added an `OcclusionMaterial` to simplify depth-only rendering of geometry ([rgerd](https://github.com/rgerd))
-- PrePass can now be used in `RenderTargets` speeding up effects like SSAO2 or MotionBlur ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Added support for morph targets to `ShaderMaterial` ([Popov72](https://github.com/Popov72))
+-   Added an `OcclusionMaterial` to simplify depth-only rendering of geometry ([rgerd](https://github.com/rgerd))
+-   PrePass can now be used in `RenderTargets` speeding up effects like SSAO2 or MotionBlur ([CraigFeldspar](https://github.com/CraigFeldspar))
+-   Added support for morph targets to `ShaderMaterial` ([Popov72](https://github.com/Popov72))
+
+### Meshes
+
+-   `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger]
 
 ### Inspector
 
-- Increased float precision to 4 ([msDestiny14](https://github.com/msDestiny14))
-- Added support for sounds in the inspector ([Deltakosh](https://github.com/deltakosh))
-- Added a debug option to show the frustum of a directional light ([Popov72](https://github.com/Popov72))
+-   Increased float precision to 4 ([msDestiny14](https://github.com/msDestiny14))
+-   Added support for sounds in the inspector ([Deltakosh](https://github.com/deltakosh))
+-   Added a debug option to show the frustum of a directional light ([Popov72](https://github.com/Popov72))
 
 ### NME
 
-- Increased float precision to 4([msDestiny14](https://github.com/msDestiny14))
-- Added ability to make input node's properties visible in the properties of a custom frame ([msDestiny14](https://github.com/msDestiny14))
+-   Increased float precision to 4([msDestiny14](https://github.com/msDestiny14))
+-   Added ability to make input node's properties visible in the properties of a custom frame ([msDestiny14](https://github.com/msDestiny14))
 
 ### GUIEditor
 
-- Added GUI Editor project to master. ([msDestiny14](https://github.com/msDestiny14))
-- Moving GUI property tab components into GUIEditor. ([msDestiny14](https://github.com/msDestiny14))
-- Added basic saving and loading funtionality. ([msDestiny14](https://github.com/msDestiny14))
-- Added more GUI controls. ([msDestiny14](https://github.com/msDestiny14))
-- Added snippet server from url functionality ([msDestiny14](https://github.com/msDestiny14))
-- Added scrolling and zooming functionality ([msDestiny14](https://github.com/msDestiny14))
-- Added resizable canvas ([msDestiny14](https://github.com/msDestiny14))
-- Added parenting system ([msDestiny14](https://github.com/msDestiny14))
-- Added ability to change zorder ([msDestiny14](https://github.com/msDestiny14))
+-   Added GUI Editor project to master. ([msDestiny14](https://github.com/msDestiny14))
+-   Moving GUI property tab components into GUIEditor. ([msDestiny14](https://github.com/msDestiny14))
+-   Added basic saving and loading funtionality. ([msDestiny14](https://github.com/msDestiny14))
+-   Added more GUI controls. ([msDestiny14](https://github.com/msDestiny14))
+-   Added snippet server from url functionality ([msDestiny14](https://github.com/msDestiny14))
+-   Added scrolling and zooming functionality ([msDestiny14](https://github.com/msDestiny14))
+-   Added resizable canvas ([msDestiny14](https://github.com/msDestiny14))
+-   Added parenting system ([msDestiny14](https://github.com/msDestiny14))
+-   Added ability to change zorder ([msDestiny14](https://github.com/msDestiny14))
 
 ### GUI
 
-- Added a `FocusableButton` gui control to simplify creating menus with keyboard navigation ([Flux159](https://github.com/Flux159))
-- Added `focus()` and `blur()` functions for controls that implement `IFocusableControl` ([Flux159](https://github.com/Flux159))
-- Added `ToggleButton` GUI control ([kintz09](https://github.com/kintz09))
-- Added shorthand methods which set all padding values at once, named `setPadding` and `setPaddingInPixels`, to the control class  ([kintz09](https://github.com/kintz09))
-- Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
-- Added `imageWidth()` and `imageHeight()` to access the source image dimensions of `Image` ([Queatz](https://github.com/Queatz))
-- Added a `FluentButtonMaterial` to give the `TouchHolographicButton` the same look and feel as the HoloLens 2 shell ([rgerd](https://github.com/rgerd))
+-   Added a `FocusableButton` gui control to simplify creating menus with keyboard navigation ([Flux159](https://github.com/Flux159))
+-   Added `focus()` and `blur()` functions for controls that implement `IFocusableControl` ([Flux159](https://github.com/Flux159))
+-   Added `ToggleButton` GUI control ([kintz09](https://github.com/kintz09))
+-   Added shorthand methods which set all padding values at once, named `setPadding` and `setPaddingInPixels`, to the control class ([kintz09](https://github.com/kintz09))
+-   Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
+-   Added `imageWidth()` and `imageHeight()` to access the source image dimensions of `Image` ([Queatz](https://github.com/Queatz))
+-   Added a `FluentButtonMaterial` to give the `TouchHolographicButton` the same look and feel as the HoloLens 2 shell ([rgerd](https://github.com/rgerd))
 
 ### WebXR
 
-- A browser error preventing the emulator to render scene is now correctly dealt with ([RaananW](https://github.com/RaananW))
-- Added a way to extend the XRSessionInit Object from inside of a feature ([RaananW](https://github.com/RaananW))
-- Added image tracking feature ([RaananW](https://github.com/RaananW))
-- Pointer Events of WebXR controllers have pointerType `xr` ([RaananW](https://github.com/RaananW))
-- better support for custom hand meshes ([RaananW](https://github.com/RaananW))
-- Allow disabling of the WebXRControllerPointerSelection feature as part of the WebXR Default Experience ([rgerd](https://github.com/rgerd))
-- Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
-- Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
-- Remove the warning for input source not found when in (touch)screen mode ([#9938](https://github.com/BabylonJS/Babylon.js/issues/9938)) ([RaananW](https://github.com/RaananW))
-- Fixed an issue with resources disposal when exiting XR ([#10012](https://github.com/BabylonJS/Babylon.js/issues/10012)) ([RaananW](https://github.com/RaananW))
+-   A browser error preventing the emulator to render scene is now correctly dealt with ([RaananW](https://github.com/RaananW))
+-   Added a way to extend the XRSessionInit Object from inside of a feature ([RaananW](https://github.com/RaananW))
+-   Added image tracking feature ([RaananW](https://github.com/RaananW))
+-   Pointer Events of WebXR controllers have pointerType `xr` ([RaananW](https://github.com/RaananW))
+-   better support for custom hand meshes ([RaananW](https://github.com/RaananW))
+-   Allow disabling of the WebXRControllerPointerSelection feature as part of the WebXR Default Experience ([rgerd](https://github.com/rgerd))
+-   Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
+-   Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
+-   Remove the warning for input source not found when in (touch)screen mode ([#9938](https://github.com/BabylonJS/Babylon.js/issues/9938)) ([RaananW](https://github.com/RaananW))
+-   Fixed an issue with resources disposal when exiting XR ([#10012](https://github.com/BabylonJS/Babylon.js/issues/10012)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 
-- Exposed `scaleDragSpeed` and added `axisFactor` for BoundingBoxGizmo ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Exposed `scaleDragSpeed` and added `axisFactor` for BoundingBoxGizmo ([CedricGuillemet](https://github.com/CedricGuillemet))
 
-- Provide additional attributes `_customRotationQuaternion` to customize the posture of the gizmo ([ecojust](https://github.com/ecojust))
-
+-   Provide additional attributes `_customRotationQuaternion` to customize the posture of the gizmo ([ecojust](https://github.com/ecojust))
 
 ### Viewer
 
-- Fixed an issue with dual callback binding in case of a forced redraw ([#9608](https://github.com/BabylonJS/Babylon.js/issues/9608)) ([RaananW](https://github.com/RaananW))
+-   Fixed an issue with dual callback binding in case of a forced redraw ([#9608](https://github.com/BabylonJS/Babylon.js/issues/9608)) ([RaananW](https://github.com/RaananW))
 
 ### Math
 
-- Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
+-   Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
 
 ## Bugs
 
-- Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
-- Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))
-- Fix ArcRotateCamera panning with axis decomposition ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix an issue with keyboard control (re)attachment. ([#9411](https://github.com/BabylonJS/Babylon.js/issues/9411)) ([RaananW](https://github.com/RaananW))
-- Fix issue where PBRSpecularGlossiness materials were excluded from export [#9423](https://github.com/BabylonJS/Babylon.js/issues/9423)([Drigax](https://github.com/drigax))
-- Fix issue when scaling is reapplied with BoundingBoxGizmo and GizmoManager ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix direct loading of a glTF string that has base64-encoded URI. ([bghgary](https://github.com/bghgary))
-- Fix capsule impostor size computation for ammojs ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix crash of some node materials using instances on iOS ([Popov72](https://github.com/Popov72))
-- Fix the code generated for the NME gradient block ([Popov72](https://github.com/Popov72))
-- Fix ssao2RenderingPipeline for orthographic cameras ([Kesshi](https://github.com/Kesshi))
-- Fix mipmaps creation in the KTX2 decoder for non square textures ([Popov72](https://github.com/Popov72))
-- Fix detail map not working in WebGL1 ([Popov72](https://github.com/Popov72))
-- Fix ArcRotateCamera behaviour when panning is disabled on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
-- Fix vertically interlaced stereoscopic rendering (`RIG_MODE_STEREOSCOPIC_INTERLACED`) not working (follow-up [#7425](https://github.com/BabylonJS/Babylon.js/issues/7425), [#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([foxxyz](https://github.com/foxxyz))
-- Fix accessibility of BaseCameraMouseWheelInput and BaseCameraPointersInput. They appear in documentation but were not available for include. ([mrdunk](https://github.com/mrdunk))
-- Fix function creation inside regularly called freeCameraMouseWheelInput method leading to excessive GC load. ([mrdunk](https://github.com/mrdunk))
-- Fix clip plane not reset to the rigth value when using mirrors ([Popov72](https://github.com/Popov72))
-- Fix lens flares not working in right handed system ([Popov72](https://github.com/Popov72))
-- Fix canvas not resized correctly in a multi-canvas scenario ([Popov72](https://github.com/Popov72))
-- Fix NaN values returned by `GetAngleBetweenVectors` when vectors are the same or directly opposite ([Popov72](https://github.com/Popov72))
-- Fix 404 occurring on some pictures in some cases when using particle systems ([Popov72](https://github.com/Popov72))
-- Fix PrePass bugs with transparency ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Fix PrePass bugs with layers ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Fix SSAO2 with PrePass sometimes causing colors brighter than they should be ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Fix PostProcess sharing between cameras/renderTargets, that would create/destroy a texture on every frame ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Fix for DualSense gamepads being incorrectly read as DualShock gamepads ([PolygonalSun](https://github.com/PolygonalSun))
-- Fix for warning in chrome about passive wheel events ([#9777](https://github.com/BabylonJS/Babylon.js/pull/9777)) ([kaliatech](https://github.com/kaliatech))
-- Fix crash when cloning material in `AssetContainer.instantiateModelsToScene` when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
-- Fix Normalized quaternion when updating the node components ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix Mesh impostor not taking LH/RH into account ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix update absolute position before use in PointerDragBehavior ([CedricGuillemet](https://github.com/CedricGuillemet))
-- Fix issue with NinePatch displaying half pixel gaps between slices on Firefox browsers. ([Pryme8](https://github.com/Pryme8))
-- Fix issue when canvas loses focus while holding a pointer button ([PolygonalSun](https://github.com/PolygonalSun))
-- Fix issue where camera controls stay detached if PointerDragBehavior is disabled prematurely ([PolygonalSun](https://github.com/PolygonalSun))
-- Fix uncatchable exception that could be thrown when initializing the environment textures ([CoPrez](https://github.com/CoPrez))
-- Fix the triplanar material when the position of the mesh it is applied to is not (0,0,0) ([Popov72](https://github.com/Popov72))
-- Fix bones serialization to include their ids. This allows to retrieve bones (animation groups, etc.) once the scene has been re-serialized ([julien-moreau](https://github.com/julien-moreau))
-- Fix an issue with hand-detachment when using hand tracking in WebXR ([#9882](https://github.com/BabylonJS/Babylon.js/issues/9882)) ([RaananW](https://github.com/RaananW))
-- Fix issue with cursor and 'doNotHandleCursors' on GUI ([msDestiny14](https://github.com/msDestiny14))
-- Fix issue with multi-views when using a transparent scene clear color ([Popov72](https://github.com/Popov72))
-- Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
-- Fix issue with WebXR teleportation logic which would cause positional headlocking on teleporation frames ([syntheticmagus](https://github.com/syntheticmagus))
+-   Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
+-   Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))
+-   Fix ArcRotateCamera panning with axis decomposition ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Fix an issue with keyboard control (re)attachment. ([#9411](https://github.com/BabylonJS/Babylon.js/issues/9411)) ([RaananW](https://github.com/RaananW))
+-   Fix issue when scaling is reapplied with BoundingBoxGizmo and GizmoManager ([CedricGuillemet](https://github.com/CedricGuillemet)
+-   Fix direct loading of a glTF string that has base64-encoded URI. ([bghgary](https://github.com/bghgary)
+-   Fix capsule impostor size computation for ammojs ([CedricGuillemet](https://github.com/CedricGuillemet)
+-   Fix crash of some node materials using instances on iOS ([Popov72](https://github.com/Popov72))
+-   Fix the code generated for the NME gradient block ([Popov72](https://github.com/Popov72))
+-   Fix ssao2RenderingPipeline for orthographic cameras ([Kesshi](https://github.com/Kesshi))
+-   Fix mipmaps creation in the KTX2 decoder for non square textures ([Popov72](https://github.com/Popov72))
+-   Fix detail map not working in WebGL1 ([Popov72](https://github.com/Popov72))
+-   Fix ArcRotateCamera behaviour when panning is disabled on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
+-   Fix vertically interlaced stereoscopic rendering (`RIG_MODE_STEREOSCOPIC_INTERLACED`) not working (follow-up [#7425](https://github.com/BabylonJS/Babylon.js/issues/7425), [#8000](https://github.com/BabylonJS/Babylon.js/issues/8000)) ([foxxyz](https://github.com/foxxyz))
+-   Fix accessibility of BaseCameraMouseWheelInput and BaseCameraPointersInput. They appear in documentation but were not available for include. ([mrdunk](https://github.com/mrdunk))
+-   Fix function creation inside regularly called freeCameraMouseWheelInput method leading to excessive GC load. ([mrdunk](https://github.com/mrdunk))
+-   Fix clip plane not reset to the rigth value when using mirrors ([Popov72](https://github.com/Popov72))
+-   Fix lens flares not working in right handed system ([Popov72](https://github.com/Popov72))
+-   Fix canvas not resized correctly in a multi-canvas scenario ([Popov72](https://github.com/Popov72))
+-   Fix NaN values returned by `GetAngleBetweenVectors` when vectors are the same or directly opposite ([Popov72](https://github.com/Popov72))
+-   Fix 404 occurring on some pictures in some cases when using particle systems ([Popov72](https://github.com/Popov72))
+-   Fix PrePass bugs with transparency ([CraigFeldspar](https://github.com/CraigFeldspar))
+-   Fix PrePass bugs with layers ([CraigFeldspar](https://github.com/CraigFeldspar))
+-   Fix SSAO2 with PrePass sometimes causing colors brighter than they should be ([CraigFeldspar](https://github.com/CraigFeldspar))
+-   Fix PostProcess sharing between cameras/renderTargets, that would create/destroy a texture on every frame ([CraigFeldspar](https://github.com/CraigFeldspar))
+-   Fix for DualSense gamepads being incorrectly read as DualShock gamepads ([PolygonalSun](https://github.com/PolygonalSun))
+-   Fix for warning in chrome about passive wheel events ([#9777](https://github.com/BabylonJS/Babylon.js/pull/9777)) ([kaliatech](https://github.com/kaliatech))
+-   Fix crash when cloning material in `AssetContainer.instantiateModelsToScene` when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
+-   Fix Normalized quaternion when updating the node components ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Fix update absolute position before use in PointerDragBehavior ([CedricGuillemet](https://github.com/CedricGuillemet))
+-   Fix issue with NinePatch displaying half pixel gaps between slices on Firefox browsers. ([Pryme8](https://github.com/Pryme8))
+-   Fix issue when canvas loses focus while holding a pointer button ([PolygonalSun](https://github.com/PolygonalSun))
+-   Fix issue where camera controls stay detached if PointerDragBehavior is disabled prematurely ([PolygonalSun](https://github.com/PolygonalSun))
+-   Fix uncatchable exception that could be thrown when initializing the environment textures ([CoPrez](https://github.com/CoPrez))
+-   Fix the triplanar material when the position of the mesh it is applied to is not (0,0,0) ([Popov72](https://github.com/Popov72))
+-   Fix bones serialization to include their ids. This allows to retrieve bones (animation groups, etc.) once the scene has been re-serialized ([julien-moreau](https://github.com/julien-moreau))
+-   Fix an issue with hand-detachment when using hand tracking in WebXR ([#9882](https://github.com/BabylonJS/Babylon.js/issues/9882)) ([RaananW](https://github.com/RaananW))
+-   Fix issue with cursor and 'doNotHandleCursors' on GUI ([msDestiny14](https://github.com/msDestiny14))
+-   Fix issue with multi-views when using a transparent scene clear color ([Popov72](https://github.com/Popov72))
+-   Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
+-   Fix issue with WebXR teleportation logic which would cause positional headlocking on teleporation frames ([syntheticmagus](https://github.com/syntheticmagus))
 
 ## Breaking changes
 
-- [List of breaking changes introduced by our compatibility with WebGPU](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges)
-  - [ReadPixels and ProceduralTexture.getContent are now async](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#readpixels-is-now-asynchronous)
-  - [Shader support differences](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#shader-code-differences)
-- Use both `mesh.visibility` and `material.alpha` values to compute the global alpha value used by the soft transparent shadow rendering code. Formerly was only using `mesh.visibility` ([Popov72](https://github.com/Popov72))
-- Depth renderer: don't render mesh if `infiniteDistance = true` or if `material.disableDepthWrite = true` ([Popov72](https://github.com/Popov72))
-- Mesh.createInstance no longer make a unique Geometry for the Mesh so updating one Geometry can affect more meshes than before. Use Mesh.makeUniqueGeometry for old behaviour. ([breakin](https://github.com/breakin))
-- Ammo.js needs to be initialized before creating the plugin with `await Ammo();` since Ammo introduced an async init in their library. ([sebavan](https://github.com/sebavan))
-- Fixed spelling of EventState.initialize() ([seritools](https://github.com/seritools))
+-   [List of breaking changes introduced by our compatibility with WebGPU](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges)
+    -   [ReadPixels and ProceduralTexture.getContent are now async](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#readpixels-is-now-asynchronous)
+    -   [Shader support differences](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#shader-code-differences)
+-   Use both `mesh.visibility` and `material.alpha` values to compute the global alpha value used by the soft transparent shadow rendering code. Formerly was only using `mesh.visibility` ([Popov72](https://github.com/Popov72))
+-   Depth renderer: don't render mesh if `infiniteDistance = true` or if `material.disableDepthWrite = true` ([Popov72](https://github.com/Popov72))
+-   Mesh.createInstance no longer make a unique Geometry for the Mesh so updating one Geometry can affect more meshes than before. Use Mesh.makeUniqueGeometry for old behaviour. ([breakin](https://github.com/breakin))
+-   Ammo.js needs to be initialized before creating the plugin with `await Ammo();` since Ammo introduced an async init in their library. ([sebavan](https://github.com/sebavan))
+-   Fixed spelling of EventState.initialize() ([seritools](https://github.com/seritools))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -52,7 +52,7 @@
 
 ### Meshes
 
--   `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger]
+-   `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger](https://github.com/FullStackForger)
 
 ### Inspector
 

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -112,7 +112,7 @@ export class LinesMesh extends Mesh {
 
     private _addClipPlaneDefine(label: string) {
         if (!this._isShaderMaterial(this._lineMaterial)) {
-            return
+            return;
         }
 
         const define = "#define " + label;

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -27,6 +27,7 @@ export class LinesMesh extends Mesh {
      * Color of the line (Default: White)
      */
     public color = new Color3(1, 1, 1);
+
     /**
      * Alpha of the line (Default: 1)
      */
@@ -113,9 +114,9 @@ export class LinesMesh extends Mesh {
         if (!this._isShaderMaterial(this._lineMaterial)) {
             return
         }
-        const define = "#define " + label;
 
-        let index = this._lineMaterial.options.defines.indexOf(define);
+        const define = "#define " + label;
+        const index = this._lineMaterial.options.defines.indexOf(define);
         if (index !== -1) {
             return;
         }
@@ -129,8 +130,7 @@ export class LinesMesh extends Mesh {
         }
 
         const define = "#define " + label;
-        let index = this._lineMaterial.options.defines.indexOf(define);
-
+        const index = this._lineMaterial.options.defines.indexOf(define);
         if (index === -1) {
             return;
         }

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -142,7 +142,7 @@ export class LinesMesh extends Mesh {
         const scene = this.getScene();
 
         // Clip planes
-        if (!this._isShaderMaterial(this._lineMaterial)) {
+        if (this._isShaderMaterial(this._lineMaterial)) {
             scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
             scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
             scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -39,7 +39,11 @@ export class LinesMesh extends Mesh {
      */
     public intersectionThreshold: number;
 
-    private _colorShader: ShaderMaterial;
+    private _lineMaterial: Material;
+
+    private _isShaderMaterial(shader: Material): shader is ShaderMaterial {
+        return shader.getClassName() === "ShaderMaterial";
+    }
 
     private color4: Color4;
 
@@ -102,43 +106,52 @@ export class LinesMesh extends Mesh {
             options.attributes.push(VertexBuffer.ColorKind);
         }
 
-        this._colorShader = new ShaderMaterial("colorShader", this.getScene(), "color", options);
+        this._lineMaterial = new ShaderMaterial("colorShader", this.getScene(), "color", options);
     }
 
     private _addClipPlaneDefine(label: string) {
+        if (!this._isShaderMaterial(this._lineMaterial)) {
+            return
+        }
         const define = "#define " + label;
-        let index = this._colorShader.options.defines.indexOf(define);
 
+        let index = this._lineMaterial.options.defines.indexOf(define);
         if (index !== -1) {
             return;
         }
 
-        this._colorShader.options.defines.push(define);
+        this._lineMaterial.options.defines.push(define);
     }
 
     private _removeClipPlaneDefine(label: string) {
+        if (!this._isShaderMaterial(this._lineMaterial)) {
+            return
+        }
+
         const define = "#define " + label;
-        let index = this._colorShader.options.defines.indexOf(define);
+        let index = this._lineMaterial.options.defines.indexOf(define);
 
         if (index === -1) {
             return;
         }
 
-        this._colorShader.options.defines.splice(index, 1);
+        this._lineMaterial.options.defines.splice(index, 1);
     }
 
     public isReady() {
         const scene = this.getScene();
 
         // Clip planes
-        scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
-        scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
-        scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");
-        scene.clipPlane4 ? this._addClipPlaneDefine("CLIPPLANE4") : this._removeClipPlaneDefine("CLIPPLANE4");
-        scene.clipPlane5 ? this._addClipPlaneDefine("CLIPPLANE5") : this._removeClipPlaneDefine("CLIPPLANE5");
-        scene.clipPlane6 ? this._addClipPlaneDefine("CLIPPLANE6") : this._removeClipPlaneDefine("CLIPPLANE6");
+        if (!this._isShaderMaterial(this._lineMaterial)) {
+            scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
+            scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
+            scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");
+            scene.clipPlane4 ? this._addClipPlaneDefine("CLIPPLANE4") : this._removeClipPlaneDefine("CLIPPLANE4");
+            scene.clipPlane5 ? this._addClipPlaneDefine("CLIPPLANE5") : this._removeClipPlaneDefine("CLIPPLANE5");
+            scene.clipPlane6 ? this._addClipPlaneDefine("CLIPPLANE6") : this._removeClipPlaneDefine("CLIPPLANE6");
+        }
 
-        if (!this._colorShader.isReady(this)) {
+        if (!this._lineMaterial.isReady(this)) {
             return false;
         }
 
@@ -156,14 +169,14 @@ export class LinesMesh extends Mesh {
      * @hidden
      */
     public get material(): Material {
-        return this._colorShader;
+        return this._lineMaterial;
     }
 
     /**
      * @hidden
      */
     public set material(value: Material) {
-        // Do nothing
+        this._lineMaterial = value
     }
 
     /**
@@ -182,7 +195,7 @@ export class LinesMesh extends Mesh {
         if (!this._geometry) {
             return this;
         }
-        const colorEffect = this._colorShader.getEffect();
+        const colorEffect = this._lineMaterial.getEffect();
 
         // VBOs
         const indexToBind = this.isUnIndexed ? null : this._geometry.getIndexBuffer();
@@ -193,10 +206,10 @@ export class LinesMesh extends Mesh {
         }
 
         // Color
-        if (!this.useVertexColor) {
+        if (!this.useVertexColor && this._isShaderMaterial(this._lineMaterial)) {
             const { r, g, b } = this.color;
             this.color4.set(r, g, b, this.alpha);
-            this._colorShader.setColor4("color", this.color4);
+            this._lineMaterial.setColor4("color", this.color4);
         }
 
         // Clip planes
@@ -228,7 +241,7 @@ export class LinesMesh extends Mesh {
      * @param doNotRecurse If children should be disposed
      */
     public dispose(doNotRecurse?: boolean): void {
-        this._colorShader.dispose(false, false, true);
+        this._lineMaterial.dispose(false, false, true);
         super.dispose(doNotRecurse);
     }
 

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -176,7 +176,7 @@ export class LinesMesh extends Mesh {
      * @hidden
      */
     public set material(value: Material) {
-        this._lineMaterial = value
+        this._lineMaterial = value;
     }
 
     /**

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -126,7 +126,7 @@ export class LinesMesh extends Mesh {
 
     private _removeClipPlaneDefine(label: string) {
         if (!this._isShaderMaterial(this._lineMaterial)) {
-            return
+            return;
         }
 
         const define = "#define " + label;

--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -142,14 +142,12 @@ export class LinesMesh extends Mesh {
         const scene = this.getScene();
 
         // Clip planes
-        if (this._isShaderMaterial(this._lineMaterial)) {
-            scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
-            scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
-            scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");
-            scene.clipPlane4 ? this._addClipPlaneDefine("CLIPPLANE4") : this._removeClipPlaneDefine("CLIPPLANE4");
-            scene.clipPlane5 ? this._addClipPlaneDefine("CLIPPLANE5") : this._removeClipPlaneDefine("CLIPPLANE5");
-            scene.clipPlane6 ? this._addClipPlaneDefine("CLIPPLANE6") : this._removeClipPlaneDefine("CLIPPLANE6");
-        }
+        scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
+        scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
+        scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");
+        scene.clipPlane4 ? this._addClipPlaneDefine("CLIPPLANE4") : this._removeClipPlaneDefine("CLIPPLANE4");
+        scene.clipPlane5 ? this._addClipPlaneDefine("CLIPPLANE5") : this._removeClipPlaneDefine("CLIPPLANE5");
+        scene.clipPlane6 ? this._addClipPlaneDefine("CLIPPLANE6") : this._removeClipPlaneDefine("CLIPPLANE6");
 
         if (!this._lineMaterial.isReady(this)) {
             return false;


### PR DESCRIPTION
PR is a follow up to BabylonJS [forum thread](https://forum.babylonjs.com/t/ability-to-change-line-material-eg-for-animated-line-shader/18625/3)

PR changes involve making use of `LineMesh.material` setter allowing to override custom line mesh material.
Custom material is stored internally as 
```
private _customShader: Nullable<ShaderMaterial>;
```
without overriding default `_colorShader` shader material. 

Additional `resetMaterial(dispose:boolean)` have been added allowing to restore original material with auto disposal (by default) of assigned custom shader material. 

Change doesn't break existing APIs, thus should be backward compatible. 

Notable change:  
`material` getter now returns `ShaderMaterial` (same for setter) instead of Material type, it is to do with calling shader defines, eg: clipping planes, etc.
 
