### PR TITLE
Exposed `scaleRatio` for GizmoManager

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -107,6 +107,7 @@
 
 - Exposed `scaleDragSpeed` and added `axisFactor` for BoundingBoxGizmo ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Provide additional attributes `_customRotationQuaternion` to customize the posture of the gizmo ([ecojust](https://github.com/ecojust))
+- Exposed `scaleRatio` for GizmoManager ([CedricGuillemet](https://github.com/CedricGuillemet))
 
 ### Viewer
 

--- a/src/Gizmos/gizmoManager.ts
+++ b/src/Gizmos/gizmoManager.ts
@@ -40,6 +40,8 @@ export class GizmoManager implements IDisposable {
     private _defaultUtilityLayer: UtilityLayerRenderer;
     private _defaultKeepDepthUtilityLayer: UtilityLayerRenderer;
     private _thickness: number = 1;
+    private _scaleRatio: number = 1;
+
     /** Node Caching for quick lookup */
     private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
     /**
@@ -86,6 +88,21 @@ export class GizmoManager implements IDisposable {
             }
         }
         return hovered;
+    }
+
+    /**
+     * Ratio for the scale of the gizmo (Default: 1)
+     */
+    public set scaleRatio(value: number) {
+        this._scaleRatio = value;
+        [this.gizmos.positionGizmo, this.gizmos.rotationGizmo, this.gizmos.scaleGizmo].forEach((gizmo) => {
+            if (gizmo) {
+                gizmo.scaleRatio = value;
+            }
+        });
+    }
+    public get scaleRatio() {
+        return this._scaleRatio;
     }
 
     /**


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/scale-gizmo-on-my-own/19192/5
scaleRatio exposed from GizmoManager to scale/position/rotation gizmos