### PR TITLE
Added more readable timestamps to the performance graph.

### DIFF
--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -477,6 +477,12 @@ export class CanvasGraphService {
         ctx.restore();
     }
 
+    /**
+     * Given a timestamp (should be the maximum timestamp in view), this function returns the maximum unit the timestamp contains. 
+     * This information can be used for formatting purposes.
+     * @param timestamp the maximum timestamp to find the maximum timestamp unit for. 
+     * @returns The maximum unit the timestamp has.
+     */
     private _getTimestampUnit(timestamp: number): TimestampUnit {
         if (timestamp / msInHour > 1) {
             return TimestampUnit.Hours;
@@ -489,9 +495,14 @@ export class CanvasGraphService {
         }
     }
 
+    /**
+     * Given a timestamp and the interval unit, this function will parse the timestamp to the appropriate format.
+     * @param timestamp The timestamp to parse
+     * @param intervalUnit The maximum unit of the maximum timestamp in an interval.
+     * @returns a string representing the parsed timestamp.
+     */
     private _parseTimestamp(timestamp: number, intervalUnit: TimestampUnit): string {
         let parsedTimestamp = "";
-
         
         if (intervalUnit >= TimestampUnit.Hours) {
             const numHours = Math.floor(timestamp / msInHour);

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -66,7 +66,7 @@ const msInHour =  msInMinute * 60;
 const tooltipDebounceTime = 32;
 
 // time in ms to wait between draws
-const drawDebounceTime = 15;
+const drawThrottleTime = 15;
 
 /**
  * This function will debounce calls to functions.
@@ -83,6 +83,24 @@ function debounce(callback: (...args: any[]) => void, time: number) {
 }
 
 /**
+ * This function will throttle calls to functions.
+ * 
+ * @param callback callback to call.
+ * @param time time to wait between calls in ms.
+ */
+ function throttle(callback: (...args: any[]) => void, time: number) {
+    let lastCalledTime: number = 0;
+    return function (...args: any[]) {
+        const now = Date.now();
+        if (now - lastCalledTime < time) {
+            return;
+        }
+        lastCalledTime = now;
+        callback(...args);
+    }
+}
+
+/*
  * This class acts as the main API for graphing given a Here is where you will find methods to let the service know new data needs to be drawn,
  * let it know something has been resized, etc! 
  */
@@ -160,9 +178,9 @@ export class CanvasGraphService {
     /**
      * This method lets the service know it should get ready to update what it is displaying.
      */
-    public update = debounce(
+    public update = throttle(
         () => this._draw(),
-        drawDebounceTime
+        drawThrottleTime
     );
 
     public resize(size: IPerfLayoutSize) {

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -70,6 +70,9 @@ export interface ICanvasGraphServiceSettings {
     datasets: IPerfDatasets;
 }
 
+/**
+ * Defines the supported timestamp units.
+ */
 export enum TimestampUnit {
     Milliseconds = 0,
     Seconds = 1,

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -69,3 +69,10 @@ export interface IPerfTicker extends IPerfMinMax {
 export interface ICanvasGraphServiceSettings {
     datasets: IPerfDatasets;
 }
+
+export enum TimestampUnit {
+    Milliseconds = 0,
+    Seconds = 1,
+    Minutes = 2,
+    Hours = 3,
+}


### PR DESCRIPTION
This PR adds more readable timestamps to the performance graph by having the timestamps on the tickers be formatted appropriately. This PR also fixes a small issue when many update calls were being sent, in which the update function would stall due to being debounced. Instead, we throttle the update function which is more like what we need. This guarantees the at most once execution within a certain time frame.

Completes the "Convert current time to ms s minutes hour" task inside #10566 

Video (pay attention to the values at the bottom!):

https://user-images.githubusercontent.com/32103099/129421968-952da83d-22a4-431e-b7d3-ab7cabb3b93f.mp4

