### PR TITLE
serialize isEnabled for lights and cameras

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -229,6 +229,7 @@
 
 ### Serializers
 
+- serialize and parse isEnabled property for lights and cameras  ([andreasplesch](https://github.com/andreasplesch))
 - Added the `exportUnusedUVs` property to the `IExportOptions` interface that will prevent any unused vertex uv attributes from being stripped during the glTF export. ([ericbroberic](https://github.com/ericbroberic))
 - glTF serializer now supports `KHR_materials_clearcoat` ([drigax](https://github.com/drigax))
 - Fixed bug where characters that didn't fit into a single UTF-16 code point were not correctly encoded in .glb exports ([darraghjburke](https://github.com/darraghjburke))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -229,7 +229,7 @@
 
 ### Serializers
 
-- serialize and parse isEnabled property for lights and cameras  ([andreasplesch](https://github.com/andreasplesch))
+- Serialize and parse isEnabled property for lights and cameras  ([andreasplesch](https://github.com/andreasplesch))
 - Added the `exportUnusedUVs` property to the `IExportOptions` interface that will prevent any unused vertex uv attributes from being stripped during the glTF export. ([ericbroberic](https://github.com/ericbroberic))
 - glTF serializer now supports `KHR_materials_clearcoat` ([drigax](https://github.com/drigax))
 - Fixed bug where characters that didn't fit into a single UTF-16 code point were not correctly encoded in .glb exports ([darraghjburke](https://github.com/darraghjburke))

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1385,10 +1385,7 @@ export class Camera extends Node {
         if (parsedCamera.isEnabled !== undefined) {
             camera.setEnabled(parsedCamera.isEnabled);
         }
-        else {
-            camera.setEnabled(true);
-        }
-
+        
         return camera;
     }
 }

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1238,6 +1238,9 @@ export class Camera extends Node {
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         serializationObject.ranges = this.serializeAnimationRanges();
 
+        // isEnabled
+        serializationObject.isEnabled = this.isEnabled();
+
         return serializationObject;
     }
 

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1385,7 +1385,7 @@ export class Camera extends Node {
         if (parsedCamera.isEnabled !== undefined) {
             camera.setEnabled(parsedCamera.isEnabled);
         }
-        
+
         return camera;
     }
 }

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1382,6 +1382,13 @@ export class Camera extends Node {
             scene.beginAnimation(camera, parsedCamera.autoAnimateFrom, parsedCamera.autoAnimateTo, parsedCamera.autoAnimateLoop, parsedCamera.autoAnimateSpeed || 1.0);
         }
 
+        if ("isEnabled" in parsedCamera) {
+            camera.setEnabled(parsedCamera.isEnabled);
+        }
+        else {
+            camera.setEnabled(true);
+        }
+
         return camera;
     }
 }

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -1238,7 +1238,6 @@ export class Camera extends Node {
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         serializationObject.ranges = this.serializeAnimationRanges();
 
-        // isEnabled
         serializationObject.isEnabled = this.isEnabled();
 
         return serializationObject;
@@ -1382,7 +1381,8 @@ export class Camera extends Node {
             scene.beginAnimation(camera, parsedCamera.autoAnimateFrom, parsedCamera.autoAnimateTo, parsedCamera.autoAnimateLoop, parsedCamera.autoAnimateSpeed || 1.0);
         }
 
-        if ("isEnabled" in parsedCamera) {
+        // Check if isEnabled is defined to be back compatible with prior serialized versions.
+        if (parsedCamera.isEnabled !== undefined) {
             camera.setEnabled(parsedCamera.isEnabled);
         }
         else {

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -716,7 +716,7 @@ export abstract class Light extends Node implements ISortableLight {
         if (parsedLight.isEnabled !== undefined) {
             light.setEnabled(parsedLight.isEnabled);
         }
-        
+
         return light;
     }
 

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -713,6 +713,13 @@ export abstract class Light extends Node implements ISortableLight {
             scene.beginAnimation(light, parsedLight.autoAnimateFrom, parsedLight.autoAnimateTo, parsedLight.autoAnimateLoop, parsedLight.autoAnimateSpeed || 1.0);
         }
 
+        if ("isEnabled" in parsedLight) {
+            light.setEnabled(parsedLight.isEnabled);
+        }
+        else {
+            light.setEnabled(true);
+        }
+
         return light;
     }
 

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -633,6 +633,9 @@ export abstract class Light extends Node implements ISortableLight {
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         serializationObject.ranges = this.serializeAnimationRanges();
 
+        // isEnabled
+        serializationObject.isEnabled = this.isEnabled();
+
         return serializationObject;
     }
 

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -716,10 +716,7 @@ export abstract class Light extends Node implements ISortableLight {
         if (parsedLight.isEnabled !== undefined) {
             light.setEnabled(parsedLight.isEnabled);
         }
-        else {
-            light.setEnabled(true);
-        }
-
+        
         return light;
     }
 

--- a/src/Lights/light.ts
+++ b/src/Lights/light.ts
@@ -633,7 +633,6 @@ export abstract class Light extends Node implements ISortableLight {
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         serializationObject.ranges = this.serializeAnimationRanges();
 
-        // isEnabled
         serializationObject.isEnabled = this.isEnabled();
 
         return serializationObject;
@@ -713,7 +712,8 @@ export abstract class Light extends Node implements ISortableLight {
             scene.beginAnimation(light, parsedLight.autoAnimateFrom, parsedLight.autoAnimateTo, parsedLight.autoAnimateLoop, parsedLight.autoAnimateSpeed || 1.0);
         }
 
-        if ("isEnabled" in parsedLight) {
+        // Check if isEnabled is defined to be back compatible with prior serialized versions.
+        if (parsedLight.isEnabled !== undefined) {
             light.setEnabled(parsedLight.isEnabled);
         }
         else {


### PR DESCRIPTION
for discussion see https://forum.babylonjs.com/t/light-serialization/25036

https://www.babylonjs-playground.com/#PM0XL0 has a few simple tests for light.
I could generate similar tests for camera. `camera.setEnabled(false)` does not seem to have an effect.

I have build artefacts if useful.

Even with only a few lines, here are some questions:

- Remove/add comments ?
- Use of `in` operator ? It does not seem common in the code base but is supported by IE11.
- replace `if` with ternary ? 
```js
node.setEnabled(
    "isEnabled" in parseNode ? parsedNode.isEnabled : true
)
```


