### PR TITLE
Scale gizmo & physics debug view fix

### DIFF
--- a/src/Debug/physicsViewer.ts
+++ b/src/Debug/physicsViewer.ts
@@ -256,20 +256,36 @@ export class PhysicsViewer {
                     // Handle compound impostors
                     var childMeshes = targetMesh.getChildMeshes().filter((c) => { return c.physicsImpostor ? 1 : 0; });
                     childMeshes.forEach((m) => {
-                        mesh = this._getDebugBoxMesh(utilityLayerScene);
-                        if (m.physicsImpostor &&  m.physicsImpostor.type === PhysicsImpostor.BoxImpostor && m.getClassName() === "Mesh") {
+                        
+                        if (m.physicsImpostor && m.getClassName() === "Mesh") {
                             const boundingInfo = m.getBoundingInfo();
                             const min = boundingInfo.boundingBox.minimum;
                             const max = boundingInfo.boundingBox.maximum;
-                            mesh.position.copyFrom(min);
-
-                            mesh.position.addInPlace(max);
-                            mesh.position.scaleInPlace(0.5);
-                            mesh.scaling.x = max.x - min.x;
-                            mesh.scaling.y = max.y - min.y;
-                            mesh.scaling.z = max.z - min.z;
+                            switch (m.physicsImpostor.type)
+                            {
+                                case PhysicsImpostor.BoxImpostor:
+                                    mesh = this._getDebugBoxMesh(utilityLayerScene);
+                                    mesh.position.copyFrom(min);
+                                    mesh.position.addInPlace(max);
+                                    mesh.position.scaleInPlace(0.5);
+                                    break;
+                                case PhysicsImpostor.SphereImpostor:
+                                    mesh = this._getDebugSphereMesh(utilityLayerScene);
+                                    break;
+                                case PhysicsImpostor.CylinderImpostor:
+                                    mesh = this._getDebugCylinderMesh(utilityLayerScene);
+                                    break;
+                                default:
+                                    mesh = null;
+                                    break;
+                            }
+                            if (mesh) {
+                                mesh.scaling.x = max.x - min.x;
+                                mesh.scaling.y = max.y - min.y;
+                                mesh.scaling.z = max.z - min.z;
+                                mesh.parent = m;
+                            }
                         }
-                        mesh.parent = m;
                     });
                 }
                 mesh = null;

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -128,11 +128,7 @@ export class AxisScaleGizmo extends Gizmo {
                 var snapped = false;
                 var dragSteps = 0;
                 if (this.uniformScaling) {
-                    this.attachedNode.getWorldMatrix().decompose(tmpVector);
-                    tmpVector.normalize();
-                    if (tmpVector.y < 0) {
-                        tmpVector.scaleInPlace(-1);
-                    }
+                    tmpVector.setAll(0.57735); // 1 / sqrt(3)
                 } else {
                     tmpVector.copyFrom(dragAxis);
                 }


### PR DESCRIPTION
Follow up on https://forum.babylonjs.com/t/gltf-basic-physics/20849/2 for improved physics debug view
Missing compounds for Sphere and Cylinders

and https://forum.babylonjs.com/t/scaling-bug-using-gizmo-manager/21062/7 for uniform scale.
Mesh genuine scale was applied twice.