### PR TITLE
Allow DOM style transparency for containers

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -93,6 +93,7 @@
 - Added two touch-enabled GUI controls, `TouchMeshButton3D` and `TouchHolographicButton`, added option on the WebXR hand tracking feature for enabling touch collisions ([rickfromwork](https://github.com/rickfromwork), [satyapoojasama](https://github.com/satyapoojasama))
 - Added `imageWidth()` and `imageHeight()` to access the source image dimensions of `Image` ([Queatz](https://github.com/Queatz))
 - Added a `FluentButtonMaterial` to give the `TouchHolographicButton` the same look and feel as the HoloLens 2 shell ([rgerd](https://github.com/rgerd))
+- Added property `renderToIntermediateTexture` to `Container` which when set to true, will render children to an intermediate texture rather than direct to host allowing for DOM style alpha blending ([BlindingHues](https://github.com/blindinghues))
 
 ### WebXR
 

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -37,7 +37,7 @@ export class Container extends Control {
         return this._renderToIntermediateTexture;
     }
     public set renderToIntermediateTexture(value: boolean) {
-        if (this._renderToIntermediateTexture == value) {
+        if (this._renderToIntermediateTexture === value) {
             return;
         }
         this._renderToIntermediateTexture = value;

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -7,6 +7,9 @@ import { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import { _TypeStore } from 'babylonjs/Misc/typeStore';
 import { PointerInfoBase } from 'babylonjs/Events/pointerEvents';
 import { serialize } from 'babylonjs/Misc/decorators';
+import { DynamicTexture } from "babylonjs/Materials/Textures/dynamicTexture";
+import { Texture } from "babylonjs/Materials/Textures/texture";
+import { Constants } from 'babylonjs/Engines/constants';
 
 /**
  * Root class for 2D containers
@@ -23,6 +26,10 @@ export class Container extends Control {
     protected _adaptWidthToChildren = false;
     /** @hidden */
     protected _adaptHeightToChildren = false;
+    /** @hidden */
+    protected _intermediateTexture: Nullable<DynamicTexture> = null;
+    /** @hidden */
+    public _renderToIntermediateTexture: boolean = false;
 
     /**
      * Gets or sets a boolean indicating that layout cycle errors should be displayed on the console
@@ -98,9 +105,11 @@ export class Container extends Control {
     /**
      * Creates a new Container
      * @param name defines the name of the container
+     * @param renderToIntermediateTexture renders children to an intermediate texture rather than directly to host, useful for alpha blending
      */
-    constructor(public name?: string) {
+    constructor(public name?: string, renderToIntermediateTexture?: boolean) {
         super(name);
+        this._renderToIntermediateTexture = renderToIntermediateTexture ? true : false;
     }
 
     protected _getTypeName(): string {
@@ -301,6 +310,19 @@ export class Container extends Control {
         if (this._isDirty || !this._cachedParentMeasure.isEqualsTo(parentMeasure)) {
             super._processMeasures(parentMeasure, context);
             this._evaluateClippingState(parentMeasure);
+            if (this._renderToIntermediateTexture) {
+                if (this._intermediateTexture && this._host.getScene() != this._intermediateTexture.getScene()) {
+                    this._intermediateTexture.dispose();
+                    this._intermediateTexture = null;
+                }
+                if (!this._intermediateTexture) {
+                    this._intermediateTexture = new DynamicTexture('', {width: this._currentMeasure.width, height: this._currentMeasure.height},
+                        this._host.getScene(), false, Texture.NEAREST_SAMPLINGMODE, Constants.TEXTUREFORMAT_RGBA, false);
+                    this._intermediateTexture.hasAlpha = true;
+                } else {
+                    this._intermediateTexture.scaleTo(this._currentMeasure.width, this._currentMeasure.height);
+                }
+            }
         }
     }
 
@@ -387,11 +409,22 @@ export class Container extends Control {
 
     /** @hidden */
     public _draw(context: CanvasRenderingContext2D, invalidatedRectangle?: Measure): void {
+        let contextToDrawTo: CanvasRenderingContext2D = (this._intermediateTexture) ? this._intermediateTexture.getContext() : context;
 
-        this._localDraw(context);
+        if (this._intermediateTexture) {
+            contextToDrawTo.save();
+            contextToDrawTo.translate(-this._currentMeasure.left, -this._currentMeasure.top);
+            if (invalidatedRectangle) {
+                contextToDrawTo.clearRect(invalidatedRectangle.left, invalidatedRectangle.top, invalidatedRectangle.width, invalidatedRectangle.height);
+            } else {
+                contextToDrawTo.clearRect(this._currentMeasure.left, this._currentMeasure.top, this._currentMeasure.width, this._currentMeasure.height);
+            }
+        }
+
+        this._localDraw(contextToDrawTo);
 
         if (this.clipChildren) {
-            this._clipForChildren(context);
+            this._clipForChildren(contextToDrawTo);
         }
 
         for (var child of this._children) {
@@ -401,7 +434,15 @@ export class Container extends Control {
                     continue;
                 }
             }
-            child._render(context, invalidatedRectangle);
+            child._render(contextToDrawTo, invalidatedRectangle);
+        }
+
+        if (this._intermediateTexture) {
+            contextToDrawTo.restore();
+            context.save();
+            context.globalAlpha = this.alpha;
+            context.drawImage(contextToDrawTo.canvas, this._currentMeasure.left, this._currentMeasure.top);
+            context.restore();
         }
     }
 
@@ -483,6 +524,9 @@ export class Container extends Control {
 
         for (var index = this.children.length - 1; index >= 0; index--) {
             this.children[index].dispose();
+        }
+        if (this._intermediateTexture) {
+            this._intermediateTexture.dispose();
         }
     }
 

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1488,7 +1488,7 @@ export class Control {
         if (Control.AllowAlphaInheritance) {
             context.globalAlpha *= this._alpha;
         } else if (this._alphaSet) {
-            context.globalAlpha = this.parent ? this.parent.alpha * this._alpha : this._alpha;
+            context.globalAlpha = (this.parent && !this.parent._renderToIntermediateTexture) ? this.parent.alpha * this._alpha : this._alpha;
         }
     }
 

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1488,7 +1488,7 @@ export class Control {
         if (Control.AllowAlphaInheritance) {
             context.globalAlpha *= this._alpha;
         } else if (this._alphaSet) {
-            context.globalAlpha = (this.parent && !this.parent._renderToIntermediateTexture) ? this.parent.alpha * this._alpha : this._alpha;
+            context.globalAlpha = (this.parent && !this.parent.renderToIntermediateTexture) ? this.parent.alpha * this._alpha : this._alpha;
         }
     }
 


### PR DESCRIPTION
By rendering children to an intermediate texture, containers can have their alpha function like in the DOM. Opaque children can overlap, and their parent container transparency set, without darkened seams appearing in the overlapping region.

https://forum.babylonjs.com/t/babylongui-container-transparency/19177/2
(my use case explained, and an example of the darkened seams [here](https://playground.babylonjs.com/#XCPP9Y#6346))

This is a bit of a niche case, but I believe the DOM style of alpha blending is quite universal, and should at least be an option. 

![image](https://user-images.githubusercontent.com/73325135/113389878-7df18300-93dc-11eb-962f-aa2a2f5751c3.png)

With this change I'm finally able to have split up SVG image elements overlap without issue for the GUI in my upcoming game. 