### PR TITLE
Add support for cannon-es in plugin (

### DIFF
--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -8,7 +8,7 @@ import { PhysicsImpostor, IPhysicsEnabledObject } from "../../Physics/physicsImp
 import { PhysicsJoint, IMotorEnabledJoint, DistanceJointData, SpringJointData } from "../../Physics/physicsJoint";
 import { PhysicsEngine } from "../../Physics/physicsEngine";
 import { PhysicsRaycastResult } from "../physicsRaycastResult";
-import { TransformNode } from '../../Meshes/transformNode';
+import { TransformNode } from "../../Meshes/transformNode";
 
 //declare var require: any;
 declare var CANNON: any;
@@ -73,7 +73,11 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
     private _removeMarkedPhysicsBodiesFromWorld(): void {
         if (this._physicsBodysToRemoveAfterStep.length > 0) {
             this._physicsBodysToRemoveAfterStep.forEach((physicsBody) => {
-                this.world.remove(physicsBody);
+                if (typeof this.world.removeBody === "function") {
+                    this.world.removeBody(physicsBody);
+                } else {
+                    this.world.remove(physicsBody);
+                }
             });
             this._physicsBodysToRemoveAfterStep = [];
         }
@@ -136,7 +140,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             this.world.addEventListener("preStep", impostor.beforeStep);
             this.world.addEventListener("postStep", impostor.afterStep);
             impostor.physicsBody.addShape(shape);
-            if (typeof this.world.addBody === 'function') {
+            if (typeof this.world.addBody === "function") {
                 this.world.addBody(impostor.physicsBody);
             } else {
                 this.world.add(impostor.physicsBody);
@@ -185,7 +189,11 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
                         }
                         childImpostor.parent = mainImpostor;
                         childImpostor.resetUpdateFlags();
-                        mainImpostor.physicsBody.addShape(this._createShape(childImpostor), new this.BJSCANNON.Vec3(pPosition.x, pPosition.y, pPosition.z), new this.BJSCANNON.Quaternion(q.x, q.y, q.z, q.w));
+                        mainImpostor.physicsBody.addShape(
+                            this._createShape(childImpostor),
+                            new this.BJSCANNON.Vec3(pPosition.x, pPosition.y, pPosition.z),
+                            new this.BJSCANNON.Quaternion(q.x, q.y, q.z, q.w)
+                        );
                         //Add the mass of the children.
                         mainImpostor.physicsBody.mass += childImpostor.getParam("mass");
                     }
@@ -666,7 +674,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
         result.z = shape.halfExtents.z * 2;
     }
 
-    public dispose() { }
+    public dispose() {}
 
     private _extendNamespace() {
         //this will force cannon to execute at least one step when using interpolation

--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -8,7 +8,7 @@ import { PhysicsImpostor, IPhysicsEnabledObject } from "../../Physics/physicsImp
 import { PhysicsJoint, IMotorEnabledJoint, DistanceJointData, SpringJointData } from "../../Physics/physicsJoint";
 import { PhysicsEngine } from "../../Physics/physicsEngine";
 import { PhysicsRaycastResult } from "../physicsRaycastResult";
-import { TransformNode } from "../../Meshes/transformNode";
+import { TransformNode } from '../../Meshes/transformNode';
 
 //declare var require: any;
 declare var CANNON: any;
@@ -140,7 +140,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             this.world.addEventListener("preStep", impostor.beforeStep);
             this.world.addEventListener("postStep", impostor.afterStep);
             impostor.physicsBody.addShape(shape);
-            if (typeof this.world.addBody === "function") {
+            if (typeof this.world.addBody === 'function') {
                 this.world.addBody(impostor.physicsBody);
             } else {
                 this.world.add(impostor.physicsBody);
@@ -189,11 +189,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
                         }
                         childImpostor.parent = mainImpostor;
                         childImpostor.resetUpdateFlags();
-                        mainImpostor.physicsBody.addShape(
-                            this._createShape(childImpostor),
-                            new this.BJSCANNON.Vec3(pPosition.x, pPosition.y, pPosition.z),
-                            new this.BJSCANNON.Quaternion(q.x, q.y, q.z, q.w)
-                        );
+                        mainImpostor.physicsBody.addShape(this._createShape(childImpostor), new this.BJSCANNON.Vec3(pPosition.x, pPosition.y, pPosition.z), new this.BJSCANNON.Quaternion(q.x, q.y, q.z, q.w));
                         //Add the mass of the children.
                         mainImpostor.physicsBody.mass += childImpostor.getParam("mass");
                     }
@@ -674,7 +670,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
         result.z = shape.halfExtents.z * 2;
     }
 
-    public dispose() {}
+    public dispose() { }
 
     private _extendNamespace() {
         //this will force cannon to execute at least one step when using interpolation


### PR DESCRIPTION
Solves a problem similar to the one fixed with [#10117](https://github.com/BabylonJS/Babylon.js/pull/10117)

The plugin should check for _cannon-es_ method **`world.removeBody()`** when getting rid of physics body. Falls back to _cannonjs_ method **`world.remove()`**

Issue has been spotted and discussed on [babylon's forum](https://forum.babylonjs.com/t/cant-dispose-of-cloned-and-impostorized-meshes/22906/5).