### PR TITLE
Better design for a Persistent Popup

### DIFF
--- a/inspector/src/components/globalState.ts
+++ b/inspector/src/components/globalState.ts
@@ -190,4 +190,8 @@ export class GlobalState {
             camera.reservedDataStore.cameraGizmo = null;
         }
     }
+
+    public onSceneExplorerClosedObservable = new Observable<void>();
+    public onActionTabsClosedObservable = new Observable<void>();
+    public onEmbedHostClosedObservable = new Observable<void>();
 }

--- a/inspector/src/components/globalState.ts
+++ b/inspector/src/components/globalState.ts
@@ -193,5 +193,4 @@ export class GlobalState {
 
     public onSceneExplorerClosedObservable = new Observable<void>();
     public onActionTabsClosedObservable = new Observable<void>();
-    public onEmbedHostClosedObservable = new Observable<void>();
 }

--- a/inspector/src/components/popupComponent.tsx
+++ b/inspector/src/components/popupComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Inspector } from "../inspector";
 
-interface IPopupComponentProps {
+export interface IPopupComponentProps {
     id: string;
     title: string;
     size: { width: number; height: number };

--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -13,6 +13,7 @@ import { SceneExplorerComponent } from "./components/sceneExplorer/sceneExplorer
 import { EmbedHostComponent } from "./components/embedHost/embedHostComponent";
 import { PropertyChangedEvent } from "./components/propertyChangedEvent";
 import { GlobalState } from "./components/globalState";
+import { PopupComponent, IPopupComponentProps } from "./components/popupComponent";
 
 interface IInternalInspectorOptions extends IInspectorOptions {
     popup: boolean;
@@ -22,11 +23,19 @@ interface IInternalInspectorOptions extends IInspectorOptions {
     embedHostWidth?: string;
 }
 
+export interface IPersistentPopupConfiguration {
+    props: IPopupComponentProps;
+    children: React.ReactNode;
+    closeWhenSceneExplorerCloses?: boolean;
+    closeWhenActionTabsCloses?: boolean;
+}
+
 export class Inspector {
     private static _SceneExplorerHost: Nullable<HTMLElement>;
     private static _ActionTabsHost: Nullable<HTMLElement>;
     private static _EmbedHost: Nullable<HTMLElement>;
     private static _NewCanvasContainer: Nullable<HTMLElement>;
+    private static _PersistentPopupHost: Nullable<HTMLElement>;
 
     private static _SceneExplorerWindow: Window;
     private static _ActionTabsWindow: Window;
@@ -150,6 +159,8 @@ export class Inspector {
                     if (options.popup) {
                         this._SceneExplorerWindow.close();
                     }
+
+                    this._GlobalState.onSceneExplorerClosedObservable.notifyObservers();
                 },
             });
             ReactDOM.render(sceneExplorerElement, this._SceneExplorerHost);
@@ -208,6 +219,8 @@ export class Inspector {
                     if (options.popup) {
                         this._ActionTabsWindow.close();
                     }
+
+                    this._GlobalState.onActionTabsClosedObservable.notifyObservers();
                 },
                 initialTab: options.initialTab,
             });
@@ -268,6 +281,8 @@ export class Inspector {
                     if (options.popup) {
                         this._EmbedHostWindow.close();
                     }
+
+                    this._GlobalState.onEmbedHostClosedObservable.notifyObservers();
                 },
                 initialTab: options.initialTab,
             });
