### PR TITLE
Fix vector string formatting

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -231,6 +231,7 @@
 - Fix some different behaviours between `ParticleSystem` and `GPUParticleSystem` when using the cylinder emitter. Also added `WebGL2ParticleSystem` (for WebGL2 support) and `ComputeShaderParticleSystem` (for WebGPU support) ([Popov72](https://github.com/Popov72))
 - Fix the `StandardMaterial` not using the tangent attribute when available ([Popov72](https://github.com/Popov72))
 - Fix code for handling getting DeviceType/DeviceSlot in DeviceInputSystem to work better with MouseEvents ([PolygonalSun](https://github.com/PolygonalSun))
+- Fix vector2/3/4 and quaternion toString formatting ([rgerd](https://github.com/rgerd))
 
 ## Breaking changes
 

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -29,7 +29,7 @@ export class Vector2 {
      * @returns a string with the Vector2 coordinates
      */
     public toString(): string {
-        return "{X: " + this.x + " Y: " + this.y + "}";
+        return `{X: ${this.x} Y: ${this.y}}`;
     }
 
     /**
@@ -815,7 +815,7 @@ export class Vector3 {
      * @returns a string with the Vector3 coordinates.
      */
     public toString(): string {
-        return "{X: " + this._x + " Y:" + this._y + " Z:" + this._z + "}";
+        return `{X: ${this._x} Y: ${this._y} Z: ${this._z}}`;
     }
 
     /**
@@ -2243,7 +2243,7 @@ export class Vector4 {
      * @returns a string containing all the vector values
      */
     public toString(): string {
-        return "{X: " + this.x + " Y:" + this.y + " Z:" + this.z + " W:" + this.w + "}";
+        return `{X: ${this.x} Y: ${this.y} Z: ${this.z} W: ${this.w}}`;
     }
 
     /**
@@ -3028,7 +3028,7 @@ export class Quaternion {
      * @returns a string with the Quaternion coordinates
      */
     public toString(): string {
-        return "{X: " + this._x + " Y:" + this._y + " Z:" + this._z + " W:" + this._w + "}";
+        return `{X: ${this._x} Y: ${this._y} Z: ${this._z} W: ${this._w}}`;
     }
 
     /**


### PR DESCRIPTION
I noticed when we print our vectors the formatting was looking like:
`{X: 2.0 Y:1.0 Z:0.5}`

So I standardized it to:
`{X: 2.0 Y: 1.0 Z: 0.5}`

To match `Vector2`, which was the only consistent one.