### PR TITLE
DepthRenderer: Fix meshes with bones not rendered

### DIFF
--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -264,6 +264,12 @@ export class DepthRenderer {
             }
             defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
             defines.push("#define BonesPerMesh " + (mesh.skeleton ? mesh.skeleton.bones.length + 1 : 0));
+
+            const skeleton = subMesh.getRenderingMesh().skeleton;
+
+            if (skeleton?.isUsingTextureForMatrices) {
+                defines.push("#define BONETEXTURE");
+            }
         } else {
             defines.push("#define NUM_BONE_INFLUENCERS 0");
         }
@@ -311,8 +317,8 @@ export class DepthRenderer {
             cachedDefines = join;
             effect = engine.createEffect("depth",
                 attribs,
-                ["world", "mBones", "viewProjection", "diffuseMatrix", "depthValues", "morphTargetInfluences", "morphTargetTextureInfo", "morphTargetTextureIndices"],
-                ["diffuseSampler", "morphTargets"], join,
+                ["world", "mBones", "boneTextureWidth", "viewProjection", "diffuseMatrix", "depthValues", "morphTargetInfluences", "morphTargetTextureInfo", "morphTargetTextureIndices"],
+                ["diffuseSampler", "morphTargets", "boneSampler"], join,
                 undefined, undefined, undefined, { maxSimultaneousMorphTargets: numMorphInfluencers });
         }
 

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -37,6 +37,9 @@ export class DepthRenderer {
     /** Enable or disable the depth renderer. When disabled, the depth texture is not updated */
     public enabled = true;
 
+    /** Force writing the transparent objects into the depth map */
+    public forceDepthWriteTransparentMeshes = false;
+
     /**
      * Specifies that the depth renderer will only be used within
      * the camera it is created for.
@@ -200,11 +203,9 @@ export class DepthRenderer {
             var index;
 
             if (depthOnlySubMeshes.length) {
-                engine.setColorWrite(false);
                 for (index = 0; index < depthOnlySubMeshes.length; index++) {
                     renderSubMesh(depthOnlySubMeshes.data[index]);
                 }
-                engine.setColorWrite(true);
             }
 
             for (index = 0; index < opaqueSubMeshes.length; index++) {
@@ -213,6 +214,12 @@ export class DepthRenderer {
 
             for (index = 0; index < alphaTestSubMeshes.length; index++) {
                 renderSubMesh(alphaTestSubMeshes.data[index]);
+            }
+
+            if (this.forceDepthWriteTransparentMeshes) {
+                for (index = 0; index < transparentSubMeshes.length; index++) {
+                    renderSubMesh(transparentSubMeshes.data[index]);
+                }
             }
         };
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/depth-of-field-issue/22281/4

Also add a new `forceDepthWriteTransparentMeshes` property + fix bug for "depth only" meshes