### PR TITLE
Fix thin instances + animated bones not rendered in the depth renderer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -144,6 +144,7 @@
 - Fix bones serialization to include their ids. This allows to retrieve bones (animation groups, etc.) once the scene has been re-serialized ([julien-moreau](https://github.com/julien-moreau))
 - Fix an issue with hand-detachment when using hand tracking in WebXR ([#9882](https://github.com/BabylonJS/Babylon.js/issues/9882)) ([RaananW](https://github.com/RaananW))
 - Fix issue with cursor and 'doNotHandleCursors' on GUI ([msDestiny14](https://github.com/msDestiny14))
+- Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -134,6 +134,7 @@ export class DepthRenderer {
                 renderingMesh._bind(subMesh, this._effect, material.fillMode);
 
                 this._effect.setMatrix("viewProjection", scene.getTransformMatrix());
+                this._effect.setMatrix("world", effectiveMesh.getWorldMatrix());
 
                 this._effect.setFloat2("depthValues", camera.minZ, camera.minZ + camera.maxZ);
 
@@ -149,7 +150,19 @@ export class DepthRenderer {
 
                 // Bones
                 if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {
-                    this._effect.setMatrices("mBones", renderingMesh.skeleton.getTransformMatrices(renderingMesh));
+                    const skeleton = renderingMesh.skeleton;
+    
+                    if (skeleton.isUsingTextureForMatrices) {
+                        const boneTexture = skeleton.getTransformMatrixTexture(renderingMesh);
+                        if (!boneTexture) {
+                            return;
+                        }
+    
+                        this._effect.setTexture("boneSampler", boneTexture);
+                        this._effect.setFloat("boneTextureWidth", 4.0 * (skeleton.bones.length + 1));
+                    } else {
+                        this._effect.setMatrices("mBones", skeleton.getTransformMatrices((renderingMesh)));
+                    }
                 }
 
                 // Morph targets

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -151,13 +151,13 @@ export class DepthRenderer {
                 // Bones
                 if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {
                     const skeleton = renderingMesh.skeleton;
-    
+
                     if (skeleton.isUsingTextureForMatrices) {
                         const boneTexture = skeleton.getTransformMatrixTexture(renderingMesh);
                         if (!boneTexture) {
                             return;
                         }
-    
+
                         this._effect.setTexture("boneSampler", boneTexture);
                         this._effect.setFloat("boneTextureWidth", 4.0 * (skeleton.bones.length + 1));
                     } else {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/dof-does-not-work-for-thin-instances/18688

I have also fixed a problem where meshes with bones using textures for matrices were not generated in the depth buffer.