### PR TITLE
pin gitpod container

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full-vnc
+FROM gitpod/workspace-full-vnc:branch-gh-github
 
 USER gitpod
 


### PR DESCRIPTION
to version with node and npm versions compatible with current build process.

fix for #11425 