### PR TITLE
Collect performance data after the scene is rendered, not before, and…

### DIFF
--- a/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollectionStrategies.ts
@@ -47,6 +47,7 @@ export class PerfCollectionStrategy {
 
     /**
      * Gets the initializer for the strategy used for collection of cpu utilization metrics.
+     * Needs the experimental compute pressure API.
      * @returns the initializer for the cpu utilization strategy
      */
     public static CpuStrategy(): PerfStrategyInitialization {

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -459,7 +459,7 @@ export class PerformanceViewerCollector {
             this.datasets.startingIndices = new DynamicFloat32Array(initialArraySize);
         }
         this._startingTimestamp = PrecisionDate.Now;
-        this._scene.onBeforeRenderObservable.add(this._collectDataAtFrame);
+        this._scene.onAfterRenderObservable.add(this._collectDataAtFrame);
         this._restoreStringEvents();
     }
 


### PR DESCRIPTION
… add a line about experimental API dependency on CPU utilization strategy.