### PR TITLE
[XR] detach and attach non-xr camera

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -174,6 +174,7 @@
 - Fix error on XR dispose due to undefined sepectator camera ([Alex-MSFT](https://github.com/Alex-MSFT))
 - Support for WebXR Foveated rendering ([#8920](https://github.com/BabylonJS/Babylon.js/issues/8920)) ([RaananW](https://github.com/RaananW))
 - Support WebXR framerate update ([#10912](https://github.com/BabylonJS/Babylon.js/issues/10912)) ([RaananW](https://github.com/RaananW))
+- Detach the non-vr camera from the canvas when entering XR and re-attach when leaving ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -16,6 +16,7 @@ import { Quaternion, Vector3 } from "../Maths/math.vector";
  */
 export class WebXRExperienceHelper implements IDisposable {
     private _nonVRCamera: Nullable<Camera> = null;
+    private _attachedToElement: boolean = false;
     private _spectatorCamera: Nullable<UniversalCamera> = null;
     private _originalSceneAutoClear = true;
     private _supported = false;
@@ -131,6 +132,7 @@ export class WebXRExperienceHelper implements IDisposable {
             // Cache pre xr scene settings
             this._originalSceneAutoClear = this.scene.autoClear;
             this._nonVRCamera = this.scene.activeCamera;
+            this._attachedToElement = !!(this._nonVRCamera?.inputs.attachedToElement);
 
             this.scene.activeCamera = this.camera;
             // do not compensate when AR session is used
@@ -151,6 +153,9 @@ export class WebXRExperienceHelper implements IDisposable {
                 // Restore scene settings
                 this.scene.autoClear = this._originalSceneAutoClear;
                 this.scene.activeCamera = this._nonVRCamera;
+                if (this._attachedToElement && this._nonVRCamera) {
+                    this._nonVRCamera.attachControl(!!(this._nonVRCamera.inputs.noPreventDefault));
+                }
                 if (sessionMode !== "immersive-ar" && this.camera.compensateOnFirstFrame) {
                     if ((<any>this._nonVRCamera).setPosition) {
                         (<any>this._nonVRCamera).setPosition(this.camera.position);

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -133,6 +133,7 @@ export class WebXRExperienceHelper implements IDisposable {
             this._originalSceneAutoClear = this.scene.autoClear;
             this._nonVRCamera = this.scene.activeCamera;
             this._attachedToElement = !!(this._nonVRCamera?.inputs.attachedToElement);
+            this._nonVRCamera?.detachControl();
 
             this.scene.activeCamera = this.camera;
             // do not compensate when AR session is used


### PR DESCRIPTION
When entering the XR scene the non-xr camera now detaches. if it was attached it re-attaches when going back to desktop mode.