### PR TITLE
Fix the capitalization of "sandbox" in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,7 +206,7 @@ gui/dist/
 .netlify
 Playground/dist/
 Playground/temp/
-Sandbox/public/dist/
+sandbox/public/dist/
 ktx2Decoder/dist/
 
 # Symlinks


### PR DESCRIPTION
Probably doesn't matter for y'all Windows and Mac folks, but on Linux "sandbox/public/dist" keeps lurking in "git status" without this fix (`Sandbox` => `sandbox`).