### PR TITLE
Added custom string events to performance viewer

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -115,7 +115,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     useEffect(() => {
         if (recordingState === RecordingState.Recording) {
             if (performanceCollector?.hasLoadedData) {
-                performanceCollector?.clear();
+                performanceCollector?.clear(true);
                 performanceCollector?.addCollectionStrategies(...defaultStrategies);
             }
             performanceCollector?.start();

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -1,5 +1,5 @@
 import { Scene } from "../../scene";
-import { IPerfDatasets, IPerfMetadata } from "../interfaces/iPerfViewer";
+import { IPerfCustomEvent, IPerfDatasets, IPerfMetadata } from "../interfaces/iPerfViewer";
 import { EventState, Observable } from "../observable";
 import { PrecisionDate } from "../precisionDate";
 import { Tools } from "../tools";
@@ -33,6 +33,8 @@ export class PerformanceViewerCollector {
     private _strategies: Map<string, IPerfViewerCollectionStrategy>;
     private _startingTimestamp: number;
     private _hasLoadedData: boolean;
+    private readonly _customEventObservable: Observable<IPerfCustomEvent>;
+    private readonly _eventRestoreSet: Set<string>;
 
     /**
      * Datastructure containing the collected datasets. Warning: you should not modify the values in here, data will be of the form [timestamp, numberOfPoints, value1, value2..., timestamp, etc...]
@@ -75,10 +77,81 @@ export class PerformanceViewerCollector {
         };
         this._strategies = new Map<string, IPerfViewerCollectionStrategy>();
         this._datasetMeta = new Map<string, IPerfMetadata>();
+        this._eventRestoreSet = new Set();
+        this._customEventObservable = new Observable();
         this.datasetObservable = new Observable();
         this.metadataObservable = new Observable((observer) => observer.callback(this._datasetMeta, new EventState(0)));
         if (_enabledStrategyCallbacks) {
             this.addCollectionStrategies(..._enabledStrategyCallbacks);
+        }
+    }
+
+    /**
+     * Registers a custom string event which will be callable via sendEvent, this method allows counting of occurences of an event being triggered.
+     * @param name The name of the event to register
+     * @param forceUpdate if the code should force add an event, and replace the last one.
+     * @returns The event registered, used in sendEvent
+     */
+    public registerEvent(name: string, forceUpdate?: boolean): IPerfCustomEvent | undefined {
+        if (this._strategies.has(name) && !forceUpdate) {
+            return;
+        }
+
+        if (this._strategies.has(name) && forceUpdate) {
+            this._strategies.get(name)?.dispose();
+            this._strategies.delete(name);
+        }
+
+        const strategy: PerfStrategyInitialization = (scene) => {
+            let counter: number = 0;
+            let value: number = 0;
+
+            const afterRenderObserver = scene.onAfterRenderObservable.add(() => {
+                value = counter;
+                counter = 0;
+            });
+
+            const stringObserver = this._customEventObservable.add((eventVal) => {
+                if (name === eventVal.name) {
+                    counter++;
+                }
+            });
+
+            return {
+                id: name,
+                getData: () => value,
+                dispose: () => {
+                    scene.onAfterRenderObservable.remove(afterRenderObserver);
+                    this._customEventObservable.remove(stringObserver);
+                }
+            };
+        };
+        const event: IPerfCustomEvent = {
+            name
+        };
+
+        this._eventRestoreSet.add(name);
+        this.addCollectionStrategies(strategy);
+
+        return event;
+    }
+
+    /**
+     * Lets the perf collector know there has been a new occurence of an event.
+     * @param event the event to handle an occurence for
+     */
+    public sendEvent(event: IPerfCustomEvent) {
+        this._customEventObservable.notifyObservers(event);
+    }
+
+    /**
+     * This event restores all custom string events if necessary.
+     */
+    private _restoreStringEvents() {
+        if (this._eventRestoreSet.size !== this._customEventObservable.observers.length) {
+            this._eventRestoreSet.forEach((event) => {
+                this.registerEvent(event, true);
+            });
         }
     }
 
@@ -89,7 +162,6 @@ export class PerformanceViewerCollector {
     public addCollectionStrategies(...strategyCallbacks: PerfStrategyInitialization[]) {
         for (const strategyCallback of strategyCallbacks) {
             const strategy = strategyCallback(this._scene);
-
             if (this._strategies.has(strategy.id)) {
                 strategy.dispose();
                 continue;
@@ -224,13 +296,19 @@ export class PerformanceViewerCollector {
 
     /**
      * Completely clear, data, ids, and strategies saved to this performance collector.
+     * @param preserveStringEventsRestore if it should preserve the string events, by default will clear string events registered when called.
      */
-    public clear() {
+    public clear(preserveStringEventsRestore?: boolean) {
         this.datasets.data = new DynamicFloat32Array(initialArraySize);
         this.datasets.ids.length = 0;
         this.datasets.startingIndices = new DynamicFloat32Array(initialArraySize);
         this._datasetMeta.clear();
+        this._strategies.forEach((strategy) => strategy.dispose());
         this._strategies.clear();
+
+        if (!preserveStringEventsRestore) {
+            this._eventRestoreSet.clear();
+        }
         this._hasLoadedData = false;
     }
 
@@ -317,6 +395,7 @@ export class PerformanceViewerCollector {
         this.datasets.data = parsedDatasets.data;
         this.datasets.startingIndices = parsedDatasets.startingIndices;
         this._datasetMeta.clear();
+        this._strategies.forEach((strategy) => strategy.dispose());
         this._strategies.clear();
 
         // populate metadata.
@@ -373,6 +452,7 @@ export class PerformanceViewerCollector {
         }
         this._startingTimestamp = PrecisionDate.Now;
         this._scene.onBeforeRenderObservable.add(this._collectDataAtFrame);
+        this._restoreStringEvents();
     }
 
     /**

--- a/src/Misc/interfaces/iPerfViewer.ts
+++ b/src/Misc/interfaces/iPerfViewer.ts
@@ -34,3 +34,13 @@ import { DynamicFloat32Array } from "../PerformanceViewer/dynamicFloat32Array";
       */
      hidden?: boolean;
 }
+
+/**
+ * Defines the shape of a custom user registered event.
+ */
+export interface IPerfCustomEvent {
+   /**
+    * The name of the event.
+    */
+   name: string;
+}


### PR DESCRIPTION
This PR adds the ability to register custom string events and let the collector know that these events have triggered.

The registerEvent will give back an object which in this case is just the id, we do this to be a bit less error prone to spelling mistakes and passing just any string. 

The code used to power it was as simple as this:
![image](https://user-images.githubusercontent.com/32103099/128747753-44c767ad-4889-4f60-8ec3-0d814a2c2c81.png)


Here is a video of it in action!

https://user-images.githubusercontent.com/32103099/128747185-96d912d5-57ea-4d68-ae2a-2b7f502ccb5e.mp4

