### PR TITLE
Animation Groups: Serialize tags and add metadata

### DIFF
--- a/src/Animations/animationGroup.ts
+++ b/src/Animations/animationGroup.ts
@@ -9,6 +9,8 @@ import { EngineStore } from "../Engines/engineStore";
 
 import "./animatable";
 import { AbstractScene } from "../abstractScene";
+import { serialize } from "../Misc/decorators";
+import { Tags } from '../Misc/tags';
 
 /**
  * This class defines the direct association between an animation and a target
@@ -97,6 +99,12 @@ export class AnimationGroup implements IDisposable {
      * This observable will notify when all animations are playing.
      */
     public onAnimationGroupPlayObservable = new Observable<AnimationGroup>();
+
+    /**
+     * Gets or sets an object used to store user defined information for the node
+     */
+    @serialize()
+    public metadata: any = null;
 
     /**
      * Gets the first frame
@@ -599,6 +607,15 @@ export class AnimationGroup implements IDisposable {
             serializationObject.targetedAnimations[targetedAnimationIndex] = targetedAnimation.serialize();
         }
 
+        if (Tags && Tags.HasTags(this)) {
+            serializationObject.tags = Tags.GetTags(this);
+        }
+
+        // Metadata
+        if (this.metadata) {
+            serializationObject.metadata = this.metadata;
+        }
+
         return serializationObject;
     }
 
@@ -632,6 +649,14 @@ export class AnimationGroup implements IDisposable {
 
         if (parsedAnimationGroup.from !== null && parsedAnimationGroup.to !== null) {
             animationGroup.normalize(parsedAnimationGroup.from, parsedAnimationGroup.to);
+        }
+
+        if (Tags) {
+            Tags.AddTagsTo(animationGroup, parsedAnimationGroup.tags);
+        }
+
+        if (parsedAnimationGroup.metadata !== undefined) {
+            animationGroup.metadata = parsedAnimationGroup.metadata;
         }
 
         return animationGroup;

--- a/src/Animations/animationGroup.ts
+++ b/src/Animations/animationGroup.ts
@@ -9,7 +9,6 @@ import { EngineStore } from "../Engines/engineStore";
 
 import "./animatable";
 import { AbstractScene } from "../abstractScene";
-import { serialize } from "../Misc/decorators";
 import { Tags } from '../Misc/tags';
 
 /**
@@ -103,7 +102,6 @@ export class AnimationGroup implements IDisposable {
     /**
      * Gets or sets an object used to store user defined information for the node
      */
-    @serialize()
     public metadata: any = null;
 
     /**


### PR DESCRIPTION
Per forum request: https://forum.babylonjs.com/t/animationgroup-tags-or-metadata/25611

Adds metadata to animation groups. Also, animation groups will now serialize (and parse) tags.