### PR TITLE
Forward Tools.*Performance* calls to Babylon Native

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -602,6 +602,22 @@ export class Node implements IBehaviorAware<Node> {
      * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
      * @return all children nodes of all types
      */
+    public getDescendants<T extends Node>(directDescendantsOnly?: boolean, predicate?: (node: Node) => node is T): T[];
+
+    /**
+     * Will return all nodes that have this node as ascendant
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @return all children nodes of all types
+     */
+    public getDescendants(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): Node[];
+
+    /**
+     * Will return all nodes that have this node as ascendant
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @return all children nodes of all types
+     */
     public getDescendants(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): Node[] {
         var results = new Array<Node>();
 
@@ -616,6 +632,22 @@ export class Node implements IBehaviorAware<Node> {
      * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
      * @returns an array of AbstractMesh
      */
+    public getChildMeshes<T extends AbstractMesh>(directDescendantsOnly?: boolean, predicate?: (node: Node) => node is T): T[];
+
+    /**
+     * Get all child-meshes of this node
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false)
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @returns an array of AbstractMesh
+     */
+    public getChildMeshes(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): AbstractMesh[];
+
+    /**
+     * Get all child-meshes of this node
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false)
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @returns an array of AbstractMesh
+     */
     public getChildMeshes(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): AbstractMesh[] {
         var results: Array<AbstractMesh> = [];
         this._getDescendants(results, directDescendantsOnly, (node: Node) => {
@@ -623,6 +655,22 @@ export class Node implements IBehaviorAware<Node> {
         });
         return results;
     }
+
+    /**
+     * Get all direct children of this node
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true)
+     * @returns an array of Node
+     */
+    public getChildren<T extends Node>(predicate?: (node: Node) => node is T, directDescendantsOnly?: boolean): T[];
+
+    /**
+     * Get all direct children of this node
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true)
+     * @returns an array of Node
+     */
+    public getChildren(predicate?: (node: Node) => boolean, directDescendantsOnly?: boolean): Node[];
 
     /**
      * Get all direct children of this node


### PR DESCRIPTION
With this change calls to `Tools.PerformanceLoggingLevel`, `Tools.StartPerformanceCounter`, and `Tools.EndPerformanceCounter` are forwarded to Babylon Native as well. This accomplishes two things:
1. It lets us enable Babylon Native performance logging from JS
2. It lets us see what is happening in Babylon.js in the context of native performance profiles

For example, in the screenshot below (Xcode Instruments), the "Points of Interest" shows two native perf intervals (the top two), and a JS interval (the bottom one - "Scene render").

![image](https://user-images.githubusercontent.com/5084643/140221878-d4e5eacc-2d0a-4466-982e-fa5633656e2a.png)

I also added an unrelated change to this PR, which is to add overloads for `Node.getChildren` (and other related `Node` functions) such that if the predicate you pass in is a type guard, the returned array will be strongly typed according to that type guard. For example:

```ts
// transformNodes will be a TransformNode[] rather than a Node[]
const transformNodes = node.getDescendants(false, (node): node is TransformNode => node instanceof TransformNode);
```