### PR TITLE
AssetContainer: Fix cloning skeleton when mesh is an instanced mesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -233,6 +233,7 @@
 - Fix the `StandardMaterial` not using the tangent attribute when available ([Popov72](https://github.com/Popov72))
 - Fix code for handling getting DeviceType/DeviceSlot in DeviceInputSystem to work better with MouseEvents ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix vector2/3/4 and quaternion toString formatting ([rgerd](https://github.com/rgerd))
+- Fix cloning skeleton when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -219,8 +219,11 @@ export class AssetContainer extends AbstractScene {
 
             for (var m of this.meshes) {
                 if (m.skeleton === s && !m.isAnInstance) {
-                    let copy = storeMap[convertionMap[m.uniqueId]];
-                    (copy as Mesh).skeleton = clone;
+                    let copy = storeMap[convertionMap[m.uniqueId]] as Mesh;
+                    if (copy.isAnInstance) {
+                        continue;
+                    }
+                    copy.skeleton = clone;
 
                     if (alreadySwappedSkeletons.indexOf(clone) !== -1) {
                         continue;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/cannot-set-property-material-of-object-object-which-has-only-a-getter/17398/2