### PR TITLE
fix(RenderTargetTexture): Fix case where the scene is null when marking meshes as light dirty

### DIFF
--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -80,8 +80,8 @@ export class RenderTargetTexture extends Texture {
 
             var result = oldPush.apply(array, items);
 
-            if (wasEmpty && this.getScene()) {
-                this.getScene()!.meshes.forEach((mesh) => {
+            if (wasEmpty) {
+                this.getScene()?.meshes.forEach((mesh) => {
                     mesh._markSubMeshesAsLightDirty();
                 });
             }
@@ -94,7 +94,7 @@ export class RenderTargetTexture extends Texture {
             var deleted = oldSplice.apply(array, [index, deleteCount]);
 
             if (array.length === 0) {
-                this.getScene()!.meshes.forEach((mesh) => {
+                this.getScene()?.meshes.forEach((mesh) => {
                     mesh._markSubMeshesAsLightDirty();
                 });
             }


### PR DESCRIPTION
I'm still struggling to understand exactly how this scenario comes about, I believe it is something like calling mesh.dispose() after the scene has already been destroyed, or is being destroyed.

Either way this fixes the following error:

```
VM91032:1 Uncaught TypeError: Cannot read property 'meshes' of null
    at eval (eval at array.splice (renderTargetTexture.js:171), <anonymous>:1:17)
    at Array.array.splice (renderTargetTexture.js:171)
    at Array.array.splice (renderTargetTexture.js:169)
    at Array.array.splice (renderTargetTexture.js:169)
    at Array.array.splice (renderTargetTexture.js:169)
    at abstractMesh.js:1573
    at Array.forEach (<anonymous>)
    at Mesh.AbstractMesh.dispose (abstractMesh.js:1557)
    at Mesh.dispose (mesh.js:2060)
    at Subscription.<anonymous> (mesh-loader.ts:136)
```