### PR TITLE
Fix error handling in basis texture

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -275,6 +275,7 @@
 - Fix discrete animation not looping correctly ([#10694](https://github.com/BabylonJS/Babylon.js/issues/10694)) ([Popov72](https://github.com/Popov72))
 - Fix support for camera output render targets ([Popov72](https://github.com/Popov72))
 - Fix `bakeTransformIntoVertices` not working when using `rotationQuaternion` + sometimes inverting winding ([Popov72](https://github.com/Popov72))
+- Fix error handling in basis texture loading ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Materials/Textures/Loaders/basisTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/basisTextureLoader.ts
@@ -56,8 +56,12 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
                 onLoad();
             }
         }).catch((err) => {
-            Tools.Warn("Failed to transcode Basis file, transcoding may not be supported on this device");
+            const errorMessage = "Failed to transcode Basis file, transcoding may not be supported on this device";
+            Tools.Warn(errorMessage);
             texture.isReady = true;
+            if (onError) {
+                onError(err);
+            }
         });
     }
 
@@ -68,7 +72,7 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
      * @param callback defines the method to call once ready to upload
      */
     public loadData(data: ArrayBufferView, texture: InternalTexture,
-        callback: (width: number, height: number, loadMipmap: boolean, isCompressed: boolean, done: () => void) => void): void {
+        callback: (width: number, height: number, loadMipmap: boolean, isCompressed: boolean, done: () => void, failedLoading?: boolean) => void): void {
         var caps = texture.getEngine().getCaps();
         var transcodeConfig = {
             supportedCompressionFormats: {
@@ -87,7 +91,7 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
         }).catch((err) => {
             Tools.Warn("Failed to transcode Basis file, transcoding may not be supported on this device");
             callback(0, 0, false, false, () => {
-            });
+            }, true);
         });
     }
 }


### PR DESCRIPTION
If the basis wasm and js files failed to load no error would have been triggered and the texture load would have thrown an exception. 

After merging, this PG - https://www.babylonjs-playground.com/#JTG6VF#2 will show the error window and not throw an exception in the console.

Fixes #10829