### PR TITLE
NME: Don't call autoConfigure when rebuilding a material because of a link deletion

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -284,6 +284,7 @@
 - Fix error handling in basis texture loading ([RaananW](https://github.com/RaananW))
 - Fix issue with deadzones for gamepads being negatively affected by sensibility values ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix parsing of particle systems sub emitters ([#10882](https://github.com/BabylonJS/Babylon.js/issues/10882)) ([Popov72](https://github.com/Popov72))
+- Fix bug in NME where a link could not be recreated after being deleted ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -385,6 +385,7 @@
 - Fixed inTangent in animationGroup ([dad72](https://github.com/dad72))
 - Fixed bug in `QuadraticErrorSimplification` not correctly optimizing mesh. ([aWeirdo](https://github.com/aWeirdo))
 - Fixed bug in `ArcRotateCamera` where setting the position would recalculate the alpha value to a value outside the current limits. ([nilss0n](https://github.com/nilss0n))
+- Fixed bug in NME where a link could not be recreated after being deleted ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -385,7 +385,6 @@
 - Fixed inTangent in animationGroup ([dad72](https://github.com/dad72))
 - Fixed bug in `QuadraticErrorSimplification` not correctly optimizing mesh. ([aWeirdo](https://github.com/aWeirdo))
 - Fixed bug in `ArcRotateCamera` where setting the position would recalculate the alpha value to a value outside the current limits. ([nilss0n](https://github.com/nilss0n))
-- Fixed bug in NME where a link could not be recreated after being deleted ([Popov72](https://github.com/Popov72))
 
 ## Breaking changes
 

--- a/nodeEditor/src/components/propertyTab/inputsPropertyTabComponent.tsx
+++ b/nodeEditor/src/components/propertyTab/inputsPropertyTabComponent.tsx
@@ -29,7 +29,7 @@ export class InputsPropertyTabComponent extends React.Component<IInputsPropertyT
         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
 
         if (ib.isConstant) {
-            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
         }
     }
 

--- a/nodeEditor/src/components/propertyTab/properties/floatPropertyTabComponent.tsx
+++ b/nodeEditor/src/components/propertyTab/properties/floatPropertyTabComponent.tsx
@@ -15,7 +15,7 @@ export class FloatPropertyTabComponent extends React.Component<IFloatPropertyTab
         return (
             <FloatLineComponent globalState={this.props.globalState} label="Value" target={this.props.inputBlock} propertyName="value" onChange={() => {
                 if (this.props.inputBlock.isConstant) {
-                    this.props.globalState.onRebuildRequiredObservable.notifyObservers();    
+                    this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);    
                 }
                 this.props.globalState.onUpdateRequiredObservable.notifyObservers();
             }}></FloatLineComponent>

--- a/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -90,7 +90,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
 
         if (ib.isConstant) {
-            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
         }
     }
 

--- a/nodeEditor/src/diagram/graphCanvas.tsx
+++ b/nodeEditor/src/diagram/graphCanvas.tsx
@@ -917,7 +917,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             link.onDisposedObservable.clear();
         });
 
-        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
     }
 
     processEditorData(editorData: IEditorData) {

--- a/nodeEditor/src/diagram/properties/conditionalNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/conditionalNodePropertyComponent.tsx
@@ -37,7 +37,7 @@ export class ConditionalPropertyTabComponent extends React.Component<IPropertyCo
                 <LineContainerComponent title="PROPERTIES">  
                     <OptionsLineComponent label="Condition" options={conditionOptions} target={conditionBlock} propertyName="condition" onSelect={(value: any) => {
                         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         this.forceUpdate();
                     }} />                  
                 </LineContainerComponent>

--- a/nodeEditor/src/diagram/properties/genericNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/genericNodePropertyComponent.tsx
@@ -63,7 +63,7 @@ export class GeneralPropertyTabComponent extends React.Component<IPropertyCompon
                             this.forceUpdate();
 
                             this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         }} />
                     }
                     {
@@ -90,7 +90,7 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         }
 
         if (!notifiers || notifiers.rebuild) {
-            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
         }
 
         if (notifiers?.activatePreviewCommand) {

--- a/nodeEditor/src/diagram/properties/gradientNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/gradientNodePropertyComponent.tsx
@@ -37,7 +37,7 @@ export class GradientPropertyTabComponent extends React.Component<IPropertyCompo
 
     forceRebuild() {
         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
     }
 
     deleteStep(step: GradientBlockColorStep) {
@@ -129,7 +129,7 @@ export class GradientPropertyTabComponent extends React.Component<IPropertyCompo
                                 }
                                 this.forceUpdate();
                                 this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                                this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                             }} />
                 </LineContainerComponent>
                 <LineContainerComponent title="STEPS">

--- a/nodeEditor/src/diagram/properties/inputNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/inputNodePropertyComponent.tsx
@@ -63,7 +63,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             }} onSelect={(value) => {
                                 inputBlock.value = value ? 1 : 0;
                                 if (inputBlock.isConstant) {
-                                    this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                    this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                                 }
                                 this.props.globalState.onUpdateRequiredObservable.notifyObservers();
                             }}/>
@@ -74,7 +74,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                                 if (inputBlock.value < inputBlock.min) {
                                     inputBlock.value = inputBlock.min;
                                     if (inputBlock.isConstant) {
-                                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                                     }
                                 }
                                 this.forceUpdate();                                
@@ -86,7 +86,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                                 if (inputBlock.value > inputBlock.max) {
                                     inputBlock.value = inputBlock.max;
                                     if (inputBlock.isConstant) {
-                                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                                     }
                                 }
                                 this.forceUpdate();
@@ -101,7 +101,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             !inputBlock.isBoolean && !cantDisplaySlider &&
                             <SliderLineComponent label="Value" globalState={this.props.globalState} target={inputBlock} propertyName="value" step={Math.abs(inputBlock.max - inputBlock.min) / 100.0} minimum={Math.min(inputBlock.min, inputBlock.max)} maximum={inputBlock.max} onChange={() => {
                                 if (inputBlock.isConstant) {
-                                    this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                    this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                                 }
                             }}/>
                         }
@@ -278,7 +278,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                                 }
                                 this.forceUpdate();
                                 this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                                this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                             }} />
                     }
                     {
@@ -287,7 +287,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             onChange={() => {
                                 this.forceUpdate();
                                 this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                                this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                                this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                             }} />
                     }
                     <OptionsLineComponent label="Mode" options={modeOptions} target={inputBlock}
@@ -319,7 +319,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             }
                             this.forceUpdate();
                             this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         }} />
                     {
                         inputBlock.isAttribute &&
@@ -328,7 +328,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             this.forceUpdate();
 
                             this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         }} />
                     }
                     {
@@ -337,7 +337,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             this.forceUpdate();
 
                             this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         }} />
                     }
                     {
@@ -351,7 +351,7 @@ export class InputPropertyTabComponent extends React.Component<IPropertyComponen
                             this.forceUpdate();
 
                             this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                            this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                            this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         }} />
                     }
                 {

--- a/nodeEditor/src/diagram/properties/lightInformationPropertyTabComponent.tsx
+++ b/nodeEditor/src/diagram/properties/lightInformationPropertyTabComponent.tsx
@@ -23,7 +23,7 @@ export class LightInformationPropertyTabComponent extends React.Component<IPrope
                     <OptionsLineComponent label="Light" noDirectUpdate={true} valuesAreStrings={true} options={lightOptions} target={lightInformationBlock} propertyName="name" onSelect={(name: any) => {
                         lightInformationBlock.light = scene.getLightByName(name);
                         this.forceUpdate();
-                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                     }} />
                 </LineContainerComponent>
             </div>

--- a/nodeEditor/src/diagram/properties/lightPropertyTabComponent.tsx
+++ b/nodeEditor/src/diagram/properties/lightPropertyTabComponent.tsx
@@ -29,7 +29,7 @@ export class LightPropertyTabComponent extends React.Component<IPropertyComponen
                             lightBlock.light = scene.getLightByName(name);
                         }
                         this.forceUpdate();
