### PR TITLE
Mesh: Fix problems when using both instances and thin instances

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1675,7 +1675,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // VBOs
-        if (!this._userInstancedBuffersStorage || !this.hasInstances || this.hasThinInstances) {
+        if (!this._userInstancedBuffersStorage || this.hasThinInstances) {
             this._geometry._bind(effect, indexToBind);
         } else {
             this._geometry._bind(effect, indexToBind, this._userInstancedBuffersStorage.vertexBuffers, this._userInstancedBuffersStorage.vertexArrayObjects);

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -1675,7 +1675,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // VBOs
-        if (!this._userInstancedBuffersStorage) {
+        if (!this._userInstancedBuffersStorage || !this.hasInstances || this.hasThinInstances) {
             this._geometry._bind(effect, indexToBind);
         } else {
             this._geometry._bind(effect, indexToBind, this._userInstancedBuffersStorage.vertexBuffers, this._userInstancedBuffersStorage.vertexArrayObjects);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/strange-thin-intances-behaviour/22112

Prioritize thin instances when using both instances and thin instances at the same time (having both enabled at the same time is not possible).
