### PR TITLE
Performance graph dynamic playhead

### DIFF
--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -13,6 +13,12 @@ const dividerSize = 2;
 // Currently the scale factor is a constant but when we add panning this may become formula based.
 const scaleFactor = 0.8;
 
+// This controls the scale factor at which we stop drawing the playhead. Below this value there tends to be flickering of the playhead as data comes in.
+const stopDrawingPlayheadThreshold = 0.95;
+
+// Threshold for the ratio at which we go from panning mode to live mode.
+const returnToLiveThreshold = 0.998;
+
 /**
  * This class acts as the main API for graphing given a Here is where you will find methods to let the service know new data needs to be drawn,
  * let it know something has been resized, etc! 
@@ -559,7 +565,7 @@ export class CanvasGraphService {
         const overflow = Math.max(0 - (pos - Math.ceil(this._sizeOfWindow * scaleFactor)), 0);
         const rightmostPos = Math.min(overflow + pos + Math.ceil(this._sizeOfWindow * (1 - scaleFactor)), latestElementPos);
 
-        return latestDataset.data[rightmostPos].timestamp/latestDataset.data[latestElementPos].timestamp > 0.998;
+        return latestDataset.data[rightmostPos].timestamp/latestDataset.data[latestElementPos].timestamp > returnToLiveThreshold;
     }
 
     /**
@@ -571,7 +577,7 @@ export class CanvasGraphService {
     private _drawPlayheadRegion(drawableArea: IGraphDrawableArea, scaleFactor: number) {
         const { _ctx: ctx } = this;
        
-        if (!ctx || scaleFactor >= 0.95) {
+        if (!ctx || scaleFactor >= stopDrawingPlayheadThreshold) {
             return;
         }
 

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -16,6 +16,9 @@ export interface IPerfMousePanningPosition {
     delta: number;
 }
 
+/**
+ * Defines structure of the object which contains information regarding the bounds of each dataset we want to consider.
+ */
 export interface IPerfIndexBounds {
     start: number;
     end: number;

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -16,6 +16,11 @@ export interface IPerfMousePanningPosition {
     delta: number;
 }
 
+export interface IPerfIndexBounds {
+    start: number;
+    end: number;
+}
+
 /**
  * Defines a structure defining the available space in a drawable area.
  */


### PR DESCRIPTION
This pull request adds the dynamic sizing of the play head!! So if we are in a panned state, the real-time data can fill the buffer of space we have.  As we get closer to the real-time data, the play head will seem to grow. As we move away, the play head will shrink and disappear. Related to #10566 

Here is the related video capture describing what is going on more in depth:

https://user-images.githubusercontent.com/32103099/125003510-59352900-e025-11eb-951e-e5f82b883c82.mp4

