### PR TITLE
Fix ETC1 decision tree in ktx2Decoder

### DIFF
--- a/ktx2Decoder/src/transcodeDecisionTree.ts
+++ b/ktx2Decoder/src/transcodeDecisionTree.ts
@@ -54,6 +54,7 @@ const DecisionTree: IDecisionTree = {
             },
             no: {
                 cap: "etc1",
+                alpha: false,
                 yes: {
                     transcodeFormat: transcodeTarget.ETC1_RGB,
                     engineFormat: COMPRESSED_RGB_ETC1_WEBGL,
@@ -240,10 +241,10 @@ export class TranscodeDecisionTree {
                 condition = condition && this._options[node.option];
             }
             if (node.alpha !== undefined) {
-                condition = condition && this._hasAlpha;
+                condition = condition && this._hasAlpha === node.alpha;
             }
             if (node.needsPowerOfTwo !== undefined) {
-                condition = condition && this._isPowerOfTwo;
+                condition = condition && this._isPowerOfTwo === node.needsPowerOfTwo;
             }
 
             this._parseNode(condition ? node.yes! : node.no!);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/opacitytexture-not-working-on-ios-15-devices/25102.

The cause is that iOS 15 removed support for ETC2 and PVRTC which caused the code to use ETC1, but we don't support two-slice ETC1 which is required for textures with alpha. This updates the decision tree to fallback to RGBA.

Note that this change means that the engine will now use raw RGBA textures instead of GPU compressed textures at runtime for ETC1S-with-alpha KTX2 assets. If newer iOS version reintroduces the removed texture compression formats (ETC2 or PVRTC), then it will be compressed on the GPU again.