### PR TITLE
Add the missing setter for the BasisTools options

### DIFF
--- a/src/Misc/basis.ts
+++ b/src/Misc/basis.ts
@@ -493,3 +493,21 @@ function workerFunc(): void {
         return dst;
     }
 }
+
+Object.defineProperty(BasisTools, "JSModuleURL", {
+    get: function (this: null) {
+        return BasisToolsOptions.JSModuleURL;
+    },
+    set: function (this: null, value: string) {
+        BasisToolsOptions.JSModuleURL = value;
+    }
+});
+
+Object.defineProperty(BasisTools, "WasmModuleURL", {
+    get: function (this: null) {
+        return BasisToolsOptions.WasmModuleURL;
+    },
+    set: function (this: null, value: string) {
+        BasisToolsOptions.WasmModuleURL = value;
+    }
+});


### PR DESCRIPTION
That was removed as part of previous module work. The setter is not setting the right object that is used throughout the framework.