-                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                     }} />
                 </LineContainerComponent>
             </div>

--- a/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
+++ b/nodeEditor/src/diagram/properties/texturePropertyTabComponent.tsx
@@ -59,7 +59,7 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
 
     updateAfterTextureLoad() {
         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
         this.forceUpdate();
     }
 

--- a/nodeEditor/src/diagram/properties/transformNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/transformNodePropertyComponent.tsx
@@ -23,7 +23,7 @@ export class TransformPropertyTabComponent extends React.Component<IPropertyComp
                         } else {
                             transformBlock.complementW = 1;
                         }
-                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                     }} isSelected={() => (this.props.block as TransformBlock).complementW === 0} />
                 </LineContainerComponent>            
             </>

--- a/nodeEditor/src/diagram/properties/trigonometryNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/trigonometryNodePropertyComponent.tsx
@@ -45,7 +45,7 @@ export class TrigonometryPropertyTabComponent extends React.Component<IPropertyC
                 <LineContainerComponent title="PROPERTIES">  
                     <OptionsLineComponent label="Operation" options={operationOptions} target={trigonometryBlock} propertyName="operation" onSelect={(value: any) => {
                         this.props.globalState.onUpdateRequiredObservable.notifyObservers();
-                        this.props.globalState.onRebuildRequiredObservable.notifyObservers();
+                        this.props.globalState.onRebuildRequiredObservable.notifyObservers(true);
                         this.forceUpdate();
                     }} />                  
                 </LineContainerComponent>

