### PR TITLE
NME: Fix potential crash when serializing a frame

### DIFF
--- a/nodeEditor/src/diagram/graphFrame.ts
+++ b/nodeEditor/src/diagram/graphFrame.ts
@@ -1410,7 +1410,9 @@ export class GraphFrame {
     {
         if(exposedPorts.length > 0) {
             for(let i = 0; i < exposedPorts.length; ++i) {
-                exposedPorts[i].exposedPortPosition = i;
+                if (exposedPorts[i]) {
+                    exposedPorts[i].exposedPortPosition = i;
+                }
             }
         }
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/node-material-editor-wont-allow-save/21833

It crashes because when serializing the "Displacement" frame, `this._exposedOutPorts` is an array with 7 elements, but the 3rd is `undefined`. So, the fix will avoid the crash, but I don't know if this undefined element is expected in the first place or not (it seems reloading the material after it has been saved is ok, though...). Pinging @msDestiny14.