### PR TITLE
Fix accessing a disposed engine for WebXR

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -266,6 +266,11 @@ export class ThinEngine {
      */
     public disableUniformBuffers = false;
 
+    /**
+    * An event triggered when the engine is disposed.
+    */
+   public readonly onDisposeObservable = new Observable<ThinEngine>();
+
     private _frameId = 0;
     /**
      * Gets the current frame id
@@ -4137,6 +4142,9 @@ export class ThinEngine {
         for (let request of this._activeRequests) {
             request.abort();
         }
+
+        this.onDisposeObservable.notifyObservers(this);
+        this.onDisposeObservable.clear();
     }
 
     /**

--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -180,7 +180,7 @@ export class WebXRSessionManager implements IDisposable {
             this.session.addEventListener("end", () => {
                 this._sessionEnded = true;
 
-                // Remove render target texture and notify frame observers
+                // Remove render target texture
                 this._rttProvider = null;
 
                 if (this._engine) {
@@ -195,6 +195,7 @@ export class WebXRSessionManager implements IDisposable {
                     this._engine._renderLoop();
                 }
 
+                // Notify frame observers
                 this.onXRSessionEnded.notifyObservers(null);
             }, { once: true });
 

--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -6,9 +6,10 @@ import { InternalTexture, InternalTextureSource } from "../Materials/Textures/in
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { WebXRRenderTarget } from "./webXRTypes";
 import { WebXRManagedOutputCanvas, WebXRManagedOutputCanvasOptions } from "./webXRManagedOutputCanvas";
+import { Engine } from "../Engines/engine";
 
 interface IRenderTargetProvider {
-    getRenderTargetForEye(eye: XREye): RenderTargetTexture;
+    getRenderTargetForEye(eye: XREye): Nullable<RenderTargetTexture>;
 }
 
 /**
@@ -16,6 +17,7 @@ interface IRenderTargetProvider {
  * @see https://doc.babylonjs.com/how_to/webxr_session_manager
  */
 export class WebXRSessionManager implements IDisposable {
+    private _engine: Nullable<Engine>;
     private _referenceSpace: XRReferenceSpace;
     private _rttProvider: Nullable<IRenderTargetProvider>;
     private _sessionEnded: boolean = false;
@@ -71,7 +73,12 @@ export class WebXRSessionManager implements IDisposable {
     constructor(
         /** The scene which the session should be created for */
         public scene: Scene
-    ) {}
+    ) {
+        this._engine = scene.getEngine();
+        this._engine.onDisposeObservable.addOnce(() => {
+            this._engine = null;
+        });
+    }
 
     /**
      * The current reference space used in this session. This reference space can constantly change!
@@ -120,9 +127,9 @@ export class WebXRSessionManager implements IDisposable {
     /**
      * Gets the correct render target texture to be rendered this frame for this eye
      * @param eye the eye for which to get the render target
-     * @returns the render target for the specified eye
+     * @returns the render target for the specified eye or null if not available
      */
-    public getRenderTargetTextureForEye(eye: XREye): RenderTargetTexture {
+    public getRenderTargetTextureForEye(eye: XREye): Nullable<RenderTargetTexture> {
         return this._rttProvider!.getRenderTargetForEye(eye);
     }
 
@@ -170,26 +177,27 @@ export class WebXRSessionManager implements IDisposable {
             this._sessionEnded = false;
 
             // handle when the session is ended (By calling session.end or device ends its own session eg. pressing home button on phone)
-            this.session.addEventListener(
-                "end",
-                () => {
-                    const engine = this.scene.getEngine();
-                    this._sessionEnded = true;
-                    // Remove render target texture and notify frame observers
-                    this._rttProvider = null;
+            this.session.addEventListener("end", () => {
+                this._sessionEnded = true;
+
+                // Remove render target texture and notify frame observers
+                this._rttProvider = null;
+
+                if (this._engine) {
                     // make sure dimensions object is restored
-                    engine.framebufferDimensionsObject = null;
+                    this._engine.framebufferDimensionsObject = null;
 
                     // Restore frame buffer to avoid clear on xr framebuffer after session end
-                    engine.restoreDefaultFramebuffer();
+                    this._engine.restoreDefaultFramebuffer();
 
                     // Need to restart render loop as after the session is ended the last request for new frame will never call callback
-                    engine.customAnimationFrameRequester = null;
-                    this.onXRSessionEnded.notifyObservers(null);
-                    engine._renderLoop();
-                },
-                { once: true }
-            );
+                    this._engine.customAnimationFrameRequester = null;
+                    this._engine._renderLoop();
+                }
+
+                this.onXRSessionEnded.notifyObservers(null);
+            }, { once: true });
+
             return this.session;
         });
     }
@@ -214,22 +222,26 @@ export class WebXRSessionManager implements IDisposable {
      * Starts rendering to the xr layer
      */
     public runXRRenderLoop() {
-        const engine = this.scene.getEngine();
+        if (this._sessionEnded || !this._engine)
+        {
+            return;
+        }
+
         // Tell the engine's render loop to be driven by the xr session's refresh rate and provide xr pose information
-        engine.customAnimationFrameRequester = {
+        this._engine.customAnimationFrameRequester = {
             requestAnimationFrame: this.session.requestAnimationFrame.bind(this.session),
             renderFunction: (timestamp: number, xrFrame: Nullable<XRFrame>) => {
-                if (this._sessionEnded) {
+                if (this._sessionEnded || !this._engine) {
                     return;
                 }
                 // Store the XR frame and timestamp in the session manager
                 this.currentFrame = xrFrame;
                 this.currentTimestamp = timestamp;
                 if (xrFrame) {
-                    engine.framebufferDimensionsObject = this.baseLayer!;
+                    this._engine.framebufferDimensionsObject = this.baseLayer!;
                     this.onXRFrameObservable.notifyObservers(xrFrame);
-                    engine._renderLoop();
-                    engine.framebufferDimensionsObject = null;
+                    this._engine._renderLoop();
+                    this._engine.framebufferDimensionsObject = null;
                 }
             },
         };
@@ -253,14 +265,14 @@ export class WebXRSessionManager implements IDisposable {
                     return rtt;
                 },
             };
-            engine.framebufferDimensionsObject = this.baseLayer;
+            this._engine.framebufferDimensionsObject = this.baseLayer;
         }
 
         // Stop window's animation frame and trigger sessions animation frame
         if (typeof window !== "undefined" && window.cancelAnimationFrame) {
-            window.cancelAnimationFrame(engine._frameHandler);
+            window.cancelAnimationFrame(this._engine._frameHandler);
         }
-        engine._renderLoop();
+        this._engine._renderLoop();
     }
 
     /**
@@ -352,9 +364,13 @@ export class WebXRSessionManager implements IDisposable {
         return this._xrNavigator.xr.native ?? false;
     }
 
-    private _createRenderTargetTexture(width: number, height: number, framebuffer: Nullable<WebGLFramebuffer> = null) {
+    private _createRenderTargetTexture(width: number, height: number, framebuffer: WebGLFramebuffer): RenderTargetTexture {
+        if (!this._engine) {
+            throw new Error("Engine is disposed");
+        }
+
         // Create internal texture
-        var internalTexture = new InternalTexture(this.scene.getEngine(), InternalTextureSource.Unknown, true);
+        var internalTexture = new InternalTexture(this._engine, InternalTextureSource.Unknown, true);
         internalTexture.width = width;
         internalTexture.height = height;
         internalTexture._framebuffer = framebuffer;


### PR DESCRIPTION
This change fixes an issue when the engine is disposed while in an active WebXR session. Ending a WebXR session is asynchronous and the event that follow are executed after the engine is already disposed.

Repro PG: https://playground.babylonjs.com/#F41V6N#308