### PR TITLE
Playground: log the error to the console

### DIFF
--- a/Playground/src/components/rendererComponent.tsx
+++ b/Playground/src/components/rendererComponent.tsx
@@ -351,6 +351,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 });
             }
         } catch (err) {
+            console.error(err);
             this.props.globalState.onErrorObservable.notifyObservers(this._tmpErrorEvent || err);
         }
     }


### PR DESCRIPTION
When there is an error in `createScene`, you only get the error message:

![image](https://user-images.githubusercontent.com/4152247/126033547-ae40990d-dd27-4bf0-9b69-33bd00fabdc0.png)

It's hard to find the problem without the stack trace, so it is now dumped in the error console log.