### PR TITLE
Fix copying snippet id to clipboard for Chrome

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -135,6 +135,7 @@
 
 ### GUI
 
+- Allow Chrome to copy the GUI snippet id to the clipboard ([BlakeOne](https://github.com/BlakeOne))
 - Added a `FocusableButton` gui control to simplify creating menus with keyboard navigation ([Flux159](https://github.com/Flux159))
 - Added `focus()` and `blur()` functions for controls that implement `IFocusableControl` ([Flux159](https://github.com/Flux159))
 - Added `ToggleButton` GUI control ([kintz09](https://github.com/kintz09))

--- a/guiEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/guiEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -222,9 +222,14 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
         savePromise(content, adt).then((snippetId: string) => {
             adt.snippetId = snippetId;
             if (navigator.clipboard) {
-                navigator.clipboard.writeText(adt.snippetId);
+                navigator.clipboard.writeText(adt.snippetId).then(() => {
+                    alert("GUI saved with ID: " + adt.snippetId + " (please note that the id was also saved to your clipboard)");
+                }).catch((err: any) => {
+                    alert("GUI saved with ID: " + adt.snippetId);
+                })
+            } else {
+                alert("GUI saved with ID: " + adt.snippetId);
             }
-            alert("GUI saved with ID: " + adt.snippetId + " (please note that the id was also saved to your clipboard)");
             this.props.globalState.onBuiltObservable.notifyObservers();
         }).catch((err: any) => {
             alert(err);


### PR DESCRIPTION
Patch to fix the issue that Chrome can't copy to the clipboard unless the document has focus, by waiting until after writing to the clipboard has finished to create the alert window. Also the user is only told that the id has been copied to the clipboard if it's written successfully.

Forum post: https://forum.babylonjs.com/t/introducing-the-gui-editor-alpha/24578/35