### PR TITLE
Make window resizable for performance viewer 

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -36,7 +36,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     }
 
     const canvasServiceCallback = (canvasService: CanvasGraphService) => {
-        canvasService.draw();
+        canvasService.update();
     };
 
     return (

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
@@ -7,6 +7,7 @@
     #performance-viewer-graph {
         grid-area: "graph";
     }
+
     #performance-viewer-sidebar {
         grid-area: "sidebar";
         display: flex;

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -1,34 +1,53 @@
+import { Observable } from 'babylonjs/Misc/observable';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { CanvasGraphService } from './canvasGraphService';
+import { IPerfLayoutSize } from './graphSupportingTypes';
 
 interface ICanvasGraphComponentProps {
     id: string;
     canvasServiceCallback: (canvasService: CanvasGraphService) => void;
+    layoutObservable?: Observable<IPerfLayoutSize>;
 }
 
 export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props: ICanvasGraphComponentProps) => {
-    const { id, canvasServiceCallback } = props;
+    const { id, canvasServiceCallback, layoutObservable } = props;
     const canvasRef: React.MutableRefObject<HTMLCanvasElement | null>  = useRef(null);
+
     useEffect(() => {
         if (!canvasRef.current) {
             return;
         }
         
-        let canvasGraphService: CanvasGraphService | undefined;
+        let cs: CanvasGraphService | undefined;
 
         // temporarily set empty array, will eventually be passed by props!
         try {
-            canvasGraphService = new CanvasGraphService(canvasRef.current, {datasets: []});
-            canvasServiceCallback(canvasGraphService);
+            cs = new CanvasGraphService(canvasRef.current, {datasets: []});
+            canvasServiceCallback(cs);
         } catch (error) {
             console.error(error);
             return;
         }
 
-        return () => canvasGraphService?.destroy();
-    }, [canvasRef])
-   
+        const layoutUpdated = (newSize: IPerfLayoutSize) => {
+            if (!canvasRef.current) {
+                return;
+            }
+            const {left, top} = canvasRef.current.getBoundingClientRect();
+            const width = newSize.width - left;
+            const height = newSize.height - top;
+            cs?.resize(width, height);
+        };
+
+        layoutObservable?.add(layoutUpdated);
+
+        return () => {
+            cs?.destroy();
+            layoutObservable?.removeCallback(layoutUpdated);
+        };
+    }, [canvasRef]);
+    
     return (
         <canvas id={id} ref={canvasRef}>
 

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -35,9 +35,9 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
                 return;
             }
             const {left, top} = canvasRef.current.getBoundingClientRect();
-            const width = newSize.width - left;
-            const height = newSize.height - top;
-            cs?.resize(width, height);
+            newSize.width = newSize.width - left;
+            newSize.height = newSize.height - top;
+            cs?.resize(newSize);
         };
 
         layoutObservable?.add(layoutUpdated);

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -1,4 +1,4 @@
-import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea, IPerfMousePanningPosition, IPerfIndexBounds, IPerfTooltip, IPerfTextMeasureCache } from "./graphSupportingTypes";
+import { ICanvasGraphServiceSettings, IPerfMinMax, IGraphDrawableArea, IPerfMousePanningPosition, IPerfIndexBounds, IPerfTooltip, IPerfTextMeasureCache, IPerfLayoutSize } from "./graphSupportingTypes";
 import { IPerfDataset, IPerfPoint } from "babylonjs/Misc/interfaces/iPerfViewer";
 import { Scalar } from "babylonjs/Maths/math.scalar";
 
@@ -126,9 +126,10 @@ export class CanvasGraphService {
         this._attachEventListeners(canvas);
     }
 
-    public resize(width: number, height: number) {
+    public resize(size: IPerfLayoutSize) {
         const { _ctx: ctx } = this;
-
+        const { width, height } = size;
+        
         if (!ctx || !ctx.canvas) {
             return;
         }
@@ -138,6 +139,7 @@ export class CanvasGraphService {
 
         ctx.canvas.width = width;
         ctx.canvas.height = height;
+
         this.draw();
     }
 

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -126,6 +126,21 @@ export class CanvasGraphService {
         this._attachEventListeners(canvas);
     }
 
+    public resize(width: number, height: number) {
+        const { _ctx: ctx } = this;
+
+        if (!ctx || !ctx.canvas) {
+            return;
+        }
+
+        this._width = width;
+        this._height = height;
+
+        ctx.canvas.width = width;
+        ctx.canvas.height = height;
+        this.draw();
+    }
+
     /**
      * This method draws the data and sets up the appropriate scales.
      */

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -130,11 +130,10 @@ export class CanvasGraphService {
     }
 
     /**
-     * This method draws the data with debounce.
-     *
+     * This method lets the service know it should get ready to update what it is displaying.
      */
     public update = debounce(
-        () => this.draw(), 
+        () => this._draw(), 
         drawDebounceTime
     );
 
@@ -155,11 +154,10 @@ export class CanvasGraphService {
         this.update();
     }
 
-    // TODO: Make this private once performanceViewerComponent can be changed (Post data layer).
     /**
      * This method draws the data and sets up the appropriate scales.
      */
-    public draw() {
+    private _draw() {
         const { _ctx: ctx } = this;
 
         if (!ctx) {

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -43,6 +43,9 @@ const maximumDatasetsAllowed = 32;
 // time in ms to wait between tooltip draws inside the mouse move.
 const tooltipDebounceTime = 32;
 
+// time in ms to wait between draws
+const drawDebounceTime = 15;
+
 /**
  * This function will debounce calls to functions.
  * 
@@ -126,6 +129,15 @@ export class CanvasGraphService {
         this._attachEventListeners(canvas);
     }
 
+    /**
+     * This method draws the data with debounce.
+     *
+     */
+    public update = debounce(
+        () => this.draw(), 
+        drawDebounceTime
+    );
+
     public resize(size: IPerfLayoutSize) {
         const { _ctx: ctx } = this;
         const { width, height } = size;
@@ -140,9 +152,10 @@ export class CanvasGraphService {
         ctx.canvas.width = width;
         ctx.canvas.height = height;
 
-        this.draw();
+        this.update();
     }
 
+    // TODO: Make this private once performanceViewerComponent can be changed (Post data layer).
     /**
      * This method draws the data and sets up the appropriate scales.
      */

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -24,6 +24,11 @@ export interface IPerfIndexBounds {
     end: number;
 }
 
+export interface IPerfLayoutSize {
+    width: number;
+    height: number;
+}
+
 /**
  * Defines the structure of the meta object for the tooltip that appears when hovering over a performance graph!
  */


### PR DESCRIPTION
This PR makes it so that the performance viewer graph takes up the remaining window size, and allows the size to dynamically adjust to the window size (so resizing the graph will allow you to have a bigger or smaller graph!). #10566 

Here is a gif for what this feature adds (as video glitches out for some reason):
![LiveDataResize](https://user-images.githubusercontent.com/32103099/126223785-19697500-8b18-4886-9e66-a58147fc1201.gif)
