### PR TITLE
Added zoom in and zoom out functionality to performance viewer 🔍

### DIFF
--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -14,8 +14,11 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
         if (!canvasRef.current) {
             return;
         }
+
         // temporarily set empty array, will eventually be passed by props!
-        canvasServiceCallback(new CanvasGraphService(canvasRef.current, {datasets: []}));
+        const canvasGraphService = new CanvasGraphService(canvasRef.current, {datasets: []});
+        canvasServiceCallback(canvasGraphService);
+        return () => canvasGraphService.destroy();
     }, [canvasRef])
    
     return (

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -307,7 +307,6 @@ export class CanvasGraphService {
 
         // Bind the zoom between [minZoom, maxZoom]
         this._sizeOfWindow = Math.min(Math.max(this._sizeOfWindow - amount, minZoom), maxZoom);
-        console.log(this._sizeOfWindow);
     }
 
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -11,7 +11,7 @@ export class CanvasGraphService {
     private _width: number;
     private _height: number;
     public readonly datasets: IPerfDataset[];
-
+    private _sizeOfWindow: number = 300;
     private _ticks: number[];
 
     /**
@@ -24,9 +24,9 @@ export class CanvasGraphService {
         this._ctx = canvas.getContext && canvas.getContext("2d");
         this._width = canvas.width;
         this._height = canvas.height;
-
         this.datasets = settings.datasets;
         this._ticks = [];
+        this._attachEventListeners(canvas);
     }
 
     /**
@@ -49,7 +49,7 @@ export class CanvasGraphService {
         // Keep only visible and non empty datasets and get a certain window of items.
         const datasets = this.datasets.filter((dataset: IPerfDataset) => !dataset.hidden && dataset.data.length > 0).map((dataset: IPerfDataset) => ({
             ...dataset,
-            data: dataset.data.slice(Math.max(dataset.data.length - 300, 0))
+            data: dataset.data.slice(Math.max(dataset.data.length - this._sizeOfWindow, 0))
         }));
 
         datasets.forEach((dataset: IPerfDataset) => {
@@ -126,7 +126,6 @@ export class CanvasGraphService {
         ctx.stroke();
         ctx.restore();
     }
-
 
     /**
      * Generates a list of ticks given the min and max of the axis, and the space available in the axis.
@@ -255,6 +254,24 @@ export class CanvasGraphService {
         }
 
         return startingPixel + normalizedValue * spaceAvailable;
+    }
+
+    private _attachEventListeners(canvas: HTMLCanvasElement) {
+        canvas.addEventListener("wheel", this._handleZoom.bind(this));
+    }
+
+
+    private _handleZoom(event: WheelEvent) {
+        event.preventDefault();
+        
+        if (!event.deltaY) {
+            return;
+        }
+
+        const amount = (event.deltaY * -0.01 | 0) * 100;
+        this._sizeOfWindow = Math.max(this._sizeOfWindow - amount, 60);
+        console.log(this._sizeOfWindow);
+        return;
     }
     
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -1,6 +1,8 @@
 import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea } from "./graphSupportingTypes";
 import { IPerfDataset, IPerfPoint } from "babylonjs/Misc/interfaces/iPerfViewer";
 
+const defaultColor = "#000";
+
 /**
  * This class acts as the main API for graphing given a Here is where you will find methods to let the service know new data needs to be drawn,
  * let it know something has been resized, etc! 
@@ -65,15 +67,22 @@ export class CanvasGraphService {
             right: this._width,
         };
 
-        this._drawTimeAxis(globalTimeMinMax, drawableArea);
+        // we will now rescale the maximum for the playhead.
+        // Currently the scale factor is a constant but when we add panning this may become formula based.
+        const scaleFactor = 0.8;
+        globalTimeMinMax.max = Math.ceil((globalTimeMinMax.max - globalTimeMinMax.min)/scaleFactor + globalTimeMinMax.min);
 
+        this._drawTimeAxis(globalTimeMinMax, drawableArea);
+        this._drawPlayheadRegion(drawableArea, scaleFactor);
+
+        // process, and then draw our points
         datasets.forEach((dataset: IPerfDataset) => {
             const valueMinMax = this._getMinMax(dataset.data.map((point: IPerfPoint) => point.value));
             const drawablePoints = dataset.data.map((point: IPerfPoint) => this._getPixelPointFromDataPoint(point, globalTimeMinMax, valueMinMax, drawableArea));
 
             let prevPoint: IPerfPoint = drawablePoints[0];
             ctx.beginPath();
-            
+            ctx.strokeStyle = dataset.color ?? defaultColor;
             drawablePoints.forEach((point: IPerfPoint) => {
                 ctx.moveTo(prevPoint.timestamp, prevPoint.value);
                 ctx.lineTo(point.timestamp, point.value);
@@ -107,6 +116,7 @@ export class CanvasGraphService {
         // draw time axis line
         ctx.save();
         ctx.beginPath();
+        ctx.strokeStyle = defaultColor;
         ctx.moveTo(drawableArea.left, drawableArea.bottom);
         ctx.lineTo(drawableArea.right, drawableArea.bottom);
         
@@ -256,12 +266,30 @@ export class CanvasGraphService {
         return startingPixel + normalizedValue * spaceAvailable;
     }
 
+    /**
+     * Add in any necessary event listeners.
+     * 
+     * @param canvas The canvas we want to attach listeners to.
+     */
     private _attachEventListeners(canvas: HTMLCanvasElement) {
-        canvas.addEventListener("wheel", this._handleZoom.bind(this));
+        canvas.addEventListener("wheel", this._handleZoom);
     }
 
+    /**
+     * We remove all event listeners we added.
+     * 
+     * @param canvas The canvas we want to remove listeners from.
+     */
+    private _removeEventListeners(canvas: HTMLCanvasElement) {
+        canvas.removeEventListener("wheel", this._handleZoom);
+    }
 
-    private _handleZoom(event: WheelEvent) {
+    /**
+     * The handler for when we want to zoom in and out of the graph.
+     * 
+     * @param event a mouse wheel event.
+     */
+    private _handleZoom = (event: WheelEvent) => {
         event.preventDefault();
         
         if (!event.deltaY) {
@@ -269,9 +297,71 @@ export class CanvasGraphService {
         }
 
         const amount = (event.deltaY * -0.01 | 0) * 100;
-        this._sizeOfWindow = Math.max(this._sizeOfWindow - amount, 60);
+        const minZoom = 60;
+
+        // The max zoom is the largest dataset's length.      
+        const maxZoom = this.datasets.map((dataset: IPerfDataset) => dataset.data.length)
+                        .reduce((maxLengthSoFar: number, currLength: number) => {
+                            return Math.max(currLength, maxLengthSoFar)
+                        }, 0);
+
+        // Bind the zoom between [minZoom, maxZoom]
+        this._sizeOfWindow = Math.min(Math.max(this._sizeOfWindow - amount, minZoom), maxZoom);
         console.log(this._sizeOfWindow);
-        return;
+    }
+
+    /**
+     * Will generate a playhead with a futurebox that takes up (1-scalefactor)*100% of the canvas.
+     * 
+     * @param drawableArea The remaining drawable area.
+     * @param scaleFactor The Percentage between 0.0 and 1.0 of the canvas the data gets drawn on.  
+     */
+    private _drawPlayheadRegion(drawableArea: IGraphDrawableArea, scaleFactor: number) {
+        const { _ctx: ctx } = this;
+       
+        if (!ctx) {
+            return;
+        }
+
+        const dividerSize = 2;
+        const dividerXPos = Math.ceil(drawableArea.right * scaleFactor);
+
+        const playheadSize = 8;
+        const playheadPos = dividerXPos - playheadSize; 
+        
+        const futureBoxPos = dividerXPos + dividerSize;
+        
+        const rectangleHeight = drawableArea.bottom - drawableArea.top - 1;
+        
+        const futureBoxColor = "#dfe9ed";
+        const dividerColor = "#0a3066";
+        const playheadColor = "#b9dbef";
+
+        ctx.save();
+        
+        ctx.fillStyle = futureBoxColor;
+        ctx.fillRect(futureBoxPos, drawableArea.top, drawableArea.right - futureBoxPos, rectangleHeight);
+        
+        ctx.fillStyle = dividerColor;
+        ctx.fillRect(dividerXPos, drawableArea.top, dividerSize, rectangleHeight);
+        
+        ctx.fillStyle = playheadColor;
+        ctx.fillRect(playheadPos, drawableArea.top, playheadSize, rectangleHeight);
+        
+        ctx.restore();
+    }
+
+    /**
+     *  Method to do cleanup when the object is done being used.
+     *
+     */
+    public destroy() {
+        if (!this._ctx || !this._ctx.canvas) {
+            return;
+        }
+
+        this._removeEventListeners(this._ctx.canvas);
+        this._ctx = null;
     }
     
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -1,5 +1,6 @@
 import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea } from "./graphSupportingTypes";
 import { IPerfDataset, IPerfPoint } from "babylonjs/Misc/interfaces/iPerfViewer";
+import { Scalar } from "babylonjs/Maths/math.scalar";
 
 const defaultColor = "#000";
 const futureBoxColor = "#dfe9ed";
@@ -316,7 +317,7 @@ export class CanvasGraphService {
                         }, 0);
 
         // Bind the zoom between [minZoom, maxZoom]
-        this._sizeOfWindow = BABYLON.Scalar.Clamp(this._sizeOfWindow - amount, minZoom, maxZoom);
+        this._sizeOfWindow = Scalar.Clamp(this._sizeOfWindow - amount, minZoom, maxZoom);
     }
 
     /**


### PR DESCRIPTION
This pullrequest implements the "Allow zooming into the graph" feature of milestone 3 in #10566. It does this by adding the following:
- Attaches an event listener on construction of the service,
- Event listener triggers whenever we use the mouse wheel to zoom in or out (Forward = in, Backwards = out).
- When triggered we will get how much to zoom based on the mouseDelta before we triggered the event and bind the zoom level to be between 60 datapoints (at minimum) and the length of the largest dataset (at maximum).
- We remove event listeners on unmount.

We also draw a playhead at the end of the data.  To help the user know where the future data is, and to move the changing bit to the center. This gives the eye something to lock onto and reduces the anxiety of the user when zooming into the graph fully. Without this the graph would look very chaotic.

To draw the playhead we do the following:
- Adjust the maximum datapoint in the x axis based on the scale factor (this will scale all of our data to scaleFactor% of the canvas). Note: The scale factor is a number between 0.0 and 1.0 representing the percentage of the canvas. Currently the scaleFactor is a constant, but if we make this dynamic we should look at if there are any occurrences of division by zero, although I don't see a point where scaleFactor will ever be 0 (as that means that the data is fully hidden and we only see the playhead ).

- We then paint the future box and a divider to 1-scaleFactor of the screen, and then paint the playhead about 8 pixels before the divider. This is done to give the user the ability to see the delta better.

Anyways here is  a video quickly showing off what is included in this PR:

https://user-images.githubusercontent.com/32103099/124183320-0b994900-da86-11eb-8708-499dcc67be17.mp4


