### PR TITLE
DeviceInputSystem: Catch pointer capture calls during pointer lock

### DIFF
--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -443,12 +443,22 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
 
                     if (!document.pointerLockElement) {
-                        this._elementToAttachTo.setPointerCapture(this._mouseId);
+                        try {
+                            this._elementToAttachTo.setPointerCapture(this._mouseId);
+                        }
+                        catch (e) {
+                            // DO NOTHING
+                        }
                     }
                 }
                 else { // Touch; Since touches are dynamically assigned, only set capture if we have an id
                     if (evt.pointerId && !document.pointerLockElement) {
-                        this._elementToAttachTo.setPointerCapture(evt.pointerId);
+                        try {
+                            this._elementToAttachTo.setPointerCapture(evt.pointerId);
+                        }
+                        catch (e) {
+                            // DO NOTHING
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR contains an added try/catch around all setPointerCapture calls in the DeviceInputSystem to prevent an error from occurring in the instance that a pointer capture is set after a pointer lock is set.  This should prevent the invalid state from breaking input.