### PR TITLE
Add missing UVs to glTF draco loader extension

### DIFF
--- a/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -83,6 +83,10 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
             loadAttribute("TANGENT", VertexBuffer.TangentKind);
             loadAttribute("TEXCOORD_0", VertexBuffer.UVKind);
             loadAttribute("TEXCOORD_1", VertexBuffer.UV2Kind);
+            loadAttribute("TEXCOORD_2", VertexBuffer.UV3Kind);
+            loadAttribute("TEXCOORD_3", VertexBuffer.UV4Kind);
+            loadAttribute("TEXCOORD_4", VertexBuffer.UV5Kind);
+            loadAttribute("TEXCOORD_5", VertexBuffer.UV6Kind);
             loadAttribute("JOINTS_0", VertexBuffer.MatricesIndicesKind);
             loadAttribute("WEIGHTS_0", VertexBuffer.MatricesWeightsKind);
             loadAttribute("COLOR_0", VertexBuffer.ColorKind);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/multiple-uv-sets-getting-lost-with-draco-compression/21830