### PR TITLE
[PG] Error coming from monaco can be an object

### DIFF
--- a/Playground/src/components/errorDisplayComponent.tsx
+++ b/Playground/src/components/errorDisplayComponent.tsx
@@ -42,7 +42,6 @@ export class ErrorDisplayComponent extends React.Component<IErrorDisplayComponen
     }
 
     public render() {
-        console.log(this.state.error);
         if (!this.state.error) {
             return null;
         }

--- a/Playground/src/components/errorDisplayComponent.tsx
+++ b/Playground/src/components/errorDisplayComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { GlobalState } from '../globalState';
-import { Nullable } from 'babylonjs/types';
+import { GlobalState } from "../globalState";
+import { Nullable } from "babylonjs/types";
 
 require("../scss/errorDisplay.scss");
 
@@ -9,20 +9,23 @@ interface IErrorDisplayComponentProps {
 }
 
 export class CompilationError {
-    message: string;
+    message:
+        | string
+        | {
+              messageText: string;
+          };
     lineNumber?: number;
     columnNumber?: number;
 }
 
-export class ErrorDisplayComponent extends React.Component<IErrorDisplayComponentProps, {error: Nullable<CompilationError>}> {    
-    
+export class ErrorDisplayComponent extends React.Component<IErrorDisplayComponentProps, { error: Nullable<CompilationError> }> {
     public constructor(props: IErrorDisplayComponentProps) {
         super(props);
 
-        this.state = {error: null};
+        this.state = { error: null };
 
         this.props.globalState.onErrorObservable.add((err) => {
-            this.setState({error: err});
+            this.setState({ error: err });
         });
     }
 
@@ -30,28 +33,25 @@ export class ErrorDisplayComponent extends React.Component<IErrorDisplayComponen
         if (this.state.error && this.state.error.lineNumber && this.state.error.columnNumber) {
             const position = {
                 lineNumber: this.state.error.lineNumber,
-                column: this.state.error.columnNumber
+                column: this.state.error.columnNumber,
             };
 
             this.props.globalState.onNavigateRequiredObservable.notifyObservers(position);
         }
-        this.setState({error: null});
+        this.setState({ error: null });
     }
 
     public render() {
-
+        console.log(this.state.error);
         if (!this.state.error) {
             return null;
         }
 
         return (
             <div className="error-display" onClick={() => this._onClick()}>
-                {
-                    this.state.error.lineNumber && this.state.error.columnNumber &&
-                    `Error at [${this.state.error.lineNumber}, ${this.state.error.columnNumber}]: `
-                }
-                {this.state.error.message}
+                {this.state.error.lineNumber && this.state.error.columnNumber && `Error at [${this.state.error.lineNumber}, ${this.state.error.columnNumber}]: `}
+                {typeof this.state.error.message === "string" ? this.state.error.message : this.state.error.message.messageText}
             </div>
-        )
+        );
     }
 }


### PR DESCRIPTION
An error message coming from the monaco editor can be an object of the following structure:

```javascript
{
    "message": {
        "messageText": "ERROR MESSAGE",
        "category": 1,
        "code": 2322,
        "next": [
            {
                "messageText": "Another ERROR MESSAGE",
                "category": 1,
                "code": 2740
            }
        ]
    },
    "lineNumber": 253,
    "columnNumber": 9
}
```

Thie PR takes that into account and displays the right error message