### PR TITLE
Playground - Typescript is not registered issue

### DIFF
--- a/Playground/src/components/errorDisplayComponent.tsx
+++ b/Playground/src/components/errorDisplayComponent.tsx
@@ -48,8 +48,9 @@ export class ErrorDisplayComponent extends React.Component<IErrorDisplayComponen
 
         return (
             <div className="error-display" onClick={() => this._onClick()}>
+                {typeof this.state.error === "string" && this.state.error}
                 {this.state.error.lineNumber && this.state.error.columnNumber && `Error at [${this.state.error.lineNumber}, ${this.state.error.columnNumber}]: `}
-                {typeof this.state.error.message === "string" ? this.state.error.message : this.state.error.message.messageText}
+                {this.state.error.message && (typeof this.state.error.message === "string" ? this.state.error.message : this.state.error.message.messageText)}
             </div>
         );
     }

--- a/Playground/src/components/rendererComponent.tsx
+++ b/Playground/src/components/rendererComponent.tsx
@@ -366,7 +366,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 });
             }
         } catch (err) {
-            console.error(err, "retrying if possible. If this error persists please notify the team.");
+            console.error(err, "Retrying if possible. If this error persists please notify the team.");
             this.props.globalState.onErrorObservable.notifyObservers(this._tmpErrorEvent || err);
         }
     }

--- a/Playground/src/components/rendererComponent.tsx
+++ b/Playground/src/components/rendererComponent.tsx
@@ -366,7 +366,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 });
             }
         } catch (err) {
-            console.error(err);
+            console.error(err, "retrying if possible. If this error persists please notify the team.");
             this.props.globalState.onErrorObservable.notifyObservers(this._tmpErrorEvent || err);
         }
     }


### PR DESCRIPTION
When monaco is not yet ready it throws an error ("typescript is not registered"). 
In the version of monaco we are using there is no way to check if the language is already registered - see related open issue - https://github.com/microsoft/monaco-editor/issues/115

The code will be reloaded once typescript is registered, so there is a short delay and the issue resolves. The problem was that the error display component was trying to display this error, which is a string (and not in the format it expected).

This resolves the issue.