### PR TITLE
Added targetHost to query and set targeted mesh with ArcRotateCamera

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -35,6 +35,7 @@
 - Added support for [cannon-es](https://github.com/pmndrs/cannon-es) to the cannonJSPlugin. ([frankieali](https://github.com/frankieali))
 - Added check for duplicates in `ShadowGenerator.addShadowCaster` ([ivankoleda](https://github.com/ivankoleda))
 - Added observable for `PointerDragBehavior` enable state ([cedricguillemet](https://github.com/cedricguillemet))
+- Added `targetHost` to query and set targeted mesh with `ArcRotateCamera` ([cedricguillemet](https://github.com/cedricguillemet))
 - Spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the corresponding `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -71,11 +71,13 @@ export class ArcRotateCamera extends TargetCamera {
      * Defines the target mesh of the camera.
      * The camera looks towards it form the radius distance.
      */
-    public get targetHost(): AbstractMesh {
-        return this._targetHost as AbstractMesh;
+    public get targetHost(): Nullable<AbstractMesh> {
+        return this._targetHost;
     }
-    public set targetHost(value: AbstractMesh) {
-        this.setTarget(value);
+    public set targetHost(value: Nullable<AbstractMesh>) {
+        if (value) {
+            this.setTarget(value);
+        }
     }
 
     /**

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -69,7 +69,7 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Defines the target mesh of the camera.
-     * The camera looks towards it form the radius distance.
+     * The camera looks towards it from the radius distance.
      */
     public get targetHost(): Nullable<AbstractMesh> {
         return this._targetHost;

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -1,4 +1,4 @@
-import { serialize, serializeAsVector3 } from "../Misc/decorators";
+import { serialize, serializeAsVector3, serializeAsMeshReference } from "../Misc/decorators";
 import { Observable } from "../Misc/observable";
 import { Nullable } from "../types";
 import { Scene } from "../scene";
@@ -52,6 +52,7 @@ export class ArcRotateCamera extends TargetCamera {
 
     @serializeAsVector3("target")
     protected _target: Vector3;
+    @serializeAsMeshReference("targetHost")
     protected _targetHost: Nullable<AbstractMesh>;
 
     /**
@@ -63,6 +64,17 @@ export class ArcRotateCamera extends TargetCamera {
         return this._target;
     }
     public set target(value: Vector3) {
+        this.setTarget(value);
+    }
+
+    /**
+     * Defines the target mesh of the camera.
+     * The camera looks towards it form the radius distance.
+     */
+    public get targetHost(): AbstractMesh {
+        return this._targetHost as AbstractMesh;
+    }
+    public set targetHost(value: AbstractMesh) {
         this.setTarget(value);
     }
 


### PR DESCRIPTION
followup https://forum.babylonjs.com/t/getting-the-mesh-set-by-cameras-settarget/24152/4

I set the property as serializable. Is it ok?