### PR TITLE
DeviceInputSystem: Modified Pointer Capture calls to improve IE 11 compatibility

### DIFF
--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -521,10 +521,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.previousState = previousButton;
                 deviceEvent.currentState = pointer[evt.button + 2];
 
-                if (deviceType === DeviceType.Mouse && this._mouseId >= 0 && this._elementToAttachTo.hasPointerCapture(this._mouseId)) {
+                if (deviceType === DeviceType.Mouse && this._mouseId >= 0 && this._elementToAttachTo.hasPointerCapture?.(this._mouseId)) {
                     this._elementToAttachTo.releasePointerCapture(this._mouseId);
                 }
-                else if (evt.pointerId && this._elementToAttachTo.hasPointerCapture(evt.pointerId)) {
+                else if (evt.pointerId && this._elementToAttachTo.hasPointerCapture?.(evt.pointerId)) {
                     this._elementToAttachTo.releasePointerCapture(evt.pointerId);
                 }
 
@@ -572,7 +572,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             if (this.isDeviceAvailable(DeviceType.Mouse)) {
                 const pointer = this._inputs[DeviceType.Mouse][0];
 
-                if (this._mouseId >= 0 && this._elementToAttachTo.hasPointerCapture(this._mouseId)) {
+                if (this._mouseId >= 0 && this._elementToAttachTo.hasPointerCapture?.(this._mouseId)) {
                     this._elementToAttachTo.releasePointerCapture(this._mouseId);
                 }
 
@@ -601,7 +601,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     const deviceSlot = +deviceSlotKey;
                     const pointerId = this._activeTouchIds[deviceSlot];
 
-                    if (this._elementToAttachTo.hasPointerCapture(pointerId)) {
+                    if (this._elementToAttachTo.hasPointerCapture?.(pointerId)) {
                         this._elementToAttachTo.releasePointerCapture(pointerId);
                     }
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -434,7 +434,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         }
                     }
 
-                    if (!document.pointerLockElement) {
+                    if (!document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
                         try {
                             this._elementToAttachTo.setPointerCapture(this._mouseId);
                         }
@@ -444,7 +444,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 }
                 else { // Touch; Since touches are dynamically assigned, only set capture if we have an id
-                    if (evt.pointerId && !document.pointerLockElement) {
+                    if (evt.pointerId && !document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
                         try {
                             this._elementToAttachTo.setPointerCapture(evt.pointerId);
                         }


### PR DESCRIPTION
IE11 doesn't support `hasPointerCapture` so each call has been modified to include optional chaining to prevent erroneous calls when it doesn't exist.