### PR TITLE
ShadowGenerator: Fix crash when disposing meshes after updating mapSize

### DIFF
--- a/src/Lights/Shadows/shadowGenerator.ts
+++ b/src/Lights/Shadows/shadowGenerator.ts
@@ -1731,7 +1731,18 @@ export class ShadowGenerator implements IShadowGenerator {
         // Reaffect the filter.
         this._applyFilterValues();
         // Reaffect Render List.
-        this._shadowMap!.renderList = renderList;
+        if (renderList) {
+            // Note: don't do this._shadowMap!.renderList = renderList;
+            // The renderList hooked array is accessing the old RenderTargetTexture (see RenderTargetTexture._hookArray), which is disposed at this point (by the call to _disposeRTTandPostProcesses)
+            if (!this._shadowMap!.renderList) {
+                this._shadowMap!.renderList = [];
+            }
+            for (const mesh of renderList) {
+                this._shadowMap!.renderList.push(mesh);
+            }
+        } else {
+            this._shadowMap!.renderList = null;
+        }
     }
 
     protected _disposeBlurPostProcesses(): void {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/mesh-dispose-trigger-uncaught-typeerror-cannot-read-property-meshes-of-null/22301/9

Simple repro: https://playground.babylonjs.com/#VRUFYH#4
