### PR TITLE
allow disabling final color clamping

### DIFF
--- a/materialsLibrary/src/cell/cellMaterial.ts
+++ b/materialsLibrary/src/cell/cellMaterial.ts
@@ -44,6 +44,7 @@ class CellMaterialDefines extends MaterialDefines {
     public CELLBASIC = true;
     public DEPTHPREPASS = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/cell/cellMaterial.ts
+++ b/materialsLibrary/src/cell/cellMaterial.ts
@@ -44,7 +44,7 @@ class CellMaterialDefines extends MaterialDefines {
     public CELLBASIC = true;
     public DEPTHPREPASS = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/fire/fireMaterial.ts
+++ b/materialsLibrary/src/fire/fireMaterial.ts
@@ -40,7 +40,7 @@ class FireMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/fire/fireMaterial.ts
+++ b/materialsLibrary/src/fire/fireMaterial.ts
@@ -40,6 +40,7 @@ class FireMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/fur/furMaterial.ts
+++ b/materialsLibrary/src/fur/furMaterial.ts
@@ -46,6 +46,7 @@ class FurMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public HIGHLEVEL = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/fur/furMaterial.ts
+++ b/materialsLibrary/src/fur/furMaterial.ts
@@ -46,7 +46,7 @@ class FurMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public HIGHLEVEL = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/gradient/gradientMaterial.ts
+++ b/materialsLibrary/src/gradient/gradientMaterial.ts
@@ -40,7 +40,7 @@ class GradientMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/gradient/gradientMaterial.ts
+++ b/materialsLibrary/src/gradient/gradientMaterial.ts
@@ -40,6 +40,7 @@ class GradientMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -26,7 +26,7 @@ class GridMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public THIN_INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -26,6 +26,7 @@ class GridMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public THIN_INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/lava/lavaMaterial.ts
+++ b/materialsLibrary/src/lava/lavaMaterial.ts
@@ -83,7 +83,7 @@ class LavaMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public UNLIT = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/lava/lavaMaterial.ts
+++ b/materialsLibrary/src/lava/lavaMaterial.ts
@@ -83,6 +83,7 @@ class LavaMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public UNLIT = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -44,7 +44,7 @@ class MixMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public MIXMAP2 = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -44,6 +44,7 @@ class MixMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public MIXMAP2 = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/normal/normalMaterial.ts
+++ b/materialsLibrary/src/normal/normalMaterial.ts
@@ -81,7 +81,7 @@ class NormalMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public LIGHTING = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/normal/normalMaterial.ts
+++ b/materialsLibrary/src/normal/normalMaterial.ts
@@ -81,6 +81,7 @@ class NormalMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public LIGHTING = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
@@ -34,6 +34,7 @@ class ShadowOnlyMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
@@ -34,7 +34,7 @@ class ShadowOnlyMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/simple/simpleMaterial.ts
+++ b/materialsLibrary/src/simple/simpleMaterial.ts
@@ -41,6 +41,7 @@ class SimpleMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/simple/simpleMaterial.ts
+++ b/materialsLibrary/src/simple/simpleMaterial.ts
@@ -41,7 +41,7 @@ class SimpleMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -30,7 +30,7 @@ class SkyMaterialDefines extends MaterialDefines {
     public VERTEXCOLOR = false;
     public VERTEXALPHA = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -30,6 +30,7 @@ class SkyMaterialDefines extends MaterialDefines {
     public VERTEXCOLOR = false;
     public VERTEXALPHA = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/terrain/terrainMaterial.ts
+++ b/materialsLibrary/src/terrain/terrainMaterial.ts
@@ -44,6 +44,7 @@ class TerrainMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/terrain/terrainMaterial.ts
+++ b/materialsLibrary/src/terrain/terrainMaterial.ts
@@ -44,7 +44,7 @@ class TerrainMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
+++ b/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
@@ -48,6 +48,7 @@ class TriPlanarMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
+++ b/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
@@ -48,7 +48,7 @@ class TriPlanarMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -70,7 +70,7 @@ class WaterMaterialDefines extends MaterialDefines implements IImageProcessingCo
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -70,6 +70,7 @@ class WaterMaterialDefines extends MaterialDefines implements IImageProcessingCo
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();

--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -123,6 +123,7 @@ class BackgroundMaterialDefines extends MaterialDefines implements IImageProcess
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
     public EXPOSURE = false;
     public MULTIVIEW = false;
 

--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -123,7 +123,7 @@ class BackgroundMaterialDefines extends MaterialDefines implements IImageProcess
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
     public EXPOSURE = false;
     public MULTIVIEW = false;
 

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -106,6 +106,7 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
 
     /** MISC. */
     public BUMPDIRECTUV = 0;

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -106,7 +106,7 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     /** MISC. */
     public BUMPDIRECTUV = 0;

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -224,6 +224,7 @@ export class PBRMaterialDefines extends MaterialDefines
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
     public EXPOSURE = false;
     public MULTIVIEW = false;
     public ORDER_INDEPENDENT_TRANSPARENCY = false;

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -224,7 +224,7 @@ export class PBRMaterialDefines extends MaterialDefines
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
     public EXPOSURE = false;
     public MULTIVIEW = false;
     public ORDER_INDEPENDENT_TRANSPARENCY = false;

--- a/src/Materials/imageProcessingConfiguration.ts
+++ b/src/Materials/imageProcessingConfiguration.ts
@@ -29,6 +29,7 @@ export interface IImageProcessingConfigurationDefines {
     SAMPLER3DGREENDEPTH: boolean;
     SAMPLER3DBGRMAP: boolean;
     IMAGEPROCESSINGPOSTPROCESS: boolean;
+    CLAMPFINALCOLOR: boolean;
 }
 
 /**
@@ -49,6 +50,7 @@ export class ImageProcessingConfigurationDefines extends MaterialDefines impleme
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public EXPOSURE = false;
+    public CLAMPFINALCOLOR = true;
 
     constructor() {
         super();
@@ -340,6 +342,29 @@ export class ImageProcessingConfiguration {
 
     /** @hidden */
     @serialize()
+    public _clampFinalColor = true;
+    /**
+     * If applyByPostProcess is set to false the final color will be clamped unless this is set to false
+     * Applies to PBR materials.
+     */
+    public get clampFinalColor(): boolean {
+        return this._clampFinalColor;
+    }
+    /**
+     * If applyByPostProcess is set to false the final color will be clamped unless this is set to false
+     * Applies to PBR materials.
+     */
+    public set clampFinalColor(value: boolean) {
+        if (this._clampFinalColor === value) {
+            return;
+        }
+
+        this._clampFinalColor = value;
+        this._updateParameters();
+    }
+
+    /** @hidden */
+    @serialize()
     public _applyByPostProcess = false;
     /**
      * Gets whether the image processing is applied through a post process or not.
@@ -451,6 +476,7 @@ export class ImageProcessingConfiguration {
             defines.COLORGRADING = false;
             defines.COLORGRADING3D = false;
             defines.IMAGEPROCESSING = false;
+            defines.CLAMPFINALCOLOR = this.clampFinalColor;
             defines.IMAGEPROCESSINGPOSTPROCESS = this.applyByPostProcess && this._isEnabled;
             return;
         }
@@ -481,6 +507,7 @@ export class ImageProcessingConfiguration {
         defines.SAMPLER3DGREENDEPTH = this.colorGradingWithGreenDepth;
         defines.SAMPLER3DBGRMAP = this.colorGradingBGR;
         defines.IMAGEPROCESSINGPOSTPROCESS = this.applyByPostProcess;
+        defines.CLAMPFINALCOLOR = this.clampFinalColor;
         defines.IMAGEPROCESSING = defines.VIGNETTE || defines.TONEMAPPING || defines.CONTRAST || defines.EXPOSURE || defines.COLORCURVES || defines.COLORGRADING;
     }
 

--- a/src/Materials/imageProcessingConfiguration.ts
+++ b/src/Materials/imageProcessingConfiguration.ts
@@ -29,7 +29,7 @@ export interface IImageProcessingConfigurationDefines {
     SAMPLER3DGREENDEPTH: boolean;
     SAMPLER3DBGRMAP: boolean;
     IMAGEPROCESSINGPOSTPROCESS: boolean;
-    CLAMPFINALCOLOR: boolean;
+    SKIPFINALCOLORCLAMP: boolean;
 }
 
 /**
@@ -50,7 +50,7 @@ export class ImageProcessingConfigurationDefines extends MaterialDefines impleme
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public EXPOSURE = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();
@@ -342,24 +342,24 @@ export class ImageProcessingConfiguration {
 
     /** @hidden */
     @serialize()
-    public _clampFinalColor = true;
+    public _skipFinalColorClamp = false;
     /**
-     * If applyByPostProcess is set to false the final color will be clamped unless this is set to false
+     * If apply by post process is set to true, setting this to true will skip the the final color clamp step in the fragment shader
      * Applies to PBR materials.
      */
-    public get clampFinalColor(): boolean {
-        return this._clampFinalColor;
+    public get skipFinalColorClamp(): boolean {
+        return this._skipFinalColorClamp;
     }
     /**
-     * If applyByPostProcess is set to false the final color will be clamped unless this is set to false
+     * If apply by post process is set to true, setting this to true will skip the the final color clamp step in the fragment shader
      * Applies to PBR materials.
      */
-    public set clampFinalColor(value: boolean) {
-        if (this._clampFinalColor === value) {
+    public set skipFinalColorClamp(value: boolean) {
+        if (this._skipFinalColorClamp === value) {
             return;
         }
 
-        this._clampFinalColor = value;
+        this._skipFinalColorClamp = value;
         this._updateParameters();
     }
 
@@ -476,7 +476,7 @@ export class ImageProcessingConfiguration {
             defines.COLORGRADING = false;
             defines.COLORGRADING3D = false;
             defines.IMAGEPROCESSING = false;
-            defines.CLAMPFINALCOLOR = this.clampFinalColor;
+            defines.SKIPFINALCOLORCLAMP = this.skipFinalColorClamp;
             defines.IMAGEPROCESSINGPOSTPROCESS = this.applyByPostProcess && this._isEnabled;
             return;
         }
@@ -507,7 +507,7 @@ export class ImageProcessingConfiguration {
         defines.SAMPLER3DGREENDEPTH = this.colorGradingWithGreenDepth;
         defines.SAMPLER3DBGRMAP = this.colorGradingBGR;
         defines.IMAGEPROCESSINGPOSTPROCESS = this.applyByPostProcess;
-        defines.CLAMPFINALCOLOR = this.clampFinalColor;
+        defines.SKIPFINALCOLORCLAMP = this.skipFinalColorClamp;
         defines.IMAGEPROCESSING = defines.VIGNETTE || defines.TONEMAPPING || defines.CONTRAST || defines.EXPOSURE || defines.COLORCURVES || defines.COLORGRADING;
     }
 

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -176,7 +176,7 @@ export class StandardMaterialDefines extends MaterialDefines
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public CLAMPFINALCOLOR = true;
+    public SKIPFINALCOLORCLAMP = false;
     public MULTIVIEW = false;
     public ORDER_INDEPENDENT_TRANSPARENCY = false;
     public ORDER_INDEPENDENT_TRANSPARENCY_16BITS = false;

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -176,6 +176,7 @@ export class StandardMaterialDefines extends MaterialDefines
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
+    public CLAMPFINALCOLOR = true;
     public MULTIVIEW = false;
     public ORDER_INDEPENDENT_TRANSPARENCY = false;
     public ORDER_INDEPENDENT_TRANSPARENCY_16BITS = false;

--- a/src/PostProcesses/imageProcessingPostProcess.ts
+++ b/src/PostProcesses/imageProcessingPostProcess.ts
@@ -361,7 +361,7 @@ export class ImageProcessingPostProcess extends PostProcess {
         SAMPLER3DBGRMAP: false,
         IMAGEPROCESSINGPOSTPROCESS: false,
         EXPOSURE: false,
-        CLAMPFINALCOLOR: true,
+        SKIPFINALCOLORCLAMP: false,
     };
 
     constructor(name: string, options: number | PostProcessOptions, camera: Nullable<Camera> = null, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT, imageProcessingConfiguration?: ImageProcessingConfiguration) {

--- a/src/PostProcesses/imageProcessingPostProcess.ts
+++ b/src/PostProcesses/imageProcessingPostProcess.ts
@@ -361,6 +361,7 @@ export class ImageProcessingPostProcess extends PostProcess {
         SAMPLER3DBGRMAP: false,
         IMAGEPROCESSINGPOSTPROCESS: false,
         EXPOSURE: false,
+        CLAMPFINALCOLOR: true,
     };
 
     constructor(name: string, options: number | PostProcessOptions, camera: Nullable<Camera> = null, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT, imageProcessingConfiguration?: ImageProcessingConfiguration) {

--- a/src/Shaders/ShadersInclude/pbrBlockImageProcessing.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockImageProcessing.fx
@@ -3,7 +3,7 @@
     // this also limits the brightness which helpfully reduces over-sparkling in bloom (native handles this in the bloom blur shader)
     //
     // Subsurface scattering also requires to stay in linear space
-#if defined(CLAMPFINALCOLOR)
+#if !defined(SKIPFINALCOLORCLAMP)
     finalColor.rgb = clamp(finalColor.rgb, 0., 30.0);
 #endif
 #else

--- a/src/Shaders/ShadersInclude/pbrBlockImageProcessing.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockImageProcessing.fx
@@ -3,7 +3,9 @@
     // this also limits the brightness which helpfully reduces over-sparkling in bloom (native handles this in the bloom blur shader)
     //
     // Subsurface scattering also requires to stay in linear space
+#if defined(CLAMPFINALCOLOR)
     finalColor.rgb = clamp(finalColor.rgb, 0., 30.0);
+#endif
 #else
     // Alway run to ensure we are going back to gamma space.
     finalColor = applyImageProcessing(finalColor);

--- a/src/Shaders/background.fragment.fx
+++ b/src/Shaders/background.fragment.fx
@@ -286,7 +286,7 @@ void main(void) {
 #ifdef IMAGEPROCESSINGPOSTPROCESS
     // Sanitize output incase invalid normals or tangents have caused div by 0 or undefined behavior
     // this also limits the brightness which helpfully reduces over-sparkling in bloom (native handles this in the bloom blur shader)
-#if defined(CLAMPFINALCOLOR)
+#if !defined(SKIPFINALCOLORCLAMP)
     color.rgb = clamp(color.rgb, 0., 30.0);
 #endif
 #else

--- a/src/Shaders/background.fragment.fx
+++ b/src/Shaders/background.fragment.fx
@@ -286,7 +286,9 @@ void main(void) {
 #ifdef IMAGEPROCESSINGPOSTPROCESS
     // Sanitize output incase invalid normals or tangents have caused div by 0 or undefined behavior
     // this also limits the brightness which helpfully reduces over-sparkling in bloom (native handles this in the bloom blur shader)
+#if defined(CLAMPFINALCOLOR)
     color.rgb = clamp(color.rgb, 0., 30.0);
+#endif
 #else
     // Alway run even to ensure going back to gamma space.
     color = applyImageProcessing(color);


### PR DESCRIPTION
At the moment there is no way of disabling the final color clamp when using the PBR material (clamp to 30).
This sets clamping as the default value, but allows the dev to disable this using the image processing configuration.