### PR TITLE
Fix emitters being disposed whereas they should not

### DIFF
--- a/src/Particles/subEmitter.ts
+++ b/src/Particles/subEmitter.ts
@@ -49,23 +49,9 @@ export class SubEmitter {
         public particleSystem: ParticleSystem
     ) {
         // Create mesh as emitter to support rotation
-        let internalEmitterMesh = false;
         if (!particleSystem.emitter || !(<AbstractMesh>particleSystem.emitter).dispose) {
             const internalClass = _TypeStore.GetClass("BABYLON.AbstractMesh");
             particleSystem.emitter = new internalClass("SubemitterSystemEmitter", particleSystem.getScene());
-            internalEmitterMesh = true;
-        }
-
-        // Automatically dispose of subemitter when system is disposed
-        if (internalEmitterMesh && !particleSystem._disposeEmitterOnDispose) {
-            particleSystem.onDisposeObservable.add(() => {
-                if (particleSystem.emitter && (<AbstractMesh>particleSystem.emitter).dispose) {
-                    // Prevent recursive dispose to break.
-                    const disposable = <AbstractMesh>particleSystem.emitter;
-                    particleSystem.emitter = Vector3.Zero();
-                    disposable.dispose();
-                }
-            });
         }
     }
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/a-problem-with-particle-system-serializations/23332/7

Sub emitters that are created as part of regular code (meaning, not by the `clone` method that is used during the lifetime of the particle system) should not dispose their `particleSystem.emitter` object, as it could be needed when they are cloned. Only cloned sub emitters should dispose their emitter, as a new emitter is created each time `clone` is called => this one is already ok, as the `clone` method is doing `clone.particleSystem._disposeEmitterOnDispose = true;`. That's why the fix consists in simply removing the code that disposes the emitter in the constructor.

I have checked that the PGs from the doc using sub emitters don't leak emitters (meshes), and that the PGs from the OP (see link above) are ok too.
