### PR TITLE
Fix FreeCameraTouchInput to work with Emulator and iOS, Add SingleTouchRotate flag

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -36,6 +36,7 @@
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))
 - Added `applyVerticalCorrection` and `projectionPlaneTilt` to perspective cameras to correct perspective projections ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Support rotation keys in universal camera ([Sebavan](https://github.com/sebavan))
+- Added flag to allow users to swap between rotation and movement for single touch on FreeCameraTouchInput ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 
@@ -261,6 +262,7 @@
 - Fix for near interaction failing when multiple utility layers are present ([rickfromwork](https://github.com/rickfromwork))
 - Fix handling of events to support multiple canvas scenarios DeviceInputSystem ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix undisposed textures in PrePass effects that would cause the scene to have more textures than expected ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Fix ThinEngine isMobile to detect changes when window is resized to allow for proper emulator evaluation ([PolygonalSun](https://github.com/PolygonalSun))
 
 ## Breaking changes
 

--- a/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -31,6 +31,11 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
     @serialize()
     public touchMoveSensibility: number = 250.0;
 
+    /**
+     * Swap touch actions so that one touch is used for rotation and multiple for movement
+     */
+    public singleFingerRotate: boolean = false;
+
     private _offsetX: Nullable<number> = null;
     private _offsetY: Nullable<number> = null;
 
@@ -69,6 +74,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
                 var evt = <IPointerEvent>p.event;
 
                 let isMouseEvent = !this.camera.getEngine().hostInformation.isMobile && evt instanceof MouseEvent;
+
                 if (!this.allowMouse && (evt.pointerType === "mouse" || isMouseEvent)) {
                     return;
                 }
@@ -179,7 +185,9 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         var camera = this.camera;
         camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
 
-        if (this._pointerPressed.length > 1) {
+        const rotateCamera = (this.singleFingerRotate && this._pointerPressed.length === 1) || (!this.singleFingerRotate && this._pointerPressed.length > 1);
+
+        if (rotateCamera) {
             camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
         } else {
             var speed = camera._computeLocalCameraSpeed();

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -509,15 +509,15 @@ export class ThinEngine {
         return false;
     }
 
-    private _framebufferDimensionsObject: Nullable<{framebufferWidth: number, framebufferHeight: number}>;
+    private _framebufferDimensionsObject: Nullable<{ framebufferWidth: number, framebufferHeight: number }>;
 
     /**
      * sets the object from which width and height will be taken from when getting render width and height
      * Will fallback to the gl object
      * @param dimensions the framebuffer width and height that will be used.
      */
-    public set framebufferDimensionsObject(dimensions: Nullable<{framebufferWidth: number, framebufferHeight: number}>) {
-      this._framebufferDimensionsObject = dimensions;
+    public set framebufferDimensionsObject(dimensions: Nullable<{ framebufferWidth: number, framebufferHeight: number }>) {
+        this._framebufferDimensionsObject = dimensions;
     }
 
     /**
@@ -627,7 +627,9 @@ export class ThinEngine {
         this._snapshotRenderingMode = mode;
     }
 
-    private static _createCanvas(width: number, height: number) : ICanvas {
+    private _checkForMobile: () => void;
+
+    private static _createCanvas(width: number, height: number): ICanvas {
         if (typeof document === "undefined") {
             return <ICanvas>(<any>(new OffscreenCanvas(width, height)));
         }
@@ -643,7 +645,7 @@ export class ThinEngine {
      * @param height height
      * @return ICanvas interface
      */
-    public createCanvas(width: number, height: number) : ICanvas {
+    public createCanvas(width: number, height: number): ICanvas {
         return ThinEngine._createCanvas(width, height);
     }
 
@@ -722,14 +724,34 @@ export class ThinEngine {
 
             // Exceptions
             if (navigator && navigator.userAgent) {
+                // Function to check if running on mobile device
+                this._checkForMobile = () => {
+                    let currentUA = navigator.userAgent;
+                    this.hostInformation.isMobile = currentUA.indexOf("Mobile") !== -1 || [
+                        'iPad Simulator',
+                        'iPhone Simulator',
+                        'iPod Simulator',
+                        'iPad',
+                        'iPhone',
+                        'iPod'
+                    ].indexOf(navigator.platform) !== -1
+                        // Needed for iOS 13+ detection
+                        || (currentUA.indexOf("Mac") !== -1 && "ontouchend" in document);
+                }
+
+                // Set initial isMobile value
+                this._checkForMobile();
+
+                // Set up event listener to check when window is resized (used to get emulator activation to work properly)
+                window.addEventListener("resize", this._checkForMobile);
+
                 let ua = navigator.userAgent;
-
-                this.hostInformation.isMobile = ua.indexOf("Mobile") !== -1;
-
                 for (var exception of ThinEngine.ExceptionList) {
                     let key = exception.key;
                     let targets = exception.targets;
                     let check = new RegExp(key);
+
+
 
                     if (check.test(ua)) {
                         if (exception.capture && exception.captureConstraint) {
@@ -1392,7 +1414,7 @@ export class ThinEngine {
      * Gets the audio context specified in engine initialization options
      * @returns an Audio Context
      */
-     public getAudioContext(): Nullable<AudioContext> {
+    public getAudioContext(): Nullable<AudioContext> {
         return this._audioContext;
     }
 
@@ -1400,7 +1422,7 @@ export class ThinEngine {
      * Gets the audio destination specified in engine initialization options
      * @returns an audio destination node
      */
-     public getAudioDestination(): Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> {
+    public getAudioDestination(): Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> {
         return this._audioDestination;
     }
 
@@ -1674,7 +1696,7 @@ export class ThinEngine {
      * @param cullBackFaces true to cull back faces, false to cull front faces (if culling is enabled)
      * @param stencil stencil states to set
      */
-     public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean, stencil?: IStencilState): void {
+    public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean, stencil?: IStencilState): void {
         // Culling
         if (this._depthCullingState.cull !== culling || force) {
             this._depthCullingState.cull = culling;
@@ -1702,7 +1724,7 @@ export class ThinEngine {
      * Set the z offset to apply to current rendering
      * @param value defines the offset to apply
      */
-     public setZOffset(value: number): void {
+    public setZOffset(value: number): void {
         this._depthCullingState.zOffset = this.useReverseDepthBuffer ? -value : value;
     }
 
@@ -1979,7 +2001,7 @@ export class ThinEngine {
         }
     }
 
-    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): void {
+    private _bindVertexBuffersAttributes(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer> }): void {
         var attributes = effect.getAttributesNames();
 
         if (!this._vaoRecordInProgress) {
@@ -2037,7 +2059,7 @@ export class ThinEngine {
      * @param overrideVertexBuffers defines optional list of avertex buffers that overrides the entries in vertexBuffers
      * @returns the new vertex array object
      */
-    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer>}): WebGLVertexArrayObject {
+    public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer> }): WebGLVertexArrayObject {
         var vao = this._gl.createVertexArray();
 
         this._vaoRecordInProgress = true;
@@ -2129,7 +2151,7 @@ export class ThinEngine {
      * @param effect defines the effect associated with the vertex buffers
      * @param overrideVertexBuffers defines optional list of avertex buffers that overrides the entries in vertexBuffers
      */
-    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: {[kind: string]: Nullable<VertexBuffer>}): void {
+    public bindBuffers(vertexBuffers: { [key: string]: Nullable<VertexBuffer> }, indexBuffer: Nullable<DataBuffer>, effect: Effect, overrideVertexBuffers?: { [kind: string]: Nullable<VertexBuffer> }): void {
         if (this._cachedVertexBuffers !== vertexBuffers || this._cachedEffectForVertexBuffers !== effect) {
             this._cachedVertexBuffers = vertexBuffers;
             this._cachedEffectForVertexBuffers = effect;
@@ -3173,7 +3195,7 @@ export class ThinEngine {
     /**
      * Gets the stencil state composer
      */
-     public get stencilStateComposer(): StencilStateComposer {
+    public get stencilStateComposer(): StencilStateComposer {
         return this._stencilStateComposer;
     }
 
@@ -3350,7 +3372,7 @@ export class ThinEngine {
     protected _createTextureBase(url: Nullable<string>, noMipmap: boolean, invertY: boolean, scene: Nullable<ISceneLike>, samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
         onLoad: Nullable<() => void> = null, onError: Nullable<(message: string, exception: any) => void> = null,
         prepareTexture: (texture: InternalTexture, extension: string, scene: Nullable<ISceneLike>, img: HTMLImageElement | ImageBitmap | { width: number, height: number }, invertY: boolean, noMipmap: boolean, isCompressed: boolean,
-        processFunction: (width: number, height: number, img: HTMLImageElement | ImageBitmap | { width: number, height: number }, extension: string, texture: InternalTexture, continuationCallback: () => void) => boolean, samplingMode: number) => void,
+            processFunction: (width: number, height: number, img: HTMLImageElement | ImageBitmap | { width: number, height: number }, extension: string, texture: InternalTexture, continuationCallback: () => void) => boolean, samplingMode: number) => void,
         prepareTextureProcessFunction: (width: number, height: number, img: HTMLImageElement | ImageBitmap | { width: number, height: number }, extension: string, texture: InternalTexture, continuationCallback: () => void) => boolean,
         buffer: Nullable<string | ArrayBuffer | ArrayBufferView | HTMLImageElement | Blob | ImageBitmap> = null, fallback: Nullable<InternalTexture> = null, format: Nullable<number> = null,
         forcedExtension: Nullable<string> = null, mimeType?: string, loaderOptions?: any, useSRGBBuffer?: boolean): InternalTexture {
@@ -4450,6 +4472,7 @@ export class ThinEngine {
                 if (!this._doNotHandleContextLost) {
                     this._renderingCanvas.removeEventListener("webglcontextlost", this._onContextLost);
                     this._renderingCanvas.removeEventListener("webglcontextrestored", this._onContextRestored);
+                    window.removeEventListener("resize", this._checkForMobile);
                 }
             }
         }
@@ -4874,7 +4897,7 @@ export class ThinEngine {
      * @hidden
      */
     public static _FileToolsLoadFile(url: string, onSuccess: (data: string | ArrayBuffer, responseURL?: string) => void, onProgress?: (ev: ProgressEvent) => void, offlineProvider?: IOfflineProvider, useArrayBuffer?: boolean, onError?: (request?: WebRequest, exception?: LoadFileError) => void): IFileRequest {
-        throw  _DevTools.WarnImport("FileTools");
+        throw _DevTools.WarnImport("FileTools");
     }
 
     /**
@@ -4901,7 +4924,7 @@ export class ThinEngine {
     // Statics
 
     private static _IsSupported: Nullable<boolean> = null;
-    private static _HasMajorPerformanceCaveat : Nullable<boolean> = null;
+    private static _HasMajorPerformanceCaveat: Nullable<boolean> = null;
 
     /**
      * Gets a boolean indicating if the engine can be instantiated (ie. if a webGL context can be found)

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -727,17 +727,10 @@ export class ThinEngine {
                 // Function to check if running on mobile device
                 this._checkForMobile = () => {
                     let currentUA = navigator.userAgent;
-                    this.hostInformation.isMobile = currentUA.indexOf("Mobile") !== -1 || [
-                        'iPad Simulator',
-                        'iPhone Simulator',
-                        'iPod Simulator',
-                        'iPad',
-                        'iPhone',
-                        'iPod'
-                    ].indexOf(navigator.platform) !== -1
-                        // Needed for iOS 13+ detection
-                        || (currentUA.indexOf("Mac") !== -1 && "ontouchend" in document);
-                }
+                    this.hostInformation.isMobile = currentUA.indexOf("Mobile") !== -1 ||
+                        // Needed for iOS 13+ detection on iPad (inspired by solution from https://stackoverflow.com/questions/9038625/detect-if-device-is-ios)
+                        (currentUA.indexOf("Mac") !== -1 && "ontouchend" in document);
+                };
 
                 // Set initial isMobile value
                 this._checkForMobile();
@@ -750,8 +743,6 @@ export class ThinEngine {
                     let key = exception.key;
                     let targets = exception.targets;
                     let check = new RegExp(key);
-
-
 
                     if (check.test(ua)) {
                         if (exception.capture && exception.captureConstraint) {
@@ -4472,8 +4463,9 @@ export class ThinEngine {
                 if (!this._doNotHandleContextLost) {
                     this._renderingCanvas.removeEventListener("webglcontextlost", this._onContextLost);
                     this._renderingCanvas.removeEventListener("webglcontextrestored", this._onContextRestored);
-                    window.removeEventListener("resize", this._checkForMobile);
                 }
+
+                window.removeEventListener("resize", this._checkForMobile);
             }
         }
 


### PR DESCRIPTION
This PR contains a couple of things.  First, there is a flag that has been added to FreeCameraTouchInput to allow users to swap the behavior of a single touch movement to either be rotation or movement.  Second, the logic for the isMobile bool in the ThinEngine has been fleshed out to properly handle iOS detection and to reevaluate itself when the window is resized.  This will allow for changes to be detected when the Chrome emulator is started.