### PR TITLE
DeviceInputSystem: Fix for keyboard blur not being recognized

### DIFF
--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -312,7 +312,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         deviceEvent.deviceType = DeviceType.Keyboard;
                         deviceEvent.deviceSlot = 0;
                         deviceEvent.inputIndex = i;
-                        deviceEvent.currentState = 1;
+                        deviceEvent.currentState = 0;
                         deviceEvent.previousState = 1;
                         this.onInputChangedObservable.notifyObservers(deviceEvent);
                     }


### PR DESCRIPTION
This PR contains a simple correction to the KeyboardEvent data being used whenever a blur event occurs.