### PR TITLE
Prevent uncatchable OOB exception in GLTF loader

### DIFF
--- a/loaders/src/glTF/glTFFileLoader.ts
+++ b/loaders/src/glTF/glTFFileLoader.ts
@@ -538,7 +538,14 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
             return this._loadFile(scene, fileOrUrl, (data) => {
                 const arrayBuffer = data as ArrayBuffer;
                 this._unpackBinaryAsync(new DataReader({
-                    readAsync: (byteOffset, byteLength) => Promise.resolve(new Uint8Array(arrayBuffer, byteOffset, byteLength)),
+                    readAsync: (byteOffset, byteLength) => {
+                        if (byteOffset + byteLength > arrayBuffer.byteLength) {
+                            return Promise.reject("ArrayBuffer not big enough to be read.");
+                        }
+
+                        const array = new Uint8Array(arrayBuffer, byteOffset, byteLength);
+                        return Promise.resolve(array);
+                    },
                     byteLength: arrayBuffer.byteLength
                 })).then((loaderData) => {
                     onSuccess(loaderData);


### PR DESCRIPTION
https://forum.babylonjs.com/t/gltffileloader-loadfile-does-not-call-onerror-callback-for-files-with-less-than-20-characters/22669