### PR TITLE
Fix issue with glTF delay loading of morph targets

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -979,13 +979,13 @@ export class GLTFLoader implements IGLTFLoader {
 
         babylonMesh.morphTargetManager = new MorphTargetManager(babylonMesh.getScene());
         babylonMesh.morphTargetManager.areUpdatesFrozen = true;
+
         for (let index = 0; index < primitive.targets.length; index++) {
             const weight = node.weights ? node.weights[index] : mesh.weights ? mesh.weights[index] : 0;
             const name = targetNames ? targetNames[index] : `morphTarget${index}`;
             babylonMesh.morphTargetManager.addTarget(new MorphTarget(name, weight, babylonMesh.getScene()));
             // TODO: tell the target whether it has positions, normals, tangents
         }
-        babylonMesh.morphTargetManager.areUpdatesFrozen = false;
     }
 
     private _loadMorphTargetsAsync(context: string, primitive: IMeshPrimitive, babylonMesh: Mesh, babylonGeometry: Geometry): Promise<void> {
@@ -1001,7 +1001,9 @@ export class GLTFLoader implements IGLTFLoader {
             promises.push(this._loadMorphTargetVertexDataAsync(`${context}/targets/${index}`, babylonGeometry, primitive.targets[index], babylonMorphTarget));
         }
 
-        return Promise.all(promises).then(() => { });
+        return Promise.all(promises).then(() => {
+            morphTargetManager.areUpdatesFrozen = false;
+        });
     }
 
     private _loadMorphTargetVertexDataAsync(context: string, babylonGeometry: Geometry, attributes: { [name: string]: number }, babylonMorphTarget: MorphTarget): Promise<void> {

--- a/src/Morph/morphTargetManager.ts
+++ b/src/Morph/morphTargetManager.ts
@@ -64,7 +64,7 @@ export class MorphTargetManager implements IDisposable {
     public enableUVMorphing = true;
 
     /**
-     * Sets a boolean indicating that adding new target will or will not update the underlying data buffers
+     * Sets a boolean indicating that adding new target or updating an existing target will not update the underlying data buffers
      */
     public set areUpdatesFrozen(block: boolean) {
         if (block) {
@@ -210,9 +210,7 @@ export class MorphTargetManager implements IDisposable {
         this._targetDataLayoutChangedObservers.push(target._onDataLayoutChanged.add(() => {
             this._syncActiveTargets(true);
         }));
-        if (!this.areUpdatesFrozen) {
-            this._syncActiveTargets(true);
-        }
+        this._syncActiveTargets(true);
     }
 
     /**
@@ -273,6 +271,10 @@ export class MorphTargetManager implements IDisposable {
     }
 
     private _syncActiveTargets(needUpdate: boolean): void {
+        if (this.areUpdatesFrozen) {
+            return;
+        }
+
         let influenceCount = 0;
         this._activeTargets.reset();
         this._supportsNormals = true;
@@ -329,7 +331,7 @@ export class MorphTargetManager implements IDisposable {
      * Synchronize the targets with all the meshes using this morph target manager
      */
     public synchronize(): void {
-        if (!this._scene) {
+        if (!this._scene || this.areUpdatesFrozen) {
             return;
         }
 


### PR DESCRIPTION
This change blocks the update of morph targets completely until all of the data is complete when loading glTF morph targets. This will fix loading glTFs that have initial morph target weights as well as improve loading perf slightly.