### PR TITLE
Add sidebar to the performance graph

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
@@ -1,23 +1,28 @@
-import { Observable } from 'babylonjs';
+import { Color3, Observable } from 'babylonjs';
 import { IPerfDataset } from 'babylonjs/Misc/interfaces/iPerfViewer';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
+import { ColorPickerLineComponent } from '../../../../sharedUiComponents/lines/colorPickerComponent';
 
 interface IPerformanceViewerSidebarComponentProps {
     datasetObservable: Observable<IPerfDataset[]>
     onToggleVisibility: (id: string, value: boolean) => void;
+    onColorChanged: (id: string, value: string) => void;
 }
 
-
 export const PerformanceViewerSidebarComponent = (props: IPerformanceViewerSidebarComponentProps) => {
-    const {onToggleVisibility, datasetObservable} = props;
-    const [content, setContent] = useState<JSX.Element>(<></>);
+    const {onToggleVisibility, datasetObservable, onColorChanged} = props;
+    // TODO: Refactor to store only metadata once data layer is implemented.
+    const [datasets, setDatasets] = useState<IPerfDataset[]>([]);
 
     useEffect(() => {
+        const onUpdateDatasets = (datasets: IPerfDataset[]) => {
+            setDatasets(datasets);
+        }
+
         datasetObservable.add(onUpdateDatasets);
         return () => {
             datasetObservable.removeCallback(onUpdateDatasets);
-            console.log(datasetObservable.hasObservers());
         }
     }, []);
 
@@ -25,30 +30,21 @@ export const PerformanceViewerSidebarComponent = (props: IPerformanceViewerSideb
         onToggleVisibility(id, !event.currentTarget.checked);
     }
 
-    const onUpdateDatasets = (datasets: IPerfDataset[]) => {
-
-        const htmlContent: JSX.Element = (
-            <>
-                {
-                    datasets.map((dataset: IPerfDataset) => {
-                        return (
-                            <div key={`perf-sidebar-item-${dataset.id}`} className={"group"}>
-                                <input type="checkbox" checked={!dataset.hidden} onChange={onCheckChange(dataset.id)} />
-                                <span>{dataset.id}</span>
-                            </div>
-                        );
-                    })
-                }
-            </>
-        )
-        
-        setContent(htmlContent);
+    const onColorChange = (id: string) => (color: string) => {
+        onColorChanged(id, color);
     }
 
     return (
-        <div id="performanceViewerSidebar">
+        <div id="performance-viewer-sidebar">
             {
-                content
+                datasets.map((dataset: IPerfDataset) => (
+                        <div key={`perf-sidebar-item-${dataset.id}`} className="sidebar-item">
+                            <input type="checkbox" checked={!dataset.hidden} onChange={onCheckChange(dataset.id)} />
+                            <span className="sidebar-item-label">{dataset.id}</span>
+                            <ColorPickerLineComponent value={Color3.FromHexString(dataset.color ?? "#000")} onColorChanged={onColorChange(dataset.id)} shouldPopRight />
+                        </div>
+                    )
+                )
             }
         </div>
     )

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
@@ -1,5 +1,6 @@
-import { Color3, Observable } from 'babylonjs';
+import { Color3 } from 'babylonjs/Maths/math.color';
 import { IPerfDataset } from 'babylonjs/Misc/interfaces/iPerfViewer';
+import { Observable } from 'babylonjs/Misc/observable';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { ColorPickerLineComponent } from '../../../../sharedUiComponents/lines/colorPickerComponent';

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
@@ -1,0 +1,55 @@
+import { Observable } from 'babylonjs';
+import { IPerfDataset } from 'babylonjs/Misc/interfaces/iPerfViewer';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+interface IPerformanceViewerSidebarComponentProps {
+    datasetObservable: Observable<IPerfDataset[]>
+    onToggleVisibility: (id: string, value: boolean) => void;
+}
+
+
+export const PerformanceViewerSidebarComponent = (props: IPerformanceViewerSidebarComponentProps) => {
+    const {onToggleVisibility, datasetObservable} = props;
+    const [content, setContent] = useState<JSX.Element>(<></>);
+
+    useEffect(() => {
+        datasetObservable.add(onUpdateDatasets);
+        return () => {
+            datasetObservable.removeCallback(onUpdateDatasets);
+            console.log(datasetObservable.hasObservers());
+        }
+    }, []);
+
+    const onCheckChange = (id: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+        onToggleVisibility(id, !event.currentTarget.checked);
+    }
+
+    const onUpdateDatasets = (datasets: IPerfDataset[]) => {
+
+        const htmlContent: JSX.Element = (
+            <>
+                {
+                    datasets.map((dataset: IPerfDataset) => {
+                        return (
+                            <div key={`perf-sidebar-item-${dataset.id}`} className={"group"}>
+                                <input type="checkbox" checked={!dataset.hidden} onChange={onCheckChange(dataset.id)} />
+                                <span>{dataset.id}</span>
+                            </div>
+                        );
+                    })
+                }
+            </>
+        )
+        
+        setContent(htmlContent);
+    }
+
+    return (
+        <div id="performanceViewerSidebar">
+            {
+                content
+            }
+        </div>
+    )
+}

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
@@ -1,0 +1,53 @@
+#performance-viewer {
+    display: grid;
+    height: 100%;
+    width: 100%;
+    grid-template-columns: 25% 75%;
+    grid-template-areas: "sidebar graph";
+    #performance-viewer-graph {
+        grid-area: "graph";
+    }
+    #performance-viewer-sidebar {
+        grid-area: "sidebar";
+        display: flex;
+        flex-direction: column;
+        
+        .sidebar-item {
+            display: inline-flex;
+            flex-direction: row;    
+            width: 100%;
+            .sidebar-item-label {
+                width: 100%;
+            }
+            .color-picker {
+                height: calc(100% - 8px);
+                margin: 4px;
+                width: 100%;
+        
+                .color-rect {
+                    height: calc(100% - 4px);
+                    border: 2px white solid;
+                    cursor: pointer;
+                    min-height: 18px;
+                }
+        
+                .color-picker-cover {
+                    position: fixed;
+                    top: 0px;
+                    right: 0px;
+                    bottom: 0px;
+                    left: 0px;
+                    z-index: 100;
+                }
+        
+                .color-picker-float {
+                    position: absolute;
+        
+                    .color-picker-container {
+                        width: 200px;
+                    }
+                }                
+            }
+        }
+    }
+}

