### PR TITLE
initial bounding info should be based on the local position

### DIFF
--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1426,7 +1426,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         if (this._boundingInfo) {
             this._boundingInfo.update(effectiveMesh.worldMatrixFromCache);
         } else {
-            this._boundingInfo = new BoundingInfo(this.absolutePosition, this.absolutePosition, effectiveMesh.worldMatrixFromCache);
+            this._boundingInfo = new BoundingInfo(this.position, this.position, effectiveMesh.worldMatrixFromCache);
         }
         this._updateSubMeshesBoundingInfo(effectiveMesh.worldMatrixFromCache);
         return this;


### PR DESCRIPTION
Related to #11091

When creating a mesh without a geometry and setting its parent the next call to create bounding info will create it using the absolute position (9i.e. the parent position's as well).
This is not the case for meshes with a geometry.

I don't see a reason this will break any existing implementation. meshes created by MeshBuilders don't have a parent when initialized, and the min-max should anyhow be local, as the world matrix is the one in charge of transforming the world center/min/max to the right coordinates

The issue can be seen here - https://playground.babylonjs.com/debug.html#YGAA79#3

Check the console and see the local center of both meshes - it should be the same, but it isn't because of the usage of absolutePosition (as the first mesh's bounding info is created only after the parent is set while the sphere's is created when the geometry is created).