### PR TITLE
Fix issue with pointerlock movement not working

### DIFF
--- a/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -131,7 +131,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
                 this.onDoubleTap(evt.pointerType);
-            } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton && !isTouch) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
+            } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton && this._currentActiveButton !== -1 && !isTouch) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
                 try {
                     srcElement.releasePointerCapture(evt.pointerId);
                 } catch (e) {

--- a/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -109,7 +109,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     }
-                } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
+                } else if ((p.type === PointerEventTypes.POINTERMOVE && srcElement && p.event.button === this._currentActiveButton && this._currentActiveButton !== -1) || (p.type === PointerEventTypes.POINTERUP && srcElement)) {
                     try {
                         srcElement.releasePointerCapture(evt.pointerId);
                     } catch (e) {


### PR DESCRIPTION
This PR contains a fix for situations where pointerlock is engaged and the camera isn't moving (FreeCamera).  This fix has also been applied to ArcRotateCamera.