### PR TITLE
test deviceInputSystem is valid before disposing

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -1837,7 +1837,9 @@ export class Engine extends ThinEngine {
         this.disableVR();
 
         // DeviceInputSystem
-        this.deviceInputSystem.dispose();
+        if (this.deviceInputSystem) {
+            this.deviceInputSystem.dispose();
+        }
 
         // Events
         if (DomManagement.IsWindowObjectExist()) {


### PR DESCRIPTION
Nightly BabylonNative VT fails with latest babylonjs nightly, 
`this.deviceInputSystem` is undefined and it stops VT.