### PR TITLE
Copy buffer if invalid typed array alignment for glTF loader

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -2225,7 +2225,7 @@ export class GLTFLoader implements IGLTFLoader {
         if (byteOffset % componentTypeLength !== 0) {
             // HACK: Copy the buffer if byte offset is not a multiple of component type byte length.
             Logger.Warn(`${context}: Copying buffer as byte offset (${byteOffset}) is not a multiple of component type byte length (${componentTypeLength})`);
-            return new constructor(buffer.slice(byteOffset, byteOffset + length), 0);
+            return new constructor(buffer.slice(byteOffset, byteOffset + length * componentTypeLength), 0);
         }
 
         return new constructor(buffer, byteOffset, length);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/error-on-importing-a-simple-glb-exported-from-blender/23314.

This change loosens the requirement for typed array alignment such that it will copy the buffer when the typed array byte alignment requirement is not met. Note that glTF load performance will suffer a bit if this happens and the glTF validation will report an error.