### PR TITLE
[XR] render GPUParticleSystem in both eyes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -95,6 +95,7 @@
 - Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
 - Remove the warning for input source not found when in (touch)screen mode ([#9938](https://github.com/BabylonJS/Babylon.js/issues/9938)) ([RaananW](https://github.com/RaananW))
 - Fixed an issue with resources disposal when exiting XR ([#10012](https://github.com/BabylonJS/Babylon.js/issues/10012)) ([RaananW](https://github.com/RaananW))
+- Fixed an issue with GPU particles rendering only in one eye ([#10035](https://github.com/BabylonJS/Babylon.js/issues/10035)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 


### PR DESCRIPTION
closing #10035

The issue was the rendering id inspection that is the same on both eyes. The current rendering camera's unique id is now taken into account.