### PR TITLE
[XR] skip initial clear on XR RTT

### DIFF
--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -449,9 +449,7 @@ export class WebXRSessionManager implements IDisposable {
         webglRTWrapper._framebuffer = framebuffer;
         renderTargetTexture._texture = internalTexture;
         renderTargetTexture.disableRescaling();
-        if (this._sessionMode === 'immersive-ar') {
-            renderTargetTexture.skipInitialClear = true;
-        }
+        renderTargetTexture.skipInitialClear = true;
 
         // Store the render target texture for cleanup when the session ends.
         this._renderTargetTextures.push(renderTargetTexture);


### PR DESCRIPTION
Fixes #11285

The main XR camera will execute clear on each frame. There is no need to clear on each render of a single eye.
It caused utility scenes to clear before rendered and resulted in unexpected behavior.