### PR TITLE
Fix for wrongly rendered GUI rectangle on resize with adaptWidthToChildren

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -197,6 +197,7 @@
 - Fix context lost handling ([#10163](https://github.com/BabylonJS/Babylon.js/issues/10163)) ([Popov72](https://github.com/Popov72))
 - Fix for GUI slider step values greater than one ([msDestiny14](https://github.com/msDestiny14))
 - Fix Instances wrongly rendered with motion blur ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Fix for wrongly rendered GUI rectangle on resize with adaptWidthToChildren ([msDestiny14](https://github.com/msDestiny14))
 
 ## Breaking changes
 

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -375,6 +375,7 @@ export class Container extends Control {
                         if (this.adaptHeightToChildren && child._height.isPixel) {
                             computedHeight = Math.max(computedHeight, child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels);
                         }
+                        this._markAsDirty();
                     }
                 }
 
@@ -395,6 +396,7 @@ export class Container extends Control {
 
                 this._postMeasure();
             }
+            
             rebuildCount++;
         }
         while (this._rebuildLayout && rebuildCount < this.maxLayoutCycle);

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -371,11 +371,9 @@ export class Container extends Control {
 
                         if (this.adaptWidthToChildren && child._width.isPixel) {
                             computedWidth = Math.max(computedWidth, child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels);
-                            this.parent?._markAsDirty();
                         }
                         if (this.adaptHeightToChildren && child._height.isPixel) {
                             computedHeight = Math.max(computedHeight, child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels);
-                            this.parent?._markAsDirty();
                         }
                     }
                 }
@@ -383,6 +381,7 @@ export class Container extends Control {
                 if (this.adaptWidthToChildren && computedWidth >= 0) {
                     computedWidth += this.paddingLeftInPixels + this.paddingRightInPixels;
                     if (this.width !== computedWidth + "px") {
+                        this.parent?._markAsDirty();
                         this.width = computedWidth + "px";
                         this._rebuildLayout = true;
                     }
@@ -390,6 +389,7 @@ export class Container extends Control {
                 if (this.adaptHeightToChildren && computedHeight >= 0) {
                     computedHeight += this.paddingTopInPixels + this.paddingBottomInPixels;
                     if (this.height !== computedHeight + "px") {
+                        this.parent?._markAsDirty();
                         this.height = computedHeight + "px";
                         this._rebuildLayout = true;
                     }

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -371,11 +371,12 @@ export class Container extends Control {
 
                         if (this.adaptWidthToChildren && child._width.isPixel) {
                             computedWidth = Math.max(computedWidth, child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels);
+                            this.parent?._markAsDirty();
                         }
                         if (this.adaptHeightToChildren && child._height.isPixel) {
                             computedHeight = Math.max(computedHeight, child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels);
+                            this.parent?._markAsDirty();
                         }
-                        this._markAsDirty();
                     }
                 }
 

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -396,7 +396,6 @@ export class Container extends Control {
 
                 this._postMeasure();
             }
-            
             rebuildCount++;
         }
         while (this._rebuildLayout && rebuildCount < this.maxLayoutCycle);


### PR DESCRIPTION
https://forum.babylonjs.com/t/rectangle-gets-corrupted-on-resize-when-using-adaptwidthtochildren-with-textblock-and-padding/20124