### PR TITLE
Updating TouchHolographicButton behaviour to match MRTK 2.0

### DIFF
--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -45,6 +45,8 @@ export class TouchHolographicButton extends TouchButton3D {
     private _plateMaterial: StandardMaterial;
     private _pickedPointObserver: Nullable<Observer<Nullable<Vector3>>>;
     private _pointerHoverObserver: Nullable<Observer<Vector3>>;
+    private _frontPlateDepth = 0.5;
+    private _backPlateDepth = 0.04;
 
     // Tooltip
     private _tooltipFade: Nullable<FadeInOutBehavior>;
@@ -223,6 +225,21 @@ export class TouchHolographicButton extends TouchButton3D {
             this._frontMaterial.rightBlobEnable = false;
         };
 
+        this.pointerDownAnimation = () => {
+            if (this._frontPlate) {
+                this._frontPlate.scaling.z *= 0.2;
+                this._frontPlate.position.z = (this._frontPlateDepth - (0.2 * this._frontPlateDepth)) / 2;
+                this._textPlate.position.z = -(this._backPlateDepth + (0.2 * this._frontPlateDepth)) / 2;
+            }
+        };
+        this.pointerUpAnimation = () => {
+            if (this._frontPlate) {
+                this._frontPlate.scaling.z *= 5;
+                this._frontPlate.position.z = (this._frontPlateDepth - this._frontPlateDepth) / 2;
+                this._textPlate.position.z = -(this._backPlateDepth + this._frontPlateDepth) / 2;
+            }
+        };
+
         this._pointerHoverObserver = this.onPointerMoveObservable.add((hoverPosition: Vector3) => {
             this._frontMaterial.globalLeftIndexTipPosition = hoverPosition;
         });
@@ -264,15 +281,16 @@ export class TouchHolographicButton extends TouchButton3D {
 
     // Mesh association
     protected _createNode(scene: Scene): TransformNode {
-        const collisionMesh = BoxBuilder.CreateBox((this.name ?? "TouchHolographicButton") + "_CollisionMesh", {
+        this.name = this.name ?? "TouchHolographicButton";
+        const collisionMesh = BoxBuilder.CreateBox(`${this.name}_collisionMesh`, {
             width: 1.0,
             height: 1.0,
-            depth: 1.0,
+            depth: this._frontPlateDepth,
         }, scene);
         collisionMesh.isPickable = true;
         collisionMesh.isNearPickable = true;
         collisionMesh.visibility = 0;
-        collisionMesh.scaling = new Vector3(1, 1, 0.5);
+        collisionMesh.position.z = -this._frontPlateDepth / 2;
 
         SceneLoader.ImportMeshAsync(
             undefined,
@@ -283,6 +301,7 @@ export class TouchHolographicButton extends TouchButton3D {
                 var importedFrontPlate = result.meshes[1];
                 importedFrontPlate.name = `${this.name}_frontPlate`;
                 importedFrontPlate.isPickable = false;
+                importedFrontPlate.scaling.z = this._frontPlateDepth;
                 importedFrontPlate.parent = collisionMesh;
                 if (!!this._frontMaterial) {
                     importedFrontPlate.material = this._frontMaterial;
@@ -290,30 +309,31 @@ export class TouchHolographicButton extends TouchButton3D {
                 this._frontPlate = importedFrontPlate;
             });
 
-        const backPlateDepth = 0.04;
         this._backPlate = BoxBuilder.CreateBox(
-            this.name + "BackMesh",
+            `${this.name}_backPlate`,
             {
                 width: 1.0,
                 height: 1.0,
-                depth: backPlateDepth,
+                depth: this._backPlateDepth,
             },
             scene
         );
 
-        this._backPlate.parent = collisionMesh;
-        this._backPlate.position.z = 0.5 - backPlateDepth / 2;
+        this._backPlate.position.z = this._backPlateDepth / 2;
         this._backPlate.isPickable = false;
 
         this._textPlate = <Mesh>super._createNode(scene);
-        this._textPlate.parent = collisionMesh;
-        this._textPlate.position.z = 0;
+        this._textPlate.name = `${this.name}_textPlate`;
         this._textPlate.isPickable = false;
+        this._textPlate.position.z = -this._frontPlateDepth / 2;
+
+        this._backPlate.addChild(collisionMesh);
+        this._backPlate.addChild(this._textPlate);
 
         this.collisionMesh = collisionMesh;
         this.collidableFrontDirection = this._backPlate.forward.negate(); // Mesh is facing the wrong way
 
-        return collisionMesh;
+        return this._backPlate;
     }
 
     protected _applyFacade(facadeTexture: AdvancedDynamicTexture) {

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -711,7 +711,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
             tmpDistanceSphereToCenter = Vector3.Distance(sphere.center, mesh.getAbsolutePosition());
             if (tmpDistanceSphereToCenter !== -1 && tmpDistanceSurfaceToCenter !== -1 && tmpDistanceSurfaceToCenter > tmpDistanceSphereToCenter) {
                 tmp = 0;
-                tmpVec.set(sphere.center.x, sphere.center.y, sphere.center.z);
+                tmpVec.copyFrom(sphere.center);
             }
 
             if (tmp !== -1 && tmp < distance) {

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -691,12 +691,12 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
         const tmpVec = TmpVectors.Vector3[1];
 
         let distance = +Infinity;
-        let tmp;
+        let tmp, tmpDistanceSphereToCenter, tmpDistanceSurfaceToCenter;
         const center = TmpVectors.Vector3[2];
-        const invert = TmpVectors.Matrix[0];
-        invert.copyFrom(mesh.getWorldMatrix());
-        invert.invert();
-        Vector3.TransformCoordinatesToRef(sphere.center, invert, center);
+        const worldToMesh = TmpVectors.Matrix[0];
+        worldToMesh.copyFrom(mesh.getWorldMatrix());
+        worldToMesh.invert();
+        Vector3.TransformCoordinatesToRef(sphere.center, worldToMesh, center);
 
         for (var index = 0; index < subMeshes.length; index++) {
             const subMesh = subMeshes[index];
@@ -705,6 +705,14 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
             Vector3.TransformCoordinatesToRef(tmpVec, mesh.getWorldMatrix(), tmpVec);
             tmp = Vector3.Distance(tmpVec, sphere.center);
+
+            // Check for finger inside of mesh
+            tmpDistanceSurfaceToCenter = Vector3.Distance(tmpVec, mesh.getAbsolutePosition());
+            tmpDistanceSphereToCenter = Vector3.Distance(sphere.center, mesh.getAbsolutePosition());
+            if (tmpDistanceSphereToCenter !== -1 && tmpDistanceSurfaceToCenter !== -1 && tmpDistanceSurfaceToCenter > tmpDistanceSphereToCenter) {
+                tmp = 0;
+                tmpVec.set(sphere.center.x, sphere.center.y, sphere.center.z);
+            }
 
             if (tmp !== -1 && tmp < distance) {
                 distance = tmp;


### PR DESCRIPTION
Button compresses on push, cursor sinks into button with finger to accurately show finger location in button.
This also fixes an issue with the button becoming unpressed too early, as the near interaction logic was only paying attention to the distance from the surface.

Done as part of #10846 