### PR TITLE
Add support for cannon-es in plugin

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -25,6 +25,7 @@
 - Added a [helper class](https://doc.babylonjs.com/typedoc/classes/babylon.debug.directionallightfrustumviewer) to display the frustum of a directional light ([Popov72](https://github.com/Popov72))
 - Improved collision detection performance ([ottoville](https://github.com/ottoville/))
 - Added new helper functions for Quaternion.FromLookDirection and Matrix.LookDirection ([Alex-MSFT](https://github.com/Alex-MSFT))
+- Added support for [cannon-es](https://github.com/pmndrs/cannon-es) to the cannonJSPlugin. ([frankieali](https://github.com/frankieali))
 
 ### Engine
 

--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -135,7 +135,11 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             this.world.addEventListener("preStep", impostor.beforeStep);
             this.world.addEventListener("postStep", impostor.afterStep);
             impostor.physicsBody.addShape(shape);
-            this.world.add(impostor.physicsBody);
+            if(typeof this.world.addBody === 'function'){
+              this.world.addBody(impostor.physicsBody);
+            } else {
+              this.world.add(impostor.physicsBody);
+            }
 
             //try to keep the body moving in the right direction by taking old properties.
             //Should be tested!

--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -135,10 +135,10 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             this.world.addEventListener("preStep", impostor.beforeStep);
             this.world.addEventListener("postStep", impostor.afterStep);
             impostor.physicsBody.addShape(shape);
-            if(typeof this.world.addBody === 'function'){
-              this.world.addBody(impostor.physicsBody);
+            if (typeof this.world.addBody === 'function') {
+                this.world.addBody(impostor.physicsBody);
             } else {
-              this.world.add(impostor.physicsBody);
+                this.world.add(impostor.physicsBody);
             }
 
             //try to keep the body moving in the right direction by taking old properties.


### PR DESCRIPTION
closes #9810

Check for cannon-es method `addBody` for generating a physics body. Fallback to cannonjs method `add`.