### PR TITLE
Fix wrong name for a cloned camera

### DIFF
--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1270,7 +1270,9 @@ export class Camera extends Node {
      * @returns the cloned camera
      */
     public clone(name: string): Camera {
-        return SerializationHelper.Clone(Camera.GetConstructorFromName(this.getClassName(), name, this.getScene(), this.interaxialDistance, this.isStereoscopicSideBySide), this);
+        const camera = SerializationHelper.Clone(Camera.GetConstructorFromName(this.getClassName(), name, this.getScene(), this.interaxialDistance, this.isStereoscopicSideBySide), this);
+        camera.name = name;
+        return camera;
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/wrong-name-assigned-to-a-cloned-camera/23763