### PR TITLE
[Modular Babylon] suggestion of keeping work out of internal texture

### DIFF
--- a/src/Materials/Textures/internalTexture.ts
+++ b/src/Materials/Textures/internalTexture.ts
@@ -143,7 +143,7 @@ export class InternalTexture extends TextureSampler {
      */
     public onLoadedObservable = new Observable<InternalTexture>();
     /**
-     * If this callback is defined is will be called instead of the default _rebuild function
+     * If this callback is defined it will be called instead of the default _rebuild function
      */
     public onRebuildCallback: Nullable<(internalTexture: InternalTexture) => {
         proxy: Nullable<InternalTexture | Promise<InternalTexture>>;

--- a/src/Materials/Textures/internalTexture.ts
+++ b/src/Materials/Textures/internalTexture.ts
@@ -82,7 +82,7 @@ export enum InternalTextureSource {
 export class InternalTexture extends TextureSampler {
 
     /** @hidden */
-    public static _UpdateRGBDAsync = (internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<void> => {
+    public static _UpdateRGBDAsync = (internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<InternalTexture> => {
         throw _DevTools.WarnImport("environmentTextureTools");
     }
 
@@ -142,6 +142,14 @@ export class InternalTexture extends TextureSampler {
      * Observable called when the texture is loaded
      */
     public onLoadedObservable = new Observable<InternalTexture>();
+    /**
+     * If this callback is defined is will be called instead of the default _rebuild function
+     */
+    public onRebuildCallback: Nullable<(internalTexture: InternalTexture) => {
+        proxy: Nullable<InternalTexture | Promise<InternalTexture>>;
+        isReady: boolean;
+        isAsync: boolean;
+    }> = null;
     /**
      * Gets the width of the texture
      */
@@ -314,14 +322,27 @@ export class InternalTexture extends TextureSampler {
 
     /** @hidden */
     public _rebuild(): void {
-        var proxy: InternalTexture;
         this.isReady = false;
         this._cachedCoordinatesMode = null;
         this._cachedWrapU = null;
         this._cachedWrapV = null;
         this._cachedWrapR = null;
         this._cachedAnisotropicFilteringLevel = null;
+        if (this.onRebuildCallback) {
+            const data = this.onRebuildCallback(this);
+            const swapAndSetIsReady = (proxyInternalTexture: InternalTexture) => {
+                proxyInternalTexture._swapAndDie(this, false);
+                this.isReady = data.isReady;
+            };
+            if (data.isAsync) {
+                (data.proxy as Promise<InternalTexture>).then(swapAndSetIsReady);
+            } else {
+                swapAndSetIsReady((data.proxy as InternalTexture));
+            }
+            return;
+        }
 
+        let proxy: InternalTexture;
         switch (this.source) {
             case InternalTextureSource.Temp:
                 break;

--- a/src/Materials/Textures/rawCubeTexture.ts
+++ b/src/Materials/Textures/rawCubeTexture.ts
@@ -81,6 +81,15 @@ export class RawCubeTexture extends CubeTexture {
 
     /** @hidden */
     public static _UpdateRGBDAsync(internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<void> {
+        internalTexture.onRebuildCallback = (_internalTexture) => {
+            const proxy = internalTexture.getEngine().createRawCubeTexture(null, internalTexture.width, internalTexture.format, internalTexture.type,
+                internalTexture.generateMipMaps, internalTexture.invertY, internalTexture.samplingMode, internalTexture._compression);
+            return {
+                proxy: EnvironmentTextureTools._UpdateRGBDAsync(proxy, internalTexture._bufferViewArrayArray!, internalTexture._sphericalPolynomial, internalTexture._lodGenerationScale, internalTexture._lodGenerationOffset),
+                isReady: true,
+                isAsync: true
+            };
+        };
         internalTexture._source = InternalTextureSource.CubeRawRGBD;
         internalTexture._bufferViewArrayArray = data;
         internalTexture._lodGenerationScale = lodScale;

--- a/src/Materials/Textures/rawCubeTexture.ts
+++ b/src/Materials/Textures/rawCubeTexture.ts
@@ -56,7 +56,7 @@ export class RawCubeTexture extends CubeTexture {
      * @returns a promise that resolves when the operation is complete
      */
     public updateRGBDAsync(data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial> = null, lodScale: number = 0.8, lodOffset: number = 0): Promise<void> {
-        return RawCubeTexture._UpdateRGBDAsync(this._texture!, data, sphericalPolynomial, lodScale, lodOffset);
+        return RawCubeTexture._UpdateRGBDAsync(this._texture!, data, sphericalPolynomial, lodScale, lodOffset).then(() => {});
     }
 
     /**
@@ -80,7 +80,7 @@ export class RawCubeTexture extends CubeTexture {
     }
 
     /** @hidden */
-    public static _UpdateRGBDAsync(internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<void> {
+    public static _UpdateRGBDAsync(internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<InternalTexture> {
         internalTexture.onRebuildCallback = (_internalTexture) => {
             const proxy = internalTexture.getEngine().createRawCubeTexture(null, internalTexture.width, internalTexture.format, internalTexture.type,
                 internalTexture.generateMipMaps, internalTexture.invertY, internalTexture.samplingMode, internalTexture._compression);
@@ -90,14 +90,6 @@ export class RawCubeTexture extends CubeTexture {
                 isAsync: true
             };
         };
-        internalTexture._source = InternalTextureSource.CubeRawRGBD;
-        internalTexture._bufferViewArrayArray = data;
-        internalTexture._lodGenerationScale = lodScale;
-        internalTexture._lodGenerationOffset = lodOffset;
-        internalTexture._sphericalPolynomial = sphericalPolynomial;
-
-        return EnvironmentTextureTools.UploadLevelsAsync(internalTexture, data).then(() => {
-            internalTexture.isReady = true;
-        });
+        return EnvironmentTextureTools._UpdateRGBDAsync(internalTexture, internalTexture._bufferViewArrayArray!, internalTexture._sphericalPolynomial, internalTexture._lodGenerationScale, internalTexture._lodGenerationOffset);
     }
 }

--- a/src/Misc/environmentTextureTools.ts
+++ b/src/Misc/environmentTextureTools.ts
@@ -715,7 +715,7 @@ export class EnvironmentTextureTools {
     }
 
     /** @hidden */
-    public static _UpdateRGBDAsync(internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<void> {
+    public static _UpdateRGBDAsync(internalTexture: InternalTexture, data: ArrayBufferView[][], sphericalPolynomial: Nullable<SphericalPolynomial>, lodScale: number, lodOffset: number): Promise<InternalTexture> {
         internalTexture._source = InternalTextureSource.CubeRawRGBD;
         internalTexture._bufferViewArrayArray = data;
         internalTexture._lodGenerationScale = lodScale;
@@ -724,6 +724,7 @@ export class EnvironmentTextureTools {
 
         return EnvironmentTextureTools.UploadLevelsAsync(internalTexture, data).then(() => {
             internalTexture.isReady = true;
+            return internalTexture;
         });
     }
 }


### PR DESCRIPTION
The side effect defined in Environment tools was not yet removed, but with this implementation there is little to no need for it, especially since it is a hidden function.

This is a standalone PR and is not related to the public-static restructure. It does complement it.