### PR TITLE
`level` output for the TextureBlock / switch for disabling level multiplication

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -78,6 +78,7 @@
 
 - Increased float precision to 4 ([msDestiny14](https://github.com/msDestiny14))
 - Added ability to make input node's properties visible in the properties of a custom frame ([msDestiny14](https://github.com/msDestiny14))
+- NME `TextureBlock`: add an output for the texture level and a switch to disable the internal multiplication (level * texture) ([#10192](https://github.com/BabylonJS/Babylon.js/pull/10192)) ([rassie](https://github.com/rassie))
 
 ### GUIEditor
 

--- a/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
+++ b/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
@@ -235,6 +235,17 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                         }}/>
                     }
                     {
+                        texture &&
+                        <CheckBoxLineComponent
+                            label="Disable multiplying by level"
+                            propertyName="disableLevelMultiplication"
+                            target={this.props.block}
+                            onValueChanged={() => {
+                                this.props.globalState.onUpdateRequiredObservable.notifyObservers();
+                            }}
+                        />
+                    }
+                    {
                         texture && texture.updateSamplingMode &&
                         <OptionsLineComponent label="Sampling" options={samplingMode} target={texture} noDirectUpdate={true} propertyName="samplingMode" onSelect={(value) => {
                             texture.updateSamplingMode(value as number);

--- a/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -177,18 +177,18 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         state._emitFunctionFromInclude("bumpFragmentFunctions", comments, {
             replaceStrings: [
                 { search: /vBumpInfos.y/g, replace: replaceForBumpInfos},
-                { search: /vTangentSpaceParams/g, replace: this._tangentSpaceParameterName},
                 { search: /vPositionW/g, replace: worldPosition.associatedVariableName + ".xyz"},
                 { search: /varying vec2 vBumpUV;/g, replace: ""},
-                { search: /uniform sampler2D bumpSampler;[\s\S]*?\}/g, replace: ""},
+                { search: /uniform sampler2D bumpSampler;/g, replace: ""},
             ]
         });
 
         state.compilationString += this._declareOutput(this.output, state) + " = vec4(0.);\r\n";
         state.compilationString += state._emitCodeFromInclude("bumpFragment", comments, {
             replaceStrings: [
-                { search: /perturbNormal\(TBN,vBumpUV\+uvOffset\)/g, replace: `perturbNormal(TBN, ${this.normalMapColor.associatedVariableName})` },
-                { search: /vBumpInfos.y/g, replace: replaceForBumpInfos},
+                { search: /perturbNormal\(TBN,texture2D\(bumpSampler,vBumpUV\+uvOffset\).xyz,vBumpInfos.y\)/g, replace: `perturbNormal(TBN, ${this.normalMapColor.associatedVariableName}, vBumpInfos.y)` },
+                { search: /vTangentSpaceParams/g, replace: this._tangentSpaceParameterName},
+                { search: /vBumpInfos.y/g, replace: replaceForBumpInfos },
                 { search: /vBumpUV/g, replace: uv.associatedVariableName},
                 { search: /vPositionW/g, replace: worldPosition.associatedVariableName + ".xyz"},
                 { search: /normalW=/g, replace: this.output.associatedVariableName + ".xyz = " },

--- a/src/Shaders/ShadersInclude/bumpFragment.fx
+++ b/src/Shaders/ShadersInclude/bumpFragment.fx
@@ -14,7 +14,7 @@
 	#elif defined(BUMP)
 		// flip the uv for the backface
 		vec2 TBNUV = gl_FrontFacing ? vBumpUV : -vBumpUV;
-		mat3 TBN = cotangent_frame(normalW * normalScale, vPositionW, TBNUV);
+		mat3 TBN = cotangent_frame(normalW * normalScale, vPositionW, TBNUV, vTangentSpaceParams);
 	#else
 		// flip the uv for the backface
 		vec2 TBNUV = gl_FrontFacing ? vDetailUV : -vDetailUV;
@@ -52,7 +52,7 @@
 		normalW = normalize(texture2D(bumpSampler, vBumpUV).xyz  * 2.0 - 1.0);
 		normalW = normalize(mat3(normalMatrix) * normalW);	
 	#elif !defined(DETAIL)
-		normalW = perturbNormal(TBN, vBumpUV + uvOffset);
+		normalW = perturbNormal(TBN, texture2D(bumpSampler, vBumpUV + uvOffset).xyz, vBumpInfos.y);
     #else
         vec3 bumpNormal = texture2D(bumpSampler, vBumpUV + uvOffset).xyz * 2.0 - 1.0;
         // Reference for normal blending: https://blog.selfshadow.com/publications/blending-in-detail/

--- a/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -7,11 +7,6 @@
 		varying vec2 vBumpUV;
 	#endif
 	uniform sampler2D bumpSampler;
-	
-	vec3 perturbNormal(mat3 cotangentFrame, vec2 uv)
-	{
-		return perturbNormal(cotangentFrame, texture2D(bumpSampler, uv).xyz, vBumpInfos.y);
-	}
 #endif
 
 #if defined(DETAIL)
@@ -23,19 +18,6 @@
 		varying vec2 vDetailUV;
 	#endif
 	uniform sampler2D detailSampler;
-#endif
-
-#if defined(BUMP)
-	vec3 perturbNormal(mat3 cotangentFrame, vec3 color)
-	{
-		return perturbNormal(cotangentFrame, color, vBumpInfos.y);
-	}
-
-	// Thanks to http://www.thetenthplanet.de/archives/1180
-	mat3 cotangent_frame(vec3 normal, vec3 p, vec2 uv)
-	{
-		return cotangent_frame(normal, p, uv, vTangentSpaceParams);
-	}
 #endif
 
 #if defined(BUMP) && defined(PARALLAX)


### PR DESCRIPTION
This PR is a playground for the discussion in https://forum.babylonjs.com/t/nme-make-texture-level-work-for-normal-maps-as-it-does-in-other-materials/19443/14. This code currently does not work (at all!), but might work someday.