### PR TITLE
Basic popup for performance viewer feature

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -1,0 +1,61 @@
+import { Scene } from "babylonjs/scene";
+import * as React from "react";
+import { useState } from "react";
+import { ButtonLineComponent } from "../../../../sharedUiComponents/lines/buttonLineComponent";
+import { CanvasGraphComponent } from "../../../graph/canvasGraphComponent";
+import { PopupComponent } from "../../../popupComponent";
+
+interface IPerformanceViewerComponentProps {
+    scene: Scene;
+}
+
+// aribitrary window size
+const initialWindowSize = { width: 1024, height: 512 };
+
+// Note this should be false when committed until the feature is fully working.
+const isEnabled = false;
+
+export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentProps> = (props: IPerformanceViewerComponentProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    // do cleanup when the window is closed
+    const onClosePerformanceViewer = (window: Window | null) => {
+        if (window) {
+            window.close();
+        }
+        setIsOpen(false);
+    }
+
+    const onPerformanceButtonClick = () => {
+        setIsOpen(true);
+    }
+
+    const onResize = () => {
+        // do nothing for now.
+    }
+
+    return (
+        <>
+            {
+                isEnabled &&
+                <ButtonLineComponent label="Open Perf Viewer" onClick={onPerformanceButtonClick} />
+            }
+            {
+                isOpen &&
+                <PopupComponent
+                    id="perf-viewer"
+                    title="Performance Viewer"
+                    size={initialWindowSize}
+                    onResize={onResize}
+                    onClose={onClosePerformanceViewer}
+                >
+                    <div id="performance-viewer">
+                        <>
+                            <CanvasGraphComponent id="myChart" />
+                        </>
+                    </div>
+                </PopupComponent>
+        }
+        </>
+    )
+}

--- a/inspector/src/components/actionTabs/tabs/statisticsTabComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/statisticsTabComponent.tsx
@@ -10,7 +10,7 @@ import { Engine } from "babylonjs/Engines/engine";
 
 import { ValueLineComponent } from "../../../sharedUiComponents/lines/valueLineComponent";
 import { BooleanLineComponent } from "../../../sharedUiComponents/lines/booleanLineComponent";
-import { PerformanceViewerComponent } from "./performanceViewer/performanceVIewerComponent";
+import { PerformanceViewerComponent } from "./performanceViewer/performanceViewerComponent";
 
 export class StatisticsTabComponent extends PaneComponent {
     private _sceneInstrumentation: Nullable<SceneInstrumentation>;

--- a/inspector/src/components/actionTabs/tabs/statisticsTabComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/statisticsTabComponent.tsx
@@ -10,6 +10,7 @@ import { Engine } from "babylonjs/Engines/engine";
 
 import { ValueLineComponent } from "../../../sharedUiComponents/lines/valueLineComponent";
 import { BooleanLineComponent } from "../../../sharedUiComponents/lines/booleanLineComponent";
+import { PerformanceViewerComponent } from "./performanceViewer/performanceVIewerComponent";
 
 export class StatisticsTabComponent extends PaneComponent {
     private _sceneInstrumentation: Nullable<SceneInstrumentation>;
@@ -72,6 +73,7 @@ export class StatisticsTabComponent extends PaneComponent {
             <div className="pane">
                 <TextLineComponent label="Version" value={Engine.Version} color="rgb(113, 159, 255)" />
                 <ValueLineComponent label="FPS" value={engine.getFps()} fractionDigits={0} />
+                <PerformanceViewerComponent scene={scene} />
                 <LineContainerComponent title="COUNT">
                     <TextLineComponent label="Total meshes" value={scene.meshes.length.toString()} />
                     <TextLineComponent label="Active meshes" value={scene.getActiveMeshes().length.toString()} />

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 
-interface IGraphComponentProps {
+interface ICanvasGraphComponentProps {
     id: string;
 }
 
-export const CanvasGraphComponent: React.FC<IGraphComponentProps> = (props: IGraphComponentProps) => {
+export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props: ICanvasGraphComponentProps) => {
     const { id } = props;
     const canvasRef: React.MutableRefObject<HTMLCanvasElement | null>  = useRef(null);
     useEffect(() => {

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
+
+interface IGraphComponentProps {
+    id: string;
+}
+
+export const CanvasGraphComponent: React.FC<IGraphComponentProps> = (props: IGraphComponentProps) => {
+    const { id } = props;
+    const canvasRef: React.MutableRefObject<HTMLCanvasElement | null>  = useRef(null);
+    useEffect(() => {
+        if (!canvasRef.current) {
+            return;
+        }
+        const ctx = canvasRef.current.getContext("2d");
+        if (!ctx) {
+            return;
+        }
+        // for now just draw a line on the screen a simple step 1.
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(100, 100);
+        ctx.stroke();
+    }, [canvasRef])
+   
+    return (
+        <canvas id={id} ref={canvasRef}>
+
+        </canvas>
+    )
+}

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -1,0 +1,3 @@
+interface IDataset {
+    // empty for now, but will contain the shape of what a data set is.
+}


### PR DESCRIPTION
This pull request adds a button to the statics tab to open up a popup with a canvas. We grab the reference to the canvas and draw a simple line. The button is hidden by default using the `isEnabled` variable. Part of #10566.