### PR TITLE
Add CSV importing and exporting of performance data!

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -3,12 +3,14 @@ import { Scene } from "babylonjs/scene";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { ButtonLineComponent } from "../../../../sharedUiComponents/lines/buttonLineComponent";
+import { FileButtonLineComponent } from "../../../../sharedUiComponents/lines/fileButtonLineComponent";
 import { CanvasGraphComponent } from "../../../graph/canvasGraphComponent";
 import { IPerfLayoutSize } from "../../../graph/graphSupportingTypes";
 import { PopupComponent } from "../../../popupComponent";
 import { PerformanceViewerSidebarComponent } from "./performanceViewerSidebarComponent";
 import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollector";
 import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
+import { Tools } from "babylonjs/Misc/tools";
 
 require('./scss/performanceViewer.scss');
 
@@ -20,7 +22,7 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = false;
+const isEnabled = true;
 
 export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentProps> = (props: IPerformanceViewerComponentProps) => {
     const { scene } = props;
@@ -39,6 +41,12 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
 
     const onPerformanceButtonClick = () => {
         setIsOpen(true);
+    }
+
+    const onLoadClick = (file: File) => {
+        Tools.ReadFile(file, (data: string) => {
+            console.log(data.split('\n').map((str) => str.replace('\r', '').split(',').filter((s) =>  s.length > 0)).filter((line) => line.length > 0));
+        });
     }
 
     const onResize = () => {
@@ -70,7 +78,10 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
         <>
             {
                 isEnabled &&
-                <ButtonLineComponent label="Open Perf Viewer" onClick={onPerformanceButtonClick} />
+                <>
+                    <ButtonLineComponent label="Open Perf Viewer" onClick={onPerformanceButtonClick} />
+                    <FileButtonLineComponent accept="csv" label="Load CSV" onClick={onLoadClick} />
+                </>
             }
             {
                 isOpen &&

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -211,6 +211,9 @@ export class PerformanceViewerCollector {
         this.metadataObservable.notifyObservers(this._datasetMeta);
     }
 
+    public loadFromFileData(data: string) {
+    }
+
     /**
      * Starts the realtime collection of data.
      * @param shouldPreserve optional boolean param, if set will preserve the dataset between calls of start.

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -21,6 +21,9 @@ const timestampColHeader = "timestamp";
 // header for the numPoints column
 const numPointsColHeader = "numPoints";
 
+// regex to capture all carriage returns in the string.
+const carriageReturnRegex = /\r/g;
+
 /**
  * The collector class handles the collection and storage of data into the appropriate array.
  * The collector also handles notifying any observers of any updates.
@@ -248,14 +251,12 @@ export class PerformanceViewerCollector {
      */
     public loadFromFileData(data: string): boolean {
         const lines =
-            data.split('\n')
+            data.replace(carriageReturnRegex, '').split('\n')
                 .map((line) => (
-                    line.replace('\r', '')
-                        .split(',')
+                    line.split(',')
                         .filter((s) =>  s.length > 0)
                 ))
                 .filter((line) => line.length > 0);
-
         const timestampIndex = 0;
         const numPointsIndex = PerformanceViewerCollector.NumberOfPointsOffset;
         if (lines.length < 2) {


### PR DESCRIPTION
This PR adds the ability to do importing, exporting and recording of perf data. The recording can take place without having opened the window now which is super useful for mobile users, because opening the performance viewer for them will give inaccurate values for draw calls and such. The exporting and importing is done via csv to also be able to view it in something like excel if needed. 

Finishes CSV related items in #10566 

A gif of the added features:
![LiveDataExportLoad](https://user-images.githubusercontent.com/32103099/128092980-b5e7f531-53ae-4989-b031-8d4257b9122e.gif)