### PR TITLE
Add CPU Strategy to performance graph and onComputePressureChanged to scene

### DIFF
--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -1,7 +1,7 @@
 import { EngineInstrumentation } from "../../Instrumentation/engineInstrumentation";
 import { Scene } from "../../scene";
 import { PrecisionDate } from "../precisionDate";
-
+declare var ComputePressureObserver: any;
 /**
  * Defines the general structure of what is necessary for a collection strategy.
  */
@@ -21,9 +21,6 @@ export interface IPerfViewerCollectionStrategy {
 }
 // Dispose which does nothing.
 const defaultDisposeImpl = () => {};
-
-// Temporary until implemented all getDatas.
-const defaultGetDataImpl = () => 0;
 
 /**
  * Initializer callback for a strategy
@@ -53,11 +50,26 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the cpu utilization strategy
      */
     public static CpuStrategy(): PerfStrategyInitialization {
+        let observer: any;
+        let value: number = 0;
+        function callback(update: any) {
+            value = update.cpuUtilization;
+        }
+          
+          
+        if ('ComputePressureObserver' in window) {
+            observer = new ComputePressureObserver(callback, {
+                // Thresholds divide the interval [0.0 .. 1.0] into ranges.
+                cpuUtilizationThresholds: [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95],
+            });
+            observer.observe && observer.observe();
+        }
+
         return () => {
             return {
                 id: "cpu utilization",
-                getData: defaultGetDataImpl,
-                dispose: defaultDisposeImpl,
+                getData: () => value,
+                dispose: () => observer?.unobserve && observer?.unobserve(),
             };
         };
     }

--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -1,7 +1,7 @@
 import { EngineInstrumentation } from "../../Instrumentation/engineInstrumentation";
 import { Scene } from "../../scene";
 import { PrecisionDate } from "../precisionDate";
-declare var ComputePressureObserver: any;
+
 /**
  * Defines the general structure of what is necessary for a collection strategy.
  */
