### PR TITLE
Add default options parameter for Create functions

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -110,6 +110,7 @@
 
 ### Meshes
 
+- Added default options parameter to Create functions. ([BlakeOne](https://github.com/BlakeOne))
 - `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger](https://github.com/FullStackForger)
 - `InstancedMesh` can now be sorted from back to front before rendering if the material is transparent ([Popov72](https://github.com/Popov72))
 - Add option to decompose the `newWorldMatrix` when passed into `TransformNode.freezeWorldMatrix`. ([bghgary](https://github.com/bghgary))

--- a/src/Meshes/Builders/boxBuilder.ts
+++ b/src/Meshes/Builders/boxBuilder.ts
@@ -130,7 +130,7 @@ export function CreateBoxVertexData(options: { size?: number, width?: number, he
  * @param scene defines the hosting scene
  * @returns the box mesh
  */
-export function CreateBox(name: string, options: { size?: number, width?: number, height?: number, depth?: number, faceUV?: Vector4[], faceColors?: Color4[], sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, wrap?: boolean, topBaseAt?: number, bottomBaseAt?: number, updatable?: boolean }, scene: Nullable<Scene> = null): Mesh {
+export function CreateBox(name: string, options: { size?: number, width?: number, height?: number, depth?: number, faceUV?: Vector4[], faceColors?: Color4[], sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, wrap?: boolean, topBaseAt?: number, bottomBaseAt?: number, updatable?: boolean } = {}, scene: Nullable<Scene> = null): Mesh {
     var box = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/cylinderBuilder.ts
+++ b/src/Meshes/Builders/cylinderBuilder.ts
@@ -313,7 +313,7 @@ export function CreateCylinderVertexData(options: { height?: number, diameterTop
  * @returns the cylinder mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#cylinder-or-cone
  */
-export function CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, diameter?: number, tessellation?: number, subdivisions?: number, arc?: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, hasRings?: boolean, enclose?: boolean, cap?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 }, scene: any): Mesh {
+export function CreateCylinder(name: string, options: { height?: number, diameterTop?: number, diameterBottom?: number, diameter?: number, tessellation?: number, subdivisions?: number, arc?: number, faceColors?: Color4[], faceUV?: Vector4[], updatable?: boolean, hasRings?: boolean, enclose?: boolean, cap?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 } = {}, scene: any): Mesh {
     var cylinder = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/discBuilder.ts
+++ b/src/Meshes/Builders/discBuilder.ts
@@ -81,7 +81,7 @@ function CreateDiscVertexData(options: { radius?: number, tessellation?: number,
  * @returns the plane polygonal mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#disc-or-regular-polygon
  */
-export function CreateDisc(name: string, options: { radius?: number, tessellation?: number, arc?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 }, scene: Nullable<Scene> = null): Mesh {
+export function CreateDisc(name: string, options: { radius?: number, tessellation?: number, arc?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 } = {}, scene: Nullable<Scene> = null): Mesh {
     var disc = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/groundBuilder.ts
+++ b/src/Meshes/Builders/groundBuilder.ts
@@ -284,7 +284,7 @@ export function CreateGroundFromHeightMapVertexData(options: { width: number, he
  * @returns the ground mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#ground
  */
-export function CreateGround(name: string, options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsY?: number, updatable?: boolean }, scene: any): Mesh {
+export function CreateGround(name: string, options: { width?: number, height?: number, subdivisions?: number, subdivisionsX?: number, subdivisionsY?: number, updatable?: boolean } = {}, scene: any): Mesh {
     var ground = new GroundMesh(name, scene);
     ground._setReady(false);
     ground._subdivisionsX = options.subdivisionsX || options.subdivisions || 1;
@@ -347,7 +347,7 @@ export function CreateTiledGround(name: string, options: { xmin: number, zmin: n
  * @see https://doc.babylonjs.com/babylon101/height_map
  * @see https://doc.babylonjs.com/how_to/set_shapes#ground-from-a-height-map
  */
-export function CreateGroundFromHeightMap(name: string, url: string, options: { width?: number, height?: number, subdivisions?: number, minHeight?: number, maxHeight?: number, colorFilter?: Color3, alphaFilter?: number, updatable?: boolean, onReady?: (mesh: GroundMesh) => void }, scene: Nullable<Scene> = null): GroundMesh {
+export function CreateGroundFromHeightMap(name: string, url: string, options: { width?: number, height?: number, subdivisions?: number, minHeight?: number, maxHeight?: number, colorFilter?: Color3, alphaFilter?: number, updatable?: boolean, onReady?: (mesh: GroundMesh) => void } = {}, scene: Nullable<Scene> = null): GroundMesh {
     var width = options.width || 10.0;
     var height = options.height || 10.0;
     var subdivisions = options.subdivisions || 1 | 0;

--- a/src/Meshes/Builders/hemisphereBuilder.ts
+++ b/src/Meshes/Builders/hemisphereBuilder.ts
@@ -10,7 +10,7 @@ import { CreateDisc } from "./discBuilder";
  * @param scene defines the hosting scene
  * @returns the hemisphere mesh
  */
-export function CreateHemisphere(name: string, options: { segments?: number, diameter?: number, sideOrientation?: number }, scene: any): Mesh {
+export function CreateHemisphere(name: string, options: { segments?: number, diameter?: number, sideOrientation?: number } = {}, scene: any): Mesh {
     if (!options.diameter) {
         options.diameter = 1;
     }

--- a/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/src/Meshes/Builders/icoSphereBuilder.ts
@@ -290,7 +290,7 @@ export function CreateIcoSphereVertexData(options: { radius?: number, radiusX?: 
  * @returns the icosahedron mesh
  * @see https://doc.babylonjs.com/how_to/polyhedra_shapes#icosphere
  */
-export function CreateIcoSphere(name: string, options: { radius?: number, radiusX?: number, radiusY?: number, radiusZ?: number, flat?: boolean, subdivisions?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean }, scene: Nullable<Scene> = null): Mesh {
+export function CreateIcoSphere(name: string, options: { radius?: number, radiusX?: number, radiusY?: number, radiusZ?: number, flat?: boolean, subdivisions?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean } = {}, scene: Nullable<Scene> = null): Mesh {
     var sphere = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/planeBuilder.ts
+++ b/src/Meshes/Builders/planeBuilder.ts
@@ -83,7 +83,7 @@ export function CreatePlaneVertexData(options: { size?: number, width?: number, 
  * @returns the plane mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#plane
  */
-export function CreatePlane(name: string, options: { size?: number, width?: number, height?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean, sourcePlane?: Plane }, scene: Nullable<Scene> = null): Mesh {
+export function CreatePlane(name: string, options: { size?: number, width?: number, height?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean, sourcePlane?: Plane } = {}, scene: Nullable<Scene> = null): Mesh {
     var plane = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/polyhedronBuilder.ts
+++ b/src/Meshes/Builders/polyhedronBuilder.ts
@@ -175,7 +175,7 @@ export function CreatePolyhedronVertexData(options: { type?: number, size?: numb
  * @returns the polyhedron mesh
  * @see https://doc.babylonjs.com/how_to/polyhedra_shapes
  */
-export function CreatePolyhedron(name: string, options: { type?: number, size?: number, sizeX?: number, sizeY?: number, sizeZ?: number, custom?: any, faceUV?: Vector4[], faceColors?: Color4[], flat?: boolean, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 }, scene: Nullable<Scene> = null): Mesh {
+export function CreatePolyhedron(name: string, options: { type?: number, size?: number, sizeX?: number, sizeY?: number, sizeZ?: number, custom?: any, faceUV?: Vector4[], faceColors?: Color4[], flat?: boolean, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 } = {}, scene: Nullable<Scene> = null): Mesh {
     var polyhedron = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/sphereBuilder.ts
+++ b/src/Meshes/Builders/sphereBuilder.ts
@@ -119,7 +119,7 @@ export function CreateSphereVertexData(options: { segments?: number, diameter?: 
  * @returns the sphere mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#sphere
  */
-export function CreateSphere(name: string, options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, arc?: number, slice?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean }, scene: Nullable<Scene> = null): Mesh {
+export function CreateSphere(name: string, options: { segments?: number, diameter?: number, diameterX?: number, diameterY?: number, diameterZ?: number, arc?: number, slice?: number, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4, updatable?: boolean } = {}, scene: Nullable<Scene> = null): Mesh {
     var sphere = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/torusBuilder.ts
+++ b/src/Meshes/Builders/torusBuilder.ts
@@ -95,7 +95,7 @@ export function CreateTorusVertexData(options: { diameter?: number, thickness?: 
  * @returns the torus mesh
  * @see https://doc.babylonjs.com/how_to/set_shapes#torus
  */
-export function CreateTorus(name: string, options: { diameter?: number, thickness?: number, tessellation?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 }, scene: any): Mesh {
+export function CreateTorus(name: string, options: { diameter?: number, thickness?: number, tessellation?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 } = {}, scene: any): Mesh {
     var torus = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);

--- a/src/Meshes/Builders/torusKnotBuilder.ts
+++ b/src/Meshes/Builders/torusKnotBuilder.ts
@@ -124,7 +124,7 @@ export function CreateTorusKnotVertexData(options: { radius?: number, tube?: num
  * @returns the torus knot mesh
  * @see  https://doc.babylonjs.com/how_to/set_shapes#torus-knot
  */
-export function CreateTorusKnot(name: string, options: { radius?: number, tube?: number, radialSegments?: number, tubularSegments?: number, p?: number, q?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 }, scene: any): Mesh {
+export function CreateTorusKnot(name: string, options: { radius?: number, tube?: number, radialSegments?: number, tubularSegments?: number, p?: number, q?: number, updatable?: boolean, sideOrientation?: number, frontUVs?: Vector4, backUVs?: Vector4 } = {}, scene: any): Mesh {
     var torusKnot = new Mesh(name, scene);
 
     options.sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);


### PR DESCRIPTION
Add default options parameter, {}, for Create functions  that don’t have any required options and don’t have a default options object already.

Forum: https://forum.babylonjs.com/t/default-options-parameter-for-create-functions/25124/3