### PR TITLE
Added ability to hover over a line which will change the opacity of other lines.

### DIFF
--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -738,7 +738,6 @@ export class CanvasGraphService {
         this._hoverPosition = null;
     }
 
-
     /**
      * Given a line defined by P1: (x1, y1) and P2: (x2, y2) get the distance of P0 (x0, y0) from the line.
      * https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
@@ -787,6 +786,11 @@ export class CanvasGraphService {
         return numerator / denominator;
     }
 
+    /**
+     * This method does preprocessing calculations for the tooltip.
+     * @param pos the position of our mouse.
+     * @param drawableArea the remaining drawable area.
+     */
     private _preprocessTooltip(pos: IPerfTooltipHoverPosition | null, drawableArea: IGraphDrawableArea) {
         const { _ctx: ctx } = this;
 

--- a/inspector/src/components/graph/canvasGraphService.ts
+++ b/inspector/src/components/graph/canvasGraphService.ts
@@ -868,7 +868,7 @@ export class CanvasGraphService {
 
             // get the shortest distance between the point and the line segment infront, and line segment behind, store the shorter distance (if shorter than distance between closest data point and mouse).
             if (
-                closestIndex + 1 < this.datasets.data.itemLength || 
+                closestIndex + 1 < this.datasets.data.itemLength &&
                 this.datasets.data.at(this.datasets.startingIndices.at(closestIndex + 1) + PerformanceViewerCollector.NumberOfPointsOffset) > idOffset
             ) {
                 const secondPointTimestamp = this.datasets.data.at(this.datasets.startingIndices.at(closestIndex + 1));
@@ -879,7 +879,7 @@ export class CanvasGraphService {
             }
 
             if (
-                closestIndex - 1 >= 0 || 
+                closestIndex - 1 >= 0 &&
                 this.datasets.data.at(this.datasets.startingIndices.at(closestIndex + 1) + PerformanceViewerCollector.NumberOfPointsOffset) > idOffset
             ) {
                 const secondPointTimestamp = this.datasets.data.at(this.datasets.startingIndices.at(closestIndex - 1));

--- a/inspector/src/components/graph/graphSupportingTypes.ts
+++ b/inspector/src/components/graph/graphSupportingTypes.ts
@@ -71,6 +71,21 @@ export interface ICanvasGraphServiceSettings {
 }
 
 /**
+ * Defines the structure representing the preprocessable tooltip information.
+ */
+export interface ITooltipPreprocessedInformation {
+    xForActualTimestamp: number;
+    numberOfTooltipItems: number;
+    longestText: string;
+    focusedId: string;
+}
+
+export interface IPerfTooltipHoverPosition {
+    xPos: number;
+    yPos: number;
+}
+
+/**
  * Defines the supported timestamp units.
  */
 export enum TimestampUnit {


### PR DESCRIPTION
This PR adds the ability to focus on a line with the mouse. This allows you to compare values across the entire line, without being distracted by other lines.

Completes "Allow hovering over a single line which changes the opacity of the other lines." in #10566

Video:

https://user-images.githubusercontent.com/32103099/130132076-eb8a8485-3c5e-4553-9c02-df89dea80af5.mp4

