### PR TITLE
Various fixes for WebGPU and WebGL

### DIFF
--- a/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -339,7 +339,7 @@ export class FluentBackplateMaterial extends PushMaterial {
                     onCompiled: this.onCompiled,
                     onError: this.onError,
                     indexParameters: { maxSimultaneousLights: 4 }
-                }, engine), defines);
+                }, engine), defines, this._materialContext);
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;

--- a/gui/src/3D/materials/fluentBackplate/shaders/fluentBackplate.vertex.fx
+++ b/gui/src/3D/materials/fluentBackplate/shaders/fluentBackplate.vertex.fx
@@ -4,7 +4,11 @@ uniform vec3 cameraPosition;
 
 attribute vec3 position;
 attribute vec3 normal;
+#ifdef TANGENT
 attribute vec3 tangent;
+#else
+const vec3 tangent = vec3(0.);
+#endif
 
 uniform float _Radius_;
 uniform float _Line_Width_;

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
@@ -221,7 +221,6 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
         });
         newTools = this.state.tools.concat(newTools);
         this.setState({tools: newTools});
-        console.log(newTools);
     }
 
     getToolParameters() : IToolParameters {

--- a/src/Compute/computeEffect.ts
+++ b/src/Compute/computeEffect.ts
@@ -140,6 +140,7 @@ export class ComputeEffect {
             platformName: this._engine.shaderPlatformName,
             processingContext: null,
             isNDCHalfZRange: this._engine.isNDCHalfZRange,
+            useReverseDepthBuffer: this._engine.useReverseDepthBuffer,
         };
 
         this._loadShader(computeSource, "Compute", "", (computeCode) => {

--- a/src/Engines/Processors/shaderProcessingOptions.ts
+++ b/src/Engines/Processors/shaderProcessingOptions.ts
@@ -19,4 +19,5 @@ export interface ProcessingOptions {
     lookForClosingBracketForUniformBuffer?: boolean;
     processingContext: Nullable<ShaderProcessingContext>;
     isNDCHalfZRange: boolean;
+    useReverseDepthBuffer: boolean;
 }

--- a/src/Engines/Processors/shaderProcessor.ts
+++ b/src/Engines/Processors/shaderProcessor.ts
@@ -278,6 +278,11 @@ export class ShaderProcessor {
         } else {
             delete preprocessors["IS_NDC_HALF_ZRANGE"];
         }
+        if (options.useReverseDepthBuffer) {
+            preprocessors["USE_REVERSE_DEPTHBUFFER"] = "";
+        } else {
+            delete preprocessors["USE_REVERSE_DEPTHBUFFER"];
+        }
 
         return preprocessors;
     }

--- a/src/Engines/Processors/shaderProcessor.ts
+++ b/src/Engines/Processors/shaderProcessor.ts
@@ -258,7 +258,7 @@ export class ShaderProcessor {
         return rootNode.process(preprocessors, options);
     }
 
-    private static _PreparePreProcessors(options: ProcessingOptions, addGLES = true): { [key: string]: string } {
+    private static _PreparePreProcessors(options: ProcessingOptions, engine: ThinEngine, addGLES = true): { [key: string]: string } {
         let defines = options.defines;
         let preprocessors: { [key: string]: string } = {};
 
@@ -273,16 +273,8 @@ export class ShaderProcessor {
         }
         preprocessors["__VERSION__"] = options.version;
         preprocessors[options.platformName] = "true";
-        if (options.isNDCHalfZRange) {
-            preprocessors["IS_NDC_HALF_ZRANGE"] = "";
-        } else {
-            delete preprocessors["IS_NDC_HALF_ZRANGE"];
-        }
-        if (options.useReverseDepthBuffer) {
-            preprocessors["USE_REVERSE_DEPTHBUFFER"] = "";
-        } else {
-            delete preprocessors["USE_REVERSE_DEPTHBUFFER"];
-        }
+
+        engine._getGlobalDefines(preprocessors);
 
         return preprocessors;
     }
@@ -302,7 +294,7 @@ export class ShaderProcessor {
 
         let defines = options.defines;
 
-        let preprocessors = this._PreparePreProcessors(options);
+        let preprocessors = this._PreparePreProcessors(options, engine);
 
         // General pre processing
         if (options.processor.preProcessor) {
@@ -329,7 +321,7 @@ export class ShaderProcessor {
 
         const defines = options.defines;
 
-        let preprocessors = this._PreparePreProcessors(options, false);
+        let preprocessors = this._PreparePreProcessors(options, engine, false);
 
         // General pre processing
         if (options.processor?.preProcessor) {

--- a/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -623,7 +623,7 @@ export class WebGPUTextureHelper {
         return useSRGBBuffer ? WebGPUConstants.TextureFormat.RGBA8UnormSRGB : WebGPUConstants.TextureFormat.RGBA8Unorm;
     }
 
-    public invertYPreMultiplyAlpha(gpuTexture: GPUTexture, width: number, height: number, format: GPUTextureFormat, invertY = false, premultiplyAlpha = false, faceIndex= 0, commandEncoder?: GPUCommandEncoder): void {
+    public invertYPreMultiplyAlpha(gpuTexture: GPUTexture, width: number, height: number, format: GPUTextureFormat, invertY = false, premultiplyAlpha = false, faceIndex= 0, mipLevel = 0, layers = 1, commandEncoder?: GPUCommandEncoder): void {
         const useOwnCommandEncoder = commandEncoder === undefined;
         const pipeline = this._getPipeline(format, PipelineType.InvertYPremultiplyAlpha, { invertY, premultiplyAlpha });
         const bindGroupLayout = pipeline.getBindGroupLayout(0);
@@ -661,10 +661,10 @@ export class WebGPUTextureHelper {
                 resource: gpuTexture.createView({
                     format,
                     dimension: WebGPUConstants.TextureViewDimension.E2d,
-                    baseMipLevel: 0,
+                    baseMipLevel: mipLevel,
                     mipLevelCount: 1,
-                    arrayLayerCount: 1,
-                    baseArrayLayer: faceIndex,
+                    arrayLayerCount: layers,
+                    baseArrayLayer: Math.max(faceIndex, 0),
                 }),
             }],
         });
@@ -678,6 +678,7 @@ export class WebGPUTextureHelper {
                 texture: outputTexture,
             }, {
                 texture: gpuTexture,
+                mipLevel,
                 origin: {
                     x: 0,
                     y: 0,
@@ -852,7 +853,7 @@ export class WebGPUTextureHelper {
         }
     }
 
-    public generateMipmaps(gpuTexture: GPUTexture, format: GPUTextureFormat, mipLevelCount: number, faceIndex= 0, commandEncoder?: GPUCommandEncoder): void {
+    public generateMipmaps(gpuTexture: GPUTexture, format: GPUTextureFormat, mipLevelCount: number, faceIndex = 0, commandEncoder?: GPUCommandEncoder): void {
         const useOwnCommandEncoder = commandEncoder === undefined;
         const pipeline = this._getPipeline(format);
         const bindGroupLayout = pipeline.getBindGroupLayout(0);
@@ -872,7 +873,7 @@ export class WebGPUTextureHelper {
                         baseMipLevel: i,
                         mipLevelCount: 1,
                         arrayLayerCount: 1,
-                        baseArrayLayer: faceIndex,
+                        baseArrayLayer: Math.max(faceIndex, 0),
                     }),
                     loadValue: WebGPUConstants.LoadOp.Load,
                     storeOp: WebGPUConstants.StoreOp.Store,
@@ -892,7 +893,7 @@ export class WebGPUTextureHelper {
                         baseMipLevel: i - 1,
                         mipLevelCount: 1,
                         arrayLayerCount: 1,
-                        baseArrayLayer: faceIndex,
+                        baseArrayLayer: Math.max(faceIndex, 0),
                     }),
                 }],
             });
@@ -1082,7 +1083,7 @@ export class WebGPUTextureHelper {
             }
 
             if (invertY || premultiplyAlpha) {
-                this.invertYPreMultiplyAlpha(gpuTexture, width, height, format, invertY, premultiplyAlpha, faceIndex, commandEncoder);
+                this.invertYPreMultiplyAlpha(gpuTexture, width, height, format, invertY, premultiplyAlpha, faceIndex, mipLevel, layers || 1, commandEncoder);
             }
         } else {
             imageBitmap = imageBitmap as ImageBitmap;
@@ -1110,7 +1111,7 @@ export class WebGPUTextureHelper {
                     // in which case it would be executed as copyExternalImageToTexture / copyExternalImageToTexture / invertYPreMultiplyAlpha / invertYPreMultiplyAlpha because the command encoder we are passed in
                     // is submitted at the end of the frame
                     commandEncoder = this._device.createCommandEncoder({});
-                    this.invertYPreMultiplyAlpha(gpuTexture, width, height, format, invertY, premultiplyAlpha, 0, commandEncoder);
+                    this.invertYPreMultiplyAlpha(gpuTexture, width, height, format, invertY, premultiplyAlpha, faceIndex, mipLevel, layers || 1, commandEncoder);
                     this._device.queue.submit([commandEncoder!.finish()]);
                     commandEncoder = null as any;
                 } else {
@@ -1131,7 +1132,7 @@ export class WebGPUTextureHelper {
                     textureExtent.depthOrArrayLayers = layers || 1;
 
                     // apply the preprocessing to this temp texture
-                    this.invertYPreMultiplyAlpha(srcTexture, width, height, format, invertY, premultiplyAlpha, 0, commandEncoder);
+                    this.invertYPreMultiplyAlpha(srcTexture, width, height, format, invertY, premultiplyAlpha, faceIndex, mipLevel, layers || 1, commandEncoder);
 
                     // copy the temp texture to the destination texture
                     commandEncoder!.copyTextureToTexture({ texture: srcTexture }, textureCopyView, textureExtent);

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -2432,6 +2432,35 @@ export class ThinEngine {
         }
     }
 
+    /** @hidden */
+    public _getGlobalDefines(defines?: { [key: string]: string }): string | undefined {
+        if (defines) {
+            if (this.isNDCHalfZRange) {
+                defines["IS_NDC_HALF_ZRANGE"] = "";
+            } else {
+                delete defines["IS_NDC_HALF_ZRANGE"];
+            }
+            if (this.useReverseDepthBuffer) {
+                defines["USE_REVERSE_DEPTHBUFFER"] = "";
+            } else {
+                delete defines["USE_REVERSE_DEPTHBUFFER"];
+            }
+            return;
+        } else {
+            let s = "";
+            if (this.isNDCHalfZRange) {
+                s += "#define IS_NDC_HALF_ZRANGE";
+            }
+            if (this.useReverseDepthBuffer) {
+                if (s) {
+                    s += "\n";
+                }
+                s += "#define USE_REVERSE_DEPTHBUFFER";
+            }
+            return s;
+        }
+    }
+
     /**
      * Create a new effect (used to store vertex/fragment shaders)
      * @param baseName defines the base name of the effect (The name of file without .fragment.fx or .vertex.fx)
@@ -2450,8 +2479,15 @@ export class ThinEngine {
         onCompiled?: Nullable<(effect: Effect) => void>, onError?: Nullable<(effect: Effect, errors: string) => void>, indexParameters?: any): Effect {
         var vertex = baseName.vertexElement || baseName.vertex || baseName.vertexToken || baseName.vertexSource || baseName;
         var fragment = baseName.fragmentElement || baseName.fragment || baseName.fragmentToken || baseName.fragmentSource || baseName;
+        const globalDefines = this._getGlobalDefines()!;
 
-        var name = vertex + "+" + fragment + "@" + (defines ? defines : (<IEffectCreationOptions>attributesNamesOrOptions).defines);
+        let fullDefines = defines ?? (<IEffectCreationOptions>attributesNamesOrOptions).defines ?? "";
+
+        if (globalDefines) {
+            fullDefines += globalDefines;
+        }
+
+        var name = vertex + "+" + fragment + "@" + fullDefines;
         if (this._compiledEffects[name]) {
             var compiledEffect = <Effect>this._compiledEffects[name];
             if (onCompiled && compiledEffect.isReady()) {

--- a/src/Engines/webgpuEngine.ts
+++ b/src/Engines/webgpuEngine.ts
@@ -1409,8 +1409,15 @@ export class WebGPUEngine extends Engine {
         onCompiled?: Nullable<(effect: Effect) => void>, onError?: Nullable<(effect: Effect, errors: string) => void>, indexParameters?: any): Effect {
         const vertex = baseName.vertexElement || baseName.vertex || baseName.vertexToken || baseName.vertexSource || baseName;
         const fragment = baseName.fragmentElement || baseName.fragment || baseName.fragmentToken || baseName.fragmentSource || baseName;
+        const globalDefines = this._getGlobalDefines()!;
 
-        const name = vertex + "+" + fragment + "@" + (defines ? defines : (<IEffectCreationOptions>attributesNamesOrOptions).defines);
+        let fullDefines = defines ?? (<IEffectCreationOptions>attributesNamesOrOptions).defines ?? "";
+
+        if (globalDefines) {
+            fullDefines += "\n" + globalDefines;
+        }
+
+        const name = vertex + "+" + fragment + "@" + fullDefines;
         if (this._compiledEffects[name]) {
             var compiledEffect = <Effect>this._compiledEffects[name];
             if (onCompiled && compiledEffect.isReady()) {

--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1326,8 +1326,6 @@ export class ShadowGenerator implements IShadowGenerator {
 
         defines.push("#define SM_DEPTHTEXTURE " + (this.usePercentageCloserFiltering || this.useContactHardeningShadow ? "1" : "0"));
 
-        defines.push("#define SM_USE_REVERSE_DEPTHBUFFER " + (this._scene.getEngine().useReverseDepthBuffer ? "1" : "0"));
-
         var mesh = subMesh.getMesh();
 
         // Normal bias.

--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -166,7 +166,6 @@ class BackgroundMaterialDefines extends MaterialDefines implements IImageProcess
     public LOGARITHMICDEPTH = false;
     public NONUNIFORMSCALING = false;
     public ALPHATEST = false;
-    public USE_REVERSE_DEPTHBUFFER = false;
 
     /**
      * Constructor of the defines.

--- a/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -223,7 +223,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
 
         state._emitFunctionFromInclude("bumpFragmentFunctions", comments, {
             replaceStrings: [
-                { search: /varying vec2 vBumpUV;/g, replace: ""},
+                { search: /#include<samplerFragmentDeclaration>\(_DEFINENAME_,BUMP,_VARYINGNAME_,Bump,_SAMPLERNAME_,bump\)/g, replace: ""},
                 { search: /uniform sampler2D bumpSampler;/g, replace: ""},
                 { search: /vec2 parallaxOcclusion\(vec3 vViewDirCoT,vec3 vNormalCoT,vec2 texCoord,float parallaxScale\)/g, replace: "#define inline\r\nvec2 parallaxOcclusion(vec3 vViewDirCoT, vec3 vNormalCoT, vec2 texCoord, float parallaxScale, sampler2D bumpSampler)" },
                 { search : /vec2 parallaxOffset\(vec3 viewDir,float heightScale\)/g, replace: "vec2 parallaxOffset(vec3 viewDir, float heightScale, float height_)" },

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -75,7 +75,6 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public UV4 = false;
     public UV5 = false;
     public UV6 = false;
-    public USE_REVERSE_DEPTHBUFFER = false;
 
     /** BONES */
     public NUM_BONE_INFLUENCERS = 0;
@@ -1064,8 +1063,6 @@ export class NodeMaterial extends PushMaterial {
         this._sharedData.blocksWithDefines.forEach((b) => {
             b.prepareDefines(mesh, this, defines, useInstances, subMesh);
         });
-
-        defines.setValue("USE_REVERSE_DEPTHBUFFER", this.getScene().getEngine().useReverseDepthBuffer, true);
 
         // Need to recompile?
         if (defines.isDirty) {

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -235,7 +235,6 @@ export class PBRMaterialDefines extends MaterialDefines
     public POINTSIZE = false;
     public FOG = false;
     public LOGARITHMICDEPTH = false;
-    public USE_REVERSE_DEPTHBUFFER = false;
 
     public FORCENORMALFORWARD = false;
 

--- a/src/Materials/effect.ts
+++ b/src/Materials/effect.ts
@@ -307,6 +307,7 @@ export class Effect implements IDisposable {
             platformName: this._engine.shaderPlatformName,
             processingContext: this._processingContext,
             isNDCHalfZRange: this._engine.isNDCHalfZRange,
+            useReverseDepthBuffer: this._engine.useReverseDepthBuffer,
         };
 
         let shaderCodes : [string | undefined, string | undefined] = [undefined, undefined];

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -94,7 +94,6 @@ export class MaterialHelper {
             defines["FOG"] = fogEnabled && this.GetFogState(mesh, scene);
             defines["NONUNIFORMSCALING"] = mesh.nonUniformScaling;
             defines["ALPHATEST"] = alphaTest;
-            defines["USE_REVERSE_DEPTHBUFFER"] = scene.getEngine().useReverseDepthBuffer;
         }
     }
 

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -123,7 +123,6 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public REFLECTIONMAP_OPPOSITEZ = false;
     public INVERTCUBICMAP = false;
     public LOGARITHMICDEPTH = false;
-    public USE_REVERSE_DEPTHBUFFER = false;
     public REFRACTION = false;
     public REFRACTIONMAP_3D = false;
     public REFLECTIONOVERALPHA = false;

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -305,11 +305,6 @@ export class DepthRenderer {
             defines.push("#define PACKED");
         }
 
-        // Reverse depth buffer
-        if (engine.useReverseDepthBuffer) {
-            defines.push("#define USE_REVERSE_DEPTHBUFFER");
-        }
-
         // Get correct effect
         var join = defines.join("\n");
         if (cachedDefines !== join) {

--- a/src/Shaders/ShadersInclude/shadowMapFragment.fx
+++ b/src/Shaders/ShadersInclude/shadowMapFragment.fx
@@ -4,13 +4,13 @@
     #if SM_USEDISTANCE == 1
         depthSM = (length(vPositionWSM - lightDataSM) + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
     #else
-        #ifdef SM_USE_REVERSE_DEPTHBUFFER
+        #ifdef USE_REVERSE_DEPTHBUFFER
             depthSM = (-zSM + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
         #else
             depthSM = (zSM + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
         #endif
     #endif
-    #ifdef SM_USE_REVERSE_DEPTHBUFFER
+    #ifdef USE_REVERSE_DEPTHBUFFER
         gl_FragDepth = clamp(1.0 - depthSM, 0.0, 1.0);
     #else
         gl_FragDepth = clamp(depthSM, 0.0, 1.0); // using depthSM (linear value) for gl_FragDepth is ok because we are using depth clamping only for ortho projections

--- a/src/Shaders/ShadersInclude/shadowMapFragment.fx
+++ b/src/Shaders/ShadersInclude/shadowMapFragment.fx
@@ -4,13 +4,13 @@
     #if SM_USEDISTANCE == 1
         depthSM = (length(vPositionWSM - lightDataSM) + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
     #else
-        #if SM_USE_REVERSE_DEPTHBUFFER == 1
+        #ifdef SM_USE_REVERSE_DEPTHBUFFER
             depthSM = (-zSM + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
         #else
             depthSM = (zSM + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
         #endif
     #endif
-    #if SM_USE_REVERSE_DEPTHBUFFER == 1
+    #ifdef SM_USE_REVERSE_DEPTHBUFFER
         gl_FragDepth = clamp(1.0 - depthSM, 0.0, 1.0);
     #else
         gl_FragDepth = clamp(depthSM, 0.0, 1.0); // using depthSM (linear value) for gl_FragDepth is ok because we are using depth clamping only for ortho projections

--- a/src/Shaders/ShadersInclude/shadowMapVertexMetric.fx
+++ b/src/Shaders/ShadersInclude/shadowMapVertexMetric.fx
@@ -10,7 +10,7 @@
     #endif
 
     // Depth texture Linear bias.
-    #ifdef SM_USE_REVERSE_DEPTHBUFFER
+    #ifdef USE_REVERSE_DEPTHBUFFER
         gl_Position.z -= biasAndScaleSM.x * gl_Position.w * BIASFACTOR;
     #else
         gl_Position.z += biasAndScaleSM.x * gl_Position.w * BIASFACTOR;
@@ -22,7 +22,7 @@
     gl_Position.z = 0.0;
 #elif SM_USEDISTANCE == 0
     // Color Texture Linear bias.
-    #ifdef SM_USE_REVERSE_DEPTHBUFFER
+    #ifdef USE_REVERSE_DEPTHBUFFER
         vDepthMetricSM = (-gl_Position.z + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
     #else
         vDepthMetricSM = (gl_Position.z + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;

--- a/src/Shaders/ShadersInclude/shadowMapVertexMetric.fx
+++ b/src/Shaders/ShadersInclude/shadowMapVertexMetric.fx
@@ -10,7 +10,7 @@
     #endif
 
     // Depth texture Linear bias.
-    #if SM_USE_REVERSE_DEPTHBUFFER == 1
+    #ifdef SM_USE_REVERSE_DEPTHBUFFER
         gl_Position.z -= biasAndScaleSM.x * gl_Position.w * BIASFACTOR;
     #else
         gl_Position.z += biasAndScaleSM.x * gl_Position.w * BIASFACTOR;
@@ -22,7 +22,7 @@
     gl_Position.z = 0.0;
 #elif SM_USEDISTANCE == 0
     // Color Texture Linear bias.
-    #if SM_USE_REVERSE_DEPTHBUFFER == 1
+    #ifdef SM_USE_REVERSE_DEPTHBUFFER
         vDepthMetricSM = (-gl_Position.z + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;
     #else
         vDepthMetricSM = (gl_Position.z + depthValuesSM.x) / depthValuesSM.y + biasAndScaleSM.x;

--- a/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
@@ -269,7 +269,7 @@
 
             vec4 uvDepthLayer = vec4(uvDepth.x, uvDepth.y, layer, uvDepth.z);
 
-            float shadow = texture(shadowSampler, uvDepthLayer);
+            float shadow = texture2D(shadowSampler, uvDepthLayer);
             shadow = mix(darkness, 1., shadow);
             return computeFallOff(shadow, clipSpace.xy, frustumEdgeFalloff);
         }
@@ -615,7 +615,7 @@
             float sumBlockerDepth = 0.0;
             float numBlocker = 0.0;
             for (int i = 0; i < searchTapCount; i ++) {
-                blockerDepth = texture(depthSampler, vec3(uvDepth.xy + (lightSizeUV * lightSizeUVCorrection * shadowMapSizeInverse * PoissonSamplers32[i].xy), layer)).r;
+                blockerDepth = texture2D(depthSampler, vec3(uvDepth.xy + (lightSizeUV * lightSizeUVCorrection * shadowMapSizeInverse * PoissonSamplers32[i].xy), layer)).r;
                 if (blockerDepth < depthMetric) {
                     sumBlockerDepth += blockerDepth;
                     numBlocker++;
@@ -681,7 +681,7 @@
                 float sumBlockerDepth = 0.0;
                 float numBlocker = 0.0;
                 for (int i = 0; i < searchTapCount; i ++) {
-                    blockerDepth = texture(depthSampler, uvDepth.xy + (lightSizeUV * shadowMapSizeInverse * PoissonSamplers32[i].xy)).r;
+                    blockerDepth = texture2D(depthSampler, uvDepth.xy + (lightSizeUV * shadowMapSizeInverse * PoissonSamplers32[i].xy)).r;
                     if (blockerDepth < depthMetric) {
                         sumBlockerDepth += blockerDepth;
                         numBlocker++;

--- a/src/Shaders/ShadersInclude/shadowsVertex.fx
+++ b/src/Shaders/ShadersInclude/shadowsVertex.fx
@@ -3,7 +3,7 @@
 		vPositionFromCamera{X} = view * worldPos;
 		for (int i = 0; i < SHADOWCSMNUM_CASCADES{X}; i++) {
 			vPositionFromLight{X}[i] = lightMatrix{X}[i] * worldPos;
-            #if USE_REVERSE_DEPTHBUFFER
+            #ifdef USE_REVERSE_DEPTHBUFFER
 			    vDepthMetric{X}[i] = (-vPositionFromLight{X}[i].z + light{X}.depthValues.x) / light{X}.depthValues.y;
             #else
 			    vDepthMetric{X}[i] = (vPositionFromLight{X}[i].z + light{X}.depthValues.x) / light{X}.depthValues.y;
@@ -11,7 +11,7 @@
 		}
 	#elif defined(SHADOW{X}) && !defined(SHADOWCUBE{X})
 		vPositionFromLight{X} = lightMatrix{X} * worldPos;
-        #if USE_REVERSE_DEPTHBUFFER
+        #ifdef USE_REVERSE_DEPTHBUFFER
 		    vDepthMetric{X} = (-vPositionFromLight{X}.z + light{X}.depthValues.x) / light{X}.depthValues.y;
         #else
 		    vDepthMetric{X} = (vPositionFromLight{X}.z + light{X}.depthValues.x) / light{X}.depthValues.y;

--- a/src/Shaders/depth.vertex.fx
+++ b/src/Shaders/depth.vertex.fx
@@ -40,7 +40,7 @@ void main(void)
 
 	gl_Position = viewProjection * finalWorld * vec4(positionUpdated, 1.0);
 	
-    #if USE_REVERSE_DEPTHBUFFER
+    #ifdef USE_REVERSE_DEPTHBUFFER
 	    vDepthMetric = ((-gl_Position.z + depthValues.x) / (depthValues.y));
     #else
 	    vDepthMetric = ((gl_Position.z + depthValues.x) / (depthValues.y));

--- a/src/Shaders/gpuRenderParticles.fragment.fx
+++ b/src/Shaders/gpuRenderParticles.fragment.fx
@@ -16,7 +16,7 @@ varying vec4 vColor;
 void main() {
 	#include<clipPlaneFragment> 
 
-	vec4 textureColor = texture(diffuseSampler, vUV);
+	vec4 textureColor = texture2D(diffuseSampler, vUV);
   	gl_FragColor = textureColor * vColor;
 
 	#ifdef BLENDMULTIPLYMODE

--- a/src/Shaders/gpuRenderParticles.vertex.fx
+++ b/src/Shaders/gpuRenderParticles.vertex.fx
@@ -104,7 +104,7 @@ void main() {
 	#endif
   float ratio = age / life;
 #ifdef COLORGRADIENTS
-	vColor = texture(colorGradientSampler, vec2(ratio, 0));
+	vColor = texture2D(colorGradientSampler, vec2(ratio, 0));
 #else
 	vColor = color * vec4(1.0 - ratio) + colorDead * vec4(ratio);
 #endif

--- a/src/Shaders/gpuUpdateParticles.compute.fx
+++ b/src/Shaders/gpuUpdateParticles.compute.fx
@@ -125,8 +125,8 @@ struct Particle {
 };
 
 [[binding(0), group(0)]] var<uniform> params : SimParams;
-[[binding(1), group(0)]] var<storage> particlesIn : [[access(read)]] Particles;
-[[binding(2), group(0)]] var<storage> particlesOut : [[access(read_write)]] Particles;
+[[binding(1), group(0)]] var<storage, read> particlesIn : Particles;
+[[binding(2), group(0)]] var<storage, read_write> particlesOut : Particles;
 [[binding(3), group(0)]] var randomSampler : sampler;
 [[binding(4), group(0)]] var randomTexture : texture_2d<f32>;
 [[binding(5), group(0)]] var randomSampler2 : sampler;

--- a/src/Shaders/minmaxRedux.fragment.fx
+++ b/src/Shaders/minmaxRedux.fragment.fx
@@ -64,7 +64,7 @@ void main(void)
 #elif defined(LAST)
 void main(void)
 {
-    discard;
     glFragColor = vec4(0.);
+    discard;
 }
 #endif

--- a/src/Shaders/vrMultiviewToSingleview.fragment.fx
+++ b/src/Shaders/vrMultiviewToSingleview.fragment.fx
@@ -6,5 +6,5 @@ uniform int imageIndex;
 
 void main(void)
 {
-	gl_FragColor = texture(multiviewSampler, vec3(vUV, imageIndex));
+	gl_FragColor = texture2D(multiviewSampler, vec3(vUV, imageIndex));
 }


### PR DESCRIPTION
The PR #10598 won't probably be merged, so I have extracted the fixes that are not related to the PR itself:
* Move global shader flag USE_REVERSE_DEPTHBUFFER in ShaderProcessor
* Fix crash of fluentBackplate with WebGPU
* Fix bump not working in node materials
* Fix gpu update particle compute after spec changes
* Fix warning in OpenGL when using the mixmax reducer
* Fix invertYPreMultiplyAlpha when using miplevel and layer