### PR TITLE
Improved texture inspector panning accesibility

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -78,7 +78,7 @@
 - Added support for sounds in the inspector ([Deltakosh](https://github.com/deltakosh))
 - Added a debug option to show the frustum of a directional light ([Popov72](https://github.com/Popov72))
 - Added support for the material stencil properties ([Popov72](https://github.com/Popov72))
-- Added space + LMB panning to inspector to improve accessibility ([darraghjburke](https://github.com/darraghjburke))
+- Added space + LMB panning to texture inspector to improve accessibility ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -78,6 +78,7 @@
 - Added support for sounds in the inspector ([Deltakosh](https://github.com/deltakosh))
 - Added a debug option to show the frustum of a directional light ([Popov72](https://github.com/Popov72))
 - Added support for the material stencil properties ([Popov72](https://github.com/Popov72))
+- Added space + LMB panning to inspector to improve accessibility ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/eyedropper.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/eyedropper.ts
@@ -29,15 +29,16 @@ export const Eyedropper : IToolData = {
         setup () {
             this.pointerObserver = this.getParameters().scene.onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
+                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled()) {
                         this.isPicking = true;
                         this.pick(pointerInfo);
                     }
-                    if (pointerInfo.type === PointerEventTypes.POINTERMOVE && this.isPicking) {
-                        this.pick(pointerInfo);
-                    }
-                    if (pointerInfo.type === PointerEventTypes.POINTERUP) {
-                        this.isPicking = false;
+                    if (this.isPicking) {
+                        if (!(pointerInfo.event.buttons & 1) || ! this.getParameters().interactionEnabled()) {
+                            this.isPicking = false;
+                        } else {
+                            this.pick(pointerInfo);
+                        }
                     }
                 }
             });

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/eyedropper.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/eyedropper.ts
@@ -29,12 +29,12 @@ export const Eyedropper : IToolData = {
         setup () {
             this.pointerObserver = this.getParameters().scene.onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled()) {
+                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled()) {
                         this.isPicking = true;
                         this.pick(pointerInfo);
                     }
                     if (this.isPicking) {
-                        if (!(pointerInfo.event.buttons & 1) || ! this.getParameters().interactionEnabled()) {
+                        if (pointerInfo.event.buttons !== 1 || !this.getParameters().interactionEnabled()) {
                             this.isPicking = false;
                         } else {
                             this.pick(pointerInfo);

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
@@ -25,10 +25,8 @@ export const Floodfill : IToolData = {
         
         setup () {
             this.pointerObserver = this.getParameters().scene.onPointerObservable.add((pointerInfo) => {
-                if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled()) {
-                        this.fill();
-                    }
+                if (pointerInfo.type === PointerEventTypes.POINTERDOWN && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                    this.fill();
                 }
             });
         }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
@@ -26,7 +26,7 @@ export const Floodfill : IToolData = {
         setup () {
             this.pointerObserver = this.getParameters().scene.onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
+                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled()) {
                         this.fill();
                     }
                 }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/floodfill.ts
@@ -26,7 +26,7 @@ export const Floodfill : IToolData = {
         setup () {
             this.pointerObserver = this.getParameters().scene.onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled()) {
+                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled()) {
                         this.fill();
                     }
                 }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
@@ -63,7 +63,7 @@ class paintbrushTool implements IToolType {
         this.pointerObserver = scene.onPointerObservable.add(async (pointerInfo) => {
             const {startPainting, stopPainting, metadata} = this.getParameters();
             if (!this.isPainting) {
-                if (pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                if (pointerInfo.type == PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
                     this.isPainting = true;
                     const circleCanvas = document.createElement('canvas');
                     circleCanvas.width = this.width;

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
@@ -63,7 +63,7 @@ class paintbrushTool implements IToolType {
         this.pointerObserver = scene.onPointerObservable.add(async (pointerInfo) => {
             const {startPainting, stopPainting, metadata} = this.getParameters();
             if (!this.isPainting) {
-                if (pointerInfo.type == PointerEventTypes.POINTERDOWN && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                if (pointerInfo.type === PointerEventTypes.POINTERDOWN && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
                     this.isPainting = true;
                     const circleCanvas = document.createElement('canvas');
                     circleCanvas.width = this.width;
@@ -77,8 +77,10 @@ class paintbrushTool implements IToolType {
                     const g = Math.floor(rgb.g * 255);
                     const b = Math.floor(rgb.b * 255);
                     let idx = 0;
-                    for(let y = -Math.floor(this.width / 2); y < Math.ceil(this.width / 2); y++) {
-                        for (let x = -Math.floor(this.width / 2); x < Math.ceil(this.width / 2); x++) {
+                    const x1 = -Math.floor(this.width / 2), x2 = Math.ceil(this.width / 2);
+                    const y1 = -Math.floor(this.width / 2), y2 = Math.ceil(this.width / 2);
+                    for(let y = y1; y < y2; y++) {
+                        for (let x = x1; x < x2; x++) {
                             pixels[idx++] = r;
                             pixels[idx++] = g;
                             pixels[idx++] = b;
@@ -91,7 +93,7 @@ class paintbrushTool implements IToolType {
                     this.paint(pointerInfo);
                   }
             } else {
-                if (!(pointerInfo.event.buttons & 1) || !this.getParameters().interactionEnabled()) {
+                if (pointerInfo.event.buttons !== 1 || !this.getParameters().interactionEnabled()) {
                     this.isPainting = false;
                     this.circleCanvas.parentNode?.removeChild(this.circleCanvas);
                     stopPainting();

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/paintbrush.tsx
@@ -62,47 +62,45 @@ class paintbrushTool implements IToolType {
 
         this.pointerObserver = scene.onPointerObservable.add(async (pointerInfo) => {
             const {startPainting, stopPainting, metadata} = this.getParameters();
-            if (pointerInfo.pickInfo?.hit) {
-                if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
-                    if (pointerInfo.event.button == 0) {
-                        this.isPainting = true;
-                        const circleCanvas = document.createElement('canvas');
-                        circleCanvas.width = this.width;
-                        circleCanvas.height = this.width;
-                        const circleCtx = circleCanvas.getContext('2d')!;
-                        circleCtx.imageSmoothingEnabled = false;
-                        let pixels = new Array(4 * this.width * this.width);
-                        const dis = this.width * this.width / 4;
-                        const rgb = Color3.FromHexString(metadata.color)!;
-                        const r = Math.floor(rgb.r * 255);
-                        const g = Math.floor(rgb.g * 255);
-                        const b = Math.floor(rgb.b * 255);
-                        let idx = 0;
-                        for(let y = -Math.floor(this.width / 2); y < Math.ceil(this.width / 2); y++) {
-                            for (let x = -Math.floor(this.width / 2); x < Math.ceil(this.width / 2); x++) {
-                                pixels[idx++] = r;
-                                pixels[idx++] = g;
-                                pixels[idx++] = b;
-                                pixels[idx++] = (x * x + y * y <= dis) ? 255 : 0;
-                            }
+            if (!this.isPainting) {
+                if (pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                    this.isPainting = true;
+                    const circleCanvas = document.createElement('canvas');
+                    circleCanvas.width = this.width;
+                    circleCanvas.height = this.width;
+                    const circleCtx = circleCanvas.getContext('2d')!;
+                    circleCtx.imageSmoothingEnabled = false;
+                    let pixels = new Array(4 * this.width * this.width);
+                    const dis = this.width * this.width / 4;
+                    const rgb = Color3.FromHexString(metadata.color)!;
+                    const r = Math.floor(rgb.r * 255);
+                    const g = Math.floor(rgb.g * 255);
+                    const b = Math.floor(rgb.b * 255);
+                    let idx = 0;
+                    for(let y = -Math.floor(this.width / 2); y < Math.ceil(this.width / 2); y++) {
+                        for (let x = -Math.floor(this.width / 2); x < Math.ceil(this.width / 2); x++) {
+                            pixels[idx++] = r;
+                            pixels[idx++] = g;
+                            pixels[idx++] = b;
+                            pixels[idx++] = (x * x + y * y <= dis) ? 255 : 0;
                         }
-                        circleCtx.putImageData(new ImageData(Uint8ClampedArray.from(pixels), this.width, this.width), 0, 0);
-                        this.circleCanvas = circleCanvas;
-                        this.ctx = await startPainting();
-                        this.paint(pointerInfo);
-                      }
-                }
-                if (pointerInfo.type === PointerEventTypes.POINTERMOVE && this.isPainting) {
+                    }
+                    circleCtx.putImageData(new ImageData(Uint8ClampedArray.from(pixels), this.width, this.width), 0, 0);
+                    this.circleCanvas = circleCanvas;
+                    this.ctx = await startPainting();
                     this.paint(pointerInfo);
-                }
-            }
-            if (pointerInfo.type === PointerEventTypes.POINTERUP) {
-                if (pointerInfo.event.button == 0) {
+                  }
+            } else {
+                if (!(pointerInfo.event.buttons & 1) || !this.getParameters().interactionEnabled()) {
                     this.isPainting = false;
                     this.circleCanvas.parentNode?.removeChild(this.circleCanvas);
                     stopPainting();
                     this.mousePos = null;
-                  }
+                } else {
+                    if (pointerInfo.pickInfo?.hit && pointerInfo.type === PointerEventTypes.POINTERMOVE) {
+                        this.paint(pointerInfo);
+                    }
+                }
             }
         });
         this.isPainting = false;

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
@@ -19,7 +19,7 @@ export const RectangleSelect : IToolData = {
             this.pointerObserver = scene.onPointerObservable.add((pointerInfo) => {
                 const {getMouseCoordinates, setMetadata, metadata} = this.getParameters();
                 if (!this.isSelecting) {
-                    if (pointerInfo.type == PointerEventTypes.POINTERDOWN && pointerInfo && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                    if (pointerInfo.type == PointerEventTypes.POINTERDOWN && pointerInfo && (pointerInfo.event.buttons === 1) && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
                         this.isSelecting = true;
                         const {x, y} = {x: this.xStart, y: this.yStart} = getMouseCoordinates(pointerInfo);
                         setMetadata({
@@ -32,7 +32,7 @@ export const RectangleSelect : IToolData = {
                         });
                     }
                 } else {
-                    if (!(pointerInfo.event.buttons & 1) || !this.getParameters().interactionEnabled()) {
+                    if (pointerInfo.event.buttons !== 1 || !this.getParameters().interactionEnabled()) {
                         this.isSelecting = false;
                         if (metadata.select.x1 === metadata.select.x2 || metadata.select.y1 === metadata.select.y2) {
                             setMetadata({

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
@@ -18,35 +18,21 @@ export const RectangleSelect : IToolData = {
             const {scene} = this.getParameters();
             this.pointerObserver = scene.onPointerObservable.add((pointerInfo) => {
                 const {getMouseCoordinates, setMetadata, metadata} = this.getParameters();
-                if (pointerInfo.pickInfo?.hit) {
-                    if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
-                        if (pointerInfo.event.button == 0) {
-                            this.isSelecting = true;
-                            const {x, y} = {x: this.xStart, y: this.yStart} = getMouseCoordinates(pointerInfo);
-                            setMetadata({
-                                select: {
-                                    x1: x,
-                                    y1: y,
-                                    x2: x,
-                                    y2: y
-                                }
-                            })
-                          }
-                    }
-                    if (pointerInfo.type === PointerEventTypes.POINTERMOVE && this.isSelecting) {
-                        const {x, y} = getMouseCoordinates(pointerInfo);
+                if (!this.isSelecting) {
+                    if (pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                        this.isSelecting = true;
+                        const {x, y} = {x: this.xStart, y: this.yStart} = getMouseCoordinates(pointerInfo);
                         setMetadata({
                             select: {
-                                x1: Math.min(x, this.xStart),
-                                y1: Math.min(y, this.yStart),
-                                x2: Math.max(x, this.xStart),
-                                y2: Math.max(y, this.yStart)
+                                x1: x,
+                                y1: y,
+                                x2: x,
+                                y2: y
                             }
-                        })
+                        });
                     }
-                }
-                if (pointerInfo.type === PointerEventTypes.POINTERUP) {
-                    if (pointerInfo.event.button == 0) {
+                } else {
+                    if (!(pointerInfo.event.buttons & 1) || !this.getParameters().interactionEnabled()) {
                         this.isSelecting = false;
                         if (metadata.select.x1 === metadata.select.x2 || metadata.select.y1 === metadata.select.y2) {
                             setMetadata({
@@ -54,6 +40,20 @@ export const RectangleSelect : IToolData = {
                                     x1: -1, y1: -1, x2: -1, y2: -1
                                 }
                             })
+                        }
+                    } else {
+                        if (pointerInfo.pickInfo?.hit && pointerInfo.type === PointerEventTypes.POINTERMOVE) {
+                            if (pointerInfo.type === PointerEventTypes.POINTERMOVE && this.isSelecting) {
+                                const {x, y} = getMouseCoordinates(pointerInfo);
+                                setMetadata({
+                                    select: {
+                                        x1: Math.min(x, this.xStart),
+                                        y1: Math.min(y, this.yStart),
+                                        x2: Math.max(x, this.xStart),
+                                        y2: Math.max(y, this.yStart)
+                                    }
+                                })
+                            }
                         }
                     }
                 }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/defaultTools/rectangleSelect.ts
@@ -19,7 +19,7 @@ export const RectangleSelect : IToolData = {
             this.pointerObserver = scene.onPointerObservable.add((pointerInfo) => {
                 const {getMouseCoordinates, setMetadata, metadata} = this.getParameters();
                 if (!this.isSelecting) {
-                    if (pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
+                    if (pointerInfo.type == PointerEventTypes.POINTERDOWN && pointerInfo && pointerInfo.event.buttons & 1 && this.getParameters().interactionEnabled() && pointerInfo.pickInfo?.hit) {
                         this.isSelecting = true;
                         const {x, y} = {x: this.xStart, y: this.yStart} = getMouseCoordinates(pointerInfo);
                         setMetadata({

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
@@ -281,7 +281,7 @@ export class TextureCanvasManager {
                     this._isPanning = true;
                 }
             }
-            else if (!leftButtonPressed && !middleButtonPressed) {
+            else if ((!leftButtonPressed || !this._keyMap[this.PAN_KEY]) && !middleButtonPressed) {
                 this._isPanning = false;
             }
             switch (pointerInfo.type) {

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
@@ -673,10 +673,7 @@ export class TextureCanvasManager {
     }
 
     public toolInteractionEnabled() {
-        if (this._keyMap[this.PAN_KEY] || this._isPanning) {
-            return false;
-        }
-        return true;
+        return !(this._keyMap[this.PAN_KEY] || this._isPanning);
     }
 
     public dispose() {

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
@@ -87,6 +87,8 @@ export class TextureCanvasManager {
 
     /** Tracks which keys are currently pressed */
     private _keyMap : any = {};
+    /** Tracks which mouse buttons are currently pressed */
+    private _buttonsPressed = 0;
 
     private readonly ZOOM_MOUSE_SPEED : number = 0.001;
     private readonly ZOOM_KEYBOARD_SPEED : number = 0.4;
@@ -94,7 +96,7 @@ export class TextureCanvasManager {
     private readonly ZOOM_OUT_KEY : string = '-';
 
     private readonly PAN_SPEED : number = 0.003;
-    private readonly PAN_MOUSE_BUTTON : number = 1; // MMB
+    private readonly PAN_KEY = 'Space';
 
     private readonly MIN_SCALE : number = 0.01;
     private readonly GRID_SCALE : number = 0.047;
@@ -267,23 +269,25 @@ export class TextureCanvasManager {
         });
 
         this._scene.onPointerObservable.add((pointerInfo) => {
+            const leftButtonPressed = pointerInfo.event.buttons & 1;
+            const middleButtonPressed = pointerInfo.event.buttons & 4;
+            if (!this._isPanning) {
+                if ((leftButtonPressed && !(this._buttonsPressed & 1) && this._keyMap[this.PAN_KEY]) || middleButtonPressed) {
+                    this._isPanning = true;
+                        this._mouseX = pointerInfo.event.x;
+                        this._mouseY = pointerInfo.event.y;
+                }
+                if (middleButtonPressed) {
+                    this._isPanning = true;
+                }
+            }
+            else if (!leftButtonPressed && !middleButtonPressed) {
+                this._isPanning = false;
+            }
             switch (pointerInfo.type) {
                 case PointerEventTypes.POINTERWHEEL:
                     const event = pointerInfo.event as IWheelEvent;
                     this._scale -= (event.deltaY * this.ZOOM_MOUSE_SPEED * this._scale);
-                    break;
-                case PointerEventTypes.POINTERDOWN:
-                    if (pointerInfo.event.button === this.PAN_MOUSE_BUTTON) {
-                        this._isPanning = true;
-                        this._mouseX = pointerInfo.event.x;
-                        this._mouseY = pointerInfo.event.y;
-                        pointerInfo.event.preventDefault();
-                    }
-                    break;
-                case PointerEventTypes.POINTERUP:
-                    if (pointerInfo.event.button === this.PAN_MOUSE_BUTTON) {
-                        this._isPanning = false;
-                    }
                     break;
                 case PointerEventTypes.POINTERMOVE:
                     if (this._isPanning) {
@@ -301,6 +305,7 @@ export class TextureCanvasManager {
                     }
                     break;
             }
+            this._buttonsPressed = pointerInfo.event.buttons;
         });
 
         this._scene.onKeyboardObservable.add((kbInfo) => {
@@ -665,6 +670,13 @@ export class TextureCanvasManager {
         Tools.ToBlob(canvas, (blob) => {
             Tools.Download(blob!, this._originalTexture.name);
         });
+    }
+
+    public toolInteractionEnabled() {
+        if (this._keyMap[this.PAN_KEY] || this._isPanning) {
+            return false;
+        }
+        return true;
     }
 
     public dispose() {

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
@@ -63,6 +63,8 @@ export interface IToolParameters {
     updatePainting: () => void;
     /** Call this when you are finished painting. */
     stopPainting: () => void;
+    /** Returns whether the tool should be allowed to interact */
+    interactionEnabled: () => boolean;
 }
 
 export interface IToolGUIProps {
@@ -235,6 +237,7 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
             metadata: this.state.metadata,
             setMetadata: (data : any) => this.setMetadata(data),
             getMouseCoordinates: (pointerInfo : PointerInfo) => this._textureCanvasManager.getMouseCoordinates(pointerInfo),
+            interactionEnabled: () => this._textureCanvasManager.toolInteractionEnabled(),
             BABYLON: BABYLON,
         };
     }
@@ -286,7 +289,10 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
     render() {
         const currentTool : ITool | undefined = this.state.tools[this.state.activeToolIndex];
         let cursor = `initial`;
-        if (currentTool && currentTool.cursor) {
+        if (!this._textureCanvasManager?.toolInteractionEnabled()) {
+            cursor = `pointer`;
+        }
+        else if (currentTool && currentTool.cursor) {
             cursor = `url(data:image/png;base64,${currentTool.cursor}) 10 10, auto`;
         }
 


### PR DESCRIPTION
This PR makes the following changes, in order to address #10394

- Pressing space + LMB now begins panning. Releasing either space or LMB will end panning. (MMB behavior is unchanged).
- Fixes bug where pressing multiple mouse buttons could cause panning to continue indefinitely.
- Tools will no longer activate if the user is panning (or pressing the spacebar). If a tool is currently active and the user begins panning, the tool will deactivate.