### PR TITLE
fix i.initFunction is not a function pg error

### DIFF
--- a/Playground/src/components/rendererComponent.tsx
+++ b/Playground/src/components/rendererComponent.tsx
@@ -21,6 +21,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
     private _canvasRef: React.RefObject<HTMLCanvasElement>;
     private _downloadManager: DownloadManager;
     private _unityToolkitWasLoaded = false;
+    private _tmpErrorEvent?: ErrorEvent;
 
     public constructor(props: IRenderingComponentProps) {
         super(props);
@@ -78,11 +79,17 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
             this._engine.resize();
         });
+
+        window.addEventListener("error", this._saveError);
     }
+
+    private _saveError = (err: ErrorEvent) => {
+        this._tmpErrorEvent = err;
+    };
 
     private async _loadScriptAsync(url: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            let script = document.createElement('script');
+            let script = document.createElement("script");
             script.src = url;
             script.onload = () => {
                 resolve();
@@ -109,7 +116,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 forceWebGL1 = true;
                 break;
         }
-        
 
         if (this._engine) {
             try {
@@ -132,7 +138,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             globalObject.canvas = canvas;
 
             if (useWebGPU) {
-                globalObject.createDefaultEngine = async function() { 
+                globalObject.createDefaultEngine = async function () {
                     var engine = new WebGPUEngine(canvas, {
                         deviceDescriptor: {
                             nonGuaranteedFeatures: [
@@ -141,12 +147,13 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                                 "pipeline-statistics-query",
                                 "depth-clamping",
                                 "depth24unorm-stencil8",
-                                "depth32float-stencil8"
-                            ]
-                    }});
+                                "depth32float-stencil8",
+                            ],
+                        },
+                    });
                     await engine.initAsync();
                     return engine;
-                }                
+                };
             } else {
                 globalObject.createDefaultEngine = function () {
                     return new Engine(canvas, true, {
@@ -241,10 +248,16 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     code += "\n" + "window.scene = " + createSceneFunction + "();";
                 }
 
-                code += `}`;  // Finish "initFunction" definition.
+                code += `}`; // Finish "initFunction" definition.
 
-                // Execute the code
-                Utilities.FastEval(code);
+                this._tmpErrorEvent = undefined;
+
+                try {
+                    // Execute the code
+                    Utilities.FastEval(code);
+                } catch (e) {
+                    (window as any).handleException(e);
+                }
 
                 await globalObject.initFunction();
 
@@ -298,7 +311,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     }
                 }
 
-                if (this._scene.activeCamera || this._scene.activeCameras && this._scene.activeCameras.length > 0) {
+                if (this._scene.activeCamera || (this._scene.activeCameras && this._scene.activeCameras.length > 0)) {
                     this._scene.render();
                 }
 
@@ -338,7 +351,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 });
             }
         } catch (err) {
-            this.props.globalState.onErrorObservable.notifyObservers(err);
+            this.props.globalState.onErrorObservable.notifyObservers(this._tmpErrorEvent || err);
         }
     }
 


### PR DESCRIPTION
Syntax errors inside a script added to the DOM are not being caught using a simple try/catch. The only way to catch those is using the window `error` event. 

This PR adds error handling in case a syntax error happened while parsing the evaluated code.

See https://forum.babylonjs.com/t/i-initfunction-is-not-a-function/21233