### PR TITLE
glTF KHR_materials_transmission: Render the opaque scene with env intensity fixed

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -244,7 +244,10 @@ class TransmissionHelper {
 
         let sceneImageProcessingapplyByPostProcess: boolean;
 
+        let saveSceneEnvIntensity: number;
         this._opaqueRenderTarget.onBeforeBindObservable.add((opaqueRenderTarget) => {
+            saveSceneEnvIntensity = this._scene.environmentIntensity;
+            this._scene.environmentIntensity = 1.0;
             sceneImageProcessingapplyByPostProcess = this._scene.imageProcessingConfiguration.applyByPostProcess;
             if (!this._options.clearColor) {
                 this._scene.clearColor.toLinearSpaceToRef(opaqueRenderTarget.clearColor);
@@ -254,6 +257,7 @@ class TransmissionHelper {
             this._scene.imageProcessingConfiguration.applyByPostProcess = true;
         });
         this._opaqueRenderTarget.onAfterUnbindObservable.add(() => {
+            this._scene.environmentIntensity = saveSceneEnvIntensity;
             this._scene.imageProcessingConfiguration.applyByPostProcess = sceneImageProcessingapplyByPostProcess;
         });
 


### PR DESCRIPTION
Render the opaque scene with a fixed 1.0 env intensity.

The `scene.environmentIntensity` intensity will be applied only on the final rendering.

Fix #10536 