### PR TITLE
Add option to specify MultiRenderTarget's depth texture format.

### DIFF
--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
@@ -61,6 +61,7 @@ const textureFormat = [
     { label: "Depth24/Stencil8", normalizable: 0, hideType: true, value: Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 },
     { label: "Depth32 float", normalizable: 0, hideType: true, value: Constants.TEXTUREFORMAT_DEPTH32_FLOAT },
     { label: "Depth16", normalizable: 0, value: Constants.TEXTUREFORMAT_DEPTH16 },
+    { label: "Depth24", normalizable: 0, value: Constants.TEXTUREFORMAT_DEPTH24 },
     { label: "RGBA BPTC UNorm", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM },
     { label: "RGB BPTC UFloat", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT },
     { label: "RGB BPTC SFloat", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_SIGNED_FLOAT },

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -187,7 +187,9 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
             samplingModes = options.samplingModes;
         }
         if (this.webGLVersion > 1 &&
-            (options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 || options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT)) {
+            (options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 ||
+             options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24 ||
+             options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT)) {
             depthTextureFormat = options.depthTextureFormat;
         }
 

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -279,7 +279,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         var glDepthTextureFormat = gl.DEPTH_COMPONENT;
         var glDepthTextureType = gl.UNSIGNED_SHORT;
         var glAttachment = gl.DEPTH_ATTACHMENT;
-        if (this.webGLVersion < 1) {
+        if (this.webGLVersion < 2) {
             glDepthTextureInternalFormat = gl.DEPTH_COMPONENT;
         } else {
             if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -187,9 +187,9 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
             samplingModes = options.samplingModes;
         }
         if (this.webGLVersion > 1 &&
-            (options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 ||
-             options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24 ||
-             options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT)) {
+            (options.depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 ||
+             options.depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24 ||
+             options.depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH32_FLOAT)) {
             depthTextureFormat = options.depthTextureFormat;
         }
 
@@ -211,7 +211,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
     rtWrapper._framebuffer = framebuffer;
     rtWrapper._depthStencilBuffer = depthStencilBuffer;
     rtWrapper._generateDepthBuffer = !generateDepthTexture && generateDepthBuffer;
-    rtWrapper._generateStencilBuffer = !generateDepthTexture && generateStencilBuffer;
+    rtWrapper._generateStencilBuffer = !useStencilTexture && generateStencilBuffer;
     rtWrapper._attachments = attachments;
 
     for (var i = 0; i < textureCount; i++) {
@@ -285,16 +285,16 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         } else {
             if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {
                 depthTextureType = Constants.TEXTURETYPE_FLOAT;
-                glDepthTextureType= gl.FLOAT;
+                glDepthTextureType = gl.FLOAT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT32F;
             } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
-                glDepthTextureType= gl.UNSIGNED_INT;
+                glDepthTextureType = gl.UNSIGNED_INT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT24;
                 glDepthTextureAttachment = gl.DEPTH_ATTACHMENT;
             } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT_24_8;
-                glDepthTextureType= gl.UNSIGNED_INT_24_8;
+                glDepthTextureType = gl.UNSIGNED_INT_24_8;
                 glDepthTextureInternalFormat = gl.DEPTH24_STENCIL8;
                 glDepthTextureFormat = gl.DEPTH_STENCIL;
                 glDepthTextureAttachment = gl.DEPTH_STENCIL_ATTACHMENT;

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -203,12 +203,12 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
     var textures: InternalTexture[] = [];
     var attachments: number[] = [];
 
-    var depthStencilBuffer = this._setupFramebufferDepthAttachments(generateStencilBuffer, generateDepthBuffer, width, height);
+    var depthStencilBuffer = this._setupFramebufferDepthAttachments(!generateDepthTexture && generateStencilBuffer, !generateDepthTexture && generateDepthBuffer, width, height);
 
     rtWrapper._framebuffer = framebuffer;
     rtWrapper._depthStencilBuffer = depthStencilBuffer;
-    rtWrapper._generateDepthBuffer = generateDepthBuffer;
-    rtWrapper._generateStencilBuffer = generateStencilBuffer;
+    rtWrapper._generateDepthBuffer = !generateDepthTexture && generateDepthBuffer;
+    rtWrapper._generateStencilBuffer = !generateDepthTexture && generateStencilBuffer;
     rtWrapper._attachments = attachments;
 
     for (var i = 0; i < textureCount; i++) {
@@ -276,7 +276,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         var glDepthTextureInternalFormat = gl.DEPTH_COMPONENT16;
         var glDepthTextureFormat = gl.DEPTH_COMPONENT;
         var glDepthTextureType = gl.UNSIGNED_SHORT;
-        var glAttachmentType = gl.DEPTH_ATTACHMENT;
+        var glAttachment = gl.DEPTH_ATTACHMENT;
         if (this.webGLVersion > 1) {
             if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {
                 depthTextureType = Constants.TEXTURETYPE_FLOAT;
@@ -286,13 +286,13 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
                 glDepthTextureType= gl.UNSIGNED_INT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT24;
-                glAttachmentType = gl.DEPTH_ATTACHMENT;
+                glAttachment = gl.DEPTH_ATTACHMENT;
             } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT_24_8;
                 glDepthTextureType= gl.UNSIGNED_INT_24_8;
                 glDepthTextureInternalFormat = gl.DEPTH24_STENCIL8;
                 glDepthTextureFormat = gl.DEPTH_STENCIL;
-                glAttachmentType = gl.DEPTH_STENCIL_ATTACHMENT;
+                glAttachment = gl.DEPTH_STENCIL_ATTACHMENT;
             }
         }
 
@@ -316,7 +316,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
 
         gl.framebufferTexture2D(
             gl.FRAMEBUFFER,
-            glAttachmentType,
+            glAttachment,
             gl.TEXTURE_2D,
             depthTexture._hardwareTexture!.underlyingResource,
             0

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -205,7 +205,8 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
     var textures: InternalTexture[] = [];
     var attachments: number[] = [];
 
-    var depthStencilBuffer = this._setupFramebufferDepthAttachments(!generateDepthTexture && generateStencilBuffer, !generateDepthTexture && generateDepthBuffer, width, height);
+    var useStencilTexture = this.webGLVersion > 1 && generateDepthTexture && options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8;
+    var depthStencilBuffer = this._setupFramebufferDepthAttachments(!useStencilTexture && generateStencilBuffer, !generateDepthTexture && generateDepthBuffer, width, height);
 
     rtWrapper._framebuffer = framebuffer;
     rtWrapper._depthStencilBuffer = depthStencilBuffer;
@@ -278,7 +279,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         var glDepthTextureInternalFormat = gl.DEPTH_COMPONENT16;
         var glDepthTextureFormat = gl.DEPTH_COMPONENT;
         var glDepthTextureType = gl.UNSIGNED_SHORT;
-        var glAttachment = gl.DEPTH_ATTACHMENT;
+        var glDepthTextureAttachment = gl.DEPTH_ATTACHMENT;
         if (this.webGLVersion < 2) {
             glDepthTextureInternalFormat = gl.DEPTH_COMPONENT;
         } else {
@@ -290,13 +291,13 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
                 glDepthTextureType= gl.UNSIGNED_INT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT24;
-                glAttachment = gl.DEPTH_ATTACHMENT;
+                glDepthTextureAttachment = gl.DEPTH_ATTACHMENT;
             } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT_24_8;
                 glDepthTextureType= gl.UNSIGNED_INT_24_8;
                 glDepthTextureInternalFormat = gl.DEPTH24_STENCIL8;
                 glDepthTextureFormat = gl.DEPTH_STENCIL;
-                glAttachment = gl.DEPTH_STENCIL_ATTACHMENT;
+                glDepthTextureAttachment = gl.DEPTH_STENCIL_ATTACHMENT;
             }
         }
 
