### PR TITLE
Add tooltips to playground menu buttons

### DIFF
--- a/Playground/src/components/commandBarComponent.tsx
+++ b/Playground/src/components/commandBarComponent.tsx
@@ -75,7 +75,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         var engineOptions = [
             {
                 label: "WebGL2",
-                tooltip: "Use WebGL 2 API",
+                tooltip: "Use WebGL 2 Renderer",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL2",
                 onClick: () => {
@@ -85,7 +85,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
             },
             {
                 label: "WebGL",
-                tooltip: "Use WebGL 1 API",
+                tooltip: "Use WebGL 1 Renderer",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL",
                 onClick: () => {
@@ -98,7 +98,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         if (!!navigator.gpu) {
             engineOptions.splice(0,0, {
                 label: "WebGPU",
-                tooltip: "Use WebGPU API (experimental)",
+                tooltip: "Use WebGPU Renderer (experimental)",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGPU",
                 onClick: () => {

--- a/Playground/src/components/commandBarComponent.tsx
+++ b/Playground/src/components/commandBarComponent.tsx
@@ -62,6 +62,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         var versionOptions = Object.keys(Versions).map(key => {
             return { 
                 label: key,
+                tooltip: `Use Babylon.js version: ${key}`,
                 storeKey: "version",
                 isActive: activeVersion === key,
                 onClick: () => {
@@ -74,6 +75,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         var engineOptions = [
             {
                 label: "WebGL2",
+                tooltip: "Use WebGL 2 API",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL2",
                 onClick: () => {
@@ -83,6 +85,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
             },
             {
                 label: "WebGL",
+                tooltip: "Use WebGL 1 API",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL",
                 onClick: () => {
@@ -95,6 +98,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         if (!!navigator.gpu) {
             engineOptions.splice(0,0, {
                 label: "WebGPU",
+                tooltip: "Use WebGPU API (experimental)",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGPU",
                 onClick: () => {
@@ -116,6 +120,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                 <CommandDropdownComponent globalState={this.props.globalState} icon="options" tooltip="Options" items={[
                     {
                         label: "Theme",
+                        tooltip: "Controls the color scheme of the playground",
                         storeKey: "theme",
                         defaultValue: "Light",
                         subItems: [
@@ -128,6 +133,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                     },  
                     {
                         label: "Font size",
+                        tooltip: "Change the font size of the code editor",
                         storeKey: "font-size",
                         defaultValue: "14",
                         subItems: [
@@ -148,46 +154,56 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                     },
                     {
                         label: "Safe mode",
+                        tooltip: "Asks to confirm if you leave page without saving",
                         storeKey: "safe-mode",
                         defaultValue: false,
                         onCheck: () => {}
                     },                     
                     {
                         label: "CTRL+S to save",
+                        tooltip: "Saves your playground code online and creates a shareable link",
                         storeKey: "ctrl-s-to-save",
                         defaultValue: true,
                         onCheck: () => {}
                     }, 
                     {
                         label: "editor",
+                        tooltip: "Show/Hide the Code Editor",
                         storeKey: "editor",
                         defaultValue: true,
                         onCheck: (value) => {this.props.globalState.onEditorDisplayChangedObservable.notifyObservers(value)}
                     }, {
                         label: "minimap",
+                        tooltip: "Show/Hide the Code Minimap",
                         storeKey: "minimap",
                         defaultValue: true,
                         onCheck: (value) => {this.props.globalState.onMinimapChangedObservable.notifyObservers(value)}
                     }, {
                         label: "fullscreen",
+                        tooltip: "Makes the canvas fullscreen",
                         onClick: () => {this.props.globalState.onFullcreenRequiredObservable.notifyObservers()}
                     },                     {
                         label: "fullscreen editor",
+                        tooltip: "Makes the code editor fullscreen",
                         onClick: () => {this.props.globalState.onEditorFullcreenRequiredObservable.notifyObservers()}
                     },                   {
                         label: "format code",
+                        tooltip: "Autoformats code",
                         onClick: () => {this.props.globalState.onFormatCodeRequiredObservable.notifyObservers()}
                     },
                     {
                         label: "metadata",
+                        tooltip: "Edit the playground title, description, and tags",
                         onClick: () => {this.props.globalState.onDisplayMetadataObservable.notifyObservers(true)}
                     },
                     {
                         label: "QR code",
+                        tooltip: "Shows a QR code that points to this playground",
                         onClick: () => {this.props.globalState.onQRCodeRequiredObservable.notifyObservers(true)}
                     },                 
                     {
                         label: "Load Unity Toolkit",
+                        tooltip: "Loads the Unity Toolkit into the playground",
                         storeKey: "unity-toolkit",
                         defaultValue: false,
                         onCheck: () => {}

--- a/Playground/src/components/commandDropdownComponent.tsx
+++ b/Playground/src/components/commandDropdownComponent.tsx
@@ -11,6 +11,7 @@ interface ICommandDropdownComponentProps {
     hamburgerMode?: boolean;
     items: {
         label: string, 
+        tooltip: string,
         onClick?: () => void, 
         onCheck?: (value: boolean) => void, 
         storeKey?: string, 
@@ -96,7 +97,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                                     Utilities.StoreStringToStore(this.props.tooltip, m.label);
                                                     this.setState({isExpanded: false, activeState: m.label});
                                                 }
-                                            }} title={m.label}>
+                                            }} title={m.tooltip}>
                                                 <div className="command-dropdown-label-text">
                                                     {(m.isActive && !this.props.hamburgerMode ? "> " : "") + m.label}
                                                 </div>

--- a/Playground/src/components/commandDropdownComponent.tsx
+++ b/Playground/src/components/commandDropdownComponent.tsx
@@ -11,7 +11,7 @@ interface ICommandDropdownComponentProps {
     hamburgerMode?: boolean;
     items: {
         label: string, 
-        tooltip: string,
+        tooltip?: string,
         onClick?: () => void, 
         onCheck?: (value: boolean) => void, 
         storeKey?: string, 
@@ -97,7 +97,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                                     Utilities.StoreStringToStore(this.props.tooltip, m.label);
                                                     this.setState({isExpanded: false, activeState: m.label});
                                                 }
-                                            }} title={m.tooltip}>
+                                            }} title={m.tooltip || m.label}>
                                                 <div className="command-dropdown-label-text">
                                                     {(m.isActive && !this.props.hamburgerMode ? "> " : "") + m.label}
                                                 </div>

--- a/Playground/src/components/hamburgerMenu.tsx
+++ b/Playground/src/components/hamburgerMenu.tsx
@@ -96,7 +96,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
         var engineOptions = [
             {
                 label: "WebGL2",
-                tooltip: "WebGL 2.0",
+                tooltip: "Use WebGL 2 Renderer",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL2",
                 onClick: () => {
@@ -106,7 +106,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
             },
             {
                 label: "WebGL",
-                tooltip: "WebGL 1.0",
+                tooltip: "Use WebGL 1 Renderer",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL",
                 onClick: () => {
@@ -119,7 +119,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
         if (!!navigator.gpu) {
             engineOptions.splice(0,0, {
                 label: "WebGPU",
-                tooltip: "WebGPU",
+                tooltip: "Use WebGPU Renderer (experimental)",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGPU",
                 onClick: () => {

--- a/Playground/src/components/hamburgerMenu.tsx
+++ b/Playground/src/components/hamburgerMenu.tsx
@@ -83,6 +83,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
         var versionOptions = Object.keys(Versions).map(key => {
             return { 
                 label: key,
+                tooltip: `Use Babylon.js version: ${key}`,
                 storeKey: "version",
                 isActive: activeVersion === key,
                 onClick: () => {
@@ -95,6 +96,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
         var engineOptions = [
             {
                 label: "WebGL2",
+                tooltip: "WebGL 2.0",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL2",
                 onClick: () => {
@@ -104,6 +106,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
             },
             {
                 label: "WebGL",
+                tooltip: "WebGL 1.0",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGL",
                 onClick: () => {
@@ -116,6 +119,7 @@ export class HamburgerMenuComponent extends React.Component<IHamburgerMenuCompon
         if (!!navigator.gpu) {
             engineOptions.splice(0,0, {
                 label: "WebGPU",
+                tooltip: "WebGPU",
                 storeKey: "engineVersion",
                 isActive: activeEngineVersion === "WebGPU",
                 onClick: () => {

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -98,6 +98,9 @@
 - Added support for the material stencil properties ([Popov72](https://github.com/Popov72))
 - Added space + LMB panning to texture inspector to improve accessibility ([darraghjburke](https://github.com/darraghjburke))
 
+### Playground
+- Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
+
 ### NME
 
 - Increased float precision to 4 ([msDestiny14](https://github.com/msDestiny14))


### PR DESCRIPTION
Adds more informative tooltips to menu buttons in the playground. Some of the button's actions are not immediately obvious so I tried to provide hints to make it more clear.