### PR TITLE
NME: Add CustomBlock to node materials

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -143,6 +143,7 @@
 - NME `TextureBlock`: add an output for the texture level and a switch to disable the internal multiplication (level * texture) ([#10192](https://github.com/BabylonJS/Babylon.js/pull/10192)) ([rassie](https://github.com/rassie))
 - Added support for parallax / parallax occlusion to the `PerturbNormal` block ([Popov72](https://github.com/Popov72))
 - Added a `SceneDepth` block to access the scene depth buffer ([Popov72](https://github.com/Popov72))
+- Added support for custom blocks ([BlakeOne](https://github.com/BlakeOne), [Popov72](https://github.com/Popov72))
 
 ### GUI
 - Added moving GUI controls to a non-overlapping position function called `moveToNonOverlappedPosition` in `AdvancedDynamicTexture`([RolandCsibrei](https://github.com/RolandCsibrei))

--- a/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -269,7 +269,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         );
     }
 
-    removeBlock(value: string): void {
+    removeCustomBlock(value: string): void {
         let blockJson = localStorage.getItem("Custom-Block-List");
         if (blockJson) {
             let blockList = JSON.parse(blockJson);
@@ -477,7 +477,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                                 tooltip={this._customBlockList[block] || ""}
                                 iconImage={deleteButton}
                                 iconTitle="Delete"
-                                onIconClick={(value) => this.removeBlock(value)}
+                                onIconClick={(value) => this.removeCustomBlock(value)}
                                 lenSuffixToRemove={11}
                             />
                         );

--- a/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -163,6 +163,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
     };
 
     private _customFrameList: { [key: string]: string };
+    private _customBlockList: { [key: string]: string };
 
     constructor(props: INodeListComponentProps) {
         super(props);
@@ -172,6 +173,11 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         let frameJson = localStorage.getItem("Custom-Frame-List");
         if (frameJson) {
             this._customFrameList = JSON.parse(frameJson);
+        }
+
+        let blockJson = localStorage.getItem("Custom-Block-List");
+        if (blockJson) {
+            this._customBlockList = JSON.parse(blockJson);
         }
 
         this._onResetRequiredObserver = this.props.globalState.onResetRequiredObservable.add(() => {
@@ -231,15 +237,65 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         }
     }
 
+    loadCustomBlock(file: File) {
+        Tools.ReadFile(
+            file,
+            async (data) => {
+                // get Block Data from file
+                let decoder = new TextDecoder("utf-8");
+                const blockData = JSON.parse(decoder.decode(data));
+                let blockName = (blockData.name || "") + "CustomBlock";
+                let blockToolTip = blockData.comments || "";
+
+                try {
+                    localStorage.setItem(blockName, JSON.stringify(blockData));
+                } catch (error) {
+                    this.props.globalState.onErrorMessageDialogRequiredObservable.notifyObservers("Error Saving Block");
+                    return;
+                }
+
+                let blockJson = localStorage.getItem("Custom-Block-List");
+                let blockList: { [key: string]: string } = {};
+                if (blockJson) {
+                    blockList = JSON.parse(blockJson);
+                }
+                blockList[blockName] = blockToolTip;
+                localStorage.setItem("Custom-Block-List", JSON.stringify(blockList));
+                this._customBlockList = blockList;
+                this.forceUpdate();
+            },
+            undefined,
+            true
+        );
+    }
+
+    removeBlock(value: string): void {
+        let blockJson = localStorage.getItem("Custom-Block-List");
+        if (blockJson) {
+            let blockList = JSON.parse(blockJson);
+            delete blockList[value];
+            localStorage.removeItem(value);
+            localStorage.setItem("Custom-Block-List", JSON.stringify(blockList));
+            this._customBlockList = blockList;
+            this.forceUpdate();
+        }
+    }
+
     render() {
         let customFrameNames: string[] = [];
         for (let frame in this._customFrameList) {
             customFrameNames.push(frame);
         }
 
+        let customBlockNames: string[] = [];
+        for (let block in this._customBlockList) {
+            customBlockNames.push(block);
+        }
+
         // Block types used to create the menu from
         const allBlocks: any = {
             Custom_Frames: customFrameNames,
+            Custom_Blocks: customBlockNames,
             Animation: ["BonesBlock", "MorphTargetsBlock"],
             Color_Management: ["ReplaceColorBlock", "PosterizeBlock", "GradientBlock", "DesaturateBlock"],
             Conversion_Blocks: ["ColorMergerBlock", "ColorSplitterBlock", "VectorMergerBlock", "VectorSplitterBlock"],
@@ -413,6 +469,18 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                                 onIconClick={(value) => this.removeItem(value)}
                             />
                         );
+                    } else if (key === "Custom_Blocks") {
+                        return (
+                            <DraggableLineWithButtonComponent
+                                key={block}
+                                data={block}
+                                tooltip={this._customBlockList[block] || ""}
+                                iconImage={deleteButton}
+                                iconTitle="Delete"
+                                onIconClick={(value) => this.removeBlock(value)}
+                                lenSuffixToRemove={11}
+                            />
+                        );
                     }
                     return <DraggableLineComponent key={block} data={block} tooltip={NodeListComponent._Tooltips[block] || ""} />;
                 });
@@ -429,6 +497,22 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                         accept=".json"
                         onIconClick={(file) => {
                             this.loadCustomFrame(file);
+                        }}
+                    />
+                );
+                blockList.push(line);
+            } else if (key === "Custom_Blocks") {
+                let line = (
+                    <LineWithFileButtonComponent
+                        key="add..."
+                        title={"Add Custom Block"}
+                        closed={false}
+                        label="Add..."
+                        uploadName={"custom-block-upload"}
+                        iconImage={addButton}
+                        accept=".json"
+                        onIconClick={(file) => {
+                            this.loadCustomBlock(file);
                         }}
                     />
                 );

--- a/nodeEditor/src/graphEditor.tsx
+++ b/nodeEditor/src/graphEditor.tsx
@@ -8,6 +8,7 @@ import { Portal } from "./portal";
 import { LogComponent, LogEntry } from "./components/log/logComponent";
 import { DataStorage } from "babylonjs/Misc/dataStorage";
 import { NodeMaterialBlockConnectionPointTypes } from "babylonjs/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes";
+import { CustomBlock } from "babylonjs/Materials/Node/Blocks/customBlock";
 import { InputBlock } from "babylonjs/Materials/Node/Blocks/Input/inputBlock";
 import { Nullable } from "babylonjs/types";
 import { MessageDialogComponent } from "./sharedComponents/messageDialog";
@@ -577,7 +578,21 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         var data = event.dataTransfer.getData("babylonjs-material-node") as string;
         let newNode: GraphNode;
 
-        if (data.indexOf("Custom") > -1) {
+        let customBlockData: any;
+
+        if (data.indexOf("CustomBlock") > -1) {
+            let storageData = localStorage.getItem(data);
+            if (!storageData) {
+                this.props.globalState.onErrorMessageDialogRequiredObservable.notifyObservers(`Error loading custom block`);
+                return;
+            }
+
+            customBlockData = JSON.parse(storageData);
+            if (!customBlockData) {
+                this.props.globalState.onErrorMessageDialogRequiredObservable.notifyObservers(`Error parsing custom block`);
+                return;
+            }
+        } else if (data.indexOf("Custom") > -1) {
             let storageData = localStorage.getItem(data);
             if (storageData) {
                 let frameData = JSON.parse(storageData);
@@ -604,7 +619,13 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         if (data.indexOf("Block") === -1) {
             newNode = this.addValueNode(data);
         } else {
-            let block = BlockTools.GetBlockFromString(data, this.props.globalState.nodeMaterial.getScene(), this.props.globalState.nodeMaterial)!;
+            let block: NodeMaterialBlock;
+            if (customBlockData) {
+                block = new CustomBlock();
+                (block as CustomBlock).options = customBlockData;
+            } else {
+                block = BlockTools.GetBlockFromString(data, this.props.globalState.nodeMaterial.getScene(), this.props.globalState.nodeMaterial)!;
+            }
 
             if (block.isUnique) {
                 const className = block.getClassName();

--- a/nodeEditor/src/graphEditor.tsx
+++ b/nodeEditor/src/graphEditor.tsx
@@ -621,7 +621,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         } else {
             let block: NodeMaterialBlock;
             if (customBlockData) {
-                block = new CustomBlock();
+                block = new CustomBlock("");
                 (block as CustomBlock).options = customBlockData;
             } else {
                 block = BlockTools.GetBlockFromString(data, this.props.globalState.nodeMaterial.getScene(), this.props.globalState.nodeMaterial)!;

--- a/nodeEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
+++ b/nodeEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
@@ -6,6 +6,7 @@ export interface IDraggableLineWithButtonComponent {
     iconImage: any;
     onIconClick: (value: string) => void;
     iconTitle: string;
+    lenSuffixToRemove?: number;
 }
 
 export class DraggableLineWithButtonComponent extends React.Component<IDraggableLineWithButtonComponent> {
@@ -23,7 +24,7 @@ export class DraggableLineWithButtonComponent extends React.Component<IDraggable
                     event.dataTransfer.setData("babylonjs-material-node", this.props.data);
                 }}
             >
-                {this.props.data.substr(0, this.props.data.length - 6)}
+                {this.props.data.substr(0, this.props.data.length - (this.props.lenSuffixToRemove ?? 6))}
                 <div
                     className="icon"
                     onClick={() => {

--- a/src/Materials/Node/Blocks/customBlock.ts
+++ b/src/Materials/Node/Blocks/customBlock.ts
@@ -1,0 +1,173 @@
+import { NodeMaterialBlock } from '../nodeMaterialBlock';
+import { NodeMaterialBlockConnectionPointTypes } from '../Enums/nodeMaterialBlockConnectionPointTypes';
+import { NodeMaterialBuildState } from '../nodeMaterialBuildState';
+import { NodeMaterialBlockTargets } from '../Enums/nodeMaterialBlockTargets';
+import { RegisterClass } from '../../../Misc/typeStore';
+import { Scene } from '../../../scene';
+import { NodeMaterialConnectionPoint } from "..";
+import { Nullable } from "../../../types";
+
+/**
+ * Custom block created from user-defined json
+ */
+export class CustomBlock extends NodeMaterialBlock {
+    private _options: any;
+    private _code: string;
+
+    /**
+     * Gets or sets the options for this custom block
+     */
+    public get options() {
+        return this._options;
+    }
+
+    public set options(options: any) {
+        this._deserializeOptions(options);
+    }
+
+    /**
+     * Creates a new CustomBlock
+     * @param name defines the block name
+     */
+    public constructor(name: string) {
+        super(name);
+    }
+
+    /**
+     * Gets the current class name
+     * @returns the class name
+     */
+    public getClassName() {
+        return "CustomBlock";
+    }
+
+    protected _buildBlock(state: NodeMaterialBuildState) {
+        super._buildBlock(state);
+
+        let code = this._code;
+
+        let functionName = this._options.functionName;
+
+        // Replace the TYPE_XXX placeholders (if any)
+        this._inputs.forEach((input) => {
+            const rexp = new RegExp("\\{TYPE_" + input.name + "\\}", "gm");
+            const type = state._getGLType(input.type);
+            code = code.replace(rexp, type);
+            functionName = functionName.replace(rexp, type);
+        });
+        this._outputs.forEach((output) => {
+            const rexp = new RegExp("\\{TYPE_" + output.name + "\\}", "gm");
+            const type = state._getGLType(output.type);
+            code = code.replace(rexp, type);
+            functionName = functionName.replace(rexp, type);
+        });
+
+        state._emitFunction(functionName, code, "");
+
+        // Declare the output variables
+        this._outputs.forEach((output) => {
+            state.compilationString += this._declareOutput(output, state) + ";\r\n";
+        });
+
+        // Generate the function call
+        state.compilationString += functionName + "(";
+
+        let hasComma = false;
+        this._inputs.forEach((input, index) => {
+            if (index > 0) {
+                state.compilationString += ", ";
+                hasComma = true;
+            }
+            state.compilationString += input.associatedVariableName;
+        });
+
+        this._outputs.forEach((output, index) => {
+            if (index > 0 || hasComma) {
+                state.compilationString += ", ";
+            }
+            state.compilationString += output.associatedVariableName;
+        });
+
+        state.compilationString += ");\r\n";
+
+        return this;
+    }
+
+    protected _dumpPropertiesCode() {
+        let codeString = super._dumpPropertiesCode();
+
+        codeString += `${this._codeVariableName}.options = ${JSON.stringify(this._options)};\r\n`;
+
+        return codeString;
+    }
+
+    public serialize(): any {
+        let serializationObject = super.serialize();
+
+        serializationObject.options = this._options;
+
+        return serializationObject;
+    }
+
+    public _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
+        this._deserializeOptions(serializationObject.options);
+
+        super._deserialize(serializationObject, scene, rootUrl);
+    }
+
+    private _deserializeOptions(options: any) {
+        this._options = options;
+        this._code = options.code.join("\r\n") + "\r\n";
+        this.name = this.name || options.name;
+        this.target = (<any> NodeMaterialBlockTargets)[options.target];
+
+        options.inParameters?.forEach((input: any, index: number) => {
+            const type = (<any> NodeMaterialBlockConnectionPointTypes)[input.type];
+            this.registerInput(input.name, type);
+
+            Object.defineProperty(this, input.name, {
+                get: function () {
+                    return this._inputs[index];
+                },
+                enumerable: true,
+                configurable: true
+            });
+        });
+
+        options.outParameters?.forEach((output: any, index: number) => {
+            this.registerOutput(output.name, (<any> NodeMaterialBlockConnectionPointTypes)[output.type]);
+
+            Object.defineProperty(this, output.name, {
+                get: function () {
+                    return this._outputs[index];
+                },
+                enumerable: true,
+                configurable: true
+            });
+
+            if (output.type === "BasedOnInput") {
+                this._outputs[index]._typeConnectionSource = this._findInputByName(output.typeFromInput)![0];
+            }
+        });
+
+        options.inLinkedConnectionTypes?.forEach((connection: any) => {
+            this._linkConnectionTypes(this._findInputByName(connection.input1)![1], this._findInputByName(connection.input2)![1]);
+        });
+    }
+
+    private _findInputByName(name: string): Nullable<[NodeMaterialConnectionPoint, number]> {
+        if (!name) {
+            return null;
+        }
+
+        for (var i = 0; i < this._inputs.length; i++) {
+            if (this._inputs[i].name === name) {
+                return [this._inputs[i], i];
+            }
+        }
+
+        return null;
+    }
+}
+
+RegisterClass("BABYLON.CustomBlock", CustomBlock);

--- a/src/Materials/Node/Blocks/customBlock.ts
+++ b/src/Materials/Node/Blocks/customBlock.ts
@@ -4,8 +4,8 @@ import { NodeMaterialBuildState } from '../nodeMaterialBuildState';
 import { NodeMaterialBlockTargets } from '../Enums/nodeMaterialBlockTargets';
 import { RegisterClass } from '../../../Misc/typeStore';
 import { Scene } from '../../../scene';
-import { NodeMaterialConnectionPoint } from "..";
 import { Nullable } from "../../../types";
+import { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 
 /**
  * Custom block created from user-defined json

--- a/src/Materials/Node/Blocks/index.ts
+++ b/src/Materials/Node/Blocks/index.ts
@@ -7,6 +7,7 @@ export * from "./addBlock";
 export * from "./scaleBlock";
 export * from "./clampBlock";
 export * from "./crossBlock";
+export * from "./customBlock";
 export * from "./dotBlock";
 export * from "./transformBlock";
 export * from "./remapBlock";


### PR DESCRIPTION
This PR is adding the `CustomBlock` block to node materials. It allows to use straight glsl code as a node material block.

The custom blocks are located right below the custom frames:
![image](https://user-images.githubusercontent.com/4152247/142686558-e1d318ac-af2d-49d5-a6cf-35aaf56bcfda.png)

The description of a custom block is a json file.

Ex:
* Perlin2D
```json
{
    "name": "Perlin2D",
    "comments": "Generates a Perlin noise single value given a vec2 and time",
    "target": "Neutral",
    "inParameters": [
        {
            "name": "p",
            "type": "Vector2"
        },
        {
            "name": "dim",
            "type": "Float"
        },
        {
            "name": "time",
            "type": "Float"
        }
    ],
    "outParameters": [
        {
            "name": "output",
            "type": "Float"
        }
    ],
    "functionName": "perlin",
    "code": [
        "float rand(vec2 co){return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);}", 
        "float rand(vec2 co, float l) {return rand(vec2(rand(co), l));}", 
        "float rand(vec2 co, float l, float t) {return rand(vec2(rand(co, l), t));}", 
        "", 
        "void perlin(vec2 p, float dim, float time, out float result) {", 
        "   vec2 pos = floor(p * dim);", 
        "   vec2 posx = pos + vec2(1.0, 0.0);", 
        "   vec2 posy = pos + vec2(0.0, 1.0);", 
        "   vec2 posxy = pos + vec2(1.0);", 
        "   ", 
        "   float c = rand(pos, dim, time);", 
        "   float cx = rand(posx, dim, time);", 
        "   float cy = rand(posy, dim, time);", 
        "   float cxy = rand(posxy, dim, time);", 
        "   ", 
        "   vec2 d = fract(p * dim);", 
        "   d = -0.5 * cos(d * 3.14159265358979323846) + 0.5;", 
        "   ", 
        "   float ccx = mix(c, cx, d.x);", 
        "   float cycxy = mix(cy, cxy, d.x);", 
        "   float center = mix(ccx, cycxy, d.y);", 
        "   ", 
        "   result = center * 2.0 - 1.0;", 
        "}"
    ]    
}
```
* multiply
```json
{
    "name": "CustomMultiply",
    "comments": "Multiplies the left and right inputs of the same type together",
    "target": "Neutral",
    "inParameters": [
        {
            "name": "left",
            "type": "AutoDetect"
        },
        {
            "name": "right",
            "type": "AutoDetect"
        }
    ],
    "outParameters": [
        {
            "name": "output",
            "type": "BasedOnInput",
            "typeFromInput": "left"
        }
    ],
    "inLinkedConnectionTypes" : [
        {
            "input1": "left",
            "input2": "right",
            "looseCoupling": false
        }
    ],
    "functionName": "multiply_{TYPE_left}",
    "code": [
        "{TYPE_output} myHelper_{TYPE_left}({TYPE_left} l, {TYPE_right} r) { return l * r; }",
        "void multiply_{TYPE_left}({TYPE_left} l, {TYPE_right} r, out {TYPE_output} result) {",
        "   result = myHelper_{TYPE_left}(l, r);",
        "}"
    ]    
}
```
The `CustomMultiply` block does the same thing than the existing `Multiply` block but I have used it as an example to demonstrate using auto-detect / BasedOnInput types: when using these special types, you must use the `{TYPE_XXX}` syntax inside the glsl code because the types are known only at runtime when connecting inputs to the block in the NME.

We will probably need at some point a UI to create/modify custom blocks: for the time being you must handle the json file by hand (see how Unity is doing it: https://docs.unity3d.com/Packages/com.unity.shadergraph@6.7/manual/Custom-Function-Node.html).

Example of a node material using Perlin2D: https://nme.babylonjs.com/#3WEKUZ#1