### PR TITLE
Add the performance viewer data collector

### DIFF
--- a/src/Misc/PerformanceViewer/dynamicFloat32Array.ts
+++ b/src/Misc/PerformanceViewer/dynamicFloat32Array.ts
@@ -43,7 +43,7 @@ export class DynamicFloat32Array {
      * @returns a subarray of the original array.
      */
     public subarray(start: number, end: number): Float32Array {
-        if (end >= start || start < 0) {
+        if (start >= end || start < 0) {
             return new Float32Array(0);
         }
 

--- a/src/Misc/PerformanceViewer/index.ts
+++ b/src/Misc/PerformanceViewer/index.ts
@@ -1,0 +1,3 @@
+export * from "./performanceViewerCollector";
+export * from "./performanceViewerCollectionStrategies";
+export * from "./dynamicFloat32Array";

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -37,7 +37,7 @@ export class PerformanceViewerCollector {
      * @param _scene the scene to collect on.
      * @param _enabledStrategyCallbacks the list of data to collect with callbacks for initialization purposes.
      */
-    constructor(private _scene: Scene, private _enabledStrategyCallbacks: PerfStrategyInitialization[]) {
+    constructor(private _scene: Scene, _enabledStrategyCallbacks?: PerfStrategyInitialization[]) {
         this.datasets = {
             ids: [],
             data: new DynamicFloat32Array(initialArraySize),
@@ -47,15 +47,22 @@ export class PerformanceViewerCollector {
         this._datasetMeta = new Map<string, IPerfMetadata>();
         this.datasetObservable = new Observable();
         this.metadataObservable = new Observable((observer) => observer.callback(this._datasetMeta, new EventState(0)));
-        this._initialize();
+        if (_enabledStrategyCallbacks) {
+            this.addCollectionStrategies(_enabledStrategyCallbacks);
+        }
     }
 
     /**
-     * Populates our internal structures and does appropriate initialization of strategies.
+     * This method adds additional collection strategies for data collection purposes.
+     * @param strategyCallbacks the list of data to collect with callbacks. 
      */
-    private _initialize() {
-        for (const strategyCallback of this._enabledStrategyCallbacks) {
+    public addCollectionStrategies(strategyCallbacks: PerfStrategyInitialization[]) {
+        for (const strategyCallback of strategyCallbacks) {
             const strategy = strategyCallback(this._scene);
+
+            if (this._strategies.has(strategy.id)) {
+                continue;
+            }
 
             this.datasets.ids.push(strategy.id);
 

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -86,7 +86,7 @@ export class PerformanceViewerCollector {
             this.datasets.ids.push(strategy.id);
 
             this._datasetMeta.set(strategy.id, {
-                color: this._getHexFromId(strategy.id),
+                color: this._getHexColorFromId(strategy.id),
             });
 
             this._strategies.set(strategy.id, strategy);
@@ -96,11 +96,11 @@ export class PerformanceViewerCollector {
     }
 
     /**
-     * Gets a 6 character hexcode from a passed in string.
+     * Gets a 6 character hexcode representing the colour from a passed in string.
      * @param id the string to get a hex code for.
      * @returns a hexcode hashed from the id.
      */
-    private _getHexFromId(id: string) {
+    private _getHexColorFromId(id: string) {
         // this first bit is just a known way of hashing a string.
         let hash = 0;
         for (let i = 0; i < id.length; i++) {

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -54,7 +54,7 @@ export class PerformanceViewerCollector {
 
     /**
      * This method adds additional collection strategies for data collection purposes.
-     * @param strategyCallbacks the list of data to collect with callbacks. 
+     * @param strategyCallbacks the list of data to collect with callbacks.
      */
     public addCollectionStrategies(strategyCallbacks: PerfStrategyInitialization[]) {
         for (const strategyCallback of strategyCallbacks) {

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -1,5 +1,5 @@
 import { Scene } from "../../scene";
-import { IPerfDatasets, IPerfDataSliceSnapshot, IPerfMetadata } from "../interfaces/iPerfViewer";
+import { IPerfDatasets, IPerfMetadata } from "../interfaces/iPerfViewer";
 import { EventState, Observable } from "../observable";
 import { PrecisionDate } from "../precisionDate";
 import { DynamicFloat32Array } from "./dynamicFloat32Array";
@@ -30,7 +30,7 @@ export class PerformanceViewerCollector {
     /**
      * An observable you can attach to get deltas in the dataset. Subscribing to this will increase memory consumption slightly, and may hurt performance due to increased garbage collection needed.
      */
-    public readonly datasetObservable: Observable<IPerfDataSliceSnapshot>;
+    public readonly datasetObservable: Observable<number[]>;
     /**
      * An observable you can attach to get the most updated map of metadatas.
      */
@@ -158,7 +158,7 @@ export class PerformanceViewerCollector {
                 slice.push(this.datasets.data.at(startingIndex + PerformanceViewerCollector.SliceDataOffset + i));
             }
 
-            this.datasetObservable.notifyObservers({slice});
+            this.datasetObservable.notifyObservers(slice);
         }
     }
 
@@ -185,7 +185,7 @@ export class PerformanceViewerCollector {
         });
 
         if (this.datasetObservable.hasObservers()) {
-            this.datasetObservable.notifyObservers({slice});
+            this.datasetObservable.notifyObservers(slice);
         }
 
     }

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -1,0 +1,201 @@
+import { Scene } from "../../scene";
+import { IPerfDatasets, IPerfDataSliceSnapshot, IPerfMetadata } from "../interfaces/iPerfViewer";
+import { EventState, Observable } from "../observable";
+import { PrecisionDate } from "../precisionDate";
+import { DynamicFloat32Array } from "./dynamicFloat32Array";
+import { IPerfViewerCollectionStrategy, PerfStrategyInitialization } from "./performanceViewerCollectionStrategies";
+
+// the initial size of our array, should be a multiple of two!
+const initialArraySize = 1800;
+
+// three octets in a hexcode. #[AA][BB][CC], i.e. 24 bits of data.
+const numberOfBitsInHexcode = 24;
+
+// Allows single numeral hex numbers to be appended by a 0.
+const hexPadding = "0";
+
+// The offset for the value of the number of points inside a slice.
+export const numberOfPointsOffset = 1;
+
+// The offset for when actual data values start appearing inside a slice.
+export const sliceDataOffset = 2;
+/**
+ * The collector class handles the collection and storage of data into the appropriate array.
+ * The collector also handles notifying any observers of any updates.
+ */
+export class PerformanceViewerCollector {
+    private _datasetMeta: Map<string, IPerfMetadata>;
+    private _strategies: Map<string, IPerfViewerCollectionStrategy>;
+    private _startingTimestamp: number;
+
+    public readonly datasets: IPerfDatasets;
+    public readonly datasetObservable: Observable<IPerfDataSliceSnapshot>;
+    public readonly metadataObservable: Observable<Map<string, IPerfMetadata>>;
+
+    /**
+     * Handles the creation of a performance viewer collector.
+     * @param _scene the scene to collect on.
+     * @param _enabledStrategyCallbacks the list of data to collect with callbacks for initialization purposes.
+     */
+    constructor(private _scene: Scene, private _enabledStrategyCallbacks: PerfStrategyInitialization[]) {
+        this.datasets = {
+            ids: [],
+            data: new DynamicFloat32Array(initialArraySize),
+            startingIndices: new DynamicFloat32Array(initialArraySize)
+        };
+        this._strategies = new Map<string, IPerfViewerCollectionStrategy>();
+        this._datasetMeta = new Map<string, IPerfMetadata>();
+        this.datasetObservable = new Observable();
+        this.metadataObservable = new Observable((observer) => observer.callback(this._datasetMeta, new EventState(0)));
+        this._initialize();
+    }
+
+    /**
+     * Populates our internal structures and does appropriate initialization of strategies.
+     */
+    private _initialize() {
+        for (const strategyCallback of this._enabledStrategyCallbacks) {
+            const strategy = strategyCallback(this._scene);
+
+            this.datasets.ids.push(strategy.id);
+
+            this._datasetMeta.set(strategy.id, {
+                color: this._getHexFromId(strategy.id),
+            });
+
+            this._strategies.set(strategy.id, strategy);
+        }
+
+        this.metadataObservable.notifyObservers(this._datasetMeta);
+    }
+
+    /**
+     * Gets a 6 character hexcode from a passed in string.
+     * @param id the string to get a hex code for.
+     * @returns a hexcode hashed from the id.
+     */
+    private _getHexFromId(id: string) {
+        // this first bit is just a known way of hashing a string.
+        let hash = 0;
+        for (let i = 0; i < id.length; i++) {
+            // (hash << 5) - hash is the same as hash * 31
+            hash = id.charCodeAt(i) + ((hash << 5) - hash);
+        }
+
+        // then we build the string octet by octet.
+        let hex = "#";
+        for (let i = 0; i < numberOfBitsInHexcode; i += 8) {
+            const octet = (hash >> i) & 0xFF;
+            hex += (hexPadding + octet.toString(16)).substr(-2);
+        }
+
+        return hex;
+    }
+
+    /**
+     * Collects data for every dataset by using the appropriate strategy. This is called every frame.
+     * This method will then notify all observers with the latest slice.
+     */
+    private _collectDataAtFrame = () => {
+        const timestamp = PrecisionDate.Now - this._startingTimestamp;
+        const numPoints = this.datasets.ids.length;
+
+        // add the starting index for the slice
+        const numberOfIndices = this.datasets.startingIndices.itemLength;
+        let startingIndex = 0;
+
+        if (numberOfIndices > 0) {
+            const previousStartingIndex = this.datasets.startingIndices.at(numberOfIndices - 1);
+            startingIndex = previousStartingIndex + this.datasets.data.at(previousStartingIndex + numberOfPointsOffset) + sliceDataOffset;
+        }
+
+        this.datasets.startingIndices.push(startingIndex);
+
+        // add the first 2 items in our slice.
+        this.datasets.data.push(timestamp);
+        this.datasets.data.push(numPoints);
+
+        // add the values inside the slice.
+        this.datasets.ids.forEach((id: string) => {
+            const strategy = this._strategies.get(id);
+
+            if (!strategy) {
+                return;
+            }
+
+            this.datasets.data.push(strategy.getData());
+        });
+
+        if (this.datasetObservable.hasObservers()) {
+            const slice: number[] = [timestamp, numPoints];
+
+            for (let i = 0; i < numPoints; i++) {
+                slice.push(this.datasets.data.at(startingIndex + sliceDataOffset + i));
+            }
+
+            this.datasetObservable.notifyObservers({slice});
+        }
+    }
+
+    /**
+     * Collects data for every dataset by using the appropriate strategy when the user wants.
+     * This method will then notify all observers with the latest slice of data.
+     */
+    public collectDataNow() {
+        const timestamp = PrecisionDate.Now - this._startingTimestamp;
+        const numPoints = this.datasets.ids.length;
+        const slice: number[] = [timestamp, numPoints];
+
+        // add the values inside the slice.
+        this.datasets.ids.forEach((id: string) => {
+            const strategy = this._strategies.get(id);
+
+            if (!strategy) {
+                return;
+            }
+
+            if (this.datasetObservable.hasObservers()) {
+                slice.push(strategy.getData());
+            }
+        });
+
+        if (this.datasetObservable.hasObservers()) {
+            this.datasetObservable.notifyObservers({slice});
+        }
+
+    }
+
+    /**
+     * Updates a property for a dataset's metadata with the value provided.
+     * @param id the id of the dataset which needs its metadata updated.
+     * @param prop the property to update.
+     * @param value the value to update the property with.
+     * @returns
+     */
+    public updateMetadata<T extends keyof IPerfMetadata>(id: string, prop: T, value: IPerfMetadata[T]) {
+        const meta = this._datasetMeta.get(id);
+
+        if (!meta) {
+            return;
+        }
+
+        meta[prop] = value;
+
+        this.metadataObservable.notifyObservers(this._datasetMeta);
+    }
+
+    /**
+     * Starts the realtime collection of data.
+     */
+    public start() {
+        this._startingTimestamp = PrecisionDate.Now;
+        this._scene.onBeforeRenderObservable.add(this._collectDataAtFrame);
+    }
+
+    /**
+     * Stops the collection of data.
+     */
+    public stop() {
+        this._scene.onBeforeRenderObservable.removeCallback(this._collectDataAtFrame);
+    }
+}

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -195,7 +195,6 @@ export class PerformanceViewerCollector {
      * @param id the id of the dataset which needs its metadata updated.
      * @param prop the property to update.
      * @param value the value to update the property with.
-     * @returns
      */
     public updateMetadata<T extends keyof IPerfMetadata>(id: string, prop: T, value: IPerfMetadata[T]) {
         const meta = this._datasetMeta.get(id);

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -14,11 +14,6 @@ const numberOfBitsInHexcode = 24;
 // Allows single numeral hex numbers to be appended by a 0.
 const hexPadding = "0";
 
-// The offset for the value of the number of points inside a slice.
-export const numberOfPointsOffset = 1;
-
-// The offset for when actual data values start appearing inside a slice.
-export const sliceDataOffset = 2;
 /**
  * The collector class handles the collection and storage of data into the appropriate array.
  * The collector also handles notifying any observers of any updates.
@@ -28,9 +23,32 @@ export class PerformanceViewerCollector {
     private _strategies: Map<string, IPerfViewerCollectionStrategy>;
     private _startingTimestamp: number;
 
+    /**
+     * Datastructure containing the collected datasets. Warning: you should not modify the values in here, data will be of the form [timestamp, numberOfPoints, value1, value2..., timestamp, etc...]
+     */
     public readonly datasets: IPerfDatasets;
+    /**
+     * An observable you can attach to get deltas in the dataset. Subscribing to this will increase memory consumption slightly, and may hurt performance due to increased garbage collection needed.
+     */
     public readonly datasetObservable: Observable<IPerfDataSliceSnapshot>;
+    /**
+     * An observable you can attach to get the most updated map of metadatas.
+     */
     public readonly metadataObservable: Observable<Map<string, IPerfMetadata>>;
+
+    /**
+     * The offset for when actual data values start appearing inside a slice.
+     */
+    public static get SliceDataOffset() {
+        return 2;
+    }
+
+    /**
+     * The offset for the value of the number of points inside a slice.
+     */
+    public static get NumberOfPointsOffset() {
+        return 1;
+    }
 
     /**
      * Handles the creation of a performance viewer collector.
@@ -113,7 +131,7 @@ export class PerformanceViewerCollector {
 
         if (numberOfIndices > 0) {
             const previousStartingIndex = this.datasets.startingIndices.at(numberOfIndices - 1);
-            startingIndex = previousStartingIndex + this.datasets.data.at(previousStartingIndex + numberOfPointsOffset) + sliceDataOffset;
+            startingIndex = previousStartingIndex + this.datasets.data.at(previousStartingIndex + PerformanceViewerCollector.NumberOfPointsOffset) + PerformanceViewerCollector.SliceDataOffset;
         }
 
         this.datasets.startingIndices.push(startingIndex);
@@ -137,7 +155,7 @@ export class PerformanceViewerCollector {
             const slice: number[] = [timestamp, numPoints];
 
             for (let i = 0; i < numPoints; i++) {
-                slice.push(this.datasets.data.at(startingIndex + sliceDataOffset + i));
+                slice.push(this.datasets.data.at(startingIndex + PerformanceViewerCollector.SliceDataOffset + i));
             }
 
             this.datasetObservable.notifyObservers({slice});

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -29,6 +29,7 @@ export class PerformanceViewerCollector {
     public readonly datasets: IPerfDatasets;
     /**
      * An observable you can attach to get deltas in the dataset. Subscribing to this will increase memory consumption slightly, and may hurt performance due to increased garbage collection needed.
+     * Updates of slices will be of the form [timestamp, numberOfPoints, value1, value2...].
      */
     public readonly datasetObservable: Observable<number[]>;
     /**
@@ -164,6 +165,7 @@ export class PerformanceViewerCollector {
 
     /**
      * Collects and then sends the latest slice to any observers by using the appropriate strategy when the user wants.
+     * The slice will be of the form [timestamp, numberOfPoints, value1, value2...]
      * This method does not add onto the collected data accessible via the datasets variable.
      */
     public getCurrentSlice() {
@@ -210,8 +212,13 @@ export class PerformanceViewerCollector {
 
     /**
      * Starts the realtime collection of data.
+     * @param shouldPreserve optional boolean param, if set will preserve the dataset between calls of start.
      */
-    public start() {
+    public start(shouldPreserve?: boolean) {
+        if (!shouldPreserve) {
+            this.datasets.data = new DynamicFloat32Array(initialArraySize);
+            this.datasets.startingIndices = new DynamicFloat32Array(initialArraySize);
+        }
         this._startingTimestamp = PrecisionDate.Now;
         this._scene.onBeforeRenderObservable.add(this._collectDataAtFrame);
     }

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -66,7 +66,7 @@ export class PerformanceViewerCollector {
         this.datasetObservable = new Observable();
         this.metadataObservable = new Observable((observer) => observer.callback(this._datasetMeta, new EventState(0)));
         if (_enabledStrategyCallbacks) {
-            this.addCollectionStrategies(_enabledStrategyCallbacks);
+            this.addCollectionStrategies(..._enabledStrategyCallbacks);
         }
     }
 
@@ -74,7 +74,7 @@ export class PerformanceViewerCollector {
      * This method adds additional collection strategies for data collection purposes.
      * @param strategyCallbacks the list of data to collect with callbacks.
      */
-    public addCollectionStrategies(strategyCallbacks: PerfStrategyInitialization[]) {
+    public addCollectionStrategies(...strategyCallbacks: PerfStrategyInitialization[]) {
         for (const strategyCallback of strategyCallbacks) {
             const strategy = strategyCallback(this._scene);
 
@@ -163,10 +163,10 @@ export class PerformanceViewerCollector {
     }
 
     /**
-     * Collects data for every dataset by using the appropriate strategy when the user wants.
-     * This method will then notify all observers with the latest slice of data.
+     * Collects and then sends the latest slice to any observers by using the appropriate strategy when the user wants.
+     * This method does not add onto the collected data accessible via the datasets variable.
      */
-    public collectDataNow() {
+    public getCurrentSlice() {
         const timestamp = PrecisionDate.Now - this._startingTimestamp;
         const numPoints = this.datasets.ids.length;
         const slice: number[] = [timestamp, numPoints];

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -55,4 +55,4 @@ export * from './timer';
 export * from "./copyTools";
 export * from "./reflector";
 export * from "./domManagement";
-export * from "./PerformanceViewer/";
+export * from "./PerformanceViewer/index";

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -55,4 +55,4 @@ export * from './timer';
 export * from "./copyTools";
 export * from "./reflector";
 export * from "./domManagement";
-export * from "./PerformanceViewer/index";
+export * from "./PerformanceViewer/";

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -55,3 +55,4 @@ export * from './timer';
 export * from "./copyTools";
 export * from "./reflector";
 export * from "./domManagement";
+export * from "./PerformanceViewer/index";

--- a/src/Misc/interfaces/iPerfViewer.ts
+++ b/src/Misc/interfaces/iPerfViewer.ts
@@ -76,13 +76,3 @@ export interface IPerfDataset {
       */
      hidden?: boolean;
 }
-
-/**
- * Defines the shape of a snapshot sent to observers.
- */
-export interface IPerfDataSliceSnapshot {
-    /**
-     * An array containing information about the latest slice.
-     */
-    slice: number[];
-}

--- a/src/Misc/interfaces/iPerfViewer.ts
+++ b/src/Misc/interfaces/iPerfViewer.ts
@@ -1,3 +1,6 @@
+import { DynamicFloat32Array } from "../PerformanceViewer/dynamicFloat32Array";
+
+// TODO: remove once everything is connected!
 /**
  * Defines what data is needed to graph a point on the performance graph.
  */
@@ -13,6 +16,7 @@ export interface IPerfPoint {
     value: number;
 }
 
+// TODO: REMOVE ONCE Everything is connected!
 /**
  * Defines the shape of a dataset that our graphing service uses for drawing purposes.
  */
@@ -36,4 +40,49 @@ export interface IPerfDataset {
      * Specifies if data should be hidden, falsey by default.
      */
     hidden?: boolean;
+}
+
+/**
+ * Defines the shape of a collection of datasets that our graphing service uses for drawing purposes.
+ */
+ export interface IPerfDatasets {
+    /**
+     * The ids of our dataset.
+     */
+    ids: string[];
+
+    /**
+     * The data to be processed by the performance graph. Each slice will be of the form of [timestamp, numberOfPoints, value1, value2...]
+     */
+    data: DynamicFloat32Array;
+
+    /**
+     * A list of starting indices for each slice of data collected. Used for fast access of an arbitrary slice inside the data array.
+     */
+    startingIndices: DynamicFloat32Array;
+}
+
+/**
+ * Defines the shape of a the metadata the graphing service uses for drawing purposes.
+ */
+ export interface IPerfMetadata {
+    /**
+     * The color of the line to be drawn.
+     */
+     color?: string;
+
+     /**
+      * Specifies if data should be hidden, falsey by default.
+      */
+     hidden?: boolean;
+}
+
+/**
+ * Defines the shape of a snapshot sent to observers.
+ */
+export interface IPerfDataSliceSnapshot {
+    /**
+     * An array containing information about the latest slice.
+     */
+    slice: number[];
 }


### PR DESCRIPTION
This PR adds the performance viewer data collector, and new interfaces to support this collection of data. We use a data structure as follows to store the datasets.

```typescript
export interface IPerfDatasets {
    /**
     * The ids of our dataset.
     */
    ids: string[];

    /**
     * The data to be processed by the performance graph. Each slice will be of the form of [timestamp, numberOfPoints, value1, value2...]
     */
    data: DynamicFloat32Array;

    /**
     * A list of starting indices for each slice of data collected. Used for fast access of an arbitrary slice inside the data array.
     */
    startingIndices: DynamicFloat32Array;
}
```

We store an array of ids for cross reference for what offset belongs to which id. We do not allow removal of individual performance strategies because of this. 

We use the data property to store all of our data in the shape as described by the comment. This allows us to eliminate redundant timestamp data being stored, and allows us to only have a single array which stores all our data. 

We use the startingIndices array for fast lookup on where each slice begins.

This overall will decrease memory consumption from the previous method of collecting data as an array of IPerfPoints and having a separate array for each dataset, and it will also increase performance! Finishes the create data collector task in #10566 