### PR TITLE
Modified onCanvasPointerOutObservable to check for bounds before notifying observers

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -657,7 +657,16 @@ export class Engine extends ThinEngine {
         };
 
         this._onCanvasPointerOut = (ev) => {
-            this.onCanvasPointerOutObservable.notifyObservers(ev);
+            let rect = this.getInputElementClientRect();
+            console.log(rect);
+            if (rect) {
+                let pointerX = ev.clientX - rect.left;
+                let pointerY = ev.clientY - rect.top;
+                if (pointerX < 0 || pointerX > rect.width || pointerY < 0 || pointerY > rect.height) {
+                    console.log(pointerX + ", " + pointerY);
+                    this.onCanvasPointerOutObservable.notifyObservers(ev);
+                }
+            }
         };
 
         if (IsWindowObjectExist()) {

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -657,13 +657,14 @@ export class Engine extends ThinEngine {
         };
 
         this._onCanvasPointerOut = (ev) => {
+            // Check for canvas and if there is a canvas, make sure that this callback is only fired when the cursor exits the canvas
+            // Note: This is a workaround for a bug with Safari
             let rect = this.getInputElementClientRect();
-            console.log(rect);
+
             if (rect) {
                 let pointerX = ev.clientX - rect.left;
                 let pointerY = ev.clientY - rect.top;
                 if (pointerX < 0 || pointerX > rect.width || pointerY < 0 || pointerY > rect.height) {
-                    console.log(pointerX + ", " + pointerY);
                     this.onCanvasPointerOutObservable.notifyObservers(ev);
                 }
             }


### PR DESCRIPTION
In Safari, there is a bug that causes a pointerout event to fire after every pointerup if pointer capture is set.  This PR changes the logic of the observable to only activate if the cursor is outside of the canvas.