### PR TITLE
Added drag scale to AxisScaleGizmo

### DIFF
--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -53,12 +53,8 @@ export class AxisScaleGizmo extends Gizmo {
     private _tmpVector = new Vector3();
     private _tmpMatrix = new Matrix();
     private _tmpMatrix2 = new Matrix();
-    
-    private _arrowTail: AbstractMesh;
-    
-    public get dragScale(): number {
-        return this._arrowTail.scaling.y;
-    }
+        
+    public dragScale = 0;
 
     /**
      * Creates an AxisScaleGizmo
@@ -85,7 +81,6 @@ export class AxisScaleGizmo extends Gizmo {
         // Build mesh + Collider
         this._gizmoMesh = new Mesh("axis", gizmoLayer.utilityLayerScene);
         const { arrowMesh, arrowTail } = this._createGizmoMesh(this._gizmoMesh, thickness);
-        this._arrowTail = arrowTail;
         const collider = this._createGizmoMesh(this._gizmoMesh, thickness + 4, true);
 
         this._gizmoMesh.lookAt(this._rootMesh.position.add(dragAxis));
@@ -102,6 +97,7 @@ export class AxisScaleGizmo extends Gizmo {
 
             arrowMesh.position.z += dragStrength / 3.5;
             arrowTail.scaling.y += dragStrength;
+            this.dragScale = arrowTail.scaling.y;
             arrowTail.position.z = arrowMesh.position.z / 2;
         };
 
@@ -109,6 +105,7 @@ export class AxisScaleGizmo extends Gizmo {
             arrowMesh.position.set(nodePosition.x, nodePosition.y, nodePosition.z);
             arrowTail.position.set(linePosition.x, linePosition.y, linePosition.z);
             arrowTail.scaling.set(lineScale.x, lineScale.y, lineScale.z);
+            this.dragScale = arrowTail.scaling.y;
             this._dragging = false;
         };
 

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -41,6 +41,11 @@ export class AxisScaleGizmo extends Gizmo {
      * Custom sensitivity value for the drag strength
      */
     public sensitivity = 1;
+    
+    /**
+     * The magnitude of the drag strength (scaling factor)
+     */
+    public dragScale = 1;
 
     private _isEnabled: boolean = true;
     private _parent: Nullable<ScaleGizmo> = null;
@@ -53,8 +58,6 @@ export class AxisScaleGizmo extends Gizmo {
     private _tmpVector = new Vector3();
     private _tmpMatrix = new Matrix();
     private _tmpMatrix2 = new Matrix();
-        
-    public dragScale = 1;
 
     /**
      * Creates an AxisScaleGizmo

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -54,7 +54,7 @@ export class AxisScaleGizmo extends Gizmo {
     private _tmpMatrix = new Matrix();
     private _tmpMatrix2 = new Matrix();
         
-    public dragScale = 0;
+    public dragScale = 1;
 
     /**
      * Creates an AxisScaleGizmo

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -53,6 +53,12 @@ export class AxisScaleGizmo extends Gizmo {
     private _tmpVector = new Vector3();
     private _tmpMatrix = new Matrix();
     private _tmpMatrix2 = new Matrix();
+    
+    private _arrowTail: AbstractMesh;
+    
+    public get dragScale(): number {
+        return this._arrowTail.scaling.y;
+    }
 
     /**
      * Creates an AxisScaleGizmo
@@ -79,6 +85,7 @@ export class AxisScaleGizmo extends Gizmo {
         // Build mesh + Collider
         this._gizmoMesh = new Mesh("axis", gizmoLayer.utilityLayerScene);
         const { arrowMesh, arrowTail } = this._createGizmoMesh(this._gizmoMesh, thickness);
+        this._arrowTail = arrowTail;
         const collider = this._createGizmoMesh(this._gizmoMesh, thickness + 4, true);
 
         this._gizmoMesh.lookAt(this._rootMesh.position.add(dragAxis));

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -41,7 +41,6 @@ export class AxisScaleGizmo extends Gizmo {
      * Custom sensitivity value for the drag strength
      */
     public sensitivity = 1;
-    
     /**
      * The magnitude of the drag strength (scaling factor)
      */


### PR DESCRIPTION
Having the drag scale is quite a useful property for developers to obtain the magnitude of scaling. Had to look into the source code to figure this out after some debugging, would be good if developers can have direct access to it (the same way PlaneRotationGizmo has .angle)