### PR TITLE
[XR] Teleportation mesh observable for target update

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -114,6 +114,7 @@
 - Added initial support for the `sessiongranted` event ([#9860](https://github.com/BabylonJS/Babylon.js/issues/9860)) ([RaananW](https://github.com/RaananW))
 - Remove the warning for input source not found when in (touch)screen mode ([#9938](https://github.com/BabylonJS/Babylon.js/issues/9938)) ([RaananW](https://github.com/RaananW))
 - Fixed an issue with resources disposal when exiting XR ([#10012](https://github.com/BabylonJS/Babylon.js/issues/10012)) ([RaananW](https://github.com/RaananW))
+- Added observable to target mesh position update for teleportation ([#9402](https://github.com/BabylonJS/Babylon.js/issues/9402)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -160,6 +160,12 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
     private _tmpQuaternion = new Quaternion();
 
     /**
+     * Skip the next teleportation. This can be controlled by the user to prevent the user from teleportation
+     * to sections that are not yet "unlocked", but should still show the teleportation mesh.
+     */
+    public skipNextTeleportation = false;
+
+    /**
      * The module's name
      */
     public static readonly Name = WebXRFeatureName.TELEPORTATION;
@@ -836,6 +842,11 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         controllerData.teleportationState.forward = false;
         this._currentTeleportationControllerId = "";
         if (this.snapPointsOnly && !this._snappedToPoint) {
+            return;
+        }
+
+        if (this.skipNextTeleportation) {
+            this.skipNextTeleportation = false;
             return;
         }
         // do the movement forward here


### PR DESCRIPTION
It is now possible to update the teleportation mesh when its position has updated.
A new observable was added that notifies when the pick info's position is used to update the teleportation target.

It is now also possible to update the lines yourself, while getting the pick info from the hit test.

Using those two methods it is possible to fully control the teleportation mesh and the path to it. If the developer wants to not allow the user to teleport on next they can set `skipNextTeleportation` to true.

Fixes #9402