### PR TITLE
Unnecessary check in physicsImposter removed

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -146,6 +146,7 @@
 - Fix an issue with hand-detachment when using hand tracking in WebXR ([#9882](https://github.com/BabylonJS/Babylon.js/issues/9882)) ([RaananW](https://github.com/RaananW))
 - Fix issue with cursor and 'doNotHandleCursors' on GUI ([msDestiny14](https://github.com/msDestiny14))
 - Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
+- Fix unable to move kinematic objects that don't have a `.rotationQuaternion` ([Quadtree](https://github.com/Quadtree))
 
 ## Breaking changes
 

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -849,7 +849,7 @@ export class PhysicsImpostor {
             this._tmpQuat.copyFrom(this.object.rotationQuaternion || new Quaternion());
         }
         if (!this._options.disableBidirectionalTransformation) {
-            this.object.rotationQuaternion && this._physicsEngine.getPhysicsPlugin().setPhysicsBodyTransformation(this, /*bInfo.boundingBox.centerWorld*/ this.object.getAbsolutePosition(), this._tmpQuat);
+            this._physicsEngine.getPhysicsPlugin().setPhysicsBodyTransformation(this, /*bInfo.boundingBox.centerWorld*/ this.object.getAbsolutePosition(), this._tmpQuat);
         }
 
         this._onBeforePhysicsStepCallbacks.forEach((func) => {


### PR DESCRIPTION
I recently encountered the bug that MackeyK24 encountered in 2018: https://forum.babylonjs.com/t/move-kinematic-rigidbodies-in-code/17568/6

Basically, as mentioned in the original forum thread it's impossible to move a kinematic body without issues unless you first set `.rotationQuaternion` on the object (unless the object started with one, some do). The workaround is easy, but it's annoying, and pretty confusing for new users.

This Playground is an example of the issue (very slightly adapted from Cedric's in the above thread): https://playground.babylonjs.com/#66PS52#120

If you remove the `ground.rotationQuaternion = null;` line, the ground moves as expected.

This PR simply removes the check for `.rotationQuaternion`. Since the check on line 849 explicitly handles the case where the quaternion is invalid, I can't imagine the check on line 852 is intended. Looking at the history of the file, I think the check was accidentally left in from an earlier version, but I could be wrong about that.