### PR TITLE
[XR] multi-pointer screen coordinates projection

### DIFF
--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -828,7 +828,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     private _augmentPointerInit(pointerEventInit: PointerEventInit, id: number, screenCoordinates?: { x: number; y: number; }): void {
         pointerEventInit.pointerId = id;
         pointerEventInit.pointerType = "xr";
-        if(screenCoordinates) {
+        if (screenCoordinates) {
             pointerEventInit.screenX = screenCoordinates.x;
             pointerEventInit.screenY = screenCoordinates.y;
         }

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -171,6 +171,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             disabledByNearInteraction: boolean;
             // event support
             eventListeners?: { [event in XREventType]?: (event: XRInputSourceEvent) => void };
+            screenCoordinates?: { x: number; y: number };
         };
     } = {};
     private _scene: Scene;
@@ -395,6 +396,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
 
                     scene.pointerX = this._screenCoordinatesRef.x;
                     scene.pointerY = this._screenCoordinatesRef.y;
+                    controllerData.screenCoordinates = {
+                        x: this._screenCoordinatesRef.x,
+                        y: this._screenCoordinatesRef.y,
+                    }
                 }
             }
 
@@ -548,6 +553,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             pointerType: "xr",
         };
         controllerData.onFrameObserver = this._xrSessionManager.onXRFrameObservable.add(() => {
+            if(controllerData.screenCoordinates && controllerData.screenCoordinates.x) {
+                pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                pointerEventInit.screenY = controllerData.screenCoordinates.y;
+            }
             if (!controllerData.pick || (this._options.disablePointerUpOnTouchOut && downTriggered)) {
                 return;
             }

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -393,12 +393,15 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                 if (camera) {
                     camera.viewport.toGlobalToRef(scene.getEngine().getRenderWidth(), scene.getEngine().getRenderHeight(), this._viewportRef);
                     Vector3.ProjectToRef(controllerGlobalPosition, this._identityMatrix, scene.getTransformMatrix(), this._viewportRef, this._screenCoordinatesRef);
+                    // stay safe
+                    if (typeof this._screenCoordinatesRef.x === "number" && typeof this._screenCoordinatesRef.y === "number" && !isNaN(this._screenCoordinatesRef.x) && !isNaN(this._screenCoordinatesRef.y)) {
+                        scene.pointerX = this._screenCoordinatesRef.x;
+                        scene.pointerY = this._screenCoordinatesRef.y;
 
-                    scene.pointerX = this._screenCoordinatesRef.x;
-                    scene.pointerY = this._screenCoordinatesRef.y;
-                    controllerData.screenCoordinates = {
-                        x: this._screenCoordinatesRef.x,
-                        y: this._screenCoordinatesRef.y,
+                        controllerData.screenCoordinates = {
+                            x: this._screenCoordinatesRef.x,
+                            y: this._screenCoordinatesRef.y,
+                        }
                     }
                 }
             }
@@ -492,6 +495,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             if (!controllerData.pick) {
                 return;
             }
+            if (controllerData.screenCoordinates) {
+                pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                pointerEventInit.screenY = controllerData.screenCoordinates.y;
+            }
             controllerData.laserPointer.material!.alpha = 0;
             discMesh.isVisible = false;
             if (controllerData.pick.hit) {
@@ -553,7 +560,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             pointerType: "xr",
         };
         controllerData.onFrameObserver = this._xrSessionManager.onXRFrameObservable.add(() => {
-            if(controllerData.screenCoordinates && controllerData.screenCoordinates.x) {
+            if (controllerData.screenCoordinates) {
                 pointerEventInit.screenX = controllerData.screenCoordinates.x;
                 pointerEventInit.screenY = controllerData.screenCoordinates.y;
             }
@@ -571,6 +578,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             }
         });
         xrController.onDisposeObservable.addOnce(() => {
+            if (controllerData.screenCoordinates) {
+                pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                pointerEventInit.screenY = controllerData.screenCoordinates.y;
+            }
             if (controllerData.pick && downTriggered && !this._options.disablePointerUpOnTouchOut) {
                 this._scene.simulatePointerUp(controllerData.pick, pointerEventInit);
             }
@@ -591,6 +602,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             (<StandardMaterial>controllerData.selectionMesh.material).disableLighting = this.disableSelectionMeshLighting;
 
             if (controllerData.pick) {
+                if (controllerData.screenCoordinates) {
+                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
+                }
                 this._scene.simulatePointerMove(controllerData.pick, pointerEventInit);
             }
         });
@@ -608,6 +623,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                         const pressed = component.changes.pressed.current;
                         if (controllerData.pick) {
                             if (this._options.enablePointerSelectionOnAllControllers || xrController.uniqueId === this._attachedController) {
+                                if (controllerData.screenCoordinates) {
+                                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
+                                }
                                 if (pressed) {
                                     this._scene.simulatePointerDown(controllerData.pick, pointerEventInit);
                                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshPickedColor;
@@ -635,6 +654,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
         } else {
             // use the select and squeeze events
             const selectStartListener = (event: XRInputSourceEvent) => {
+                if (controllerData.screenCoordinates) {
+                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
+                }
                 if (controllerData.xrController && event.inputSource === controllerData.xrController.inputSource && controllerData.pick) {
                     this._scene.simulatePointerDown(controllerData.pick, pointerEventInit);
                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshPickedColor;
@@ -643,6 +666,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             };
 
             const selectEndListener = (event: XRInputSourceEvent) => {
+                if (controllerData.screenCoordinates) {
+                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
+                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
+                }
                 if (controllerData.xrController && event.inputSource === controllerData.xrController.inputSource && controllerData.pick) {
                     this._scene.simulatePointerUp(controllerData.pick, pointerEventInit);
                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshDefaultColor;

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -511,10 +511,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             if (!controllerData.pick) {
                 return;
             }
-            if (controllerData.screenCoordinates) {
-                pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                pointerEventInit.screenY = controllerData.screenCoordinates.y;
-            }
+            this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
             controllerData.laserPointer.material!.alpha = 0;
             discMesh.isVisible = false;
             if (controllerData.pick.hit) {
@@ -577,10 +574,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             pointerType: "xr",
         };
         controllerData.onFrameObserver = this._xrSessionManager.onXRFrameObservable.add(() => {
-            if (controllerData.screenCoordinates) {
-                pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                pointerEventInit.screenY = controllerData.screenCoordinates.y;
-            }
+            this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
             if (!controllerData.pick || (this._options.disablePointerUpOnTouchOut && downTriggered)) {
                 return;
             }
@@ -595,10 +589,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             }
         });
         xrController.onDisposeObservable.addOnce(() => {
-            if (controllerData.screenCoordinates) {
-                pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                pointerEventInit.screenY = controllerData.screenCoordinates.y;
-            }
+            this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
             if (controllerData.pick && downTriggered && !this._options.disablePointerUpOnTouchOut) {
                 this._scene.simulatePointerUp(controllerData.pick, pointerEventInit);
                 controllerData.finalPointerUpTriggered = true;
@@ -620,10 +611,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             (<StandardMaterial>controllerData.selectionMesh.material).disableLighting = this.disableSelectionMeshLighting;
 
             if (controllerData.pick) {
-                if (controllerData.screenCoordinates) {
-                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
-                }
+                this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                 this._scene.simulatePointerMove(controllerData.pick, pointerEventInit);
             }
         });
@@ -641,10 +629,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                         const pressed = component.changes.pressed.current;
                         if (controllerData.pick) {
                             if (this._options.enablePointerSelectionOnAllControllers || xrController.uniqueId === this._attachedController) {
-                                if (controllerData.screenCoordinates) {
-                                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
-                                }
+                                this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                                 if (pressed) {
                                     this._scene.simulatePointerDown(controllerData.pick, pointerEventInit);
                                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshPickedColor;
@@ -672,10 +657,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
         } else {
             // use the select and squeeze events
             const selectStartListener = (event: XRInputSourceEvent) => {
-                if (controllerData.screenCoordinates) {
-                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
-                }
+                this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                 if (controllerData.xrController && event.inputSource === controllerData.xrController.inputSource && controllerData.pick) {
                     this._scene.simulatePointerDown(controllerData.pick, pointerEventInit);
                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshPickedColor;
@@ -684,10 +666,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             };
 
             const selectEndListener = (event: XRInputSourceEvent) => {
-                if (controllerData.screenCoordinates) {
-                    pointerEventInit.screenX = controllerData.screenCoordinates.x;
-                    pointerEventInit.screenY = controllerData.screenCoordinates.y;
-                }
+                this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                 if (controllerData.xrController && event.inputSource === controllerData.xrController.inputSource && controllerData.pick) {
                     this._scene.simulatePointerUp(controllerData.pick, pointerEventInit);
                     (<StandardMaterial>controllerData.selectionMesh.material).emissiveColor = this.selectionMeshDefaultColor;
@@ -744,6 +723,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                     pointerId: controllerData.id,
                     pointerType: "xr",
                 };
+                this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                 this._scene.simulatePointerUp(new PickingInfo(), pointerEventInit);
             }
 
@@ -843,6 +823,15 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             distance *= -1;
         }
         _laserPointer.position.z = distance / 2 + 0.05;
+    }
+
+    private _augmentPointerInit(pointerEventInit: PointerEventInit, id: number, screenCoordinates?: { x: number; y: number; }): void {
+        pointerEventInit.pointerId = id;
+        pointerEventInit.pointerType = "xr";
+        if(screenCoordinates) {
+            pointerEventInit.screenX = screenCoordinates.x;
+            pointerEventInit.screenY = screenCoordinates.y;
+        }
     }
 
     /** @hidden */

--- a/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/src/XR/features/WebXRControllerPointerSelection.ts
@@ -401,7 +401,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                         controllerData.screenCoordinates = {
                             x: this._screenCoordinatesRef.x,
                             y: this._screenCoordinatesRef.y,
-                        }
+                        };
                     }
                 }
             }


### PR DESCRIPTION
This PR will allow passing the projected screen coordinates of controllers in XR.

The data will be available in `event.screenX` and `event.screenY` (if available at all).