### PR TITLE
Add tooltips to inspector items

### DIFF
--- a/inspector/src/components/sceneExplorer/treeItemLabelComponent.tsx
+++ b/inspector/src/components/sceneExplorer/treeItemLabelComponent.tsx
@@ -24,7 +24,7 @@ export class TreeItemLabelComponent extends React.Component<ITreeItemLabelCompon
 
     render() {
         return (
-            <div className="title" onClick={() => this.onClick()}>
+            <div className="title" title={this.props.label} onClick={() => this.onClick()}>
                 <div className="titleIcon">
                     <FontAwesomeIcon icon={this.props.icon} color={this.props.color} />
                 </div>


### PR DESCRIPTION
It's currently very difficult to read lengthy names in the inspector. Your only option is to increase the width of the inspector, and there's a limit on how large it can grow to, so some names are just impossible to read. This is especially problematic because you'll often have multiple objects in a scene with names like `SomeReallyLongName_1` and `SomeReallyLongName_2`, making it difficult to distinguish between them.

This PR simply adds a tooltip so you can hover over an element and see the full name without needing to click on it.

![image](https://user-images.githubusercontent.com/1342157/143315240-30674ef0-8fd4-438e-a0fa-307a8330b647.png)
