### PR TITLE
MeshImpostor local position transform

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -143,6 +143,7 @@
 - Fix for warning in chrome about passive wheel events ([#9777](https://github.com/BabylonJS/Babylon.js/pull/9777)) ([kaliatech](https://github.com/kaliatech))
 - Fix crash when cloning material in `AssetContainer.instantiateModelsToScene` when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
 - Fix Normalized quaternion when updating the node components ([CedricGuillemet](https://github.com/CedricGuillemet))
+- Fix Mesh impostor not taking LH/RH into account ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fix update absolute position before use in PointerDragBehavior ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fix issue with NinePatch displaying half pixel gaps between slices on Firefox browsers. ([Pryme8](https://github.com/Pryme8))
 - Fix issue when canvas loses focus while holding a pointer button ([PolygonalSun](https://github.com/PolygonalSun))

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -572,8 +572,8 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 vertexPositions = [];
             }
 
-            // top level matrix used for shape transform doesn't take scale into account. 
-            // Moreover, every children vertex position must be in that space. 
+            // top level matrix used for shape transform doesn't take scale into account.
+            // Moreover, every children vertex position must be in that space.
             // So, each vertex position here is transform by (mesh world matrix * toplevelMatrix -1)
             var topLevelQuaternion;
             if (topLevelObject.rotationQuaternion) {

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -571,16 +571,30 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
             if (!vertexPositions) {
                 vertexPositions = [];
             }
-            object.computeWorldMatrix(false);
+
+            // top level matrix used for shape transform doesn't take scale into account. 
+            // Moreover, every children vertex position must be in that space. 
+            // So, each vertex position here is transform by (mesh world matrix * toplevelMatrix -1)
+            var topLevelQuaternion;
+            if (topLevelObject.rotationQuaternion) {
+                topLevelQuaternion = topLevelObject.rotationQuaternion;
+            } else if (topLevelObject.rotation) {
+                topLevelQuaternion = Quaternion.FromEulerAngles(topLevelObject.rotation.x, topLevelObject.rotation.y, topLevelObject.rotation.z);
+            } else {
+                topLevelQuaternion = Quaternion.Identity();
+            }
+            const topLevelMatrix = Matrix.Compose(Vector3.One(), topLevelQuaternion, topLevelObject.position);
+            topLevelMatrix.invertToRef(this._tmpMatrix);
+            const wm = object.computeWorldMatrix(false);
+            const localMatrix = wm.multiply(this._tmpMatrix);
+
             var faceCount = indices.length / 3;
             for (var i = 0; i < faceCount; i++) {
                 var triPoints = [];
                 for (var point = 0; point < 3; point++) {
                     var v = new Vector3(vertexPositions[(indices[(i * 3) + point] * 3) + 0], vertexPositions[(indices[(i * 3) + point] * 3) + 1], vertexPositions[(indices[(i * 3) + point] * 3) + 2]);
 
-                    // Adjust for initial scaling
-                    Matrix.ScalingToRef(object.scaling.x, object.scaling.y, object.scaling.z, this._tmpMatrix);
-                    v = Vector3.TransformCoordinates(v, this._tmpMatrix);
+                    v = Vector3.TransformCoordinates(v, localMatrix);
 
                     var vec: any;
                     if (point == 0) {


### PR DESCRIPTION
followup https://forum.babylonjs.com/t/ammo-js-plugin-left-handed-coordinate-bug/18943/4
positions for mesh impostor must be in toplevelObject space once its ammo transform is setup (without scale). So, compute a local matrix that is the mesh world transform in ammo top level transform space.