### PR TITLE
Added DO_NOT_ALTER_FILE_COORDINATES to STLFileLoader.

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -56,6 +56,7 @@
 - Added support for custom timeout in WebRequest. ([jamidwyer](https://github.com/jamidwyer/))
 - Improved support for MSFT_lod, now LOD levels are loaded and accurately displayed according to screen coverage ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added support for direct loading [base64 data URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) for all loader ([CoPrez](https://github.com/CoPrez))
+- Added DO_NOT_ALTER_FILE_COORDINATES flag to STL loader ([AlbertoPa](https://github.com/AlbertoPa))
 
 ### Navigation
 


### PR DESCRIPTION
When

BABYLON.STLFileLoader.DO_NOT_ALTER_FILE_COORDINATES = true;

the coordinates provided by the STL files are used as is, without
swapping the Y and Z axes. The default value is false to preserve
backward compatibility.