### PR TITLE
WebGPU: Simplify the ComputeShader interface

### DIFF
--- a/src/Engines/Extensions/engine.computeShader.ts
+++ b/src/Engines/Extensions/engine.computeShader.ts
@@ -6,9 +6,15 @@ import { Nullable } from "../../types";
 
 /**
  * Type used to locate a resource in a compute shader.
- * Note that for the time being the string variant does not work because reflection is not implemented in browsers yet
+ * TODO: remove this when browsers support reflection for wgsl shaders
+*/
+export type ComputeBindingLocation = { group: number, binding: number };
+
+/**
+ * Type used to lookup a resource and retrieve its binding location
+ * TODO: remove this when browsers support reflection for wgsl shaders
  */
-export type ComputeBindingLocation = { group: number, binding: number } | string;
+export type ComputeBindingMapping = { [key: string]: ComputeBindingLocation };
 
 /** @hidden */
 export enum ComputeBindingType {
@@ -19,12 +25,7 @@ export enum ComputeBindingType {
 }
 
 /** @hidden */
-export type ComputeBindingList = { [key: string]: { location: ComputeBindingLocation, type: ComputeBindingType, object: any } };
-
-/** @hidden */
-export function BindingLocationToString(location: ComputeBindingLocation): string {
-    return (location as any).group !== undefined ? (location as any).group + "_" + (location as any).binding : <string>location;
-}
+export type ComputeBindingList = { [key: string]: { type: ComputeBindingType, object: any } };
 
 declare module "../../Engines/thinEngine" {
     export interface ThinEngine {
@@ -56,8 +57,9 @@ declare module "../../Engines/thinEngine" {
          * @param x The number of workgroups to execute on the X dimension
          * @param y The number of workgroups to execute on the Y dimension
          * @param z The number of workgroups to execute on the Z dimension
+         * @param bindingsMapping list of bindings mapping (key is property name, value is binding location)
          */
-        computeDispatch(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number): void;
+        computeDispatch(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number, bindingsMapping?: ComputeBindingMapping): void;
 
         /**
          * Gets a boolean indicating if all created compute effects are ready
@@ -99,7 +101,7 @@ ThinEngine.prototype.createComputeContext = function(): IComputeContext | undefi
     return undefined;
 };
 
-ThinEngine.prototype.computeDispatch = function(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number): void {
+ThinEngine.prototype.computeDispatch = function(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number, bindingsMapping?: ComputeBindingMapping): void {
     throw new Error("computeDispatch: This engine does not support compute shaders!");
 };
 

--- a/src/Engines/WebGPU/webgpuComputeContext.ts
+++ b/src/Engines/WebGPU/webgpuComputeContext.ts
@@ -3,7 +3,7 @@ import { IComputeContext } from "../../Compute/IComputeContext";
 import { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { UniformBuffer } from "../../Materials/uniformBuffer";
 import { Logger } from "../../Misc/logger";
-import { ComputeBindingList, ComputeBindingType } from "../Extensions/engine.computeShader";
+import { ComputeBindingList, ComputeBindingMapping, ComputeBindingType } from "../Extensions/engine.computeShader";
 import { WebGPUCacheSampler } from "./webgpuCacheSampler";
 import * as WebGPUConstants from './webgpuConstants';
 import { WebGPUHardwareTexture } from "./webgpuHardwareTexture";
@@ -18,15 +18,19 @@ export class WebGPUComputeContext implements IComputeContext {
     private _cacheSampler: WebGPUCacheSampler;
     private _bindGroups: GPUBindGroup[];
 
-    public getBindGroups(bindings: ComputeBindingList, computePipeline: GPUComputePipeline): GPUBindGroup[] {
+    public getBindGroups(bindings: ComputeBindingList, computePipeline: GPUComputePipeline, bindingsMapping?: ComputeBindingMapping): GPUBindGroup[] {
+        if (!bindingsMapping) {
+            throw new Error("WebGPUComputeContext.getBindGroups: bindingsMapping is required until browsers support reflection for wgsl shaders!");
+        }
         if (this._bindGroups.length === 0) {
             const bindGroupEntries: GPUBindGroupEntry[][] = [];
             for (const key in bindings) {
                 const binding = bindings[key],
-                    group = (binding.location as any).group,
-                    index = (binding.location as any).binding,
-                    type = binding.type,
-                    object = binding.object;
+                      location = bindingsMapping[key],
+                      group = location.group,
+                      index = location.binding,
+                      type = binding.type,
+                      object = binding.object;
 
                 let entries = bindGroupEntries[group];
                 if (!entries) {

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -50,7 +50,7 @@ import { WebGPUTimestampQuery } from "./WebGPU/webgpuTimestampQuery";
 import { ComputeEffect, IComputeEffectCreationOptions } from "../Compute/computeEffect";
 import { IComputePipelineContext } from "../Compute/IComputePipelineContext";
 import { WebGPUComputePipelineContext } from "./WebGPU/webgpuComputePipelineContext";
-import { ComputeBindingList } from "./Extensions/engine.computeShader";
+import { ComputeBindingList, ComputeBindingMapping } from "./Extensions/engine.computeShader";
 import { IComputeContext } from "../Compute/IComputeContext";
 import { WebGPUComputeContext } from "./WebGPU/webgpuComputeContext";
 
@@ -1581,8 +1581,9 @@ export class WebGPUEngine extends Engine {
      * @param x The number of workgroups to execute on the X dimension
      * @param y The number of workgroups to execute on the Y dimension
      * @param z The number of workgroups to execute on the Z dimension
+     * @param bindingsMapping list of bindings mapping (key is property name, value is binding location)
      */
-    public computeDispatch(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number): void {
+    public computeDispatch(effect: ComputeEffect, context: IComputeContext, bindings: ComputeBindingList, x: number, y?: number, z?: number, bindingsMapping?: ComputeBindingMapping): void {
         const contextPipeline = effect._pipelineContext as WebGPUComputePipelineContext;
         const computeContext = context as WebGPUComputeContext;
 
@@ -1597,7 +1598,7 @@ export class WebGPUEngine extends Engine {
 
         computePass.setPipeline(contextPipeline.computePipeline);
 
-        const bindGroups = computeContext.getBindGroups(bindings, contextPipeline.computePipeline);
+        const bindGroups = computeContext.getBindGroups(bindings, contextPipeline.computePipeline, bindingsMapping);
         for (let i = 0; i < bindGroups.length; ++i) {
             const bindGroup = bindGroups[i];
             if (!bindGroup) {


### PR DESCRIPTION
I have simplified the interface so that it is easier to switch to using reflection for wgsl shaders when browsers support it.