### PR TITLE
Fix for display grid rendering

### DIFF
--- a/gui/src/2D/controls/displayGrid.ts
+++ b/gui/src/2D/controls/displayGrid.ts
@@ -183,7 +183,7 @@ export class DisplayGrid extends Control {
                 context.strokeStyle = this._minorLineColor;
                 context.lineWidth = this._minorLineTickness;
 
-                for (var x = -cellCountX / 2; x < cellCountX / 2; x++) {
+                for (var x = -cellCountX / 2 + 1; x < cellCountX / 2; x++) {
                     const cellX = left + x * this.cellWidth;
 
                     context.beginPath();
@@ -193,7 +193,7 @@ export class DisplayGrid extends Control {
                     context.stroke();
                 }
 
-                for (var y = -cellCountY / 2; y < cellCountY / 2; y++) {
+                for (var y = -cellCountY / 2 + 1; y < cellCountY / 2; y++) {
                     const cellY = top + y * this.cellHeight;
 
                     context.beginPath();


### PR DESCRIPTION
I increased the starting index by 1 so it wouldn't draw the left and top boarders Now it is balanced with the bottom and right side.

![image](https://user-images.githubusercontent.com/67929198/131410250-f480377b-7843-4901-a99d-5e3ddd8e4361.png)

https://github.com/BabylonJS/Babylon.js/issues/10952