### PR TITLE
add POINTERDOUBLETAP mask for BaseCameraPointerInput observer

### DIFF
--- a/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -225,7 +225,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         this._observer = this.camera.getScene().onPointerObservable.add(
             this._pointerInput,
             PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP |
-            PointerEventTypes.POINTERMOVE);
+            PointerEventTypes.POINTERMOVE | PointerEventTypes.POINTERDOUBLETAP);
 
         this._onLostFocus = () => {
             this.pointA = this.pointB = null;


### PR DESCRIPTION
Make observer of BaseCameraPointerInput check POINTERDOUBLETAP with respect of _pointerInput function that handles this type by call overrided onDoubleTap method