### PR TITLE
Fix context restore for .ktx2 textures

### DIFF
--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -193,7 +193,7 @@ export class SkyMaterial extends PushMaterial {
         if (defines.IMAGEPROCESSINGPOSTPROCESS !== scene.imageProcessingConfiguration.applyByPostProcess) {
             defines.markAsMiscDirty();
         }
-       
+
         // Get correct effect
         if (defines.isDirty) {
             defines.markAsProcessed();

--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -190,6 +190,10 @@ export class SkyMaterial extends PushMaterial {
         // Attribs
         MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, false);
 
+        if (defines.IMAGEPROCESSINGPOSTPROCESS !== scene.imageProcessingConfiguration.applyByPostProcess) {
+            defines.markAsMiscDirty();
+        }
+       
         // Get correct effect
         if (defines.isDirty) {
             defines.markAsProcessed();

--- a/src/Materials/Textures/internalTexture.ts
+++ b/src/Materials/Textures/internalTexture.ts
@@ -365,7 +365,7 @@ export class InternalTexture {
                     proxy._swapAndDie(this, false);
                     rebuildSamples();
                     this.isReady = true;
-                }, null, this._buffer, undefined, this.format, undefined, undefined, undefined, undefined, this._useSRGBBuffer);
+                }, null, this._buffer, undefined, this.format, this._extension, undefined, undefined, undefined, this._useSRGBBuffer);
                 return;
 
             case InternalTextureSource.Raw:

--- a/src/Misc/khronosTextureContainer2.ts
+++ b/src/Misc/khronosTextureContainer2.ts
@@ -238,6 +238,7 @@ export class KhronosTextureContainer2 {
             }
         }
 
+        internalTexture._extension = ".ktx2";
         internalTexture.width = data.mipmaps[0].width;
         internalTexture.height = data.mipmaps[0].height;
         internalTexture.isReady = true;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/trying-to-get-a-handle-on-webgl-context-lost/19848/24

Also fix the effect for the sky material not being rebuilt when `scene.imageProcessingConfiguration.applyByPostProcess` changes.