### PR TITLE
Fix LastCreateScene value when deleting scenes

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4481,6 +4481,14 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.metadata = null;
 
         if (EngineStore._LastCreatedScene === this) {
+            if (this._engine.scenes.length > 1) {
+                EngineStore._LastCreatedScene = this._engine.scenes[this._engine.scenes.length - 2];
+            } else {
+                EngineStore._LastCreatedScene = null;
+            }
+        }
+
+        if (EngineStore._LastCreatedScene === this) {
             EngineStore._LastCreatedScene = null;
         }
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4488,10 +4488,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             }
         }
 
-        if (EngineStore._LastCreatedScene === this) {
-            EngineStore._LastCreatedScene = null;
-        }
-
         this.skeletons = [];
         this.morphTargetManagers = [];
         this._transientComponents = [];

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4480,14 +4480,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.afterRender = null;
         this.metadata = null;
 
-        if (EngineStore._LastCreatedScene === this) {
-            if (this._engine.scenes.length > 1) {
-                EngineStore._LastCreatedScene = this._engine.scenes[this._engine.scenes.length - 2];
-            } else {
-                EngineStore._LastCreatedScene = null;
-            }
-        }
-
         this.skeletons = [];
         this.morphTargetManagers = [];
         this._transientComponents = [];
@@ -4676,6 +4668,14 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         if (index > -1) {
             this._engine.scenes.splice(index, 1);
+        }
+
+        if (EngineStore._LastCreatedScene === this) {
+            if (this._engine.scenes.length > 0) {
+                EngineStore._LastCreatedScene = this._engine.scenes[this._engine.scenes.length - 1];
+            } else {
+                EngineStore._LastCreatedScene = null;
+            }
         }
 
         index = this._engine._virtualScenes.indexOf(this);


### PR DESCRIPTION
I'm not sure it is a fix, maybe it is expected that `LastCreatedScene` is null when we delete the last created scene, even if there are still some other scenes alive...

However, personally I would expect to have the "last scene not disposed" in `LastCreatedScene`, so let's tell what you think.

