### PR TITLE
Fix heightmap creation for cannonJS

### DIFF
--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -525,7 +525,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             }
 
             //calculate the new center using a pivot (since this.BJSCANNON.js doesn't center height maps)
-            const p = Matrix.Translation(boundingInfo.boundingBox.extendSizeWorld.x, 0, -boundingInfo.boundingBox.extendSizeWorld.z);
+            const p = Matrix.Translation(-boundingInfo.boundingBox.extendSizeWorld.x, 0, -boundingInfo.boundingBox.extendSizeWorld.z);
             mesh.setPreTransformMatrix(p);
             mesh.computeWorldMatrix(true);
 


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/physics-not-detecting-heightmap-collision-with-latest-5-alpha/23695

Translation to center heightmap was wrong