### PR TITLE
Exposing backplate visibility on TouchHolographicButton

### DIFF
--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -41,6 +41,7 @@ export class TouchHolographicButton extends TouchButton3D {
     private _text: string;
     private _imageUrl: string;
     private _shareMaterials = true;
+    private _isBackplateVisible = true;
     private _frontMaterial: FluentButtonMaterial;
     private _backMaterial: StandardMaterial;
     private _plateMaterial: StandardMaterial;
@@ -185,7 +186,6 @@ export class TouchHolographicButton extends TouchButton3D {
     public get backMaterial(): StandardMaterial {
         return this._backMaterial;
     }
-
     /**
      * Gets the front material used by this button
      */
@@ -205,6 +205,22 @@ export class TouchHolographicButton extends TouchButton3D {
      */
     public get shareMaterials(): boolean {
         return this._shareMaterials;
+    }
+
+    /**
+     * Sets whether the backplate is visible or hidden. Hiding the backplate is not recommended without some sort of replacement
+     */
+    public set isBackplateVisible(isVisible: boolean) {
+        if (this.mesh && !!this._backMaterial) {
+            if (isVisible && !this._isBackplateVisible) {
+                this._backPlate.visibility = 1;
+            }
+            else if (!isVisible && this._isBackplateVisible) {
+                this._backPlate.visibility = 0;
+            }
+        }
+
+        this._isBackplateVisible = isVisible;
     }
 
     /**
@@ -372,8 +388,8 @@ export class TouchHolographicButton extends TouchButton3D {
     }
 
     protected _affectMaterial(mesh: Mesh) {
-        // Back
         if (this._shareMaterials) {
+            // Back
             if (!this._host._touchSharedMaterials["backFluentMaterial"]) {
                 this._createBackMaterial(mesh);
                 this._host._touchSharedMaterials["backFluentMaterial"] = this._backMaterial;
@@ -396,6 +412,10 @@ export class TouchHolographicButton extends TouchButton3D {
         this._createPlateMaterial(mesh);
         this._backPlate.material = this._backMaterial;
         this._textPlate.material = this._plateMaterial;
+
+        if (!this._isBackplateVisible) {
+            this._backPlate.visibility = 0;
+        }
         if (!!this._frontPlate) {
             this._frontPlate.material = this._frontMaterial;
         }

--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -186,6 +186,7 @@ export class TouchHolographicButton extends TouchButton3D {
     public get backMaterial(): StandardMaterial {
         return this._backMaterial;
     }
+
     /**
      * Gets the front material used by this button
      */

--- a/gui/src/3D/controls/touchHolographicMenu.ts
+++ b/gui/src/3D/controls/touchHolographicMenu.ts
@@ -136,9 +136,7 @@ export class TouchHolographicMenu extends VolumeBasedPanel {
     public addButton(button: TouchHolographicButton): TouchHolographicMenu {
         super.addControl(button);
 
-        if (button.backMaterial) {
-            button.backMaterial.alpha = 0;
-        }
+        button.isBackplateVisible = false;
 
         return this;
     }


### PR DESCRIPTION
This change exposes setting the visibility of the backplate on the TouchHolographicButton, for use when placing the button up against other surfaces. This new parameter is immediately utilized by the TouchHolographicMenu class.

Also changed how the backplate is made transparent, so that buttons with a shared material aren't affected when a TouchHolographicMenu is created (previously, it would disable the backplate on _all_ buttons, since the material was shared).

Done as part of #10846