### PR TITLE
Add getTextureByName to Scene

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -17,6 +17,7 @@
 
 ### General
 
+- Added `getTextureByName` to `Scene` ([BlakeOne](https://github.com/BlakeOne))
 - Added `getControlsByType` to `AdvancedDynamicTexture` ([BlakeOne](https://github.com/BlakeOne))
 - Added `zoomToMouseLocation` on `ArcRotateCamera` ([lovettchris](https://github.com/lovettchris))
 - Added static CenterToRef for vectors 2/3/4 ([aWeirdo](https://github.com/aWeirdo))

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2823,6 +2823,21 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     }
 
     /**
+     * Gets a texture using its name
+     * @param name defines the texture's name
+     * @return the texture or null if none found.
+     */
+     public getTextureByName(name: string): Nullable<BaseTexture> {
+        for (var index = 0; index < this.textures.length; index++) {
+            if (this.textures[index].name === name) {
+                return this.textures[index];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Gets a camera using its Id
      * @param id defines the Id to look for
      * @returns the camera or null if not found


### PR DESCRIPTION
Patch to add getTextureByName method to the Scene class.

Forum request: https://forum.babylonjs.com/t/why-no-scene-gettexturebyname-method/8746/4