### PR TITLE
Add tickers to the performance graph

### DIFF
--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -34,8 +34,8 @@ const stopDrawingPlayheadThreshold = 0.95;
 // Threshold for the ratio at which we go from panning mode to live mode.
 const returnToLiveThreshold = 0.998;
 
-// Font to use on the tooltip!
-const tooltipFont = "12px Arial";
+// Font to use on the addons such as tooltips and tickers!
+const graphAddonFont = "12px Arial";
 
 // A string containing the alphabet, used in line height calculation for the font.
 const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -85,7 +85,7 @@ export class CanvasGraphService {
     private _tickerTextCache: IPerfTextMeasureCache;
     private _tickerItems: IPerfTicker[];
 
-    private readonly _tooltipLineHeight: number;
+    private readonly _addonFontLineHeight: number;
     private readonly _defaultLineHeight: number;
 
     public readonly datasets: IPerfDatasets;
@@ -127,9 +127,9 @@ export class CanvasGraphService {
         this._axisHeight = axisLineLength + axisPadding + this._defaultLineHeight + axisPadding;
 
         this._ctx.save();
-        this._ctx.font = tooltipFont;
+        this._ctx.font = graphAddonFont;
         const fontMetrics = this._ctx.measureText(alphabet);
-        this._tooltipLineHeight = fontMetrics.actualBoundingBoxAscent + fontMetrics.actualBoundingBoxDescent;
+        this._addonFontLineHeight = fontMetrics.actualBoundingBoxAscent + fontMetrics.actualBoundingBoxDescent;
         this._ctx.restore();
 
         this.datasets = settings.datasets;
@@ -319,7 +319,7 @@ export class CanvasGraphService {
         });
 
         ctx.save();        
-        ctx.font = tooltipFont;
+        ctx.font = graphAddonFont;
         ctx.textBaseline = "middle";
         ctx.textAlign = "left";
 
@@ -335,7 +335,7 @@ export class CanvasGraphService {
         
         drawableArea.right -= width;
 
-        const textHeight = this._tooltipLineHeight + Math.floor(tooltipHorizontalPadding/2);
+        const textHeight = this._addonFontLineHeight + Math.floor(tooltipHorizontalPadding/2);
 
         const x = drawableArea.right + tickerHorizontalPadding;
         let y = drawableArea.top + textHeight;
@@ -663,12 +663,12 @@ export class CanvasGraphService {
 
         ctx.save();
 
-        ctx.font = tooltipFont;
+        ctx.font = graphAddonFont;
         ctx.textBaseline = "middle";
         ctx.textAlign = "left";
 
-        const boxLength = this._tooltipLineHeight;
-        const textHeight = this._tooltipLineHeight + Math.floor(tooltipHorizontalPadding / 2);
+        const boxLength = this._addonFontLineHeight;
+        const textHeight = this._addonFontLineHeight + Math.floor(tooltipHorizontalPadding / 2);
 
         // initialize width with cached value or measure width of longest text and update cache.
         let width: number;

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -115,7 +115,7 @@ export class CanvasGraphService {
 
         for (let i = 0; i < maximumDatasetsAllowed; i++) {
             this._tooltipItems.push({text: "", color: ""});
-            this._tickerItems.push({id: "", max: 0, min: 0});
+            this._tickerItems.push({text: "", id: "", max: 0, min: 0});
         }
 
         if (!this._ctx) {
@@ -306,13 +306,15 @@ export class CanvasGraphService {
             }
 
             const valueMinMax = this._getMinMax(bounds, idOffset);
-            const text = `${id}: (max: ${valueMinMax.max.toFixed(2)}, min: ${valueMinMax.min.toFixed(2)})`
+            const latestValue = this.datasets.data.at(this.datasets.startingIndices.at(bounds.end - 1) + PerformanceViewerCollector.SliceDataOffset + idOffset);
+            const text = `${id}: ${latestValue.toFixed(2)} (max: ${valueMinMax.max.toFixed(2)}, min: ${valueMinMax.min.toFixed(2)})`
             if (text.length > longestText.length) {
                 longestText = text;
             }
             this._tickerItems[numberOfTickers].id = id;
             this._tickerItems[numberOfTickers].max = valueMinMax.max;
             this._tickerItems[numberOfTickers].min = valueMinMax.min;
+            this._tickerItems[numberOfTickers].text = text;
             numberOfTickers++;
         });
 
@@ -322,7 +324,8 @@ export class CanvasGraphService {
         ctx.textAlign = "left";
 
         let width: number;
-        if (this._tickerTextCache.text === longestText) {
+        // if the lengths are the same the estimate should be good enough given the padding.
+        if (this._tickerTextCache.text.length === longestText.length) {
             width = this._tickerTextCache.width;
         } else {
             width = ctx.measureText(longestText).width + 2 * tickerHorizontalPadding;
@@ -338,8 +341,7 @@ export class CanvasGraphService {
         let y = drawableArea.top + textHeight;
         for (let i = 0; i < numberOfTickers; i++) {
             const tickerItem = this._tickerItems[i];
-            const text = `${tickerItem.id}: (max: ${tickerItem.max.toFixed(2)}, min: ${tickerItem.min.toFixed(2)})`
-            ctx.fillText(text, x, y);
+            ctx.fillText(tickerItem.text, x, y);
             y += textHeight;
         }
         ctx.restore();

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -60,6 +60,7 @@ export interface IGraphDrawableArea {
  */
 export interface IPerfTicker extends IPerfMinMax {
     id: string;
+    text: string;
 }
 
 /**

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -56,6 +56,13 @@ export interface IGraphDrawableArea {
 }
 
 /**
+ * Defines the structure representing necessary ticker information. 
+ */
+export interface IPerfTicker extends IPerfMinMax {
+    id: string;
+}
+
+/**
  * Defines what settings our canvas graphing service accepts
  */
 export interface ICanvasGraphServiceSettings {


### PR DESCRIPTION
This PR adds basic ticker capability to provide the user with the bounds of the graph (what the bottom most and top most value mean in the view.) and the most current value. Completes the "Have tickers update with relevant info on the right side bar" #10566 

Here is a video showing what has been added:

https://user-images.githubusercontent.com/32103099/127904757-57cdcb3f-771a-418c-852f-611910e5c26b.mp4

