### PR TITLE
fix worker thread init for Recast-Detour

### DIFF
--- a/Playground/workers/navMeshWorker.js
+++ b/Playground/workers/navMeshWorker.js
@@ -10,37 +10,37 @@ onmessage = function(messageEvent) {
     const parameters = meshData[4];
 
     // initialize Recast
-    var recast = Recast();
+    Recast().then((recast) => {
+        // build rc config from parameters
+        const rc = new recast.rcConfig();
+        rc.cs = parameters.cs;
+        rc.ch = parameters.ch;
+        rc.borderSize = parameters.borderSize ? parameters.borderSize : 0;
+        rc.tileSize = parameters.tileSize ? parameters.tileSize : 0;
+        rc.walkableSlopeAngle = parameters.walkableSlopeAngle;
+        rc.walkableHeight = parameters.walkableHeight;
+        rc.walkableClimb = parameters.walkableClimb;
+        rc.walkableRadius = parameters.walkableRadius;
+        rc.maxEdgeLen = parameters.maxEdgeLen;
+        rc.maxSimplificationError = parameters.maxSimplificationError;
+        rc.minRegionArea = parameters.minRegionArea;
+        rc.mergeRegionArea = parameters.mergeRegionArea;
+        rc.maxVertsPerPoly = parameters.maxVertsPerPoly;
+        rc.detailSampleDist = parameters.detailSampleDist;
+        rc.detailSampleMaxError = parameters.detailSampleMaxError;
 
-    // build rc config from parameters
-    const rc = new recast.rcConfig();
-    rc.cs = parameters.cs;
-    rc.ch = parameters.ch;
-    rc.borderSize = parameters.borderSize ? parameters.borderSize : 0;
-    rc.tileSize = parameters.tileSize ? parameters.tileSize : 0;
-    rc.walkableSlopeAngle = parameters.walkableSlopeAngle;
-    rc.walkableHeight = parameters.walkableHeight;
-    rc.walkableClimb = parameters.walkableClimb;
-    rc.walkableRadius = parameters.walkableRadius;
-    rc.maxEdgeLen = parameters.maxEdgeLen;
-    rc.maxSimplificationError = parameters.maxSimplificationError;
-    rc.minRegionArea = parameters.minRegionArea;
-    rc.mergeRegionArea = parameters.mergeRegionArea;
-    rc.maxVertsPerPoly = parameters.maxVertsPerPoly;
-    rc.detailSampleDist = parameters.detailSampleDist;
-    rc.detailSampleMaxError = parameters.detailSampleMaxError;
+        // create navmesh and build it from message datas
+        const navMesh = new recast.NavMesh();
+        navMesh.build(positions, offset, indices, indicesLength, rc);
 
-    // create navmesh and build it from message datas
-    const navMesh = new recast.NavMesh();
-    navMesh.build(positions, offset, indices, indicesLength, rc);
+        // get recast uint8array
+        const navmeshData = navMesh.getNavmeshData();
+        const arrView = new Uint8Array(recast.HEAPU8.buffer, navmeshData.dataPointer, navmeshData.size);
+        const ret = new Uint8Array(navmeshData.size);
+        ret.set(arrView);
+        navMesh.freeNavmeshData(navmeshData);
 
-    // get recast uint8array
-    const navmeshData = navMesh.getNavmeshData();
-    const arrView = new Uint8Array(recast.HEAPU8.buffer, navmeshData.dataPointer, navmeshData.size);
-    const ret = new Uint8Array(navmeshData.size);
-    ret.set(arrView);
-    navMesh.freeNavmeshData(navmeshData);
-
-    // job done, returns the result
-    postMessage(ret);
+        // job done, returns the result
+        postMessage(ret);
+    });
 }


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/recastjs-plugin-is-broken/23698

worker thread init was broken because when I checked it, recast.js was not available on the preview CDN.
Apparently, `await` doesn't work with workerthread (found no info why, maybe you know)