### PR TITLE
Add Observable.FromPromise

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -47,6 +47,7 @@
 - Allow the possibility to override the radius delta calculation for mouse wheel event ([RaananW](https://github.com/RaananW))
 - Modified behavior for FreeCamera and ArcRotateCamera so that default mouse dragging movements now account for what button was used to initiate it ([PolygonalSun](https://github.com/PolygonalSun))
 - Added coroutine capabilities to `Observable`s ([syntheticmagus](https://github.com/syntheticmagus))
+- Added an `Observable.FromPromise` utility method ([Symbitic](https://github.com/Symbitic))
 - Added a global OnTextureLoadErrorObservable to handle texture loading errors during model load ([RaananW](https://github.com/RaananW))
 - Add support to encode and decode .env environment textures using WebP instead of PNG ([simonihmig](https://github.com/simonihmig))
 - Added a new stereoscopic screen rig camera ([RaananW](https://github.com/RaananW))

--- a/src/Misc/observable.ts
+++ b/src/Misc/observable.ts
@@ -157,7 +157,7 @@ export class Observable<T> {
     private _eventState: EventState;
 
     private _onObserverAdded: Nullable<(observer: Observer<T>) => void>;
-    
+
     /**
      * Create an observable from a Promise.
      * @param promise a promise to observe for fulfillment.

--- a/src/Misc/observable.ts
+++ b/src/Misc/observable.ts
@@ -157,6 +157,30 @@ export class Observable<T> {
     private _eventState: EventState;
 
     private _onObserverAdded: Nullable<(observer: Observer<T>) => void>;
+    
+    /**
+     * Create an observable from a Promise.
+     * @param promise a promise to observe for fulfillment.
+     * @param onErrorObservable an observable to notify if a promise was rejected.
+     * @returns the new Observable
+     */
+    public static FromPromise<T, E = Error>(promise: Promise<T>, onErrorObservable?: Observable<E>): Observable<T> {
+        let observable = new Observable<T>();
+
+        promise
+            .then((ret: T) => {
+                observable.notifyObservers(ret);
+            })
+            .catch((err) => {
+                if (onErrorObservable) {
+                    onErrorObservable.notifyObservers(err as E);
+                } else {
+                    throw err;
+                }
+            });
+
+        return observable;
+    }
 
     /**
      * Gets the list of observers


### PR DESCRIPTION
Adds an `Observable.FromPromise` utility method to create an Observable from a Promise.

This will probably be used more by developers than within Babylon itself, but I still think it could be a useful utility because it will help people to link non-Babylon libraries into their applications.

I also created a pull request (BabylonJS/Documentation/pull/339) to add it to the documentation.