### PR TITLE
Optimize scene UBOs

### DIFF
--- a/src/Engines/Extensions/engine.multiview.ts
+++ b/src/Engines/Extensions/engine.multiview.ts
@@ -131,15 +131,28 @@ declare module "../../scene" {
     }
 }
 
+function createMultiviewUbo(engine: Engine, name?: string) {
+    const ubo = new UniformBuffer(engine, undefined, true, name);
+    ubo.addUniform("viewProjection", 16);
+    ubo.addUniform("viewProjectionR", 16);
+    ubo.addUniform("view", 16);
+    ubo.addUniform("projection", 16);
+    ubo.addUniform("viewPosition", 4);
+    return ubo;
+}
+
+const currentCreateSceneUniformBuffer = Scene.prototype.createSceneUniformBuffer;
+
 Scene.prototype._transformMatrixR = Matrix.Zero();
 Scene.prototype._multiviewSceneUbo = null;
 Scene.prototype._createMultiviewUbo = function () {
-    this._multiviewSceneUbo = new UniformBuffer(this.getEngine(), undefined, true, "scene_multiview");
-    this._multiviewSceneUbo.addUniform("viewProjection", 16);
-    this._multiviewSceneUbo.addUniform("viewProjectionR", 16);
-    this._multiviewSceneUbo.addUniform("view", 16);
-    this._multiviewSceneUbo.addUniform("projection", 16);
-    this._multiviewSceneUbo.addUniform("viewPosition", 4);
+    this._multiviewSceneUbo = createMultiviewUbo(this.getEngine(), "scene_multiview");
+};
+Scene.prototype.createSceneUniformBuffer = function (name?: string): UniformBuffer {
+    if (this._multiviewSceneUbo) {
+        return createMultiviewUbo(this.getEngine(), name);
+    }
+    return currentCreateSceneUniformBuffer.bind(this)(name);
 };
 Scene.prototype._updateMultiviewUbo = function (viewR?: Matrix, projectionR?: Matrix) {
     if (viewR && projectionR) {

--- a/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -493,6 +493,7 @@ export class WebGPUTextureHelper {
             case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3:
                 return useSRGBBuffer ? WebGPUConstants.TextureFormat.BC2RGBAUnormSRGB : WebGPUConstants.TextureFormat.BC2RGBAUnorm;
             case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT1:
+            case Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1:
                 return useSRGBBuffer ? WebGPUConstants.TextureFormat.BC1RGBAUnormSRGB : WebGPUConstants.TextureFormat.BC1RGBAUnorm;
         }
 

--- a/src/Materials/uniformBuffer.ts
+++ b/src/Materials/uniformBuffer.ts
@@ -578,7 +578,7 @@ export class UniformBuffer {
             return;
         }
 
-        if (this._buffers?.[this._bufferIndex][1]) {
+        if (this._buffers && this._buffers.length > 1 && this._buffers[this._bufferIndex][1]) {
             if (this._buffersEqual(this._bufferData, this._buffers[this._bufferIndex][1]!)) {
                 this._needSync = false;
                 this._createBufferOnWrite = this._engine._features.trackUbosInFrame;

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2191,6 +2191,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      */
     public setSceneUniformBuffer(ubo: UniformBuffer): void {
         this._sceneUbo = ubo;
+        this._viewUpdateFlag = -1;
+        this._projectionUpdateFlag = -1;
     }
 
     /**


### PR DESCRIPTION
In this PR, new scene UBOs are created and used in subsystems where at least one data of the scene UBO (view/projection matrix, eye position) is modified compared to the regular (final) scene rendering.

It is the case for `MirrorTexture`, (CSM) `ShadowGenerator` and `ReflectionProbe`. In each case a new scene UBO (or 6 for reflection probe and n for CSM with n layers) is created and used in place of the regular scene ubo to perform the subsystem rendering. This way, the regular scene ubo (and each of the specifically created scene UBO) holds only a single GPU buffer which enables some optimizations inside the `UniformBuffer` class (we get rid of a comparison between two arrays of float + an array copy if the comparison is different). Also, having a single GPU buffer in the scene UB class is better for the fast path mode in WebGPU as it can lead to fewer recreations of the fast path bundle.