### PR TITLE
Add type guard overloads to Node to narrow return type of filtered children/descendants

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -617,6 +617,22 @@ export class Node implements IBehaviorAware<Node> {
      * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
      * @return all children nodes of all types
      */
+    public getDescendants<T extends Node>(directDescendantsOnly?: boolean, predicate?: (node: Node) => node is T): T[];
+
+    /**
+     * Will return all nodes that have this node as ascendant
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @return all children nodes of all types
+     */
+    public getDescendants(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): Node[];
+
+    /**
+     * Will return all nodes that have this node as ascendant
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @return all children nodes of all types
+     */
     public getDescendants(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): Node[] {
         var results = new Array<Node>();
 
@@ -631,6 +647,22 @@ export class Node implements IBehaviorAware<Node> {
      * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
      * @returns an array of AbstractMesh
      */
+    public getChildMeshes<T extends AbstractMesh>(directDescendantsOnly?: boolean, predicate?: (node: Node) => node is T): T[];
+
+    /**
+     * Get all child-meshes of this node
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false)
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @returns an array of AbstractMesh
+     */
+    public getChildMeshes(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): AbstractMesh[];
+
+    /**
+     * Get all child-meshes of this node
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false)
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @returns an array of AbstractMesh
+     */
     public getChildMeshes(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): AbstractMesh[] {
         var results: Array<AbstractMesh> = [];
         this._getDescendants(results, directDescendantsOnly, (node: Node) => {
@@ -638,6 +670,22 @@ export class Node implements IBehaviorAware<Node> {
         });
         return results;
     }
+
+    /**
+     * Get all direct children of this node
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true)
+     * @returns an array of Node
+     */
+    public getChildren<T extends Node>(predicate?: (node: Node) => node is T, directDescendantsOnly?: boolean): T[];
+
+    /**
+     * Get all direct children of this node
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true)
+     * @returns an array of Node
+     */
+    public getChildren(predicate?: (node: Node) => boolean, directDescendantsOnly?: boolean): Node[];
 
     /**
      * Get all direct children of this node


### PR DESCRIPTION
Add overloads for `Node.getChildren` (and other related `Node` functions) such that if the predicate you pass in is a type guard, the returned array will be narrowed according to that type guard. For example:

```ts
// transformNodes will be a Node[] (existing function prior to this PR)
const transformNodes = node.getDescendants(false, (node): boolean => node instanceof TransformNode);

// transformNodes will be a TransformNode[] rather than a Node[] (using the type guard overload added in this PR)
const transformNodes = node.getDescendants(false, (node): node is TransformNode => node instanceof TransformNode);
```

This is exactly the same as how it works for `Array.filter`.