@@ -50,26 +50,15 @@ export class PerfCollectionStrategy {
      * @returns the initializer for the cpu utilization strategy
      */
     public static CpuStrategy(): PerfStrategyInitialization {
-        let observer: any;
-        let value: number = 0;
-        function callback(update: any) {
-            value = update.cpuUtilization;
-        }
-          
-          
-        if ('ComputePressureObserver' in window) {
-            observer = new ComputePressureObserver(callback, {
-                // Thresholds divide the interval [0.0 .. 1.0] into ranges.
-                cpuUtilizationThresholds: [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95],
+        return (scene) => {
+            let value = 0;
+            const computePressureObserver = scene.onComputePressureChanged.add((update) => {
+                value = update.cpuUtilization;
             });
-            observer.observe && observer.observe();
-        }
-
-        return () => {
             return {
                 id: "cpu utilization",
                 getData: () => value,
-                dispose: () => observer?.unobserve && observer?.unobserve(),
+                dispose: () => scene.onComputePressureChanged.remove(computePressureObserver),
             };
         };
     }

--- a/src/Misc/computePressure.ts
+++ b/src/Misc/computePressure.ts
@@ -1,7 +1,7 @@
 /**
  * A wrapper for the experimental compute pressure api which allows a callback to be called whenever certain thresholds are met.
  */
-export class ComputePressureObserver {
+export class ComputePressureObserverWrapper {
     private _observer: any;
     /**
      * A compute pressure observer will call this callback, whenever these thresholds are met.
@@ -9,7 +9,7 @@ export class ComputePressureObserver {
      * @param thresholds An object containing the thresholds used to decide what value to to return for each update property (average of start and end of a threshold boundary).
      */
     constructor(callback: (update: IComputePressureData) => void, thresholds: IComputePressureThresholds) {
-        if (ComputePressureObserver.IsAvailable) {
+        if (ComputePressureObserverWrapper.IsAvailable) {
             this._observer = new (<any>window).ComputePressureObserver(callback, thresholds);
         }
     }

--- a/src/Misc/computePressure.ts
+++ b/src/Misc/computePressure.ts
@@ -1,0 +1,59 @@
+/**
+ * A wrapper for the experimental compute pressure api which allows a callback to be called whenever certain thresholds are met.
+ */
+export class ComputePressureObserver {
+    private _observer: any;
+    /**
+     * A compute pressure observer will call this callback, whenever these thresholds are met.
+     * @param callback The callback that is called whenever thresholds are met.
+     * @param thresholds An object containing the thresholds used to decide what value to to return for each update property (average of start and end of a threshold boundary).
+     */
+    constructor(callback: (update: IComputePressureData) => void, thresholds: IComputePressureThresholds) {
+        if ('ComputePressureObserver' in window) {
+            this._observer = new (<any>window).ComputePressureObserver(callback, thresholds);
+        }
+    }
+
+    /**
+     * Method that must be called to begin observing changes, and triggering callbacks.
+     */
+    observe(): void {
+        this._observer?.observe && this._observer?.observe();
+    }
+
+    /**
+     * Method that must be called to stop observing changes and triggering callbacks (cleanup function).
+     */
+    unobserve(): void {
+        this._observer?.unobserve && this._observer?.unobserve();
+    }
+}
+
+/**
+ * An interface defining the shape of the thresholds parameter in the experimental compute pressure api
+ */
+export interface IComputePressureThresholds {
+    /**
+     * Thresholds to make buckets out of for the cpu utilization, the average between the start and end points of a threshold will be returned to the callback.
+     */
+    cpuUtilizationThresholds: number[];
+    /**
+     * Thresholds to make buckets out of for the cpu speed, the average between the start and end points of a threshold will be returned to the callback.
+     * 0.5 represents base speed.
+     */
+    cpuSpeedThresholds: number[];
+}
+
+/**
+ * An interface defining the shape of the data sent to the callback in the compute pressure observer.
+ */
+export interface IComputePressureData {
+    /**
+     * The cpu utilization which will be a number between 0.0 and 1.0.
+     */
+    cpuUtilization: number;
+    /**
+     * The cpu speed which will be a number between 0.0 and 1.0.
+     */
+    cpuSpeed: number;
+}

--- a/src/Misc/computePressure.ts
+++ b/src/Misc/computePressure.ts
@@ -9,9 +9,16 @@ export class ComputePressureObserver {
      * @param thresholds An object containing the thresholds used to decide what value to to return for each update property (average of start and end of a threshold boundary).
      */
     constructor(callback: (update: IComputePressureData) => void, thresholds: IComputePressureThresholds) {
-        if ('ComputePressureObserver' in window) {
+        if (ComputePressureObserver.IsAvailable) {
             this._observer = new (<any>window).ComputePressureObserver(callback, thresholds);
         }
+    }
+
+    /**
+     * Returns true if ComputePressureObserver is available for use, false otherwise.
+     */
+    public static get IsAvailable() {
+        return 'ComputePressureObserver' in window;
     }
 
     /**

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -55,4 +55,5 @@ export * from './timer';
 export * from "./copyTools";
 export * from "./reflector";
 export * from "./domManagement";
+export * from "./computePressure";
 export * from "./PerformanceViewer/index";

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -38,7 +38,7 @@ import { FileTools, LoadFileError, RequestFileError, ReadFileError } from './Mis
 import { IClipPlanesHolder } from './Misc/interfaces/iClipPlanesHolder';
 import { IPointerEvent } from "./Events/deviceInputEvents";
 import { LightConstants } from "./Lights/lightConstants";
-import { IComputePressureData, ComputePressureObserver } from "./Misc/computePressure";
+import { IComputePressureData, ComputePressureObserverWrapper } from "./Misc/computePressure";
 
 declare type Ray = import("./Culling/ray").Ray;
 declare type TrianglePickingPredicate = import("./Culling/ray").TrianglePickingPredicate;
@@ -1506,8 +1506,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             this._engine.onNewSceneAddedObservable.notifyObservers(this);
         }
 
-        if (ComputePressureObserver.IsAvailable) {
-            this._computePressureObserver = new ComputePressureObserver((update) => {
+        if (ComputePressureObserverWrapper.IsAvailable) {
+            this._computePressureObserver = new ComputePressureObserverWrapper((update) => {
                 this.onComputePressureChanged.notifyObservers(update);
             }, {
                 // Thresholds divide the interval [0.0 .. 1.0] into ranges.
@@ -5212,7 +5212,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         throw _DevTools.WarnImport("performanceViewerSceneExtension");
     }
 
-    private _computePressureObserver: ComputePressureObserver | undefined;
+    private _computePressureObserver: ComputePressureObserverWrapper | undefined;
 
     /**
      * An event triggered when the cpu usage/speed meets certain thresholds.

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -1506,7 +1506,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             this._engine.onNewSceneAddedObservable.notifyObservers(this);
         }
 
-        if ('ComputePressureObserver' in window) {
+        if (ComputePressureObserver.IsAvailable) {
             this._computePressureObserver = new ComputePressureObserver((update) => {
                 this.onComputePressureChanged.notifyObservers(update);
             }, {


### PR DESCRIPTION
This PR adds the ability to track cpu utilization in the performance graph, and the ability to subscribe to compute pressure changes by using the scene object.

Completes the "connect cpu usage to graph " in #10566 
Adds the "onComputePressureChanged" mentioned in #10464 