### PR TITLE
Color4.FromHexString default alpha to 1

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -340,6 +340,7 @@
 
 ## Breaking changes
 
+- When a seven character hex string is passed to `Color4.FromHexString`, the alpha component will default to 1 instead of defaulting all components (r, g, b, and a) to 0. ([BlakeOne](https://github.com/BlakeOne))
 - [List of breaking changes introduced by our compatibility with WebGPU](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges)
   - [ReadPixels and ProceduralTexture.getContent are now async](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#readpixels-is-now-asynchronous)
   - [Shader support differences](https://doc.babylonjs.com/advanced_topics/webGPU/webGPUBreakingChanges#shader-code-differences)

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -388,6 +388,7 @@
 
 ## Breaking changes
 
+- When a seven character hex string is passed to `Color4.FromHexString`, the alpha component will default to 1 instead of defaulting all components (r, g, b, and a) to 0. ([BlakeOne](https://github.com/BlakeOne))
 - `FollowCamera.target` was renamed to `FollowCamera.meshTarget` to not be in conflict with `TargetCamera.target` ([Deltakosh](https://github.com/deltakosh))
 - `EffectRenderer.render` now takes a `RenderTargetTexture` or an `InternalTexture` as the output texture and only a single `EffectWrapper` for its first argument ([Popov72](https://github.com/Popov72))
 - Sound's `updateOptions` takes `options.length` and `options.offset` as seconds and not milliseconds ([RaananW](https://github.com/RaananW))

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -388,7 +388,6 @@
 
 ## Breaking changes
 
-- When a seven character hex string is passed to `Color4.FromHexString`, the alpha component will default to 1 instead of defaulting all components (r, g, b, and a) to 0. ([BlakeOne](https://github.com/BlakeOne))
 - `FollowCamera.target` was renamed to `FollowCamera.meshTarget` to not be in conflict with `TargetCamera.target` ([Deltakosh](https://github.com/deltakosh))
 - `EffectRenderer.render` now takes a `RenderTargetTexture` or an `InternalTexture` as the output texture and only a single `EffectWrapper` for its first argument ([Popov72](https://github.com/Popov72))
 - Sound's `updateOptions` takes `options.length` and `options.offset` as seconds and not milliseconds ([RaananW](https://github.com/RaananW))

--- a/src/Maths/math.color.ts
+++ b/src/Maths/math.color.ts
@@ -984,14 +984,14 @@ export class Color4 {
      * @returns a new Color4 object
      */
     public static FromHexString(hex: string): Color4 {
-        if (hex.substring(0, 1) !== "#" || hex.length !== 9) {
+        if (hex.substring(0, 1) !== "#" || (hex.length !== 9 && hex.length !== 7)) {
             return new Color4(0.0, 0.0, 0.0, 0.0);
         }
 
         var r = parseInt(hex.substring(1, 3), 16);
         var g = parseInt(hex.substring(3, 5), 16);
         var b = parseInt(hex.substring(5, 7), 16);
-        var a = parseInt(hex.substring(7, 9), 16);
+        var a = hex.length === 9 ? parseInt(hex.substring(7, 9), 16) : 255;
 
         return Color4.FromInts(r, g, b, a);
     }


### PR DESCRIPTION
Patch to default alpha to 1 when a 7 char hex string is passed to Color4.FromHexString, to allow standard hex strings to be copied and pasted from color table websites, etc., more conveniently without having to add "ff" to the string each time.
When an empty or invalid string is passed, all 4 components still default to 0, in keeping with the original behavior.
Forum posts with more info on the use case for this are here: https://forum.babylonjs.com/t/default-alpha-to-1-for-color4-fromhexstring/25226/3