### PR TITLE
Fix for GridMaterial line intersections

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -100,6 +100,7 @@
 
 ### Materials
 
+- Added property `useMaxLine` to `GridMaterial`, which affects the brightness of line intersections. ([BlakeOne](https://github.com/BlakeOne))
 - Added an `OcclusionMaterial` to simplify depth-only rendering of geometry ([rgerd](https://github.com/rgerd))
 - PrePass can now be used in `RenderTargets` speeding up effects like SSAO2 or MotionBlur ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Added support for morph targets to `ShaderMaterial` ([Popov72](https://github.com/Popov72))
@@ -245,7 +246,6 @@
 
 ## Bugs
 
-- Fix for GridMaterial line intersections, which were previously too bright. ([BlakeOne](https://github.com/BlakeOne))
 - Fix incorrect GUI.TextBlock width when resizeToFit is true & fontStyle is italic ([Kalkut](https://github.com/Kalkut))
 - Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -245,6 +245,7 @@
 
 ## Bugs
 
+- Fix for GridMaterial line intersections, which were previously too bright. ([BlakeOne](https://github.com/BlakeOne))
 - Fix incorrect GUI.TextBlock width when resizeToFit is true & fontStyle is italic ([Kalkut](https://github.com/Kalkut))
 - Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))

--- a/materialsLibrary/src/grid/grid.fragment.fx
+++ b/materialsLibrary/src/grid/grid.fragment.fx
@@ -90,8 +90,8 @@ void main(void) {
     y *= normalImpactOnAxis(normal.y);
     z *= normalImpactOnAxis(normal.z);
     
-    // Create the grid value by combining axis.
-    float grid=clamp(max(max(x,y),z),0.,1.);
+    // Create the grid value from the max axis.
+    float grid = clamp(max(max(x, y), z), 0., 1.);
     
     // Create the color.
     vec3 color = mix(mainColor, lineColor, grid);

--- a/materialsLibrary/src/grid/grid.fragment.fx
+++ b/materialsLibrary/src/grid/grid.fragment.fx
@@ -90,9 +90,14 @@ void main(void) {
     y *= normalImpactOnAxis(normal.y);
     z *= normalImpactOnAxis(normal.z);
     
+#ifdef MAX_LINE    
     // Create the grid value from the max axis.
     float grid = clamp(max(max(x, y), z), 0., 1.);
-    
+#else
+    // Create the grid value by combining axes.
+    float grid = clamp(x + y + z, 0., 1.);
+#endif
+
     // Create the color.
     vec3 color = mix(mainColor, lineColor, grid);
 

--- a/materialsLibrary/src/grid/grid.fragment.fx
+++ b/materialsLibrary/src/grid/grid.fragment.fx
@@ -91,7 +91,7 @@ void main(void) {
     z *= normalImpactOnAxis(normal.z);
     
     // Create the grid value by combining axis.
-    float grid = clamp(x + y + z, 0., 1.);
+    float grid=clamp(max(max(x,y),z),0.,1.);
     
     // Create the color.
     vec3 color = mix(mainColor, lineColor, grid);

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -27,7 +27,7 @@ class GridMaterialDefines extends MaterialDefines {
     public INSTANCES = false;
     public THIN_INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public SKIPFINALCOLORCLAMP = false;    
+    public SKIPFINALCOLORCLAMP = false;
 
     constructor() {
         super();

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -21,12 +21,13 @@ class GridMaterialDefines extends MaterialDefines {
     public TRANSPARENT = false;
     public FOG = false;
     public PREMULTIPLYALPHA = false;
+    public MAX_LINE = false;
     public UV1 = false;
     public UV2 = false;
     public INSTANCES = false;
     public THIN_INSTANCES = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
-    public SKIPFINALCOLORCLAMP = false;
+    public SKIPFINALCOLORCLAMP = false;    
 
     constructor() {
         super();
@@ -88,6 +89,12 @@ export class GridMaterial extends PushMaterial {
     @serialize()
     public preMultiplyAlpha = false;
 
+    /**
+     * Determines if the max line value will be used instead of the sum wherever grid lines intersect.
+     */
+     @serialize()
+     public useMaxLine = false;
+
     @serializeAsTexture("opacityTexture")
     private _opacityTexture: BaseTexture;
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
@@ -140,6 +147,11 @@ export class GridMaterial extends PushMaterial {
 
         if (defines.PREMULTIPLYALPHA != this.preMultiplyAlpha) {
             defines.PREMULTIPLYALPHA = !defines.PREMULTIPLYALPHA;
+            defines.markAsUnprocessed();
+        }
+
+        if (defines.MAX_LINE != this.useMaxLine) {
+            defines.MAX_LINE = !defines.MAX_LINE;
             defines.markAsUnprocessed();
         }
 

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -92,8 +92,8 @@ export class GridMaterial extends PushMaterial {
     /**
      * Determines if the max line value will be used instead of the sum wherever grid lines intersect.
      */
-     @serialize()
-     public useMaxLine = false;
+    @serialize()
+    public useMaxLine = false;
 
     @serializeAsTexture("opacityTexture")
     private _opacityTexture: BaseTexture;
@@ -150,7 +150,7 @@ export class GridMaterial extends PushMaterial {
             defines.markAsUnprocessed();
         }
 
-        if (defines.MAX_LINE != this.useMaxLine) {
+        if (defines.MAX_LINE !== this.useMaxLine) {
             defines.MAX_LINE = !defines.MAX_LINE;
             defines.markAsUnprocessed();
         }


### PR DESCRIPTION
Fixes the issue seen in the below playground where the points of intersection between the grid lines are too bright, by using the max axis contribution instead of the sum of the axes contributions.

Playground: https://playground.babylonjs.com/#2KKVBH#113
Forum: https://forum.babylonjs.com/t/fix-for-gridmaterial-line-intersections/25644