### PR TITLE
ThinEngine.MinimizeMemoryFootprint

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -175,8 +175,30 @@ export class ThinEngine {
         { key: "Mac OS.+Chrome\/72", capture: null, captureConstraint: null, targets: ["vao"] }
     ];
 
+    private static _textureLoaders: Nullable<IInternalTextureLoader[]>;
+
     /** @hidden */
-    public static _TextureLoaders: IInternalTextureLoader[] = [];
+    public static get _TextureLoaders(): IInternalTextureLoader[] {
+        if (!ThinEngine._textureLoaders) {
+            ThinEngine._textureLoaders = [];
+            ThinEngine._TextureLoaderFactories.forEach((factory) => {
+                ThinEngine._textureLoaders!.push(factory.create());
+            });
+        }
+        return ThinEngine._textureLoaders!;
+    }
+
+    /** @hidden */
+    public static _TextureLoaderFactories: { create: () => IInternalTextureLoader, dispose: (loader: IInternalTextureLoader) => void }[] = [];
+
+    public static MinimizeMemoryFootprint(): void {
+        if (ThinEngine._textureLoaders) {
+            for (let idx = 0; idx < ThinEngine._TextureLoaderFactories.length; ++idx) {
+                ThinEngine._TextureLoaderFactories[idx].dispose(ThinEngine._textureLoaders![idx]);
+            }
+            ThinEngine._textureLoaders = null;
+        }
+    }
 
     /**
      * Returns the current npm package of the sdk

--- a/src/Materials/Textures/Loaders/basisTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/basisTextureLoader.ts
@@ -97,4 +97,7 @@ export class _BasisTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _BasisTextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _BasisTextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => {}
+});

--- a/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -104,4 +104,7 @@ export class _DDSTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _DDSTextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _DDSTextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => {}
+});

--- a/src/Materials/Textures/Loaders/envTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/envTextureLoader.ts
@@ -76,4 +76,7 @@ export class _ENVTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _ENVTextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _ENVTextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => {}
+});

--- a/src/Materials/Textures/Loaders/hdrTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/hdrTextureLoader.ts
@@ -69,4 +69,7 @@ export class _HDRTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _HDRTextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _HDRTextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => {}
+});

--- a/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -98,4 +98,7 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.unshift(new _KTXTextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _KTXTextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => { KhronosTextureContainer2.Uninitialize(); }
+});

--- a/src/Materials/Textures/Loaders/tgaTextureLoader.ts
+++ b/src/Materials/Textures/Loaders/tgaTextureLoader.ts
@@ -54,4 +54,7 @@ export class _TGATextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _TGATextureLoader());
+Engine._TextureLoaderFactories.push({
+    create: () => { return new _TGATextureLoader() },
+    dispose: (loader: IInternalTextureLoader) => {}
+});

--- a/src/Misc/khronosTextureContainer2.ts
+++ b/src/Misc/khronosTextureContainer2.ts
@@ -131,6 +131,14 @@ export class KhronosTextureContainer2 {
         }
     }
 
+    public static Uninitialize(): void {
+        KhronosTextureContainer2._WorkerPoolPromise?.then((pool) => {
+            pool.dispose();
+        });
+        // TODO: Get rid of the rest of the resources?
+        KhronosTextureContainer2._Initialized = false;
+    }
+
     /**
      * Constructor
      * @param engine The engine to use


### PR DESCRIPTION
Sketch of mechanism for bouncing the texture loaders to release those resources when they're not being used.

Not sure the best way to characterize this without exposing implementation details, hence the generic "MinimizeMemoryFootprint" name. Philosophically, what this is trying to do is let developers inform the engine that a change in the engine's usage is about to happen (for example, we might be done loading the scene now and expect to go into a long period of rendering without loading) such that this is a good time to let go of certain resources that may have been cached. Right now, it's a generic name with a specific purpose, so this isn't a great fit; we should probably either decide to make specific and consequently expose (at least indirectly) the existence of the `_TextureLoaders` through the contract, or we should go generic and decide (even if we don't do it now) that this method may also release other kinds of resources in the future, too. Assuming we want this change at all, that is 😃; would love to discuss the preferred direction.

This came up while looking into a [forum question about KTX2](https://forum.babylonjs.com/t/how-to-release-ressources-for-ktx2-textures/25176), during which it became clear that the texture loaders can hold onto substantial resources statically. This isn't a fix for that issue -- there appears to be a memory leak in the KTX2 loader Web worker, and fixing that leak is the actual fix -- but this could be used as a workaround for that issue as well, especially if the leak turns out to be inside one of the KTX2 WASMs itself, which we don't produce ourselves and so can't fix directly.