### PR TITLE
Fix resize->save bug in texture inspector

### DIFF
--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasComponent.tsx
@@ -13,8 +13,8 @@ export class TextureCanvasComponent extends React.Component<ITextureCanvasCompon
     render() {
         return <div>
             <canvas id="canvas-ui" ref={this.props.canvasUI} tabIndex={1}></canvas>
-            <canvas id="canvas-2D" ref={this.props.canvas2D} width={this.props.texture.getSize().width} height={this.props.texture.getSize().height} hidden={true}></canvas>
-            <canvas id="canvas-3D" ref={this.props.canvas3D} width={this.props.texture.getSize().width} height={this.props.texture.getSize().height} hidden={true}></canvas>
+            <canvas id="canvas-2D" ref={this.props.canvas2D} hidden={true}></canvas>
+            <canvas id="canvas-3D" ref={this.props.canvas3D} hidden={true}></canvas>
         </div>
     }
 }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureCanvasManager.ts
@@ -153,7 +153,6 @@ export class TextureCanvasManager {
         this._setMetadata = setMetadata;
         this._setMipLevel = setMipLevel;
 
-        this._size = texture.getSize();
         this._originalTexture = texture;
         this._originalInternalTexture = this._originalTexture._texture;
         this._engine = new Engine(this._UICanvas, true);
@@ -163,6 +162,8 @@ export class TextureCanvasManager {
         this._camera = new FreeCamera('camera', new Vector3(0, 0, -1), this._scene);
         this._camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
         this._cameraPos = new Vector2();
+
+        this.setSize(texture.getSize());
 
         this._channelsTexture = new HtmlElementTexture('ct', this._2DCanvas, { engine: this._engine, scene: null, samplingMode: Texture.NEAREST_SAMPLINGMODE, generateMipMaps: true });
 
@@ -612,9 +613,11 @@ export class TextureCanvasManager {
         this._2DCanvas.height = this._size.height;
         this._3DCanvas.width = this._size.width;
         this._3DCanvas.height = this._size.height;
-        this._planeMaterial.setInt('w', this._size.width);
-        this._planeMaterial.setInt('h', this._size.height);
-        if (oldSize.width != size.width || oldSize.height != size.height) {
+        if (this._planeMaterial) {
+            this._planeMaterial.setInt('w', this._size.width);
+            this._planeMaterial.setInt('h', this._size.height);
+        }
+        if (!oldSize || oldSize.width != size.width || oldSize.height != size.height) {
             this._cameraPos.x = 0;
             this._cameraPos.y = 0;
             this._scale = 1.5 / Math.max(this._size.width, this._size.height);


### PR DESCRIPTION
Forum post for context: https://forum.babylonjs.com/t/texture-swap-incorrectly-accounted-for-when-exporting-modified-babylon-scene-from-sandbox/24184/4

If you resize a texture in the texture inspector, or upload a texture with a different size, then try to save your texture, you will get an empty image file. This is because the canvas size was being controlled by React. The texture size would change, then several frames later the React component would re-render. Changing the size of the canvas causes it to be cleared.

This PR takes away control of the canvas size from React to prevent the canvas from being cleared when the re-render happens. Now canvas size is controlled completely imperatively, so there are no unexpected resizes.