### PR TITLE
Add panning to the performance profiler graph!

### DIFF
--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -58,7 +58,7 @@ export class CanvasGraphService {
         this.clear();
 
         // Get global min max of time axis (across all datasets).
-        let globalTimeMinMax = {min: Infinity, max: 0};
+        const globalTimeMinMax = {min: Infinity, max: 0};
 
         // TODO: Make better sliding window code (accounting for zoom and pan).
         // TODO: Perhaps see if i can reduce the number of allocations.
@@ -68,10 +68,10 @@ export class CanvasGraphService {
             data: dataset.data.slice(Math.max(dataset.data.length - this._sizeOfWindow, 0))
         }));
 
+        // timestamps will be in sorted order so we can simply do the following.
         datasets.forEach((dataset: IPerfDataset) => {
-            const timeMinMax = this._getMinMax(dataset.data.map((point: IPerfPoint) => point.timestamp));            
-            globalTimeMinMax.min = Math.min(timeMinMax.min, globalTimeMinMax.min);
-            globalTimeMinMax.max = Math.max(timeMinMax.max, globalTimeMinMax.max);
+            globalTimeMinMax.min = Math.min(dataset.data[0].timestamp, globalTimeMinMax.min);
+            globalTimeMinMax.max = Math.max(dataset.data[dataset.data.length - 1].timestamp, globalTimeMinMax.max);
         });
 
         const drawableArea: IGraphDrawableArea = {

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -1,4 +1,4 @@
-import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea, IPerfMousePosition } from "./graphSupportingTypes";
+import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea, IPerfMousePanningPosition } from "./graphSupportingTypes";
 import { IPerfDataset, IPerfPoint } from "babylonjs/Misc/interfaces/iPerfViewer";
 import { Scalar } from "babylonjs/Maths/math.scalar";
 
