### PR TITLE
DeviceInputSystem: Fix FakeMove

### DIFF
--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -395,10 +395,11 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     fireFakeMove = false;
                 }
                 // Lets Propagate the event for move with same position.
-                if (fireFakeMove) {
+                if (fireFakeMove && evt.button !== -1) {
                     deviceEvent.inputIndex = PointerInput.FakeMove;
                     deviceEvent.previousState = 0;
                     deviceEvent.currentState = 0;
+                    pointer[evt.button + 2] =  Math.abs(pointer[evt.button + 2] - 1); // Reverse state of button if evt.button has value
 
                     this.onInputChangedObservable.notifyObservers(deviceEvent);
                 }

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -399,7 +399,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     deviceEvent.inputIndex = PointerInput.FakeMove;
                     deviceEvent.previousState = 0;
                     deviceEvent.currentState = 0;
-                    pointer[evt.button + 2] =  Math.abs(pointer[evt.button + 2] - 1); // Reverse state of button if evt.button has value
+                    // The pointer buttons in PointerInput are in the same order as they are used for the MouseEvent button property, just offset by 2.
+                    // eg. PointerInput.LeftClick = 2 vs MouseEvent.button = Left Click = 0
+                    // Because of this, we need to offset our indices by two when storing in our inputs array.
+                    pointer[evt.button + 2] = (pointer[evt.button + 2] ? 0 : 1); // Reverse state of button if evt.button has value
 
                     this.onInputChangedObservable.notifyObservers(deviceEvent);
                 }


### PR DESCRIPTION
This PR adds a line to make sure that the input array where the device state for Mouse is correct, with respect to move events.