### PR TITLE
Implement the rest of the strategies for the performance viewer, except the CPU Strategy

### DIFF
--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -26,7 +26,7 @@ const defaultDisposeImpl = () => {};
 const defaultGetDataImpl = () => 0;
 
 /**
- * Initializer callback for a strategy, we allow sceneInstrumentation to save on allocations of this object as a lot of default strategies use it.
+ * Initializer callback for a strategy
  */
 export type PerfStrategyInitialization = (scene: Scene) => IPerfViewerCollectionStrategy;
 /**
@@ -152,13 +152,13 @@ export class PerfCollectionStrategy {
      */
     public static DrawCallsStrategy(): PerfStrategyInitialization {
         return (scene) => {
-            const drawCallsCounter = scene.getEngine()._drawCalls;
             const onBeforeAnimationsObserver = scene.onBeforeAnimationsObservable.add(() => {
-                drawCallsCounter.fetchNewFrame();
+                scene.getEngine()._drawCalls.fetchNewFrame();
             });
+
             return {
                 id: "draw calls",
-                getData: () => drawCallsCounter.current,
+                getData: () => scene.getEngine()._drawCalls.current,
                 dispose: () => {
                     scene.onBeforeAnimationsObservable.remove(onBeforeAnimationsObserver);
                 },

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -1,4 +1,5 @@
 import { EngineInstrumentation } from "../../Instrumentation/engineInstrumentation";
+import { SceneInstrumentation } from "../../Instrumentation/sceneInstrumentation";
 import { Scene } from "../../scene";
 
 /**
@@ -58,10 +59,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total meshes strategy
      */
     public static TotalMeshesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "total meshes",
-                getData: defaultGetDataImpl,
+                getData: () => scene.meshes.length,
             };
         };
     }
@@ -71,10 +72,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the active meshes strategy
      */
     public static ActiveMeshesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "active meshes",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getActiveMeshes().length,
             };
         };
     }
@@ -84,10 +85,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the active indices strategy
      */
     public static ActiveIndiciesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "active indices",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getActiveIndices(),
             };
         };
     }
@@ -97,10 +98,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the active faces strategy
      */
     public static ActiveFacesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "active faces",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getActiveIndices() / 3,
             };
         };
     }
@@ -110,10 +111,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the active bones strategy
      */
     public static ActiveBonesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "active bones",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getActiveBones(),
             };
         };
     }
@@ -123,10 +124,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the active particles strategy
      */
     public static ActiveParticlesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "active particles",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getActiveParticles(),
             };
         };
     }
@@ -136,10 +137,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the draw calls strategy
      */
     public static DrawCallsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
             return {
                 id: "draw calls",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.drawCallsCounter.current,
             };
         };
     }
@@ -149,10 +151,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total lights strategy
      */
     public static TotalLightsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "total lights",
-                getData: defaultGetDataImpl,
+                getData: () => scene.lights.length,
             };
         };
     }
@@ -162,10 +164,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total vertices strategy
      */
     public static TotalVerticesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "total vertices",
-                getData: defaultGetDataImpl,
+                getData: () => scene.getTotalVertices(),
             };
         };
     }
@@ -175,10 +177,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total materials strategy
      */
     public static TotalMaterialsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "total materials",
-                getData: defaultGetDataImpl,
+                getData: () => scene.materials.length,
             };
         };
     }
@@ -188,10 +190,10 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total textures strategy
      */
     public static TotalTexturesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
             return {
                 id: "total textures",
-                getData: defaultGetDataImpl,
+                getData: () => scene.textures.length,
             };
         };
     }
@@ -201,10 +203,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the absolute fps strategy
      */
     public static AbsoluteFpsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureFrameTime = true;
             return {
                 id: "absolute fps",
-                getData: defaultGetDataImpl,
+                getData: () => 1000.0 / sceneInstrumentation.frameTimeCounter.lastSecAverage,
             };
         };
     }
@@ -214,10 +218,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the meshes selection time strategy
      */
     public static MeshesSelectionStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureActiveMeshesEvaluationTime = true;
             return {
                 id: "meshes selection time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.activeMeshesEvaluationTimeCounter.lastSecAverage,
             };
         };
     }
@@ -227,10 +233,13 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the render targets time strategy
      */
     public static RenderTargetsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureRenderTargetsRenderTime = true;
+
             return {
                 id: "render targets time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.renderTargetsRenderTimeCounter.lastSecAverage,
             };
         };
     }
@@ -240,10 +249,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the particles time strategy
      */
     public static ParticlesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureParticlesRenderTime = true;
             return {
                 id: "particles time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.particlesRenderTimeCounter.lastSecAverage,
             };
         };
     }
@@ -253,10 +264,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the sprites time strategy
      */
     public static SpritesStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureSpritesRenderTime = true;
             return {
                 id: "sprites time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.spritesRenderTimeCounter.lastSecAverage,
             };
         };
     }
@@ -266,10 +279,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the animations time strategy
      */
     public static AnimationsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureAnimationsTime = true;
             return {
                 id: "animations time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.animationsTimeCounter.lastSecAverage,
             };
         };
     }
