### PR TITLE
Native resource handles + command buffer

### DIFF
--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -127,6 +127,10 @@ interface INativeEngine {
     readonly COMMAND_SETTEXTURE: number;
     readonly COMMAND_BINDVERTEXARRAY: number;
     readonly COMMAND_SETSTATE: number;
+    readonly COMMAND_SETFLOAT: number;
+    readonly COMMAND_SETFLOAT2: number;
+    readonly COMMAND_SETFLOAT3: number;
+    readonly COMMAND_SETFLOAT4: number;
 
     dispose(): void;
 
@@ -1861,7 +1865,11 @@ export class NativeEngine extends Engine {
             return false;
         }
 
-        this._native.setFloat(uniform, value);
+        //this._native.setFloat(uniform, value);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETFLOAT);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(uniform);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(value);
+        this._commandBufferEncoder.finishEncodingCommand();
         return true;
     }
 
@@ -1870,7 +1878,12 @@ export class NativeEngine extends Engine {
             return false;
         }
 
-        this._native.setFloat2(uniform, x, y);
+        //this._native.setFloat2(uniform, x, y);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETFLOAT2);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(uniform);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(x);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(y);
+        this._commandBufferEncoder.finishEncodingCommand();
         return true;
     }
 
@@ -1879,7 +1892,13 @@ export class NativeEngine extends Engine {
             return false;
         }
 
-        this._native.setFloat3(uniform, x, y, z);
+        //this._native.setFloat3(uniform, x, y, z);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETFLOAT3);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(uniform);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(x);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(y);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(z);
+        this._commandBufferEncoder.finishEncodingCommand();
         return true;
     }
 
@@ -1888,7 +1907,14 @@ export class NativeEngine extends Engine {
             return false;
         }
 
