### PR TITLE
Provide the preprocessed URL to the error handler

### DIFF
--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -206,7 +206,7 @@ export class FileTools {
 
             if (onError) {
                 const inputText = url || input.toString();
-                onError(`Error while trying to load image: ${inputText}`, err);
+                onError(`Error while trying to load image: ${((inputText.indexOf('http') === 0 || inputText.length < 64) ? inputText : inputText.slice(0, 64) + "...")}`, err);
             }
 
             if (usingObjectURL && img.src) {

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -205,8 +205,8 @@ export class FileTools {
             img.removeEventListener("error", errorHandler);
 
             if (onError) {
-                const inputText = input.toString();
-                onError("Error while trying to load image: " + (inputText.length < 32 ? inputText : inputText.slice(0, 32) + "..."), err);
+                const inputText = url || input.toString();
+                onError(`Error while trying to load image: ${inputText}`, err);
             }
 
             if (usingObjectURL && img.src) {


### PR DESCRIPTION
If the URL was changed by the preprocessing function the old URL will be delivered when the error occurs.