### PR TITLE
Fix loading directly from File objects

### DIFF
--- a/src/Loading/sceneLoader.ts
+++ b/src/Loading/sceneLoader.ts
@@ -525,25 +525,7 @@ export class SceneLoader {
             });
         }
 
-        const manifestChecked = () => {
-            if (pluginDisposed) {
-                return;
-            }
-
-            const successCallback = (data: string | ArrayBuffer, request?: WebRequest) => {
-                dataCallback(data, request ? request.responseURL : undefined);
-            };
-
-            const errorCallback = (error: RequestFileError) => {
-                onError(error.message, error);
-            };
-
-            request = plugin.requestFile
-                ? plugin.requestFile(scene, fileInfo.url, successCallback, onProgress, useArrayBuffer, errorCallback)
-                : scene._requestFile(fileInfo.url, successCallback, onProgress, true, useArrayBuffer, errorCallback);
-        };
-
-        if (StringTools.StartsWith(fileInfo.url, "file:") && fileInfo.file) {
+        if (fileInfo.file) {
             // Loading file from disk via input file or drag'n'drop
             const errorCallback = (error: ReadFileError) => {
                 onError(error.message, error);
@@ -553,6 +535,24 @@ export class SceneLoader {
                 ? plugin.readFile(scene, fileInfo.file, dataCallback, onProgress, useArrayBuffer, errorCallback)
                 : scene._readFile(fileInfo.file, dataCallback, onProgress, useArrayBuffer, errorCallback);
         } else {
+            const manifestChecked = () => {
+                if (pluginDisposed) {
+                    return;
+                }
+
+                const successCallback = (data: string | ArrayBuffer, request?: WebRequest) => {
+                    dataCallback(data, request ? request.responseURL : undefined);
+                };
+
+                const errorCallback = (error: RequestFileError) => {
+                    onError(error.message, error);
+                };
+
+                request = plugin.requestFile
+                    ? plugin.requestFile(scene, fileInfo.url, successCallback, onProgress, useArrayBuffer, errorCallback)
+                    : scene._requestFile(fileInfo.url, successCallback, onProgress, true, useArrayBuffer, errorCallback);
+            };
+
             const engine = scene.getEngine();
             let canUseOfflineSupport = engine.enableOfflineSupport;
             if (canUseOfflineSupport) {
@@ -592,7 +592,7 @@ export class SceneLoader {
         }
         else if ((sceneFilename as File).name) {
             const sceneFile = sceneFilename as File;
-            url = rootUrl + sceneFile.name;
+            url = `file:${sceneFile.name}`;
             name = sceneFile.name;
             file = sceneFile;
         }

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -703,9 +703,20 @@ describe('Babylon Scene Loader', function() {
             });
         });
 
+        it('Files input', () => {
+            return Promise.all([
+                BABYLON.Tools.LoadFileAsync("/Playground/scenes/Box/Box.gltf", true),
+                BABYLON.Tools.LoadFileAsync("/Playground/scenes/Box/Box.bin", true)
+            ]).then(([gltf, bin]: [ArrayBuffer, ArrayBuffer]) => {
+                BABYLON.FilesInput.FilesToLoad["box.gltf"] = new File([gltf], "Box.gltf");
+                BABYLON.FilesInput.FilesToLoad["box.bin"] = new File([bin], "Box.bin");
+                return BABYLON.SceneLoader.LoadAsync("file:", "Box.gltf");
+            });
+        });
+
         it('File object', () => {
-            BABYLON.Tools.LoadFileAsync("/Playground/scenes/Box/Box.gltf").then((gltf) => {
-                return BABYLON.SceneLoader.LoadAsync("/Playground/scenes/Box/", new File([gltf], "Box.gltf"));
+            return BABYLON.Tools.LoadFileAsync("/Playground/scenes/BoomBox.glb").then((glb) => {
+                return BABYLON.SceneLoader.LoadAsync("", new File([glb], "BoomBox.glb"));
             });
         });
 
@@ -718,17 +729,6 @@ describe('Babylon Scene Loader', function() {
             BABYLON.FileTools.PreprocessUrl = (url) => urlRedirects[url] || url;
             const resetPreprocessUrl = () => BABYLON.FileTools.PreprocessUrl = oldPreprocessUrl;
             return BABYLON.SceneLoader.LoadAsync("file:///", "Box.gltf").then(resetPreprocessUrl, resetPreprocessUrl);
-        });
-
-        it('Files input', () => {
-            return Promise.all([
-                BABYLON.Tools.LoadFileAsync("/Playground/scenes/Box/Box.gltf", true),
-                BABYLON.Tools.LoadFileAsync("/Playground/scenes/Box/Box.bin", true)
-            ]).then(([gltf, bin]: [ArrayBuffer, ArrayBuffer]) => {
-                BABYLON.FilesInput.FilesToLoad["box.gltf"] = new File([gltf], "Box.gltf");
-                BABYLON.FilesInput.FilesToLoad["box.bin"] = new File([bin], "Box.bin");
-                return BABYLON.SceneLoader.LoadAsync("file:", "Box.gltf");
-            });
         });
     });
 });


### PR DESCRIPTION
See https://github.com/BabylonJS/Babylon.js/issues/5579#issuecomment-813734228

This fixes the the load code such that you can pass in a File object without specifying `file:` for the rootUrl parameter. Also fixed incorrect unit test for testing this scenario.