### PR TITLE
Alias re-export of FileTools to avoid naming conflict with LTSFileTools

### DIFF
--- a/src/Misc/fileTools.lts.ts
+++ b/src/Misc/fileTools.lts.ts
@@ -13,7 +13,7 @@ declare type RequestFileError = import('./fileTools').RequestFileError;
  * @hidden
  * @deprecated import the needed function from fileTools.ts
  */
-export let FileTools: any;
+export let LTSFileTools: any;
 /** @hidden */
 export const _injectLTSFileTools = (
     DecodeBase64UrlToBinary: (uri: string) => ArrayBuffer,
@@ -35,7 +35,7 @@ export const _injectLTSFileTools = (
  * @hidden
  * @deprecated
  */
-    FileTools = {
+    LTSFileTools = {
         DecodeBase64UrlToBinary,
         DecodeBase64UrlToString,
         DefaultRetryStrategy: FileToolsOptions.DefaultRetryStrategy,
@@ -51,7 +51,7 @@ export const _injectLTSFileTools = (
         SetCorsBehavior,
     };
 
-    Object.defineProperty(FileTools, "DefaultRetryStrategy", {
+    Object.defineProperty(LTSFileTools, "DefaultRetryStrategy", {
         get: function (this: null) {
             return FileToolsOptions.DefaultRetryStrategy;
         },
@@ -60,7 +60,7 @@ export const _injectLTSFileTools = (
         }
     });
 
-    Object.defineProperty(FileTools, "BaseUrl", {
+    Object.defineProperty(LTSFileTools, "BaseUrl", {
         get: function (this: null) {
             return FileToolsOptions.BaseUrl;
         },
@@ -69,7 +69,7 @@ export const _injectLTSFileTools = (
         }
     });
 
-    Object.defineProperty(FileTools, "PreprocessUrl", {
+    Object.defineProperty(LTSFileTools, "PreprocessUrl", {
         get: function (this: null) {
             return FileToolsOptions.PreprocessUrl;
         },
@@ -78,7 +78,7 @@ export const _injectLTSFileTools = (
         }
     });
 
-    Object.defineProperty(FileTools, "CorsBehavior", {
+    Object.defineProperty(LTSFileTools, "CorsBehavior", {
         get: function (this: null) {
             return FileToolsOptions.CorsBehavior;
         },

--- a/src/Misc/fileTools.ts
+++ b/src/Misc/fileTools.ts
@@ -594,6 +594,6 @@ const initSideEffects = () => {
 initSideEffects();
 
 // LTS. Export FileTools in this module for backward compatibility.
-import { _injectLTSFileTools, FileTools } from './fileTools.lts';
+import { _injectLTSFileTools, LTSFileTools } from './fileTools.lts';
 _injectLTSFileTools(DecodeBase64UrlToBinary, DecodeBase64UrlToString, FileToolsOptions, IsBase64DataUrl, IsFileURL, LoadFile, LoadImage, ReadFile, RequestFile, SetCorsBehavior);
-export { FileTools };
+export { LTSFileTools as FileTools };


### PR DESCRIPTION
When integrating into our consuming react-native application the final re-export of FileTools is causing a naming conflict in the module map, which causes the application to fail to load with the following error:
`ERROR TypeError: property is not configurable, js engine: hermes`

This PR proposes a way to fix this by aliasing the export to avoid the naming conflict.