### PR TITLE
add gulp and typescript to devDependencies in Tools/Gulp/package.json…

### DIFF
--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -16,5 +16,9 @@
     },
     "dependencies": {
         "node-sass": "^4.14.1"
+    },
+    "devDependencies": {
+        "gulp": "4.0.0",
+        "typescript": "~4.2.4"
     }
 }


### PR DESCRIPTION
Currently, the build requires a systemwide global install of specific versions of gulp (4.0.0 exactly?) and typescript (https://doc.babylonjs.com/divingDeeper/developWithBjs/howToStart#install-typescript-and-gulp). This change adds them as dev dependencies in the Gulp package, so "npm run build" can succeed (at least on my machine) without requiring a global install of these packages.

This seems like much more the "npm way", and avoids having to pollute my global package repository (or conflict with other projects that would want other versions of gulp!) but there may be ramifications I'm not aware of.