### PR TITLE
adding setMeshTarget to the ArcRotateFollow camera

### DIFF
--- a/src/Cameras/followCamera.ts
+++ b/src/Cameras/followCamera.ts
@@ -276,6 +276,14 @@ export class ArcFollowCamera extends TargetCamera {
         target: Nullable<AbstractMesh>,
         scene: Scene) {
         super(name, Vector3.Zero(), scene);
+        this.setMeshTarget(target);
+    }
+
+    /**
+     * Sets the mesh to follow with this camera.
+     * @param target the target to follow
+     */
+    public setMeshTarget(target: Nullable<AbstractMesh>) {
         this._meshTarget = target;
         this._follow();
     }

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -236,7 +236,7 @@ export class TargetCamera extends Camera {
 
     /**
      * Defines the target the camera should look at.
-     * @param target Defines the new target as a Vector or a mesh
+     * @param target Defines the new target as a Vector
      */
     public setTarget(target: Vector3): void {
         this.upVector.normalize();


### PR DESCRIPTION
Shortly discussed here - https://forum.babylonjs.com/t/followcamera-settarget-does-not-accept-mesh/18687