### PR TITLE
Modified Safari pointerout workaround to use elementFromPoint

### DIFF
--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -657,16 +657,10 @@ export class Engine extends ThinEngine {
         };
 
         this._onCanvasPointerOut = (ev) => {
-            // Check for canvas and if there is a canvas, make sure that this callback is only fired when the cursor exits the canvas
+            // Check that the element at the point of the pointer out isn't the canvas and if it isn't, notify observers
             // Note: This is a workaround for a bug with Safari
-            let rect = this.getInputElementClientRect();
-
-            if (rect) {
-                let pointerX = ev.clientX - rect.left;
-                let pointerY = ev.clientY - rect.top;
-                if (pointerX < 0 || pointerX > rect.width || pointerY < 0 || pointerY > rect.height) {
-                    this.onCanvasPointerOutObservable.notifyObservers(ev);
-                }
+            if (document.elementFromPoint(ev.clientX, ev.clientY) !== canvas) {
+                this.onCanvasPointerOutObservable.notifyObservers(ev);
             }
         };
 


### PR DESCRIPTION
This PR contains a change for `engine.onCanvasPointerOutObservable` to use `document.elementFromPoint` rather than manually calculating where the pointer is and seeing if it was in the canvas.