### PR TITLE
Throw error if irradiance coefficients are missing in EXT_lights_image_based

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
+++ b/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
@@ -124,6 +124,10 @@ export class EXT_lights_image_based implements IGLTFLoaderExtension {
                     Matrix.FromQuaternionToRef(rotation, babylonTexture.getReflectionTextureMatrix());
                 }
 
+                if (!light.irradianceCoefficients) {
+                    throw new Error(`${context}: Irradiance coefficients are missing`);
+                }
+
                 const sphericalHarmonics = SphericalHarmonics.FromArray(light.irradianceCoefficients);
                 sphericalHarmonics.scaleInPlace(light.intensity);
 


### PR DESCRIPTION
Fixes #10232