### PR TITLE
Fix PhysicsImposter for negatively scaled mesh

### DIFF
--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -621,6 +621,10 @@ export class PhysicsImpostor {
             const boundingInfo = this.object.getBoundingInfo();
             // get the global scaling of the object
             const size = boundingInfo.boundingBox.extendSize.scale(2).multiplyInPlace(scaling);
+            // correct the size for negative scaling (e.g. flipped mesh)
+            size.x *= this.object.scaling.x < 0 ? -1 : 1;
+            size.y *= this.object.scaling.y < 0 ? -1 : 1;
+            size.z *= this.object.scaling.z < 0 ? -1 : 1;
             //bring back the rotation
             this.object.rotationQuaternion = q;
             //calculate the world matrix with the new rotation
@@ -638,7 +642,12 @@ export class PhysicsImpostor {
     public getObjectCenter(): Vector3 {
         if (this.object.getBoundingInfo) {
             let boundingInfo = this.object.getBoundingInfo();
-            return boundingInfo.boundingBox.centerWorld;
+            const centerWorld = boundingInfo.boundingBox.centerWorld.clone();
+            // correct the size for negative scaling (e.g. flipped mesh)
+            centerWorld.x *= this.object.scaling.x < 0 ? -1 : 1;
+            centerWorld.y *= this.object.scaling.y < 0 ? -1 : 1;
+            centerWorld.z *= this.object.scaling.z < 0 ? -1 : 1;
+            return centerWorld;
         } else {
             return this.object.position;
         }


### PR DESCRIPTION
Hi!

This is my first pull request and I would like to contribute!

When importing glb (gltf) files from Blender I've noticed the meshes are scaled negatively in one axis. As a consequence the physics imposters on these meshes are not created correctly. In example playgrounds ([#66PS52](https://playground.babylonjs.com/#66PS52), [#DGEP8N](https://playground.babylonjs.com/#DGEP8N)) this is 'corrected' with the following code:

```
m.scaling.x = Math.abs(m.scaling.x);
m.scaling.y = Math.abs(m.scaling.y);
m.scaling.z = Math.abs(m.scaling.z);
```

There are two problems with this workaround:
1. It forces the user to flip the mesh, thereby not allowing the user to use the mesh in the original orientation.
2. The calculated mesh center coordinate is wrong, this is apparent when using a non-symmetric mesh.

**Minimal playground reproduction of the issue: https://playground.babylonjs.com/#TWVYMQ#5**

In the playground, you can immediately see that the calculated physics imposter is wrong. You can try the workaround by enabling line 28 (`cube.scaling.y = -cube.scaling.y;`) but you'll see that the box is aligned incorrectly, also the mesh is flipped which is not what I want.

The proposed solution is to adjust for the sign of the scaling when calling `getObjectExtendSize` and `getObjectCenter`. This seems to resolve my issue.

I haven't found a nice `Vector3` helper method for this operation, any ideas?

What are your thoughts?

Thanks a lot!


Related discussion: https://forum.babylonjs.com/t/how-to-correctly-import-gltf-and-add-physics/20234/3