### PR TITLE
Fix baked vertex animation support in ShaderMaterial

### DIFF
--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -720,6 +720,12 @@ export class ShaderMaterial extends Material {
 
         // Baked Vertex Animation
         if (mesh) {
+            const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
+
+            if (bvaManager && bvaManager.isEnabled) {
+                defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
+            }
+
             MaterialHelper.PrepareAttributesForBakedVertexAnimation(attribs, mesh, defines);
         }
 


### PR DESCRIPTION
Fix `ShaderMaterial` for BVA.

What @RaananW was saying in #11317 was that `#define ` could be removed from the string pushed in the `defines` array, not that all the code could be removed. But in fact it can't be done anyway because the automatic adding of `#define` is done for defines passed to the constructor of `ShaderMaterial`, which is not our case here.