### PR TITLE
Update the components for the performance viewer to use our performance collector.

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -1,4 +1,4 @@
-import { Observable } from "babylonjs";
+import { Observable } from "babylonjs/Misc/observable";
 import { Scene } from "babylonjs/scene";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -52,16 +52,17 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     }
 
     useEffect(() => {
-        let perfCollector: PerformanceViewerCollector | undefined;
+        const perfCollector = new PerformanceViewerCollector(scene, [PerfCollectionStrategy.GpuFrameTimeStrategy(), PerfCollectionStrategy.FpsStrategy()]);
+        setPerformanceCollector(perfCollector);
+    }, []);
+
+    useEffect(() => {
         if (isOpen) {
-            perfCollector = new PerformanceViewerCollector(scene, [PerfCollectionStrategy.GpuFrameTimeStrategy(), PerfCollectionStrategy.FpsStrategy()]);
-            perfCollector.start();
-            setPerformanceCollector(perfCollector);
+            performanceCollector?.start();
         }
 
         return () => {
-            perfCollector?.stop();
-            setPerformanceCollector(undefined);
+            performanceCollector?.stop();
         }
     }, [isOpen]);
 

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -1,10 +1,16 @@
+import { Observable } from "babylonjs";
 import { Scene } from "babylonjs/scene";
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ButtonLineComponent } from "../../../../sharedUiComponents/lines/buttonLineComponent";
 import { CanvasGraphComponent } from "../../../graph/canvasGraphComponent";
-import { CanvasGraphService } from "../../../graph/canvasGraphService";
+import { IPerfLayoutSize } from "../../../graph/graphSupportingTypes";
 import { PopupComponent } from "../../../popupComponent";
