### PR TITLE
Remove unnecessary bind calls when using instancing

### DIFF
--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -736,7 +736,9 @@ export abstract class EffectLayer {
             const effect = this._effectLayerMapGenerationDrawWrapper.effect!;
 
             engine.enableEffect(this._effectLayerMapGenerationDrawWrapper);
-            renderingMesh._bind(subMesh, effect, Material.TriangleFillMode);
+            if (!hardwareInstancedRendering) {
+                renderingMesh._bind(subMesh, effect, Material.TriangleFillMode);
+            }
 
             effect.setMatrix("viewProjection", scene.getTransformMatrix());
 

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1111,7 +1111,9 @@ export class ShadowGenerator implements IShadowGenerator {
 
             engine.enableEffect(drawWrapper);
 
-            renderingMesh._bind(subMesh, effect, material.fillMode);
+            if (!hardwareInstancedRendering) {
+                renderingMesh._bind(subMesh, effect, material.fillMode);
+            }
 
             this.getTransformMatrix(); // make sure _cachedDirection et _cachedPosition are up to date
 

--- a/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -339,7 +339,9 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
                 const effect = drawWrapper.effect!;
 
                 engine.enableEffect(drawWrapper);
-                renderingMesh._bind(subMesh, effect, material.fillMode);
+                if (!hardwareInstancedRendering) {
+                    renderingMesh._bind(subMesh, effect, material.fillMode);
+                }
 
                 if (renderingMesh === this.mesh) {
                     material.bind(effectiveMesh.getWorldMatrix(), renderingMesh);

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -137,7 +137,9 @@ export class DepthRenderer {
 
                 engine.enableEffect(drawWrapper);
 
-                renderingMesh._bind(subMesh, effect, material.fillMode);
+                if (!hardwareInstancedRendering) {
+                    renderingMesh._bind(subMesh, effect, material.fillMode);
+                }
 
                 effect.setMatrix("viewProjection", scene.getTransformMatrix());
                 effect.setMatrix("world", effectiveMesh.getWorldMatrix());

--- a/src/Rendering/outlineRenderer.ts
+++ b/src/Rendering/outlineRenderer.ts
@@ -202,7 +202,9 @@ export class OutlineRenderer implements ISceneComponent {
         // Morph targets
         MaterialHelper.BindMorphTargetParameters(renderingMesh, effect);
 
-        renderingMesh._bind(subMesh, effect, material.fillMode);
+        if (!hardwareInstancedRendering) {
+            renderingMesh._bind(subMesh, effect, material.fillMode);
+        }
 
         // Alpha test
         if (material && material.needAlphaTesting()) {


### PR DESCRIPTION
When using instancing, the mesh bind call is done in the `_processRendering` method, so no need to do it earlier.