### PR TITLE
Normalize quat/update matrix for drag behavior

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -133,6 +133,8 @@
 - Fix for DualSense gamepads being incorrectly read as DualShock gamepads ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix for warning in chrome about passive wheel events ([#9777](https://github.com/BabylonJS/Babylon.js/pull/9777)) ([kaliatech](https://github.com/kaliatech))
 - Fix crash when cloning material in `AssetContainer.instantiateModelsToScene` when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
+- Fix Normalized quaternion when updating the node components ([CedricGuillemet](https://github.com/CedricGuillemet))
+- Fix update absolute position before use in PointerDragBehavior ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fix issue with NinePatch displaying half pixel gaps between slices on Firefox browsers. ([Pryme8](https://github.com/Pryme8))
 - Fix issue when canvas loses focus while holding a pointer button ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix issue where camera controls stay detached if PointerDragBehavior is disabled prematurely ([PolygonalSun](https://github.com/PolygonalSun))

--- a/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -320,7 +320,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this.currentDraggingPointerID = pointerId;
             this.lastDragPosition.copyFrom(pickedPoint);
             this.onDragStartObservable.notifyObservers({ dragPlanePoint: pickedPoint, pointerId: this.currentDraggingPointerID });
-            this._targetPosition.copyFrom((this.attachedNode).absolutePosition);
+            this._targetPosition.copyFrom((this.attachedNode).getAbsolutePosition());
 
             // Detatch camera controls
             if (this.detachCameraControls && this._scene.activeCamera && this._scene.activeCamera.inputs && !this._scene.activeCamera.leftCamera) {
@@ -450,7 +450,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this._dragPlane.lookAt(ray.origin);
         }
         // Update the position of the drag plane so it doesn't get out of sync with the node (eg. when moving back and forth quickly)
-        this._dragPlane.position.copyFrom(this.attachedNode.absolutePosition);
+        this._dragPlane.position.copyFrom(this.attachedNode.getAbsolutePosition());
 
         this._dragPlane.computeWorldMatrix(true);
     }

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -258,6 +258,7 @@ export class Gizmo implements IDisposable {
 
                 if (targetCamera.rotationQuaternion) {
                     targetCamera.rotationQuaternion.copyFrom(this._tempQuaternion);
+                    targetCamera.rotationQuaternion.normalize();
                 }
             }
 
@@ -276,6 +277,7 @@ export class Gizmo implements IDisposable {
             if (!transform.billboardMode) {
                 if (transform.rotationQuaternion) {
                     transform.rotationQuaternion.copyFrom(this._tempQuaternion);
+                    transform.rotationQuaternion.normalize();
                 } else {
                     transform.rotation = this._tempQuaternion.toEulerAngles();
                 }


### PR DESCRIPTION
follow up for https://forum.babylonjs.com/t/massive-bug-gizmo-rotationquaternion/18666/6
and https://forum.babylonjs.com/t/undesirable-bounding-box-gizmo-custom-drag-behavior/18660

- normalize quaternion out of matrix update
- compute absolute position before using it in pointerdragbehavior plane

Not much to say for the quaternion normalization. It drifted after a while when decomposing/recomposing the values.
For the dragbehavior, this happens when select and dragging the node (with button up), the absolute position is (0,0,0) and the mesh got an offset. Fixed by computing the absolute position before using it.