### PR TITLE
New rig camera (and a small restructure)

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -46,6 +46,7 @@
 - Added coroutine capabilities to `Observable`s ([syntheticmagus](https://github.com/syntheticmagus))
 - Added a global OnTextureLoadErrorObservable to handle texture loading errors during model load ([RaananW](https://github.com/RaananW))
 - Add support to encode and decode .env environment textures using WebP instead of PNG ([simonihmig](https://github.com/simonihmig))
+- Added a new stereoscopic screen rig camera ([RaananW](https://github.com/RaananW))
 
 ### Engine
 

--- a/src/Cameras/RigModes/stereoscopicAnaglyphRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicAnaglyphRigMode.ts
@@ -2,7 +2,7 @@ import { Camera } from "../camera";
 import { PassPostProcess } from "../../PostProcesses/passPostProcess";
 import { AnaglyphPostProcess } from "../../PostProcesses/anaglyphPostProcess";
 
-Camera._setStereoscopicAnaglyphRigMode = function (camera: Camera) {
+export const setStereoscopicAnaglyphRigMode = function (camera: Camera) {
     camera._rigCameras[0]._rigPostProcess = new PassPostProcess(camera.name + "_passthru", 1.0, camera._rigCameras[0]);
     camera._rigCameras[1]._rigPostProcess = new AnaglyphPostProcess(camera.name + "_anaglyph", 1.0, camera._rigCameras);
 };

--- a/src/Cameras/RigModes/stereoscopicAnaglyphRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicAnaglyphRigMode.ts
@@ -2,7 +2,10 @@ import { Camera } from "../camera";
 import { PassPostProcess } from "../../PostProcesses/passPostProcess";
 import { AnaglyphPostProcess } from "../../PostProcesses/anaglyphPostProcess";
 
-export const setStereoscopicAnaglyphRigMode = function (camera: Camera) {
+/**
+ * @hidden
+ */
+export function setStereoscopicAnaglyphRigMode(camera: Camera) {
     camera._rigCameras[0]._rigPostProcess = new PassPostProcess(camera.name + "_passthru", 1.0, camera._rigCameras[0]);
     camera._rigCameras[1]._rigPostProcess = new AnaglyphPostProcess(camera.name + "_anaglyph", 1.0, camera._rigCameras);
-};
+}

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -3,7 +3,10 @@ import { Viewport } from '../../Maths/math.viewport';
 import { PassPostProcess } from '../../PostProcesses/passPostProcess';
 import { StereoscopicInterlacePostProcessI } from '../../PostProcesses/stereoscopicInterlacePostProcess';
 
-export const setStereoscopicRigMode = function (camera: Camera) {
+/**
+ * @hidden
+ */
+export function setStereoscopicRigMode(camera: Camera): void {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
     var isCrossEye = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
     var isInterlaced = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_INTERLACED;
@@ -17,4 +20,4 @@ export const setStereoscopicRigMode = function (camera: Camera) {
         camera._rigCameras[isCrossEye ? 1 : 0].viewport = new Viewport(0, 0, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
         camera._rigCameras[isCrossEye ? 0 : 1].viewport = new Viewport(isStereoscopicHoriz ? 0.5 : 0, isStereoscopicHoriz ? 0 : 0.5, isStereoscopicHoriz ? 0.5 : 1.0, isStereoscopicHoriz ? 1.0 : 0.5);
     }
-};
+}

--- a/src/Cameras/RigModes/stereoscopicRigMode.ts
+++ b/src/Cameras/RigModes/stereoscopicRigMode.ts
@@ -3,7 +3,7 @@ import { Viewport } from '../../Maths/math.viewport';
 import { PassPostProcess } from '../../PostProcesses/passPostProcess';
 import { StereoscopicInterlacePostProcessI } from '../../PostProcesses/stereoscopicInterlacePostProcess';
 
-Camera._setStereoscopicRigMode = function (camera: Camera) {
+export const setStereoscopicRigMode = function (camera: Camera) {
     var isStereoscopicHoriz = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL || camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
     var isCrossEye = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED;
     var isInterlaced = camera.cameraRigMode === Camera.RIG_MODE_STEREOSCOPIC_INTERLACED;

--- a/src/Cameras/RigModes/vrRigMode.ts
+++ b/src/Cameras/RigModes/vrRigMode.ts
@@ -6,7 +6,7 @@ import { VRCameraMetrics } from "../VR/vrCameraMetrics";
 import { Logger } from '../../Misc/logger';
 import { Viewport } from '../../Maths/math.viewport';
 
-Camera._setVRRigMode = function (camera: Camera, rigParams: any) {
+export const setVRRigMode = function (camera: Camera, rigParams: any) {
     var metrics = <VRCameraMetrics>rigParams.vrCameraMetrics || VRCameraMetrics.GetDefault();
 
     camera._rigCameras[0]._cameraRigParams.vrMetrics = metrics;

--- a/src/Cameras/RigModes/vrRigMode.ts
+++ b/src/Cameras/RigModes/vrRigMode.ts
@@ -6,7 +6,10 @@ import { VRCameraMetrics } from "../VR/vrCameraMetrics";
 import { Logger } from '../../Misc/logger';
 import { Viewport } from '../../Maths/math.viewport';
 
-export const setVRRigMode = function (camera: Camera, rigParams: any) {
+/**
+ * @hidden
+ */
+export function setVRRigMode(camera: Camera, rigParams: any) {
     var metrics = <VRCameraMetrics>rigParams.vrCameraMetrics || VRCameraMetrics.GetDefault();
 
     camera._rigCameras[0]._cameraRigParams.vrMetrics = metrics;
@@ -40,4 +43,4 @@ export const setVRRigMode = function (camera: Camera, rigParams: any) {
         camera._rigCameras[0]._rigPostProcess = new VRDistortionCorrectionPostProcess("VR_Distort_Compensation_Left", camera._rigCameras[0], false, metrics);
         camera._rigCameras[1]._rigPostProcess = new VRDistortionCorrectionPostProcess("VR_Distort_Compensation_Right", camera._rigCameras[1], true, metrics);
     }
-};
+}

--- a/src/Cameras/RigModes/webVRRigMode.ts
+++ b/src/Cameras/RigModes/webVRRigMode.ts
@@ -2,7 +2,10 @@ import { Camera } from "../camera";
 import { Matrix } from "../../Maths/math.vector";
 import { Viewport } from '../../Maths/math.viewport';
 
-export const setWebVRRigMode = function (camera: Camera, rigParams: any) {
+/**
+ * @hidden
+ */
+export function setWebVRRigMode(camera: Camera, rigParams: any) {
     if (rigParams.vrDisplay) {
         var leftEye = rigParams.vrDisplay.getEyeParameters('left');
         var rightEye = rigParams.vrDisplay.getEyeParameters('right');
@@ -31,4 +34,4 @@ export const setWebVRRigMode = function (camera: Camera, rigParams: any) {
         camera._rigCameras[1].parent = camera;
         camera._rigCameras[1]._getViewMatrix = camera._getWebVRViewMatrix;
     }
-};
+}

--- a/src/Cameras/RigModes/webVRRigMode.ts
+++ b/src/Cameras/RigModes/webVRRigMode.ts
@@ -2,7 +2,7 @@ import { Camera } from "../camera";
 import { Matrix } from "../../Maths/math.vector";
 import { Viewport } from '../../Maths/math.viewport';
 
-Camera._setWebVRRigMode = function (camera: Camera, rigParams: any) {
+export const setWebVRRigMode = function (camera: Camera, rigParams: any) {
     if (rigParams.vrDisplay) {
         var leftEye = rigParams.vrDisplay.getEyeParameters('left');
         var rightEye = rigParams.vrDisplay.getEyeParameters('right');

--- a/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
@@ -39,5 +39,5 @@ export class AnaglyphArcRotateCamera extends ArcRotateCamera {
         return "AnaglyphArcRotateCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
@@ -3,9 +3,7 @@ import { ArcRotateCamera } from "../../Cameras/arcRotateCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicAnaglyphRigMode";
+import { setStereoscopicAnaglyphRigMode } from "../RigModes/stereoscopicAnaglyphRigMode";
 
 Node.AddNodeConstructor("AnaglyphArcRotateCamera", (name, scene, options) => {
     return () => new AnaglyphArcRotateCamera(name, 0, 0, 1.0, Vector3.Zero(), options.interaxial_distance, scene);
@@ -40,4 +38,6 @@ export class AnaglyphArcRotateCamera extends ArcRotateCamera {
     public getClassName(): string {
         return "AnaglyphArcRotateCamera";
     }
+
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
@@ -35,5 +35,5 @@ export class AnaglyphFreeCamera extends FreeCamera {
         return "AnaglyphFreeCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
@@ -3,9 +3,7 @@ import { FreeCamera } from "../../Cameras/freeCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicAnaglyphRigMode";
+import { setStereoscopicAnaglyphRigMode } from "../RigModes/stereoscopicAnaglyphRigMode";
 
 Node.AddNodeConstructor("AnaglyphFreeCamera", (name, scene, options) => {
     return () => new AnaglyphFreeCamera(name, Vector3.Zero(), options.interaxial_distance, scene);
@@ -36,4 +34,6 @@ export class AnaglyphFreeCamera extends FreeCamera {
     public getClassName(): string {
         return "AnaglyphFreeCamera";
     }
+
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
@@ -3,9 +3,7 @@ import { GamepadCamera } from "../../Cameras/gamepadCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicAnaglyphRigMode";
+import { setStereoscopicAnaglyphRigMode } from "../RigModes/stereoscopicAnaglyphRigMode";
 
 Node.AddNodeConstructor("AnaglyphGamepadCamera", (name, scene, options) => {
     return () => new AnaglyphGamepadCamera(name, Vector3.Zero(), options.interaxial_distance, scene);
@@ -36,4 +34,6 @@ export class AnaglyphGamepadCamera extends GamepadCamera {
     public getClassName(): string {
         return "AnaglyphGamepadCamera";
     }
+
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
@@ -35,5 +35,5 @@ export class AnaglyphGamepadCamera extends GamepadCamera {
         return "AnaglyphGamepadCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
@@ -4,8 +4,7 @@ import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
 
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicAnaglyphRigMode";
+import { setStereoscopicAnaglyphRigMode } from "../RigModes/stereoscopicAnaglyphRigMode";
 
 Node.AddNodeConstructor("AnaglyphUniversalCamera", (name, scene, options) => {
     return () => new AnaglyphUniversalCamera(name, Vector3.Zero(), options.interaxial_distance, scene);
@@ -36,4 +35,6 @@ export class AnaglyphUniversalCamera extends UniversalCamera {
     public getClassName(): string {
         return "AnaglyphUniversalCamera";
     }
+
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
@@ -36,5 +36,5 @@ export class AnaglyphUniversalCamera extends UniversalCamera {
         return "AnaglyphUniversalCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(this);
+    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/index.ts
+++ b/src/Cameras/Stereoscopic/index.ts
@@ -6,3 +6,4 @@ export * from "./stereoscopicArcRotateCamera";
 export * from "./stereoscopicFreeCamera";
 export * from "./stereoscopicGamepadCamera";
 export * from "./stereoscopicUniversalCamera";
+export * from "./stereoscopicScreenUniversalCamera";

--- a/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
@@ -3,9 +3,7 @@ import { ArcRotateCamera } from "../../Cameras/arcRotateCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicRigMode";
+import { setStereoscopicRigMode } from "../RigModes/stereoscopicRigMode";
 
 Node.AddNodeConstructor("StereoscopicArcRotateCamera", (name, scene, options) => {
     return () => new StereoscopicArcRotateCamera(name, 0, 0, 1.0, Vector3.Zero(), options.interaxial_distance, options.isStereoscopicSideBySide, scene);
@@ -41,4 +39,6 @@ export class StereoscopicArcRotateCamera extends ArcRotateCamera {
     public getClassName(): string {
         return "StereoscopicArcRotateCamera";
     }
+
+    protected _setRigMode = setStereoscopicRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
@@ -40,5 +40,5 @@ export class StereoscopicArcRotateCamera extends ArcRotateCamera {
         return "StereoscopicArcRotateCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(this);
+    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
@@ -37,5 +37,5 @@ export class StereoscopicFreeCamera extends FreeCamera {
         return "StereoscopicFreeCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(this);
+    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
@@ -3,9 +3,7 @@ import { FreeCamera } from "../../Cameras/freeCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicRigMode";
+import { setStereoscopicRigMode } from "../RigModes/stereoscopicRigMode";
 
 Node.AddNodeConstructor("StereoscopicFreeCamera", (name, scene, options) => {
     return () => new StereoscopicFreeCamera(name, Vector3.Zero(), options.interaxial_distance, options.isStereoscopicSideBySide, scene);
@@ -38,4 +36,6 @@ export class StereoscopicFreeCamera extends FreeCamera {
     public getClassName(): string {
         return "StereoscopicFreeCamera";
     }
+
+    protected _setRigMode = setStereoscopicRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
@@ -3,9 +3,7 @@ import { GamepadCamera } from "../../Cameras/gamepadCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicRigMode";
+import { setStereoscopicRigMode } from "../RigModes/stereoscopicRigMode";
 
 Node.AddNodeConstructor("StereoscopicGamepadCamera", (name, scene, options) => {
     return () => new StereoscopicGamepadCamera(name, Vector3.Zero(), options.interaxial_distance, options.isStereoscopicSideBySide, scene);
@@ -38,4 +36,6 @@ export class StereoscopicGamepadCamera extends GamepadCamera {
     public getClassName(): string {
         return "StereoscopicGamepadCamera";
     }
+
+    protected _setRigMode = setStereoscopicRigMode.bind(this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
@@ -37,5 +37,5 @@ export class StereoscopicGamepadCamera extends GamepadCamera {
         return "StereoscopicGamepadCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(this);
+    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
@@ -38,14 +38,14 @@ export class StereoscopicScreenUniversalCamera extends UniversalCamera {
      * Creates a new StereoscopicScreenUniversalCamera
      * @param name defines camera name
      * @param position defines initial position
-     * @param distanceFromScreen defines distance between each color axis
-     * @param distanceBetweenEyes defines is stereoscopic is done side by side or over under
      * @param scene defines the hosting scene
+     * @param _distanceToProjectionPlane defines distance between each color axis
+     * @param distanceBetweenEyes defines is stereoscopic is done side by side or over under
      */
-    constructor(name: string, position: Vector3, scene: Scene, distanceFromScreen: number = 1, distanceBetweenEyes: number = 0.0325) {
+    constructor(name: string, position: Vector3, scene: Scene, _distanceToProjectionPlane: number = 1, distanceBetweenEyes: number = 0.0325) {
         super(name, position, scene);
         this._distanceBetweenEyes = distanceBetweenEyes;
-        this._distanceToProjectionPlane = distanceFromScreen;
+        this._distanceToProjectionPlane = _distanceToProjectionPlane;
         this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL, {});
     }
 

--- a/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
@@ -22,6 +22,9 @@ export class StereoscopicScreenUniversalCamera extends UniversalCamera {
         this._distanceBetweenEyes = newValue;
     }
 
+    /**
+     * distance between the eyes
+     */
     public get distanceBetweenEyes(): number {
         return this._distanceBetweenEyes;
     }
@@ -31,6 +34,9 @@ export class StereoscopicScreenUniversalCamera extends UniversalCamera {
         this._distanceToProjectionPlane = newValue;
     }
 
+    /**
+     * Distance to projection plane (should be the same units the like distance between the eyes)
+     */
     public get distanceToProjectionPlane(): number {
         return this._distanceToProjectionPlane;
     }
@@ -86,7 +92,7 @@ export class StereoscopicScreenUniversalCamera extends UniversalCamera {
 
     private _updateCamera(camera: TargetCamera, cameraIndex: number) {
         const b = cameraIndex === 0 ? this.distanceBetweenEyes : -this.distanceBetweenEyes;
-        const z = cameraIndex === 0 ? this.distanceBetweenEyes / this.distanceToProjectionPlane : -this.distanceBetweenEyes / this.distanceToProjectionPlane;
+        const z = b / this.distanceToProjectionPlane;
         camera.position.set(-b, 0, -this.distanceToProjectionPlane);
         camera.setTarget(new Vector3(-b, 0, 0));
         const transform = camera.parent as TransformNode;

--- a/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
@@ -1,0 +1,105 @@
+import { Camera } from "../../Cameras/camera";
+import { UniversalCamera } from "../../Cameras/universalCamera";
+import { Scene } from "../../scene";
+import { Matrix, Vector3 } from "../../Maths/math.vector";
+import { Nullable } from "../../types";
+import { TargetCamera } from "../targetCamera";
+import { TransformNode } from "../../Meshes/transformNode";
+import { Viewport } from "../../Maths/math.viewport";
+
+/**
+ * Camera used to simulate stereoscopic rendering (based on UniversalCamera)
+ * @see https://doc.babylonjs.com/features/cameras
+ */
+export class StereoscopicScreenUniversalCamera extends UniversalCamera {
+
+    private _dirty = true;
+    private _distanceToProjectionPlane: number;
+    private _distanceBetweenEyes: number;
+
+    public set distanceBetweenEyes(newValue: number) {
+        this._dirty = true;
+        this._distanceBetweenEyes = newValue;
+    }
+
+    public get distanceBetweenEyes(): number {
+        return this._distanceBetweenEyes;
+    }
+
+    public set distanceToProjectionPlane(newValue: number) {
+        this._dirty = true;
+        this._distanceToProjectionPlane = newValue;
+    }
+
+    public get distanceToProjectionPlane(): number {
+        return this._distanceToProjectionPlane;
+    }
+    /**
+     * Creates a new StereoscopicScreenUniversalCamera
+     * @param name defines camera name
+     * @param position defines initial position
+     * @param distanceFromScreen defines distance between each color axis
+     * @param distanceBetweenEyes defines is stereoscopic is done side by side or over under
+     * @param scene defines the hosting scene
+     */
+    constructor(name: string, position: Vector3, scene: Scene, distanceFromScreen: number = 1, distanceBetweenEyes: number = 0.0325) {
+        super(name, position, scene);
+        this._distanceBetweenEyes = distanceBetweenEyes;
+        this._distanceToProjectionPlane = distanceFromScreen;
+        this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL, {});
+    }
+
+    /**
+     * Gets camera class name
+     * @returns StereoscopicScreenUniversalCamera
+     */
+    public getClassName(): string {
+        return "StereoscopicUniversalCamera";
+    }
+
+    /**
+     * @hidden
+     */
+    public createRigCamera(name: string, cameraIndex: number): Nullable<Camera> {
+        const camera = new TargetCamera(name, Vector3.Zero(), this.getScene());
+        const transform = new TransformNode('tm' + name, this.getScene());
+        camera.parent = transform;
+        transform.setPivotMatrix(Matrix.Identity(), false);
+        transform.parent = this;
+        camera.isRigCamera = true;
+        camera.rigParent = this;
+        return camera;
+    }
+
+    /**
+     * @hidden
+     */
+    public _updateRigCameras() {
+        super._updateRigCameras();
+        if (this._dirty) {
+            for (let cameraIndex = 0; cameraIndex < this._rigCameras.length; cameraIndex++) {
+                this._updateCamera(this._rigCameras[cameraIndex] as TargetCamera, cameraIndex);
+            }
+            this._dirty = false;
+        }
+    }
+
+    private _updateCamera(camera: TargetCamera, cameraIndex: number) {
+        const b = cameraIndex === 0 ? this.distanceBetweenEyes : -this.distanceBetweenEyes;
+        const z = cameraIndex === 0 ? this.distanceBetweenEyes / this.distanceToProjectionPlane : -this.distanceBetweenEyes / this.distanceToProjectionPlane;
+        camera.position.set(-b, 0, -this.distanceToProjectionPlane);
+        camera.setTarget(new Vector3(-b, 0, 0));
+        const transform = camera.parent as TransformNode;
+        const m = transform.getPivotMatrix();
+        m.setTranslationFromFloats(b, 0, 0);
+        m.setRowFromFloats(2, z, 0, 1, 0);
+    }
+
+    protected _setRigMode() {
+        this._rigCameras[0].viewport = new Viewport(0, 0, 0.5, 1);
+        this._rigCameras[1].viewport = new Viewport(0.5, 0, 0.5, 1.0);
+        for (let cameraIndex = 0; cameraIndex < this._rigCameras.length; cameraIndex++) {
+            this._updateCamera(this._rigCameras[cameraIndex] as TargetCamera, cameraIndex);
+        }
+    }
+}

--- a/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
@@ -36,5 +36,5 @@ export class StereoscopicUniversalCamera extends UniversalCamera {
         return "StereoscopicUniversalCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(this);
+    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
 }

--- a/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
@@ -3,9 +3,7 @@ import { UniversalCamera } from "../../Cameras/universalCamera";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/stereoscopicRigMode";
+import { setStereoscopicRigMode } from "../RigModes/stereoscopicRigMode";
 
 Node.AddNodeConstructor("StereoscopicFreeCamera", (name, scene, options) => {
     return () => new StereoscopicUniversalCamera(name, Vector3.Zero(), options.interaxial_distance, options.isStereoscopicSideBySide, scene);
@@ -37,4 +35,6 @@ export class StereoscopicUniversalCamera extends UniversalCamera {
     public getClassName(): string {
         return "StereoscopicUniversalCamera";
     }
+
+    protected _setRigMode = setStereoscopicRigMode.bind(this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
@@ -4,11 +4,9 @@ import { VRCameraMetrics } from "./vrCameraMetrics";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
+import { setVRRigMode } from "../RigModes/vrRigMode";
 
 import "../Inputs/arcRotateCameraVRDeviceOrientationInput";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/vrRigMode";
 
 Node.AddNodeConstructor("VRDeviceOrientationFreeCamera", (name, scene) => {
     return () => new VRDeviceOrientationArcRotateCamera(name, 0, 0, 1.0, Vector3.Zero(), scene);
@@ -47,4 +45,6 @@ export class VRDeviceOrientationArcRotateCamera extends ArcRotateCamera {
     public getClassName(): string {
         return "VRDeviceOrientationArcRotateCamera";
     }
+
+    protected _setRigMode = setVRRigMode.bind(this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
@@ -46,5 +46,5 @@ export class VRDeviceOrientationArcRotateCamera extends ArcRotateCamera {
         return "VRDeviceOrientationArcRotateCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(this);
+    protected _setRigMode = setVRRigMode.bind(null, this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
@@ -39,5 +39,5 @@ export class VRDeviceOrientationFreeCamera extends DeviceOrientationCamera {
         return "VRDeviceOrientationFreeCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(this);
+    protected _setRigMode = setVRRigMode.bind(null, this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
@@ -4,9 +4,7 @@ import { VRCameraMetrics } from "./vrCameraMetrics";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/vrRigMode";
+import { setVRRigMode } from "../RigModes/vrRigMode";
 
 Node.AddNodeConstructor("VRDeviceOrientationFreeCamera", (name, scene) => {
     return () => new VRDeviceOrientationFreeCamera(name, Vector3.Zero(), scene);
@@ -40,4 +38,6 @@ export class VRDeviceOrientationFreeCamera extends DeviceOrientationCamera {
     public getClassName(): string {
         return "VRDeviceOrientationFreeCamera";
     }
+
+    protected _setRigMode = setVRRigMode.bind(this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
@@ -39,5 +39,5 @@ export class VRDeviceOrientationGamepadCamera extends VRDeviceOrientationFreeCam
         return "VRDeviceOrientationGamepadCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(this);
+    protected _setRigMode = setVRRigMode.bind(null, this);
 }

--- a/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
@@ -3,6 +3,7 @@ import { VRCameraMetrics } from "./vrCameraMetrics";
 import { Scene } from "../../scene";
 import { Vector3 } from "../../Maths/math.vector";
 import { Node } from "../../node";
+import { setVRRigMode } from "../RigModes/vrRigMode";
 
 import "../../Gamepads/gamepadSceneComponent";
 
@@ -37,4 +38,6 @@ export class VRDeviceOrientationGamepadCamera extends VRDeviceOrientationFreeCam
     public getClassName(): string {
         return "VRDeviceOrientationGamepadCamera";
     }
+
+    protected _setRigMode = setVRRigMode.bind(this);
 }

--- a/src/Cameras/VR/webVRCamera.ts
+++ b/src/Cameras/VR/webVRCamera.ts
@@ -329,7 +329,7 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
         });
     }
 
-    protected _setRigMode = setWebVRRigMode.bind(this);
+    protected _setRigMode = setWebVRRigMode.bind(null, this);
 
     /**
      * Gets the device distance from the ground in meters.

--- a/src/Cameras/VR/webVRCamera.ts
+++ b/src/Cameras/VR/webVRCamera.ts
@@ -15,13 +15,11 @@ import { Ray } from "../../Culling/ray";
 import { HemisphericLight } from "../../Lights/hemisphericLight";
 import { Logger } from '../../Misc/logger';
 import { VRMultiviewToSingleviewPostProcess } from '../../PostProcesses/vrMultiviewToSingleviewPostProcess';
-
-// Side effect import to define the stereoscopic mode.
-import "../RigModes/webVRRigMode";
+import { Tools } from '../../Misc/tools';
+import { setWebVRRigMode } from "../RigModes/webVRRigMode";
 
 // Side effect import to add webvr support to engine
 import "../../Engines/Extensions/engine.webVR";
-import { Tools } from '../../Misc/tools';
 
 Node.AddNodeConstructor("WebVRFreeCamera", (name, scene) => {
     return () => new WebVRFreeCamera(name, Vector3.Zero(), scene);
@@ -330,6 +328,8 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
             }
         });
     }
+
+    protected _setRigMode = setWebVRRigMode.bind(this);
 
     /**
      * Gets the device distance from the ground in meters.

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1122,46 +1122,14 @@ export class Camera extends Node {
             }
         }
 
-        switch (this.cameraRigMode) {
-            case Camera.RIG_MODE_STEREOSCOPIC_ANAGLYPH:
-                Camera._setStereoscopicAnaglyphRigMode(this);
-                break;
-            case Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_PARALLEL:
-            case Camera.RIG_MODE_STEREOSCOPIC_SIDEBYSIDE_CROSSEYED:
-            case Camera.RIG_MODE_STEREOSCOPIC_OVERUNDER:
-            case Camera.RIG_MODE_STEREOSCOPIC_INTERLACED:
-                Camera._setStereoscopicRigMode(this);
-                break;
-            case Camera.RIG_MODE_VR:
-                Camera._setVRRigMode(this, rigParams);
-                break;
-            case Camera.RIG_MODE_WEBVR:
-                Camera._setWebVRRigMode(this, rigParams);
-                break;
-        }
+        this._setRigMode(rigParams);
 
         this._cascadePostProcessesToRigCams();
         this.update();
     }
 
-    /** @hidden */
-    public static _setStereoscopicRigMode(camera: Camera) {
-        throw "Import Cameras/RigModes/stereoscopicRigMode before using stereoscopic rig mode";
-    }
-
-    /** @hidden */
-    public static _setStereoscopicAnaglyphRigMode(camera: Camera) {
-        throw "Import Cameras/RigModes/stereoscopicAnaglyphRigMode before using stereoscopic anaglyph rig mode";
-    }
-
-    /** @hidden */
-    public static _setVRRigMode(camera: Camera, rigParams: any) {
-        throw "Import Cameras/RigModes/vrRigMode before using VR rig mode";
-    }
-
-    /** @hidden */
-    public static _setWebVRRigMode(camera: Camera, rigParams: any) {
-        throw "Import Cameras/RigModes/WebVRRigMode before using Web VR rig mode";
+    protected _setRigMode(rigParams: any) {
+        // no-op
     }
 
     /** @hidden */


### PR DESCRIPTION
introducing a new rig camera type: Stereoscopic Screen Universal Camera

This camera is meant to be used on real screens producing 3d image from side-by-side images.

A quick restructure of the rig camera in camera.ts was also done (and a small change in all other related cameras).

Once deployed this playground will display a 3d scene that can be viewed on a screen - #WU1KL6#3 (until merged it will fail).

