### PR TITLE
Fix goToFrame when multiple calls are made

### DIFF
--- a/src/Animations/animatable.ts
+++ b/src/Animations/animatable.ts
@@ -22,6 +22,7 @@ export class Animatable {
     private _speedRatio = 1;
     private _weight = -1.0;
     private _syncRoot: Nullable<Animatable> = null;
+    private _frameToSyncFromJump: Nullable<number> = 0;
 
     /**
      * Gets or sets a boolean indicating if the animatable must be disposed and removed at the end of the animation.
@@ -269,8 +270,8 @@ export class Animatable {
 
         if (runtimeAnimations[0]) {
             var fps = runtimeAnimations[0].animation.framePerSecond;
-            var currentFrame = runtimeAnimations[0].currentFrame;
-            var delay = this.speedRatio === 0 ? 0 : ((frame - currentFrame) / fps * 1000) / this.speedRatio;
+            this._frameToSyncFromJump = this._frameToSyncFromJump ?? runtimeAnimations[0].currentFrame;
+            var delay = this.speedRatio === 0 ? 0 : ((frame - this._frameToSyncFromJump) / fps * 1000) / this.speedRatio;
             this._manualJumpDelay = -delay;
         }
 
@@ -386,6 +387,7 @@ export class Animatable {
         if (this._manualJumpDelay !== null) {
             this._localDelayOffset += this._manualJumpDelay;
             this._manualJumpDelay = null;
+            this._frameToSyncFromJump = null;
         }
 
         if (this._weight === 0) { // We consider that an animation with a weight === 0 is "actively" paused


### PR DESCRIPTION
When in a paused state, multiple calls to "gotoFrame" create an incorrect _manualJumpDelay. This occurs because the currentFrame of the first RuntimeAnimation is used to determine the that offset. But the currentframe is set on each call regardless of whether the animatable is paused or not. So it uses the offset of the last call to gotoFrame rather than the currentFrame it is actually paused on. I added a local field to keep track of the true currentframe.