### PR TITLE
DeviceInputSystem - Fix issue where mouse is deregistered on MacOS

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -235,6 +235,7 @@
 - Fix code for handling getting DeviceType/DeviceSlot in DeviceInputSystem to work better with MouseEvents ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix vector2/3/4 and quaternion toString formatting ([rgerd](https://github.com/rgerd))
 - Fix cloning skeleton when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
+- Fix issue with DeviceInputSystem where Mouse was being deregistered on Safari/MacOS ([PolygonalSun](https://github.com/PolygonalSun))
 
 ## Breaking changes
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -527,7 +527,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 this.onInputChangedObservable.notifyObservers(deviceEvent);
 
                 // We don't want to unregister the mouse because we may miss input data when a mouse is moving after a click
-                if (evt.pointerType !== "mouse") {
+                if (deviceType !== DeviceType.Mouse) {
                     this._unregisterDevice(deviceType, deviceSlot);
                 }
             }


### PR DESCRIPTION
This change uses the deviceType to determine if a mouse is being used before deregistering a pointer device.  Originally, PointerEvent.pointerType was being used but doesn't populate on PointerEvents in Safari.