### PR TITLE
Avoid radius lock when radius is 0

### DIFF
--- a/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
+++ b/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
@@ -125,13 +125,14 @@ export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
         previousPinchSquaredDistance: number,
         pinchSquaredDistance: number
     ): void {
+        const radius = (this.camera.radius || 0.01);
         if (this.useNaturalPinchZoom) {
-            this.camera.radius = this.camera.radius *
+            this.camera.radius = radius *
                 Math.sqrt(previousPinchSquaredDistance) / Math.sqrt(pinchSquaredDistance);
         } else if (this.pinchDeltaPercentage) {
             this.camera.inertialRadiusOffset +=
                 (pinchSquaredDistance - previousPinchSquaredDistance) * 0.001 *
-                this.camera.radius * this.pinchDeltaPercentage;
+                radius * this.pinchDeltaPercentage;
         }
         else {
             this.camera.inertialRadiusOffset +=

--- a/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
+++ b/src/Cameras/Inputs/arcRotateCameraPointersInput.ts
@@ -17,6 +17,11 @@ export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
     public camera: ArcRotateCamera;
 
     /**
+     * The minimum radius used for pinch, to avoid radius lock at 0
+     */
+    public static MinimumRadiusForPinch: number = 0.001;
+
+    /**
      * Gets the class name of the current input.
      * @returns the class name
      */
@@ -125,7 +130,7 @@ export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
         previousPinchSquaredDistance: number,
         pinchSquaredDistance: number
     ): void {
-        const radius = (this.camera.radius || 0.01);
+        const radius = (this.camera.radius || ArcRotateCameraPointersInput.MinimumRadiusForPinch);
         if (this.useNaturalPinchZoom) {
             this.camera.radius = radius *
                 Math.sqrt(previousPinchSquaredDistance) / Math.sqrt(pinchSquaredDistance);


### PR DESCRIPTION
When pinching to zoom and getting to radius === 0 the camera radius will lock at 0 due to the multiplication in camera.radius.
This simply makes sure that radius has a minimal value