### PR TITLE
Create structure for a persistent popup component that doesn't clos…

### DIFF
--- a/inspector/src/components/globalState.ts
+++ b/inspector/src/components/globalState.ts
@@ -12,6 +12,7 @@ import { CameraGizmo } from "babylonjs/Gizmos/cameraGizmo";
 import { PropertyChangedEvent } from "./propertyChangedEvent";
 import { ReplayRecorder } from "./replayRecorder";
 import { DataStorage } from "babylonjs/Misc/dataStorage";
+import { ReactNode } from "react";
 
 export class GlobalState {
     public onSelectionChangedObservable: Observable<any>;
@@ -22,6 +23,8 @@ export class GlobalState {
     public onPluginActivatedObserver: Nullable<Observer<ISceneLoaderPlugin | ISceneLoaderPluginAsync>>;
     public onNewSceneObservable = new Observable<Scene>();
     public sceneImportDefaults: { [key: string]: any } = {};
+
+    public onPopupRenderObservable = new Observable<Nullable<() => ReactNode>>();
 
     public validationResults: Nullable<IGLTFValidationResults> = null;
     public onValidationResultsUpdatedObservable = new Observable<Nullable<IGLTFValidationResults>>();

--- a/inspector/src/components/globalState.ts
+++ b/inspector/src/components/globalState.ts
@@ -13,6 +13,7 @@ import { PropertyChangedEvent } from "./propertyChangedEvent";
 import { ReplayRecorder } from "./replayRecorder";
 import { DataStorage } from "babylonjs/Misc/dataStorage";
 import { ReactNode } from "react";
+import { IPopupComponentProps } from "./popupComponent";
 
 export class GlobalState {
     public onSelectionChangedObservable: Observable<any>;
@@ -24,7 +25,8 @@ export class GlobalState {
     public onNewSceneObservable = new Observable<Scene>();
     public sceneImportDefaults: { [key: string]: any } = {};
 
-    public onPopupRenderObservable = new Observable<Nullable<() => ReactNode>>();
+    public onPopupPropsChangedObservable = new Observable<IPopupComponentProps>();
+    public onPopupContentRenderChangedObservable = new Observable<Nullable<() => ReactNode>>();
 
     public validationResults: Nullable<IGLTFValidationResults> = null;
     public onValidationResultsUpdatedObservable = new Observable<Nullable<IGLTFValidationResults>>();

--- a/inspector/src/components/persistentPopupHostComponent.tsx
+++ b/inspector/src/components/persistentPopupHostComponent.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { PopupComponent } from "./popupComponent";
+import { Nullable } from "babylonjs/types";
+import { GlobalState } from "./globalState";
+import { Observer } from "babylonjs/Misc/observable";
+
+interface IPersistentPopupHostComponentProps {
+    globalState?: GlobalState;
+}
+
+interface IPersistentPopupHostComponentState {
+    renderFunction?: Nullable<() => React.ReactNode>;
+}
+
+/**
+ * This component is a persistent popup host that subscribes to any popup changes 
+ * @param props 
+ */
+export class PersistentPopupHostComponent extends React.Component<IPersistentPopupHostComponentProps, IPersistentPopupHostComponentState> {
+    private _renderFunctionChangeObserver?: Nullable<Observer<Nullable<() => React.ReactNode>>>;
+
+    constructor(props : IPersistentPopupHostComponentProps) {
+        super(props);
+
+        this.state = {};
+
+        this._renderFunctionChangeObserver = this.props.globalState?.onPopupRenderObservable.add((renderFunction) => {
+            this.setState({renderFunction});
+        });
+    }
+
+    componentWillUnmount() {
+        if (this._renderFunctionChangeObserver) {
+            this.props.globalState?.onPopupRenderObservable.remove(this._renderFunctionChangeObserver!);
+        }
+    }
+
+    render() {
+        return (
+            this.state.renderFunction ? <PopupComponent id="test" title="test" size={{width: 100, height: 100}} onClose={() => {}}>
+                {this.state.renderFunction()}
+            </PopupComponent> : null
+        )
+    }
+}

--- a/inspector/src/components/popupComponent.tsx
+++ b/inspector/src/components/popupComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Inspector } from "../inspector";
 
-interface IPopupComponentProps {
+export interface IPopupComponentProps {
     id: string;
     title: string;
     size: { width: number; height: number };

--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -13,6 +13,7 @@ import { SceneExplorerComponent } from "./components/sceneExplorer/sceneExplorer
 import { EmbedHostComponent } from "./components/embedHost/embedHostComponent";
 import { PropertyChangedEvent } from "./components/propertyChangedEvent";
 import { GlobalState } from "./components/globalState";
+import { PersistentPopupHostComponent } from "./components/persistentPopupHostComponent";
 
 interface IInternalInspectorOptions extends IInspectorOptions {
     popup: boolean;
@@ -31,6 +32,8 @@ export class Inspector {
     private static _SceneExplorerWindow: Window;
     private static _ActionTabsWindow: Window;
     private static _EmbedHostWindow: Window;
+
+    private static _PopupHost: Nullable<HTMLElement>;
 
     private static _Scene: Scene;
     private static _OpenedPane = 0;
@@ -112,6 +115,10 @@ export class Inspector {
             if (!options.overlay) {
                 this._SceneExplorerHost.style.position = "relative";
             }
+
+            this._PopupHost = parentControlExplorer.ownerDocument!.createElement("div");
+            this._PopupHost.id = "popup-host";
+            this._PopupHost.style.position = "absolute";
         }
 
         // Scene
@@ -153,6 +160,8 @@ export class Inspector {
                 },
             });
             ReactDOM.render(sceneExplorerElement, this._SceneExplorerHost);
+            const popupElement = React.createElement(PersistentPopupHostComponent, {globalState: this._GlobalState});
+            ReactDOM.render(popupElement, this._PopupHost);
         }
     }
 

--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -116,9 +116,6 @@ export class Inspector {
                 this._SceneExplorerHost.style.position = "relative";
             }
 
-            this._PopupHost = parentControlExplorer.ownerDocument!.createElement("div");
-            this._PopupHost.id = "popup-host";
-            this._PopupHost.style.position = "absolute";
         }
 
         // Scene
@@ -160,8 +157,6 @@ export class Inspector {
                 },
             });
             ReactDOM.render(sceneExplorerElement, this._SceneExplorerHost);
