### PR TITLE
Add check for duplicates in ShadowCaster render list

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -27,6 +27,7 @@
 - Added new helper functions for Quaternion.FromLookDirection and Matrix.LookDirection ([Alex-MSFT](https://github.com/Alex-MSFT))
 - Added support for clip planes to the edge renderer ([#10053](https://github.com/BabylonJS/Babylon.js/issues/10053)) ([Popov72](https://github.com/Popov72))
 - Added support for [cannon-es](https://github.com/pmndrs/cannon-es) to the cannonJSPlugin. ([frankieali](https://github.com/frankieali))
+- Added check for duplicates in addShadowCaster ([ivankoleda](https://github.com/ivankoleda))
 
 ### Engine
 

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -731,10 +731,15 @@ export class ShadowGenerator implements IShadowGenerator {
             (renderedMesh) => { renderListMap[renderedMesh.name] = undefined; },
         );
 
-        var meshes = includeDescendants ? [mesh, ...mesh.getChildMeshes()] : [mesh];
-        for (var addedMesh of meshes) {
-            if (!renderListMap.hasOwnProperty(addedMesh.name)) {
-                this._shadowMap.renderList.push(addedMesh);
+        if (!renderListMap.hasOwnProperty(mesh.name)) {
+            this._shadowMap.renderList.push(mesh);
+        }
+        if (!includeDescendants) {
+            return this;
+        }
+        for (var childMesh of mesh.getChildMeshes()) {
+            if (!renderListMap.hasOwnProperty(childMesh.name)) {
+                this._shadowMap.renderList.push(childMesh);
             }
         }
 

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -726,20 +726,15 @@ export class ShadowGenerator implements IShadowGenerator {
             this._shadowMap.renderList = [];
         }
 
-        var renderListMap: Record<string, undefined> = {};
-        this._shadowMap.renderList.forEach(
-            (renderedMesh) => { renderListMap[renderedMesh.name] = undefined; },
-        );
-
-        if (!renderListMap.hasOwnProperty(mesh.name)) {
+        if (this._shadowMap.renderList.indexOf(mesh) === -1) {
             this._shadowMap.renderList.push(mesh);
         }
-        if (!includeDescendants) {
-            return this;
-        }
-        for (var childMesh of mesh.getChildMeshes()) {
-            if (!renderListMap.hasOwnProperty(childMesh.name)) {
-                this._shadowMap.renderList.push(childMesh);
+
+        if (includeDescendants) {
+            for (var childMesh of mesh.getChildMeshes()) {
+                if (this._shadowMap.renderList.indexOf(childMesh) === -1) {
+                    this._shadowMap.renderList.push(childMesh);
+                }
             }
         }
 

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -726,10 +726,16 @@ export class ShadowGenerator implements IShadowGenerator {
             this._shadowMap.renderList = [];
         }
 
-        this._shadowMap.renderList.push(mesh);
+        var renderListMap: Record<string, undefined> = {};
+        this._shadowMap.renderList.forEach(
+            (renderedMesh) => { renderListMap[renderedMesh.name] = undefined; },
+        );
 
-        if (includeDescendants) {
-            this._shadowMap.renderList.push(...mesh.getChildMeshes());
+        var meshes = includeDescendants ? [mesh, ...mesh.getChildMeshes()] : [mesh];
+        for (var addedMesh of meshes) {
+            if (!renderListMap.hasOwnProperty(addedMesh.name)) {
+                this._shadowMap.renderList.push(addedMesh);
+            }
         }
 
         return this;


### PR DESCRIPTION
Closes #9573

It would be really helpful for meshes with large trees of descendants to be filtered for duplicates automatically.
I create map to reduce complexity of these checks, but let me know if this is an overkill in this case.