### PR TITLE
Make get absolutePosition consistent with getAbsolutePosition

### DIFF
--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -363,7 +363,7 @@ export class TransformNode extends Node {
      * Returns a Vector3.
      */
     public get absolutePosition(): Vector3 {
-        return this._absolutePosition;
+        return this.getAbsolutePosition();
     }
 
     /**


### PR DESCRIPTION
Here's the PR to change TransformNode's property getter, get absolutePosition,  to call getAbsolutePosition to keep the API consistent (currently get absolutePosition fails to call computeWorldMatrix).

https://forum.babylonjs.com/t/transformnode-getabsoluteposition-vs-get-absoluteposition/23772/7