### PR TITLE
[XR] Initial support for WebXR camera parenting

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -103,6 +103,7 @@
 - Added space + LMB panning to texture inspector to improve accessibility ([darraghjburke](https://github.com/darraghjburke))
 
 ### Playground
+
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME
@@ -164,6 +165,7 @@
 - Improved functionality of `WebXRNearInteraction` and updated coverage to be enabled on Behaviors and Gizmos ([rickfromwork](https://github.com/rickfromwork))
 - Introduced framework support for XR-based eye tracking. XR eye tracking is not yet supported in webXR, but is supported in BabylonNative using OpenXR. ([rickfromwork](https://github.com/rickfromwork))
 - Introduced spectator mode for desktop VR experiences and fixed an issue with XR camera in the activeCameras array ([#10560](https://github.com/BabylonJS/Babylon.js/issues/10560)) ([RaananW](https://github.com/RaananW))
+- Initial support for WebXR camera parenting ([#10593](https://github.com/BabylonJS/Babylon.js/issues/10593)) ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -349,6 +349,7 @@ export class Camera extends Node {
     private _refreshFrustumPlanes = true;
     private _storedFov: number;
     private _stateStored: boolean;
+    private _absoluteRotation: Quaternion = Quaternion.Identity();
 
     /**
      * Instantiates a new camera object.
@@ -1289,11 +1290,9 @@ export class Camera extends Node {
      * Returns the current camera absolute rotation
      */
     public get absoluteRotation(): Quaternion {
-        var result = Quaternion.Zero();
+        this.getWorldMatrix().decompose(undefined, this._absoluteRotation);
 
-        this.getWorldMatrix().decompose(undefined, result);
-
-        return result;
+        return this._absoluteRotation;
     }
 
     /**

--- a/src/XR/features/WebXRControllerPhysics.ts
+++ b/src/XR/features/WebXRControllerPhysics.ts
@@ -305,8 +305,8 @@ export class WebXRControllerPhysics extends WebXRAbstractFeature {
         this._delta = this._xrSessionManager.currentTimestamp - this._lastTimestamp;
         this._lastTimestamp = this._xrSessionManager.currentTimestamp;
         if (this._headsetMesh && this._headsetImpostor) {
-            this._headsetMesh.position.copyFrom(this._options.xrInput.xrCamera.position);
-            this._headsetMesh.rotationQuaternion!.copyFrom(this._options.xrInput.xrCamera.rotationQuaternion!);
+            this._headsetMesh.position.copyFrom(this._options.xrInput.xrCamera.globalPosition);
+            this._headsetMesh.rotationQuaternion!.copyFrom(this._options.xrInput.xrCamera.absoluteRotation);
             if (this._options.xrInput.xrCamera._lastXRViewerPose?.linearVelocity) {
                 const lv = this._options.xrInput.xrCamera._lastXRViewerPose.linearVelocity;
                 this._tmpVector.set(lv.x, lv.y, lv.z);

--- a/src/XR/features/WebXRControllerTeleportation.ts
+++ b/src/XR/features/WebXRControllerTeleportation.ts
@@ -456,7 +456,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                         if (index === -1) {
                             return false;
                         }
-                        return this._floorMeshes[index].absolutePosition.y < this._options.xrInput.xrCamera.position.y;
+                        return this._floorMeshes[index].absolutePosition.y < this._options.xrInput.xrCamera.globalPosition.y;
                     });
                     if (pick && pick.pickedMesh && this._options.pickBlockerMeshes && this._options.pickBlockerMeshes.indexOf(pick.pickedMesh) !== -1) {
                         return;

--- a/src/XR/webXRCamera.ts
+++ b/src/XR/webXRCamera.ts
@@ -225,6 +225,8 @@ export class WebXRCamera extends FreeCamera {
             const pos = view.transform.position;
             const orientation = view.transform.orientation;
 
+            currentRig.parent = this.parent;
+
             currentRig.position.set(pos.x, pos.y, pos.z);
             currentRig.rotationQuaternion.set(orientation.x, orientation.y, orientation.z, orientation.w);
             if (!this._scene.useRightHandedSystem) {

--- a/src/XR/webXRInput.ts
+++ b/src/XR/webXRInput.ts
@@ -98,7 +98,7 @@ export class WebXRInput implements IDisposable {
         this._frameObserver = this.xrSessionManager.onXRFrameObservable.add((frame) => {
             // Update controller pose info
             this.controllers.forEach((controller) => {
-                controller.updateFromXRFrame(frame, this.xrSessionManager.referenceSpace);
+                controller.updateFromXRFrame(frame, this.xrSessionManager.referenceSpace, this.xrCamera);
             });
         });
 

--- a/src/XR/webXRInputSource.ts
+++ b/src/XR/webXRInputSource.ts
@@ -6,6 +6,7 @@ import { Scene } from "../scene";
 import { WebXRAbstractMotionController } from "./motionController/webXRAbstractMotionController";
 import { WebXRMotionControllerManager } from "./motionController/webXRMotionControllerManager";
 import { Tools } from "../Misc/tools";
+import { WebXRCamera } from "./webXRCamera";
 
 let idCount = 0;
 
@@ -180,7 +181,7 @@ export class WebXRInputSource {
      * @param xrFrame xr frame to update the pose with
      * @param referenceSpace reference space to use
      */
-    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace) {
+    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace, xrCamera: WebXRCamera) {
         const pose = xrFrame.getPose(this.inputSource.targetRaySpace, referenceSpace);
         this._lastXRPose = pose;
 
@@ -195,6 +196,7 @@ export class WebXRInputSource {
                 this.pointer.rotationQuaternion!.z *= -1;
                 this.pointer.rotationQuaternion!.w *= -1;
             }
+            this.pointer.parent = xrCamera.parent;
         }
 
         // Update the grip mesh if it exists
@@ -211,6 +213,7 @@ export class WebXRInputSource {
                     this.grip.rotationQuaternion!.w *= -1;
                 }
             }
+            this.grip.parent = xrCamera.parent;
         }
         if (this.motionController) {
             // either update buttons only or also position, if in gamepad mode


### PR DESCRIPTION
It is now possible to set the camera's parent and make the camera follow a node.

#Fixes 10593

Note regarding this feature - the parent's position will not change the XR reference space like teleportation does. This presents a way for the WebXR camera to be moved without changing the reference space at all. 