### PR TITLE
Add new universalPadding to GUI controls

### DIFF
--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -383,16 +383,16 @@ export class Container extends Control {
                     if (child._layout(this._measureForChildren, context)) {
 
                         if (this.adaptWidthToChildren && child._width.isPixel) {
-                            computedWidth = Math.max(computedWidth, child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels);
+                            computedWidth = Math.max(computedWidth, child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels);
                         }
                         if (this.adaptHeightToChildren && child._height.isPixel) {
-                            computedHeight = Math.max(computedHeight, child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels);
+                            computedHeight = Math.max(computedHeight, child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels);
                         }
                     }
                 }
 
                 if (this.adaptWidthToChildren && computedWidth >= 0) {
-                    computedWidth += this.paddingLeftInPixels + this.paddingRightInPixels;
+                    computedWidth += this._paddingLeftInPixels + this._paddingRightInPixels;
                     if (this.width !== computedWidth + "px") {
                         this.parent?._markAsDirty();
                         this.width = computedWidth + "px";
@@ -400,7 +400,7 @@ export class Container extends Control {
                     }
                 }
                 if (this.adaptHeightToChildren && computedHeight >= 0) {
-                    computedHeight += this.paddingTopInPixels + this.paddingBottomInPixels;
+                    computedHeight += this._paddingTopInPixels + this._paddingBottomInPixels;
                     if (this.height !== computedHeight + "px") {
                         this.parent?._markAsDirty();
                         this.height = computedHeight + "px";

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -66,7 +66,7 @@ export class Control {
     public _prevCurrentMeasureTransformedIntoGlobalSpace = Measure.Empty();
     /** @hidden */
     protected _cachedParentMeasure = Measure.Empty();
-    private _universalPadding  = false;
+    private _descendentsOnlyPadding = false;
     private _paddingLeft = new ValueAndUnit(0);
     private _paddingRight = new ValueAndUnit(0);
     private _paddingTop = new ValueAndUnit(0);
@@ -798,19 +798,20 @@ export class Control {
     }
 
     /**
-     * Gets or sets a value indicating the padding should work like in CSS (inside the control)
+     * Gets or sets a value indicating the padding should work like in CSS.
+     * Basically, it will add the padding amount on each side of the parent control for its children.
      */
      @serialize()
-     public get universalPadding(): boolean {
-        return this._universalPadding;
+     public get descendentsOnlyPadding(): boolean {
+        return this._descendentsOnlyPadding;
      }
  
-     public set universalPadding(value: boolean) {
-        if (this._universalPadding === value) {
+     public set descendentsOnlyPadding(value: boolean) {
+        if (this._descendentsOnlyPadding === value) {
              return;
         }
 
-        this._universalPadding = value;
+        this._descendentsOnlyPadding = value;
         this._markAsDirty();
      } 
 
@@ -846,7 +847,7 @@ export class Control {
 
     /** @hidden */
     public get _paddingLeftInPixels(): number {
-        if (this._universalPadding) {
+        if (this._descendentsOnlyPadding) {
             return 0;
         }
 
@@ -885,7 +886,7 @@ export class Control {
 
     /** @hidden */
     public get _paddingRightInPixels(): number {
-        if (this._universalPadding) {
+        if (this._descendentsOnlyPadding) {
             return 0;
         }
 
@@ -924,7 +925,7 @@ export class Control {
  
     /** @hidden */
     public get _paddingTopInPixels(): number {
-        if (this._universalPadding) {
+        if (this._descendentsOnlyPadding) {
             return 0;
         }
 
@@ -963,7 +964,7 @@ export class Control {
 
     /** @hidden */
     public get _paddingBottomInPixels(): number {
-        if (this._universalPadding) {
+        if (this._descendentsOnlyPadding) {
             return 0;
         }
 
@@ -1656,7 +1657,7 @@ export class Control {
         this._tempPaddingMeasure.copyFrom(parentMeasure);
 
         // Apply padding if in correct mode
-        if (this.parent && this.parent.universalPadding) {
+        if (this.parent && this.parent.descendentsOnlyPadding) {
             this._tempPaddingMeasure.left += this.parent.paddingLeftInPixels;
             this._tempPaddingMeasure.top += this.parent.paddingTopInPixels;
             this._tempPaddingMeasure.width -= this.parent.paddingLeftInPixels + this.parent.paddingRightInPixels;   
@@ -1777,7 +1778,7 @@ export class Control {
                 break;
         }
 
-        if (!this.universalPadding) {
+        if (!this.descendentsOnlyPadding) {
             if (this._paddingLeft.isPixel) {
                 this._currentMeasure.left += this._paddingLeft.getValue(this._host);
                 this._currentMeasure.width -= this._paddingLeft.getValue(this._host);

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -813,7 +813,7 @@ export class Control {
 
         this._descendentsOnlyPadding = value;
         this._markAsDirty();
-     } 
+     }
 
     /**
      * Gets or sets a value indicating the padding to use on the left of the control
@@ -922,7 +922,7 @@ export class Control {
         }
         this.paddingTop = value + "px";
     }
- 
+
     /** @hidden */
     public get _paddingTopInPixels(): number {
         if (this._descendentsOnlyPadding) {
@@ -1660,7 +1660,7 @@ export class Control {
         if (this.parent && this.parent.descendentsOnlyPadding) {
             this._tempPaddingMeasure.left += this.parent.paddingLeftInPixels;
             this._tempPaddingMeasure.top += this.parent.paddingTopInPixels;
-            this._tempPaddingMeasure.width -= this.parent.paddingLeftInPixels + this.parent.paddingRightInPixels;   
+            this._tempPaddingMeasure.width -= this.parent.paddingLeftInPixels + this.parent.paddingRightInPixels;
             this._tempPaddingMeasure.height -= this.parent.paddingTopInPixels + this.parent.paddingBottomInPixels;
         }
 

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -806,7 +806,7 @@ export class Control {
      public get descendentsOnlyPadding(): boolean {
         return this._descendentsOnlyPadding;
      }
- 
+
      public set descendentsOnlyPadding(value: boolean) {
         if (this._descendentsOnlyPadding === value) {
              return;

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -37,6 +37,7 @@ export class Control {
     public parent: Nullable<Container>;
     /** @hidden */
     public _currentMeasure = Measure.Empty();
+    /** @hidden */
     public _tempPaddingMeasure = Measure.Empty();
     private _fontFamily = "Arial";
     private _fontStyle = "";

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -146,7 +146,7 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                     }
                 } else {
-                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels;
+                    stackHeight += child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels;
                 }
             } else {
                 if (child.left !== stackWidth + "px") {
@@ -160,13 +160,13 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                     }
                 } else {
-                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels;
+                    stackWidth += child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels;
                 }
             }
         }
 
-        stackWidth += this.paddingLeftInPixels + this.paddingRightInPixels;
-        stackHeight += this.paddingTopInPixels + this.paddingBottomInPixels;
+        stackWidth += this._paddingLeftInPixels + this._paddingRightInPixels;
+        stackHeight += this._paddingTopInPixels + this._paddingBottomInPixels;
 
         this._doNotTrackManualChanges = true;
 

--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -308,13 +308,13 @@ export class TextBlock extends Control {
 
         if (this._resizeToFit) {
             if (this._textWrapping === TextWrapping.Clip) {
-                let newWidth = (this.paddingLeftInPixels + this.paddingRightInPixels + maxLineWidth) | 0;
+                let newWidth = (this._paddingLeftInPixels + this._paddingRightInPixels + maxLineWidth) | 0;
                 if (newWidth !== this._width.internalValue) {
                     this._width.updateInPlace(newWidth, ValueAndUnit.UNITMODE_PIXEL);
                     this._rebuildLayout = true;
                 }
             }
-            let newHeight = (this.paddingTopInPixels + this.paddingBottomInPixels + this._fontOffset.height * this._lines.length) | 0;
+            let newHeight = (this._paddingTopInPixels + this._paddingBottomInPixels + this._fontOffset.height * this._lines.length) | 0;
 
             if (this._lines.length > 0 && this._lineSpacing.internalValue !== 0) {
                 let lineSpacing = 0;
@@ -529,9 +529,9 @@ export class TextBlock extends Control {
                 if (!this._fontOffset) {
                     this._fontOffset = Control._GetFontOffset(context.font);
                 }
-                const lines = this._lines ? this._lines : this._breakLines(this.widthInPixels - this.paddingLeftInPixels - this.paddingRightInPixels, context);
+                const lines = this._lines ? this._lines : this._breakLines(this.widthInPixels - this._paddingLeftInPixels - this._paddingRightInPixels, context);
 
-                let newHeight = this.paddingTopInPixels + this.paddingBottomInPixels + this._fontOffset.height * lines.length;
+                let newHeight = this._paddingTopInPixels + this._paddingBottomInPixels + this._fontOffset.height * lines.length;
 
                 if (lines.length > 0 && this._lineSpacing.internalValue !== 0) {
                     let lineSpacing = 0;


### PR DESCRIPTION
With a 10px padding on left and right on the green rectangle (which contains the red one)
Before:
![image](https://user-images.githubusercontent.com/1306056/144328928-9470d8d5-24d8-4da4-af04-db5a58a7fb90.png)

After:
![image](https://user-images.githubusercontent.com/1306056/144329017-938f1186-1e97-41ec-8dab-e3e80c6a056d.png)


Code:
```
 // GUI
  var advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("UI");

  var rect1 = new BABYLON.GUI.Rectangle();
  rect1.width = 0.2;
  rect1.height = "40px";
  rect1.color = "Orange";
  rect1.thickness = 4;
  rect1.background = "green";
  rect1.paddingLeft = "10px";
  rect1.paddingRight = "10px";
  advancedTexture.addControl(rect1);

  var rect2 = new BABYLON.GUI.Rectangle();
  rect2.width= "100%";
  rect2.height= "100%";
  rect2.background = "red";

  rect1.addControl(rect2);   


  var panel = new BABYLON.GUI.StackPanel();
  panel.width = "200px";
  panel.isVertical = false;
  panel.horizontalAlignment = BABYLON.GUI.Control.HORIZONTAL_ALIGNMENT_RIGHT;
  panel.verticalAlignment = BABYLON.GUI.Control.VERTICAL_ALIGNMENT_CENTER;
  advancedTexture.addControl(panel);

  var checkbox = new BABYLON.GUI.Checkbox();
  checkbox.width = "20px";
  checkbox.height = "20px";
  checkbox.isChecked = false;
  checkbox.color = "green";
  checkbox.onIsCheckedChangedObservable.add(function(value) {
      rect1.universalPadding = !rect1.universalPadding
  });
  panel.addControl(checkbox);    

  var header = new BABYLON.GUI.TextBlock();
  header.text = "New mode";
  header.width = "180px";
  header.marginLeft = "5px";
  header.textHorizontalAlignment = BABYLON.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
  header.color = "white";
  panel.addControl(header);   
```

cc @PatrickRyanMS FYI