### PR TITLE
Fix for hands for 6DofDrag behavior update

### DIFF
--- a/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
@@ -226,11 +226,17 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
         virtualMeshesInfo.originMesh.removeChild(virtualMeshesInfo.pivotMesh);
     }
 
-    private _pointerUpdateXR(controllerTransform: AbstractMesh, pointerId: number, zDragFactor: number) {
+    private _pointerUpdateXR(controllerAimTransform: TransformNode, controllerGripTransform: Nullable<TransformNode>, pointerId: number, zDragFactor: number) {
         const virtualMeshesInfo = this._virtualMeshesInfo[pointerId];
         virtualMeshesInfo.pivotMesh.computeWorldMatrix(true);
-        virtualMeshesInfo.originMesh.position.copyFrom(controllerTransform.position);
-        virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(controllerTransform.rotationQuaternion!);
+        virtualMeshesInfo.dragMesh.computeWorldMatrix(true);
+        virtualMeshesInfo.originMesh.position.copyFrom(controllerAimTransform.position);
+        if (this._dragging === this._dragType.NEAR_DRAG && controllerGripTransform) {
+            virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(controllerGripTransform.rotationQuaternion!);
+        }
+        else {
+            virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(controllerAimTransform.rotationQuaternion!);
+        }
 
         // Z scaling logic
         // Camera.getForwardRay modifies TmpVectors.Vector[0-3], so cache it in advance
@@ -242,25 +248,25 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
         const controllerDragDistance = originDragDirection.length();
         originDragDirection.normalize();
 
-        const cameraToPivot = TmpVectors.Vector3[2];
-        const controllerToPivot = TmpVectors.Vector3[3];
-        virtualMeshesInfo.pivotMesh.absolutePosition.subtractToRef(this._pointerCamera!.globalPosition, cameraToPivot);
-        virtualMeshesInfo.pivotMesh.absolutePosition.subtractToRef(virtualMeshesInfo.originMesh.position, controllerToPivot);
-        const controllerToPivotDistance = controllerToPivot.length();
-        cameraToPivot.normalize();
-        controllerToPivot.normalize();
+        const cameraToDrag = TmpVectors.Vector3[2];
+        const controllerToDrag = TmpVectors.Vector3[3];
+        virtualMeshesInfo.dragMesh.absolutePosition.subtractToRef(this._pointerCamera!.globalPosition, cameraToDrag);
+        virtualMeshesInfo.dragMesh.absolutePosition.subtractToRef(virtualMeshesInfo.originMesh.position, controllerToDrag);
+        const controllerToDragDistance = controllerToDrag.length();
+        cameraToDrag.normalize();
+        controllerToDrag.normalize();
 
-        const controllerDragScaling = Math.abs(Vector3.Dot(originDragDirection, controllerToPivot)) * Vector3.Dot(originDragDirection, cameraForwardVec);
-        let zOffsetScaling = controllerDragScaling * zDragFactor * controllerDragDistance * controllerToPivotDistance;
+        const controllerDragScaling = Math.abs(Vector3.Dot(originDragDirection, controllerToDrag)) * Vector3.Dot(originDragDirection, cameraForwardVec);
+        let zOffsetScaling = controllerDragScaling * zDragFactor * controllerDragDistance * controllerToDragDistance;
 
         // Prevent pulling the mesh through the controller
-        if (zOffsetScaling + controllerToPivotDistance < 0.1) {
-            zOffsetScaling = Math.min(controllerToPivotDistance, 0.1);
+        if (zOffsetScaling + controllerToDragDistance < 0.1) {
+            zOffsetScaling = Math.min(controllerToDragDistance, 0.1);
         }
-        controllerToPivot.scaleInPlace(zOffsetScaling);
+        controllerToDrag.scaleInPlace(zOffsetScaling);
 
-        virtualMeshesInfo.pivotMesh.setAbsolutePosition(virtualMeshesInfo.pivotMesh.absolutePosition.add(controllerToPivot));
-        virtualMeshesInfo.dragMesh.setAbsolutePosition(virtualMeshesInfo.dragMesh.absolutePosition.add(controllerToPivot));
+        virtualMeshesInfo.pivotMesh.setAbsolutePosition(virtualMeshesInfo.pivotMesh.absolutePosition.add(controllerToDrag));
+        virtualMeshesInfo.dragMesh.setAbsolutePosition(virtualMeshesInfo.dragMesh.absolutePosition.add(controllerToDrag));
     }
 
     /**
@@ -294,8 +300,8 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
                     pointerInfo.pickInfo.hit &&
                     pointerInfo.pickInfo.pickedMesh &&
                     pointerInfo.pickInfo.pickedPoint &&
-                    pointerInfo.pickInfo.ray &&
-                    (!isXRPointer || pointerInfo.pickInfo.originTransform) &&
+                    pointerInfo.pickInfo.ray && 
+                    (!isXRPointer || pointerInfo.pickInfo.aimTransform) &&
                     pickPredicate(pointerInfo.pickInfo.pickedMesh)
                 ) {
                     if (!this.allowMultiPointer && this.currentDraggingPointerIds.length > 0) {
@@ -316,9 +322,13 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
 
                     if (isXRPointer) {
                         this._dragging = pointerInfo.pickInfo.originMesh ? this._dragType.NEAR_DRAG : this._dragType.DRAG_WITH_CONTROLLER;
-                        const controllerTransform = pointerInfo.pickInfo.originTransform!;
-                        virtualMeshesInfo.originMesh.position.copyFrom(controllerTransform.position);
-                        virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(controllerTransform.rotationQuaternion!);
+                        virtualMeshesInfo.originMesh.position.copyFrom(pointerInfo.pickInfo.aimTransform!.position);
+                        if (this._dragging === this._dragType.NEAR_DRAG && pointerInfo.pickInfo.gripTransform) {
+                            virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(pointerInfo.pickInfo.gripTransform.rotationQuaternion!);
+                        }
+                        else {
+                            virtualMeshesInfo.originMesh.rotationQuaternion!.copyFrom(pointerInfo.pickInfo.aimTransform!.rotationQuaternion!);
+                        }
                     }
                     else {
                         this._dragging = this._dragType.DRAG;
@@ -396,7 +406,7 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
                 if (registeredPointerIndex !== -1 &&
                     virtualMeshesInfo.dragging &&
                     pointerInfo.pickInfo &&
-                    (pointerInfo.pickInfo.ray || pointerInfo.pickInfo.originTransform))
+                    (pointerInfo.pickInfo.ray || pointerInfo.pickInfo.aimTransform))
                 {
                     let zDragFactor = this.zDragFactor;
 
@@ -411,7 +421,7 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
                         this._pointerUpdate2D(pointerInfo.pickInfo.ray!, pointerId, zDragFactor);
                     }
                     else {
-                        this._pointerUpdateXR(pointerInfo.pickInfo.originTransform!, pointerId, zDragFactor);
+                        this._pointerUpdateXR(pointerInfo.pickInfo.aimTransform!, pointerInfo.pickInfo.gripTransform, pointerId, zDragFactor);
                     }
 
                     // Get change in rotation

--- a/src/Behaviors/Meshes/sixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/sixDofDragBehavior.ts
@@ -44,7 +44,7 @@ export class SixDofDragBehavior extends BaseSixDofDragBehavior {
     /**
      * Should the behavior rotate 1:1 with the motion controller, when one is used.
      */
-    public rotateWithMotionController = false;
+    public rotateWithMotionController = true;
 
     /**
      *  The name of the behavior

--- a/src/Collisions/pickingInfo.ts
+++ b/src/Collisions/pickingInfo.ts
@@ -1,6 +1,7 @@
 import { Nullable, FloatArray } from "../types";
 import { Vector3, Vector2, TmpVectors } from "../Maths/math.vector";
 import { AbstractMesh } from "../Meshes/abstractMesh";
+import { TransformNode } from "../Meshes/transformNode";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Sprite } from "../Sprites/sprite";
 
@@ -42,21 +43,25 @@ export class PickingInfo {
     public subMeshId = 0;
     /** If a sprite was picked, this will be the sprite the pick collided with */
     public pickedSprite: Nullable<Sprite> = null;
-
     /** If we are picking a mesh with thin instance, this will give you the picked thin instance */
     public thinInstanceIndex = -1;
+    /**
+     * The ray that was used to perform the picking.
+     */
+    public ray: Nullable<Ray> = null;
     /**
      * If a mesh was used to do the picking (eg. 6dof controller) as a "near interaction", this will be populated.
      */
     public originMesh: Nullable<AbstractMesh> = null;
     /**
-     * The mesh used for picking (eg. 6dof controller), if one exists.
+     * The aim-space transform of the input used for picking, if it is an XR input source.
      */
-    public originTransform: Nullable<AbstractMesh> = null;
+    public aimTransform: Nullable<TransformNode> = null;
     /**
-     * The ray that was used to perform the picking.
+     * The grip-space transform of the input used for picking, if it is an XR input source.
+     * Some XR sources, such as input coming from head mounted displays, do not have this.
      */
-    public ray: Nullable<Ray> = null;
+    public gripTransform: Nullable<TransformNode> = null;
 
     /**
      * Gets the normal corresponding to the face the pick collided with

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -124,7 +124,6 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             xrController,
             laserPointer,
             selectionMesh,
-            xrControllerTransform: null,
             meshUnderPointer: null,
             pick: null,
             tmpRay: new Ray(new Vector3(), new Vector3()),
@@ -158,7 +157,6 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     private _controllers: {
         [controllerUniqueId: string]: {
             xrController?: WebXRInputSource;
-            xrControllerTransform: Nullable<AbstractMesh>;
             webXRCamera?: WebXRCamera;
             selectionComponent?: WebXRControllerComponent;
             onButtonChangedObserver?: Nullable<Observer<WebXRControllerComponent>>;
@@ -267,7 +265,6 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                 webXRCamera,
                 laserPointer,
                 selectionMesh,
-                xrControllerTransform: null,
                 meshUnderPointer: null,
                 pick: null,
                 tmpRay: new Ray(new Vector3(), new Vector3()),
@@ -351,7 +348,6 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             if (controllerData.xrController) {
                 controllerGlobalPosition = controllerData.xrController.pointer.position;
                 controllerData.xrController.getWorldPointerRayToRef(controllerData.tmpRay);
-                controllerData.xrControllerTransform = controllerData.xrController.grip || null;
             } else if (controllerData.webXRCamera) {
                 controllerGlobalPosition = controllerData.webXRCamera.position;
                 controllerData.webXRCamera.getForwardRayToRef(controllerData.tmpRay);
@@ -395,8 +391,9 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                 controllerData.pick = originalScenePick;
             }
 
-            if (controllerData.pick) {
-                controllerData.pick.originTransform = controllerData.xrControllerTransform;
+            if (controllerData.pick && controllerData.xrController) {
+                controllerData.pick.aimTransform = controllerData.xrController.pointer;
+                controllerData.pick.gripTransform = controllerData.xrController.grip || null;
             }
 
             const pick = controllerData.pick;

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -21,7 +21,6 @@ import { Color3 } from "../../Maths/math.color";
 
 type ControllerData = {
     xrController?: WebXRInputSource;
-    xrControllerTransform: Nullable<AbstractMesh>;
     squeezeComponent?: WebXRControllerComponent;
     selectionComponent?: WebXRControllerComponent;
     onButtonChangedObserver?: Nullable<Observer<WebXRControllerComponent>>;
@@ -95,7 +94,6 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
         this._controllers[xrController.uniqueId] = {
             xrController,
-            xrControllerTransform: null,
             meshUnderPointer: null,
             nearInteractionMesh: null,
             pick: null,
@@ -340,8 +338,6 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                         }
                     }
                 }
-
-                controllerData.xrControllerTransform = controllerData.xrController.grip || null;
             } else {
                 return;
             }
@@ -664,7 +660,8 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                     pickingInfo.hit = result.hit;
                     pickingInfo.pickedMesh = mesh;
                     pickingInfo.pickedPoint = result.pickedPoint;
-                    pickingInfo.originTransform = controllerData.xrControllerTransform;
+                    pickingInfo.aimTransform = controllerData.xrController.pointer;
+                    pickingInfo.gripTransform = controllerData.xrController.grip || null;
                     pickingInfo.originMesh = controllerData.pickIndexMeshTip;
                     pickingInfo.distance = result.distance;
                 }


### PR DESCRIPTION
Since hand tracking had a separation between hand rotation and hand ray rotation (unlike motion controllers, which rotate the ray with the controller), I needed to put in some extra logic to ensure the ray always pointed to the target mesh in an intuitive manner.
This ended up requiring both the aim and grip pose to be sent in the pick info, as the aim pose followed the targeting ray, but grip pose allowed for 3D manipulation.

Also switched to using the drag mesh (instead of the pivot mesh) for XR manipulation, to be more accurate to the point of rotation.