+import { PerformanceViewerSidebarComponent } from "./performanceViewerSidebarComponent";
+import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollector";
+import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
+
+require('./scss/performanceViewer.scss');
 
 interface IPerformanceViewerComponentProps {
     scene: Scene;
@@ -14,10 +20,14 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = false;
+const isEnabled = true;
 
 export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentProps> = (props: IPerformanceViewerComponentProps) => {
+    const { scene } = props;
     const [isOpen, setIsOpen] = useState(false);
+    const [ performanceCollector, setPerformanceCollector ] = useState<PerformanceViewerCollector | undefined>();
+    const [layoutObservable] = useState(new Observable<IPerfLayoutSize>());
+    const popupRef = useRef<PopupComponent | null>(null);
 
     // do cleanup when the window is closed
     const onClosePerformanceViewer = (window: Window | null) => {
@@ -32,12 +42,28 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     }
 
     const onResize = () => {
-        // do nothing for now.
+        if (!popupRef.current) {
+            return;
+        }
+        const window = popupRef.current.getWindow();
+        const width = window?.innerWidth ?? 0;
+        const height = window?.innerHeight ?? 0;
+        layoutObservable.notifyObservers({width, height});
     }
 
-    const canvasServiceCallback = (canvasService: CanvasGraphService) => {
-        canvasService.update();
-    };
+    useEffect(() => {
+        let perfCollector: PerformanceViewerCollector | undefined;
+        if (isOpen) {
+            perfCollector = new PerformanceViewerCollector(scene, [PerfCollectionStrategy.GpuFrameTimeStrategy(), PerfCollectionStrategy.FpsStrategy()]);
+            perfCollector.start();
+            setPerformanceCollector(perfCollector);
+        }
+
+        return () => {
+            perfCollector?.stop();
+            setPerformanceCollector(undefined);
+        }
+    }, [isOpen]);
 
     return (
         <>
@@ -51,13 +77,15 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
                     id="perf-viewer"
                     title="Performance Viewer"
                     size={initialWindowSize}
+                    ref={popupRef}
                     onResize={onResize}
                     onClose={onClosePerformanceViewer}
                 >
                     <div id="performance-viewer">
-                        <>
-                            <CanvasGraphComponent id="myChart" canvasServiceCallback={canvasServiceCallback} />
-                        </>
+                        {performanceCollector && <>
+                            <PerformanceViewerSidebarComponent collector={performanceCollector} />
+                            <CanvasGraphComponent id="performance-viewer-graph" layoutObservable={layoutObservable} scene={scene} collector={performanceCollector} />
+                        </>}
                     </div>
                 </PopupComponent>
         }

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -20,7 +20,7 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = true;
+const isEnabled = false;
 
 export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentProps> = (props: IPerformanceViewerComponentProps) => {
     const { scene } = props;

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerSidebarComponent.tsx
@@ -1,48 +1,52 @@
 import { Color3 } from 'babylonjs/Maths/math.color';
-import { IPerfDataset } from 'babylonjs/Misc/interfaces/iPerfViewer';
-import { Observable } from 'babylonjs/Misc/observable';
+import { IPerfMetadata } from 'babylonjs/Misc/interfaces/iPerfViewer';
+import { PerformanceViewerCollector } from 'babylonjs/Misc/PerformanceViewer/performanceViewerCollector';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { ColorPickerLineComponent } from '../../../../sharedUiComponents/lines/colorPickerComponent';
 
 interface IPerformanceViewerSidebarComponentProps {
-    datasetObservable: Observable<IPerfDataset[]>
-    onToggleVisibility: (id: string, value: boolean) => void;
-    onColorChanged: (id: string, value: string) => void;
+    collector: PerformanceViewerCollector;
 }
 
+type MetadataEntry = [string, IPerfMetadata];
+
 export const PerformanceViewerSidebarComponent = (props: IPerformanceViewerSidebarComponentProps) => {
-    const {onToggleVisibility, datasetObservable, onColorChanged} = props;
-    // TODO: Refactor to store only metadata once data layer is implemented.
-    const [datasets, setDatasets] = useState<IPerfDataset[]>([]);
+    const { collector } = props;
+    const [metadata, setMetadata] = useState<MetadataEntry[]>([]);
 
     useEffect(() => {
-        const onUpdateDatasets = (datasets: IPerfDataset[]) => {
-            setDatasets(datasets);
+        const onUpdateMetadata = (metadata: Map<string, IPerfMetadata>) => {
+            const entries: MetadataEntry[] = [];
+            // convert to iterable list of entries
+            metadata.forEach((value: IPerfMetadata, key) => {
+                entries.push([key, value]);
+            });
+            setMetadata(entries);
         }
 
-        datasetObservable.add(onUpdateDatasets);
+        collector.metadataObservable.add(onUpdateMetadata);
         return () => {
-            datasetObservable.removeCallback(onUpdateDatasets);
+            collector.metadataObservable.removeCallback(onUpdateMetadata);
         }
     }, []);
 
     const onCheckChange = (id: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
-        onToggleVisibility(id, !event.currentTarget.checked);
+        collector.updateMetadata(id, "hidden", !event.currentTarget.checked);
     }
 
     const onColorChange = (id: string) => (color: string) => {
-        onColorChanged(id, color);
+        collector.updateMetadata(id, "color", color);
     }
 
     return (
         <div id="performance-viewer-sidebar">
             {
-                datasets.map((dataset: IPerfDataset) => (
-                        <div key={`perf-sidebar-item-${dataset.id}`} className="sidebar-item">
-                            <input type="checkbox" checked={!dataset.hidden} onChange={onCheckChange(dataset.id)} />
-                            <span className="sidebar-item-label">{dataset.id}</span>
-                            <ColorPickerLineComponent value={Color3.FromHexString(dataset.color ?? "#000")} onColorChanged={onColorChange(dataset.id)} shouldPopRight />
+                metadata.map(([id, metadata]) => (
+                        <div key={`perf-sidebar-item-${id}`} className="sidebar-item">
+                            <input type="checkbox" checked={!metadata.hidden} onChange={onCheckChange(id)} />
+                            <span className="sidebar-item-label">{id}</span>
+                            <ColorPickerLineComponent value={Color3.FromHexString(metadata.color ?? "#000")} onColorChanged={onColorChange(id)} shouldPopRight />
                         </div>
                     )
                 )

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -63,7 +63,7 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
         return () => {
             cs?.destroy();
             layoutObservable?.removeCallback(layoutUpdated);
-            collector.datasetObservable.removeCallback(dataUpdated);
+            scene.onAfterRenderObservable.removeCallback(dataUpdated);
             collector.metadataObservable.removeCallback(metaUpdated);
         };
     }, [canvasRef]);

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -1,17 +1,21 @@
+import { PerformanceViewerCollector } from 'babylonjs/Misc/PerformanceViewer/performanceViewerCollector';
 import { Observable } from 'babylonjs/Misc/observable';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { CanvasGraphService } from './canvasGraphService';
 import { IPerfLayoutSize } from './graphSupportingTypes';
+import { IPerfMetadata } from 'babylonjs/Misc/interfaces/iPerfViewer';
+import { Scene } from 'babylonjs/scene';
 
 interface ICanvasGraphComponentProps {
     id: string;
-    canvasServiceCallback: (canvasService: CanvasGraphService) => void;
+    scene: Scene;
+    collector: PerformanceViewerCollector
     layoutObservable?: Observable<IPerfLayoutSize>;
 }
 
 export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props: ICanvasGraphComponentProps) => {
-    const { id, canvasServiceCallback, layoutObservable } = props;
+    const { id, collector, scene, layoutObservable } = props;
     const canvasRef: React.MutableRefObject<HTMLCanvasElement | null>  = useRef(null);
 
     useEffect(() => {
@@ -21,10 +25,9 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
         
         let cs: CanvasGraphService | undefined;
 
-        // temporarily set empty array, will eventually be passed by props!
+        // TODO: SET datasets as collector.datasets once canvas graph service pr is up.
         try {
             cs = new CanvasGraphService(canvasRef.current, {datasets: []});
-            canvasServiceCallback(cs);
         } catch (error) {
             console.error(error);
             return;
@@ -40,11 +43,28 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
             cs?.resize(newSize);
         };
 
+        const dataUpdated = () => {
+            cs?.update();
+        };
+
+        const metaUpdated = (_: Map<string, IPerfMetadata>) => {
+            if (!cs) {
+                return;
+            }
+            // TODO: add this line once canvas graph service pr is up. cs.metadata = meta;
+            cs.update();
+        };
+        
+        scene.onAfterRenderObservable.add(dataUpdated);
+        collector.metadataObservable.add(metaUpdated);
+
         layoutObservable?.add(layoutUpdated);
 
         return () => {
             cs?.destroy();
             layoutObservable?.removeCallback(layoutUpdated);
+            collector.datasetObservable.removeCallback(dataUpdated);
+            collector.metadataObservable.removeCallback(metaUpdated);
         };
     }, [canvasRef]);
     


### PR DESCRIPTION
This PR adds the necessary changes to allow the components to use the perf collector! This PR will add the corresponding notifier for the layout. This PR also keeps the canvasGraphService within the canvasGraphComponent (no more weird callbacks LOL). 

Right now we create the Performance collector within the performanceViewerComponent but in the future we will use a scene extension to handle the creation for us. 

Completes the "Begin collecting fps data" in #10566. 