### PR TITLE
Add intensityTexture to PBR sub surface

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -359,7 +359,7 @@ export class KHR_materials_transmission implements IGLTFLoaderExtension {
             (extension.transmissionTexture as ITextureInfo).nonColorData = true;
             return this._loader.loadTextureInfoAsync(`${context}/transmissionTexture`, extension.transmissionTexture, undefined)
                 .then((texture: BaseTexture) => {
-                    pbrMaterial.subSurface.thicknessTexture = texture;
+                    pbrMaterial.subSurface.intensityTexture = texture;
                     pbrMaterial.subSurface.useGltfStyleThicknessTexture = true;
                     pbrMaterial.subSurface.useMaskFromThicknessTexture = true;
                 });

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -275,6 +275,8 @@ export class PBRMaterialDefines extends MaterialDefines
     public SS_THICKNESSANDMASK_TEXTURE = false;
     public SS_THICKNESSANDMASK_TEXTUREDIRECTUV = 0;
     public SS_HAS_THICKNESS = false;
+    public SS_INTENSITY_TEXTURE = false;
+    public SS_INTENSITY_TEXTUREDIRECTUV = 0;
 
     public SS_REFRACTIONMAP_3D = false;
     public SS_REFRACTIONMAP_OPPOSITEZ = false;

--- a/src/Materials/materialFlags.ts
+++ b/src/Materials/materialFlags.ts
@@ -293,4 +293,20 @@ export class MaterialFlags {
         this._ThicknessTextureEnabled = value;
         Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
+
+    private static _IntensityTextureEnabled = true;
+    /**
+     * Are intensity textures enabled in the application.
+     */
+    public static get IntensityTextureEnabled(): boolean {
+        return this._ThicknessTextureEnabled;
+    }
+    public static set IntensityTextureEnabled(value: boolean) {
+        if (this._IntensityTextureEnabled === value) {
+            return;
+        }
+
+        this._IntensityTextureEnabled = value;
+        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+    }
 }

--- a/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -37,6 +37,9 @@ struct subSurfaceOutParams
     #ifdef SS_THICKNESSANDMASK_TEXTURE
         const in vec4 thicknessMap,
     #endif
+    #ifdef SS_INTENSITY_TEXTURE
+        const in vec4 intensityMap,
+    #endif
     #ifdef REFLECTION
         #ifdef SS_TRANSLUCENCY
             const in mat4 reflectionMatrix,
@@ -155,6 +158,23 @@ struct subSurfaceOutParams
         #endif
     #else
         float thickness = vThicknessParam.y;
+    #endif
+
+    #ifdef SS_INTENSITY_TEXTURE
+        #if defined(SS_USE_GLTF_THICKNESS_TEXTURE)
+            #ifdef SS_REFRACTION
+                refractionIntensity *= intensityMap.r;
+            #elif defined(SS_TRANSLUCENCY)
+                translucencyIntensity *= intensityMap.r;
+            #endif
+        #else
+            #ifdef SS_REFRACTION
+                refractionIntensity *= intensityMap.g;
+            #endif
+            #ifdef SS_TRANSLUCENCY
+                translucencyIntensity *= intensityMap.b;
+            #endif
+        #endif
     #endif
 
     // _________________________________________________________________________________________

--- a/src/Shaders/ShadersInclude/pbrFragmentDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrFragmentDeclaration.fx
@@ -154,6 +154,11 @@ uniform mat4 view;
         uniform mat4 thicknessMatrix;
     #endif
 
+    #ifdef SS_INTENSITY_TEXTURE
+        uniform vec2 vIntensityInfos;
+        uniform mat4 intensityMatrix;
+    #endif
+
     uniform vec2 vThicknessParam;
     uniform vec3 vDiffusionDistance;
     uniform vec4 vTintColor;

--- a/src/Shaders/ShadersInclude/pbrFragmentSamplersDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrFragmentSamplersDeclaration.fx
@@ -276,4 +276,15 @@
         #endif
         uniform sampler2D thicknessSampler;
     #endif
+
+    #ifdef SS_INTENSITY_TEXTURE
+        #if SS_INTENSITY_TEXTUREDIRECTUV == 1
+            #define vIntensityUV vMainUV1
+        #elif SS_INTENSITY_TEXTUREDIRECTUV == 2
+            #define vIntensityUV vMainUV2
+        #else
+            varying vec2 vIntensityUV;
+        #endif
+        uniform sampler2D intensitySampler;
+    #endif
 #endif

--- a/src/Shaders/ShadersInclude/pbrUboDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrUboDeclaration.fx
@@ -90,7 +90,9 @@ uniform Material {
     vec4 vRefractionInfos;
     mat4 refractionMatrix;
     vec2 vThicknessInfos;
+    vec2 vIntensityInfos;
     mat4 thicknessMatrix;
+    mat4 intensityMatrix;
     vec2 vThicknessParam;
     vec3 vDiffusionDistance;
     vec4 vTintColor;

--- a/src/Shaders/ShadersInclude/pbrVertexDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrVertexDeclaration.fx
@@ -119,6 +119,11 @@ uniform float pointSize;
         uniform vec2 vThicknessInfos;
         uniform mat4 thicknessMatrix;
     #endif
+
+    #ifdef SS_INTENSITY_TEXTURE
+        uniform vec2 vIntensityInfos;
+        uniform mat4 intensityMatrix;
+    #endif
 #endif
 
 #ifdef NORMAL

--- a/src/Shaders/pbr.fragment.fx
+++ b/src/Shaders/pbr.fragment.fx
@@ -451,6 +451,10 @@ void main(void) {
             vec4 thicknessMap = texture2D(thicknessSampler, vThicknessUV + uvOffset);
         #endif
 
+        #ifdef SS_INTENSITY_TEXTURE
+            vec4 intensityMap = texture2D(intensitySampler, vIntensityUV + uvOffset);
+        #endif
+
         subSurfaceBlock(
             vSubSurfaceIntensity,
             vThicknessParam,
@@ -459,6 +463,9 @@ void main(void) {
             specularEnvironmentReflectance,
         #ifdef SS_THICKNESSANDMASK_TEXTURE
             thicknessMap,
+        #endif
+        #ifdef SS_INTENSITY_TEXTURE
+            intensityMap,
         #endif
         #ifdef REFLECTION
             #ifdef SS_TRANSLUCENCY

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -115,6 +115,10 @@ varying vec2 vBumpUV;
     #if defined(SS_THICKNESSANDMASK_TEXTURE) && SS_THICKNESSANDMASK_TEXTUREDIRECTUV == 0
         varying vec2 vThicknessUV;
     #endif
+
+    #if defined(SS_INTENSITY_TEXTURE) && SS_INTENSITY_TEXTUREDIRECTUV == 0
+        varying vec2 vIntensityUV;
+    #endif
 #endif
 
 // Output
@@ -466,6 +470,17 @@ void main(void) {
         else
         {
             vThicknessUV = vec2(thicknessMatrix * vec4(uv2, 1.0, 0.0));
+        }
+    #endif
+
+    #if defined(SS_INTENSITY_TEXTURE) && SS_INTENSITY_TEXTUREDIRECTUV == 0
+        if (vIntensityInfos.x == 0.)
+        {
+            vIntensityUV = vec2(intensityMatrix * vec4(uvUpdated, 1.0, 0.0));
+        }
+        else
+        {
+            vIntensityUV = vec2(intensityMatrix * vec4(uv2, 1.0, 0.0));
         }
     #endif
 #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/render-artifacts-with-khr-materials-volume-and-khr-materials-transmission/21414/2

It fixes a problem with glTF when both a transmission and a thickness textures are provided as part of the transmission / volume extensions.

Note that there's an optimisation that will only use a single sampler if both textures are identical.