### PR TITLE
Sort instances from back to front if material is transparent

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -55,6 +55,7 @@
 ### Meshes
 
 - `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger](https://github.com/FullStackForger)
+- `InstancedMesh` can now be sorted from back to front before rendering if the material is transparent ([Popov72](https://github.com/Popov72))
 
 ### Inspector
 

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -37,6 +37,8 @@ export class InstancedMesh extends AbstractMesh {
 
     /** @hidden */
     public _indexInSourceMeshInstanceArray = -1;
+    /** @hidden */
+    public _distanceToCamera: number = 0;
 
     constructor(name: string, source: Mesh) {
         super(name, source.getScene());

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -219,6 +219,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     public static readonly BOTTOM = 4;
 
     /**
+     * Indicates that the instanced meshes should be sorted from back to front before rendering if their material is transparent
+     */
+     public static INSTANCEDMESH_SORT_TRANSPARENT = false;
+
+    /**
      * Gets the default side orientation.
      * @param orientation the orientation to value to attempt to get
      * @returns the default orientation
@@ -1693,6 +1698,16 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             }
 
             if (visibleInstances) {
+                if (Mesh.INSTANCEDMESH_SORT_TRANSPARENT && this._scene.activeCamera && subMesh.getMaterial()?.needAlphaBlendingForMesh(subMesh.getRenderingMesh())) {
+                    const cameraPosition = this._scene.activeCamera.globalPosition;
+                    for (let instanceIndex = 0; instanceIndex < visibleInstances.length; instanceIndex++) {
+                        const instanceMesh = visibleInstances[instanceIndex];
+                        instanceMesh._distanceToCamera = Vector3.Distance(instanceMesh.getBoundingInfo().boundingSphere.centerWorld, cameraPosition);
+                    }
+                    visibleInstances.sort((m1, m2) => {
+                        return m1._distanceToCamera > m2._distanceToCamera ? -1 : m1._distanceToCamera < m2._distanceToCamera ? 1 : 0;
+                    });
+                }
                 for (var instanceIndex = 0; instanceIndex < visibleInstances.length; instanceIndex++) {
                     var instance = visibleInstances[instanceIndex];
                     instance.getWorldMatrix().copyToArray(instanceStorage.instancesData, offset);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/instanced-mesh-with-alpha-1-0-is-still-semi-transparent/19669

To avoid breaking changes, it is enabled if `Mesh.INSTANCEDMESH_SORT_TRANSPARENT = true` (`false` by default).

Would have been better to put the flag on `InstancedMesh.SORT_TRANSPARENT` instead but `InstancedMesh` is only used as a type in **mesh.ts**, it's not possible to access `InstancedMesh.SORT_TRANSPARENT`.

To avoid complicating/slowing down the implementation, the `self` instance is not taken into account in the sorting process (that would require to create a new separate array from `visibleInstances` each draw): so it's best to disable the master mesh when using this new feature.

[Doc update](https://github.com/BabylonJS/Documentation/pull/204)