### PR TITLE
Coroutine addition for observables

### DIFF
--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -10,6 +10,7 @@ export * from "./filesInput";
 export * from "./HighDynamicRange/index";
 export * from "./khronosTextureContainer";
 export * from "./observable";
+export * from "./observableCoroutine";
 export * from "./performanceMonitor";
 export * from "./promise";
 export * from "./sceneOptimizer";

--- a/src/Misc/observableCoroutine.ts
+++ b/src/Misc/observableCoroutine.ts
@@ -1,0 +1,53 @@
+import { Nullable } from "../types";
+import { Observable } from "./observable";
+
+declare module "./observable" {
+    export interface Observable<T> {
+        /**
+         * Internal list of iterators and promise resolvers associated with coroutines.
+         */
+        coroutineIterators: Nullable<Array<{ iterator: Iterator<void, void, void>, resolver: () => void, rejecter: () => void }>>;
+
+        /**
+         * Runs a coroutine asynchronously on this observable
+         * @param coroutineIterator the iterator resulting from having started the coroutine
+         * @returns a promise which will be resolved when the coroutine finishes or rejected if the coroutine is cancelled
+         */
+        runCoroutineAsync(coroutineIterator: Iterator<void, void, void>): Promise<void>;
+
+        /**
+         * Cancels all coroutines currently running on this observable
+         */
+        cancelAllCoroutines(): void;
+    }
+}
+
+Observable.prototype.runCoroutineAsync = function (coroutineIterator: Iterator<void, void, void>): Promise<void> {
+    if (!this.coroutineIterators) {
+        this.coroutineIterators = [];
+
+        this.add(() => {
+            for (let idx = this.coroutineIterators!.length - 1; idx >= 0; --idx) {
+                if (this.coroutineIterators![idx].iterator.next().done) {
+                    this.coroutineIterators![idx].resolver();
+                    this.coroutineIterators!.splice(idx, 1);
+                }
+            }
+        });
+    }
+
+    return new Promise((resolver, rejecter) => {
+        this.coroutineIterators?.push({
+            iterator: coroutineIterator,
+            resolver: resolver,
+            rejecter: rejecter
+        });
+    });
+};
+
+Observable.prototype.cancelAllCoroutines = function (): void {
+    this.coroutineIterators!.forEach((coroutine) => {
+        coroutine.rejecter();
+    });
+    this.coroutineIterators = [];
+};


### PR DESCRIPTION
Simple mechanism/syntactic sugar to allow the use of coroutine syntax with Babylon.js observables.