### PR TITLE
[XR] Teleportation line - force rendering group when defined

### DIFF
--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -882,6 +882,9 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
             this._quadraticBezierCurve = this._options.generateRayPathMesh(quadraticBezierVectors.getPoints(), pickInfo);
         }
         this._quadraticBezierCurve.isPickable = false;
+        if (this._options.renderingGroupId !== undefined) {
+            this._quadraticBezierCurve.renderingGroupId = this._options.renderingGroupId;
+        }
     }
 
     private _teleportForward(controllerId: string) {


### PR DESCRIPTION
Not too much to say - if rendering group id is defined by the user, set it to the line mesh created when teleporting.