### PR TITLE
Added optional preserveScalingSign to addChild and setParent to keep sign

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -38,6 +38,7 @@
 - Added check for duplicates in `ShadowGenerator.addShadowCaster` ([ivankoleda](https://github.com/ivankoleda))
 - Added observable for `PointerDragBehavior` enable state ([cedricguillemet](https://github.com/cedricguillemet))
 - Added `targetHost` to query and set targeted mesh with `ArcRotateCamera` ([cedricguillemet](https://github.com/cedricguillemet))
+- Added optional `preserveScalingSign` to `addChild` and `setParent` to keep scaling sign ([cedricguillemet](https://github.com/cedricguillemet))
 - Spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the corresponding `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -4784,7 +4784,6 @@ export class Matrix {
 
         scale = scale || MathTmp.Vector3[0];
         if (preserveScalingNode) {
-            
             const signX = preserveScalingNode.scaling.x < 0 ? -1 : 1;
             const signY = preserveScalingNode.scaling.y < 0 ? -1 : 1;
             const signZ = preserveScalingNode.scaling.z < 0 ? -1 : 1;
@@ -4797,7 +4796,6 @@ export class Matrix {
             scale.y *= signY;
             scale.z *= signZ;
         } else {
-            scale = scale || MathTmp.Vector3[0];
             scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
             scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
             scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -4760,9 +4760,10 @@ export class Matrix {
      * @param scale defines the scale vector3 given as a reference to update
      * @param rotation defines the rotation quaternion given as a reference to update
      * @param translation defines the translation vector3 given as a reference to update
+     * @param preserveScalingNode Use scaling sign coming from this node. Otherwise scaling sign might change.
      * @returns true if operation was successful
      */
-    public decompose(scale?: Vector3, rotation?: Quaternion, translation?: Vector3): boolean {
+    public decompose(scale?: Vector3, rotation?: Quaternion, translation?: Vector3, preserveScalingNode?: TransformNode): boolean {
         if (this._isIdentity) {
             if (translation) {
                 translation.setAll(0);
@@ -4782,12 +4783,28 @@ export class Matrix {
         }
 
         scale = scale || MathTmp.Vector3[0];
-        scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
-        scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
-        scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
+        if (preserveScalingNode) {
+            
+            const signX = preserveScalingNode.scaling.x < 0 ? -1 : 1;
+            const signY = preserveScalingNode.scaling.y < 0 ? -1 : 1;
+            const signZ = preserveScalingNode.scaling.z < 0 ? -1 : 1;
 
-        if (this.determinant() <= 0) {
-            scale.y *= -1;
+            scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
+            scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
+            scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
+
+            scale.x *= signX;
+            scale.y *= signY;
+            scale.z *= signZ;
+        } else {
+            scale = scale || MathTmp.Vector3[0];
+            scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
+            scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
+            scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
+
+            if (this.determinant() <= 0) {
+                scale.y *= -1;
+            }
         }
 
         if (scale._x === 0 || scale._y === 0 || scale._z === 0) {

--- a/src/Maths/math.vector.ts
+++ b/src/Maths/math.vector.ts
@@ -4783,23 +4783,20 @@ export class Matrix {
         }
 
         scale = scale || MathTmp.Vector3[0];
+
+        scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
+        scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
+        scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
+
         if (preserveScalingNode) {
             const signX = preserveScalingNode.scaling.x < 0 ? -1 : 1;
             const signY = preserveScalingNode.scaling.y < 0 ? -1 : 1;
             const signZ = preserveScalingNode.scaling.z < 0 ? -1 : 1;
 
-            scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
-            scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
-            scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
-
             scale.x *= signX;
             scale.y *= signY;
             scale.z *= signZ;
         } else {
-            scale.x = Math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2]);
-            scale.y = Math.sqrt(m[4] * m[4] + m[5] * m[5] + m[6] * m[6]);
-            scale.z = Math.sqrt(m[8] * m[8] + m[9] * m[9] + m[10] * m[10]);
-
             if (this.determinant() <= 0) {
                 scale.y *= -1;
             }

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1992,10 +1992,11 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     /**
      * Adds the passed mesh as a child to the current mesh
      * @param mesh defines the child mesh
+     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
      * @returns the current mesh
      */
-    public addChild(mesh: AbstractMesh): AbstractMesh {
-        mesh.setParent(this);
+    public addChild(mesh: AbstractMesh, preserveScalingSign: boolean = false): AbstractMesh {
+        mesh.setParent(this, preserveScalingSign);
         return this;
     }
 

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -2003,6 +2003,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     /**
      * Removes the passed mesh from the current mesh children list
      * @param mesh defines the child mesh
+     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
      * @returns the current mesh
      */
     public removeChild(mesh: AbstractMesh, preserveScalingSign: boolean = false): AbstractMesh {

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -2005,8 +2005,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
      * @param mesh defines the child mesh
      * @returns the current mesh
      */
-    public removeChild(mesh: AbstractMesh): AbstractMesh {
-        mesh.setParent(null);
+    public removeChild(mesh: AbstractMesh, preserveScalingSign: boolean = false): AbstractMesh {
+        mesh.setParent(null, preserveScalingSign);
         return this;
     }
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -744,9 +744,10 @@ export class TransformNode extends Node {
      * The node will remain exactly where it is and its position / rotation will be updated accordingly
      * @see https://doc.babylonjs.com/how_to/parenting
      * @param node the node ot set as the parent
+     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
      * @returns this TransformNode.
      */
-    public setParent(node: Nullable<Node>): TransformNode {
+    public setParent(node: Nullable<Node>, preserveScalingSign: boolean = false): TransformNode {
         if (!node && !this.parent) {
             return this;
         }
@@ -757,7 +758,7 @@ export class TransformNode extends Node {
 
         if (!node) {
             this.computeWorldMatrix(true);
-            this.getWorldMatrix().decompose(scale, quatRotation, position);
+            this.getWorldMatrix().decompose(scale, quatRotation, position, preserveScalingSign? this : undefined);
         } else {
             var diffMatrix = TmpVectors.Matrix[0];
             var invParentMatrix = TmpVectors.Matrix[1];
@@ -767,7 +768,7 @@ export class TransformNode extends Node {
 
             node.getWorldMatrix().invertToRef(invParentMatrix);
             this.getWorldMatrix().multiplyToRef(invParentMatrix, diffMatrix);
-            diffMatrix.decompose(scale, quatRotation, position);
+            diffMatrix.decompose(scale, quatRotation, position, preserveScalingSign? this : undefined);
         }
 
         if (this.rotationQuaternion) {

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -758,7 +758,7 @@ export class TransformNode extends Node {
 
         if (!node) {
             this.computeWorldMatrix(true);
-            this.getWorldMatrix().decompose(scale, quatRotation, position, preserveScalingSign? this : undefined);
+            this.getWorldMatrix().decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
         } else {
             var diffMatrix = TmpVectors.Matrix[0];
             var invParentMatrix = TmpVectors.Matrix[1];
@@ -768,7 +768,7 @@ export class TransformNode extends Node {
 
             node.getWorldMatrix().invertToRef(invParentMatrix);
             this.getWorldMatrix().multiplyToRef(invParentMatrix, diffMatrix);
-            diffMatrix.decompose(scale, quatRotation, position, preserveScalingSign? this : undefined);
+            diffMatrix.decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
         }
 
         if (this.rotationQuaternion) {


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/mesh-addchild-with-negative-scaling-transforms-child-rotation-incorrectly/25052

reuse scaling sign coming from a node. Decompose recompute positive scaling and update rotation accordingly. Here, scaling sign is preserve so node scaling/rotation doesn't change after addChild/RemoveChild.