### PR TITLE
Mark createPickingRay matrix as explicitly nullable.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -30,6 +30,7 @@
 - Added check for duplicates in addShadowCaster ([ivankoleda](https://github.com/ivankoleda))
 - spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the correspondgin `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
+- Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))
 
 ### Engine
 

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -595,7 +595,7 @@ declare module "../scene" {
     }
 }
 
-Scene.prototype.createPickingRay = function (x: number, y: number, world: Matrix, camera: Nullable<Camera>, cameraViewSpace = false): Ray {
+Scene.prototype.createPickingRay = function (x: number, y: number, world: Nullable<Matrix>, camera: Nullable<Camera>, cameraViewSpace = false): Ray {
     let result = Ray.Zero();
 
     this.createPickingRayToRef(x, y, world, result, camera, cameraViewSpace);
@@ -603,7 +603,7 @@ Scene.prototype.createPickingRay = function (x: number, y: number, world: Matrix
     return result;
 };
 
-Scene.prototype.createPickingRayToRef = function (x: number, y: number, world: Matrix, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false): Scene {
+Scene.prototype.createPickingRayToRef = function (x: number, y: number, world: Nullable<Matrix>, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false): Scene {
     var engine = this.getEngine();
 
     if (!camera) {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4770,7 +4770,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param cameraViewSpace defines if picking will be done in view space (false by default)
      * @returns a Ray
      */
-    public createPickingRay(x: number, y: number, world: Matrix, camera: Nullable<Camera>, cameraViewSpace = false): Ray {
+    public createPickingRay(x: number, y: number, world: Nullable<Matrix>, camera: Nullable<Camera>, cameraViewSpace = false): Ray {
         throw _DevTools.WarnImport("Ray");
     }
 
@@ -4784,7 +4784,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param cameraViewSpace defines if picking will be done in view space (false by default)
      * @returns the current scene
      */
-    public createPickingRayToRef(x: number, y: number, world: Matrix, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false): Scene {
+    public createPickingRayToRef(x: number, y: number, world: Nullable<Matrix>, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false): Scene {
         throw _DevTools.WarnImport("Ray");
     }
 


### PR DESCRIPTION
The createPickingRay and createPickingRayToRef functions will default to an identity matrix if no matrix is supplied.  This change just makes it more obvious that null is a valid argument to pass into these functions (as the doc comment already suggests).