### PR TITLE
[XR] WebXR spectator mode for desktop VR experiences

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -157,7 +157,7 @@
 - Added support for XRFrame.fillPoses and XRFrame.fillJointRadii ([#10454](https://github.com/BabylonJS/Babylon.js/issues/10454)) ([rgerd](https://github.com/rgerd))
 - Improved functionality of `WebXRNearInteraction` and updated coverage to be enabled on Behaviors and Gizmos ([rickfromwork](https://github.com/rickfromwork))
 - Introduced framework support for XR-based eye tracking. XR eye tracking is not yet supported in webXR, but is supported in BabylonNative using OpenXR. ([rickfromwork](https://github.com/rickfromwork))
-- Introduced spectator mode for desktop VR experiences and fixed an issue with XR camera in the activeCameras array ([#9938](https://github.com/BabylonJS/Babylon.js/issues/10560)) ([RaananW](https://github.com/RaananW))
+- Introduced spectator mode for desktop VR experiences and fixed an issue with XR camera in the activeCameras array ([#10560](https://github.com/BabylonJS/Babylon.js/issues/10560)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -157,6 +157,7 @@
 - Added support for XRFrame.fillPoses and XRFrame.fillJointRadii ([#10454](https://github.com/BabylonJS/Babylon.js/issues/10454)) ([rgerd](https://github.com/rgerd))
 - Improved functionality of `WebXRNearInteraction` and updated coverage to be enabled on Behaviors and Gizmos ([rickfromwork](https://github.com/rickfromwork))
 - Introduced framework support for XR-based eye tracking. XR eye tracking is not yet supported in webXR, but is supported in BabylonNative using OpenXR. ([rickfromwork](https://github.com/rickfromwork))
+- Introduced spectator mode for desktop VR experiences and fixed an issue with XR camera in the activeCameras array ([#9938](https://github.com/BabylonJS/Babylon.js/issues/10560)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4284,6 +4284,20 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
     }
 
+    private checkCameraRenderTarget(camera: Nullable<Camera>) {
+        if (camera?.outputRenderTarget && !camera?.isRigCamera) {
+            camera.outputRenderTarget._cleared = false;
+        }
+        if (camera?.rigCameras?.length) {
+            for (let i = 0; i < camera.rigCameras.length; ++i) {
+                const rtt = camera.rigCameras[i].outputRenderTarget;
+                if (rtt) {
+                    rtt._cleared = false;
+                }
+            }
+        }
+    }
+
     /**
      * Render the scene
      * @param updateCameras defines a boolean indicating if cameras must update according to their inputs (true by default)
@@ -4300,22 +4314,9 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         this._frameId++;
         this._defaultFrameBufferCleared = false;
-        const checkRtt = (camera: Nullable<Camera>) => {
-            if (camera?.outputRenderTarget && !camera?.isRigCamera) {
-                camera.outputRenderTarget._cleared = false;
-            }
-            if (camera?.rigCameras?.length) {
-                for (let i = 0; i < camera.rigCameras.length; ++i) {
-                    const rtt = camera.rigCameras[i].outputRenderTarget;
-                    if (rtt) {
-                        rtt._cleared = false;
-                    }
-                }
-            }
-        };
-        checkRtt(this.activeCamera);
+        this.checkCameraRenderTarget(this.activeCamera);
         if (this.activeCameras?.length) {
-            this.activeCameras.forEach(checkRtt);
+            this.activeCameras.forEach(this.checkCameraRenderTarget);
         }
 
         // Register components that have been associated lately to the scene.

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4300,24 +4300,22 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         this._frameId++;
         this._defaultFrameBufferCleared = false;
-        if (this._activeCamera?.outputRenderTarget && !this.activeCamera?.isRigCamera) {
-            this._activeCamera.outputRenderTarget._cleared = false;
-        }
-        if (this._activeCamera?.rigCameras?.length) {
-            for (let i = 0; i < this._activeCamera.rigCameras.length; ++i) {
-                const rtt = this._activeCamera.rigCameras[i].outputRenderTarget;
-                if (rtt) {
-                    rtt._cleared = false;
+        const checkRtt = (camera: Nullable<Camera>) => {
+            if (camera?.outputRenderTarget && !camera?.isRigCamera) {
+                camera.outputRenderTarget._cleared = false;
+            }
+            if (camera?.rigCameras?.length) {
+                for (let i = 0; i < camera.rigCameras.length; ++i) {
+                    const rtt = camera.rigCameras[i].outputRenderTarget;
+                    if (rtt) {
+                        rtt._cleared = false;
+                    }
                 }
             }
-        }
+        };
+        checkRtt(this.activeCamera);
         if (this.activeCameras?.length) {
-            for (let i = 0; i < this.activeCameras.length; ++i) {
-                const rtt = this.activeCameras[i].outputRenderTarget;
-                if (rtt) {
-                    rtt._cleared = false;
-                }
-            }
+            this.activeCameras.forEach(checkRtt);
         }
 
         // Register components that have been associated lately to the scene.


### PR DESCRIPTION
This PR enables spectator mode - cloning the first rig camera's view to the desktop canvas.
As written in the codedoc - this is expected to degrtade performance due to the extra render call of a camera (and technically the entire scene).

Fixes #10560

To use a different camera type or manipulate the camera on your own you can create the camera and set it to be the second in the activeCameras array:

```javascript
scene.activeCameras = [webXrcamera, yourNewCamera];
```

An important thing to remember is that the dimensions object will need to be reset in order for the new camera to render correctly:

```javascript
scene.onAfterRenderCameraObservable.add((camera) => {
  if (camera === webXrCamera) {
    // reset the dimensions object for correct resizing
    scene.getEngine().framebufferDimensionsObject = null;
  }
});
```

You can then update the camera's transformation (or not, if it is not needed) on each XRFrame