### PR TITLE
GUI: Fix highlights not displayed because of children clipping

### DIFF
--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -450,6 +450,8 @@ export class Container extends Control {
 
         this._localDraw(contextToDrawTo);
 
+        context.save();
+
         if (this.clipChildren) {
             this._clipForChildren(contextToDrawTo);
         }
@@ -471,6 +473,8 @@ export class Container extends Control {
             context.drawImage(contextToDrawTo.canvas, this._currentMeasure.left, this._currentMeasure.top);
             context.restore();
         }
+
+        context.restore();
     }
 
     public getDescendantsToRef(results: Control[], directDescendantsOnly: boolean = false, predicate?: (control: Control) => boolean): void {


### PR DESCRIPTION
`Rectangle._clipForChildren` is drawing the rounded rectangle and call `context.clip()` to clip against this rounded rectangle.

As the highlights is drawn after `_clipForChildren` is called, it is also clipped by the rounded rectangle which isn't what we want.

That's why I have added a `context.save` / `context.restore` inside/at the end of `Container._draw` (the clipping is done after the call to `context.save()` so `context.restore()` will restore a non-clipped area (or at least the clipped area of the parent control, which is what we want anyway)). However, I don't know if saving/restoring the context where I do it has any side-effects or not...

PG: https://playground.babylonjs.com/#XCPP9Y#8737