### PR TITLE
Fix skyMaterial for azimuth != 0.25

### DIFF
--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -308,8 +308,8 @@ export class SkyMaterial extends PushMaterial {
             var theta = Math.PI * (this.inclination - 0.5);
             var phi = 2 * Math.PI * (this.azimuth - 0.5);
 
-            this.sunPosition.x = this.distance * Math.cos(phi);
-            this.sunPosition.y = this.distance * Math.sin(phi) * Math.sin(theta);
+            this.sunPosition.x = this.distance * Math.cos(phi) * Math.cos(theta);
+            this.sunPosition.y = this.distance * Math.sin(-theta);
             this.sunPosition.z = this.distance * Math.sin(phi) * Math.cos(theta);
 
             Quaternion.FromUnitVectorsToRef(Vector3.UpReadOnly, this.up, this._skyOrientation);


### PR DESCRIPTION
Current skyMaterial updateSunPosition() works incorrectly for azimuth != 0.25

How to face the bug:
1. Set azimuth to 0.5
2. Set inclination to any value, sun is still sitting on the horizon

The problem is within math in updateSunPosition(), this pull requests fixes it.