### PR TITLE
DeviceSourceManager - Fix touch on iOS

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -257,6 +257,7 @@
 - Fix NativeEngine not setting default depth test function to LEQUAL ([rgerd](https://github.com/rgerd))
 - Fix an exception where loading a very small STL file could result in attempting to read outside the files range ([CoPrez](https://github.com/CoPrez))
 - Fix support of `useReverseDepthBuffer` throughout the engine ([Popov72](https://github.com/Popov72))
+- Fix issue with handling of negative Pointer IDs in DeviceInputSystem ([PolygonalSun](https://github.com/PolygonalSun))
 
 ## Breaking changes
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -624,9 +624,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 }
                 // Clear all active touches
                 while (this._activeTouchIds.pop() !== undefined) { }
-
-                    this._activeTouchIds.pop();
-                }
             }
         });
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -623,7 +623,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 }
                 // Clear all active touches
-                while (this._activeTouchIds.length > 0) {
+                while (this._activeTouchIds.pop() !== undefined) { }
+
                     this._activeTouchIds.pop();
                 }
             }

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -599,16 +599,17 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 // Get list of active touch ids and clear each one in the inputs array
                 for (const deviceSlotKey in Object.keys(this._activeTouchIds)) {
-                    const deviceSlot = this._activeTouchIds[+deviceSlotKey];
+                    const pointerId = +deviceSlotKey;
+                    const deviceSlot = this._activeTouchIds[pointerId];
 
-                    if (this._elementToAttachTo.hasPointerCapture(+deviceSlotKey)) {
-                        this._elementToAttachTo.releasePointerCapture(+deviceSlotKey);
+                    if (this._elementToAttachTo.hasPointerCapture(pointerId)) {
+                        this._elementToAttachTo.releasePointerCapture(pointerId);
                     }
 
                     if (pointer[deviceSlot]?.[PointerInput.LeftClick] === 1) {
                         pointer[deviceSlot][PointerInput.LeftClick] = 0;
 
-                        const evt: IEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, +deviceSlotKey, PointerInput.LeftClick, 1, this, this._elementToAttachTo);
+                        const evt: IEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, pointerId, PointerInput.LeftClick, 1, this, this._elementToAttachTo);
                         const deviceEvent = evt as IDeviceEvent;
                         deviceEvent.deviceType = DeviceType.Mouse;
                         deviceEvent.deviceSlot = deviceSlot;

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -622,7 +622,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 }
                 // Clear all active touches
-                this._activeTouchIds = [];
+                this._activeTouchIds.length = 0;
             }
         });
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -623,7 +623,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 }
                 // Clear all active touches
-                while(this._activeTouchIds.length > 0) {
+                while (this._activeTouchIds.length > 0) {
                     this._activeTouchIds.pop();
                 }
             }


### PR DESCRIPTION
Because of how iOS handles pointerIds in pointer events (uses negative numbers), I've added an array in the DeviceInputSystem to track all negative values and assign them a positive value that works with the DeviceSourceManager.