### PR TITLE
raw texture conversion for byte textures

### DIFF
--- a/src/Engines/Extensions/engine.rawTexture.ts
+++ b/src/Engines/Extensions/engine.rawTexture.ts
@@ -503,8 +503,11 @@ function _convertRGBtoRGBATextureData(rgbData: any, width: number, height: numbe
     } else if (textureType === Constants.TEXTURETYPE_HALF_FLOAT) {
         rgbaData = new Uint16Array(width * height * 4);
         val1 = 15360; // 15360 is the encoding of 1 in half float
-    } else {
+    } else if (textureType === Constants.TEXTURETYPE_UNSIGNED_INTEGER) {
         rgbaData = new Uint32Array(width * height * 4);
+    }
+     else {
+        rgbaData = new Uint8Array(width * height * 4);
     }
 
     // Convert each pixel.

--- a/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
+++ b/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
@@ -327,8 +327,11 @@ function _convertRGBtoRGBATextureData(rgbData: any, width: number, height: numbe
     } else if (textureType === Constants.TEXTURETYPE_HALF_FLOAT) {
         rgbaData = new Uint16Array(width * height * 4);
         val1 = 15360; // 15360 is the encoding of 1 in half float
-    } else {
+    } else if (textureType === Constants.TEXTURETYPE_UNSIGNED_INTEGER) {
         rgbaData = new Uint32Array(width * height * 4);
+    }
+     else {
+        rgbaData = new Uint8Array(width * height * 4);
     }
 
     // Convert each pixel.


### PR DESCRIPTION
Addresses the filtering caps issue from https://forum.babylonjs.com/t/skybox-removed-after-loading-model-in-v4-x-but-not-in-v5-alpha/23729/42

Repro https://playground.babylonjs.com/#E0EDQH#16