### PR TITLE
Fix light update gizmo

### DIFF
--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -16,6 +16,7 @@ import { PointerEventTypes, PointerInfo } from '../Events/pointerEvents';
 import { LinesMesh } from '../Meshes/linesMesh';
 import { PointerDragBehavior } from "../Behaviors/Meshes/pointerDragBehavior";
 import { ShadowLight } from "../Lights/shadowLight";
+import { Light } from "../Lights/light";
 
 /**
  * Cache built by each axis. Used for managing state between all elements of gizmo for enhanced UI
@@ -332,23 +333,29 @@ export class Gizmo implements IDisposable {
                 lmat.copyFrom(bone.getWorldMatrix());
             }
             bone.markAsDirty();
-        } else if (this._attachedNode.getClassName() === "SpotLight" || this._attachedNode.getClassName() === "PointLight" || this._attachedNode.getClassName() === "DirectionalLight") {
-            var light = this._attachedNode as ShadowLight;
-            const parent = light.parent;
+        } else {
+            const light = this._attachedNode as ShadowLight;
+            if (light.getTypeID)
+            {
+                const type = light.getTypeID();
+                if (type === Light.LIGHTTYPEID_DIRECTIONALLIGHT || type === Light.LIGHTTYPEID_SPOTLIGHT|| type === Light.LIGHTTYPEID_POINTLIGHT) {
+                    const parent = light.parent;
 
-            if (parent) {
-                var invParent = this._tempMatrix1;
-                var nodeLocalMatrix = this._tempMatrix2;
-                parent.getWorldMatrix().invertToRef(invParent);
-                light.getWorldMatrix().multiplyToRef(invParent, nodeLocalMatrix);
-                nodeLocalMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
-            } else {
-                this._attachedNode._worldMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
+                    if (parent) {
+                        var invParent = this._tempMatrix1;
+                        var nodeLocalMatrix = this._tempMatrix2;
+                        parent.getWorldMatrix().invertToRef(invParent);
+                        light.getWorldMatrix().multiplyToRef(invParent, nodeLocalMatrix);
+                        nodeLocalMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
+                    } else {
+                        this._attachedNode._worldMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
+                    }
+                    // setter doesn't copy values. Need a new Vector3
+                    light.position = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
+                    Vector3.Backward(false).rotateByQuaternionToRef(this._tempQuaternion, this._tempVector);
+                    light.direction = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
+                }
             }
-            // setter doesn't copy values. Need a new Vector3
-            light.position = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
-            Vector3.Backward(false).rotateByQuaternionToRef(this._tempQuaternion, this._tempVector);
-            light.direction = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
         }
     }
 

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -15,6 +15,7 @@ import { StandardMaterial } from '../Materials/standardMaterial';
 import { PointerEventTypes, PointerInfo } from '../Events/pointerEvents';
 import { LinesMesh } from '../Meshes/linesMesh';
 import { PointerDragBehavior } from "../Behaviors/Meshes/pointerDragBehavior";
+import { ShadowLight } from "../Lights/shadowLight";
 
 /**
  * Cache built by each axis. Used for managing state between all elements of gizmo for enhanced UI
@@ -331,6 +332,23 @@ export class Gizmo implements IDisposable {
                 lmat.copyFrom(bone.getWorldMatrix());
             }
             bone.markAsDirty();
+        } else if (this._attachedNode.getClassName() === "SpotLight" || this._attachedNode.getClassName() === "PointLight" || this._attachedNode.getClassName() === "DirectionalLight") {
+            var light = this._attachedNode as ShadowLight;
+            const parent = light.parent;
+
+            if (parent) {
+                var invParent = this._tempMatrix1;
+                var nodeLocalMatrix = this._tempMatrix2;
+                parent.getWorldMatrix().invertToRef(invParent);
+                light.getWorldMatrix().multiplyToRef(invParent, nodeLocalMatrix);
+                nodeLocalMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
+            } else {
+                this._attachedNode._worldMatrix.decompose(undefined, this._tempQuaternion, this._tempVector);
+            }
+            // setter doesn't copy values. Need a new Vector3
+            light.position = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
+            Vector3.Backward(false).rotateByQuaternionToRef(this._tempQuaternion, this._tempVector);
+            light.direction = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
         }
     }
 

--- a/src/Gizmos/gizmo.ts
+++ b/src/Gizmos/gizmo.ts
@@ -338,7 +338,7 @@ export class Gizmo implements IDisposable {
             if (light.getTypeID)
             {
                 const type = light.getTypeID();
-                if (type === Light.LIGHTTYPEID_DIRECTIONALLIGHT || type === Light.LIGHTTYPEID_SPOTLIGHT|| type === Light.LIGHTTYPEID_POINTLIGHT) {
+                if (type === Light.LIGHTTYPEID_DIRECTIONALLIGHT || type === Light.LIGHTTYPEID_SPOTLIGHT || type === Light.LIGHTTYPEID_POINTLIGHT) {
                     const parent = light.parent;
 
                     if (parent) {

--- a/src/Gizmos/lightGizmo.ts
+++ b/src/Gizmos/lightGizmo.ts
@@ -153,11 +153,15 @@ export class LightGizmo extends Gizmo {
             this._attachedMeshParent.freezeWorldMatrix(this._light.parent.getWorldMatrix());
         }
 
+        // For light positon and direction, a dirty flag is set to true in the setter
+        // It means setting values individualy or copying values willl not call setter and
+        // dirty flag will not be set to true. Hence creating a new Vector3.
         if ((this._light as any).position) {
             // If the gizmo is moved update the light otherwise update the gizmo to match the light
             if (!this.attachedMesh!.position.equals(this._cachedPosition)) {
                 // update light to match gizmo
-                (this._light as any).position.copyFrom(this.attachedMesh!.position);
+                const position = this.attachedMesh!.position;
+                (this._light as any).position = new Vector3(position.x, position.y, position.z);
                 this._cachedPosition.copyFrom(this.attachedMesh!.position);
             } else {
                 // update gizmo to match light
@@ -171,7 +175,8 @@ export class LightGizmo extends Gizmo {
             // If the gizmo is moved update the light otherwise update the gizmo to match the light
             if (Vector3.DistanceSquared(this.attachedMesh!.forward, this._cachedForward) > 0.0001) {
                 // update light to match gizmo
-                (this._light as any).direction.copyFrom(this.attachedMesh!.forward);
+                const direction = this.attachedMesh!.forward;
+                (this._light as any).direction = new Vector3(direction.x, direction.y, direction.z);
                 this._cachedForward.copyFrom(this.attachedMesh!.forward);
             } else if (Vector3.DistanceSquared(this.attachedMesh!.forward, (this._light as any).direction) > 0.0001) {
                 // update gizmo to match light


### PR DESCRIPTION
fixes https://github.com/BabylonJS/Babylon.js/issues/11075
Light projection matrix update is done thanks to a dirty flag. That flag is set to true in the setter. But copying values does call the setter and no update on the projection matrix. Calling setter instead.