### PR TITLE
Fix instances disappearing in frozen mode

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -61,6 +61,7 @@ export class _CreationDataStorage {
 class _InstanceDataStorage {
     public visibleInstances: any = {};
     public batchCache = new _InstancesBatch();
+    public batchCacheReplacementModeInFrozenMode = new _InstancesBatch();
     public instancesBufferSize = 32 * 16 * 4; // let's start with a maximum of 32 instances
     public instancesBuffer: Nullable<Buffer>;
     public instancesPreviousBuffer: Nullable<Buffer>;
@@ -1750,8 +1751,15 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /** @hidden */
     public _getInstancesRenderList(subMeshId: number, isReplacementMode: boolean = false): _InstancesBatch {
-        if (this._instanceDataStorage.isFrozen && this._instanceDataStorage.previousBatch) {
-            return this._instanceDataStorage.previousBatch;
+        if (this._instanceDataStorage.isFrozen) {
+            if (isReplacementMode) {
+                this._instanceDataStorage.batchCacheReplacementModeInFrozenMode.hardwareInstancedRendering[subMeshId] = false;
+                this._instanceDataStorage.batchCacheReplacementModeInFrozenMode.renderSelf[subMeshId] = true;
+                return this._instanceDataStorage.batchCacheReplacementModeInFrozenMode;
+            }
+            if (this._instanceDataStorage.previousBatch) {
+                return this._instanceDataStorage.previousBatch;
+            }
         }
         var scene = this.getScene();
         const isInIntermediateRendering = scene._isInIntermediateRendering();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/unexpected-mesh-behaviour-in-scene-with-glow-layer-and-frozen-active-meshes/24414

A bit of context:

When a mesh has some instances that have the same determinant than their source mesh and other instances that have an opposite determinant, those latter instances are handled/rendered in another pass and are not part of the `visibleInstances` array of the source mesh. 

When in frozen mode, the `previousBatch` was returned each time `_getInstancesRenderList` was called:
```typescript
       if (this._instanceDataStorage.isFrozen && this._instanceDataStorage.previousBatch) {
            return this._instanceDataStorage.previousBatch;
        }
```
The problem is that `_getInstancesRenderList` is called several times for the same mesh, one time to collect the regular instances (those having the same determinant) and some other times for instances that have an opposite determinant. When not in frozen mode, those latter calls are returning a batch corresponding to each instance, but in frozen mode those calls are inheriting the first batch, the one corresponding to the regular instances and thus the rendering is failing. The fix simply returns a batch correctly constructed for the instance concerned by the call.
