### PR TITLE
fix playground link in jsdoc for `DirectionalLightFrustumViewer`

### DIFF
--- a/src/Debug/directionalLightFrustumViewer.ts
+++ b/src/Debug/directionalLightFrustumViewer.ts
@@ -12,7 +12,7 @@ import { Scene } from "../scene";
 
 /**
  * Class used to render a debug view of the frustum for a directional light
- * @see https://playground.babylonjs.com/#7EFGSG#3
+ * @see https://playground.babylonjs.com/#7EFGSG#4
  * @since 5.0.0
  */
 export class DirectionalLightFrustumViewer {


### PR DESCRIPTION
updated playground because `DirectionalLightFrustumViewer` pulled from `BABYLON.Debug` namespace to `BABYLON`