--- a/sharedUiComponents/lines/colorPickerComponent.tsx
+++ b/sharedUiComponents/lines/colorPickerComponent.tsx
@@ -7,6 +7,7 @@ export interface IColorPickerComponentProps {
     linearHint?: boolean;
     onColorChanged: (newOne: string) => void;
     icon? : string;
+    shouldPopRight?: boolean;
 }
 
 interface IColorPickerComponentState {
@@ -46,7 +47,11 @@ export class ColorPickerLineComponent extends React.Component<IColorPickerCompon
         }
 
         div.style.top = top + "px";
-        div.style.left = host.getBoundingClientRect().left - div.getBoundingClientRect().width + "px";
+        if (!this.props.shouldPopRight) {
+            div.style.left = host.getBoundingClientRect().left - div.getBoundingClientRect().width + "px";
+        } else {
+            div.style.left = host.getBoundingClientRect().left + "px";
+        }
     }
 
     shouldComponentUpdate(nextProps: IColorPickerComponentProps, nextState: IColorPickerComponentState) {


### PR DESCRIPTION
This PR addresses adding a sidebar to the performance viewer. This sidebar allows the user to toggle what data sources are visible, and the color for each data source. #10566 

Currently we store the entire dataset as both metadata and data are merged into one object right now. This state storage will be a lot more light weight once we separate the objects as we will only store the metadata in the sidebar.

A change I had to make in an established component is a setting to specify if the colour picker should pop right or not.  This was done with the addition of an optional boolean variable. If it is unset, we pop left (which is the current default behaviour). If it is set to true we don't pop left. If false we also pop left which is default behaviour. Overall this should not have any behaviour changes to existing components.

Here is the video showing the behaviour:

https://user-images.githubusercontent.com/32103099/126194702-a6d1130d-7b9c-4e6e-bd60-df50ff68091a.mp4

