### PR TITLE
Add tooltip to the performance graph on hover.

### DIFF
--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -14,11 +14,19 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
         if (!canvasRef.current) {
             return;
         }
+        
+        let canvasGraphService: CanvasGraphService | undefined;
 
         // temporarily set empty array, will eventually be passed by props!
-        const canvasGraphService = new CanvasGraphService(canvasRef.current, {datasets: []});
-        canvasServiceCallback(canvasGraphService);
-        return () => canvasGraphService.destroy();
+        try {
+            canvasGraphService = new CanvasGraphService(canvasRef.current, {datasets: []});
+            canvasServiceCallback(canvasGraphService);
+        } catch (error) {
+            console.error(error);
+            return;
+        }
+
+        return () => canvasGraphService?.destroy();
     }, [canvasRef])
    
     return (

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -404,6 +404,7 @@ export class CanvasGraphService {
      */
     private _attachEventListeners(canvas: HTMLCanvasElement) {
         canvas.addEventListener("wheel", this._handleZoom);
+        canvas.addEventListener("mousemove", this._handleDataHover);
         canvas.addEventListener("mousedown", this._handlePanStart);
         // The user may stop panning outside of the canvas size so we should add the event listener to the document.
         canvas.ownerDocument.addEventListener("mouseup", this._handlePanStop);
@@ -416,8 +417,17 @@ export class CanvasGraphService {
      */
     private _removeEventListeners(canvas: HTMLCanvasElement) {
         canvas.removeEventListener("wheel", this._handleZoom);
+        canvas.removeEventListener("mousemove", this._handleDataHover);
         canvas.removeEventListener("mousedown", this._handlePanStart);
         canvas.ownerDocument.removeEventListener("mouseup", this._handlePanStop);
+    }
+    
+    private _handleDataHover = (event: MouseEvent) => {
+        if (this._panPosition) {
+            // we don't want to do anything if we are in the middle of panning.
+            return;
+        }
+        this._datasetBounds.forEach((value, key) => console.log({key, ...value}));
     }
 
     /**

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -56,8 +56,8 @@ export class CanvasGraphService {
     private _drawableArea: IGraphDrawableArea;
     private _axisHeight: number;
     
-    private readonly _tooltipLineHeight;
-    private readonly _defaultLineHeight;
+    private readonly _tooltipLineHeight: number;
+    private readonly _defaultLineHeight: number;
 
     public readonly datasets: IPerfDataset[];
 
@@ -79,20 +79,19 @@ export class CanvasGraphService {
         this._globalTimeMinMax = {min: Infinity, max: 0};
         this._drawableArea = {top: 0, left: 0, right: 0, bottom: 0};
 
-        if (this._ctx) {
-            const defaultMetrics = this._ctx.measureText(alphabet);
-            this._defaultLineHeight = defaultMetrics.actualBoundingBoxAscent + defaultMetrics.actualBoundingBoxDescent;
-            this._axisHeight = axisLineLength + axisPadding + this._defaultLineHeight + axisPadding;
-
-            this._ctx.save();
-            this._ctx.font = tooltipFont;
-            const fontMetrics = this._ctx.measureText(alphabet);
-            this._tooltipLineHeight = fontMetrics.actualBoundingBoxAscent + fontMetrics.actualBoundingBoxDescent;
-            this._ctx.restore();
-        } else {
-            this._tooltipLineHeight = 1;
-            this._defaultLineHeight = 1;
+        if (!this._ctx) {
+            throw Error("No canvas context accessible");
         }
+
+        const defaultMetrics = this._ctx.measureText(alphabet);
+        this._defaultLineHeight = defaultMetrics.actualBoundingBoxAscent + defaultMetrics.actualBoundingBoxDescent;
+        this._axisHeight = axisLineLength + axisPadding + this._defaultLineHeight + axisPadding;
+
+        this._ctx.save();
+        this._ctx.font = tooltipFont;
+        const fontMetrics = this._ctx.measureText(alphabet);
+        this._tooltipLineHeight = fontMetrics.actualBoundingBoxAscent + fontMetrics.actualBoundingBoxDescent;
+        this._ctx.restore();
 
         this.datasets = settings.datasets;
 

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -521,7 +521,6 @@ export class CanvasGraphService {
         },
         tooltipDebounceTime
     )
-        
 
     /**
      * Handles what to do when we stop hovering over the canvas.

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -25,6 +25,14 @@ export interface IPerfIndexBounds {
 }
 
 /**
+ * Defines the structure of the meta object for the tooltip that appears when hovering over a performance graph!
+ */
+export interface IPerfTooltip {
+    text: string;
+    color: string
+}
+
+/**
  * Defines a structure defining the available space in a drawable area.
  */
 export interface IGraphDrawableArea {

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -33,6 +33,14 @@ export interface IPerfTooltip {
 }
 
 /**
+ * Defines the structure of a cache object used to store the result of measureText().
+ */
+export interface IPerfTextMeasureCache {
+    text: string;
+    width: number;
+}
+
+/**
  * Defines a structure defining the available space in a drawable area.
  */
 export interface IGraphDrawableArea {


### PR DESCRIPTION
This PR adds the necessary functionality to draw a tooltip over the data in the graph. This will allow the user to simply hover over a point of interest and the tooltip will show the value at that location for all data sources.

Completes the "Allow for hovering over data points and displaying the actual values." of #10566 

Video of what this PR adds:

https://user-images.githubusercontent.com/32103099/125531626-850aedd6-6c1d-4712-a9ec-d94c18cee50d.mp4


