### PR TITLE
Persistent "disable level multiplication" switch

### DIFF
--- a/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
+++ b/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
@@ -235,7 +235,6 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                         }}/>
                     }
                     {
-                        texture &&
                         <CheckBoxLineComponent
                             label="Disable multiplying by level"
                             propertyName="disableLevelMultiplication"


### PR DESCRIPTION
Follow-up to 4a17889b7118fad8edbc934fc8fbf1d4d433dd75 (PR #10192). "Disable level multiplication" needs to be shown even if no texture is loaded, since otherwise developing a material from NME becomes more difficult.