### PR TITLE
Fix JsDoc of Buffer.create

### DIFF
--- a/src/Buffers/buffer.ts
+++ b/src/Buffers/buffer.ts
@@ -117,7 +117,8 @@ export class Buffer {
     // Methods
 
     /**
-     * Store data into the buffer. If the buffer was already used it will be either recreated or updated depending on isUpdatable property
+     * Store data into the buffer. Creates the buffer if not used already.
+     * If the buffer was already used, it will be updated only if it is updatable, otherwise it will do nothing.
      * @param data defines the data to store
      */
     public create(data: Nullable<DataArray> = null): void {


### PR DESCRIPTION
minor jsodc update for function `Buffer.create` that will do nothing if the buffer is already used but not updatable.

This change is not worth a line in 'What's new' :)