### PR TITLE
update package-lock.json version to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "babylonjs",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.19",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
I don't know if something is supposed to do this automatically in your spiffy CI setup, but the file keeps popping up in my "git status" after I run "npm install", and... normally I think it's supposed to match...?