### PR TITLE
NME: Fix lights not being correctly bound for a node material

### DIFF
--- a/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -263,7 +263,7 @@ export class LightBlock extends NodeMaterialBlock {
         }
 
         // Fragment
-        state.sharedData.bindableBlocks.push(this);
+        state.sharedData.forcedBindableBlocks.push(this);
         state.sharedData.blocksWithDefines.push(this);
 
         let comments = `//${this.name}`;

--- a/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -954,7 +954,7 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         }
 
         // Fragment
-        state.sharedData.bindableBlocks.push(this);
+        state.sharedData.forcedBindableBlocks.push(this);
         state.sharedData.blocksWithDefines.push(this);
         state.sharedData.blockingBlocks.push(this);
 

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -1287,12 +1287,16 @@ export class NodeMaterial extends PushMaterial {
         this.bindOnlyWorldMatrix(world);
 
         let mustRebind = this._mustRebind(scene, effect, mesh.visibility);
+        let sharedData = this._sharedData;
 
         if (mustRebind) {
-            let sharedData = this._sharedData;
             if (effect) {
                 // Bindable blocks
                 for (var block of sharedData.bindableBlocks) {
+                    block.bind(effect, this, mesh, subMesh);
+                }
+
+                for (var block of sharedData.forcedBindableBlocks) {
                     block.bind(effect, this, mesh, subMesh);
                 }
 
@@ -1300,6 +1304,10 @@ export class NodeMaterial extends PushMaterial {
                 for (var inputBlock of sharedData.inputBlocks) {
                     inputBlock._transmit(effect, scene);
                 }
+            }
+        } else if (!this.isFrozen) {
+            for (var block of sharedData.forcedBindableBlocks) {
+                block.bind(effect, this, mesh, subMesh);
             }
         }
 

--- a/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
+++ b/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
@@ -44,6 +44,11 @@ export class NodeMaterialBuildStateSharedData {
     public bindableBlocks = new Array<NodeMaterialBlock>();
 
     /**
+     * Bindable blocks (Blocks that need to set data to the effect) that will always be called (by bindForSubMesh), contrary to bindableBlocks that won't be called if _mustRebind() returns false
+     */
+    public forcedBindableBlocks = new Array<NodeMaterialBlock>();
+
+     /**
      * List of blocks that can provide a compilation fallback
      */
     public blocksWithFallbacks = new Array<NodeMaterialBlock>();


### PR DESCRIPTION
This PG does not work as expected:
https://playground.babylonjs.com/#2R086I#4

There are two lights, one with intensity=0 which is lighting only the sphere and the other with intensity=1 which is lighting only the ground.

In the PG, both the sphere and the ground are black because the lights are not correctly bound for the 2nd object (the ground) because `this._mustRebind(scene, effect, mesh.visibility)` (in `NodeMaterial.bindForSubMesh`) returns `false` for the ground, as the material is the same for both objects.

We should do like the `StandardMaterial` and `PBRMaterial`, where the binding of the lights is conditionned to `mustRebind || !isFrozen`.