### PR TITLE
Fixed saveFileAsync url when it has query strings

### DIFF
--- a/src/Offline/database.ts
+++ b/src/Offline/database.ts
@@ -592,7 +592,7 @@ export class Database implements IOfflineProvider {
             // Create XHR
             var xhr = new WebRequest();
             var fileData: any;
-            xhr.open("GET", url + "?" + Date.now());
+            xhr.open("GET", url + (url.match(/\?/) == null ? "?" : "&") + Date.now());
 
             if (useArrayBuffer) {
                 xhr.responseType = "arraybuffer";


### PR DESCRIPTION
Issue #10503