--- a/nodeEditor/src/globalState.ts
+++ b/nodeEditor/src/globalState.ts
@@ -22,7 +22,7 @@ export class GlobalState {
     hostDocument: HTMLDocument;
     hostWindow: Window;
     onSelectionChangedObservable = new Observable<Nullable<GraphNode | NodeLink | GraphFrame | NodePort | FramePortData>>();
-    onRebuildRequiredObservable = new Observable<void>();
+    onRebuildRequiredObservable = new Observable<boolean>();
     onBuiltObservable = new Observable<void>();
     onResetRequiredObservable = new Observable<void>();
     onUpdateRequiredObservable = new Observable<void>();

--- a/nodeEditor/src/graphEditor.tsx
+++ b/nodeEditor/src/graphEditor.tsx
@@ -152,9 +152,9 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             showPreviewPopUp: false
         };
 
-        this.props.globalState.onRebuildRequiredObservable.add(() => {
+        this.props.globalState.onRebuildRequiredObservable.add((autoConfigure) => {
             if (this.props.globalState.nodeMaterial) {
-                this.buildMaterial();
+                this.buildMaterial(autoConfigure);
             }
         });
 
@@ -233,7 +233,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
                 }
 
                 this.props.globalState.onSelectionChangedObservable.notifyObservers(null);  
-                this.props.globalState.onRebuildRequiredObservable.notifyObservers();  
+                this.props.globalState.onRebuildRequiredObservable.notifyObservers(false);
                 return;
             }
 
@@ -422,14 +422,14 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         this._graphCanvas.zoomToFit();
     }
 
-    buildMaterial() {
+    buildMaterial(autoConfigure = true) {
         if (!this.props.globalState.nodeMaterial) {
             return;
         }
 
         try {
             this.props.globalState.nodeMaterial.options.emitComments = true;
-            this.props.globalState.nodeMaterial.build(true);
+            this.props.globalState.nodeMaterial.build(true, undefined, autoConfigure);
             this.props.globalState.onLogRequiredObservable.notifyObservers(new LogEntry("Node material build successful", false));
         }
         catch (err) {

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -553,9 +553,11 @@ export class NodeMaterial extends PushMaterial {
         return this._sharedData && this._sharedData.hints.needAlphaTesting;
     }
 
-    private _initializeBlock(node: NodeMaterialBlock, state: NodeMaterialBuildState, nodesToProcessForOtherBuildState: NodeMaterialBlock[]) {
+    private _initializeBlock(node: NodeMaterialBlock, state: NodeMaterialBuildState, nodesToProcessForOtherBuildState: NodeMaterialBlock[], autoConfigure = true) {
         node.initialize(state);
-        node.autoConfigure(this);
+        if (autoConfigure) {
+            node.autoConfigure(this);
+        }
         node._preparationId = this._buildId;
 
         if (this.attachedBlocks.indexOf(node) === -1) {
@@ -585,7 +587,7 @@ export class NodeMaterial extends PushMaterial {
                         && block._preparationId !== this._buildId) {
                         nodesToProcessForOtherBuildState.push(block);
                     }
-                    this._initializeBlock(block, state, nodesToProcessForOtherBuildState);
+                    this._initializeBlock(block, state, nodesToProcessForOtherBuildState, autoConfigure);
                 }
             }
         }
@@ -630,8 +632,9 @@ export class NodeMaterial extends PushMaterial {
      * Build the material and generates the inner effect
      * @param verbose defines if the build should log activity
      * @param updateBuildId defines if the internal build Id should be updated (default is true)
+     * @param autoConfigure defines if the autoConfigure method should be called when initializing blocks (default is true)
      */
-    public build(verbose: boolean = false, updateBuildId = true) {
+    public build(verbose: boolean = false, updateBuildId = true, autoConfigure = true) {
         this._buildWasSuccessful = false;
         var engine = this.getScene().getEngine();
 
@@ -669,12 +672,12 @@ export class NodeMaterial extends PushMaterial {
 
         for (var vertexOutputNode of this._vertexOutputNodes) {
             vertexNodes.push(vertexOutputNode);
-            this._initializeBlock(vertexOutputNode, this._vertexCompilationState, fragmentNodes);
+            this._initializeBlock(vertexOutputNode, this._vertexCompilationState, fragmentNodes, autoConfigure);
         }
 
         for (var fragmentOutputNode of this._fragmentOutputNodes) {
             fragmentNodes.push(fragmentOutputNode);
-            this._initializeBlock(fragmentOutputNode, this._fragmentCompilationState, vertexNodes);
+            this._initializeBlock(fragmentOutputNode, this._fragmentCompilationState, vertexNodes, autoConfigure);
         }
 
         // Optimize


### PR DESCRIPTION
See https://forum.babylonjs.com/t/nme-disconnects-block-when-moving/23177/6

The problem was that when recreating the material after a link deletion, the autoConfigure method was called, which recreated the link we just deleted.