### PR TITLE
feature: custom timeout

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -49,6 +49,7 @@
 - Added a `Prefiltered` option to the `CubeTextureAssetTask` ([MackeyK24](https://github.com/MackeyK24))
 - Added support for more uv sets to glTF loader. ([bghgary](https://github.com/bghgary))
 - Added support for KHR_materials_volume for glTF loader. ([MiiBond](https://github.com/MiiBond/))
+- Added support for custom timeout in WebRequest. ([jamidwyer](https://github.com/jamidwyer/))
 
 ### Navigation
 

--- a/src/Misc/webRequest.ts
+++ b/src/Misc/webRequest.ts
@@ -104,6 +104,17 @@ export class WebRequest implements IWebRequest {
         this._xhr.responseType = value;
     }
 
+    /**
+     * Gets or sets the timeout value in milliseconds
+     */
+     public get timeout(): number {
+        return this._xhr.timeout;
+    }
+
+    public set timeout(value: number) {
+        this._xhr.timeout = value;
+    }
+    
     /** @hidden */
     public addEventListener<K extends keyof XMLHttpRequestEventMap>(type: K, listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     public addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {


### PR DESCRIPTION
The default timeout for xhr and WebRequest is 0, which means there is not timeout. This allows users to set their own value for timeout.