### PR TITLE
Grey axis for disabled dragBehavior

### DIFF
--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -174,10 +174,10 @@ export class AxisDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = ((this._isHovered || this._dragging) && this.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
+                var material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
-                    if ((<LinesMesh>m).color) {
+                    if ((<LinesMesh>m).color && this.dragBehavior.enabled) {
                         (<LinesMesh>m).color = material.diffuseColor;
                     }
                 });

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -174,7 +174,7 @@ export class AxisDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
+                const material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color && this.dragBehavior.enabled) {

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -163,7 +163,8 @@ export class AxisDragGizmo extends Gizmo {
             material: this._coloredMaterial,
             hoverMaterial: this._hoverMaterial,
             disableMaterial: this._disableMaterial,
-            active: false
+            active: false,
+            dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(collider as Mesh, cache);
 
@@ -173,7 +174,7 @@ export class AxisDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial;
+                var material = ((this._isHovered || this._dragging) && this.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color) {

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -190,10 +190,10 @@ export class AxisScaleGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = ((this._isHovered || this._dragging) && this.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
+                var material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
-                    if ((<LinesMesh>m).color) {
+                    if ((<LinesMesh>m).color && this.dragBehavior.enabled) {
                         (<LinesMesh>m).color = material.diffuseColor;
                     }
                 });

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -190,7 +190,7 @@ export class AxisScaleGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
+                const material = this.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color && this.dragBehavior.enabled) {

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -179,7 +179,8 @@ export class AxisScaleGizmo extends Gizmo {
             material: this._coloredMaterial,
             hoverMaterial: this._hoverMaterial,
             disableMaterial: this._disableMaterial,
-            active: false
+            active: false,
+            dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(this._gizmoMesh, cache);
 
@@ -189,7 +190,7 @@ export class AxisScaleGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial;
+                var material = ((this._isHovered || this._dragging) && this.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color) {

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -339,7 +339,7 @@ export class Gizmo implements IDisposable {
                     gizmoAxisCache.forEach((cache) => {
                         if (cache.colliderMeshes && cache.gizmoMeshes) {
                             const isHovered = (cache.colliderMeshes?.indexOf((pointerInfo?.pickInfo?.pickedMesh as Mesh)) != -1);
-                            const material = cache.dragBehavior.enabled ? ((isHovered || cache.active ) ? cache.hoverMaterial : cache.material) : cache.disableMaterial;
+                            const material = cache.dragBehavior.enabled ? (isHovered || cache.active ? cache.hoverMaterial : cache.material) : cache.disableMaterial;
                             cache.gizmoMeshes.forEach((m: Mesh) => {
                                 m.material = material;
                                 if ((m as LinesMesh).color) {

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -14,6 +14,7 @@ import { TransformNode } from '../Meshes/transformNode';
 import { StandardMaterial } from '../Materials/standardMaterial';
 import { PointerEventTypes, PointerInfo } from '../Events/pointerEvents';
 import { LinesMesh } from '../Meshes/linesMesh';
+import { PointerDragBehavior } from "../Behaviors/Meshes/pointerDragBehavior";
 
 /**
  * Cache built by each axis. Used for managing state between all elements of gizmo for enhanced UI
@@ -31,6 +32,8 @@ export interface GizmoAxisCache {
     disableMaterial: StandardMaterial;
     /** Used to indicate Active state of the Gizmo */
     active: boolean;
+    /** DragBehavior */
+    dragBehavior: PointerDragBehavior;
 }
 /**
  * Renders gizmos on top of an existing scene which provide controls for position, rotation, etc.
@@ -336,7 +339,7 @@ export class Gizmo implements IDisposable {
                     gizmoAxisCache.forEach((cache) => {
                         if (cache.colliderMeshes && cache.gizmoMeshes) {
                             const isHovered = (cache.colliderMeshes?.indexOf((pointerInfo?.pickInfo?.pickedMesh as Mesh)) != -1);
-                            const material = isHovered || cache.active ? cache.hoverMaterial : cache.material;
+                            const material = cache.dragBehavior.enabled ? ((isHovered || cache.active ) ? cache.hoverMaterial : cache.material) : cache.disableMaterial;
                             cache.gizmoMeshes.forEach((m: Mesh) => {
                                 m.material = material;
                                 if ((m as LinesMesh).color) {
@@ -356,7 +359,7 @@ export class Gizmo implements IDisposable {
                         statusMap!.active = true;
                         gizmoAxisCache.forEach((cache) => {
                             const isHovered = (cache.colliderMeshes?.indexOf((pointerInfo?.pickInfo?.pickedMesh as Mesh)) != -1);
-                            const material = isHovered || cache.active ? cache.hoverMaterial : cache.disableMaterial;
+                            const material = ((isHovered || cache.active) && cache.dragBehavior.enabled) ? cache.hoverMaterial : cache.disableMaterial;
                             cache.gizmoMeshes.forEach((m: Mesh) => {
                                 m.material = material;
                                 if ((m as LinesMesh).color) {
@@ -373,7 +376,7 @@ export class Gizmo implements IDisposable {
                         cache.active = false;
                         dragging = false;
                         cache.gizmoMeshes.forEach((m: Mesh) => {
-                            m.material = cache.material;
+                            m.material = cache.dragBehavior.enabled ? cache.material : cache.disableMaterial;
                             if ((m as LinesMesh).color) {
                                 (m as LinesMesh).color = cache.material.diffuseColor;
                             }

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -135,7 +135,7 @@ export class PlaneDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
+                const material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                 });

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -135,7 +135,7 @@ export class PlaneDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = ((this._isHovered || this._dragging) && cache.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
+                var material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                 });

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -124,7 +124,8 @@ export class PlaneDragGizmo extends Gizmo {
             material: this._coloredMaterial,
             hoverMaterial: this._hoverMaterial,
             disableMaterial: this._disableMaterial,
-            active: false
+            active: false,
+            dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache((this._gizmoMesh as Mesh), cache);
 
@@ -134,7 +135,7 @@ export class PlaneDragGizmo extends Gizmo {
             }
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial;
+                var material = ((this._isHovered || this._dragging) && cache.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                 });

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -285,7 +285,8 @@ export class PlaneRotationGizmo extends Gizmo {
             material: this._coloredMaterial,
             hoverMaterial: this._hoverMaterial,
             disableMaterial: this._disableMaterial,
-            active: false
+            active: false,
+            dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(this._gizmoMesh, cache);
 
@@ -297,7 +298,7 @@ export class PlaneRotationGizmo extends Gizmo {
             this.dragBehavior.maxDragAngle = PlaneRotationGizmo.MaxDragAngle;
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial;
+                var material = ((this._isHovered || this._dragging) && cache.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color) {

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -298,7 +298,7 @@ export class PlaneRotationGizmo extends Gizmo {
             this.dragBehavior.maxDragAngle = PlaneRotationGizmo.MaxDragAngle;
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
+                const material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
                     if ((<LinesMesh>m).color && cache.dragBehavior.enabled) {

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -298,10 +298,10 @@ export class PlaneRotationGizmo extends Gizmo {
             this.dragBehavior.maxDragAngle = PlaneRotationGizmo.MaxDragAngle;
             this._isHovered = !!(cache.colliderMeshes.indexOf(<Mesh>pointerInfo?.pickInfo?.pickedMesh) != -1);
             if (!this._parent) {
-                var material = ((this._isHovered || this._dragging) && cache.dragBehavior.enabled) ? this._hoverMaterial : this._coloredMaterial;
+                var material = cache.dragBehavior.enabled ? (this._isHovered || this._dragging ? this._hoverMaterial : this._coloredMaterial) : this._disableMaterial;
                 cache.gizmoMeshes.forEach((m: Mesh) => {
                     m.material = material;
-                    if ((<LinesMesh>m).color) {
+                    if ((<LinesMesh>m).color && cache.dragBehavior.enabled) {
                         (<LinesMesh>m).color = material.diffuseColor;
                     }
                 });

--- a/src/Gizmos/scaleGizmo.ts
+++ b/src/Gizmos/scaleGizmo.ts
@@ -161,7 +161,8 @@ export class ScaleGizmo extends Gizmo {
             material: this._coloredMaterial,
             hoverMaterial: this._hoverMaterial,
             disableMaterial: this._disableMaterial,
-            active: false
+            active: false,
+            dragBehavior: uniformScaleGizmo.dragBehavior
         };
 
         this.addToAxisCache(uniformScaleGizmo._rootMesh, cache);


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/how-to-disable-gizmo-highlight-while-dragbehavior-enabled-is-set-false/19640/3

Use disableMaterial for axis that have their dragBehavior disabled.