### PR TITLE
Fix to input on blur

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -903,6 +903,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             Object.entries(this._lastControlDown).forEach(([key, value]) => {
                 value._onCanvasBlur();
             });
+            this.focusedControl = null;
             this._lastControlDown = {};
         });
     }


### PR DESCRIPTION
Input will now be blurred when the scene is blurred. 

Related to an issue in this forum post.:
https://forum.babylonjs.com/t/how-to-make-gui-scene-block-pointer-and-key-events-on-main-scene/17559/3