### PR TITLE
Reduce MergeMeshes resource utilization

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -4871,7 +4871,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             vertexData.transform(wm);
             return vertexData;
         };
-        const vertexData = getVertexDataFromMesh(source).merge(meshes.slice(1).map(mesh => getVertexDataFromMesh(mesh)));
+        const vertexData = getVertexDataFromMesh(source).merge(meshes.slice(1).map((mesh) => getVertexDataFromMesh(mesh)));
 
         if (!meshSubclass) {
             meshSubclass = new Mesh(source.name + "_merged", source.getScene());

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -545,15 +545,15 @@ export class VertexData {
     }
 
     private static _mergeElement(source: Nullable<FloatArray>, others: readonly Nullable<FloatArray>[]): Nullable<FloatArray> {
-        if (!others || others.length === 0) {
+        const nonNullOthers = others.filter((other): other is FloatArray => other !== null && other !== undefined);
+
+        if (nonNullOthers.length === 0) {
             return source;
         }
 
         if (!source) {
-            return this._mergeElement(others[1], others.slice(1));
+            return this._mergeElement(nonNullOthers[1], nonNullOthers.slice(1));
         }
-
-        const nonNullOthers = others.filter((other): other is FloatArray => other !== null);
 
         const len = source.length + nonNullOthers.reduce((othersSumLen, other) => othersSumLen += other.length, 0);
 

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -471,7 +471,7 @@ export class VertexData {
     public merge(others: VertexData | VertexData[], use32BitsIndices = false): VertexData {
         this._validate();
 
-        others = others instanceof VertexData ? [others] : others;
+        others = Array.isArray(others) ? others : [others];
 
         for (const other of others) {
             other._validate();
@@ -493,14 +493,14 @@ export class VertexData {
             }
         }
 
-        const totalIndices = (this.indices?.length || 0) + others.reduce((othersSumLen, other) => othersSumLen += (other.indices?.length || 0), 0);
+        const totalIndices = others.reduce((indexSum, vertexData) => indexSum + (vertexData.indices?.length ?? 0), this.indices?.length ?? 0);
         if (totalIndices > 0) {
+
+            let indicesOffset = this.indices?.length ?? 0;
 
             if (!this.indices) {
                 this.indices = new Array<number>(totalIndices);
             }
-
-            let indicesOffset = this.indices.length;
 
             if (this.indices.length !== totalIndices) {
                 if (Array.isArray(this.indices)) {
@@ -552,10 +552,10 @@ export class VertexData {
         }
 
         if (!source) {
-            return this._mergeElement(nonNullOthers[1], nonNullOthers.slice(1));
+            return this._mergeElement(nonNullOthers[0], nonNullOthers.slice(1));
         }
 
-        const len = source.length + nonNullOthers.reduce((othersSumLen, other) => othersSumLen += other.length, 0);
+        const len = nonNullOthers.reduce((sumLen, elements) => sumLen + elements.length, source.length);
 
         if (source instanceof Float32Array) {
             // use non-loop method when the source is Float32Array

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -526,20 +526,20 @@ export class VertexData {
             }
         }
 
-        this.positions = VertexData._mergeElement(this.positions, others.map(other => other.positions));
-        this.normals = VertexData._mergeElement(this.normals, others.map(other => other.normals));
-        this.tangents = VertexData._mergeElement(this.tangents, others.map(other => other.tangents));
-        this.uvs = VertexData._mergeElement(this.uvs, others.map(other => other.uvs));
-        this.uvs2 = VertexData._mergeElement(this.uvs2, others.map(other => other.uvs2));
-        this.uvs3 = VertexData._mergeElement(this.uvs3, others.map(other => other.uvs3));
-        this.uvs4 = VertexData._mergeElement(this.uvs4, others.map(other => other.uvs4));
-        this.uvs5 = VertexData._mergeElement(this.uvs5, others.map(other => other.uvs5));
-        this.uvs6 = VertexData._mergeElement(this.uvs6, others.map(other => other.uvs6));
-        this.colors = VertexData._mergeElement(this.colors, others.map(other => other.colors));
-        this.matricesIndices = VertexData._mergeElement(this.matricesIndices, others.map(other => other.matricesIndices));
-        this.matricesWeights = VertexData._mergeElement(this.matricesWeights, others.map(other => other.matricesWeights));
-        this.matricesIndicesExtra = VertexData._mergeElement(this.matricesIndicesExtra, others.map(other => other.matricesIndicesExtra));
-        this.matricesWeightsExtra = VertexData._mergeElement(this.matricesWeightsExtra, others.map(other => other.matricesWeightsExtra));
+        this.positions = VertexData._mergeElement(this.positions, others.map((other) => other.positions));
+        this.normals = VertexData._mergeElement(this.normals, others.map((other) => other.normals));
+        this.tangents = VertexData._mergeElement(this.tangents, others.map((other) => other.tangents));
+        this.uvs = VertexData._mergeElement(this.uvs, others.map((other) => other.uvs));
+        this.uvs2 = VertexData._mergeElement(this.uvs2, others.map((other) => other.uvs2));
+        this.uvs3 = VertexData._mergeElement(this.uvs3, others.map((other) => other.uvs3));
+        this.uvs4 = VertexData._mergeElement(this.uvs4, others.map((other) => other.uvs4));
+        this.uvs5 = VertexData._mergeElement(this.uvs5, others.map((other) => other.uvs5));
+        this.uvs6 = VertexData._mergeElement(this.uvs6, others.map((other) => other.uvs6));
+        this.colors = VertexData._mergeElement(this.colors, others.map((other) => other.colors));
+        this.matricesIndices = VertexData._mergeElement(this.matricesIndices, others.map((other) => other.matricesIndices));
+        this.matricesWeights = VertexData._mergeElement(this.matricesWeights, others.map((other) => other.matricesWeights));
+        this.matricesIndicesExtra = VertexData._mergeElement(this.matricesIndicesExtra, others.map((other) => other.matricesIndicesExtra));
+        this.matricesWeightsExtra = VertexData._mergeElement(this.matricesWeightsExtra, others.map((other) => other.matricesWeightsExtra));
 
         return this;
     }


### PR DESCRIPTION
`MergeMeshes` tends to be heavily used in Babylon React Native to reduce the size of the scene graph since JS execution is relatively slow without JIT. However, `MergeMeshes` can be relatively slow (e.g. a few seconds when merging say 200-300 meshes for a glb, or a few hundred milliseconds when merging a few dozen meshes created at runtime, which can be a noticeable hitch). Given this, I spent a little time profiling `MergeMeshes` and improving several aspects of it:
- Rather than merge pairs of meshes repeatedly until all meshes are merged, just merge all meshes in one pass.
- Figure out how big we'll need the arrays to be up front and allocate them only once (the final size needed for all merged meshes).
- Don't use `Array.concat` as it is really slow and can't merge more than two arrays at once.

These changes make `MergeMeshes` about **5x-10x faster**, depending on the scenario. It also **reduces memory pressure about about 10x-12x**.

### Before
In this example, there were about 250 meshes. It took about 1.5 seconds and memory spiked up to about 1.4GB.
![image](https://user-images.githubusercontent.com/5084643/124642044-37c91700-de44-11eb-9dd8-5541e7341847.png)

### After
Again, 250 meshes, but now taking about 233ms and memory climbing to only about 129mb (without big memory spikes and big GCs).
![image](https://user-images.githubusercontent.com/5084643/124642165-60511100-de44-11eb-9a65-c56aeee34936.png)

Unfortunately the change in perf was not as significant in Babylon Native, so I will have another round of changes coming that specifically targets native.