### PR TITLE
Use DomManagement in touchHolographicButton

### DIFF
--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -18,6 +18,7 @@ import { Color3 } from "babylonjs/Maths/math.color";
 import { TouchButton3D } from "./touchButton3D";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 import { SceneLoader } from "babylonjs/Loading/sceneLoader";
+import { DomManagement } from "babylonjs/Misc/domManagement";
 
 /**
  * Class used to create a holographic button in 3D
@@ -232,8 +233,7 @@ export class TouchHolographicButton extends TouchButton3D {
 
     private _rebuildContent(): void {
         this._disposeFacadeTexture();
-        // HACK: Temporary fix for BabylonNative while we wait for the polyfill.
-        if (!!document.createElement) {
+        if (DomManagement.IsDocumentAvailable()) {
             let panel = new StackPanel();
             panel.isVertical = true;
 

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -53,3 +53,4 @@ export * from "./trajectoryClassifier";
 export * from './timer';
 export * from "./copyTools";
 export * from "./reflector";
+export * from "./domManagement";


### PR DESCRIPTION
We have been facing a crash in BabylonReactNative because the `document` object itself was not defined-- a crash we were not seeing in BabylonNative due to a [sneaky line](https://github.com/BabylonJS/BabylonNative/blob/7db725408f83a9f9df9999de0c0e6b85362450c0/Apps/Playground/UWP/App.cpp#L294).
