### PR TITLE
Compile time bounds checking for TmpVectors

### DIFF
--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -6318,20 +6318,20 @@ export class Matrix {
  * Same as Tmp but not exported to keep it only for math functions to avoid conflicts
  */
 class MathTmp {
-    public static Vector3: Vector3[] = ArrayTools.BuildArray(11, Vector3.Zero);
-    public static Matrix: Matrix[] = ArrayTools.BuildArray(2, Matrix.Identity);
-    public static Quaternion: Quaternion[] = ArrayTools.BuildArray(3, Quaternion.Zero);
+    public static Vector3 = ArrayTools.BuildTuple(11, Vector3.Zero);
+    public static Matrix = ArrayTools.BuildTuple(2, Matrix.Identity);
+    public static Quaternion = ArrayTools.BuildTuple(3, Quaternion.Zero);
 }
 
 /**
  * @hidden
  */
 export class TmpVectors {
-    public static Vector2: Vector2[] = ArrayTools.BuildArray(3, Vector2.Zero); // 3 temp Vector2 at once should be enough
-    public static Vector3: Vector3[] = ArrayTools.BuildArray(13, Vector3.Zero); // 13 temp Vector3 at once should be enough
-    public static Vector4: Vector4[] = ArrayTools.BuildArray(3, Vector4.Zero); // 3 temp Vector4 at once should be enough
-    public static Quaternion: Quaternion[] = ArrayTools.BuildArray(2, Quaternion.Zero); // 2 temp Quaternion at once should be enough
-    public static Matrix: Matrix[] = ArrayTools.BuildArray(8, Matrix.Identity); // 8 temp Matrices at once should be enough
+    public static Vector2 = ArrayTools.BuildTuple(3, Vector2.Zero); // 3 temp Vector2 at once should be enough
+    public static Vector3 = ArrayTools.BuildTuple(13, Vector3.Zero); // 13 temp Vector3 at once should be enough
+    public static Vector4 = ArrayTools.BuildTuple(3, Vector4.Zero); // 3 temp Vector4 at once should be enough
+    public static Quaternion = ArrayTools.BuildTuple(2, Quaternion.Zero); // 2 temp Quaternion at once should be enough
+    public static Matrix = ArrayTools.BuildTuple(8, Matrix.Identity); // 8 temp Matrices at once should be enough
 }
 
 _TypeStore.RegisteredTypes["BABYLON.Vector2"] = Vector2;

--- a/src/Misc/arrayTools.ts
+++ b/src/Misc/arrayTools.ts
@@ -1,12 +1,30 @@
+/** @hidden */
+interface TupleTypes<T> {
+    2:  [T, T];
+    3:  [T, T, T];
+    4:  [T, T, T, T];
+    5:  [T, T, T, T, T];
+    6:  [T, T, T, T, T, T];
+    7:  [T, T, T, T, T, T, T];
+    8:  [T, T, T, T, T, T, T, T];
+    9:  [T, T, T, T, T, T, T, T, T];
+    10: [T, T, T, T, T, T, T, T, T, T];
+    11: [T, T, T, T, T, T, T, T, T, T, T];
+    12: [T, T, T, T, T, T, T, T, T, T, T, T];
+    13: [T, T, T, T, T, T, T, T, T, T, T, T, T];
+    14: [T, T, T, T, T, T, T, T, T, T, T, T, T, T];
+    15: [T, T, T, T, T, T, T, T, T, T, T, T, T, T, T];
+}
+
 /**
  * Class containing a set of static utilities functions for arrays.
  */
 export class ArrayTools {
     /**
-     * Returns an array of the given size filled with element built from the given constructor and the parameters
-     * @param size the number of element to construct and put in the array
+     * Returns an array of the given size filled with elements built from the given constructor and the parameters.
+     * @param size the number of element to construct and put in the array.
      * @param itemBuilder a callback responsible for creating new instance of item. Called once per array entry.
-     * @returns a new array filled with new objects
+     * @returns a new array filled with new objects.
      */
     public static BuildArray<T>(size: number, itemBuilder: () => T): Array<T> {
         const a: T[] = [];
@@ -14,5 +32,15 @@ export class ArrayTools {
             a.push(itemBuilder());
         }
         return a;
+    }
+
+    /**
+     * Returns a tuple of the given size filled with elements built from the given constructor and the parameters.
+     * @param size he number of element to construct and put in the tuple.
+     * @param itemBuilder a callback responsible for creating new instance of item. Called once per tuple entry.
+     * @returns a new tuple filled with new objects.
+     */
+    public static BuildTuple<T, N extends keyof TupleTypes<unknown>>(size: N, itemBuilder: () => T): TupleTypes<T>[N] {
+        return ArrayTools.BuildArray(size, itemBuilder) as any;
     }
 }


### PR DESCRIPTION
I recently wrote some new code in Babylon.js that uses `TmpVectors`. I found this a little difficult to use because I needed to go to the definition to know how many temp objects were created for each array, and it felt very prone to human error. To address this, I added a `BuildTuple` function next to the `BuildArray` function that returns a strongly typed tuple (fixed length) and use the `BuildTuple` function in `TmpVectors`. `BuildArray` is used elsewhere in the code where it looks like it should also use `BuildTuple`, but in many (all?) of those cases, it also looks like it could just be using `TmpVectors` instead of creating new private temp storage. I'm happy to make changes there too, I just wasn't sure if there was any reason for these private versions other than being legacy.

With `BuildTuple`, attempting to index into the tuple/array out of range will cause a compile error, and intellisense makes it clear how many temp elements are available:
![image](https://user-images.githubusercontent.com/5084643/127040595-f77cb8a9-2bf5-44ac-b905-4766e2590e41.png)

![image](https://user-images.githubusercontent.com/5084643/127040670-b0f436e1-7d56-4f3f-ace4-e20d9860902c.png)

![image](https://user-images.githubusercontent.com/5084643/127040681-2ebaf1a6-28df-4966-a199-1c09b4cee1a6.png)

It's probably possible to define the tuple types more generically using some kind of recursive conditional type, but my understanding is that recursive types often significantly impact TypeScript compiler performance, and in this case we never create more than 13 elements so just manually defining the tuple types is perfectly manageable.