### PR TITLE
Fix symlink .gitignore to work (on my machine, at least)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,7 @@ Playground/temp/
 Sandbox/public/dist/
 ktx2Decoder/dist/
 
-# Symlinks
-inspector/src/sharedUiComponents/**/*
-nodeEditor/src/sharedUiComponents/**/*
-guiEditor/src/sharedUiComponents/**/*
+# Symlinks created during build
+inspector/src/sharedUiComponents
+nodeEditor/src/sharedUiComponents
+guiEditor/src/sharedUiComponents


### PR DESCRIPTION
I work on Linux, and .gitignore patterns like `inspector/src/sharedUiComponents/**/*` were not working for the sharedUiComponents symlink. The replacement, simpler `inspector/src/sharedUiComponents` pattern works for me, and _should_ work for people on Windows, etc.