### PR TITLE
Provide additional attributes to customize the posture of the gizmo

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -97,6 +97,9 @@
 
 - Exposed `scaleDragSpeed` and added `axisFactor` for BoundingBoxGizmo ([CedricGuillemet](https://github.com/CedricGuillemet))
 
+- Provide additional attributes `_customRotationQuaternion` to customize the posture of the gizmo ([ecojust](https://github.com/ecojust))
+
+
 ### Viewer
 
 - Fixed an issue with dual callback binding in case of a forced redraw ([#9608](https://github.com/BabylonJS/Babylon.js/issues/9608)) ([RaananW](https://github.com/RaananW))

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -203,7 +203,7 @@ export class Gizmo implements IDisposable {
             else {
                 if (this._customRotationQuaternion) {
                     this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion);
-                }else {
+                } else {
                     this._rootMesh.rotationQuaternion!.set(0, 0, 0, 1);
                 }
             }

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -167,10 +167,15 @@ export class Gizmo implements IDisposable {
     }
 
     /**
-     * update customRotationQuaternion
-     * @param customRotationQuaternion Quaternion that defines the gizmo‘s pose
+     * poseture that the gizmo will be display
+     * * When set null, default value will be used (Quaternion(0, 0, 0, 1))
      */
-    public setCustomRotationQuaternion(customRotationQuaternion: Nullable<Quaternion>) {
+
+    public get customRotationQuaternion(): Nullable<Quaternion> {
+        return this._customRotationQuaternion;
+    }
+
+    public set customRotationQuaternion(customRotationQuaternion: Nullable<Quaternion>) {
         this._customRotationQuaternion = customRotationQuaternion;
     }
 
@@ -196,7 +201,7 @@ export class Gizmo implements IDisposable {
                 effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!);
             }
             else {
-                this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion || new Quaternion(0, 0, 0, 1));
+                this._customRotationQuaternion ? (this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion)) : (this._rootMesh.rotationQuaternion!.set(0, 0, 0, 1));
             }
 
             // Scale

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -201,7 +201,11 @@ export class Gizmo implements IDisposable {
                 effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!);
             }
             else {
-                this._customRotationQuaternion ? (this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion)) : (this._rootMesh.rotationQuaternion!.set(0, 0, 0, 1));
+                if (this._customRotationQuaternion) {
+                    this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion);
+                }else {
+                    this._rootMesh.rotationQuaternion!.set(0, 0, 0, 1);
+                }
             }
 
             // Scale

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -42,6 +42,7 @@ export class Gizmo implements IDisposable {
     public _rootMesh: Mesh;
     private _attachedMesh: Nullable<AbstractMesh> = null;
     private _attachedNode: Nullable<Node> = null;
+    private _customRotationQuaternion: Nullable<Quaternion> = null;
 
     /**
      * Ratio for the scale of the gizmo (Default: 1)
@@ -167,6 +168,14 @@ export class Gizmo implements IDisposable {
     }
 
     /**
+     * update customRotationQuaternion
+     * @param customRotationQuaternion Quaternion that defines the gizmo‘s pose
+     */
+    public setCustomRotationQuaternion(customRotationQuaternion: Nullable<Quaternion>) {
+        this._customRotationQuaternion = customRotationQuaternion;
+    }
+
+    /**
      * Updates the gizmo to match the attached mesh's position/rotation
      */
     protected _update() {
@@ -188,7 +197,7 @@ export class Gizmo implements IDisposable {
                 effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!);
             }
             else {
-                this._rootMesh.rotationQuaternion!.set(0, 0, 0, 1);
+                this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion || new Quaternion(0, 0, 0, 1));
             }
 
             // Scale


### PR DESCRIPTION
Sometimes we want the gizmo to be displayed in a specific posture，

Neither attachedMesh’s  posture nor default value(new Quaternion(0, 0, 0, 1)).

So，i think it is necessary to provide an attribute(_customRotationQuaternion) to support this demand.