### PR TITLE
Add scene extension for the performance collector.

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -23,7 +23,7 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = true;
+const isEnabled = false;
 
 // list of strategies to add to perf graph automatically.
 const defaultStrategies = [

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -11,6 +11,7 @@ import { PerformanceViewerSidebarComponent } from "./performanceViewerSidebarCom
 import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollector";
 import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
 import { Tools } from "babylonjs/Misc/tools";
+import 'babylonjs/Misc/PerformanceViewer/performanceViewerSceneExtension';
 
 require('./scss/performanceViewer.scss');
 
@@ -22,10 +23,15 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = false;
+const isEnabled = true;
 
 // list of strategies to add to perf graph automatically.
-const defaultStrategies = [PerfCollectionStrategy.GpuFrameTimeStrategy(), PerfCollectionStrategy.FpsStrategy()];
+const defaultStrategies = [
+                            PerfCollectionStrategy.GpuFrameTimeStrategy(),
+                            PerfCollectionStrategy.FpsStrategy(), 
+                            PerfCollectionStrategy.DrawCallsStrategy(),
+                            PerfCollectionStrategy.ActiveMeshesStrategy(),
+                        ];
 
 enum RecordingState {
     NotRecording = "Begin Recording",
@@ -93,7 +99,8 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     }
 
     useEffect(() => {
-        const perfCollector = new PerformanceViewerCollector(scene, defaultStrategies);
+        const perfCollector = scene._getPerfCollector();
+        perfCollector.addCollectionStrategies(...defaultStrategies);
         setPerformanceCollector(perfCollector);
     }, []);
 

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -465,7 +465,7 @@ export class CanvasGraphService {
     private _getPixelForNumber(num: number, minMax: IPerfMinMax, startingPixel: number, spaceAvailable: number, shouldFlipValue: boolean) {
         const { min, max } = minMax;
         // Perform a min-max normalization to rescale the value onto a [0, 1] scale given the min and max of the dataset.
-        let normalizedValue = (num - min) / (max - min);
+        let normalizedValue = max !== min ? (num - min) / (max - min) : 1;
 
         // if we should make this a [1, 0] range instead (higher numbers = smaller pixel value)
         if (shouldFlipValue) {

--- a/src/Misc/PerformanceViewer/index.ts
+++ b/src/Misc/PerformanceViewer/index.ts
@@ -1,3 +1,4 @@
 export * from "./performanceViewerCollector";
 export * from "./performanceViewerCollectionStrategies";
 export * from "./dynamicFloat32Array";
+export * from "./performanceViewerSceneExtension";

--- a/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
@@ -7,4 +7,4 @@ Scene.prototype._getPerfCollector = function(this: Scene): PerformanceViewerColl
     }
 
     return this._perfCollector;
-}
+};

--- a/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
@@ -1,0 +1,10 @@
+import { Scene } from "../../scene";
+import { PerformanceViewerCollector } from "./performanceViewerCollector";
+
+Scene.prototype._getPerfCollector = function(): PerformanceViewerCollector {
+    if (!this._perfCollector) {
+        this._perfCollector = new PerformanceViewerCollector(this);
+    }
+
+    return this._perfCollector;
+}

--- a/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerSceneExtension.ts
@@ -1,7 +1,7 @@
 import { Scene } from "../../scene";
 import { PerformanceViewerCollector } from "./performanceViewerCollector";
 
-Scene.prototype._getPerfCollector = function(): PerformanceViewerCollector {
+Scene.prototype._getPerfCollector = function(this: Scene): PerformanceViewerCollector {
     if (!this._perfCollector) {
         this._perfCollector = new PerformanceViewerCollector(this);
     }

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -5185,8 +5185,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         });
     }
 
-    /** @hidden */
-    public _perfCollector: Nullable<PerformanceViewerCollector> = null;
+    /**
+     * Internal perfCollector instance used for sharing between inspector and playground.
+     * Marked as protected to allow sharing between prototype extensions, but disallow access at toplevel. 
+     */
+    protected _perfCollector: Nullable<PerformanceViewerCollector> = null;
 
     /** @hidden */
     public _getPerfCollector(): PerformanceViewerCollector {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -66,7 +66,7 @@ declare type MorphTargetManager = import("./Morph/morphTargetManager").MorphTarg
 declare type Effect = import("./Materials/effect").Effect;
 declare type MorphTarget = import("./Morph/morphTarget").MorphTarget;
 declare type WebVRFreeCamera = import("./Cameras/VR/webVRCamera").WebVRFreeCamera;
-declare type PerformanceViewerCollector = import("Misc/PerformanceViewer/performanceViewerCollector").PerformanceViewerCollector;
+declare type PerformanceViewerCollector = import("./Misc/PerformanceViewer/performanceViewerCollector").PerformanceViewerCollector;
 
 /**
  * Define an interface for all classes that will hold resources

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -5187,7 +5187,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
     /**
      * Internal perfCollector instance used for sharing between inspector and playground.
-     * Marked as protected to allow sharing between prototype extensions, but disallow access at toplevel. 
+     * Marked as protected to allow sharing between prototype extensions, but disallow access at toplevel.
      */
     protected _perfCollector: Nullable<PerformanceViewerCollector> = null;
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -66,6 +66,7 @@ declare type MorphTargetManager = import("./Morph/morphTargetManager").MorphTarg
 declare type Effect = import("./Materials/effect").Effect;
 declare type MorphTarget = import("./Morph/morphTarget").MorphTarget;
 declare type WebVRFreeCamera = import("./Cameras/VR/webVRCamera").WebVRFreeCamera;
+declare type PerformanceViewerCollector = import("Misc/PerformanceViewer/performanceViewerCollector").PerformanceViewerCollector;
 
 /**
  * Define an interface for all classes that will hold resources
@@ -5182,5 +5183,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 reject(error);
             });
         });
+    }
+
+    /** @hidden */
+    public _perfCollector: Nullable<PerformanceViewerCollector> = null;
+
+    /** @hidden */
+    public _getPerfCollector(): PerformanceViewerCollector {
+        throw _DevTools.WarnImport("performanceViewerSceneExtension");
     }
 }


### PR DESCRIPTION
This PR Adds a scene extension for the PerformanceCollector 😄 it also adds additional defaults to the performance graph and fixes some bugs surrounding if max = min (now it shows at top of graph instead of not showing at all). Completes the "Add activemeshes, frame time and draw calls to the graph" and the "add a scene extension" tasks in #10566 

This scene extension is public hidden for now, until everything is ready for use by the user.