### PR TITLE
[XR] Allow movement on the Y axis with controllers

### DIFF
--- a/src/XR/features/WebXRControllerMovement.ts
+++ b/src/XR/features/WebXRControllerMovement.ts
@@ -422,7 +422,6 @@ export class WebXRControllerMovement extends WebXRAbstractFeature {
             // move according to forward direction based on camera speed
             Vector3.TransformCoordinatesToRef(this._tmpTranslationDirection, this._tmpRotationMatrix, this._tmpMovementTranslation);
             this._tmpMovementTranslation.scaleInPlace(this._xrInput.xrCamera._computeLocalCameraSpeed() * this._featureContext.movementSpeed);
-            this._tmpMovementTranslation.y = 0;
 
             this._xrInput.xrCamera.cameraDirection.addInPlace(this._tmpMovementTranslation);
         }


### PR DESCRIPTION
Allow movement on the Y axis if collisions are not enabled. This will make the XR movement the same as the free camera's keyboard control - you are moving in the direction you are looking at. With collisions enabled you can achieve an "fps" camera in XR.

After merging check with this example: https://playground.babylonjs.com/#AZML8U#3