### PR TITLE
Fix compounds with CannonJS

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -190,6 +190,7 @@
 - Fix issue when scaling is reapplied with BoundingBoxGizmo and GizmoManager ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Fix direct loading of a glTF string that has base64-encoded URI. ([bghgary](https://github.com/bghgary))
 - Fix capsule impostor size computation for ammojs ([CedricGuillemet](https://github.com/CedricGuillemet)
+- Fix compound shapes for CannonJS plugin ([cedricguillemet](https://github.com/cedricguillemet))
 - Fix crash of some node materials using instances on iOS ([Popov72](https://github.com/Popov72))
 - Fix the code generated for the NME gradient block ([Popov72](https://github.com/Popov72))
 - Fix ssao2RenderingPipeline for orthographic cameras ([Kesshi](https://github.com/Kesshi))


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/collider-not-colliding-in-cannon-playground/22556
Compound with Cannon was broken for a few versions (before 4.1)
Shapes must be relative to body: inverse transform absolute position and orientation.