@@ -279,10 +294,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the physics time strategy
      */
     public static PhysicsStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.capturePhysicsTime = true;
             return {
                 id: "physics time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.physicsTimeCounter.lastSecAverage,
             };
         };
     }
@@ -292,10 +309,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the render time strategy
      */
     public static RenderStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureRenderTime = true;
             return {
                 id: "render time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.renderTimeCounter.lastSecAverage,
             };
         };
     }
@@ -305,10 +324,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total frame time strategy
      */
     public static FrameTotalStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureFrameTime = true;
             return {
                 id: "total frame time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.frameTimeCounter.lastSecAverage,
             };
         };
     }
@@ -318,10 +339,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the inter-frame time strategy
      */
     public static InterFrameStrategy(): PerfStrategyInitialization {
-        return () => {
+        return (scene) => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureInterFrameTime = true
             return {
                 id: "inter-frame time",
-                getData: defaultGetDataImpl,
+                getData: () => sceneInstrumentation.interFrameTimeCounter.lastSecAverage,
             };
         };
     }

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -152,15 +152,21 @@ export class PerfCollectionStrategy {
      */
     public static DrawCallsStrategy(): PerfStrategyInitialization {
         return (scene) => {
+            let drawCalls = 0;
             const onBeforeAnimationsObserver = scene.onBeforeAnimationsObservable.add(() => {
                 scene.getEngine()._drawCalls.fetchNewFrame();
             });
 
+            const onAfterRenderObserver = scene.onAfterRenderObservable.add(() => {
+                drawCalls = scene.getEngine()._drawCalls.current
+            });
+
             return {
                 id: "draw calls",
-                getData: () => scene.getEngine()._drawCalls.current,
+                getData: () => drawCalls,
                 dispose: () => {
                     scene.onBeforeAnimationsObservable.remove(onBeforeAnimationsObserver);
+                    scene.onAfterRenderObservable.remove(onAfterRenderObserver);
                 },
             };
         };

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -20,9 +20,9 @@ export interface IPerfViewerCollectionStrategy {
 const defaultGetDataImpl = () => 0;
 
 /**
- * Initializer callback for a strategy
+ * Initializer callback for a strategy, we allow sceneInstrumentation to save on allocations of this object as a lot of default strategies use it.
  */
-export type PerfStrategyInitialization = (scene: Scene) => IPerfViewerCollectionStrategy;
+export type PerfStrategyInitialization = (scene: Scene, sceneInstrumentation: SceneInstrumentation) => IPerfViewerCollectionStrategy;
 /**
  * Defines the predefined strategies used in the performance viewer.
  */
@@ -137,8 +137,7 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the draw calls strategy
      */
     public static DrawCallsStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             return {
                 id: "draw calls",
                 getData: () => sceneInstrumentation.drawCallsCounter.current,
@@ -203,12 +202,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the absolute fps strategy
      */
     public static AbsoluteFpsStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureFrameTime = true;
             return {
                 id: "absolute fps",
-                getData: () => 1000.0 / sceneInstrumentation.frameTimeCounter.lastSecAverage,
+                getData: () => 1000.0 / sceneInstrumentation.frameTimeCounter.current,
             };
         };
     }
@@ -218,12 +216,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the meshes selection time strategy
      */
     public static MeshesSelectionStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureActiveMeshesEvaluationTime = true;
             return {
                 id: "meshes selection time",
-                getData: () => sceneInstrumentation.activeMeshesEvaluationTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.activeMeshesEvaluationTimeCounter.current,
             };
         };
     }
@@ -233,13 +230,12 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the render targets time strategy
      */
     public static RenderTargetsStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureRenderTargetsRenderTime = true;
 
             return {
                 id: "render targets time",
-                getData: () => sceneInstrumentation.renderTargetsRenderTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.renderTargetsRenderTimeCounter.current,
             };
         };
     }
@@ -249,12 +245,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the particles time strategy
      */
     public static ParticlesStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureParticlesRenderTime = true;
             return {
                 id: "particles time",
-                getData: () => sceneInstrumentation.particlesRenderTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.particlesRenderTimeCounter.current,
             };
         };
     }
@@ -264,12 +259,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the sprites time strategy
      */
     public static SpritesStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureSpritesRenderTime = true;
             return {
                 id: "sprites time",
-                getData: () => sceneInstrumentation.spritesRenderTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.spritesRenderTimeCounter.current,
             };
         };
     }
@@ -279,12 +273,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the animations time strategy
      */
     public static AnimationsStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureAnimationsTime = true;
             return {
                 id: "animations time",
-                getData: () => sceneInstrumentation.animationsTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.animationsTimeCounter.current,
             };
         };
     }
@@ -294,12 +287,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the physics time strategy
      */
     public static PhysicsStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.capturePhysicsTime = true;
             return {
                 id: "physics time",
-                getData: () => sceneInstrumentation.physicsTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.physicsTimeCounter.current,
             };
         };
     }
