### PR TITLE
Fix crash in gltf exporter on materials with baseTexture

### DIFF
--- a/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -815,7 +815,7 @@ export class _GLTFMaterialExporter {
         if (hasTextureCoords) {
             const albedoTexture = (babylonPBRMaterial as PBRMaterial).albedoTexture || (babylonPBRMaterial as PBRMetallicRoughnessMaterial).baseTexture;
             if (albedoTexture) {
-                promises.push(this._exportTextureAsync((babylonPBRMaterial as any).albedoTexture, mimeType).then((glTFTexture) => {
+                promises.push(this._exportTextureAsync(albedoTexture, mimeType).then((glTFTexture) => {
                     if (glTFTexture) {
                         glTFPbrMetallicRoughness.baseColorTexture = glTFTexture;
                     }


### PR DESCRIPTION
The exporter checks for albedo OR base texture when calling _convertMetalRoughFactorsToMetallicRoughnessAsync, but then re-gets the albedo texture from the material and passes that into the exportTexture function.  This doesn't work if you have a baseTexture but no albedo.