### PR TITLE
[XR] remove disabled features from the enabled list

### DIFF
--- a/src/XR/webXRFeaturesManager.ts
+++ b/src/XR/webXRFeaturesManager.ts
@@ -310,6 +310,7 @@ export class WebXRFeaturesManager implements IDisposable {
             feature.enabled = false;
             this.detachFeature(name);
             feature.featureImplementation.dispose();
+            delete this._features[name];
             return true;
         }
         return false;
@@ -321,7 +322,6 @@ export class WebXRFeaturesManager implements IDisposable {
     public dispose(): void {
         this.getEnabledFeatures().forEach((feature) => {
             this.disableFeature(feature);
-            this._features[feature].featureImplementation.dispose();
         });
     }
 


### PR DESCRIPTION
Until now we had a "enabled" flag, but it was not directly used when checking for colliding features.

Disabled features will now be out of the features list after being disposed correctly.