### PR TITLE
Make _spectatorCamera nullable and fix error on dispose

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -167,6 +167,7 @@
 - Introduced spectator mode for desktop VR experiences and fixed an issue with XR camera in the activeCameras array ([#10560](https://github.com/BabylonJS/Babylon.js/issues/10560)) ([RaananW](https://github.com/RaananW))
 - Initial support for WebXR camera parenting ([#10593](https://github.com/BabylonJS/Babylon.js/issues/10593)) ([RaananW](https://github.com/RaananW))
 - Fix ReflectionProbe for WebXR ([#10390](https://github.com/BabylonJS/Babylon.js/issues/10390)) ([RaananW](https://github.com/RaananW))
+- Fix error on XR dispose due to undefined sepectator camera ([Alex-MSFT](https://github.com/Alex-MSFT))
 
 ### Gizmos
 

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -16,7 +16,7 @@ import { Quaternion, Vector3 } from "../Maths/math.vector";
  */
 export class WebXRExperienceHelper implements IDisposable {
     private _nonVRCamera: Nullable<Camera> = null;
-    private _spectatorCamera: UniversalCamera;
+    private _spectatorCamera: Nullable<UniversalCamera> = null;
     private _originalSceneAutoClear = true;
     private _supported = false;
     private _spectatorMode = false;
@@ -88,7 +88,7 @@ export class WebXRExperienceHelper implements IDisposable {
         this.onStateChangedObservable.clear();
         this.onInitialXRPoseSetObservable.clear();
         this.sessionManager.dispose();
-        this._spectatorCamera.dispose();
+        this._spectatorCamera?.dispose();
         if (this._nonVRCamera) {
             this.scene.activeCamera = this._nonVRCamera;
         }
@@ -198,8 +198,10 @@ export class WebXRExperienceHelper implements IDisposable {
     public enableSpectatorMode(): void {
         if (!this._spectatorMode) {
             const updateSpectatorCamera = () => {
-                this._spectatorCamera.position.copyFrom(this.camera.rigCameras[0].globalPosition);
-                this._spectatorCamera.rotationQuaternion.copyFrom(this.camera.rigCameras[0].absoluteRotation);
+                if (this._spectatorCamera) {
+                    this._spectatorCamera.position.copyFrom(this.camera.rigCameras[0].globalPosition);
+                    this._spectatorCamera.rotationQuaternion.copyFrom(this.camera.rigCameras[0].absoluteRotation);
+                }
             };
             const onStateChanged = () => {
                 if (this.state === WebXRState.IN_XR) {


### PR DESCRIPTION
_spectatorCamera will only be initialized if enableSpectatorMode is called at least once, otherwise it is undefined.  This PR fixes an error encountered when disposing the XR object if the spectator camera was not initialized.