### PR TITLE
Restore invalid baes64 glb format for backcompat

### DIFF
--- a/loaders/src/glTF/glTFFileLoader.ts
+++ b/loaders/src/glTF/glTFFileLoader.ts
@@ -627,6 +627,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
     /** @hidden */
     public canDirectLoad(data: string): boolean {
         return (data.indexOf("asset") !== -1 && data.indexOf("version") !== -1)
+            || StringTools.StartsWith(data, "data:base64," + GLTFFileLoader.magicBase64Encoded) // this is technically incorrect, but will continue to support for backcompat.
             || StringTools.StartsWith(data, "data:;base64," + GLTFFileLoader.magicBase64Encoded)
             || StringTools.StartsWith(data, "data:application/octet-stream;base64," + GLTFFileLoader.magicBase64Encoded)
             || StringTools.StartsWith(data, "data:model/gltf-binary;base64," + GLTFFileLoader.magicBase64Encoded);
@@ -634,7 +635,8 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
 
     /** @hidden */
     public directLoad(scene: Scene, data: string): Promise<any> {
-        if (StringTools.StartsWith(data, ";base64," + GLTFFileLoader.magicBase64Encoded) ||
+        if (StringTools.StartsWith(data, "base64," + GLTFFileLoader.magicBase64Encoded) || // this is technically incorrect, but will continue to support for backcompat.
+            StringTools.StartsWith(data, ";base64," + GLTFFileLoader.magicBase64Encoded) ||
             StringTools.StartsWith(data, "application/octet-stream;base64," + GLTFFileLoader.magicBase64Encoded) ||
             StringTools.StartsWith(data, "model/gltf-binary;base64," + GLTFFileLoader.magicBase64Encoded)) {
             const arrayBuffer = FileTools.DecodeBase64UrlToBinary(data);

--- a/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
+++ b/tests/unit/babylon/src/Loading/babylon.sceneLoader.tests.ts
@@ -775,7 +775,7 @@ describe('Babylon Scene Loader', function() {
 
         it('should direct load a glTF file without specifying a pluginExtension', () => {
             const scene = new BABYLON.Scene(subject);
-            return BABYLON.SceneLoader.ImportMeshAsync("", "", `data:${gltfRaw}`, scene, undefined).then((result) => {
+            return BABYLON.SceneLoader.ImportMeshAsync("", "", `data:${gltfRaw}`, scene).then((result) => {
                 expect(result.meshes.length).to.eq(2);
                 expect(result.meshes[1].getTotalVertices()).to.eq(3);
             });
@@ -800,6 +800,14 @@ describe('Babylon Scene Loader', function() {
         it('should direct load a base64 encoded glb with an invalid mime type and pluginExtension specified', () => {
             const scene = new BABYLON.Scene(subject);
             return BABYLON.SceneLoader.ImportMeshAsync("", "", `data:image/jpg;base64,${glbBase64}`, scene, undefined, ".glb").then((result) => {
+                expect(result.meshes.length).to.eq(2);
+                expect(result.meshes[1].getTotalVertices()).to.eq(24);
+            });
+        });
+
+        it('should direct load an incorrectly formatted base64 encoded glb (backcompat)', () => {
+            const scene = new BABYLON.Scene(subject);
+            return BABYLON.SceneLoader.ImportMeshAsync("", "", `data:base64,${glbBase64}`, scene).then((result) => {
                 expect(result.meshes.length).to.eq(2);
                 expect(result.meshes[1].getTotalVertices()).to.eq(24);
             });


### PR DESCRIPTION
See https://forum.babylonjs.com/t/incompatibility-between-4-2-0-and-preview-in-the-handling-of-base64-encoded-data-urls-for-gltf/21948.