### PR TITLE
scene pointerMoveTrianglePredicate

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -49,6 +49,7 @@
 - Added a global OnTextureLoadErrorObservable to handle texture loading errors during model load ([RaananW](https://github.com/RaananW))
 - Add support to encode and decode .env environment textures using WebP instead of PNG ([simonihmig](https://github.com/simonihmig))
 - Added a new stereoscopic screen rig camera ([RaananW](https://github.com/RaananW))
+- Extended functionality for pointer move with scene pointerMoveTrianglePredicate ([phaselock]https://github.com/lockphase)
 
 ### Engine
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -49,7 +49,7 @@
 - Added a global OnTextureLoadErrorObservable to handle texture loading errors during model load ([RaananW](https://github.com/RaananW))
 - Add support to encode and decode .env environment textures using WebP instead of PNG ([simonihmig](https://github.com/simonihmig))
 - Added a new stereoscopic screen rig camera ([RaananW](https://github.com/RaananW))
-- Extended functionality for pointer move with scene pointerMoveTrianglePredicate ([phaselock]https://github.com/lockphase)
+- Extended functionality for pointer move with scene pointerMoveTrianglePredicate ([phaselock](https://github.com/lockphase))
 
 ### Engine
 

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -678,8 +678,8 @@ export class InputManager {
             }
 
             // Meshes
-			var pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerMovePredicate, false, scene.cameraToUseForPointers, scene.pointerMoveTrianglePredicate);
-			
+            var pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerMovePredicate, false, scene.cameraToUseForPointers, scene.pointerMoveTrianglePredicate);
+
             this._processPointerMove(pickResult, evt as IPointerEvent);
         };
 

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -678,8 +678,8 @@ export class InputManager {
             }
 
             // Meshes
-            var pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerMovePredicate, false, scene.cameraToUseForPointers);
-
+			var pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerMovePredicate, false, scene.cameraToUseForPointers, scene.pointerMoveTrianglePredicate);
+			
             this._processPointerMove(pickResult, evt as IPointerEvent);
         };
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -704,6 +704,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public onPointerUp: (evt: IPointerEvent, pickInfo: Nullable<PickingInfo>, type: PointerEventTypes) => void;
     /** Callback called when a pointer pick is detected */
     public onPointerPick: (evt: IPointerEvent, pickInfo: PickingInfo) => void;
+	
+	/**
+     * Gets or sets a predicate used to select candidate faces for a pointer move event
+     */
+    public pointerMoveTrianglePredicate: ((p0: Vector3, p1: Vector3, p2: Vector3, ray: Ray) => boolean) | undefined;
 
     /**
      * This observable event is triggered when any ponter event is triggered. It is registered during Scene.attachControl() and it is called BEFORE the 3D engine process anything (mesh/sprite picking for instance).

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -704,8 +704,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public onPointerUp: (evt: IPointerEvent, pickInfo: Nullable<PickingInfo>, type: PointerEventTypes) => void;
     /** Callback called when a pointer pick is detected */
     public onPointerPick: (evt: IPointerEvent, pickInfo: PickingInfo) => void;
-	
-	/**
+
+    /**
      * Gets or sets a predicate used to select candidate faces for a pointer move event
      */
     public pointerMoveTrianglePredicate: ((p0: Vector3, p1: Vector3, p2: Vector3, ray: Ray) => boolean) | undefined;


### PR DESCRIPTION
Pls see: https://forum.babylonjs.com/t/scene-trianglepickingpredicate/24088

The default picking during pointer move is somewhat limiting in cases where the scene has many assets (with distinct action managers) which may be partially occluded to the user. Allowing a user to define custom triangle picking predicate extends the functionality of pointer move events while still preserving compatibility with action managers.