### PR TITLE
Fix canUseGLInstanceID computation

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -982,7 +982,7 @@ export class ThinEngine {
             multiview: this._gl.getExtension('OVR_multiview2'),
             oculusMultiview: this._gl.getExtension('OCULUS_multiview'),
             depthTextureExtension: false,
-            canUseGLInstanceID: !(this._badOS && this._webGLVersion <= 1),
+            canUseGLInstanceID: this._webGLVersion > 1,
             canUseGLVertexID: this._webGLVersion > 1,
             supportComputeShaders: false,
         };


### PR DESCRIPTION
Even if the `ANGLE_instanced_arrays` extension is supported in WebGL1, `gl_InstanceID` is not available as per [the spec of the extension](https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/).

See also some explanations on why it is not supported [here](https://www.khronos.org/webgl/public-mailing-list/public_webgl/1301/msg00066.php):

> gl_InstanceID is a very deliberate "omission" from ANGLE_instanced_arrays, because that is the *other* style of instancing. I'm sure we've covered this before in this forum -- the attribute divisor, (in the ARB/ANGLE_instanced_arrays extension) is often called the dx9-style instancing. The instanceID accessible in the shader is the dx10-style instancing and is introduced by the ARB_draw_instanced extension, and is only supported on GL3 (aka DX10) hardware or better. If we put that in the ANGLE/Webgl extension, you wouldn't get any instancing on when running on DX9 hardware/API. 

So, `canUseGLInstanceID` should simply be equal to `this._webGLVersion > 1`.