### PR TITLE
[XR] prevent XR's RTT from scaling when using the optimizer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -114,6 +114,7 @@
 - Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
 - Remove the warning for input source not found when in (touch)screen mode ([#9938](https://github.com/BabylonJS/Babylon.js/issues/9938)) ([RaananW](https://github.com/RaananW))
 - Fixed an issue with resources disposal when exiting XR ([#10012](https://github.com/BabylonJS/Babylon.js/issues/10012)) ([RaananW](https://github.com/RaananW))
+- Prevent the XR render target texture from rescaling when using the scene optimizer ([#10135](https://github.com/BabylonJS/Babylon.js/issues/10135)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -244,6 +244,7 @@ export class RenderTargetTexture extends Texture {
     protected _textureMatrix: Matrix;
     protected _samples = 1;
     protected _renderTargetOptions: RenderTargetCreationOptions;
+    private _canRescale = true;
     /**
      * Gets render target creation options that were used.
      */
@@ -572,10 +573,17 @@ export class RenderTargetTexture extends Texture {
     }
 
     /**
+     * Don't allow this render target texture to rescale. Mainly used to prevent rescaling by the scene optimizer.
+     */
+    public disableRescaling() {
+        this._canRescale = false;
+    }
+
+    /**
      * Get if the texture can be rescaled or not.
      */
     public get canRescale(): boolean {
-        return true;
+        return this._canRescale;
     }
 
     /**

--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -387,6 +387,7 @@ export class WebXRSessionManager implements IDisposable {
         // Create render target texture from the internal texture
         const renderTargetTexture = new RenderTargetTexture("XR renderTargetTexture", { width: width, height: height }, this.scene, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, true);
         renderTargetTexture._texture = internalTexture;
+        renderTargetTexture.disableRescaling();
 
         // Store the render target texture for cleanup when the session ends.
         this._renderTargetTextures.push(renderTargetTexture);


### PR DESCRIPTION
Closing #10135

This was implemented this way to keep the canRescale property read-only while still allowing to disable it when needed.