### PR TITLE
Improve Sound.setPosition performance

### DIFF
--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -625,6 +625,9 @@ export class Sound {
      * @param newPosition Defines the new position
      */
     public setPosition(newPosition: Vector3): void {
+        if (newPosition.equals(this._position)) {
+            return;
+        }
         this._position = newPosition;
 
         if (Engine.audioEngine?.canUseWebAudio && this.spatialSound && this._soundPanner && !isNaN(this._position.x) && !isNaN(this._position.y) && !isNaN(this._position.z)) {


### PR DESCRIPTION
On a publicly deployed project I'm working on we've had numerous users report severe audio degradation over time on iOS and Safari. The project uses spatial audio. 

On both platforms the CPU usage was ticking upwards quickly. Digging in it turns out that setting a position of the `PannerNode` on every frame even when the position has not changed, as can happen via e.g. world matrix update observables, has adverse performance effects on WebKit.

Checking and returning early if the current and new positions are equal seems to have remedied this performance issue.

Happy to discuss further!