### PR TITLE
add support for stackPanel.childSpacing

### DIFF
--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -145,9 +145,11 @@ export class StackPanel extends Container {
     }
 
     protected _postMeasure(): void {
-        var stackWidth = 0;
-        var stackHeight = 0;
-        for (var child of this._children) {
+        let stackWidth = 0;
+        let stackHeight = 0;
+        const childrenCount = this._children.length;
+        for (let index = 0; index < childrenCount; index++) {
+            const child = this._children[index];
             if (!child.isVisible || child.notRenderable) {
                 continue;
             }
@@ -164,7 +166,7 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                     }
                 } else {
-                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels + this._spacing;
+                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }
             } else {
                 if (child.left !== stackWidth + "px") {
@@ -178,15 +180,9 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                     }
                 } else {
-                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels + this._spacing;
+                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }
             }
-        }
-
-        if (this._isVertical) {
-            stackHeight -= this._spacing;
-        } else {
-            stackWidth -= this._spacing;
         }
 
         stackWidth += this.paddingLeftInPixels + this.paddingRightInPixels;

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -183,6 +183,12 @@ export class StackPanel extends Container {
             }
         }
 
+        if (this._isVertical) {
+            stackHeight -= this._childSpacing;
+        } else {
+            stackWidth -= this._childSpacing;
+        }
+
         stackWidth += this.paddingLeftInPixels + this.paddingRightInPixels;
         stackHeight += this.paddingTopInPixels + this.paddingBottomInPixels;
 

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -16,7 +16,7 @@ export class StackPanel extends Container {
     private _manualWidth = false;
     private _manualHeight = false;
     private _doNotTrackManualChanges = false;
-    private _childSpacing = 0;
+    private _spacing = 0;
 
     /**
      * Gets or sets a boolean indicating that layout warnings should be ignored
@@ -43,16 +43,16 @@ export class StackPanel extends Container {
      * Gets or sets the margin (in pixel) between each child.
      */
      @serialize()
-     public get childSpacing(): number {
-         return this._childSpacing;
+     public get spacing(): number {
+         return this._spacing;
      }
  
-     public set childSpacing(value: number) {
-         if (this._childSpacing === value) {
+     public set spacing(value: number) {
+         if (this._spacing === value) {
              return;
          }
  
-         this._childSpacing = value;
+         this._spacing = value;
          this._markAsDirty();
      }
 
@@ -164,7 +164,7 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                     }
                 } else {
-                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels + this._childSpacing;
+                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels + this._spacing;
                 }
             } else {
                 if (child.left !== stackWidth + "px") {
@@ -178,15 +178,15 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                     }
                 } else {
-                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels + this._childSpacing;
+                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels + this._spacing;
                 }
             }
         }
 
         if (this._isVertical) {
-            stackHeight -= this._childSpacing;
+            stackHeight -= this._spacing;
         } else {
-            stackWidth -= this._childSpacing;
+            stackWidth -= this._spacing;
         }
 
         stackWidth += this.paddingLeftInPixels + this.paddingRightInPixels;

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -40,7 +40,7 @@ export class StackPanel extends Container {
     }
 
     /**
-     * Gets or sets the margin (in pixel) between each child.
+     * Gets or sets the spacing (in pixels) between each child.
      */
      @serialize()
      public get spacing(): number {

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -46,12 +46,12 @@ export class StackPanel extends Container {
      public get spacing(): number {
          return this._spacing;
      }
- 
+
      public set spacing(value: number) {
          if (this._spacing === value) {
              return;
          }
- 
+
          this._spacing = value;
          this._markAsDirty();
      }

--- a/gui/src/2D/controls/stackPanel.ts
+++ b/gui/src/2D/controls/stackPanel.ts
@@ -16,9 +16,10 @@ export class StackPanel extends Container {
     private _manualWidth = false;
     private _manualHeight = false;
     private _doNotTrackManualChanges = false;
+    private _childSpacing = 0;
 
     /**
-     * Gets or sets a boolean indicating that layou warnings should be ignored
+     * Gets or sets a boolean indicating that layout warnings should be ignored
      */
     @serialize()
     public ignoreLayoutWarnings = false;
@@ -37,6 +38,23 @@ export class StackPanel extends Container {
         this._isVertical = value;
         this._markAsDirty();
     }
+
+    /**
+     * Gets or sets the margin (in pixel) between each child.
+     */
+     @serialize()
+     public get childSpacing(): number {
+         return this._childSpacing;
+     }
+ 
+     public set childSpacing(value: number) {
+         if (this._childSpacing === value) {
+             return;
+         }
+ 
+         this._childSpacing = value;
+         this._markAsDirty();
+     }
 
     /**
      * Gets or sets panel width.
@@ -146,7 +164,7 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                     }
                 } else {
-                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels;
+                    stackHeight += child._currentMeasure.height + child.paddingTopInPixels + child.paddingBottomInPixels + this._childSpacing;
                 }
             } else {
                 if (child.left !== stackWidth + "px") {
@@ -160,7 +178,7 @@ export class StackPanel extends Container {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                     }
                 } else {
-                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels;
+                    stackWidth += child._currentMeasure.width + child.paddingLeftInPixels + child.paddingRightInPixels + this._childSpacing;
                 }
             }
         }


### PR DESCRIPTION
Code:
```
  var panel = new BABYLON.GUI.StackPanel();    
  panel.childSpacing = 10;
  advancedTexture.addControl(panel);   

  var button = BABYLON.GUI.Button.CreateSimpleButton("but", "Click Me");
  button.width = 0.2;
  button.height = "40px";
  button.color = "white";
  button.background = "green";
  panel.addControl(button);     

  var button2 = BABYLON.GUI.Button.CreateSimpleButton("but2", "Click Me also!");
  button2.width = 0.2;
  button2.height = "40px";
  button2.color = "white";
  button2.background = "green";
  panel.addControl(button2);      
  
  button2 = BABYLON.GUI.Button.CreateSimpleButton("but2", "Click Me also!");
  button2.width = 0.2;
  button2.height = "40px";
  button2.color = "white";
  button2.background = "green";
  panel.addControl(button2);   

  button2 = BABYLON.GUI.Button.CreateSimpleButton("but2", "Click Me also!");
  button2.width = 0.2;
  button2.height = "40px";
  button2.color = "white";
  button2.background = "green";
  panel.addControl(button2);   

  button2 = BABYLON.GUI.Button.CreateSimpleButton("but2", "Click Me also!");
  button2.width = 0.2;
  button2.height = "40px";
  button2.color = "white";
  button2.background = "green";
  panel.addControl(button2);   
```

Output:
![image](https://user-images.githubusercontent.com/1306056/144330195-838133a5-f8d2-4384-9755-d3a2db2a1e6e.png)

