### PR TITLE
Added exportUnusedUVs property to the IExportOptions interface

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -142,6 +142,7 @@
 - Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
 
 ### Serializers
+
 - Added the `exportUnusedUVs` property to the `IExportOptions` interface that will prevent any unused vertex uv attributes from being stripped during the glTF export. ([ericbroberic](https://github.com/ericbroberic))
 
 ## Bugs

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -141,6 +141,9 @@
 
 - Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
 
+### Serializers
+- Added the `exportUnusedUVs` property to the `IExportOptions` interface that will prevent any unused vertex uv attributes from being stripped during the glTF export. ([ericbroberic](https://github.com/ericbroberic))
+
 ## Bugs
 
 - Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1525,7 +1525,7 @@ export class _Exporter {
 
                     for (const attribute of attributeData) {
                         const attributeKind = attribute.kind;
-                        if (attributeKind === VertexBuffer.UVKind || attributeKind === VertexBuffer.UV2Kind) {
+                        if ((attributeKind === VertexBuffer.UVKind || attributeKind === VertexBuffer.UV2Kind) && !this._options.exportUnusedUVs) {
                             if (glTFMaterial && !this._glTFMaterialExporter._hasTexturesPresent(glTFMaterial)) {
                                 continue;
                             }

--- a/serializers/src/glTF/2.0/glTFSerializer.ts
+++ b/serializers/src/glTF/2.0/glTFSerializer.ts
@@ -32,6 +32,11 @@ export interface IExportOptions {
     exportWithoutWaitingForScene?: boolean;
 
     /**
+     * Indicates if unused vertex uv attributes should be included in export
+     */
+    exportUnusedUVs?: boolean;
+
+    /**
      * Indicates if coordinate system swapping root nodes should be included in export
      */
     includeCoordinateSystemConversionNodes?: boolean;


### PR DESCRIPTION
Allows the prevention of uv attributes from being stripped from the gltf export in the case where a material does not have any textures assigned (unused uvs).

Forum Post: https://forum.babylonjs.com/t/glb-export-in-a-service-context/20445