### PR TITLE
Remove rebuildInParallel from materials / lights

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -924,7 +924,6 @@ export class ThinEngine {
     protected _rebuildBuffers(): void {
         // Uniforms
         for (var uniformBuffer of this._uniformBuffers) {
-            uniformBuffer._alreadyBound = false;
             uniformBuffer._rebuild();
         }
     }

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1487,7 +1487,7 @@ export class ShadowGenerator implements IShadowGenerator {
                                 "vClipPlane", "vClipPlane2", "vClipPlane3", "vClipPlane4", "vClipPlane5", "vClipPlane6", "softTransparentShadowSM",
                                 "morphTargetTextureInfo", "morphTargetTextureIndices"];
                 const samplers = ["diffuseSampler", "boneSampler", "morphTargets"];
-                const uniformBuffers = ["Mesh", "Scene"];
+                const uniformBuffers = ["Scene", "Mesh"];
 
                 // Custom shader?
                 if (this.customShaderOptions) {

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -381,16 +381,11 @@ export abstract class Light extends Node {
      * @param scene The scene where the light belongs to
      * @param effect The effect we are binding the data to
      * @param useSpecular Defines if specular is supported
-     * @param rebuildInParallel Specifies whether the shader is rebuilding in parallel
      * @param receiveShadows Defines if the effect (mesh) we bind the light for receives shadows
      */
-    public _bindLight(lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean, rebuildInParallel = false, receiveShadows = true): void {
+    public _bindLight(lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean, receiveShadows = true): void {
         let iAsString = lightIndex.toString();
         let needUpdate = false;
-
-        if (rebuildInParallel && this._uniformBuffer._alreadyBound) {
-            return;
-        }
 
         this._uniformBuffer.bindToEffect(effect, "Light" + iAsString);
 

--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -1135,7 +1135,7 @@ export class BackgroundMaterial extends PushMaterial {
 
         if (mustRebind || !this.isFrozen) {
             if (scene.lightsEnabled) {
-                MaterialHelper.BindLights(scene, mesh, this._activeEffect, defines, this._maxSimultaneousLights, false);
+                MaterialHelper.BindLights(scene, mesh, this._activeEffect, defines, this._maxSimultaneousLights);
             }
 
             // View

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -850,8 +850,6 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      */
     public readonly detailMap = new DetailMapConfiguration(this._markAllSubMeshesAsTexturesDirty.bind(this));
 
-    protected _rebuildInParallel = false;
-
     /**
      * Instantiates a new PBRMaterial instance.
      *
@@ -1119,7 +1117,6 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             // Use previous effect while new one is compiling
             if (this.allowShaderHotSwapping && previousEffect && !effect.isReady()) {
                 effect = previousEffect;
-                this._rebuildInParallel = true;
                 defines.markAsUnprocessed();
 
                 if (lightDisposed) {
@@ -1128,7 +1125,6 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                     return false;
                 }
             } else {
-                this._rebuildInParallel = false;
                 scene.resetCachedMaterial();
                 subMesh.setEffect(effect, defines, this._materialContext);
                 this.buildUniformLayout();
@@ -2087,7 +2083,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         if (mustRebind || !this.isFrozen) {
             // Lights
             if (scene.lightsEnabled && !this._disableLighting) {
-                MaterialHelper.BindLights(scene, mesh, this._activeEffect, defines, this._maxSimultaneousLights, this._rebuildInParallel);
+                MaterialHelper.BindLights(scene, mesh, this._activeEffect, defines, this._maxSimultaneousLights);
             }
 
             // View

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -801,11 +801,10 @@ export class MaterialHelper {
      * @param scene The scene where the light belongs to
      * @param effect The effect we are binding the data to
      * @param useSpecular Defines if specular is supported
-     * @param rebuildInParallel Specifies whether the shader is rebuilding in parallel
      * @param receiveShadows Defines if the effect (mesh) we bind the light for receives shadows
      */
-    public static BindLight(light: Light, lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean, rebuildInParallel = false, receiveShadows = true): void {
-        light._bindLight(lightIndex, scene, effect, useSpecular, rebuildInParallel, receiveShadows);
+    public static BindLight(light: Light, lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean, receiveShadows = true): void {
+        light._bindLight(lightIndex, scene, effect, useSpecular, receiveShadows);
     }
 
     /**
@@ -815,15 +814,14 @@ export class MaterialHelper {
      * @param effect The effect we are binding the data to
      * @param defines The generated defines for the effect
      * @param maxSimultaneousLights The maximum number of light that can be bound to the effect
-     * @param rebuildInParallel Specifies whether the shader is rebuilding in parallel
      */
-    public static BindLights(scene: Scene, mesh: AbstractMesh, effect: Effect, defines: any, maxSimultaneousLights = 4, rebuildInParallel = false): void {
+    public static BindLights(scene: Scene, mesh: AbstractMesh, effect: Effect, defines: any, maxSimultaneousLights = 4): void {
         let len = Math.min(mesh.lightSources.length, maxSimultaneousLights);
 
         for (var i = 0; i < len; i++) {
 
             let light = mesh.lightSources[i];
-            this.BindLight(light, i, scene, effect, typeof defines === "boolean" ? defines : defines["SPECULARTERM"], rebuildInParallel, mesh.receiveShadows);
+            this.BindLight(light, i, scene, effect, typeof defines === "boolean" ? defines : defines["SPECULARTERM"], mesh.receiveShadows);
         }
     }
 

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -723,7 +723,6 @@ export class StandardMaterial extends PushMaterial {
     protected _worldViewProjectionMatrix = Matrix.Zero();
     protected _globalAmbientColor = new Color3(0, 0, 0);
     protected _useLogarithmicDepth: boolean;
-    protected _rebuildInParallel = false;
 
     /**
      * Instantiates a new standard material.
@@ -1279,7 +1278,6 @@ export class StandardMaterial extends PushMaterial {
                 // Use previous effect while new one is compiling
                 if (this.allowShaderHotSwapping && previousEffect && !effect.isReady()) {
                     effect = previousEffect;
-                    this._rebuildInParallel = true;
                     defines.markAsUnprocessed();
 
                     if (lightDisposed) {
@@ -1288,7 +1286,6 @@ export class StandardMaterial extends PushMaterial {
                         return false;
                     }
                 } else {
-                    this._rebuildInParallel = false;
                     scene.resetCachedMaterial();
                     subMesh.setEffect(effect, defines, this._materialContext);
                     this.buildUniformLayout();
@@ -1610,7 +1607,7 @@ export class StandardMaterial extends PushMaterial {
         if (mustRebind || !this.isFrozen) {
             // Lights
             if (scene.lightsEnabled && !this._disableLighting) {
-                MaterialHelper.BindLights(scene, mesh, effect, defines, this._maxSimultaneousLights, this._rebuildInParallel);
+                MaterialHelper.BindLights(scene, mesh, effect, defines, this._maxSimultaneousLights);
             }
 
             // View

--- a/src/Materials/uniformBuffer.ts
+++ b/src/Materials/uniformBuffer.ts
@@ -42,9 +42,6 @@ export class UniformBuffer {
     private _name: string;
     private _currentFrameId: number;
 
-    /** @hidden */
-    public _alreadyBound = false;
-
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
     private static _tempBuffer = new Float32Array(UniformBuffer._MAX_UNIFORM_SIZE);
@@ -982,7 +979,6 @@ export class UniformBuffer {
             return;
         }
 
-        this._alreadyBound = true;
         effect.bindUniformBuffer(this._buffer, name);
     }
 


### PR DESCRIPTION
That will remove some wrong transient states that led to some WebGL warnings in the console log sometimes ("Two textures of different types use the same sampler location.", "It is undefined behaviour to have a used but unbound uniform buffer.", "It is undefined behaviour to use a uniform buffer that is too small.").