### PR TITLE
Check mesh is valid SifDofDragBehavior

### DIFF
--- a/src/Behaviors/Meshes/sixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/sixDofDragBehavior.ts
@@ -231,9 +231,8 @@ export class SixDofDragBehavior extends BaseSixDofDragBehavior {
     public detach(): void {
         super.detach();
 
-        (this._ownerNode as Mesh).isNearGrabbable = false;
-
         if (this._ownerNode) {
+            (this._ownerNode as Mesh).isNearGrabbable = false;
             this._ownerNode.getScene().onBeforeRenderObservable.remove(this._sceneRenderObserver);
         }
 


### PR DESCRIPTION
follow up on https://forum.babylonjs.com/t/gizmo-manager-dispose-issue/22061
Check mesh is not null before setting isNearGrabbable