### PR TITLE
Fix warning when cloning mesh

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -518,6 +518,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                     "hasInstances",
                     "source",
                     "worldMatrixInstancedBuffer",
+                    "previousWorldMatrixInstancedBuffer",
                     "hasLODLevels",
                     "geometry",
                     "isBlocked",


### PR DESCRIPTION
See https://forum.babylonjs.com/t/previous-worldmatrixinstancedbuffer-warnings-in-ffox/20144/2