### PR TITLE
Update addContainerTask and addMeshTask signatures

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -60,6 +60,7 @@
 - Added the ability to load a GUI from the snippet server and project it onto a mesh ([PirateJC](https://github.com/piratejc))
 - Added `mapPanning` on `ArcRotateCamera` ([Hypnosss](https://github.com/Hypnosss))
 - Added resetLastInteractionTime() to the auto rotate behavior ([RaananW](https://github.com/RaananW))
+- Update `addContainerTask` and `addMeshTask` signatures on `AssetsManager` to allow receiving a File as the sceneFilename argument. ([carolhmj](https://github.com/carolhmj))
 
 ### Engine
 

--- a/src/Misc/assetsManager.ts
+++ b/src/Misc/assetsManager.ts
@@ -928,10 +928,10 @@ export class AssetsManager {
      * @param taskName defines the name of the new task
      * @param meshesNames defines the name of meshes to load
      * @param rootUrl defines the root url to use to locate files
-     * @param sceneFilename defines the filename of the scene file
+     * @param sceneFilename defines the filename of the scene file or the File itself
      * @returns a new ContainerAssetTask object
      */
-    public addContainerTask(taskName: string, meshesNames: any, rootUrl: string, sceneFilename: string): ContainerAssetTask {
+    public addContainerTask(taskName: string, meshesNames: any, rootUrl: string, sceneFilename: string | File): ContainerAssetTask {
         var task = new ContainerAssetTask(taskName, meshesNames, rootUrl, sceneFilename);
         this._tasks.push(task);
 
@@ -943,10 +943,10 @@ export class AssetsManager {
      * @param taskName defines the name of the new task
      * @param meshesNames defines the name of meshes to load
      * @param rootUrl defines the root url to use to locate files
-     * @param sceneFilename defines the filename of the scene file
+     * @param sceneFilename defines the filename of the scene file or the File itself
      * @returns a new MeshAssetTask object
      */
-    public addMeshTask(taskName: string, meshesNames: any, rootUrl: string, sceneFilename: string): MeshAssetTask {
+    public addMeshTask(taskName: string, meshesNames: any, rootUrl: string, sceneFilename: string | File): MeshAssetTask {
         var task = new MeshAssetTask(taskName, meshesNames, rootUrl, sceneFilename);
         this._tasks.push(task);
 


### PR DESCRIPTION
Without the PR, this playgrounds doesn't work on Typescript because of types: https://playground.babylonjs.com/#1FJAXJ#14
With the PR, it accepts the argument and create the tasks successfully.
