### PR TITLE
fix bounds for heightMesh Cannon

### DIFF
--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -525,9 +525,11 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
             }
 
             //calculate the new center using a pivot (since this.BJSCANNON.js doesn't center height maps)
-            const p = Matrix.Translation(-boundingInfo.boundingBox.extendSizeWorld.x, 0, -boundingInfo.boundingBox.extendSizeWorld.z);
+            const p = Matrix.Translation(boundingInfo.boundingBox.extendSizeWorld.x, 0, -boundingInfo.boundingBox.extendSizeWorld.z);
             mesh.setPreTransformMatrix(p);
             mesh.computeWorldMatrix(true);
+            // force bounding box recomputation
+            boundingInfo = mesh.getBoundingInfo();
 
             //calculate the translation
             var translation = boundingInfo.boundingBox.centerWorld.subtract(center).subtract(mesh.position).negate();


### PR DESCRIPTION
This fix was not enough for Cannon Heightmesh : https://github.com/BabylonJS/Babylon.js/pull/11040
This one is better