### PR TITLE
Eliminate coroutine step recursion

### DIFF
--- a/src/Misc/coroutine.ts
+++ b/src/Misc/coroutine.ts
@@ -117,7 +117,7 @@ export function runCoroutine<T>(coroutine: AsyncCoroutine<T>, scheduler: Corouti
                 reschedule = false;
             }
         } while (reschedule);
-    }
+    };
 
     resume();
 }

--- a/src/Misc/coroutine.ts
+++ b/src/Misc/coroutine.ts
@@ -116,7 +116,6 @@ export function runCoroutine<T>(coroutine: AsyncCoroutine<T>, scheduler: Corouti
                 // If shouldReschedule is defined at this point, then the coroutine must have stepped asynchronously, so stop looping and let the coroutine be resumed later.
                 reschedule = false;
             }
-
         } while (reschedule);
     }
 

--- a/src/Misc/observableCoroutine.ts
+++ b/src/Misc/observableCoroutine.ts
@@ -13,9 +13,9 @@ function createObservableScheduler<T>(observable: Observable<any>): { scheduler:
         }
     });
 
-    const scheduler = (coroutine: AsyncCoroutine<T>, onSuccess: (stepResult: CoroutineStep<T>) => void, onError: (stepError: any) => void) => {
+    const scheduler = (coroutine: AsyncCoroutine<T>, onStep: (stepResult: CoroutineStep<T>) => void, onError: (stepError: any) => void) => {
         coroutines.push(coroutine);
-        onSteps.push(onSuccess);
+        onSteps.push(onStep);
         onErrors.push(onError);
     };
 


### PR DESCRIPTION
I tried profiling `MergeMeshesAsync` in Safari and it was basically un-profilable. :) The problem was that coroutines can be stepped synchronously (either in batches for the yielding scheduler, or entirely with the inline scheduler), and when they are stepped synchronously it was done recursively (the `resume` function calling the `resume` function). This resulted in very deep call stacks, with CPU time spread over many stack frames that are conceptually the same function. To fix this, I changed the `runCoroutine` function to loop as long as stepping is synchronous, and only exit the loop when a step is asynchronous (in which case we rely on completion of the async step to resume the coroutine and start the loop again). This makes profiling wayyyy better.