### PR TITLE
Set Material's 'metadata' property as serializable

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -65,6 +65,7 @@
 - Added support for local cube map to refraction cube texture ([Popov72](https://github.com/Popov72))
 - Added the `cullBackFaces` property to `Material` ([Popov72](https://github.com/Popov72))
 - Added the `stencil` object property to `Material` ([Popov72](https://github.com/Popov72))
+- Set the `metadata` property on `Material` to be serializable, so that it can be properly loaded from .babylon files ([jlivak](https://github.com/jlivak))
 
 ### Meshes
 

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -215,6 +215,7 @@ export class Material implements IAnimatable {
     /**
      * Gets or sets user defined metadata
      */
+    @serialize()
     public metadata: any = null;
 
     /**


### PR DESCRIPTION
Noticed this issue while working with .babylon files created from the Maya exporter.  The exporter will export metadata attributes on materials, however Babylon will not load them since the metadata field isn't marked for serialization on Material like it is on Node.

This PR also marks Material's metadata field as serializable so that those values can be properly loaded from .babylon files, like how they already can be for Lights and Meshes.