### PR TITLE
Fix issue introduced with #10976

### DIFF
--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -235,9 +235,9 @@ export class Gizmo implements IDisposable {
      * Handle position/translation when using an attached node using pivot
      */
     protected _handlePivot() {
-        const attachedNodeTransform = this._attachedNode as TransformNode;
+        const attachedNodeTransform = this._attachedNode as any;
         // check there is an active pivot for the TransformNode attached
-        if (attachedNodeTransform.usePivotMatrix && attachedNodeTransform.position) {
+        if (attachedNodeTransform.usePivotMatrix && attachedNodeTransform.usePivotMatrix() && attachedNodeTransform.position) {
             // When a TransformNode has an active pivot, even without parenting,
             // translation from the world matrix is different from TransformNode.position.
             // Pivot works like a virtual parent that's using the node orientation.

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -237,7 +237,7 @@ export class Gizmo implements IDisposable {
     protected _handlePivot() {
         const attachedNodeTransform = this._attachedNode as any;
         // check there is an active pivot for the TransformNode attached
-        if (attachedNodeTransform.usePivotMatrix && attachedNodeTransform.usePivotMatrix() && attachedNodeTransform.position) {
+        if (attachedNodeTransform.isUsingPivotMatrix && attachedNodeTransform.isUsingPivotMatrix() && attachedNodeTransform.position) {
             // When a TransformNode has an active pivot, even without parenting,
             // translation from the world matrix is different from TransformNode.position.
             // Pivot works like a virtual parent that's using the node orientation.

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -203,7 +203,7 @@ export class TransformNode extends Node {
     /**
      * return true if a pivot has been set
      */
-     public usePivotMatrix(): boolean {
+     public isUsingPivotMatrix(): boolean {
          return this._usePivotMatrix;
      }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -203,7 +203,7 @@ export class TransformNode extends Node {
     /**
      * return true if a pivot has been set
      */
-     public get usePivotMatrix(): boolean {
+     public usePivotMatrix(): boolean {
          return this._usePivotMatrix;
      }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -202,6 +202,7 @@ export class TransformNode extends Node {
 
     /**
      * return true if a pivot has been set
+     * @returns true if a pivot matrix is used
      */
      public isUsingPivotMatrix(): boolean {
          return this._usePivotMatrix;


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/setting-getter-only-property-usepivotmatrix/23531
Trying to clone a getter only produces an error.
I replaced the getter with a function. I changed the only place where it's used. I have to change the cast from TransformNode to any because some objects (camera/light) do not inherit from TransformNode.