### PR TITLE
Added the cullBackFaces property to Material

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -41,8 +41,9 @@
 - Update glTF validator to `2.0.0-dev.3.3`. ([bghgary](https://github.com/bghgary))
 - Added support for KHR_xmp_json_ld for glTF loader. ([Sebavan](https://github.com/sebavan/), [bghgary](https://github.com/bghgary))
 - Added a `OptimizeNormals` option to the OBJ loader to smooth lighting ([Popov72](https://github.com/Popov72))
-- Added a `Prefiltered` option to the CubeTextureAssetTask ([MackeyK24](https://github.com/MackeyK24))
+- Added a `Prefiltered` option to the `CubeTextureAssetTask` ([MackeyK24](https://github.com/MackeyK24))
 - Added support for more uv sets to glTF loader. ([bghgary](https://github.com/bghgary))
+- Added support for KHR_materials_volume for glTF loader. ([MiiBond](https://github.com/MiiBond/))
 
 ### Navigation
 
@@ -57,7 +58,7 @@
 - Added support for morph targets to `ShaderMaterial` ([Popov72](https://github.com/Popov72))
 - Added support for clip planes to the `ShaderMaterial` ([Popov72](https://github.com/Popov72))
 - Added support for local cube map to refraction cube texture ([Popov72](https://github.com/Popov72))
-- Added support for KHR_materials_volume for glTF loader. ([MiiBond](https://github.com/MiiBond/))
+- Added the `cullBackFaces` property to `Material` ([Popov72](https://github.com/Popov72))
 
 ### Meshes
 

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -668,7 +668,7 @@ export class WaterMaterial extends PushMaterial {
 
             // Transform
             scene.setTransformMatrix(savedViewMatrix, scene.getProjectionMatrix());
-            scene.getEngine().cullBackFaces = true;
+            scene.getEngine().cullBackFaces = null;
             scene._mirroredCameraPosition = null;
         };
     }

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -740,19 +740,20 @@ export class Engine extends ThinEngine {
 
     /**
      * Set various states to the webGL context
-     * @param culling defines backface culling state
+     * @param culling defines culling state: true to enable culling, false to disable it
      * @param zOffset defines the value to apply to zOffset (0 by default)
      * @param force defines if states must be applied even if cache is up to date
      * @param reverseSide defines if culling must be reversed (CCW instead of CW and CW instead of CCW)
+     * @param cullBackFaces true to cull back faces, false to cull front faces (if culling is enabled)
      */
-    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false): void {
+    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean): void {
         // Culling
         if (this._depthCullingState.cull !== culling || force) {
             this._depthCullingState.cull = culling;
         }
 
         // Cull face
-        var cullFace = this.cullBackFaces ? this._gl.BACK : this._gl.FRONT;
+        var cullFace = (this.cullBackFaces ?? cullBackFaces ?? true) ? this._gl.BACK : this._gl.FRONT;
         if (this._depthCullingState.cullFace !== cullFace || force) {
             this._depthCullingState.cullFace = cullFace;
         }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1193,8 +1193,8 @@ export class NativeEngine extends Engine {
         this._native.setViewPort(viewport.x, viewport.y, viewport.width, viewport.height);
     }
 
-    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false): void {
-        this._native.setState(culling, zOffset, this.cullBackFaces, reverseSide);
+    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean): void {
+        this._native.setState(culling, zOffset, this.cullBackFaces ?? cullBackFaces ?? true, reverseSide);
     }
 
     /**

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -240,9 +240,10 @@ export class ThinEngine {
     public isFullscreen = false;
 
     /**
-     * Gets or sets a boolean indicating if back faces must be culled (true by default)
+     * Gets or sets a boolean indicating if back faces must be culled. If false, front faces are culled instead (true by default)
+     * If non null, this takes precedence over the value from the material
      */
-    public cullBackFaces = true;
+    public cullBackFaces: Nullable<boolean> = null;
 
     /**
      * Gets or sets a boolean indicating if the engine must keep rendering even if the window is not in foregroun

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -3436,20 +3436,20 @@ export class WebGPUEngine extends Engine {
 
     /**
      * Set various states to the context
-     * @param culling defines backface culling state
+     * @param culling defines culling state: true to enable culling, false to disable it
      * @param zOffset defines the value to apply to zOffset (0 by default)
      * @param force defines if states must be applied even if cache is up to date
      * @param reverseSide defines if culling must be reversed (CCW instead of CW and CW instead of CCW)
+     * @param cullBackFaces true to cull back faces, false to cull front faces (if culling is enabled)
      */
-    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false): void {
+    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean): void {
         // Culling
         if (this._depthCullingState.cull !== culling || force) {
             this._depthCullingState.cull = culling;
         }
 
         // Cull face
-        // var cullFace = this.cullBackFaces ? this._gl.BACK : this._gl.FRONT;
-        var cullFace = this.cullBackFaces ? 1 : 2;
+        var cullFace = (this.cullBackFaces ?? cullBackFaces ?? true) ? 1 : 2;
         if (this._depthCullingState.cullFace !== cullFace || force) {
             this._depthCullingState.cullFace = cullFace;
         }

--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -710,7 +710,7 @@ export abstract class EffectLayer {
         }
 
         const reverse = sideOrientation === Material.ClockWiseSideOrientation;
-        engine.setState(material.backFaceCulling, material.zOffset, undefined, reverse);
+        engine.setState(material.backFaceCulling, material.zOffset, undefined, reverse, material.cullBackFaces);
 
         // Managing instances
         var batch = renderingMesh._getInstancesRenderList(subMesh._id, !!replacementMesh);

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1080,7 +1080,7 @@ export class ShadowGenerator implements IShadowGenerator {
         }
 
         // Culling
-        engine.setState(material.backFaceCulling);
+        engine.setState(material.backFaceCulling, undefined, undefined, undefined, material.cullBackFaces);
 
         // Managing instances
         var batch = renderingMesh._getInstancesRenderList(subMesh._id, !!subMesh.getReplacementMesh());
@@ -1184,7 +1184,7 @@ export class ShadowGenerator implements IShadowGenerator {
             effectiveMesh.transferToEffect(world);
 
             if (this.forceBackFacesOnly) {
-                engine.setState(true, 0, false, true);
+                engine.setState(true, 0, false, true, material.cullBackFaces);
             }
 
             // Observables
@@ -1196,7 +1196,7 @@ export class ShadowGenerator implements IShadowGenerator {
                 (isInstance, world) => effect.setMatrix("world", world));
 
             if (this.forceBackFacesOnly) {
-                engine.setState(true, 0, false, false);
+                engine.setState(true, 0, false, false, material.cullBackFaces);
             }
 
             // Observables

--- a/src/Materials/Textures/mirrorTexture.ts
+++ b/src/Materials/Textures/mirrorTexture.ts
@@ -183,7 +183,7 @@ export class MirrorTexture extends RenderTargetTexture {
 
         this.onAfterRenderObservable.add(() => {
             scene.updateTransformMatrix();
-            scene.getEngine().cullBackFaces = true;
+            scene.getEngine().cullBackFaces = null;
             scene._mirroredCameraPosition = null;
 
             scene.clipPlane = saveClipPlane;

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -284,7 +284,7 @@ export class Material implements IAnimatable {
     protected _backFaceCulling = true;
 
     /**
-     * Sets the back-face culling state
+     * Sets the culling state (true to enable culling, false to disable)
      */
     public set backFaceCulling(value: boolean) {
         if (this._backFaceCulling === value) {
@@ -295,13 +295,37 @@ export class Material implements IAnimatable {
     }
 
     /**
-     * Gets the back-face culling state
+     * Gets the culling state
      */
     public get backFaceCulling(): boolean {
         return this._backFaceCulling;
     }
 
     /**
+     * Specifies if back or front faces should be called (when culling is enabled)
+     */
+     @serialize("cullBackFaces")
+     protected _cullBackFaces = true;
+ 
+     /**
+      * Sets the type of faces that should be culled (true for back faces, false for front faces)
+      */
+     public set cullBackFaces(value: boolean) {
+         if (this._cullBackFaces === value) {
+             return;
+         }
+         this._cullBackFaces = value;
+         this.markAsDirty(Material.TextureDirtyFlag);
+     }
+ 
+     /**
+      * Gets the type of faces that should be culled
+      */
+     public get cullBackFaces(): boolean {
+         return this._cullBackFaces;
+     }
+ 
+     /**
      * Stores the value for side orientation
      */
     @serialize()
@@ -916,7 +940,7 @@ export class Material implements IAnimatable {
         var reverse = orientation === Material.ClockWiseSideOrientation;
 
         engine.enableEffect(effect ? effect : this._getDrawWrapper());
-        engine.setState(this.backFaceCulling, this.zOffset, false, reverse);
+        engine.setState(this.backFaceCulling, this.zOffset, false, reverse, this.cullBackFaces);
 
         return reverse;
     }

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -302,7 +302,7 @@ export class Material implements IAnimatable {
     }
 
     /**
-     * Specifies if back or front faces should be called (when culling is enabled)
+     * Specifies if back or front faces should be culled (when culling is enabled)
      */
      @serialize("cullBackFaces")
      protected _cullBackFaces = true;

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -306,7 +306,7 @@ export class Material implements IAnimatable {
      */
      @serialize("cullBackFaces")
      protected _cullBackFaces = true;
- 
+
      /**
       * Sets the type of faces that should be culled (true for back faces, false for front faces)
       */
@@ -317,14 +317,14 @@ export class Material implements IAnimatable {
          this._cullBackFaces = value;
          this.markAsDirty(Material.TextureDirtyFlag);
      }
- 
+
      /**
       * Gets the type of faces that should be culled
       */
      public get cullBackFaces(): boolean {
          return this._cullBackFaces;
      }
- 
+
      /**
      * Stores the value for side orientation
      */

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2033,9 +2033,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         if (!this._effectiveMaterial.backFaceCulling && this._effectiveMaterial.separateCullingPass) {
-            engine.setState(true, this._effectiveMaterial.zOffset, false, !reverse);
+            engine.setState(true, this._effectiveMaterial.zOffset, false, !reverse, this._effectiveMaterial.cullBackFaces);
             this._processRendering(this, subMesh, effect, fillMode, batch, hardwareInstancedRendering, this._onBeforeDraw, this._effectiveMaterial);
-            engine.setState(true, this._effectiveMaterial.zOffset, false, reverse);
+            engine.setState(true, this._effectiveMaterial.zOffset, false, reverse, this._effectiveMaterial.cullBackFaces);
 
             if (this._internalMeshDataInfo._onBetweenPassObservable) {
                 this._internalMeshDataInfo._onBetweenPassObservable.notifyObservers(subMesh);

--- a/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -315,7 +315,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             var engine = scene.getEngine();
 
             // Culling
-            engine.setState(material.backFaceCulling);
+            engine.setState(material.backFaceCulling, undefined, undefined, undefined, material.cullBackFaces);
 
             // Managing instances
             var batch = renderingMesh._getInstancesRenderList(subMesh._id, !!subMesh.getReplacementMesh());

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -117,7 +117,7 @@ export class DepthRenderer {
             }
 
             // Culling and reverse (right handed system)
-            engine.setState(material.backFaceCulling, 0, false, scene.useRightHandedSystem);
+            engine.setState(material.backFaceCulling, 0, false, scene.useRightHandedSystem, material.cullBackFaces);
 
             // Managing instances
             var batch = renderingMesh._getInstancesRenderList(subMesh._id, !!subMesh.getReplacementMesh());


### PR DESCRIPTION
The `cullBackFaces` from engine can now be `null` and is used as an override to the new `Material.cullBackFaces` property when non null.