@@ -383,6 +398,7 @@ export class Inspector {
         if (options.embedMode && options.showExplorer && options.showInspector) {
             if (options.popup) {
                 this._CreateEmbedHost(scene, options, this._CreatePopup("INSPECTOR", "_EmbedHostWindow"), Inspector.OnSelectionChangeObservable);
+                this._EmbedHostWindow.addEventListener("beforeunload", () => this._GlobalState.onEmbedHostClosedObservable.notifyObservers());
             } else {
                 if (!rootElement) {
                     return;
@@ -413,12 +429,14 @@ export class Inspector {
                     this._SceneExplorerHost.style.width = "0";
                 }
                 this._CreateSceneExplorer(scene, options, this._CreatePopup("SCENE EXPLORER", "_SceneExplorerWindow"));
+                this._SceneExplorerWindow.addEventListener("beforeunload", () => this._GlobalState.onSceneExplorerClosedObservable.notifyObservers());
             }
             if (options.showInspector) {
                 if (this._ActionTabsHost) {
                     this._ActionTabsHost.style.width = "0";
                 }
                 this._CreateActionTabs(scene, options, this._CreatePopup("INSPECTOR", "_ActionTabsWindow"));
+                this._ActionTabsWindow.addEventListener("beforeunload", () => this._GlobalState.onActionTabsClosedObservable.notifyObservers());
             }
         } else {
             let parentControl = (options.globalRoot ? options.globalRoot : rootElement!.parentElement) as HTMLElement;
@@ -537,6 +555,7 @@ export class Inspector {
             this._RemoveElementFromDOM(this._ActionTabsHost);
 
             this._ActionTabsHost = null;
+            this._GlobalState.onEmbedHostClosedObservable.notifyObservers();
         }
 
         if (this._SceneExplorerHost) {
@@ -547,6 +566,7 @@ export class Inspector {
             }
 
             this._SceneExplorerHost = null;
+            this._GlobalState.onSceneExplorerClosedObservable.notifyObservers();
         }
 
         if (this._EmbedHost) {
@@ -556,6 +576,7 @@ export class Inspector {
                 this._EmbedHost.parentElement.removeChild(this._EmbedHost);
             }
             this._EmbedHost = null;
+            this._GlobalState.onEmbedHostClosedObservable.notifyObservers();
         }
 
         Inspector._OpenedPane = 0;
@@ -564,6 +585,45 @@ export class Inspector {
         if (!this._GlobalState.onPluginActivatedObserver) {
             SceneLoader.OnPluginActivatedObservable.remove(this._GlobalState.onPluginActivatedObserver);
             this._GlobalState.onPluginActivatedObserver = null;
+        }
+    }
+
+    private static _OnSceneExplorerClosedObserver: Nullable<Observer<void>>;
+    private static _OnActionTabsClosedObserver: Nullable<Observer<void>>;
+    private static _OnEmbedHostClosedObserver: Nullable<Observer<void>>;
+
+    public static _CreatePersistentPopup(config: IPersistentPopupConfiguration, hostElement: HTMLElement) {
+        if (this._PersistentPopupHost) {
+            this._ClosePersistentPopup();
+        }
+        this._PersistentPopupHost = hostElement.ownerDocument.createElement("div");
+        const popupElement = React.createElement(PopupComponent, config.props, config.children);
+        ReactDOM.render(popupElement, this._PersistentPopupHost);
+        if (config.closeWhenActionTabsCloses || config.closeWhenSceneExplorerCloses) {
+            this._OnEmbedHostClosedObserver = this._GlobalState.onEmbedHostClosedObservable.add(() => this._ClosePersistentPopup());
+            if (config.closeWhenSceneExplorerCloses) {
+                this._OnSceneExplorerClosedObserver = this._GlobalState.onSceneExplorerClosedObservable.add(() => this._ClosePersistentPopup());
+            }
+            if (config.closeWhenActionTabsCloses) {
+                this._OnActionTabsClosedObserver = this._GlobalState.onActionTabsClosedObservable.add(() => this._ClosePersistentPopup());
+            }
+        }     
+    }
+
+    public static _ClosePersistentPopup() {
+        if (this._PersistentPopupHost) {
+            ReactDOM.unmountComponentAtNode(this._PersistentPopupHost);
+            this._PersistentPopupHost.remove();
+            this._PersistentPopupHost = null;
+        }
+        if (this._OnSceneExplorerClosedObserver) {
+            this._GlobalState.onSceneExplorerClosedObservable.remove(this._OnSceneExplorerClosedObserver);
+        }
+        if (this._OnActionTabsClosedObserver) {
+            this._GlobalState.onActionTabsClosedObservable.remove(this._OnActionTabsClosedObserver);
+        }
+        if (this._OnEmbedHostClosedObserver) {
+            this._GlobalState.onEmbedHostClosedObservable.remove(this._OnEmbedHostClosedObserver);
         }
     }
 }

--- a/inspector/src/inspector.ts
+++ b/inspector/src/inspector.ts
@@ -45,6 +45,9 @@ export class Inspector {
     private static _OpenedPane = 0;
     private static _OnBeforeRenderObserver: Nullable<Observer<Scene>>;
 
+    private static _OnSceneExplorerClosedObserver: Nullable<Observer<void>>;
+    private static _OnActionTabsClosedObserver: Nullable<Observer<void>>;
+
     public static OnSelectionChangeObservable = new Observable<any>();
     public static OnPropertyChangedObservable = new Observable<PropertyChangedEvent>();
     private static _GlobalState = new GlobalState();
@@ -591,9 +594,6 @@ export class Inspector {
         }
     }
 
-    private static _OnSceneExplorerClosedObserver: Nullable<Observer<void>>;
-    private static _OnActionTabsClosedObserver: Nullable<Observer<void>>;
-
     public static _CreatePersistentPopup(config: IPersistentPopupConfiguration, hostElement: HTMLElement) {
         if (this._PersistentPopupHost) {
             this._ClosePersistentPopup();
@@ -620,9 +620,11 @@ export class Inspector {
         }
         if (this._OnSceneExplorerClosedObserver) {
             this._GlobalState.onSceneExplorerClosedObservable.remove(this._OnSceneExplorerClosedObserver);
+            this._OnSceneExplorerClosedObserver = null;
         }
         if (this._OnActionTabsClosedObserver) {
             this._GlobalState.onActionTabsClosedObservable.remove(this._OnActionTabsClosedObserver);
+            this._OnActionTabsClosedObserver = null;
         }
     }
 }


### PR DESCRIPTION
To open up a persistent popup:
```javascript
import {Inspector} from "./inspector"
const config = {
      props: 
           {id: "test",
            title: "test",
            size: {width: 800, height: 600},
            onClose: () => {}
      },
      children: <div>test</div>,
      closeWhenActionTabsCloses: true
  }

Inspector._CreatePersistentPopup(config, document.body);
```

To close a persistent popup: 
```javascript
Inspector.ClosePersistentPopup();
```