@@ -320,7 +321,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
 
         gl.framebufferTexture2D(
             gl.FRAMEBUFFER,
-            glAttachment,
+            glDepthTextureAttachment,
             gl.TEXTURE_2D,
             depthTexture._hardwareTexture!.underlyingResource,
             0

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -279,7 +279,9 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         var glDepthTextureFormat = gl.DEPTH_COMPONENT;
         var glDepthTextureType = gl.UNSIGNED_SHORT;
         var glAttachment = gl.DEPTH_ATTACHMENT;
-        if (this.webGLVersion > 1) {
+        if (this.webGLVersion < 1) {
+            glDepthTextureInternalFormat = gl.DEPTH_COMPONENT;
+        } else {
             if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {
                 depthTextureType = Constants.TEXTURETYPE_FLOAT;
                 glDepthTextureType= gl.FLOAT;

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -205,7 +205,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
     var textures: InternalTexture[] = [];
     var attachments: number[] = [];
 
-    var useStencilTexture = this.webGLVersion > 1 && generateDepthTexture && options.depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8;
+    var useStencilTexture = this.webGLVersion > 1 && generateDepthTexture && options.depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24_STENCIL8;
     var depthStencilBuffer = this._setupFramebufferDepthAttachments(!useStencilTexture && generateStencilBuffer, !generateDepthTexture && generateDepthBuffer, width, height);
 
     rtWrapper._framebuffer = framebuffer;

--- a/src/Engines/Extensions/engine.multiRender.ts
+++ b/src/Engines/Extensions/engine.multiRender.ts
@@ -283,16 +283,16 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: RenderTargetTe
         if (this.webGLVersion < 2) {
             glDepthTextureInternalFormat = gl.DEPTH_COMPONENT;
         } else {
-            if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {
+            if (depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH32_FLOAT) {
                 depthTextureType = Constants.TEXTURETYPE_FLOAT;
                 glDepthTextureType = gl.FLOAT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT32F;
-            } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24) {
+            } else if (depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
                 glDepthTextureType = gl.UNSIGNED_INT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT24;
                 glDepthTextureAttachment = gl.DEPTH_ATTACHMENT;
-            } else if (depthTextureFormat == Constants.TEXTUREFORMAT_DEPTH24_STENCIL8) {
+            } else if (depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24_STENCIL8) {
                 depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT_24_8;
                 glDepthTextureType = gl.UNSIGNED_INT_24_8;
                 glDepthTextureInternalFormat = gl.DEPTH24_STENCIL8;

--- a/src/Engines/constants.ts
+++ b/src/Engines/constants.ts
@@ -164,6 +164,8 @@ export class Constants {
   public static readonly TEXTUREFORMAT_DEPTH32_FLOAT = 14;
   /** Depth 16 bits */
   public static readonly TEXTUREFORMAT_DEPTH16 = 15;
+  /** Depth 24 bits */
+  public static readonly TEXTUREFORMAT_DEPTH24 = 16;
 
   /** Compressed BC7 */
   public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM = 36492;

--- a/src/Materials/Textures/multiRenderTarget.ts
+++ b/src/Materials/Textures/multiRenderTarget.ts
@@ -171,7 +171,7 @@ export class MultiRenderTarget extends RenderTargetTexture {
             generateDepthTexture: generateDepthTexture,
             depthTextureFormat: depthTextureFormat,
             types: types,
-            textureCount: count,
+            textureCount: count
         };
 
         this._count = count;

--- a/src/Materials/Textures/multiRenderTarget.ts
+++ b/src/Materials/Textures/multiRenderTarget.ts
@@ -37,7 +37,7 @@ export interface IMultiRenderTargetOptions {
     /**
      * Define depth texture format to use
      */
-    depthTextueFormat?: number;
+    depthTextureFormat?: number;
     /**
      * Define the number of desired draw buffers
      */
@@ -137,6 +137,7 @@ export class MultiRenderTarget extends RenderTargetTexture {
     constructor(name: string, size: any, count: number, scene: Scene, options?: IMultiRenderTargetOptions, textureNames?: string[]) {
         var generateMipMaps = options && options.generateMipMaps ? options.generateMipMaps : false;
         var generateDepthTexture = options && options.generateDepthTexture ? options.generateDepthTexture : false;
+        var depthTextureFormat = options && options.depthTextureFormat ? options.depthTextureFormat : Constants.TEXTUREFORMAT_DEPTH16;
         var doNotChangeAspectRatio = !options || options.doNotChangeAspectRatio === undefined ? true : options.doNotChangeAspectRatio;
         var drawOnlyOnFirstAttachmentByDefault = options && options.drawOnlyOnFirstAttachmentByDefault ? options.drawOnlyOnFirstAttachmentByDefault : false;
         super(name, size, scene, generateMipMaps, doNotChangeAspectRatio,
@@ -168,8 +169,9 @@ export class MultiRenderTarget extends RenderTargetTexture {
             generateDepthBuffer: generateDepthBuffer,
             generateStencilBuffer: generateStencilBuffer,
             generateDepthTexture: generateDepthTexture,
+            depthTextureFormat: depthTextureFormat,
             types: types,
-            textureCount: count
+            textureCount: count,
         };
 
         this._count = count;

--- a/src/Materials/Textures/multiRenderTarget.ts
+++ b/src/Materials/Textures/multiRenderTarget.ts
@@ -35,6 +35,10 @@ export interface IMultiRenderTargetOptions {
      */
     generateDepthTexture?: boolean;
     /**
+     * Define depth texture format to use
+     */
+    depthTextueFormat?: number;
+    /**
      * Define the number of desired draw buffers
      */
     textureCount?: number;


### PR DESCRIPTION
For WebGL 2, this change allows for choosing the depth texture format (16, 24, 24_S8, or 32F). Default is the same as before: 16 bits.

As an optimization, glRenderBuffers do not need to be created if a depth(/stencil) texture is being generated since it will be put on the framebuffer's depth/stencil attachment instead.