### PR TITLE
Use Layer render camera for Scene ray picking

### DIFF
--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -200,7 +200,7 @@ export class UtilityLayerRenderer implements IDisposable {
                             scenePick = new PickingInfo();
                         }
                     } else {
-                        let previousActiveCamera: Nullable<Camera> = null
+                        let previousActiveCamera: Nullable<Camera> = null;
                         // If a camera is set for rendering with this layer
                         // it will also be used for the ray computation
                         // To preserve back compat and because scene.pick always use activeCamera

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -200,9 +200,26 @@ export class UtilityLayerRenderer implements IDisposable {
                             scenePick = new PickingInfo();
                         }
                     } else {
+                        let previousActiveCamera: Nullable<Camera> = null
+                        // If a camera is set for rendering with this layer
+                        // it will also be used for the ray computation
+                        // To preserve back compat and because scene.pick always use activeCamera
+                        // it's substituted temporarily and a new scenePick is forced.
+                        // otherwise, the ray with previously active camera is always used.
+                        // It's set back to previous activeCamera after operation.
+                        if (this._renderCamera)
+                        {
+                            previousActiveCamera = scene.activeCamera;
+                            scene.activeCamera = this._renderCamera;
+                            prePointerInfo.ray = null;
+                        }
                         scenePick = prePointerInfo.ray
                             ? scene.pickWithRay(prePointerInfo.ray)
                             : scene.pick(originalScene.pointerX, originalScene.pointerY);
+                        if (previousActiveCamera)
+                        {
+                            scene.activeCamera = previousActiveCamera;
+                        }
                     }
 
                     return scenePick;

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -209,8 +209,8 @@ export class UtilityLayerRenderer implements IDisposable {
                         // It's set back to previous activeCamera after operation.
                         if (this._renderCamera)
                         {
-                            previousActiveCamera = scene.activeCamera;
-                            scene.activeCamera = this._renderCamera;
+                            previousActiveCamera = scene._activeCamera;
+                            scene._activeCamera = this._renderCamera;
                             prePointerInfo.ray = null;
                         }
                         scenePick = prePointerInfo.ray
@@ -218,7 +218,7 @@ export class UtilityLayerRenderer implements IDisposable {
                             : scene.pick(originalScene.pointerX, originalScene.pointerY);
                         if (previousActiveCamera)
                         {
-                            scene.activeCamera = previousActiveCamera;
+                            scene._activeCamera = previousActiveCamera;
                         }
                     }
 


### PR DESCRIPTION
fixes https://forum.babylonjs.com/t/gizmo-issue-with-two-viewports-and-gui/22229/3
Use layer render camera for scene ray picking when it's not null.