-        this._native.setFloat4(uniform, x, y, z, w);
+        //this._native.setFloat4(uniform, x, y, z, w);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETFLOAT4);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(uniform);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(x);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(y);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(z);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(w);
+        this._commandBufferEncoder.finishEncodingCommand();
         return true;
     }
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -123,6 +123,7 @@ interface INativeEngine {
     readonly STENCIL_OP_PASS_Z_DECRSAT: number;
     readonly STENCIL_OP_PASS_Z_INVERT: number;
 
+    readonly COMMAND_DELETEVERTEXARRAY: number;
     readonly COMMAND_SETMATRICES: number;
     readonly COMMAND_SETTEXTURE: number;
     readonly COMMAND_BINDVERTEXARRAY: number;
@@ -815,7 +816,7 @@ class Buffer<T extends ArrayLike<number> & {[n: number]: number, set(array: Arra
     private index = 0;
 
     public constructor(typedArray: new (size: number) => T, onBufferChanged: (buffer: T) => void) {
-        this.buffer = new typedArray(1024);
+        this.buffer = new typedArray(10240);
         onBufferChanged(this.buffer);
     }
 
@@ -1073,7 +1074,8 @@ export class NativeEngine extends Engine {
     public dispose(): void {
         super.dispose();
         if (this._boundBuffersVertexArray) {
-            this._native.deleteVertexArray(this._boundBuffersVertexArray);
+            //this._native.deleteVertexArray(this._boundBuffersVertexArray);
+            this._deleteVertexArray(this._boundBuffersVertexArray);
         }
         this._native.dispose();
     }
@@ -1197,7 +1199,8 @@ export class NativeEngine extends Engine {
 
     public bindBuffers(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<NativeDataBuffer>, effect: Effect): void {
         if (this._boundBuffersVertexArray) {
-            this._native.deleteVertexArray(this._boundBuffersVertexArray);
+            //this._native.deleteVertexArray(this._boundBuffersVertexArray);
+            this._deleteVertexArray(this._boundBuffersVertexArray);
         }
         this._boundBuffersVertexArray = this._native.createVertexArray();
         this._recordVertexArrayObject(this._boundBuffersVertexArray, vertexBuffers, indexBuffer, effect);
@@ -1211,6 +1214,12 @@ export class NativeEngine extends Engine {
         return vertexArray;
     }
 
+    private _deleteVertexArray(vertexArray: unknown) {
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_DELETEVERTEXARRAY);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(vertexArray);
+        this._commandBufferEncoder.finishEncodingCommand();
+    }
+
     public bindVertexArrayObject(vertexArray: WebGLVertexArrayObject): void {
         //this._native.bindVertexArray(vertexArray);
         this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_BINDVERTEXARRAY);
@@ -1219,7 +1228,8 @@ export class NativeEngine extends Engine {
     }
 
     public releaseVertexArrayObject(vertexArray: WebGLVertexArrayObject) {
-        this._native.deleteVertexArray(vertexArray);
+        //this._native.deleteVertexArray(vertexArray);
+        this._deleteVertexArray(vertexArray);
     }
 
     public getAttributes(pipelineContext: IPipelineContext, attributesNames: string[]): number[] {

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -134,6 +134,7 @@ interface INativeEngine {
     readonly COMMAND_SETTEXTUREWRAPMODE: number;
     readonly COMMAND_DRAWINDEXED: number;
     readonly COMMAND_CLEAR: number;
+    readonly COMMAND_SETSTENCIL: number;
 
     dispose(): void;
 
@@ -1536,12 +1537,29 @@ export class NativeEngine extends Engine {
     }
 
     private applyStencil(): void {
-        this._native.setStencil(this._stencilMask,
+        // this._native.setStencil(this._stencilMask,
+        //     this._getStencilOpFail(this._stencilOpStencilFail),
+        //     this._getStencilDepthFail(this._stencilOpDepthFail),
+        //     this._getStencilDepthPass(this._stencilOpStencilDepthPass),
+        //     this._getStencilFunc(this._stencilFunc),
+        //     this._stencilFuncRef);
+        this._setStencil(this._stencilMask,
             this._getStencilOpFail(this._stencilOpStencilFail),
             this._getStencilDepthFail(this._stencilOpDepthFail),
             this._getStencilDepthPass(this._stencilOpStencilDepthPass),
             this._getStencilFunc(this._stencilFunc),
             this._stencilFuncRef);
+    }
+
+    private _setStencil(mask: number, stencilOpFail: number, depthOpFail: number, depthOpPass: number, func: number, ref: number) {
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETSTENCIL);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(mask);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(stencilOpFail);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(depthOpFail);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(depthOpPass);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(func);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(ref);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     /**
@@ -1553,7 +1571,13 @@ export class NativeEngine extends Engine {
         if (enable) {
             this.applyStencil();
         } else {
-            this._native.setStencil(255,
+            // this._native.setStencil(255,
+            //     this._native.STENCIL_OP_FAIL_S_KEEP,
+            //     this._native.STENCIL_OP_FAIL_Z_KEEP,
+            //     this._native.STENCIL_OP_PASS_Z_KEEP,
+            //     this._native.STENCIL_TEST_ALWAYS,
+            //     0);
+            this._setStencil(255,
                 this._native.STENCIL_OP_FAIL_S_KEEP,
                 this._native.STENCIL_OP_FAIL_Z_KEEP,
                 this._native.STENCIL_OP_PASS_Z_KEEP,

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -126,6 +126,7 @@ interface INativeEngine {
     readonly COMMAND_SETMATRICES: number;
     readonly COMMAND_SETTEXTURE: number;
     readonly COMMAND_BINDVERTEXARRAY: number;
+    readonly COMMAND_SETSTATE: number;
 
     dispose(): void;
 
@@ -1374,7 +1375,13 @@ export class NativeEngine extends Engine {
     }
 
     public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean, stencil?: IStencilState): void {
-        this._native.setState(culling, zOffset, this.cullBackFaces ?? cullBackFaces ?? true, reverseSide);
+        //this._native.setState(culling, zOffset, this.cullBackFaces ?? cullBackFaces ?? true, reverseSide);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETSTATE);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(culling);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(zOffset);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(this.cullBackFaces ?? cullBackFaces ?? true);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(reverseSide);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     /**

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -132,6 +132,7 @@ interface INativeEngine {
     readonly COMMAND_SETFLOAT3: number;
     readonly COMMAND_SETFLOAT4: number;
     readonly COMMAND_SETTEXTUREWRAPMODE: number;
+    readonly COMMAND_DRAWINDEXED: number;
 
     dispose(): void;
 
@@ -1215,7 +1216,12 @@ export class NativeEngine extends Engine {
         // if (instancesCount) {
         //     this._gl.drawElementsInstanced(drawMode, indexCount, indexFormat, indexStart * mult, instancesCount);
         // } else {
-        this._native.drawIndexed(fillMode, indexStart, indexCount);
+        //this._native.drawIndexed(fillMode, indexStart, indexCount);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_DRAWINDEXED);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
+        this._commandBufferEncoder.finishEncodingCommand();
         // }
     }
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -125,6 +125,7 @@ interface INativeEngine {
 
     readonly COMMAND_SETMATRICES: number;
     readonly COMMAND_SETTEXTURE: number;
+    readonly COMMAND_BINDVERTEXARRAY: number;
 
     dispose(): void;
 
@@ -1162,7 +1163,8 @@ export class NativeEngine extends Engine {
         }
         this._boundBuffersVertexArray = this._native.createVertexArray();
         this._recordVertexArrayObject(this._boundBuffersVertexArray, vertexBuffers, indexBuffer, effect);
-        this._native.bindVertexArray(this._boundBuffersVertexArray);
+        //this._native.bindVertexArray(this._boundBuffersVertexArray);
+        this.bindVertexArrayObject(this._boundBuffersVertexArray);
     }
 
     public recordVertexArrayObject(vertexBuffers: { [key: string]: VertexBuffer; }, indexBuffer: Nullable<NativeDataBuffer>, effect: Effect): WebGLVertexArrayObject {
@@ -1172,7 +1174,10 @@ export class NativeEngine extends Engine {
     }
 
     public bindVertexArrayObject(vertexArray: WebGLVertexArrayObject): void {
-        this._native.bindVertexArray(vertexArray);
+        //this._native.bindVertexArray(vertexArray);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_BINDVERTEXARRAY);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(vertexArray);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     public releaseVertexArrayObject(vertexArray: WebGLVertexArrayObject) {
@@ -1306,7 +1311,7 @@ export class NativeEngine extends Engine {
     }
 
     public _releaseEffect(effect: Effect): void {
-        // TODO
+        // TODO: is this where we can call a deleteProgram function on NativeEngine?
     }
 
     public _deletePipelineContext(pipelineContext: IPipelineContext): void {

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -124,6 +124,8 @@ interface INativeEngine {
     readonly STENCIL_OP_PASS_Z_INVERT: number;
 
     readonly COMMAND_DELETEVERTEXARRAY: number;
+    readonly COMMAND_DELETEINDEXBUFFER: number;
+    readonly COMMAND_DELETEVERTEXBUFFER: number;
     readonly COMMAND_SETMATRICES: number;
     readonly COMMAND_SETTEXTURE: number;
     readonly COMMAND_BINDVERTEXARRAY: number;
@@ -2720,12 +2722,18 @@ export class NativeEngine extends Engine {
 
     protected _deleteBuffer(buffer: NativeDataBuffer): void {
         if (buffer.nativeIndexBuffer) {
-            this._native.deleteIndexBuffer(buffer.nativeIndexBuffer);
+            //this._native.deleteIndexBuffer(buffer.nativeIndexBuffer);
+            this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_DELETEINDEXBUFFER);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(buffer.nativeIndexBuffer);
+            this._commandBufferEncoder.finishEncodingCommand();
             delete buffer.nativeIndexBuffer;
         }
 
         if (buffer.nativeVertexBuffer) {
-            this._native.deleteVertexBuffer(buffer.nativeVertexBuffer);
+            //this._native.deleteVertexBuffer(buffer.nativeVertexBuffer);
+            this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_DELETEVERTEXBUFFER);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(buffer.nativeVertexBuffer);
+            this._commandBufferEncoder.finishEncodingCommand();
             delete buffer.nativeVertexBuffer;
         }
     }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -131,6 +131,7 @@ interface INativeEngine {
     readonly COMMAND_SETFLOAT2: number;
     readonly COMMAND_SETFLOAT3: number;
     readonly COMMAND_SETFLOAT4: number;
+    readonly COMMAND_SETTEXTUREWRAPMODE: number;
 
     dispose(): void;
 
@@ -2570,7 +2571,12 @@ export class NativeEngine extends Engine {
             return false;
         }
 
-        this._native.setTextureWrapMode(
+        // this._native.setTextureWrapMode(
+        //     internalTexture._hardwareTexture.underlyingResource,
+        //     this._getAddressMode(texture.wrapU),
+        //     this._getAddressMode(texture.wrapV),
+        //     this._getAddressMode(texture.wrapR));
+        this._setTextureWrapMode(
             internalTexture._hardwareTexture.underlyingResource,
             this._getAddressMode(texture.wrapU),
             this._getAddressMode(texture.wrapV),
@@ -2581,6 +2587,15 @@ export class NativeEngine extends Engine {
         this._setTextureCore(uniform, internalTexture._hardwareTexture.underlyingResource);
 
         return true;
+    }
+
+    private _setTextureWrapMode(texture: WebGLTexture, addressModeU: number, addressModeV: number, addressModeW: number) {
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETTEXTUREWRAPMODE);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(texture);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(addressModeU);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(addressModeV);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(addressModeW);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     private _setTextureCore(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>) {

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -124,6 +124,7 @@ interface INativeEngine {
     readonly STENCIL_OP_PASS_Z_INVERT: number;
 
     readonly COMMAND_SETMATRICES: number;
+    readonly COMMAND_SETTEXTURE: number;
 
     dispose(): void;
 
@@ -187,7 +188,7 @@ interface INativeEngine {
     setTextureSampling(texture: WebGLTexture, filter: number): void; // filter is a NativeFilter.XXXX value.
     setTextureWrapMode(texture: WebGLTexture, addressModeU: number, addressModeV: number, addressModeW: number): void; // addressModes are NativeAddressMode.XXXX values.
     setTextureAnisotropicLevel(texture: WebGLTexture, value: number): void;
-    setTexture(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>): void;
+    //setTexture(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>): void;
     copyTexture(desination: Nullable<WebGLTexture>, source: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
     createImageBitmap(data: ArrayBufferView): ImageBitmap;
@@ -2494,7 +2495,8 @@ export class NativeEngine extends Engine {
         if (!texture) {
             if (this._boundTexturesCache[channel] != null) {
                 this._activeChannel = channel;
-                this._native.setTexture(uniform, null);
+                //this._native.setTexture(uniform, null);
+                this._setTextureCore(uniform, null);
             }
             return false;
         }
@@ -2537,9 +2539,17 @@ export class NativeEngine extends Engine {
             this._getAddressMode(texture.wrapR));
         this._updateAnisotropicLevel(texture);
 
-        this._native.setTexture(uniform, internalTexture._hardwareTexture.underlyingResource);
+        //this._native.setTexture(uniform, internalTexture._hardwareTexture.underlyingResource);
+        this._setTextureCore(uniform, internalTexture._hardwareTexture.underlyingResource);
 
         return true;
+    }
+
+    private _setTextureCore(uniform: WebGLUniformLocation, texture: Nullable<WebGLTexture>) {
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_SETTEXTURE);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(uniform);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(texture);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     // TODO: Share more of this logic with the base implementation.
@@ -2580,7 +2590,8 @@ export class NativeEngine extends Engine {
         }
         if (texture && texture._hardwareTexture) {
             const webGLTexture = texture._hardwareTexture.underlyingResource;
-            this._native.setTexture(uniform, webGLTexture);
+            //this._native.setTexture(uniform, webGLTexture);
+            this._setTextureCore(uniform, webGLTexture);
         }
     }
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -133,6 +133,7 @@ interface INativeEngine {
     readonly COMMAND_SETFLOAT4: number;
     readonly COMMAND_SETTEXTUREWRAPMODE: number;
     readonly COMMAND_DRAWINDEXED: number;
+    readonly COMMAND_CLEAR: number;
 
     dispose(): void;
 
@@ -1106,7 +1107,18 @@ export class NativeEngine extends Engine {
             throw new Error("reverse depth buffer is not currently implemented");
         }
 
-        this._native.clear(backBuffer && color ? color : undefined, depth ? 1.0 : undefined, stencil ? 0 : undefined);
+        //this._native.clear(backBuffer && color ? color : undefined, depth ? 1.0 : undefined, stencil ? 0 : undefined);
+        this._commandBufferEncoder.beginEncodingCommand(this._native.COMMAND_CLEAR);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(Boolean(backBuffer && color));
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(color?.r);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(color?.g);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(color?.b);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(color?.a ?? 1);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(depth);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(1);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(stencil);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(0);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     public createIndexBuffer(indices: IndicesArray, updateable?: boolean): NativeDataBuffer {


### PR DESCRIPTION
The Babylon Native half of this change is here: https://github.com/BabylonJS/BabylonNative/pull/873

Engine related resources created by Babylon Native (such as textures, vertex arrays, index buffers, etc.) are all treated as opaque objects. JavaScript doesn't do anything with them other than store them and pass them back to other Babylon Native functions. With this change, those opaque resources are now assumed to be numeric handles (see the associated Babylon Native changes). Since these handles are numeric, they can now easily be encoded into a "command buffer." The command buffer accumulates commands over the course of a single `scene.render` call, and then "submits" the command buffer to native at the end. For more complex scenes, this reduces the number of calls into native from thousands to just one. Additionally, since the command arguments are just read as numeric values out of typed arrays, the cost of retrieving args on the native side is pretty much eliminated. When profiling the JavaScript with Safari on iOS (for a scenario where I have a single mesh with ~250 submeshes), it claims that ~65% of CPU time is spent making those native calls. After this change, it claims 0.4% of CPU time is spent making those native calls. That said, with the profiler not attached, this change does not triple the frame rate (as the previous numbers might suggest), but does increase frame rate by about 50% which is still substantial.

There is a bunch of work to do to finish this change:
- [ ] Convert a bunch more functions to use the command buffer (not everything, but probably all functions that set state or delete resources (creating resources needs to continue to be synchronous, or the numeric resource handles need to be generated on the JS side and passed to the native side)).
- [ ] The command and argument buffers are just a fixed size that was big enough for my test scene. The buffers need to grow as needed, and we need a heuristic for shrinking them as well (e.g. at the end of a scene render, after calling `submitCommandBuffer`, maybe call a `resizeCommandBuffers` function that shrinks them down to the size needed for the last submit, or maybe the max of the last five submits, or something like that).
- [ ] Delete shader programs at the right time (maybe from `_releaseEffect`). Probably need input from @bghgary on this.
- [ ] We may want to have some kind of command buffer validation. The command and command arg encoding and decoding must happen in the same order or things will be totally broken, and this is hard to diagnose. Command validation could do something like record the order of encoding operations in another buffer (a validation buffer) which the native side could use to ensure decoding happens in the same order. We'd want this to be an explicit opt-in from JS, like a call to `nativeEngine.enableCommandBufferValidation()` that perhaps would replace the command buffer encoding functions to do extra work (so there is no overhead when not doing validation) and pass the validation buffer to native so it has it and knows to do the extra validation work.
- [ ] Remove all the commented out code (left there to make testing the old code path easy).
- [ ] Merge master.