### PR TITLE
Rename step in ScreenSpaceReflection Shader

### DIFF
--- a/src/PostProcesses/screenSpaceReflectionPostProcess.ts
+++ b/src/PostProcesses/screenSpaceReflectionPostProcess.ts
@@ -157,7 +157,7 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
             effect.setFloat("threshold", this.threshold);
             effect.setFloat("reflectionSpecularFalloffExponent", this.reflectionSpecularFalloffExponent);
             effect.setFloat("strength", this.strength);
-            effect.setFloat("step", this.step);
+            effect.setFloat("stepSize", this.step);
             effect.setFloat("roughnessFactor", this.roughnessFactor);
         };
     }

--- a/src/Shaders/screenSpaceReflection.fragment.fx
+++ b/src/Shaders/screenSpaceReflection.fragment.fx
@@ -11,7 +11,7 @@ uniform sampler2D positionSampler;
 uniform mat4 view;
 uniform mat4 projection;
 
-uniform float step;
+uniform float stepSize;
 uniform float strength;
 uniform float threshold;
 uniform float roughnessFactor;
@@ -88,7 +88,7 @@ ReflectionInfo getReflectionInfo(vec3 dir, vec3 hitCoord)
     vec4 projectedCoord;
     float sampledDepth;
 
-    dir *= step;
+    dir *= stepSize;
 
     for(int i = 0; i < REFLECTION_SAMPLES; i++)
     {


### PR DESCRIPTION
The SSR post process shader has a uniform float named `step`, but `step` is a function in GLSL.
![image](https://user-images.githubusercontent.com/1342157/137983971-c675aeee-5d4b-45fa-a839-806753a2d56a.png)
It still compiles fine on the web, but for Babylon Native this causes issues. See: https://github.com/BabylonJS/BabylonNative/issues/922

This PR changes only the name of the uniform, not the member variable on the class, so it will not break backward compatibility. (If we want to change the member variable as well, I can add getters + setters for the old name, but it didn't seem necessary to me.)