### PR TITLE
Texture error when cached

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -3522,8 +3522,10 @@ export class ThinEngine {
                     this._createTextureBase(EngineStore.FallbackTexture, noMipmap, texture.invertY, scene, samplingMode, null, onError, prepareTexture, prepareTextureProcessFunction, buffer, texture);
                 }
 
+                message = (message || "Unknown error") + (EngineStore.UseFallbackTexture ? " - Fallback texture was used" : "");
+                texture.onErrorObservable.notifyObservers({ message, exception });
                 if (onError) {
-                    onError((message || "Unknown error") + (EngineStore.UseFallbackTexture ? " - Fallback texture was used" : ""), exception);
+                    onError(message, exception);
                 }
             }
             else {

--- a/src/Materials/Textures/internalTexture.ts
+++ b/src/Materials/Textures/internalTexture.ts
@@ -137,6 +137,10 @@ export class InternalTexture extends TextureSampler {
      */
     public onLoadedObservable = new Observable<InternalTexture>();
     /**
+     * Observable called when the texture load is raising an error
+     */
+     public onErrorObservable = new Observable<Partial<{ message: string, exception: any }>>();
+    /**
      * If this callback is defined it will be called instead of the default _rebuild function
      */
     public onRebuildCallback: Nullable<(internalTexture: InternalTexture) => {
@@ -466,6 +470,8 @@ export class InternalTexture extends TextureSampler {
      */
     public dispose(): void {
         this._references--;
+        this.onLoadedObservable.clear();
+        this.onErrorObservable.clear();
         if (this._references === 0) {
             this._engine._releaseTexture(this);
             this._hardwareTexture = null;

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -457,7 +457,11 @@ export class Texture extends BaseTexture {
             if (this._texture.isReady) {
                 TimingTools.SetImmediate(() => load());
             } else {
-                this._texture.onLoadedObservable.add(load);
+                const loadObserver = this._texture.onLoadedObservable.add(load);
+                this._texture.onErrorObservable.add((e) => {
+                    errorHandler(e.message, e.exception);
+                    this._texture?.onLoadedObservable.remove(loadObserver);
+                });
             }
         }
     }


### PR DESCRIPTION
https://forum.babylonjs.com/t/creation-of-texture-using-a-url-which-has-already-caused-failure-will-not-trigger-onerror-handler/24322/3