### PR TITLE
Fix for link with mesh and render scale

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -601,8 +601,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                     continue;
                 }
                 control.notRenderable = false;
-                // Account for RenderScale.
-                projectedPosition.scaleInPlace(this.renderScale);
+
                 control._moveToProjectedPosition(projectedPosition);
             }
         }


### PR DESCRIPTION
https://forum.babylonjs.com/t/control-linkwithmesh-breaks-when-advanceddynamictexture-renderscale-is-not-1/24301/4