### PR TITLE
[XR] introducing controller cache

### DIFF
--- a/src/XR/motionController/webXRMotionControllerManager.ts
+++ b/src/XR/motionController/webXRMotionControllerManager.ts
@@ -226,7 +226,7 @@ export class WebXRMotionControllerManager {
                 return this._ProfileLoadingPromises[profileToLoad];
             })
             .then((profile: IMotionControllerProfile) => {
-                return new WebXRProfiledMotionController(scene, xrInput, profile, this.BaseRepositoryUrl, controllerCache);
+                return new WebXRProfiledMotionController(scene, xrInput, profile, this.BaseRepositoryUrl, this.DisableControllerCache ? undefined : controllerCache);
             });
     }
 

--- a/src/XR/motionController/webXRMotionControllerManager.ts
+++ b/src/XR/motionController/webXRMotionControllerManager.ts
@@ -25,6 +25,11 @@ const controllerCache: Array<{
     path: string;
     meshes: AbstractMesh[]
 }> = [];
+
+/**
+ * Motion controller manager is managing the different webxr profiles and makes sure the right
+ * controller is being loaded.
+ */
 export class WebXRMotionControllerManager {
     private static _AvailableControllers: { [type: string]: MotionControllerConstructor } = {};
     private static _Fallbacks: { [profileId: string]: string[] } = {};
@@ -45,6 +50,10 @@ export class WebXRMotionControllerManager {
      */
     public static UseOnlineRepository: boolean = true;
 
+    /**
+     * Disable the controller cache and load the models each time a new WebXRProfileMotionController is loaded.
+     * Defaults to true.
+     */
     public static DisableControllerCache: boolean = true;
 
     /**

--- a/src/XR/motionController/webXRProfiledMotionController.ts
+++ b/src/XR/motionController/webXRProfiledMotionController.ts
@@ -30,16 +30,23 @@ export class WebXRProfiledMotionController extends WebXRAbstractMotionController
      */
     public profileId: string;
 
-    constructor(scene: Scene, xrInput: XRInputSource, _profile: IMotionControllerProfile, private _repositoryUrl: string) {
-        super(scene, _profile.layouts[xrInput.handedness || "none"], xrInput.gamepad as any, xrInput.handedness);
+    constructor(scene: Scene, xrInput: XRInputSource, _profile: IMotionControllerProfile, private _repositoryUrl: string,
+        private controllerCache?: Array<{
+            filename: string;
+            path: string;
+            meshes: AbstractMesh[]
+        }>) {
+        super(scene, _profile.layouts[xrInput.handedness || "none"], xrInput.gamepad as any, xrInput.handedness, undefined, controllerCache);
         this.profileId = _profile.profileId;
     }
 
     public dispose() {
         super.dispose();
-        Object.keys(this._touchDots).forEach((visResKey) => {
-            this._touchDots[visResKey].dispose();
-        });
+        if (!this.controllerCache) {
+            Object.keys(this._touchDots).forEach((visResKey) => {
+                this._touchDots[visResKey].dispose();
+            });
+        }
     }
 
     protected _getFilenameAndPath(): { filename: string; path: string } {

--- a/src/XR/webXRInput.ts
+++ b/src/XR/webXRInput.ts
@@ -170,5 +170,8 @@ export class WebXRInput implements IDisposable {
         this.xrSessionManager.onXRSessionEnded.remove(this._sessionEndedObserver);
         this.onControllerAddedObservable.clear();
         this.onControllerRemovedObservable.clear();
+
+        // clear the controller cache
+        WebXRMotionControllerManager.ClearControllerCache();
     }
 }

--- a/src/XR/webXRInputSource.ts
+++ b/src/XR/webXRInputSource.ts
@@ -149,12 +149,12 @@ export class WebXRInputSource {
      */
     public dispose() {
         if (this.grip) {
-            this.grip.dispose(false, true);
+            this.grip.dispose(true);
         }
         if (this.motionController) {
             this.motionController.dispose();
         }
-        this.pointer.dispose();
+        this.pointer.dispose(true);
         this.onMotionControllerInitObservable.clear();
         this.onMeshLoadedObservable.clear();
         this.onDisposeObservable.notifyObservers(this);


### PR DESCRIPTION
Controllers will be cached in a static cache. They will not dispose until dispose is called and will be disabled until needed.

This will speed up re-entering sessions and will save some bandwidth if the controller is being disposed and reloaded

The default behavior was not changed. Models will only be cached if the flag is set to true.

Fixes #10188