### PR TITLE
Modify ArcRotateCamera and FreeCamera to account for which button is pressed

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -40,6 +40,7 @@
 - Added the ability to load a fullscreen GUI from the snippet server ([PirateJC](https://github.com/piratejc))
 - Updated the gravity parameter in `Scene.enablePhysics()` as optional to fit the current behaviour ([Faber](https://https://github.com/Faber-smythe))
 - Allow the possibility to override the radius delta calculation for mouse wheel event ([RaananW](https://github.com/RaananW))
+- Modified behavior for FreeCamera and ArcRotateCamera so that default mouse dragging movements now account for what button was used to initiate it ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 

--- a/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -32,6 +32,8 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
      */
     protected _buttonsPressed: number;
 
+    private _currentActiveButton: number = -1;
+
     /**
      * Defines the buttons associated with the input to handle camera move.
      */
@@ -118,6 +120,9 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     };
                 }
 
+                if (this._currentActiveButton === -1) {
+                    this._currentActiveButton = evt.button;
+                }
                 this.onButtonDown(evt);
 
                 if (!noPreventDefault) {
@@ -126,7 +131,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
                 this.onDoubleTap(evt.pointerType);
-            } else if (p.type === PointerEventTypes.POINTERUP && srcElement) {
+            } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
                 try {
                     srcElement.releasePointerCapture(evt.pointerId);
                 } catch (e) {
@@ -173,6 +178,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     previousMultiTouchPanPosition = null;
                 }
 
+                this._currentActiveButton = -1;
                 this.onButtonUp(evt);
 
                 if (!noPreventDefault) {

--- a/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -120,7 +120,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     };
                 }
 
-                if (this._currentActiveButton === -1) {
+                if (this._currentActiveButton === -1 && !isTouch) {
                     this._currentActiveButton = evt.button;
                 }
                 this.onButtonDown(evt);
@@ -131,7 +131,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
                 this.onDoubleTap(evt.pointerType);
-            } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
+            } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton && !isTouch) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
                 try {
                     srcElement.releasePointerCapture(evt.pointerId);
                 } catch (e) {

--- a/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -42,6 +42,9 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
      * If the camera should be rotated automatically based on pointer movement
      */
     public _allowCameraRotation = true;
+
+    private _currentActiveButton: number = -1;
+
     /**
      * Manage the mouse inputs to control the movement of a free camera.
      * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
@@ -88,6 +91,10 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                         //Nothing to do with the error. Execution will continue.
                     }
 
+                    if (this._currentActiveButton === -1) {
+                        this._currentActiveButton = evt.button;
+                    }
+
                     this.previousPosition = {
                         x: evt.clientX,
                         y: evt.clientY,
@@ -102,12 +109,13 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     }
-                } else if (p.type === PointerEventTypes.POINTERUP && srcElement) {
+                } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
                     try {
                         srcElement.releasePointerCapture(evt.pointerId);
                     } catch (e) {
                         //Nothing to do with the error.
                     }
+                    this._currentActiveButton = -1;
 
                     this.previousPosition = null;
                     if (!noPreventDefault) {

--- a/tests/unit/babylon/src/Cameras/babylon.pointerInput.tests.ts
+++ b/tests/unit/babylon/src/Cameras/babylon.pointerInput.tests.ts
@@ -4,7 +4,7 @@
  * Many PointerEvent properties are read-only so using real "new PointerEvent()"
  * is unpractical.
  */
-interface MockPointerEvent {
+ interface MockPointerEvent {
     target?: HTMLElement;
     type?: string;
     button?: number;
@@ -218,7 +218,7 @@ describe("BaseCameraPointersInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(1);
             expect(this.cameraInput.countOnButtonDown).to.equal(1);
@@ -230,7 +230,7 @@ describe("BaseCameraPointersInput", function () {
             // Drag.
             event.type = "pointermove";
             event.clientX = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(2);
             expect(this.cameraInput.countOnButtonDown).to.equal(1);
@@ -270,7 +270,7 @@ describe("BaseCameraPointersInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(1);
             expect(this.cameraInput.countOnButtonDown).to.equal(1);
@@ -282,7 +282,7 @@ describe("BaseCameraPointersInput", function () {
             // Drag.
             event.type = "pointermove";
             event.clientX = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(2);
             expect(this.cameraInput.countOnButtonDown).to.equal(1);
@@ -312,7 +312,7 @@ describe("BaseCameraPointersInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(3);
             expect(this.cameraInput.countOnButtonDown).to.equal(2);
@@ -324,7 +324,7 @@ describe("BaseCameraPointersInput", function () {
             // Drag again.
             event.type = "pointermove";
             event.clientY = 2000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(this.cameraInput.countOnTouch).to.equal(4);
             expect(this.cameraInput.countOnButtonDown).to.equal(2);
@@ -791,14 +791,14 @@ describe("ArcRotateCameraInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, {})).to.be.true;
 
             // Move X coordinate. Drag camera.
             event.type = "pointermove";
             event.clientX = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialAlphaOffset: ValChange.Decrease })).to.be.true;
 
@@ -822,14 +822,14 @@ describe("ArcRotateCameraInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, {})).to.be.true;
 
             // Move X coordinate. Drag camera.
             event.type = "pointermove";
             event.clientX = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialAlphaOffset: ValChange.Decrease })).to.be.true;
 
@@ -850,14 +850,14 @@ describe("ArcRotateCameraInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, {})).to.be.true;
 
             // Move Y coordinate. Drag camera.
             event.type = "pointermove";
             event.clientY = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;
 
@@ -884,21 +884,21 @@ describe("ArcRotateCameraInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, {})).to.be.true;
 
             // Move Y coordinate. Drag camera. (Not panning yet.)
             event.type = "pointermove";
             event.clientY = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;
 
             // Move X coordinate with Ctrl key depressed. Panning now.
             event.type = "pointermove";
             event.clientY = 2000;
-            event.button = 0;
+            event.button = -1;
             event.ctrlKey = true; // Will cause pan motion.
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialPanningY: ValChange.Increase })).to.be.true;
@@ -906,7 +906,7 @@ describe("ArcRotateCameraInput", function () {
             // Move X coordinate having released Ctrl.
             event.type = "pointermove";
             event.clientY = 3000;
-            event.button = 0;
+            event.button = -1;
             event.ctrlKey = false; // Will cancel pan motion.
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;
@@ -933,14 +933,14 @@ describe("ArcRotateCameraInput", function () {
 
             // Start moving.
             event.type = "pointermove";
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, {})).to.be.true;
 
             // Move Y coordinate. Drag camera.
             event.type = "pointermove";
             event.clientY = 1000;
-            event.button = 0;
+            event.button = -1;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;
 
@@ -948,7 +948,7 @@ describe("ArcRotateCameraInput", function () {
             // Panning disabled so continue regular drag..
             event.type = "pointermove";
             event.clientY = 1500;
-            event.button = 0;
+            event.button = -1;
             event.ctrlKey = true; // Will cause pan motion.
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;
@@ -956,7 +956,7 @@ describe("ArcRotateCameraInput", function () {
             // Move X coordinate having released Ctrl.
             event.type = "pointermove";
             event.clientY = 3000;
-            event.button = 0;
+            event.button = -1;
             event.ctrlKey = false;
             simulateEvent(this.cameraInput, event);
             expect(verifyChanges(this.camera, this.cameraCachePos, { inertialBetaOffset: ValChange.Decrease })).to.be.true;


### PR DESCRIPTION
This PR contains a modification for the ArcRotateCamera and FreeCamera's mouse movement behavior to keep track of what button was pressed to initiate a drag/rotate camera movement.  Touch should behave the same as it works differently from Mouse.