### PR TITLE
NME: Fix the strength input parameter of the `PerturbNormal` block

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -161,6 +161,7 @@
 - Fix thin instances + animated bones not rendered in the depth renderer ([Popov72](https://github.com/Popov72))
 - Fix issue with WebXR teleportation logic which would cause positional headlocking on teleporation frames ([syntheticmagus](https://github.com/syntheticmagus))
 - Fix for GUI renderAtIdealSize ([msDestiny14](https://github.com/msDestiny14))
+- Fix the strength input parameter of the NME `PerturbNormal` block that was handled as a 1/strength value ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -151,7 +151,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
 
         state._emitUniformFromString(this._tangentSpaceParameterName, "vec2");
 
-        let replaceForBumpInfos = this.strength.isConnectedToInputBlock && this.strength.connectInputBlock!.isConstant ? `${state._emitFloat(1.0 / this.strength.connectInputBlock!.value)}` : `1.0 / ${this.strength.associatedVariableName}`;
+        let replaceForBumpInfos = this.strength.isConnectedToInputBlock && this.strength.connectInputBlock!.isConstant ? `${state._emitFloat(this.strength.connectInputBlock!.value)}` : `${this.strength.associatedVariableName}`;
 
         state._emitExtension("derivatives", "#extension GL_OES_standard_derivatives : enable");
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/strange-behaviours-in-node-material-normals/19216

This parameter was passed as `1/strength` to the shader instead of simply `strength`.
