### PR TITLE
Fix skin export

### DIFF
--- a/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -1,7 +1,7 @@
 import { IBufferView, AccessorType, AccessorComponentType, IAccessor } from "babylonjs-gltf2interface";
 
 import { FloatArray, Nullable } from "babylonjs/types";
-import { Vector3, Vector4, Quaternion, Matrix } from "babylonjs/Maths/math.vector";
+import { Vector3, Vector4, Quaternion } from "babylonjs/Maths/math.vector";
 
 /**
  * @hidden
@@ -192,17 +192,6 @@ export class _GLTFUtilities {
             tangent.y /= length;
             tangent.z /= length;
         }
-    }
-
-    public static _GetRightHandedMatrixFromRef(matrix: Matrix) {
-        const m = matrix.m;
-        Matrix.FromValuesToRef(
-            m[0], m[1], -m[2], m[3],
-            m[4], m[5], -m[6], m[7],
-            -m[8], m[9], m[10], m[11],
-            m[12], m[13], m[14], m[15],
-            matrix
-        );
     }
 
     public static _GetDataAccessorElementCount(accessorType: AccessorType) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/export-to-glb-of-unmodified-model-with-animations-is-having-deformations-on-bones/24010

The main problem is that the inverse bind matrix is being converted to right handed when it shouldn't be. The inverse bind matrix has nothing to do with handedness.

Other changes:
- Removed outputting skeleton since the code for this is wrong and outputting skeleton is not required.
- Removed writing byteStride for inverse bind matrices since that's not allowed.
- Added a warning when exporting bones that are not linked to a transform node since this is not supported yet.