### PR TITLE
WebGPU: fix automatic use of CLAMP address mode for some render targets

### DIFF
--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -780,7 +780,7 @@ export class WebGPUEngine extends Engine {
             this._viewportsCurrent[index].w = w;
             this._viewportsCurrent[index].h = h;
 
-            renderPass.setViewport(x, y, w, h, 0, 1);
+            renderPass.setViewport(Math.floor(x), Math.floor(y), Math.floor(w), Math.floor(h), 0, 1);
 
             if (this.dbgVerboseLogsForFirstFrames) {
                 if ((this as any)._count === undefined) { (this as any)._count = 0; }

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -2492,7 +2492,7 @@ export class WebGPUEngine extends Engine {
             texture._textureArray = textures;
             texture._cachedWrapU = Constants.TEXTURE_CLAMP_ADDRESSMODE;
             texture._cachedWrapV = Constants.TEXTURE_CLAMP_ADDRESSMODE;
-    
+
             this._internalTexturesCache.push(texture);
 
             this._textureHelper.createGPUTextureForInternalTexture(texture);

--- a/src/Misc/dds.ts
+++ b/src/Misc/dds.ts
@@ -756,6 +756,8 @@ ThinEngine.prototype.createPrefilteredCubeTexture = function(rootUrl: string, sc
             glTextureFromLod.width = Math.pow(2, Math.max(Scalar.Log2(width) - mipmapIndex, 0));
             glTextureFromLod.height = glTextureFromLod.width;
             glTextureFromLod.isCube = true;
+            glTextureFromLod._cachedWrapU = Constants.TEXTURE_CLAMP_ADDRESSMODE;
+            glTextureFromLod._cachedWrapV = Constants.TEXTURE_CLAMP_ADDRESSMODE;
             this._bindTextureDirectly(gl.TEXTURE_CUBE_MAP, glTextureFromLod, true);
 
             glTextureFromLod.samplingMode = Constants.TEXTURE_LINEAR_LINEAR;


### PR DESCRIPTION
Also fixes a "The viewport must be contained in the render targets" error (in [this](https://playground.babylonjs.com/#1KUJ0A#305) PG for eg).