### PR TITLE
Fix some .babylon files not loading anymore

### DIFF
--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -118,7 +118,7 @@ var loadDetailLevels = (scene: Scene, mesh: AbstractMesh) => {
 };
 
 var findParent = (parentId: any, scene: Scene) => {
-    if (isNaN(parentId)) {
+    if (typeof parentId !== "number") {
         return scene.getLastEntryById(parentId);
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/upgrading-from-alpha-37-to-alpha-61-multiple-issues/25603/8

`isNaN("12")` is false, which was the problem with the file linked in the forum thread.

`if (!Number.isFinite(parentId))` would be a better fix but it is not supported by IE11... See https://stackabuse.com/javascript-check-if-variable-is-a-number/

Note that `typeof` does not catch the `Infinite` / `NaN` values (those are `number` according to `typeof`) values but it's not a problem here.