### PR TITLE
NME trigonometry block: add the missing Sqrt entry in the drop down list

### DIFF
--- a/nodeEditor/src/diagram/properties/trigonometryNodePropertyComponent.tsx
+++ b/nodeEditor/src/diagram/properties/trigonometryNodePropertyComponent.tsx
@@ -24,6 +24,7 @@ export class TrigonometryPropertyTabComponent extends React.Component<IPropertyC
             {label: "Round", value: TrigonometryBlockOperations.Round},
             {label: "Ceiling", value: TrigonometryBlockOperations.Ceiling},
             {label: "Floor", value: TrigonometryBlockOperations.Floor},
+            {label: "Sqrt", value: TrigonometryBlockOperations.Sqrt},
             {label: "ArcCos", value: TrigonometryBlockOperations.ArcCos},
             {label: "ArcSin", value: TrigonometryBlockOperations.ArcSin},
             {label: "ArcTan", value: TrigonometryBlockOperations.ArcTan},


### PR DESCRIPTION
See https://forum.babylonjs.com/t/converting-the-oblivion-radar-display-to-nme/24118/6