@@ -309,12 +301,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the render time strategy
      */
     public static RenderStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureRenderTime = true;
             return {
                 id: "render time",
-                getData: () => sceneInstrumentation.renderTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.renderTimeCounter.current,
             };
         };
     }
@@ -324,12 +315,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the total frame time strategy
      */
     public static FrameTotalStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureFrameTime = true;
             return {
                 id: "total frame time",
-                getData: () => sceneInstrumentation.frameTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.frameTimeCounter.current,
             };
         };
     }
@@ -339,12 +329,11 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the inter-frame time strategy
      */
     public static InterFrameStrategy(): PerfStrategyInitialization {
-        return (scene) => {
-            const sceneInstrumentation = new SceneInstrumentation(scene);
+        return (_, sceneInstrumentation) => {
             sceneInstrumentation.captureInterFrameTime = true;
             return {
                 id: "inter-frame time",
-                getData: () => sceneInstrumentation.interFrameTimeCounter.lastSecAverage,
+                getData: () => sceneInstrumentation.interFrameTimeCounter.current,
             };
         };
     }
@@ -359,7 +348,7 @@ export class PerfCollectionStrategy {
             engineInstrumentation.captureGPUFrameTime = true;
             return {
                 id: "gpu frame time",
-                getData: () => Math.max(engineInstrumentation.gpuFrameTimeCounter.lastSecAverage * 0.000001, 0),
+                getData: () => Math.max(engineInstrumentation.gpuFrameTimeCounter.current * 0.000001, 0),
             };
         };
     }

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -158,7 +158,7 @@ export class PerfCollectionStrategy {
             });
 
             const onAfterRenderObserver = scene.onAfterRenderObservable.add(() => {
-                drawCalls = scene.getEngine()._drawCalls.current
+                drawCalls = scene.getEngine()._drawCalls.current;
             });
 
             return {
@@ -487,7 +487,7 @@ export class PerfCollectionStrategy {
             const onAfterRenderObserver = scene.onAfterRenderObservable.add(() => {
                 startTime = PrecisionDate.Now;
             });
-  
+
             return {
                 id: "inter-frame time",
                 getData: () => timeTaken,

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -341,7 +341,7 @@ export class PerfCollectionStrategy {
     public static InterFrameStrategy(): PerfStrategyInitialization {
         return (scene) => {
             const sceneInstrumentation = new SceneInstrumentation(scene);
-            sceneInstrumentation.captureInterFrameTime = true
+            sceneInstrumentation.captureInterFrameTime = true;
             return {
                 id: "inter-frame time",
                 getData: () => sceneInstrumentation.interFrameTimeCounter.lastSecAverage,

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -1,3 +1,4 @@
+import { SceneInstrumentation } from "../../Instrumentation/sceneInstrumentation";
 import { Scene } from "../../scene";
 import { IPerfDatasets, IPerfMetadata } from "../interfaces/iPerfViewer";
 import { EventState, Observable } from "../observable";
@@ -22,6 +23,7 @@ export class PerformanceViewerCollector {
     private _datasetMeta: Map<string, IPerfMetadata>;
     private _strategies: Map<string, IPerfViewerCollectionStrategy>;
     private _startingTimestamp: number;
+    private _sceneInstrumentation: SceneInstrumentation;
 
     /**
      * Datastructure containing the collected datasets. Warning: you should not modify the values in here, data will be of the form [timestamp, numberOfPoints, value1, value2..., timestamp, etc...]
@@ -57,6 +59,7 @@ export class PerformanceViewerCollector {
      * @param _enabledStrategyCallbacks the list of data to collect with callbacks for initialization purposes.
      */
     constructor(private _scene: Scene, _enabledStrategyCallbacks?: PerfStrategyInitialization[]) {
+        this._sceneInstrumentation = new SceneInstrumentation(_scene);
         this.datasets = {
             ids: [],
             data: new DynamicFloat32Array(initialArraySize),
@@ -77,7 +80,7 @@ export class PerformanceViewerCollector {
      */
     public addCollectionStrategies(...strategyCallbacks: PerfStrategyInitialization[]) {
         for (const strategyCallback of strategyCallbacks) {
-            const strategy = strategyCallback(this._scene);
+            const strategy = strategyCallback(this._scene, this._sceneInstrumentation);
 
             if (this._strategies.has(strategy.id)) {
                 continue;

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -243,6 +243,5 @@ export class PerformanceViewerCollector {
         this.datasetObservable.clear();
         this.metadataObservable.clear();
         (<any>this.datasets) = null;
-        (<any>this._scene) = null;
     }
 }


### PR DESCRIPTION
This PR Implements the rest of the strategies except for the cpu strategy within the default strategies we provide. This helps with the "Allow for the collection of draw calls, number of active meshes, frame time." and it helps complete the "Collect everything under count and frame steps duration" stretch goal #10566. 

Note: You will not be able to see all of these strategies on the graph by default, only a select portion that we will define, and then the user will be able to add more through the shared perfviewercollector. 