### PR TITLE
Fix on Css for color picker

### DIFF
--- a/guiEditor/src/components/propertyTab/propertyTab.scss
+++ b/guiEditor/src/components/propertyTab/propertyTab.scss
@@ -829,7 +829,7 @@ hr.ge {
 
             .textInputLine {
                 grid-column: 3;
-                margin-left: -5px;
+                padding-left: 0px;
             }
     
             .color3 {


### PR DESCRIPTION
There was an issue where the color picker was not able to be selected because an element was on top of it.

![image](https://user-images.githubusercontent.com/67929198/140559180-adcda9f7-cc90-42bd-bd1a-b77c8ecd0402.png)