-            const popupElement = React.createElement(PersistentPopupHostComponent, {globalState: this._GlobalState});
-            ReactDOM.render(popupElement, this._PopupHost);
         }
     }
 
@@ -182,9 +177,19 @@ export class Inspector {
             if (!options.overlay) {
                 this._ActionTabsHost.style.position = "relative";
             }
+
+            this._PopupHost = parentControlActions.ownerDocument!.createElement("div");
+            this._PopupHost.id = "popup-host";
+            this._PopupHost.style.position = "absolute";
         }
 
         if (this._ActionTabsHost) {
+
+            if (this._PopupHost) {
+                const popupElement = React.createElement(PersistentPopupHostComponent, {globalState: this._GlobalState});
+                ReactDOM.render(popupElement, this._PopupHost);
+            }
+
             this._OpenedPane++;
             const actionTabsElement = React.createElement(ActionTabsComponent, {
                 globalState: this._GlobalState,
@@ -216,6 +221,12 @@ export class Inspector {
 
                     if (options.popup) {
                         this._ActionTabsWindow.close();
+                    }
+
+                    // Clean up popup host once the Action Tabs are closed.
+                    if (this._PopupHost) {
+                        ReactDOM.unmountComponentAtNode(this._PopupHost);
+                        this._RemoveElementFromDOM(this._PopupHost);
                     }
                 },
                 initialTab: options.initialTab,


### PR DESCRIPTION
…e when the inspector tab is changed.

Usage example:

* To open a popup: 
```javascript
globalState.onPopupContentRenderChangedObservable.notifyObservers(() => {
  return <div>Popup contents...</div>
});
```

* To close a popup:
```javascript
globalState.onPopupContentRenderChangedObservable.notifyObservers(null);
```