### PR TITLE
Fix ShaderMaterial when in frozen mode

### DIFF
--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -127,6 +127,7 @@ export class ShaderMaterial extends Material {
     private _cachedWorldViewProjectionMatrix = new Matrix();
     private _multiview: boolean = false;
     private _cachedDefines: string;
+    private _effectUsesInstances: boolean;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = "https://snippet.babylonjs.com";
@@ -571,7 +572,7 @@ export class ShaderMaterial extends Material {
     public isReady(mesh?: AbstractMesh, useInstances?: boolean, subMesh?: SubMesh): boolean {
         let effect = this.getEffect();
         if (effect && this.isFrozen) {
-            if (effect._wasPreviouslyReady) {
+            if (effect._wasPreviouslyReady && this._effectUsesInstances === useInstances) {
                 return true;
             }
         }
@@ -807,6 +808,8 @@ export class ShaderMaterial extends Material {
                 this._onEffectCreatedObservable.notifyObservers(onCreatedEffectParameters);
             }
         }
+
+        this._effectUsesInstances = !!useInstances;
 
         if (!effect?.isReady() ?? true) {
             return false;


### PR DESCRIPTION
See this PG: https://playground.babylonjs.com/#6GFJNR#143

There should be 2 cubes but we only see one (the 2nd cube is an instance).

That's because the sphere is using the shader material in a non instanced mode, meaning the effect is generated in a non instanced mode. Because the material is frozen, when displaying the cube this effect will be reused and not regenerated, leading to the wrong display.