### PR TITLE
Fixing resizing behavior of HolographicSlate

### DIFF
--- a/gui/src/3D/controls/control3D.ts
+++ b/gui/src/3D/controls/control3D.ts
@@ -25,7 +25,7 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
     private _downPointerIds: { [id: number]: number } = {}; // Store number of pointer downs per ID, from near and far interactions
     private _isVisible = true;
 
-    /** Gets or sets the control position  in world space */
+    /** Gets or sets the control position in world space */
     public get position(): Vector3 {
         if (!this._node) {
             return Vector3.Zero();
@@ -42,7 +42,7 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
         this._node.position = value;
     }
 
-    /** Gets or sets the control scaling  in world space */
+    /** Gets or sets the control scaling in world space */
     public get scaling(): Vector3 {
         if (!this._node) {
             return new Vector3(1, 1, 1);

--- a/gui/src/3D/gizmos/slateGizmo.ts
+++ b/gui/src/3D/gizmos/slateGizmo.ts
@@ -177,19 +177,18 @@ export class SlateGizmo extends Gizmo {
             0
         );
 
+        if (keepAspectRatio) {
+            // Extra logic to ensure the ratio is maintained when the vector has been clamped
+            const ratio = dimensions.x / dimensions.y;
+            clampedDimensions.x = Math.max(clampedDimensions.x, clampedDimensions.y * ratio);
+            clampedDimensions.y = Math.max(clampedDimensions.y, clampedDimensions.x / ratio);
+        }
+
         // Calculating the real impact of vector on clamped dimensions
         impact.copyFrom(clampedDimensions).subtractInPlace(dimensions);
 
-        let factor = TmpVectors.Vector3[2];
-        factor.copyFrom(impact);
-        if (keepAspectRatio) {
-            // We want to keep aspect ratio of vector while clamping so we move by the minimum of the 2 dimensions
-            factor.x = Math.min(Math.abs(clampedDimensions.x - dimensions.x), Math.abs(clampedDimensions.y - dimensions.y));
-            factor.y = factor.x;
-        }
-
-        vector.x = Math.sign(vector.x) * Math.abs(factor.x);
-        vector.y = Math.sign(vector.y) * Math.abs(factor.y);
+        vector.x = Math.sign(vector.x) * Math.abs(impact.x);
+        vector.y = Math.sign(vector.y) * Math.abs(impact.y);
     }
 
     private _moveHandle(originStart: Vector3, dimensionsStart: Vector3, offset: Vector3, masks: HandleMasks, isCorner: boolean) {

--- a/gui/src/3D/gizmos/slateGizmo.ts
+++ b/gui/src/3D/gizmos/slateGizmo.ts
@@ -1,5 +1,6 @@
 import { Gizmo } from "babylonjs/Gizmos/gizmo";
 import { Matrix, Quaternion, TmpVectors, Vector3 } from "babylonjs/Maths/math.vector";
+import { Scene } from "babylonjs/scene";
 import { AbstractMesh } from "babylonjs/Meshes/abstractMesh";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Observer } from "babylonjs/Misc/observable";
@@ -429,7 +430,7 @@ export class SlateGizmo extends Gizmo {
 
     public dispose() {
         this.gizmoLayer.originalScene.onBeforeRenderObservable.remove(this._renderObserver);
-        
+
         // Will dispose rootMesh and all descendants
         super.dispose();
 


### PR DESCRIPTION
This fixes two issues:
- Resizing the HolographicSlate object after creation would not correctly resize the associated slate bounding box
- Resizing the slate using the corner manipulators would not maintain the aspect ratio, and would instead scale at a 1:1 pixel ratio (instead of a 1:1% ratio)

Also corrects two spots where the description for a Gizmo property getter had double spaces.

Done as part of #10846