### PR TITLE
Fix colors refresh for gizmos

### DIFF
--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -167,6 +167,7 @@ export class AxisDragGizmo extends Gizmo {
             dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(collider as Mesh, cache);
+        this._axisCache = cache;
 
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
             if (this._customMeshSet) {
@@ -187,6 +188,7 @@ export class AxisDragGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
+            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/axisDragGizmo.ts
+++ b/src/Gizmos/axisDragGizmo.ts
@@ -188,7 +188,7 @@ export class AxisDragGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
-            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
+            this._setGizmoMeshMaterial(this.dragBehavior.enabled ? this._coloredMaterial : this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -185,6 +185,7 @@ export class AxisScaleGizmo extends Gizmo {
             dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(this._gizmoMesh, cache);
+        this._axisCache = cache;
 
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
             if (this._customMeshSet) {
@@ -235,6 +236,7 @@ export class AxisScaleGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
+            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/axisScaleGizmo.ts
+++ b/src/Gizmos/axisScaleGizmo.ts
@@ -236,7 +236,7 @@ export class AxisScaleGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
-            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
+            this._setGizmoMeshMaterial(this.dragBehavior.enabled ? this._coloredMaterial : this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -46,6 +46,7 @@ export class Gizmo implements IDisposable {
     private _attachedMesh: Nullable<AbstractMesh> = null;
     private _attachedNode: Nullable<Node> = null;
     private _customRotationQuaternion: Nullable<Quaternion> = null;
+    protected _axisCache: Nullable<GizmoAxisCache> = null;
     /**
      * Ratio for the scale of the gizmo (Default: 1)
      */
@@ -318,6 +319,25 @@ export class Gizmo implements IDisposable {
                 lmat.copyFrom(bone.getWorldMatrix());
             }
             bone.markAsDirty();
+        }
+    }
+
+    /**
+     * refresh gizmo mesh material depending on state of dragBehavior
+     * @param enabledDragBehavior drag behavior is enabled or not
+     * @param enableddMaterial material to apply if drag behavior is enabled
+     * @param disableMaterial material to apply if drag behavior is disenabled
+     */
+    protected _refreshForDragBehavior(enabledDragBehavior: boolean, enabledMaterial: StandardMaterial, disableMaterial: StandardMaterial) {
+        const gizmoMeshes = this._axisCache?.gizmoMeshes;
+        if (gizmoMeshes) {
+            const material = enabledDragBehavior ? enabledMaterial : disableMaterial;
+            gizmoMeshes.forEach((m: Mesh) => {
+                m.material = material;
+                if ((<LinesMesh>m).color) {
+                    (<LinesMesh>m).color = material.diffuseColor;
+                }
+            });
         }
     }
 

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -323,15 +323,12 @@ export class Gizmo implements IDisposable {
     }
 
     /**
-     * refresh gizmo mesh material depending on state of dragBehavior
-     * @param enabledDragBehavior drag behavior is enabled or not
-     * @param enableddMaterial material to apply if drag behavior is enabled
-     * @param disableMaterial material to apply if drag behavior is disenabled
+     * refresh gizmo mesh material
+     * @param material material to apply
      */
-    protected _refreshForDragBehavior(enabledDragBehavior: boolean, enabledMaterial: StandardMaterial, disableMaterial: StandardMaterial) {
+    protected _setGizmoMeshMaterial(material: StandardMaterial) {
         const gizmoMeshes = this._axisCache?.gizmoMeshes;
         if (gizmoMeshes) {
-            const material = enabledDragBehavior ? enabledMaterial : disableMaterial;
             gizmoMeshes.forEach((m: Mesh) => {
                 m.material = material;
                 if ((<LinesMesh>m).color) {

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -146,7 +146,7 @@ export class PlaneDragGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
-            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
+            this._setGizmoMeshMaterial(this.dragBehavior.enabled ? this._coloredMaterial : this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/planeDragGizmo.ts
+++ b/src/Gizmos/planeDragGizmo.ts
@@ -128,6 +128,7 @@ export class PlaneDragGizmo extends Gizmo {
             dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache((this._gizmoMesh as Mesh), cache);
+        this._axisCache = cache;
 
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
             if (this._customMeshSet) {
@@ -145,6 +146,7 @@ export class PlaneDragGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
+            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -289,6 +289,7 @@ export class PlaneRotationGizmo extends Gizmo {
             dragBehavior: this.dragBehavior
         };
         this._parent?.addToAxisCache(this._gizmoMesh, cache);
+        this._axisCache = cache;
 
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
             if (this._customMeshSet) {
@@ -328,6 +329,7 @@ export class PlaneRotationGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
+            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/planeRotationGizmo.ts
+++ b/src/Gizmos/planeRotationGizmo.ts
@@ -329,7 +329,7 @@ export class PlaneRotationGizmo extends Gizmo {
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
-            this._refreshForDragBehavior(this.dragBehavior.enabled, this._coloredMaterial, this._disableMaterial);
+            this._setGizmoMeshMaterial(this.dragBehavior.enabled ? this._coloredMaterial : this._disableMaterial);
         }
     }
 

--- a/src/Gizmos/scaleGizmo.ts
+++ b/src/Gizmos/scaleGizmo.ts
@@ -166,6 +166,7 @@ export class ScaleGizmo extends Gizmo {
         };
 
         this.addToAxisCache(uniformScaleGizmo._rootMesh, cache);
+        this._axisCache = cache;
 
         return uniformScaleGizmo;
     }


### PR DESCRIPTION
followup https://forum.babylonjs.com/t/major-gizmo-bug/21724
update gizmo colors when attached mesh/node changes without pointer events to refresh it.