### PR TITLE
Add callback property to FramingBehavior

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -160,7 +160,7 @@
 
 ### Behaviors
 
-- Added `onTargetFramingAnimationEnd` callback to `FramingBehavior` ([BlakeOne](https://github.com/BlakeOne))
+- Added `onTargetFramingAnimationEndObservable` to `FramingBehavior` ([BlakeOne](https://github.com/BlakeOne))
 - Added `FollowBehavior`, a behavior that makes the assigned mesh hover around a camera, while facing it ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added `SurfaceMagnetismBehavior`, a behavior that makes the assigned mesh stick on surfaces of other meshes ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added `DefaultBehavior`, a behavior that will be common to several 3D GUI controls, orchestrating `SixDoFDragBehavior`, `FollowBehavior` and `SurfaceMagnetismBehavior` ([CraigFeldspar](https://github.com/CraigFeldspar))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -160,6 +160,7 @@
 
 ### Behaviors
 
+- Added `onTargetFramingAnimationEnd` callback to `FramingBehavior` ([BlakeOne](https://github.com/BlakeOne))
 - Added `FollowBehavior`, a behavior that makes the assigned mesh hover around a camera, while facing it ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added `SurfaceMagnetismBehavior`, a behavior that makes the assigned mesh stick on surfaces of other meshes ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added `DefaultBehavior`, a behavior that will be common to several 3D GUI controls, orchestrating `SixDoFDragBehavior`, `FollowBehavior` and `SurfaceMagnetismBehavior` ([CraigFeldspar](https://github.com/CraigFeldspar))

--- a/src/Behaviors/Cameras/framingBehavior.ts
+++ b/src/Behaviors/Cameras/framingBehavior.ts
@@ -2,6 +2,7 @@ import { Behavior } from "../../Behaviors/behavior";
 import { Camera } from "../../Cameras/camera";
 import { ArcRotateCamera } from "../../Cameras/arcRotateCamera";
 import { ExponentialEase, EasingFunction } from "../../Animations/easing";
+import { Observable } from "../../Misc/observable";
 import { Nullable } from "../../types";
 import { PointerInfoPre, PointerEventTypes } from "../../Events/pointerEvents";
 import { PrecisionDate } from "../../Misc/precisionDate";
@@ -23,6 +24,11 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
         return "Framing";
     }
 
+    /**
+     * An event triggered when the animation to zoom on target mesh has ended
+     */
+    public onTargetFramingAnimationEndObservable = new Observable<Nullable<AbstractMesh>>();
+
     private _mode = FramingBehavior.FitFrustumSidesMode;
     private _radiusScale = 1.0;
     private _positionScale = 0.5;
@@ -30,8 +36,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     private _elevationReturnTime = 1500;
     private _elevationReturnWaitTime = 1000;
     private _zoomStopsAnimation = false;
-    private _framingTime = 1500;
-    private _onTargetFramingAnimationEnd: Nullable<() => void>;
+    private _framingTime = 1500;    
 
     /**
      * The easing function used by animations
@@ -160,20 +165,6 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     }
 
     /**
-     * Sets the onTargetFramingAnimationEnd callback
-    */
-    public set onTargetFramingAnimationEnd(onTargetFramingAnimationEnd: Nullable<() => void>) {
-        this._onTargetFramingAnimationEnd = onTargetFramingAnimationEnd;
-    }
-
-    /**
-     * Gets the onTargetFramingAnimationEnd callback
-    */
-    public get onTargetFramingAnimationEnd() {
-        return this._onTargetFramingAnimationEnd;
-    }
-
-    /**
      * Define if the behavior should automatically change the configured
      * camera limits and sensibilities.
      */
@@ -217,7 +208,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
 
         this._onMeshTargetChangedObserver = camera.onMeshTargetChangedObservable.add((mesh) => {
             if (mesh) {
-                this.zoomOnMesh(mesh, undefined, this._onTargetFramingAnimationEnd);
+                this.zoomOnMesh(mesh, undefined, () => this.onTargetFramingAnimationEndObservable.notifyObservers(null));
             }
         });
 

--- a/src/Behaviors/Cameras/framingBehavior.ts
+++ b/src/Behaviors/Cameras/framingBehavior.ts
@@ -31,6 +31,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     private _elevationReturnWaitTime = 1000;
     private _zoomStopsAnimation = false;
     private _framingTime = 1500;
+    private _onTargetFramingAnimationEnd: Nullable<() => void>;
 
     /**
      * The easing function used by animations
@@ -159,6 +160,20 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     }
 
     /**
+     * Sets the onTargetFramingAnimationEnd callback
+    */
+    public set onTargetFramingAnimationEnd(onTargetFramingAnimationEnd: Nullable<() => void>) {
+        this._onTargetFramingAnimationEnd = onTargetFramingAnimationEnd;
+    }
+
+    /**
+     * Gets the onTargetFramingAnimationEnd callback
+    */
+    public get onTargetFramingAnimationEnd() {
+        return this._onTargetFramingAnimationEnd;
+    }
+
+    /**
      * Define if the behavior should automatically change the configured
      * camera limits and sensibilities.
      */
@@ -202,7 +217,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
 
         this._onMeshTargetChangedObserver = camera.onMeshTargetChangedObservable.add((mesh) => {
             if (mesh) {
-                this.zoomOnMesh(mesh);
+                this.zoomOnMesh(mesh, undefined, this._onTargetFramingAnimationEnd);
             }
         });
 

--- a/src/Behaviors/Cameras/framingBehavior.ts
+++ b/src/Behaviors/Cameras/framingBehavior.ts
@@ -36,7 +36,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     private _elevationReturnTime = 1500;
     private _elevationReturnWaitTime = 1000;
     private _zoomStopsAnimation = false;
-    private _framingTime = 1500;    
+    private _framingTime = 1500;
 
     /**
      * The easing function used by animations

--- a/src/Behaviors/Cameras/framingBehavior.ts
+++ b/src/Behaviors/Cameras/framingBehavior.ts
@@ -27,7 +27,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
     /**
      * An event triggered when the animation to zoom on target mesh has ended
      */
-    public onTargetFramingAnimationEndObservable = new Observable<Nullable<AbstractMesh>>();
+    public onTargetFramingAnimationEndObservable = new Observable<void>();
 
     private _mode = FramingBehavior.FitFrustumSidesMode;
     private _radiusScale = 1.0;
@@ -208,7 +208,9 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
 
         this._onMeshTargetChangedObserver = camera.onMeshTargetChangedObservable.add((mesh) => {
             if (mesh) {
-                this.zoomOnMesh(mesh, undefined, () => this.onTargetFramingAnimationEndObservable.notifyObservers(null));
+                this.zoomOnMesh(mesh, undefined, () => {
+                    this.onTargetFramingAnimationEndObservable.notifyObservers();
+                });
             }
         });
 


### PR DESCRIPTION
Add a callback property to FramingBehavior that gets passed to zoomOnMesh when the target is changed, so that  we can more easily know when the animation has ended.

Forum: https://forum.babylonjs.com/t/how-can-i-see-when-a-framingbehavior-animation-has-finished/25086/6