### PR TITLE
Log an error if using logarithmic depth with an orthographic camera

### DIFF
--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -960,7 +960,11 @@ export class MaterialHelper {
      */
     public static BindLogDepth(defines: any, effect: Effect, scene: Scene): void {
         if (defines["LOGARITHMICDEPTH"]) {
-            effect.setFloat("logarithmicDepthConstant", 2.0 / (Math.log((<Camera>scene.activeCamera).maxZ + 1.0) / Math.LN2));
+            const camera = <Camera>scene.activeCamera;
+            if (camera.mode === Camera.ORTHOGRAPHIC_CAMERA) {
+                Logger.Error("Logarithmic depth is not compatible with orthographic cameras!", 20);
+            }
+            effect.setFloat("logarithmicDepthConstant", 2.0 / (Math.log(camera.maxZ + 1.0) / Math.LN2));
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/using-an-orthographic-camera-and-uselogarithmicdepth-at-the-same-time-makes-the-scene-rendering-out-of-order/25171/3