### PR TITLE
Teleportation fix

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -148,6 +148,7 @@
 - Fix issue with cursor and 'doNotHandleCursors' on GUI ([msDestiny14](https://github.com/msDestiny14))
 - Fix issue with multi-views when using a transparent scene clear color ([Popov72](https://github.com/Popov72))
 - Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
+- Fix issue with WebXR teleportation logic which would cause positional headlocking on teleporation frames ([syntheticmagus](https://github.com/syntheticmagus))
 
 ## Breaking changes
 

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -4125,6 +4125,19 @@ export class Matrix {
     }
 
     /**
+     * Switch transform matrix handedness (invert z). Note that this is an in-place operation.
+     * @returns this matrix
+     */
+    public switchHandedness(): Matrix {
+        this._m[2] *= -1;
+        this._m[6] *= -1;
+        this._m[8] *= -1;
+        this._m[9] *= -1;
+        this._m[14] *= -1;
+        return this;
+    }
+
+    /**
      * Copy the current matrix from the given one
      * @param other defines the source matrix
      * @returns the current updated matrix

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -4125,19 +4125,6 @@ export class Matrix {
     }
 
     /**
-     * Switch transform matrix handedness (invert z). Note that this is an in-place operation.
-     * @returns this matrix
-     */
-    public switchHandedness(): Matrix {
-        this._m[2] *= -1;
-        this._m[6] *= -1;
-        this._m[8] *= -1;
-        this._m[9] *= -1;
-        this._m[14] *= -1;
-        return this;
-    }
-
-    /**
      * Copy the current matrix from the given one
      * @param other defines the source matrix
      * @returns the current updated matrix

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -573,7 +573,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                                         // rotate in the right direction positive is right
                                         controllerData.teleportationState.rotating = true;
                                         const rotation = this.rotationAngle * (axesData.x > 0 ? 1 : -1) * (this._xrSessionManager.scene.useRightHandedSystem ? -1 : 1);
-                                        this._options.xrInput.xrCamera.rotationQuaternion.multiplyInPlace(Quaternion.FromEulerAngles(0, rotation, 0));
+                                        Quaternion.FromEulerAngles(0, rotation, 0).multiplyToRef(this._options.xrInput.xrCamera.rotationQuaternion, this._options.xrInput.xrCamera.rotationQuaternion);
                                     }
                                 } else {
                                     if (this._currentTeleportationControllerId === controllerData.xrController.uniqueId) {
@@ -834,7 +834,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
             this._options.xrInput.xrCamera.onBeforeCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
             this._options.xrInput.xrCamera.position.copyFrom(this._options.teleportationTargetMesh.position);
             this._options.xrInput.xrCamera.position.y += height;
-            this._options.xrInput.xrCamera.rotationQuaternion.multiplyInPlace(Quaternion.FromEulerAngles(0, controllerData.teleportationState.currentRotation - (this._xrSessionManager.scene.useRightHandedSystem ? Math.PI : 0), 0));
+            Quaternion.FromEulerAngles(0, controllerData.teleportationState.currentRotation - (this._xrSessionManager.scene.useRightHandedSystem ? Math.PI : 0), 0).multiplyToRef(this._options.xrInput.xrCamera.rotationQuaternion, this._options.xrInput.xrCamera.rotationQuaternion);
             this._options.xrInput.xrCamera.onAfterCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
         }
     }

--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -278,11 +278,20 @@ export class WebXRCamera extends FreeCamera {
             transformMat.invert();
 
             if (!this._scene.useRightHandedSystem) {
-                transformMat.switchHandedness();
+                transformMat.toggleModelMatrixHandInPlace();
             }
 
             transformMat.decompose(undefined, this._referenceQuaternion, this._referencedPosition);
-            const transform = new XRRigidTransform(this._referencedPosition, this._referenceQuaternion);
+            const transform = new XRRigidTransform({
+                x: this._referencedPosition.x,
+                y: this._referencedPosition.y,
+                z: this._referencedPosition.z
+            }, {
+                x: this._referenceQuaternion.x,
+                y: this._referenceQuaternion.y,
+                z: this._referenceQuaternion.z,
+                w: this._referenceQuaternion.w
+            });
             this._xrSessionManager.referenceSpace = this._xrSessionManager.referenceSpace.getOffsetReferenceSpace(transform);
         }
     }

--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -1,4 +1,4 @@
-import { Vector3, Matrix, Quaternion } from "../Maths/math.vector";
+import { Vector3, Matrix, Quaternion, TmpVectors } from "../Maths/math.vector";
 import { Scene } from "../scene";
 import { Camera } from "../Cameras/camera";
 import { FreeCamera } from "../Cameras/freeCamera";
@@ -13,11 +13,11 @@ import { WebXRTrackingState } from "./webXRTypes";
  * @see https://doc.babylonjs.com/how_to/webxr_camera
  */
 export class WebXRCamera extends FreeCamera {
+    private static _ScaleReadOnly = Vector3.One();
+
     private _firstFrame = false;
     private _referenceQuaternion: Quaternion = Quaternion.Identity();
     private _referencedPosition: Vector3 = new Vector3();
-    private _xrInvPositionCache: Vector3 = new Vector3();
-    private _xrInvQuaternionCache = Quaternion.Identity();
     private _trackingState: WebXRTrackingState = WebXRTrackingState.NOT_TRACKING;
 
     /**
@@ -268,63 +268,22 @@ export class WebXRCamera extends FreeCamera {
     private _updateReferenceSpace() {
         // were position & rotation updated OUTSIDE of the xr update loop
         if (!this.position.equals(this._referencedPosition) || !this.rotationQuaternion.equals(this._referenceQuaternion)) {
-            this.position.subtractToRef(this._referencedPosition, this._referencedPosition);
-            this._referenceQuaternion.conjugateInPlace();
-            this._referenceQuaternion.multiplyToRef(this.rotationQuaternion, this._referenceQuaternion);
-            this._updateReferenceSpaceOffset(this._referencedPosition, this._referenceQuaternion.normalize());
-        }
-    }
+            const referencedMat = TmpVectors.Matrix[0];
+            const poseMat = TmpVectors.Matrix[1];
+            const transformMat = TmpVectors.Matrix[2];
 
-    private _updateReferenceSpaceOffset(positionOffset: Vector3, rotationOffset?: Quaternion, ignoreHeight: boolean = false) {
-        if (!this._xrSessionManager.referenceSpace || !this._xrSessionManager.currentFrame) {
-            return;
-        }
-        // Compute the origin offset based on player position/orientation.
-        this._xrInvPositionCache.copyFrom(positionOffset);
-        if (rotationOffset) {
-            this._xrInvQuaternionCache.copyFrom(rotationOffset);
-        } else {
-            this._xrInvQuaternionCache.copyFromFloats(0, 0, 0, 1);
-        }
+            Matrix.ComposeToRef(WebXRCamera._ScaleReadOnly, this._referenceQuaternion, this._referencedPosition, referencedMat);
+            Matrix.ComposeToRef(WebXRCamera._ScaleReadOnly, this.rotationQuaternion, this.position, poseMat);
+            referencedMat.invert().multiplyToRef(poseMat, transformMat);
+            transformMat.invert();
 
-        // right handed system
-        if (!this._scene.useRightHandedSystem) {
-            this._xrInvPositionCache.z *= -1;
-            this._xrInvQuaternionCache.z *= -1;
-            this._xrInvQuaternionCache.w *= -1;
-        }
-
-        this._xrInvPositionCache.negateInPlace();
-        this._xrInvQuaternionCache.conjugateInPlace();
-        // transform point according to rotation with pivot
-        this._xrInvPositionCache.rotateByQuaternionToRef(this._xrInvQuaternionCache, this._xrInvPositionCache);
-        if (ignoreHeight) {
-            this._xrInvPositionCache.y = 0;
-        }
-        const transform = new XRRigidTransform({ x: this._xrInvPositionCache.x, y: this._xrInvPositionCache.y, z: this._xrInvPositionCache.z }, { x: this._xrInvQuaternionCache.x, y: this._xrInvQuaternionCache.y, z: this._xrInvQuaternionCache.z, w: this._xrInvQuaternionCache.w });
-        // Update offset reference to use a new originOffset with the teleported
-        // player position and orientation.
-        // This new offset needs to be applied to the base ref space.
-        const referenceSpace = this._xrSessionManager.referenceSpace.getOffsetReferenceSpace(transform);
-
-        const pose = this._xrSessionManager.currentFrame && this._xrSessionManager.currentFrame.getViewerPose(referenceSpace);
-
-        if (pose) {
-            const pos = new Vector3(pose.transform.position.x, pose.transform.position.y, pose.transform.position.z);
             if (!this._scene.useRightHandedSystem) {
-                pos.z *= -1;
+                transformMat.switchHandedness();
             }
-            this.position.subtractToRef(pos, pos);
-            if (!this._scene.useRightHandedSystem) {
-                pos.z *= -1;
-            }
-            pos.negateInPlace();
 
-            const transform2 = new XRRigidTransform({ x: pos.x, y: pos.y, z: pos.z });
-            // Update offset reference to use a new originOffset with the teleported
-            // player position and orientation.
-            // This new offset needs to be applied to the base ref space.
-            this._xrSessionManager.referenceSpace = referenceSpace.getOffsetReferenceSpace(transform2);
+            transformMat.decompose(undefined, this._referenceQuaternion, this._referencedPosition);
+            const transform = new XRRigidTransform(this._referencedPosition, this._referenceQuaternion);
+            this._xrSessionManager.referenceSpace = this._xrSessionManager.referenceSpace.getOffsetReferenceSpace(transform);
         }
     }
 }


### PR DESCRIPTION
Fix for issue with reference space change logic in WebXRCamera and teleportation logic which was causing the camera to become positionally headlocked during continuous motion.