### PR TITLE
Make serializer explicitly point to default material

### DIFF
--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -3474,6 +3474,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             }
         } else {
             this.material = null;
+            serializationObject.materialId = this._scene.defaultMaterial.id;
         }
 
         // Morph targets


### PR DESCRIPTION
Currently, if you serialize a scene with a mesh that has material == null, the material field in the JSON will be left blank. This means that when you load the .babylon file into a new scene, all those meshes will use the new scene's default material.

Instead, we should explicitly point to the original scene's default material.

Effectively, if I change the default material in my scene and then export to .babylon, I will not see those changes in my new scene. This PR fixes that.