### PR TITLE
fix crash in sixDofDragBehavior.ts

### DIFF
--- a/src/Behaviors/Meshes/sixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/sixDofDragBehavior.ts
@@ -233,6 +233,8 @@ export class SixDofDragBehavior extends BaseSixDofDragBehavior {
             this._ownerNode.getScene().onBeforeRenderObservable.remove(this._sceneRenderObserver);
         }
 
-        this._virtualTransformNode.dispose();
+        if (this._virtualTransformNode) {
+            this._virtualTransformNode.dispose();
+        }
     }
 }


### PR DESCRIPTION
Follow up on https://forum.babylonjs.com/t/not-able-to-access-gizmos-when-2-cameras-are-activated/21680
If node/mesh is not attached to the behavior, a crash happens when it's detached from gizmomanager.