### PR TITLE
VAT fails with ShaderMaterial

### DIFF
--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -667,7 +667,14 @@ export class ShaderMaterial extends PushMaterial {
                 }
             }
         } else {
-            defines.push("#define NUM_BONE_INFLUENCERS 0");
+            const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
+
+            if (bvaManager && bvaManager.isEnabled) {
+                defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
+            }
+            else {
+                defines.push("#define NUM_BONE_INFLUENCERS 0");
+            }
         }
 
         // Morph

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -740,6 +740,19 @@ export class ShaderMaterial extends PushMaterial {
 
             if (bvaManager && bvaManager.isEnabled) {
                 defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
+                if (this._options.uniforms.indexOf("bakedVertexAnimationSettings") === -1) {
+                    this._options.uniforms.push("bakedVertexAnimationSettings");
+                }
+                if (this._options.uniforms.indexOf("bakedVertexAnimationTextureSizeInverted") === -1) {
+                    this._options.uniforms.push("bakedVertexAnimationTextureSizeInverted");
+                }
+                if (this._options.uniforms.indexOf("bakedVertexAnimationTime") === -1) {
+                    this._options.uniforms.push("bakedVertexAnimationTime");
+                }
+
+                if (this._options.samplers.indexOf("bakedVertexAnimationTexture") === -1) {
+                    this._options.samplers.push("bakedVertexAnimationTexture");
+                }
             }
 
             MaterialHelper.PrepareAttributesForBakedVertexAnimation(attribs, mesh, defines);

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -667,14 +667,7 @@ export class ShaderMaterial extends PushMaterial {
                 }
             }
         } else {
-            const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
-
-            if (bvaManager && bvaManager.isEnabled) {
-                defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
-            }
-            else {
-                defines.push("#define NUM_BONE_INFLUENCERS 0");
-            }
+            defines.push("#define NUM_BONE_INFLUENCERS 0");
         }
 
         // Morph


### PR DESCRIPTION
VAT doesn't work with a ShaderMaterial, PG that reproduces the error: https://playground.babylonjs.com/#11GAIH#153

```
BJS - [17:55:14]: Error: VERTEX SHADER ERROR: 0:45: 'matricesIndices' : undeclared identifier
```

This is because `NUM_BONE_INFLUENCERS` is not defined. This patch defines it.