### PR TITLE
SahderMaterial - add #define if it's not there.

### DIFF
--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -534,7 +534,7 @@ export class ShaderMaterial extends Material {
         for (var index = 0; index < this._options.defines.length; index++) {
             const defineToAdd = this._options.defines[index].indexOf("#define") === 0 ?
                 this._options.defines[index] :
-                `#define  + ${this._options.defines[index]}`;
+                `#define ${this._options.defines[index]}`;
             defines.push(defineToAdd);
         }
 

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -532,7 +532,10 @@ export class ShaderMaterial extends Material {
         }
 
         for (var index = 0; index < this._options.defines.length; index++) {
-            defines.push(this._options.defines[index]);
+            const defineToAdd = this._options.defines[index].indexOf("#define") === 0 ?
+                this._options.defines[index] :
+                `#define  + ${this._options.defines[index]}`;
+            defines.push(defineToAdd);
         }
 
         for (var index = 0; index < this._options.attributes.length; index++) {


### PR DESCRIPTION
As per our documentation, it is possible to add defines in a shader material. The array is then being added as is to the defines array when compiling, but #define is not added if not set. This contradicts out documentation. Setting `defines: ["MyDefine"]`) will fail, as it wil add the line `MyDefine` to the shader.

