### PR TITLE
Fix crashes when using motion blur with skinned meshes

### DIFF
--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -866,10 +866,10 @@ export class MaterialHelper {
                 if (matrices) {
                     effect.setMatrices("mBones", matrices);
                     if (prePassConfiguration && mesh.getScene().prePassRenderer && mesh.getScene().prePassRenderer!.getIndex(Constants.PREPASS_VELOCITY_TEXTURE_TYPE)) {
-                        if (prePassConfiguration.previousBones[mesh.uniqueId]) {
-                            effect.setMatrices("mPreviousBones", prePassConfiguration.previousBones[mesh.uniqueId]);
+                        if (!prePassConfiguration.previousBones[mesh.uniqueId]) {
+                            prePassConfiguration.previousBones[mesh.uniqueId] = matrices.slice();
                         }
-
+                        effect.setMatrices("mPreviousBones", prePassConfiguration.previousBones[mesh.uniqueId]);
                         MaterialHelper._CopyBonesTransformationMatrices(matrices, prePassConfiguration.previousBones[mesh.uniqueId]);
                     }
                 }

--- a/src/Materials/prePassConfiguration.ts
+++ b/src/Materials/prePassConfiguration.ts
@@ -34,7 +34,7 @@ export class PrePassConfiguration {
      * @param uniforms defines the current uniform list.
      */
     public static AddUniforms(uniforms: string[]): void {
-        uniforms.push("previousWorld", "previousViewProjection");
+        uniforms.push("previousWorld", "previousViewProjection", "mPreviousBones");
     }
 
     /**

--- a/src/Shaders/geometry.vertex.fx
+++ b/src/Shaders/geometry.vertex.fx
@@ -53,11 +53,6 @@ varying vec3 vPositionW;
 
 #ifdef VELOCITY
 uniform mat4 previousViewProjection;
-#ifdef BONES_VELOCITY_ENABLED
-#if NUM_BONE_INFLUENCERS > 0
-uniform mat4 mPreviousBones[BonesPerMesh];
-#endif
-#endif
 
 varying vec4 vCurrentPosition;
 varying vec4 vPreviousPosition;


### PR DESCRIPTION
Forcing the geometry buffer: https://playground.babylonjs.com/#5ZRSFV#9
Using the prepass renderer: https://playground.babylonjs.com/#5ZRSFV#10

Both PGs crash without the PR but work when applied.

Note that we must disable using textures to store bones (line 96): for the time being, motion blur for skinned objects is not supported with this option.