### PR TITLE
LinesMesh: Fix using clip planes with custom material

### DIFF
--- a/src/Meshes/linesMesh.ts
+++ b/src/Meshes/linesMesh.ts
@@ -9,7 +9,6 @@ import { InstancedMesh } from "../Meshes/instancedMesh";
 import { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
 import { ShaderMaterial } from "../Materials/shaderMaterial";
-import { MaterialHelper } from '../Materials/materialHelper';
 
 import "../Shaders/color.fragment";
 import "../Shaders/color.vertex";
@@ -93,7 +92,8 @@ export class LinesMesh extends Mesh {
             attributes: [VertexBuffer.PositionKind],
             uniforms: ["vClipPlane", "vClipPlane2", "vClipPlane3", "vClipPlane4", "vClipPlane5", "vClipPlane6", "world", "viewProjection"],
             needAlphaBlending: true,
-            defines: defines
+            defines: defines,
+            useClipPlane: null,
         };
 
         if (useVertexAlpha === false) {
@@ -116,45 +116,7 @@ export class LinesMesh extends Mesh {
         }
     }
 
-    private _addClipPlaneDefine(label: string) {
-        if (!this._isShaderMaterial(this._lineMaterial)) {
-            return;
-        }
-
-        const define = "#define " + label;
-        const index = this._lineMaterial.options.defines.indexOf(define);
-        if (index !== -1) {
-            return;
-        }
-
-        this._lineMaterial.options.defines.push(define);
-    }
-
-    private _removeClipPlaneDefine(label: string) {
-        if (!this._isShaderMaterial(this._lineMaterial)) {
-            return;
-        }
-
-        const define = "#define " + label;
-        const index = this._lineMaterial.options.defines.indexOf(define);
-        if (index === -1) {
-            return;
-        }
-
-        this._lineMaterial.options.defines.splice(index, 1);
-    }
-
     public isReady() {
-        const scene = this.getScene();
-
-        // Clip planes
-        scene.clipPlane ? this._addClipPlaneDefine("CLIPPLANE") : this._removeClipPlaneDefine("CLIPPLANE");
-        scene.clipPlane2 ? this._addClipPlaneDefine("CLIPPLANE2") : this._removeClipPlaneDefine("CLIPPLANE2");
-        scene.clipPlane3 ? this._addClipPlaneDefine("CLIPPLANE3") : this._removeClipPlaneDefine("CLIPPLANE3");
-        scene.clipPlane4 ? this._addClipPlaneDefine("CLIPPLANE4") : this._removeClipPlaneDefine("CLIPPLANE4");
-        scene.clipPlane5 ? this._addClipPlaneDefine("CLIPPLANE5") : this._removeClipPlaneDefine("CLIPPLANE5");
-        scene.clipPlane6 ? this._addClipPlaneDefine("CLIPPLANE6") : this._removeClipPlaneDefine("CLIPPLANE6");
-
         if (!this._lineMaterial.isReady(this, !!this._userInstancedBuffersStorage)) {
             return false;
         }
@@ -216,8 +178,6 @@ export class LinesMesh extends Mesh {
             this._lineMaterial.setColor4("color", this.color4);
         }
 
-        // Clip planes
-        MaterialHelper.BindClipPlane(colorEffect!, this.getScene());
         return this;
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/adding-material-to-linesmesh-results-in-bug-in-clipplane/25063.

Note that `ShaderMaterial` now supports clip planes, so a bit of code can be removed from `LinesMesh`.