### PR TITLE
Support WebP in environmentTextureTools

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -45,6 +45,7 @@
 - Modified behavior for FreeCamera and ArcRotateCamera so that default mouse dragging movements now account for what button was used to initiate it ([PolygonalSun](https://github.com/PolygonalSun))
 - Added coroutine capabilities to `Observable`s ([syntheticmagus](https://github.com/syntheticmagus))
 - Added a global OnTextureLoadErrorObservable to handle texture loading errors during model load ([RaananW](https://github.com/RaananW))
+- Add support to encode and decode .env environment textures using WebP instead of PNG ([simonihmig](https://github.com/simonihmig))
 
 ### Engine
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -2219,10 +2219,6 @@ export class NativeEngine extends Engine {
 
                 EnvironmentTextureTools.UploadEnvSpherical(texture, info);
 
-                if (info.version !== 1) {
-                    throw new Error(`Unsupported babylon environment map version "${info.version}"`);
-                }
-
                 let specularInfo = info.specular as EnvironmentTextureSpecularInfoV1;
                 if (!specularInfo) {
                     throw new Error(`Nothing else parsed so far`);

--- a/src/Misc/environmentTextureTools.ts
+++ b/src/Misc/environmentTextureTools.ts
@@ -20,8 +20,7 @@ import "../Materials/Textures/baseTexture.polynomial";
 import "../Shaders/rgbdEncode.fragment";
 import "../Shaders/rgbdDecode.fragment";
 
-type EnvironmentTextureImageType = 'image/png' | 'image/webp';
-const defaultEnvironmentTextureImageType: EnvironmentTextureImageType = 'image/png';
+const defaultEnvironmentTextureImageType = 'image/png';
 
 /**
  * Raw texture data and descriptor sufficient for WebGL texture upload
@@ -48,9 +47,9 @@ export interface EnvironmentTextureInfo {
     specular: any;
 
     /**
-     * The image type used to encode the image data.
+     * The mime type used to encode the image data.
      */
-    imageType?: EnvironmentTextureImageType;
+    imageType?: string;
 }
 
 /**
@@ -104,11 +103,14 @@ interface EnvironmentTextureIrradianceInfoV1 {
     xy: Array<number>;
 }
 
+/**
+ * Options for creating environment textures
+ */
 export interface CreateEnvTextureOptions {
     /**
      * The mime type of encoded images.
      */
-    imageType?: EnvironmentTextureImageType;
+    imageType?: string;
 
     /**
      * the image quality of encoded WebP images.
@@ -445,7 +447,7 @@ export class EnvironmentTextureTools {
      * @param imageType the mime type of the image data
      * @returns a promise
      */
-    public static UploadLevelsAsync(texture: InternalTexture, imageData: ArrayBufferView[][], imageType: EnvironmentTextureImageType = defaultEnvironmentTextureImageType): Promise<void> {
+    public static UploadLevelsAsync(texture: InternalTexture, imageData: ArrayBufferView[][], imageType: string = defaultEnvironmentTextureImageType): Promise<void> {
         if (!Tools.IsExponentOfTwo(texture.width)) {
             throw new Error("Texture size must be a power of two");
         }

--- a/src/Misc/environmentTextureTools.ts
+++ b/src/Misc/environmentTextureTools.ts
@@ -105,7 +105,15 @@ interface EnvironmentTextureIrradianceInfoV1 {
 }
 
 export interface CreateEnvTextureOptions {
+    /**
+     * The mime type of encoded images.
+     */
     imageType?: EnvironmentTextureImageType;
+
+    /**
+     * the image quality of encoded WebP images.
+     */
+    imageQuality?: number;
 }
 
 /**
@@ -163,6 +171,7 @@ export class EnvironmentTextureTools {
      * @param texture defines the cube texture to convert in env file
      * @param options options for the conversion process
      * @param options.imageType the mime type for the encoded images, with support for "image/png" (default) and "image/webp"
+     * @param options.imageQuality the image quality of encoded WebP images.
      * @return a promise containing the environment data if successful.
      */
     public static async CreateEnvTextureAsync(texture: BaseTexture, options: CreateEnvTextureOptions = {}): Promise<ArrayBuffer> {
@@ -223,7 +232,7 @@ export class EnvironmentTextureTools {
 
                 const rgbdEncodedData = await engine._readTexturePixels(tempTexture, faceWidth, faceWidth);
 
-                const imageEncodedData = await Tools.DumpDataAsync(faceWidth, faceWidth, rgbdEncodedData, imageType, undefined, false, true);
+                const imageEncodedData = await Tools.DumpDataAsync(faceWidth, faceWidth, rgbdEncodedData, imageType, undefined, false, true, options.imageQuality);
 
                 specularTextures[i * 6 + face] = imageEncodedData as ArrayBuffer;
 

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -674,7 +674,7 @@ export class Tools {
                         }
                     };
                     fileReader.readAsArrayBuffer(blob!);
-                });
+                }, mimeType);
             } else {
                 Tools.EncodeScreenshotCanvasData(successCallback, mimeType, fileName, canvas);
             }

--- a/src/Misc/tools.ts
+++ b/src/Misc/tools.ts
@@ -617,8 +617,9 @@ export class Tools {
      * @param fileName defines the filename to download. If present, the result will automatically be downloaded
      * @param invertY true to invert the picture in the Y dimension
      * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
+     * @param quality defines the quality of the result
      */
-    public static DumpData(width: number, height: number, data: ArrayBufferView, successCallback?: (data: string | ArrayBuffer) => void, mimeType: string = "image/png", fileName?: string, invertY = false, toArrayBuffer = false) {
+    public static DumpData(width: number, height: number, data: ArrayBufferView, successCallback?: (data: string | ArrayBuffer) => void, mimeType: string = "image/png", fileName?: string, invertY = false, toArrayBuffer = false, quality?: number) {
         // Create a 2D canvas to store the result
         if (!Tools._ScreenshotCanvas) {
             Tools._ScreenshotCanvas = document.createElement("canvas");
@@ -674,9 +675,9 @@ export class Tools {
                         }
                     };
                     fileReader.readAsArrayBuffer(blob!);
-                }, mimeType);
+                }, mimeType, quality);
             } else {
-                Tools.EncodeScreenshotCanvasData(successCallback, mimeType, fileName, canvas);
+                Tools.EncodeScreenshotCanvasData(successCallback, mimeType, fileName, canvas, quality);
             }
         }
     }
@@ -686,16 +687,16 @@ export class Tools {
      * @param width defines the rendering width
      * @param height defines the rendering height
      * @param data the data array
-     * @param successCallback defines the callback triggered once the data are available
      * @param mimeType defines the mime type of the result
      * @param fileName defines the filename to download. If present, the result will automatically be downloaded
      * @param invertY true to invert the picture in the Y dimension
      * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
+     * @param quality defines the quality of the result
      * @return a promise that resolve to the final data
      */
-    public static DumpDataAsync(width: number, height: number, data: ArrayBufferView, mimeType: string = "image/png", fileName?: string, invertY = false, toArrayBuffer = false): Promise<string | ArrayBuffer> {
+    public static DumpDataAsync(width: number, height: number, data: ArrayBufferView, mimeType: string = "image/png", fileName?: string, invertY = false, toArrayBuffer = false, quality?: number): Promise<string | ArrayBuffer> {
         return new Promise((resolve) => {
-            Tools.DumpData(width, height, data, (result) => resolve(result), mimeType, fileName, invertY, toArrayBuffer);
+            Tools.DumpData(width, height, data, (result) => resolve(result), mimeType, fileName, invertY, toArrayBuffer, quality);
         });
     }
 
@@ -705,8 +706,9 @@ export class Tools {
      * @param canvas Defines the canvas to extract the data from
      * @param successCallback Defines the callback triggered once the data are available
      * @param mimeType Defines the mime type of the result
+     * @param quality defines the quality of the result
      */
-    static ToBlob(canvas: HTMLCanvasElement, successCallback: (blob: Nullable<Blob>) => void, mimeType: string = "image/png"): void {
+    static ToBlob(canvas: HTMLCanvasElement, successCallback: (blob: Nullable<Blob>) => void, mimeType: string = "image/png", quality?: number): void {
         // We need HTMLCanvasElement.toBlob for HD screenshots
         if (!canvas.toBlob) {
             //  low performance polyfill based on toDataURL (https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob)
@@ -725,7 +727,7 @@ export class Tools {
         }
         canvas.toBlob(function (blob) {
             successCallback(blob);
-        }, mimeType);
+        }, mimeType, quality);
     }
 
     /**
@@ -734,10 +736,11 @@ export class Tools {
      * @param mimeType defines the mime type of the result
      * @param fileName defines he filename to download. If present, the result will automatically be downloaded
      * @param canvas canvas to get the data from. If not provided, use the default screenshot canvas
+     * @param quality defines the quality of the result
      */
-    static EncodeScreenshotCanvasData(successCallback?: (data: string) => void, mimeType: string = "image/png", fileName?: string, canvas?: HTMLCanvasElement): void {
+    static EncodeScreenshotCanvasData(successCallback?: (data: string) => void, mimeType: string = "image/png", fileName?: string, canvas?: HTMLCanvasElement, quality?: number): void {
         if (successCallback) {
-            var base64Image = (canvas ?? Tools._ScreenshotCanvas).toDataURL(mimeType);
+            var base64Image = (canvas ?? Tools._ScreenshotCanvas).toDataURL(mimeType, quality);
             successCallback(base64Image);
         }
         else {
@@ -764,7 +767,7 @@ export class Tools {
                     img.src = url;
                     newWindow.document.body.appendChild(img);
                 }
-            }, mimeType);
+            }, mimeType, quality);
         }
     }
 


### PR DESCRIPTION
This adds support for encoding and decoding WebP images in .env files. See https://forum.babylonjs.com/t/support-webp-for-env-maps/23644

The default type remains PNG, so the changes should be fully backwards compatible. I tested this by locally changing the arguments to [CreateEnvTextureAsync](https://github.com/BabylonJS/Babylon.js/blob/master/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx#L254) in the Inspector, exporting some sample environments with different settings, and dropping them again into the sandbox. Everything seems to work fine. Not sure if there is some additional test coverage we can add here?

The second commit adds an optional `quality` argument to a bunch of Blob-related tools, so that it can be passed finally to `canvas.toBlob()`, which supports this argument for WebP images (at least in Chrome).

The results are quite satisfying. The playground's original [`environment.dds`](https://playground.babylonjs.com/textures/environment.dds) gave these results when converted to .env:
* using PNG: 271KB
* using WebP w/ default quality (0.8): 71KB
* using WebP w/ quality=0.5: 64KB
* using WebP w/ quality=0.1: 57KB

You can find these sample files [here](https://drive.google.com/drive/folders/1QKwSN0gl8EA5PzWRF-TUsHyCNLV4hrCR?usp=sharing)

I didn't update the Inspector to allow exporting .env files using WebP yet, but can do this in a separate PR when this is merged!

