### PR TITLE
Add pre-defined Audio Context and Destination options to AudioEngine.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -37,6 +37,7 @@
 - Added NativeEngine configuration object parameter. ([drigax](https://github.com/drigax))
 - Added NativeEngine support for signed byte and unsigned short vertex buffer attribute types ([Alex-MSFT](https://github.com/Alex-MSFT))
 - Added support for sRGB buffers, native in WebGL2 / WebGPU and through the `EXT_sRGB` extension in WebGL1. There's a new parameter to the `Texture` constructor that enables this feature ([Popov72](https://github.com/Popov72))
+- Added IAudioEngineOptions interface to provide the audio engine with a pre-defined Audio Context and audio destination node. ([Vandy](https://github.com/svanderbeck11))
 
 ### Loaders
 

--- a/src/Audio/Interfaces/IAudioEngineOptions.ts
+++ b/src/Audio/Interfaces/IAudioEngineOptions.ts
@@ -1,0 +1,13 @@
+/**
+ * Interface used to define options for the Audio Engine
+ */
+export interface IAudioEngineOptions {
+    /**
+    * Specifies an existing Audio Context for the audio engine
+    */
+    audioContext?: AudioContext;
+    /**
+    * Specifies a destination node for the audio engine
+    */
+    audioDestination?: AudioDestinationNode | MediaStreamAudioDestinationNode;
+}

--- a/src/Audio/audioEngine.ts
+++ b/src/Audio/audioEngine.ts
@@ -7,20 +7,8 @@ import { Engine } from "../Engines/engine";
 import { IAudioEngine } from './Interfaces/IAudioEngine';
 import { DomManagement } from "../Misc/domManagement";
 
-export interface AudioEngineOptions {
-     /**
-     * Specifies an existing Audio Context for the audio engine
-     */
-      audioContext?: AudioContext;
-      
-      /**
-       * Specifies a destination node for the audio engine
-       */
-      audioDestination?: AudioDestinationNode|MediaStreamAudioDestinationNode;
-}
-
 // Sets the default audio engine to Babylon.js
-Engine.AudioEngineFactory = (hostElement: Nullable<HTMLElement>, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) => { return new AudioEngine(hostElement,audioContext,audioDestination); };
+Engine.AudioEngineFactory = (hostElement: Nullable<HTMLElement>, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>) => { return new AudioEngine(hostElement, audioContext, audioDestination); };
 
 /**
  * This represents the default audio engine used in babylon.
@@ -107,7 +95,7 @@ export class AudioEngine implements IAudioEngine {
      * of audio contexts you can create.
      * @param hostElement defines the host element where to display the mute icon if necessary
      */
-    constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) {
+    constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>) {
         if (!DomManagement.IsWindowObjectExist()) {
             return;
         }
@@ -168,15 +156,15 @@ export class AudioEngine implements IAudioEngine {
     private _initializeAudioContext() {
         try {
             if (this.canUseWebAudio) {
-                if(!this._audioContext){
+                if (!this._audioContext) {
                     this._audioContext = new AudioContext();
                 }
                 // create a global volume gain node
                 this.masterGain = this._audioContext.createGain();
                 this.masterGain.gain.value = 1;
-                if(!this._audioDestination){
-					this._audioDestination = this._audioContext.destination;					
-				}
+                if (!this._audioDestination) {
+                    this._audioDestination = this._audioContext.destination;
+                }
                 this.masterGain.connect(this._audioDestination);
                 this._audioContextInitialized = true;
                 if (this._audioContext.state === "running") {

--- a/src/Audio/audioEngine.ts
+++ b/src/Audio/audioEngine.ts
@@ -97,7 +97,7 @@ export class AudioEngine implements IAudioEngine {
      * @param audioContext defines the audio context to be used by the audio engine
      * @param audioDestination defines the audio destination node to be used by audio engine
      */
-    constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>) {
+    constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext> = null, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> = null) {
         if (!DomManagement.IsWindowObjectExist()) {
             return;
         }

--- a/src/Audio/audioEngine.ts
+++ b/src/Audio/audioEngine.ts
@@ -7,8 +7,20 @@ import { Engine } from "../Engines/engine";
 import { IAudioEngine } from './Interfaces/IAudioEngine';
 import { DomManagement } from "../Misc/domManagement";
 
+export interface AudioEngineOptions {
+     /**
+     * Specifies an existing Audio Context for the audio engine
+     */
+      audioContext?: AudioContext;
+      
+      /**
+       * Specifies a destination node for the audio engine
+       */
+      audioDestination?: AudioDestinationNode|MediaStreamAudioDestinationNode;
+}
+
 // Sets the default audio engine to Babylon.js
-Engine.AudioEngineFactory = (hostElement: Nullable<HTMLElement>) => { return new AudioEngine(hostElement); };
+Engine.AudioEngineFactory = (hostElement: Nullable<HTMLElement>, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) => { return new AudioEngine(hostElement,audioContext,audioDestination); };
 
 /**
  * This represents the default audio engine used in babylon.
@@ -20,6 +32,7 @@ export class AudioEngine implements IAudioEngine {
     private _audioContextInitialized = false;
     private _muteButton: Nullable<HTMLButtonElement> = null;
     private _hostElement: Nullable<HTMLElement>;
+    public _audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> = null;
 
     /**
      * Gets whether the current host supports Web Audio and thus could create AudioContexts.
@@ -94,7 +107,7 @@ export class AudioEngine implements IAudioEngine {
      * of audio contexts you can create.
      * @param hostElement defines the host element where to display the mute icon if necessary
      */
-    constructor(hostElement: Nullable<HTMLElement> = null) {
+    constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) {
         if (!DomManagement.IsWindowObjectExist()) {
             return;
         }
@@ -105,6 +118,8 @@ export class AudioEngine implements IAudioEngine {
 
         var audioElem = document.createElement('audio');
         this._hostElement = hostElement;
+        this._audioContext = audioContext;
+        this._audioDestination = audioDestination;
 
         try {
             if (audioElem && !!audioElem.canPlayType && (audioElem.canPlayType('audio/mpeg; codecs="mp3"').replace(/^no$/, '') ||
@@ -153,11 +168,16 @@ export class AudioEngine implements IAudioEngine {
     private _initializeAudioContext() {
         try {
             if (this.canUseWebAudio) {
-                this._audioContext = new AudioContext();
+                if(!this._audioContext){
+                    this._audioContext = new AudioContext();
+                }
                 // create a global volume gain node
                 this.masterGain = this._audioContext.createGain();
                 this.masterGain.gain.value = 1;
-                this.masterGain.connect(this._audioContext.destination);
+                if(!this._audioDestination){
+					this._audioDestination = this._audioContext.destination;					
+				}
+                this.masterGain.connect(this._audioDestination);
                 this._audioContextInitialized = true;
                 if (this._audioContext.state === "running") {
                     // Do not wait for the promise to unlock.

--- a/src/Audio/audioEngine.ts
+++ b/src/Audio/audioEngine.ts
@@ -20,7 +20,7 @@ export class AudioEngine implements IAudioEngine {
     private _audioContextInitialized = false;
     private _muteButton: Nullable<HTMLButtonElement> = null;
     private _hostElement: Nullable<HTMLElement>;
-    public _audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> = null;
+    private _audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> = null;
 
     /**
      * Gets whether the current host supports Web Audio and thus could create AudioContexts.
@@ -94,6 +94,8 @@ export class AudioEngine implements IAudioEngine {
      * There should be only one per page as some browsers restrict the number
      * of audio contexts you can create.
      * @param hostElement defines the host element where to display the mute icon if necessary
+     * @param audioContext defines the audio context to be used by the audio engine
+     * @param audioDestination defines the audio destination node to be used by audio engine
      */
     constructor(hostElement: Nullable<HTMLElement> = null, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>) {
         if (!DomManagement.IsWindowObjectExist()) {

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -454,7 +454,8 @@ export class Engine extends ThinEngine {
      * Default AudioEngine factory responsible of creating the Audio Engine.
      * By default, this will create a BabylonJS Audio Engine if the workload has been embedded.
      */
-    public static AudioEngineFactory: (hostElement: Nullable<HTMLElement>) => IAudioEngine;
+    public static AudioEngineFactory: (hostElement: Nullable<HTMLElement>,audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) => IAudioEngine;
+    
 
     /**
      * Default offline support factory responsible of creating a tool used to store data locally.
@@ -584,7 +585,7 @@ export class Engine extends ThinEngine {
 
                 // Create Audio Engine if needed.
                 if (!Engine.audioEngine && options.audioEngine && Engine.AudioEngineFactory) {
-                    Engine.audioEngine = Engine.AudioEngineFactory(this.getRenderingCanvas());
+                    Engine.audioEngine = Engine.AudioEngineFactory(this.getRenderingCanvas(), this.getAudioContext(), this.getAudioDestination());
                 }
             }
 
@@ -659,7 +660,7 @@ export class Engine extends ThinEngine {
 
         // Create Audio Engine if needed.
         if (!Engine.audioEngine && audioEngine && Engine.AudioEngineFactory) {
-            Engine.audioEngine = Engine.AudioEngineFactory(this.getRenderingCanvas());
+            Engine.audioEngine = Engine.AudioEngineFactory(this.getRenderingCanvas(), this.getAudioContext(), this.getAudioDestination());
         }
     }
 

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -454,8 +454,7 @@ export class Engine extends ThinEngine {
      * Default AudioEngine factory responsible of creating the Audio Engine.
      * By default, this will create a BabylonJS Audio Engine if the workload has been embedded.
      */
-    public static AudioEngineFactory: (hostElement: Nullable<HTMLElement>,audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>) => IAudioEngine;
-    
+    public static AudioEngineFactory: (hostElement: Nullable<HTMLElement>, audioContext: Nullable<AudioContext>, audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>) => IAudioEngine;
 
     /**
      * Default offline support factory responsible of creating a tool used to store data locally.

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -39,6 +39,7 @@ import { IMaterialContext } from "./IMaterialContext";
 import { IDrawContext } from "./IDrawContext";
 import { StencilStateComposer } from "../States/stencilStateComposer";
 import { StorageBuffer } from "../Buffers/storageBuffer";
+import { AudioEngineOptions } from '../Audio/audioEngine';
 
 declare type WebRequest = import("../Misc/webRequest").WebRequest;
 declare type LoadFileError = import("../Misc/fileTools").LoadFileError;
@@ -81,6 +82,8 @@ export interface HostInformation {
     isMobile: boolean;
 }
 
+
+
 /** Interface defining initialization parameters for Engine class */
 export interface EngineOptions extends WebGLContextAttributes {
     /**
@@ -103,6 +106,11 @@ export interface EngineOptions extends WebGLContextAttributes {
      * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
      */
     audioEngine?: boolean;
+    /**
+     * Specifies options for the audio engine
+     */
+    audioEngineOptions?: AudioEngineOptions;
+    
     /**
      * Defines if animations should run using a deterministic lock step
      * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
@@ -307,6 +315,8 @@ export class ThinEngine {
     protected _renderingCanvas: Nullable<HTMLCanvasElement>;
     protected _windowIsBackground = false;
     protected _creationOptions: EngineOptions;
+    protected _audioContext: Nullable<AudioContext>;
+    protected _audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>
 
     protected _highPrecisionShadersAllowed = true;
     /** @hidden */
@@ -623,7 +633,7 @@ export class ThinEngine {
         if ((canvasOrContext as any).getContext) {
             canvas = <HTMLCanvasElement>canvasOrContext;
             this._renderingCanvas = canvas;
-
+            
             if (antialias !== undefined) {
                 options.antialias = antialias;
             }
@@ -646,6 +656,14 @@ export class ThinEngine {
 
             if (options.audioEngine === undefined) {
                 options.audioEngine = true;
+            }
+
+            if (options.audioEngineOptions !== undefined && options.audioEngineOptions.audioContext !== undefined) {
+                this._audioContext = options.audioEngineOptions.audioContext;
+            }
+
+            if (options.audioEngineOptions !== undefined && options.audioEngineOptions.audioDestination !== undefined) {
+                this._audioDestination = options.audioEngineOptions.audioDestination;
             }
 
             if (options.stencil === undefined) {
@@ -1327,6 +1345,22 @@ export class ThinEngine {
      */
     public getRenderingCanvas(): Nullable<HTMLCanvasElement> {
         return this._renderingCanvas;
+    }
+
+    /**
+     * Gets the audio context specified in engine initialization options
+     * @returns an Audio Context
+     */
+     public getAudioContext(): Nullable<AudioContext> {
+        return this._audioContext;
+    }
+
+    /**
+     * Gets the audio destination specified in engine initialization options
+     * @returns an audio destination node
+     */
+     public getAudioDestination(): Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode> {
+        return this._audioDestination;
     }
 
     /**

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -39,7 +39,7 @@ import { IMaterialContext } from "./IMaterialContext";
 import { IDrawContext } from "./IDrawContext";
 import { StencilStateComposer } from "../States/stencilStateComposer";
 import { StorageBuffer } from "../Buffers/storageBuffer";
-import { AudioEngineOptions } from '../Audio/audioEngine';
+import { IAudioEngineOptions } from '../Audio/Interfaces/IAudioEngineOptions';
 
 declare type WebRequest = import("../Misc/webRequest").WebRequest;
 declare type LoadFileError = import("../Misc/fileTools").LoadFileError;
@@ -82,8 +82,6 @@ export interface HostInformation {
     isMobile: boolean;
 }
 
-
-
 /** Interface defining initialization parameters for Engine class */
 export interface EngineOptions extends WebGLContextAttributes {
     /**
@@ -109,8 +107,8 @@ export interface EngineOptions extends WebGLContextAttributes {
     /**
      * Specifies options for the audio engine
      */
-    audioEngineOptions?: AudioEngineOptions;
-    
+    audioEngineOptions?: IAudioEngineOptions;
+
     /**
      * Defines if animations should run using a deterministic lock step
      * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
@@ -316,7 +314,7 @@ export class ThinEngine {
     protected _windowIsBackground = false;
     protected _creationOptions: EngineOptions;
     protected _audioContext: Nullable<AudioContext>;
-    protected _audioDestination: Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode>
+    protected _audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>;
 
     protected _highPrecisionShadersAllowed = true;
     /** @hidden */
@@ -633,7 +631,7 @@ export class ThinEngine {
         if ((canvasOrContext as any).getContext) {
             canvas = <HTMLCanvasElement>canvasOrContext;
             this._renderingCanvas = canvas;
-            
+
             if (antialias !== undefined) {
                 options.antialias = antialias;
             }
@@ -1359,7 +1357,7 @@ export class ThinEngine {
      * Gets the audio destination specified in engine initialization options
      * @returns an audio destination node
      */
-     public getAudioDestination(): Nullable<AudioDestinationNode|MediaStreamAudioDestinationNode> {
+     public getAudioDestination(): Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> {
         return this._audioDestination;
     }
 


### PR DESCRIPTION
Added the ability for the audio engine to take an existing Audio Context and a specific Audio Destination node.  Discussed on forum https://forum.babylonjs.com/t/custom-audio-context/21080.