### PR TITLE
Allow skipping the rtt initial clearing

### DIFF
--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -237,6 +237,10 @@ export class RenderTargetTexture extends Texture {
     public _generateMipMaps: boolean;
     /** @hidden */
     public _cleared = false;
+    /**
+     * Skip the initial clear of the rtt at the beginning of the frame render loop
+     */
+    public skipInitialClear = false;
     protected _renderingManager: RenderingManager;
     /** @hidden */
     public _waitingRenderList?: string[];

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4001,7 +4001,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             const rtt = camera.outputRenderTarget;
             if (rtt.onClearObservable.hasObservers()) {
                 rtt.onClearObservable.notifyObservers(this._engine);
-            } else {
+            } else if (!rtt.skipInitialClear) {
                 this._engine.clear(rtt.clearColor || this.clearColor, !rtt._cleared, true, true);
                 rtt._cleared = true;
             }


### PR DESCRIPTION
This is important in XR scenarios.
See https://github.com/BabylonJS/BabylonReactNative/pull/278