### PR TITLE
Dispose _dragPlane when detaching in PointerDragBehavior

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -186,6 +186,7 @@
 - Exposed `scaleRatio` for `GizmoManager` ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Added constructor parameters to customize colors for rotation gizmos on `RotationGizmo` ([jekelija](https://github.com/jekelija))
 - Added constructor parameters to allow turning off `updateScale` on RotationGizmo ([jekelija](https://github.com/jekelija))
+- Dispose `_dragPlane` when detaching in `PointerDragBehavior` ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fixed wrong matrix with nodes having pivot point ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Gizmos that have draggable components now support near interactions via `WebXRNearInteraction` ([rickfromwork](https://github.com/rickfromwork)) 
 

--- a/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -491,6 +491,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
         if (this._beforeRenderObserver) {
             this._scene.onBeforeRenderObservable.remove(this._beforeRenderObserver);
         }
+        this._dragPlane.dispose();
         this.releaseDrag();
     }
 }


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/actionmanager-pointerdragbehavior-as-a-resource/23671/6
Tested with inspector on multiple meshes, multiple times.