### PR TITLE
[XR] pointer up during render loop

### DIFF
--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -651,26 +651,28 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             });
         }
 
-        // Fire a pointerup
-        const pointerEventInit: PointerEventInit = {
-            pointerId: controllerData.id,
-            pointerType: "xr",
-        };
-        this._scene.simulatePointerUp(new PickingInfo(), pointerEventInit);
+        this._xrSessionManager.scene.onBeforeRenderObservable.addOnce(() => {
+            // Fire a pointerup
+            const pointerEventInit: PointerEventInit = {
+                pointerId: controllerData.id,
+                pointerType: "xr",
+            };
+            this._scene.simulatePointerUp(new PickingInfo(), pointerEventInit);
 
-        controllerData.selectionMesh.dispose();
-        controllerData.laserPointer.dispose();
-        // remove from the map
-        delete this._controllers[xrControllerUniqueId];
-        if (this._attachedController === xrControllerUniqueId) {
-            // check for other controllers
-            const keys = Object.keys(this._controllers);
-            if (keys.length) {
-                this._attachedController = keys[0];
-            } else {
-                this._attachedController = "";
+            controllerData.selectionMesh.dispose();
+            controllerData.laserPointer.dispose();
+            // remove from the map
+            delete this._controllers[xrControllerUniqueId];
+            if (this._attachedController === xrControllerUniqueId) {
+                // check for other controllers
+                const keys = Object.keys(this._controllers);
+                if (keys.length) {
+                    this._attachedController = keys[0];
+                } else {
+                    this._attachedController = "";
+                }
             }
-        }
+        });
     }
 
     private _generateNewMeshPair(meshParent: Node) {


### PR DESCRIPTION
Due to the XR architecture, simulated pointer up event must be executed within the render loop to make sure interaction with different elements (mainly GUI) works correctly.

The pointer up (and controller clearing) is not executed on the next rendered frame. I am using scene and not the xrFrame to make sure it is executed even when closing the XR session.