### PR TITLE
Prioritize adaptToDeviceRatio in the right order

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -668,7 +668,7 @@ export class ThinEngine {
             return;
         }
 
-        adaptToDeviceRatio = adaptToDeviceRatio ?? options.adaptToDeviceRatio ?? false;
+        adaptToDeviceRatio = adaptToDeviceRatio || options.adaptToDeviceRatio || false;
 
         if ((canvasOrContext as any).getContext) {
             canvas = <HTMLCanvasElement>canvasOrContext;


### PR DESCRIPTION
`options.adaptToDeviceRatio` was being ignored because the variable `adaptToDeviceRatio` it is set to be false in the `Engine` constructor and `??` is checking if the item is undefined (and not "falsy").
