### PR TITLE
Customize delta calculation for mouse wheel event

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -39,6 +39,7 @@
 - Added flag to allow users to swap between rotation and movement for single touch on FreeCameraTouchInput ([PolygonalSun](https://github.com/PolygonalSun))
 - Added the ability to load a fullscreen GUI from the snippet server ([PirateJC](https://github.com/piratejc))
 - Updated the gravity parameter in `Scene.enablePhysics()` as optional to fit the current behaviour ([Faber](https://https://github.com/Faber-smythe))
+- Allow the possibility to override the radius delta calculation for mouse wheel event ([RaananW](https://github.com/RaananW))
 
 ### Engine
 


### PR DESCRIPTION
This PR allows overriding the current radius delta calculation of the arc rotate mouse wheel input processor.

It also allows extending this class and overriding the current function instead.