### PR TITLE
DepthRenderer: Fix isActiveIntermediate not reset for transparent meshes

### DIFF
--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -230,6 +230,10 @@ export class DepthRenderer {
                 for (index = 0; index < transparentSubMeshes.length; index++) {
                     renderSubMesh(transparentSubMeshes.data[index]);
                 }
+            } else {
+                for (index = 0; index < transparentSubMeshes.length; index++) {
+                    transparentSubMeshes.data[index].getEffectiveMesh()._internalAbstractMeshDataInfo._isActiveIntermediate = false;
+                }
             }
         };
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/mesh-instances-disappear-when-source-mesh-is-culled-under-specific-circumstances/22585