### PR TITLE
Clamp tintColorAtDistance to avoid values of 0.0

### DIFF
--- a/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
+++ b/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
@@ -522,7 +522,7 @@ export class PBRSubSurfaceConfiguration {
             uniformBuffer.updateFloat4("vTintColor", this.tintColor.r,
                 this.tintColor.g,
                 this.tintColor.b,
-                this.tintColorAtDistance);
+                Math.max(0.00001, this.tintColorAtDistance));
 
             uniformBuffer.updateFloat3("vSubSurfaceIntensity", this.refractionIntensity, this.translucencyIntensity, 0);
         }


### PR DESCRIPTION
When tintColorAtDistance has a value of 0.0, bad math happens :)

Here's a Playground example. The absorption colour is red.
https://playground.babylonjs.com/#WGZLGJ#3294