### PR TITLE
AutoRotate behavior - allow resetting the last interaction time

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -59,6 +59,7 @@
 - Extended functionality for pointer move with scene pointerMoveTrianglePredicate ([phaselock](https://github.com/lockphase))
 - Added the ability to load a GUI from the snippet server and project it onto a mesh ([PirateJC](https://github.com/piratejc))
 - Added `mapPanning` on `ArcRotateCamera` ([Hypnosss](https://github.com/Hypnosss))
+- Added resetLastInteractionTime() to the auto rotate behavior ([RaananW](https://github.com/RaananW))
 
 ### Engine
 

--- a/src/Behaviors/Cameras/autoRotationBehavior.ts
+++ b/src/Behaviors/Cameras/autoRotationBehavior.ts
@@ -161,6 +161,14 @@ export class AutoRotationBehavior implements Behavior<ArcRotateCamera> {
     }
 
     /**
+     * Force-reset the last interaction time
+     * @param customTime an optional time that will be used instead of the current last interaction time. For example `Date.now()`
+     */
+    public resetLastInteractionTime(customTime?: number): void {
+        this._lastInteractionTime = customTime ?? PrecisionDate.Now;
+    }
+
+    /**
      * Returns true if user is scrolling.
      * @return true if user is scrolling.
      */


### PR DESCRIPTION
The defaultr behavior is setting the last interaction time to -Infinity.

_lastInteractionTime is the last time a user triggered an input on the camera, but only after the behavior was constructed. which means that without user interaction on the first frame the camera will automatically start rotating.

This will allow the dev to force-update _lastInteractionTime when called. It's practically a "fake user interaction", while maintaining backwards compatibility.