### PR TITLE
Fix crash when calling engine.dispose

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -833,7 +833,7 @@ export class ThinEngine {
             await initEngine();
             // Rebuild effects
             this._rebuildEffects();
-            this._rebuildComputeEffects();
+            this._rebuildComputeEffects?.();
             // Rebuild textures
             this._rebuildInternalTextures();
             // Rebuild buffers
@@ -4198,7 +4198,7 @@ export class ThinEngine {
 
         // Release effects
         this.releaseEffects();
-        this.releaseComputeEffects();
+        this.releaseComputeEffects?.();
 
         // Unbind
         this.unbindAllAttributes();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/engine-dispose-throws-this-releasecomputeeffects-is-not-a-function/20880