### PR TITLE
Buffers: allow more generic buffer creation and wrapping of existing GPU buffers

### DIFF
--- a/src/Buffers/buffer.ts
+++ b/src/Buffers/buffer.ts
@@ -32,7 +32,7 @@ export class Buffer {
      * @param useBytes set to true if the stride in in bytes (optional)
      * @param divisor sets an optional divisor for instances (1 by default)
      */
-    constructor(engine: any, data: DataArray, updatable: boolean, stride = 0, postponeInternalCreation = false, instanced = false, useBytes = false, divisor?: number) {
+    constructor(engine: any, data: DataArray | DataBuffer, updatable: boolean, stride = 0, postponeInternalCreation = false, instanced = false, useBytes = false, divisor?: number) {
         if (engine.getScene) { // old versions of VertexBuffer accepted 'mesh' instead of 'engine'
             this._engine = engine.getScene().getEngine();
         }
@@ -44,7 +44,13 @@ export class Buffer {
         this._instanced = instanced;
         this._divisor = divisor || 1;
 
-        this._data = data;
+        if (data instanceof DataBuffer) {
+            this._data = null;
+            this._buffer = data;
+        } else {
+            this._data = data;
+            this._buffer = null;
+        }
 
         this.byteStride = useBytes ? stride : stride * Float32Array.BYTES_PER_ELEMENT;
 
@@ -314,7 +320,7 @@ export class VertexBuffer {
      * @param divisor defines the instance divisor to use (1 by default)
      * @param takeBufferOwnership defines if the buffer should be released when the vertex buffer is disposed
      */
-    constructor(engine: any, data: DataArray | Buffer, kind: string, updatable: boolean, postponeInternalCreation?: boolean, stride?: number,
+    constructor(engine: any, data: DataArray | Buffer | DataBuffer, kind: string, updatable: boolean, postponeInternalCreation?: boolean, stride?: number,
         instanced?: boolean, offset?: number, size?: number, type?: number, normalized = false, useBytes = false, divisor = 1, takeBufferOwnership = false) {
         if (data instanceof Buffer) {
             this._buffer = data;

--- a/src/Buffers/storageBuffer.ts
+++ b/src/Buffers/storageBuffer.ts
@@ -16,7 +16,7 @@ export class StorageBuffer {
      * Creates a new storage buffer instance
      * @param engine The engine the buffer will be created inside
      * @param size The size of the buffer in bytes
-     * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE will be automatically added.
+     * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE flag will be automatically added.
      */
     constructor(engine: ThinEngine, size: number, creationFlags = Constants.BUFFER_CREATIONFLAG_READ | Constants.BUFFER_CREATIONFLAG_WRITE) {
         this._engine = engine;

--- a/src/Buffers/storageBuffer.ts
+++ b/src/Buffers/storageBuffer.ts
@@ -1,6 +1,7 @@
 import { ThinEngine } from "../Engines/thinEngine";
 import { DataBuffer } from "../Buffers/dataBuffer";
 import { DataArray } from "../types";
+import { Constants } from "../Engines/constants";
 
 /**
  * This class is a small wrapper around a native buffer that can be read and/or written
@@ -9,32 +10,29 @@ export class StorageBuffer {
     private _engine: ThinEngine;
     private _buffer: DataBuffer;
     private _bufferSize: number;
-    private _read: boolean;
-    private _write: boolean;
+    private _creationFlags: number;
 
     /**
      * Creates a new storage buffer instance
      * @param engine The engine the buffer will be created inside
-     * @param read true if the buffer is readable (default: true)
-     * @param write true if the buffer is writable (default: true)
      * @param size The size of the buffer in bytes
+     * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE will be automatically added.
      */
-    constructor(engine: ThinEngine, size: number, read = true, write = true) {
+    constructor(engine: ThinEngine, size: number, creationFlags = Constants.BUFFER_CREATIONFLAG_READ | Constants.BUFFER_CREATIONFLAG_WRITE) {
         this._engine = engine;
         this._engine._storageBuffers.push(this);
-        this._create(size, read, write);
+        this._create(size, creationFlags);
     }
 
-    private _create(size: number, read: boolean, write: boolean): void {
+    private _create(size: number, creationFlags: number): void {
         this._bufferSize = size;
-        this._read = read;
-        this._write = write;
-        this._buffer = this._engine.createStorageBuffer(size, read, write);
+        this._creationFlags = creationFlags;
+        this._buffer = this._engine.createStorageBuffer(size, creationFlags);
     }
 
     /** @hidden */
     public _rebuild(): void {
-        this._create(this._bufferSize, this._read, this._write);
+        this._create(this._bufferSize, this._creationFlags);
     }
 
     /**

--- a/src/Engines/Extensions/engine.storageBuffer.ts
+++ b/src/Engines/Extensions/engine.storageBuffer.ts
@@ -7,11 +7,10 @@ declare module "../../Engines/thinEngine" {
         /**
          * Creates a storage buffer
          * @param data the data for the storage buffer or the size of the buffer
-         * @param read true if the buffer is readable
-         * @param write true if the buffer is writable
+         * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE will be automatically added
          * @returns the new buffer
          */
-        createStorageBuffer(data: DataArray | number, read: boolean, write: boolean): DataBuffer;
+        createStorageBuffer(data: DataArray | number, creationFlags: number): DataBuffer;
 
         /**
          * Updates a storage buffer
@@ -34,7 +33,7 @@ declare module "../../Engines/thinEngine" {
     }
 }
 
-ThinEngine.prototype.createStorageBuffer = function (data: DataArray | number, read: boolean, write: boolean): DataBuffer {
+ThinEngine.prototype.createStorageBuffer = function (data: DataArray | number, creationFlags: number): DataBuffer {
     throw new Error("createStorageBuffer: Unsupported method in this engine!");
 };
 

--- a/src/Engines/Extensions/engine.storageBuffer.ts
+++ b/src/Engines/Extensions/engine.storageBuffer.ts
@@ -7,7 +7,7 @@ declare module "../../Engines/thinEngine" {
         /**
          * Creates a storage buffer
          * @param data the data for the storage buffer or the size of the buffer
-         * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE will be automatically added
+         * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE flag will be automatically added
          * @returns the new buffer
          */
         createStorageBuffer(data: DataArray | number, creationFlags: number): DataBuffer;

--- a/src/Engines/constants.ts
+++ b/src/Engines/constants.ts
@@ -555,6 +555,19 @@ export class Constants {
      */
     public static readonly PREPASS_ALBEDO_TEXTURE_TYPE = 7;
 
+    /** Flag to create a readable buffer (the buffer can be the source of a copy) */
+    public static readonly BUFFER_CREATIONFLAG_READ = 1;
+    /** Flag to create a writable buffer (the buffer can be the destination of a copy) */
+    public static readonly BUFFER_CREATIONFLAG_WRITE = 2;
+    /** Flag to create a buffer suitable to be used as a uniform buffer */
+    public static readonly BUFFER_CREATIONFLAG_UNIFORM = 4;
+    /** Flag to create a buffer suitable to be used as a vertex buffer */
+    public static readonly BUFFER_CREATIONFLAG_VERTEX = 8;
+    /** Flag to create a buffer suitable to be used as an index buffer */
+    public static readonly BUFFER_CREATIONFLAG_INDEX = 16;
+    /** Flag to create a buffer suitable to be used as a storage buffer */
+    public static readonly BUFFER_CREATIONFLAG_STORAGE = 32;
+
     /**
      * Prefixes used by the engine for sub mesh draw wrappers
      */

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -1304,11 +1304,14 @@ export class WebGPUEngine extends Engine {
     /**
      * Creates a storage buffer
      * @param data the data for the storage buffer or the size of the buffer
-     * @param read true if the buffer is readable
-     * @param write true if the buffer is writable
+     * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE will be automatically added
      * @returns the new buffer
      */
-     public createStorageBuffer(data: DataArray | number, read: boolean, write: boolean): DataBuffer {
+     public createStorageBuffer(data: DataArray | number, creationFlags: number): DataBuffer {
+        return this._createBuffer(data, creationFlags | Constants.BUFFER_CREATIONFLAG_STORAGE);
+    }
+
+    private _createBuffer(data: DataArray | number, creationFlags: number): DataBuffer {
         let view: ArrayBufferView | number;
 
         if (data instanceof Array) {
@@ -1321,8 +1324,27 @@ export class WebGPUEngine extends Engine {
             view = data;
         }
 
-        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Storage | (read ? WebGPUConstants.BufferUsage.CopySrc : 0) | (write ? WebGPUConstants.BufferUsage.CopyDst : 0));
-        return dataBuffer;
+        let flags = 0;
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_READ) {
+            flags |= WebGPUConstants.BufferUsage.CopySrc;
+        }
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_WRITE) {
+            flags |= WebGPUConstants.BufferUsage.CopyDst;
+        }
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_UNIFORM) {
+            flags |= WebGPUConstants.BufferUsage.Uniform;
+        }
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_VERTEX) {
+            flags |= WebGPUConstants.BufferUsage.Vertex;
+        }
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_INDEX) {
+            flags |= WebGPUConstants.BufferUsage.Index;
+        }
+        if (creationFlags & Constants.BUFFER_CREATIONFLAG_STORAGE) {
+            flags |= WebGPUConstants.BufferUsage.Storage;
+        }
+
+        return this._bufferManager.createBuffer(view, flags);
     }
 
     /**

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -263,10 +263,11 @@ export class Geometry implements IGetSetVerticesData {
      * Affect a vertex buffer to the geometry. the vertexBuffer.getKind() function is used to determine where to store the data
      * @param buffer defines the vertex buffer to use
      * @param totalVertices defines the total number of vertices for position kind (could be null)
+     * @param disposeExistingBuffer disposes the existing buffer, if any (default: true)
      */
-    public setVerticesBuffer(buffer: VertexBuffer, totalVertices: Nullable<number> = null): void {
+    public setVerticesBuffer(buffer: VertexBuffer, totalVertices: Nullable<number> = null, disposeExistingBuffer = true): void {
         var kind = buffer.getKind();
-        if (this._vertexBuffers[kind]) {
+        if (this._vertexBuffers[kind] && disposeExistingBuffer) {
             this._vertexBuffers[kind].dispose();
         }
 

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1477,14 +1477,15 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
      * Sets the mesh global Vertex Buffer
      * @param buffer defines the buffer to use
+     * @param disposeExistingBuffer disposes the existing buffer, if any (default: true)
      * @returns the current mesh
      */
-    public setVerticesBuffer(buffer: VertexBuffer): Mesh {
+    public setVerticesBuffer(buffer: VertexBuffer, disposeExistingBuffer = true): Mesh {
         if (!this._geometry) {
             this._geometry = Geometry.CreateGeometryForMesh(this);
         }
 
-        this._geometry.setVerticesBuffer(buffer);
+        this._geometry.setVerticesBuffer(buffer, null, disposeExistingBuffer);
         return this;
     }
 

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -141,6 +141,8 @@ class _InternalMeshDataInfo {
     public _onMeshReadyObserverAdded: (observer: Observer<Mesh>) => void;
 
     public _effectiveMaterial: Nullable<Material> = null;
+
+    public _forcedInstanceCount: number = 0;
 }
 
 /**
@@ -406,6 +408,19 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     public _delayInfo: Array<string>;
     /** @hidden */
     public _delayLoadingFunction: (any: any, mesh: Mesh) => void;
+
+    /**
+     * Gets or sets the forced number of instances to display.
+     * If 0 (default value), the number of instances is not forced and depends on the draw type
+     * (regular / instance / thin instances mesh)
+     */
+    public get forcedInstanceCount(): number {
+        return this._internalMeshDataInfo._forcedInstanceCount;
+    }
+
+    public set forcedInstanceCount(count: number) {
+        this._internalMeshDataInfo._forcedInstanceCount = count;
+    }
 
     /** @hidden */
     public _instanceDataStorage = new _InstanceDataStorage();
@@ -1678,12 +1693,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         if (this._unIndexed || fillMode == Material.PointFillMode) {
             // or triangles as points
-            engine.drawArraysType(fillMode, subMesh.verticesStart, subMesh.verticesCount, instancesCount);
+            engine.drawArraysType(fillMode, subMesh.verticesStart, subMesh.verticesCount, this.forcedInstanceCount || instancesCount);
         } else if (fillMode == Material.WireFrameFillMode) {
             // Triangles as wireframe
-            engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, instancesCount);
+            engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, this.forcedInstanceCount || instancesCount);
         } else {
-            engine.drawElementsType(fillMode, subMesh.indexStart, subMesh.indexCount, instancesCount);
+            engine.drawElementsType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
         }
 
         return this;


### PR DESCRIPTION
The PR allows to use an existing GPU buffer (`DataBuffer`) in a `Buffer` object so that we can create a `VertexBuffer` around a storage buffer filled by a compute shader (for eg).

Also, storage buffer creation now takes a creation flag to flag the buffer for specific additional usages (as uniform buffer, vertex buffer, index buffer, etc).

Finally I have added a `Mesh.forcedInstanceCount` property as discussed offline with @deltakosh.