### PR TITLE
Fix warning when cloning a mesh

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -564,6 +564,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                     "worldMatrixFromCache",
                     "hasThinInstances",
                     "cloneMeshMap",
+                    "hasBoundingInfo",
                 ],
                 ["_poseMatrix"]
             );


### PR DESCRIPTION
See https://forum.babylonjs.com/t/setting-getter-only-property-hasboundinginfo/23312