### PR TITLE
Contain the perf collection buttons inside line container component.

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { ButtonLineComponent } from "../../../../sharedUiComponents/lines/buttonLineComponent";
 import { FileButtonLineComponent } from "../../../../sharedUiComponents/lines/fileButtonLineComponent";
+import { LineContainerComponent } from "../../../../sharedUiComponents/lines/lineContainerComponent";
 import { CanvasGraphComponent } from "../../../graph/canvasGraphComponent";
 import { IPerfLayoutSize } from "../../../graph/graphSupportingTypes";
 import { PopupComponent } from "../../../popupComponent";
@@ -12,7 +13,6 @@ import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/per
 import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
 import { Tools } from "babylonjs/Misc/tools";
 import 'babylonjs/Misc/PerformanceViewer/performanceViewerSceneExtension';
-import { LineContainerComponent } from "../../../../sharedUiComponents/lines/lineContainerComponent";
 
 require('./scss/performanceViewer.scss');
 

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -12,6 +12,7 @@ import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/per
 import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
 import { Tools } from "babylonjs/Misc/tools";
 import 'babylonjs/Misc/PerformanceViewer/performanceViewerSceneExtension';
+import { LineContainerComponent } from "../../../../sharedUiComponents/lines/lineContainerComponent";
 
 require('./scss/performanceViewer.scss');
 
@@ -132,12 +133,12 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
         <>
             {
                 isEnabled &&
-                <>
+                <LineContainerComponent title="Performance Viewer">
                     <ButtonLineComponent label="Open Realtime Perf Viewer" onClick={onPerformanceButtonClick} />
                     <FileButtonLineComponent accept="csv" label="Load Perf Viewer using CSV" onClick={onLoadClick} />
                     <ButtonLineComponent label="Export Perf to CSV" onClick={onExportClick} />
                     {!isOpen && <ButtonLineComponent label={recordingState} onClick={onToggleRecording} />}
-                </>
+                </LineContainerComponent>
             }
             {
                 isOpen &&


### PR DESCRIPTION
This PR adds a line container component around the buttons, previously they were at top level under fps.

Completes the " Group all the buttons inside of an "accordion" component like how the count and frame steps are." in #10566 


What it looks like now:
![image](https://user-images.githubusercontent.com/32103099/129422513-32cdcb73-46f6-446d-a7a5-a010d859b173.png)
