### PR TITLE
Fix problem that VRExperienceHelper does not always respect the useXR…

### DIFF
--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -722,8 +722,8 @@ export class VRExperienceHelper {
         // check for VR support:
 
         const vrSupported = 'getVRDisplays' in navigator;
-        // no VR support? force XR
-        if (!vrSupported) {
+        // no VR support? force XR but only when it is not set because web vr can work without the getVRDisplays
+        if (!vrSupported && webVROptions.useXR === undefined) {
             webVROptions.useXR = true;
         }
 


### PR DESCRIPTION
I have a problem after upgrading to babylon 4.2. The VRExperienceHelper is not backwards compatible any more which prevents me from using VR in my IOS app. It all comes down the following code:

const vrSupported = 'vrSupported' in navigator;
 // no VR support? force XR
if (!vrSupported) {
            webVROptions.useXR = true;
}

The code assumes that, if vrSupported is not defined, the vr helper can not possibly work and switches to web XR. But this not the case. Babylon VR can work without the getVRDisplays. (I use this it in my ios cordova app ergometer-space ) To make it work in my project I need to set useXR to false. However this code wil turn it on again and there is no way around it. So I think the code must change into this:

if (!vrSupported && webVROptions.useXR === undefined) {
            webVROptions.useXR = true;
}
