### PR TITLE
Added return to live button for the performance graph

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
@@ -5,11 +5,11 @@ interface IPerformancePlayheadButtonProps {
     returnToPlayhead: Observable<void>
 }
 export const PerformancePlayheadButtonComponent: React.FC<IPerformancePlayheadButtonProps> = ({returnToPlayhead}) => {
-    const onReturnToLiveClick = () => {
+    const onReturnToPlayheadClick = () => {
         returnToPlayhead.notifyObservers();
     }
 
     return (
-        <button className="performancePlayheadButton" onClick={onReturnToLiveClick} title="Return to Playhead">Return</button>
+        <button className="performancePlayheadButton" onClick={onReturnToPlayheadClick} title="Return to Playhead">Return</button>
     )
 }

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
@@ -1,0 +1,15 @@
+import { Observable } from 'babylonjs/Misc/observable';
+import * as React from 'react';
+
+interface IPerformancePlayheadButtonProps {
+    returnToPlayhead: Observable<void>
+}
+export const PerformancePlayheadButtonComponent: React.FC<IPerformancePlayheadButtonProps> = ({returnToPlayhead}) => {
+    const onReturnToLiveClick = () => {
+        returnToPlayhead.notifyObservers();
+    }
+
+    return (
+        <button className="performanceLiveButton" onClick={onReturnToLiveClick}>Return to Playhead</button>
+    )
+}

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performancePlayheadButtonComponent.tsx
@@ -10,6 +10,6 @@ export const PerformancePlayheadButtonComponent: React.FC<IPerformancePlayheadBu
     }
 
     return (
-        <button className="performanceLiveButton" onClick={onReturnToLiveClick}>Return to Playhead</button>
+        <button className="performancePlayheadButton" onClick={onReturnToLiveClick} title="Return to Playhead">Return</button>
     )
 }

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -25,7 +25,7 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = true;
+const isEnabled = false;
 
 // list of strategies to add to perf graph automatically.
 const defaultStrategies = [

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -13,6 +13,7 @@ import { PerformanceViewerCollector } from "babylonjs/Misc/PerformanceViewer/per
 import { PerfCollectionStrategy } from "babylonjs/Misc/PerformanceViewer/performanceViewerCollectionStrategies";
 import { Tools } from "babylonjs/Misc/tools";
 import 'babylonjs/Misc/PerformanceViewer/performanceViewerSceneExtension';
+import { PerformancePlayheadButtonComponent } from "./performancePlayheadButtonComponent";
 
 require('./scss/performanceViewer.scss');
 
@@ -24,7 +25,7 @@ interface IPerformanceViewerComponentProps {
 const initialWindowSize = { width: 1024, height: 512 };
 
 // Note this should be false when committed until the feature is fully working.
-const isEnabled = false;
+const isEnabled = true;
 
 // list of strategies to add to perf graph automatically.
 const defaultStrategies = [
@@ -46,6 +47,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
     const [recordingState, setRecordingState] = useState(RecordingState.NotRecording);
     const [ performanceCollector, setPerformanceCollector ] = useState<PerformanceViewerCollector | undefined>();
     const [layoutObservable] = useState(new Observable<IPerfLayoutSize>());
+    const [returnToLiveObservable] = useState(new Observable<void>());
     const popupRef = useRef<PopupComponent | null>(null);
 
     // do cleanup when the window is closed
@@ -152,8 +154,9 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
                 >
                     <div id="performance-viewer">
                         {performanceCollector && <>
+                            <PerformancePlayheadButtonComponent returnToPlayhead={returnToLiveObservable} />
                             <PerformanceViewerSidebarComponent collector={performanceCollector} />
-                            <CanvasGraphComponent id="performance-viewer-graph" layoutObservable={layoutObservable} scene={scene} collector={performanceCollector} />
+                            <CanvasGraphComponent id="performance-viewer-graph" returnToLiveObservable={returnToLiveObservable} layoutObservable={layoutObservable} scene={scene} collector={performanceCollector} />
                         </>}
                     </div>
                 </PopupComponent>

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -156,7 +156,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
                         {performanceCollector && <>
                             <PerformancePlayheadButtonComponent returnToPlayhead={returnToLiveObservable} />
                             <PerformanceViewerSidebarComponent collector={performanceCollector} />
-                            <CanvasGraphComponent id="performance-viewer-graph" returnToLiveObservable={returnToLiveObservable} layoutObservable={layoutObservable} scene={scene} collector={performanceCollector} />
+                            <CanvasGraphComponent id="performance-viewer-graph" returnToPlayheadObservable={returnToLiveObservable} layoutObservable={layoutObservable} scene={scene} collector={performanceCollector} />
                         </>}
                     </div>
                 </PopupComponent>

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
@@ -1,4 +1,4 @@
-$buttonHeight: 25px;
+$buttonHeight: 30px;
 
 #performance-viewer {
     display: grid;
@@ -8,11 +8,14 @@ $buttonHeight: 25px;
     grid-template-rows: $buttonHeight;
     grid-template-areas: ". liveButton"
                          "sidebar graph";
-    .performanceLiveButton {
+    .performancePlayheadButton {
         grid-area: liveButton;
         height: $buttonHeight;
-        width: 150px;
+        width: 100px;
         justify-self: right;
+        background-color: #dcdfe1;
+        color: #2e3f47;
+        outline: 2px #2e3f47;
         margin: 5px;
     }
 

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/scss/performanceViewer.scss
@@ -1,15 +1,27 @@
+$buttonHeight: 25px;
+
 #performance-viewer {
     display: grid;
     height: 100%;
     width: 100%;
     grid-template-columns: 25% 75%;
-    grid-template-areas: "sidebar graph";
+    grid-template-rows: $buttonHeight;
+    grid-template-areas: ". liveButton"
+                         "sidebar graph";
+    .performanceLiveButton {
+        grid-area: liveButton;
+        height: $buttonHeight;
+        width: 150px;
+        justify-self: right;
+        margin: 5px;
+    }
+
     #performance-viewer-graph {
-        grid-area: "graph";
+        grid-area: graph;
     }
 
     #performance-viewer-sidebar {
-        grid-area: "sidebar";
+        grid-area: sidebar;
         display: flex;
         flex-direction: column;
         

--- a/inspector/src/components/graph/canvasGraphComponent.tsx
+++ b/inspector/src/components/graph/canvasGraphComponent.tsx
@@ -12,10 +12,11 @@ interface ICanvasGraphComponentProps {
     scene: Scene;
     collector: PerformanceViewerCollector
     layoutObservable?: Observable<IPerfLayoutSize>;
+    returnToPlayheadObservable?: Observable<void>;
 }
 
 export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props: ICanvasGraphComponentProps) => {
-    const { id, collector, scene, layoutObservable } = props;
+    const { id, collector, scene, layoutObservable, returnToPlayheadObservable } = props;
     const canvasRef: React.MutableRefObject<HTMLCanvasElement | null>  = useRef(null);
 
     useEffect(() => {
@@ -53,12 +54,16 @@ export const CanvasGraphComponent: React.FC<ICanvasGraphComponentProps> = (props
             cs.metadata = meta;
             cs.update();
         };
+
+        const resetDataPosition = () => {
+            cs?.resetDataPosition();
+        }
         
         scene.onAfterRenderObservable.add(dataUpdated);
         collector.metadataObservable.add(metaUpdated);
 
         layoutObservable?.add(layoutUpdated);
-
+        returnToPlayheadObservable?.add(resetDataPosition);
         return () => {
             cs?.destroy();
             layoutObservable?.removeCallback(layoutUpdated);

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -183,6 +183,10 @@ export class CanvasGraphService {
         drawThrottleTime
     );
 
+    /**
+     * Update the canvas graph service with the new height and width of the canvas.
+     * @param size The new size of the canvas.
+     */
     public resize(size: IPerfLayoutSize) {
         const { _ctx: ctx } = this;
         const { width, height } = size;
@@ -198,6 +202,13 @@ export class CanvasGraphService {
         ctx.canvas.height = height;
 
         this.update();
+    }
+
+    /**
+     * Force resets the position in the data, effectively returning to the most current data.
+     */
+    public resetDataPosition() {
+        this._position = null;
     }
 
     /**


### PR DESCRIPTION
This PR simply adds a button with the word "Return" which returns the view to the latest data position. 

Completes the "Add a go back to live button" in #10566 