### PR TITLE
Exclude unused material in glTFExporter

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -329,6 +329,7 @@
 - Fix for SkyMaterial sun position not working with non-default azimuth  ([AdversInc](https://github.com/adversinc))
 - Fix issue where default free camera rotation didn't work during pointer lock ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix issue with wrong definition of a returned BASIS format ([RaananW](https://github.com/RaananW))
+- Fix glTF exporter exports unused materials from excluded meshes ([daoshengmu](https://github.com/daoshengmu))
 
 ## Breaking changes
 

--- a/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -122,23 +122,23 @@ export class _GLTFMaterialExporter {
      * @param mimeType texture mime type
      * @param images array of images
      * @param textures array of textures
-     * @param materials array of materials
+     * @param materials set of materials
      * @param imageData mapping of texture names to base64 textures
      * @param hasTextureCoords specifies if texture coordinates are present on the material
      */
-    public _convertMaterialsToGLTFAsync(babylonMaterials: Material[], mimeType: ImageMimeType, hasTextureCoords: boolean) {
+    public _convertMaterialsToGLTFAsync(exportMaterials: Set<Material>, mimeType: ImageMimeType, hasTextureCoords: boolean) {
         let promises: Promise<IMaterial>[] = [];
-        for (let babylonMaterial of babylonMaterials) {
-            if (babylonMaterial.getClassName() === "StandardMaterial") {
-                promises.push(this._convertStandardMaterialAsync(babylonMaterial as StandardMaterial, mimeType, hasTextureCoords));
+        exportMaterials.forEach((material) => {
+            if (material.getClassName() === "StandardMaterial") {
+                promises.push(this._convertStandardMaterialAsync(material as StandardMaterial, mimeType, hasTextureCoords));
             }
-            else if (babylonMaterial.getClassName().indexOf("PBR") !== -1) {
-                promises.push(this._convertPBRMaterialAsync(babylonMaterial as PBRMaterial, mimeType, hasTextureCoords));
+            else if (material.getClassName().indexOf("PBR") !== -1) {
+                promises.push(this._convertPBRMaterialAsync(material as PBRMaterial, mimeType, hasTextureCoords));
             }
             else {
-                Tools.Warn(`Unsupported material type: ${babylonMaterial.name}`);
+                Tools.Warn(`Unsupported material type: ${material.name}`);
             }
-        }
+        });
 
         return Promise.all(promises).then(() => { /* do nothing */ });
     }

--- a/tests/unit/babylon/serializers/babylon.glTFSerializer.tests.ts
+++ b/tests/unit/babylon/serializers/babylon.glTFSerializer.tests.ts
@@ -80,8 +80,8 @@ describe('Babylon glTF Serializer', () => {
                     const jsonString = glTFData.glTFFiles['test.gltf'] as string;
                     const jsonData = JSON.parse(jsonString);
 
-                    // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials
-                    Object.keys(jsonData).length.should.be.equal(9);
+                    // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes
+                    Object.keys(jsonData).length.should.be.equal(8);
 
                     // positions, normals, indices
                     jsonData.accessors.length.should.be.equal(3);
@@ -133,8 +133,8 @@ describe('Babylon glTF Serializer', () => {
                 animation.channels[0].target.node.should.be.equal(0);
                 animation.channels[0].target.path.should.be.equal('translation');
                 jsonData.animations[0].samplers.length.should.be.equal(1);
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-                Object.keys(jsonData).length.should.be.equal(10);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, animations
+                Object.keys(jsonData).length.should.be.equal(9);
                 // positions, normals, indices, animation keyframe data, animation data
                 jsonData.accessors.length.should.be.equal(5);
                 // generator, version
@@ -182,8 +182,8 @@ describe('Babylon glTF Serializer', () => {
                 animation.samplers[0].input.should.be.equal(3);
                 animation.samplers[0].output.should.be.equal(4);
                 jsonData.animations[0].samplers.length.should.be.equal(1);
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-                Object.keys(jsonData).length.should.be.equal(10);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, animations
+                Object.keys(jsonData).length.should.be.equal(9);
                 // positions, normals, indices, animation keyframe data, animation data
                 jsonData.accessors.length.should.be.equal(5);
                 // generator, version
@@ -231,8 +231,8 @@ describe('Babylon glTF Serializer', () => {
                 animation.samplers[0].input.should.be.equal(3);
                 animation.samplers[0].output.should.be.equal(4);
                 jsonData.animations[0].samplers.length.should.be.equal(1);
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-                Object.keys(jsonData).length.should.be.equal(10);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, animations
+                Object.keys(jsonData).length.should.be.equal(9);
                 // positions, normals, indices, animation keyframe data, animation data
                 jsonData.accessors.length.should.be.equal(5);
                 // generator, version
@@ -280,8 +280,8 @@ describe('Babylon glTF Serializer', () => {
                 animation.samplers[0].input.should.be.equal(3);
                 animation.samplers[0].output.should.be.equal(4);
                 jsonData.animations[0].samplers.length.should.be.equal(1);
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-                Object.keys(jsonData).length.should.be.equal(10);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, animations
+                Object.keys(jsonData).length.should.be.equal(9);
                 // positions, normals, indices, animation keyframe data, animation data
                 jsonData.accessors.length.should.be.equal(5);
                 // generator, version
@@ -353,8 +353,8 @@ describe('Babylon glTF Serializer', () => {
                 animation.samplers[0].interpolation.should.be.equal('LINEAR');
                 animation.samplers[0].input.should.be.equal(5);
                 animation.samplers[0].output.should.be.equal(6);
-                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, materials, animations
-                Object.keys(jsonData).length.should.be.equal(10);
+                // accessors, asset, buffers, bufferViews, meshes, nodes, scene, scenes, animations
+                Object.keys(jsonData).length.should.be.equal(9);
                 // positions, normals, indices, rotation animation keyframe data, rotation animation data, scale animation keyframe data, scale animation data
                 jsonData.accessors.length.should.be.equal(7);
                 // generator, version


### PR DESCRIPTION
Fixes #10009

- Excluding materials if they are not used by exported meshes.
- Collecting only exported nodes and materials beyond processing them.