### PR TITLE
Fixing setParent with pivot

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -345,6 +345,7 @@
 - Fix issue with wrong definition of a returned BASIS format ([RaananW](https://github.com/RaananW))
 - Fix glTF exporter exports unused materials from excluded meshes ([daoshengmu](https://github.com/daoshengmu))
 - Fix glTFLoader 2.0 when dealing with glTF files that contain no meshes ([simonihmig](https://github.com/simonihmig))
+- Fix issue with setParent and meshes with a pivot ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Behaviors/Meshes/followBehavior.ts
+++ b/src/Behaviors/Meshes/followBehavior.ts
@@ -344,7 +344,7 @@ export class FollowBehavior implements Behavior<TransformNode> {
     }
 
     private _updateLeashing(camera: Camera) {
-        if (this.attachedNode) {
+        if (this.attachedNode && this._enabled) {
             let oldParent = this.attachedNode.parent;
             this.attachedNode.setParent(null);
 

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -765,7 +765,7 @@ export class TransformNode extends Node {
         this.computeWorldMatrix(true);
 
         let currentRotation = this.rotationQuaternion;
-        if(!currentRotation) {
+        if (!currentRotation) {
             currentRotation = TransformNode._TmpRotation;
             Quaternion.RotationYawPitchRollToRef(this._rotation.y, this._rotation.x, this._rotation.z, currentRotation);
         }

--- a/src/Meshes/transformNode.ts
+++ b/src/Meshes/transformNode.ts
@@ -203,9 +203,9 @@ export class TransformNode extends Node {
      * return true if a pivot has been set
      * @returns true if a pivot matrix is used
      */
-     public isUsingPivotMatrix(): boolean {
-         return this._usePivotMatrix;
-     }
+    public isUsingPivotMatrix(): boolean {
+        return this._usePivotMatrix;
+    }
 
     /**
       * Gets or sets the rotation property : a Vector3 defining the rotation value in radians around each local axis X, Y, Z  (default is (0.0, 0.0, 0.0)).
@@ -732,17 +732,16 @@ export class TransformNode extends Node {
     * @param property if set to "rotation" the objects rotationQuaternion will be set to null
     * @returns this  node
     */
-     public markAsDirty(property?: string): Node {
-        // We need to explicitely update the children
+    public markAsDirty(property?: string): Node {
+        // We need to explicitly update the children
         // as the scene.evaluateActiveMeshes will not poll the transform nodes
         if (this._children) {
-            for (let child of this._children)
-            {
+            for (let child of this._children) {
                 child.markAsDirty(property);
             }
         }
         return super.markAsDirty(property);
-     }
+    }
 
     /**
      * Defines the passed node as the parent of the current node.
@@ -757,24 +756,27 @@ export class TransformNode extends Node {
             return this;
         }
 
-        var quatRotation = TmpVectors.Quaternion[0];
-        var position = TmpVectors.Vector3[0];
-        var scale = TmpVectors.Vector3[1];
+        const quatRotation = TmpVectors.Quaternion[0];
+        const position = TmpVectors.Vector3[0];
+        const scale = TmpVectors.Vector3[1];
+        const invParentMatrix = TmpVectors.Matrix[1];
+        Matrix.IdentityToRef(invParentMatrix);
+        const diffMatrix = TmpVectors.Matrix[0];
+        this.computeWorldMatrix(true);
 
-        if (!node) {
-            this.computeWorldMatrix(true);
-            this.getWorldMatrix().decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
-        } else {
-            var diffMatrix = TmpVectors.Matrix[0];
-            var invParentMatrix = TmpVectors.Matrix[1];
-
-            this.computeWorldMatrix(true);
-            node.computeWorldMatrix(true);
-
-            node.getWorldMatrix().invertToRef(invParentMatrix);
-            this.getWorldMatrix().multiplyToRef(invParentMatrix, diffMatrix);
-            diffMatrix.decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
+        // current global transformation without pivot
+        Matrix.ComposeToRef(this.scaling, this.rotationQuaternion || Quaternion.RotationYawPitchRoll(this.rotation.y, this.rotation.x, this.rotation.z), this.position, diffMatrix);
+        if (this.parent) {
+            this.parent.computeWorldMatrix(true).invertToRef(invParentMatrix);
+            diffMatrix.multiplyToRef(invParentMatrix, diffMatrix);
         }
+
+        if (node) {
+            node.computeWorldMatrix(true).invertToRef(invParentMatrix);
+            diffMatrix.multiplyToRef(invParentMatrix, diffMatrix);
+            (diffMatrix).decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
+        }
+        diffMatrix.decompose(scale, quatRotation, position, preserveScalingSign ? this : undefined);
 
         if (this.rotationQuaternion) {
             this.rotationQuaternion.copyFrom(quatRotation);


### PR DESCRIPTION
Fixes #11524

When using the `setParent` on a node with a pivot the pivot would have been applied to the final transformation (world matrix) of the node and decompose would take this values. This would lead to a never-ending movement on the node's side. See this playground:

https://playground.babylonjs.com/#2J03YY#8

This PR fixes this issue.

Issue #11524 is influenced by this bug and will be fixes when this is merged.