### PR TITLE
[GUI] Correct pointer events for rig cameras

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -167,6 +167,7 @@
 - `VolumeBasedPanel`'s constructor now accepts a name parameter, similar to other controls ([rickfromwork](https://github.com/rickfromwork))
 - Added `loadLayoutAsync` in the `XmlLoader`. Now the layouts can be loaded asynchronously rather than providing a callback.
 - Introduced a new opt-in property to `Gui3DManager`, `useRealisticScaling`, that will automatically scale 3D GUI components like buttons to MRTK standards for better sizing in XR experiences. ([rickfromwork](https://github.com/rickfromwork))
+- Added support for full screen UI and rig cameras ([#11544](https://github.com/BabylonJS/Babylon.js/issues/11544)) ([RaananW](https://github.com/RaananW))
 
 ### Behaviors
 

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -810,8 +810,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 this._defaultMousePointerId = (pi.event as IPointerEvent).pointerId; // This is required to make sure we have the correct pointer ID for wheel
             }
 
-            let camera = scene.cameraToUseForPointers || scene.activeCamera;
-            let engine = scene.getEngine();
+            const camera = scene.cameraToUseForPointers || scene.activeCamera;
+            const engine = scene.getEngine();
+            const originalCameraToUseForPointers = scene.cameraToUseForPointers;
 
             if (!camera) {
                 tempViewport.x = 0;
@@ -819,8 +820,32 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 tempViewport.width = engine.getRenderWidth();
                 tempViewport.height = engine.getRenderHeight();
             } else {
-                camera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), tempViewport);
+                if (camera.rigCameras.length) {
+                    // rig camera - we need to find the camera to use for this event
+                    let rigViewport = new Viewport(0, 0, 1, 1);
+                    camera.rigCameras.forEach((rigCamera) => {
+                        // generate the viewport of this camera
+                        rigCamera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), rigViewport);
+                        let x = scene.pointerX / engine.getHardwareScalingLevel() - rigViewport.x;
+                        let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - rigViewport.y - rigViewport.height);
+                        // check if the pointer is in the camera's viewport
+                        if (x < 0 || y < 0 || x > rigViewport.width || y > rigViewport.height) {
+                            // out of viewport - don't use this camera
+                            return;
+                        }
+                        // set the camera to use for pointers until this pointer loop is over
+                        scene.cameraToUseForPointers = rigCamera;
+                        // set the viewport
+                        tempViewport.x = rigViewport.x;
+                        tempViewport.y = rigViewport.y;
+                        tempViewport.width = rigViewport.width;
+                        tempViewport.height = rigViewport.height;
+                    });
+                } else {
+                    camera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), tempViewport);
+                }
             }
+
 
             let x = scene.pointerX / engine.getHardwareScalingLevel() - tempViewport.x;
             let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - tempViewport.y - tempViewport.height);
@@ -832,6 +857,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             if (this._shouldBlockPointer) {
                 pi.skipOnPointerObservable = this._shouldBlockPointer;
             }
+            // if overridden by a rig camera - reset back to the original value
+            scene.cameraToUseForPointers = originalCameraToUseForPointers;
         });
         this._attachToOnPointerOut(scene);
         this._attachToOnBlur(scene);

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -846,7 +846,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 }
             }
 
-
             let x = scene.pointerX / engine.getHardwareScalingLevel() - tempViewport.x;
             let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - tempViewport.y - tempViewport.height);
             this._shouldBlockPointer = false;


### PR DESCRIPTION
Pointer events were using the current active camera, but in case of a camera with rig children it would take the parent camera and its viewport.

This PR sets the camera to be used with pointers for the rig camera that the mouse is in its viewport (and resets it afterwards).

Fixes #11544