@@ -23,7 +23,7 @@ export class CanvasGraphService {
     private _height: number;
     private _sizeOfWindow: number = 300;
     private _ticks: number[];
-    private _panStart: IPerfMousePosition | null;
+    private _panPosition: IPerfMousePanningPosition | null;
     private _positions: Map<string, number>;
     public readonly datasets: IPerfDataset[];
 
@@ -38,7 +38,7 @@ export class CanvasGraphService {
         this._width = canvas.width;
         this._height = canvas.height;
         this._ticks = [];
-        this._panStart = null;
+        this._panPosition = null;
         this._positions = new Map<string, number>();
         
         this.datasets = settings.datasets;
@@ -365,7 +365,7 @@ export class CanvasGraphService {
         }
         const canvas = ctx.canvas;
 
-        this._panStart = {
+        this._panPosition = {
             xPos: event.clientX,
             delta: 0,
         };
@@ -378,11 +378,11 @@ export class CanvasGraphService {
      * @param event The mouse event that contains positional information.
      */
     private _handlePan = (event: MouseEvent) => {
-        if (!this._panStart) {
+        if (!this._panPosition) {
             return;
         }
 
-        const pixelDelta = this._panStart.delta + event.clientX - this._panStart.xPos;
+        const pixelDelta = this._panPosition.delta + event.clientX - this._panPosition.xPos;
         const pixelsPerItem = this._width / this._sizeOfWindow;
         const itemsDelta = pixelDelta / pixelsPerItem | 0;
 
@@ -406,12 +406,12 @@ export class CanvasGraphService {
         });
 
         if (itemsDelta === 0) {
-            this._panStart.delta += pixelDelta;
+            this._panPosition.delta += pixelDelta;
         } else {
-            this._panStart.delta = 0;
+            this._panPosition.delta = 0;
         }
 
-        this._panStart.xPos = event.clientX;
+        this._panPosition.xPos = event.clientX;
 
     }
 
@@ -433,7 +433,7 @@ export class CanvasGraphService {
 
         const canvas = ctx.canvas;
         canvas.removeEventListener("mousemove", this._handlePan);
-        this._panStart = null;
+        this._panPosition = null;
     }
 
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -64,7 +64,11 @@ export class CanvasGraphService {
 
         // TODO: Perhaps see if i can reduce the number of allocations.
         // Keep only visible and non empty datasets and get a certain window of items.
-        const datasets = this.datasets.filter((dataset: IPerfDataset) => !dataset.hidden && dataset.data.length > 0).map((dataset: IPerfDataset) => {
+        const datasets = this.datasets.map((dataset: IPerfDataset) => {
+            // skip hidden and empty datasets!
+            if (dataset.data.length === 0 || !!dataset.hidden) {
+                return dataset;
+            }
             const pos = this._positions.get(dataset.id) ?? dataset.data.length - 1;
             let start = pos - Math.ceil(this._sizeOfWindow * scaleFactor);
             let startOverflow = 0;
@@ -89,7 +93,7 @@ export class CanvasGraphService {
                 ...dataset,
                 data: dataset.data.slice(start, end)
             }
-        });
+        }).filter((dataset: IPerfDataset) => !dataset.hidden && dataset.data.length > 0);
 
         // timestamps will be in sorted order so we can simply do the following.
         datasets.forEach((dataset: IPerfDataset) => {

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -323,6 +323,8 @@ export class CanvasGraphService {
      */
     private _removeEventListeners(canvas: HTMLCanvasElement) {
         canvas.removeEventListener("wheel", this._handleZoom);
+        canvas.removeEventListener("mousedown", this._handlePanStart);
+        canvas.ownerDocument.addEventListener("mouseup", this._handlePanStop);
     }
 
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -324,7 +324,7 @@ export class CanvasGraphService {
     private _removeEventListeners(canvas: HTMLCanvasElement) {
         canvas.removeEventListener("wheel", this._handleZoom);
         canvas.removeEventListener("mousedown", this._handlePanStart);
-        canvas.ownerDocument.addEventListener("mouseup", this._handlePanStop);
+        canvas.ownerDocument.removeEventListener("mouseup", this._handlePanStop);
     }
 
     /**

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -8,7 +8,10 @@ import { IPerfDataset } from "babylonjs/Misc/interfaces/iPerfViewer"
     max: number;
 }
 
-export interface IPerfMousePosition {
+/**
+ * Defines structure of the object which contains information related to panning.
+ */
+export interface IPerfMousePanningPosition {
     xPos: number;
     delta: number;
 }

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -8,6 +8,11 @@ import { IPerfDataset } from "babylonjs/Misc/interfaces/iPerfViewer"
     max: number;
 }
 
+export interface IPerfMousePosition {
+    xPos: number;
+    delta: number;
+}
+
 /**
  * Defines a structure defining the available space in a drawable area.
  */

--- a/src/Misc/interfaces/iPerfViewer.ts
+++ b/src/Misc/interfaces/iPerfViewer.ts
@@ -23,6 +23,11 @@ export interface IPerfDataset {
     color?: string;
 
     /**
+     * The id of the dataset.
+     */
+    id: string;
+
+    /**
      * The data to be processed by the performance graph.
      */
     data: IPerfPoint[];


### PR DESCRIPTION
The following PR handles panning to the profiler graph. What this means is the user will be able to pan which will keep the user in the position they've panned to, instead of dragging them along with the real time data (as seen in real time mode).  The user can resume to real time by "catching up" to the real time data, be this through zooming out all the way or panning to catch up. 

Right now it may be a bit confusing to figure out where the real time data is due to the playhead being static. In a future PR it will become dynamic, so that it will only come fully into view as you catch up/have caught up to the real time data. This PR only deals with the panning functionality, and returning to "real time mode". 

Completes the "Allow for panning of the graph" item in #10566 

Here's a video showing what is possible with this PR:

https://user-images.githubusercontent.com/32103099/124811344-615f6c80-df30-11eb-81b9-464e1e18efc2.mp4

