### PR TITLE
Changing the WebXRNearInteraction/WebXRPointerSelection class interaction

### DIFF
--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -328,7 +328,8 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
         return null;
     }
 
-    public getPointerSelectionDisabledByPointerId(id: number): boolean {
+    /** @hidden */
+    public _getPointerSelectionDisabledByPointerId(id: number): boolean {
         const keys = Object.keys(this._controllers);
 
         for (let i = 0; i < keys.length; ++i) {
@@ -339,7 +340,8 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
         return true;
     }
 
-    public setPointerSelectionDisabledByPointerId(id: number, state: boolean) {
+    /** @hidden */
+    public _setPointerSelectionDisabledByPointerId(id: number, state: boolean) {
         const keys = Object.keys(this._controllers);
 
         for (let i = 0; i < keys.length; ++i) {

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -422,14 +422,14 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                     controllerData.pickedPointVisualCue.isVisible = true;
 
                     if (this._farInteractionFeature && this._farInteractionFeature.attached) {
-                        this._farInteractionFeature.setPointerSelectionDisabledByPointerId(controllerData.id, true);
+                        this._farInteractionFeature._setPointerSelectionDisabledByPointerId(controllerData.id, true);
                     }
                 } else {
                     controllerData.meshUnderPointer = null;
                     controllerData.pickedPointVisualCue.isVisible = false;
 
                     if (this._farInteractionFeature && this._farInteractionFeature.attached) {
-                        this._farInteractionFeature.setPointerSelectionDisabledByPointerId(controllerData.id, false);
+                        this._farInteractionFeature._setPointerSelectionDisabledByPointerId(controllerData.id, false);
                     }
                 }
             }
@@ -464,7 +464,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
     private _isControllerReadyForNearInteraction(id: number) {
         if (this._farInteractionFeature) {
-            return this._farInteractionFeature.getPointerSelectionDisabledByPointerId(id);
+            return this._farInteractionFeature._getPointerSelectionDisabledByPointerId(id);
         }
 
         return true;


### PR DESCRIPTION
Changing the WebXRNearInteraction class to enable/disable WebXRControllerPointerSelection's class on a per-controller basis.

This prevents the user from getting in to unexpected situations when multiple hands are involved, such as an idle hand influencing whether the other hand can interact with objects via near interaction.

This also reduces potential noise from calling attach/detach on the WebXRControllerPointerSelection feature every time a near interaction starts/ends.