### PR TITLE
prepass SSS + alpha bug

### DIFF
--- a/src/Shaders/pbr.fragment.fx
+++ b/src/Shaders/pbr.fragment.fx
@@ -612,7 +612,7 @@ void main(void) {
             float scatteringDiffusionProfile = 255.;
         #endif
 
-        gl_FragData[PREPASS_IRRADIANCE_INDEX] = vec4(clamp(irradiance, vec3(0.), vec3(1.)), scatteringDiffusionProfile / 255.); // Irradiance + SS diffusion profile
+        gl_FragData[PREPASS_IRRADIANCE_INDEX] = vec4(clamp(irradiance, vec3(0.), vec3(1.)), writeGeometryInfo * scatteringDiffusionProfile / 255.); // Irradiance + SS diffusion profile
     #else
         gl_FragData[0] = vec4(finalColor.rgb, finalColor.a);
     #endif


### PR DESCRIPTION
prepass now correctly doesn't write irradiance when pixels are under the alpha cutoff value of 0.4