### PR TITLE
Avoid the need for global install during "npm build"

### DIFF
--- a/Tools/Gulp/tasks/gulpTasks-testsES6.js
+++ b/Tools/Gulp/tasks/gulpTasks-testsES6.js
@@ -42,11 +42,13 @@ gulp.task("tests-es6Modules", function(done) {
         }
 
         colorConsole.log("Bundle test app with webpack");
+        shelljs.config.fatal = false;  // Special error reporting below.
         webpack_result = shelljs.exec("npx webpack", {cwd: es6TestsFolder});
-        if (webpack_result.stdout)
+        if (webpack_result.code != 0) {
             colorConsole.error(`webpack stdout:\n${webpack_result.stdout}`);
-        if (webpack_result.stderr)
             colorConsole.error(`webpack stderr:\n${webpack_result.stderr}`);
+            throw "webpack operation failed in tests-es6Modules";
+        }
     }
     finally {
         Object.assign(shelljs.config, savedShellConfig);

--- a/Tools/Publisher/tasks/prepareAdditionalDevPackages.js
+++ b/Tools/Publisher/tasks/prepareAdditionalDevPackages.js
@@ -1,11 +1,17 @@
 // Dependecies.
 const fs = require('fs-extra');
+const minimist = require("minimist");
 const rmDir = require("../../NodeHelpers/rmDir");
 const colorConsole = require("../../NodeHelpers/colorConsole");
 var shelljs = require("shelljs");
 
 // Global Variables.
 const config = require("../../Config/config.js");
+
+// Parse Command Line.
+const commandLineOptions = minimist(process.argv.slice(2), {
+    boolean: ["noGlobalInstall"],
+});
 
 /**
  * Prepare a Additional Dev folder npm linked for test purpose.
@@ -23,15 +29,17 @@ function prepareAdditionalDevPackages() {
         colorConsole.log("    Copy Package folder " + packagePath.cyan + " to " + packageDevPath.cyan);
         fs.copySync(packagePath, packageDevPath);
 
-        colorConsole.log("    Execute Npm Link command");
-        const command = `npm link`;
-        const result = shelljs.exec(command, { 
-            async: false,
-            cwd: packageDevPath
-        });
+        if (!commandLineOptions.noGlobalInstall) {
+            colorConsole.log("    Install Global Package Link (npm link)");
 
-        if (result.code != 0) {
-            throw "Failed to link the ES6 package."
+            const savedShellConfig = {...shelljs.config};
+            try {
+                Object.assign(shelljs.config, {verbose: true, silent: false, fatal: true});
+                shelljs.exec('npm link', {cwd: packageDevPath});
+            }
+            finally {
+                Object.assign(shelljs.config, savedShellConfig);
+            }
         }
 
         colorConsole.emptyLine();

--- a/Tools/Publisher/tasks/prepareUMDDevPackages.js
+++ b/Tools/Publisher/tasks/prepareUMDDevPackages.js
@@ -1,5 +1,6 @@
 // Dependecies.
 const fs = require('fs-extra');
+const minimist = require("minimist");
 const path = require('path');
 const rmDir = require("../../NodeHelpers/rmDir");
 const colorConsole = require("../../NodeHelpers/colorConsole");
@@ -7,6 +8,11 @@ const shelljs = require("shelljs");
 
 // Global Variables.
 const config = require("../../Config/config.js");
+
+// Parse Command Line.
+const commandLineOptions = minimist(process.argv.slice(2), {
+    boolean: ["noGlobalInstall"],
+});
 
 /**
  * Prepare a UMD Dev folder npm linked for test purpose.
@@ -30,32 +36,27 @@ function prepareUMDDevPackages() {
         colorConsole.log("    Copy Package folder " + packagePath.cyan + " to " + packageDevPath.cyan);
         fs.copySync(packagePath, packageDevPath);
 
-        const packageUMDDevJSONPath = path.join(packageDevPath, "package.json");
-        const packageUMDDevJSON = require(packageUMDDevJSONPath);
-        for (let dependency in packageUMDDevJSON.dependencies) {
-            if (dependency.indexOf("babylon") > -1) {
-                colorConsole.log("    Execute Npm Link " + dependency.yellow);
-                const command = `npm link ${dependency}`;
-                const result = shelljs.exec(command, { 
-                    async: false,
-                    cwd: packageDevPath
-                });
+        if (!commandLineOptions.noGlobalInstall) {
+            const packageUMDDevJSONPath = path.join(packageDevPath, "package.json");
+            const packageUMDDevJSON = require(packageUMDDevJSONPath);
 
-                if (result.code != 0) {
-                    throw "Failed to link the ES6 package."
+            const savedShellConfig = {...shelljs.config};
+            try {
+                Object.assign(shelljs.config, {verbose: true, silent: false, fatal: true});
+
+                for (let dependency in packageUMDDevJSON.dependencies) {
+                    if (dependency.indexOf("babylon") > -1) {
+                        colorConsole.log(`    Add Dependency Link (npm link ${dependency.yellow})`);
+                        shelljs.exec(`npm link ${dependency}`, {cwd: packageDevPath});
+                    }
                 }
+
+                colorConsole.log("    Install Global Package Link (npm link)");
+                shelljs.exec('npm link', {cwd: packageDevPath});
             }
-        }
-
-        colorConsole.log("    Execute Npm Link command");
-        const command = `npm link`;
-        const result = shelljs.exec(command, { 
-            async: false,
-            cwd: packageDevPath
-        });
-
-        if (result.code != 0) {
-            throw "Failed to link the ES6 package."
+            finally {
+                Object.assign(shelljs.config, savedShellConfig);
+            }
         }
 
         colorConsole.emptyLine();


### PR DESCRIPTION
No-argument "npm link" updates the global package repository, which is unfortunate and sometimes impossible (by default on Linux, the global repository isn't writable without sudo).

This changes a couple things to avoid that:
- With `--noGlobalInstall`, avoids the "npm link" calls in the prepare{Es6,UMD,Additional}DevPackages build tasks
- Regardless of the flag, directly links to the temp-install for testing, rather than linking from the global repository

(Maybe the "npm link" calls could be removed entirely instead of flag-disabled, but I wasn't sure if other people used the global linkage in their workflow... I'm only testing "npm run build" / "npm run start" at the moment.) The way shelljs is used in these spots is also changed to be more compact and robust.