### PR TITLE
DeviceInputSystem: Move Observables to single location

### DIFF
--- a/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
@@ -4,7 +4,7 @@ import { DeviceType } from "../InputDevices/deviceEnums";
 import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "../Interfaces/inputInterfaces";
 
 /** @hidden */
-export class NativeDeviceInputSystem implements IDeviceInputSystem {
+export class NativeDeviceInputSystemImpl implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onInputChanged = (deviceEvent: IDeviceEvent) => { };

--- a/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
@@ -1,38 +1,28 @@
-import { Observable } from "../../Misc/observable";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType } from "../InputDevices/deviceEnums";
 import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "../Interfaces/inputInterfaces";
 
 /** @hidden */
-export class NativeDeviceInputWrapper implements IDeviceInputSystem {
-    /**
-     * Observable for devices being connected
-     */
-    public readonly onDeviceConnectedObservable: Observable<{ deviceType: DeviceType; deviceSlot: number; }>;
-    /**
-     * Observable for devices being disconnected
-     */
-    public readonly onDeviceDisconnectedObservable: Observable<{ deviceType: DeviceType; deviceSlot: number; }>;
-    /**
-     * Observable for changes to device input
-     */
-    public readonly onInputChangedObservable: Observable<IDeviceEvent>;
+export class NativeDeviceInputSystem implements IDeviceInputSystem {
+    public onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
+    public onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
+    public onInputChanged: (deviceEvent: IDeviceEvent) => void;
 
     private _nativeInput: INativeInput;
 
     public constructor(nativeInput?: INativeInput) {
         this._nativeInput = nativeInput || this._createDummyNativeInput();
-        this.onDeviceConnectedObservable = new Observable<{ deviceType: DeviceType; deviceSlot: number; }>();
-        this.onDeviceDisconnectedObservable = new Observable<{ deviceType: DeviceType; deviceSlot: number; }>();
-        this.onInputChangedObservable = new Observable<IDeviceEvent>();
+        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onInputChanged = (deviceEvent: IDeviceEvent) => { };
 
         this._nativeInput.onDeviceConnected = (deviceType, deviceSlot) => {
-            this.onDeviceConnectedObservable.notifyObservers({ deviceType, deviceSlot });
+            this.onDeviceConnected(deviceType, deviceSlot);
         };
 
         this._nativeInput.onDeviceDisconnected = (deviceType, deviceSlot) => {
-            this.onDeviceDisconnectedObservable.notifyObservers({ deviceType, deviceSlot });
+            this.onDeviceDisconnected(deviceType, deviceSlot);
         };
 
         this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState, eventData) => {
@@ -45,7 +35,7 @@ export class NativeDeviceInputWrapper implements IDeviceInputSystem {
             deviceEvent.previousState = previousState;
             deviceEvent.currentState = currentState;
 
-            this.onInputChangedObservable.notifyObservers(deviceEvent);
+            this.onInputChanged(deviceEvent);
         };
     }
 
@@ -82,9 +72,9 @@ export class NativeDeviceInputWrapper implements IDeviceInputSystem {
      * Dispose of all the observables
      */
     public dispose(): void {
-        this.onDeviceConnectedObservable.clear();
-        this.onDeviceDisconnectedObservable.clear();
-        this.onInputChangedObservable.clear();
+        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onInputChanged = (deviceEvent: IDeviceEvent) => { };
     }
 
     /**

--- a/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/nativeDeviceInputSystem.ts
@@ -5,17 +5,14 @@ import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "../Interfaces/in
 
 /** @hidden */
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
-    public onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
-    public onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
-    public onInputChanged: (deviceEvent: IDeviceEvent) => void;
+    public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
+    public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
+    public onInputChanged = (deviceEvent: IDeviceEvent) => { };
 
-    private _nativeInput: INativeInput;
+    private readonly _nativeInput: INativeInput;
 
     public constructor(nativeInput?: INativeInput) {
         this._nativeInput = nativeInput || this._createDummyNativeInput();
-        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onInputChanged = (deviceEvent: IDeviceEvent) => { };
 
         this._nativeInput.onDeviceConnected = (deviceType, deviceSlot) => {
             this.onDeviceConnected(deviceType, deviceSlot);
@@ -72,9 +69,9 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
      * Dispose of all the observables
      */
     public dispose(): void {
-        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onInputChanged = (deviceEvent: IDeviceEvent) => { };
+        this.onDeviceConnected = () => { };
+        this.onDeviceDisconnected = () => { };
+        this.onInputChanged = () => { };
     }
 
     /**

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -10,7 +10,7 @@ import { IDeviceEvent, IDeviceInputSystem } from "../Interfaces/inputInterfaces"
 /** @hidden */
 export class WebDeviceInputSystem implements IDeviceInputSystem {
     /** onDeviceConnected property */
-    public set onDeviceConnected (callback: (deviceType: DeviceType, deviceSlot: number) => void) {
+    public set onDeviceConnected(callback: (deviceType: DeviceType, deviceSlot: number) => void) {
         this._onDeviceConnected = callback;
 
         // Iterate through each active device and rerun new callback
@@ -27,7 +27,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         }
     }
 
-    public get onDeviceConnected (): (deviceType: DeviceType, deviceSlot: number) => void {
+    public get onDeviceConnected(): (deviceType: DeviceType, deviceSlot: number) => void {
         return this._onDeviceConnected;
     }
 
@@ -79,9 +79,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._eventPrefix = Tools.GetPointerPrefix(engine);
         this._engine = engine;
 
-        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => {};
-        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => {};
-        this.onInputChanged = (deviceEvent: IDeviceEvent) => {};
+        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
+        this.onInputChanged = (deviceEvent: IDeviceEvent) => { };
 
         this.configureEvents();
     }
@@ -150,9 +150,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
      */
     public dispose(): void {
         // Observables
-        this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => {};
-        this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => {};
-        this.onInputChanged = (deviceEvent: IDeviceEvent) => {};
+        this.onDeviceConnected = () => { };
+        this.onDeviceDisconnected = () => { };
+        this.onInputChanged = () => { };
 
         if (this._elementToAttachTo) {
             this._removeEvents();

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -8,7 +8,7 @@ import { DeviceType, PointerInput } from "../InputDevices/deviceEnums";
 import { IDeviceEvent, IDeviceInputSystem } from "../Interfaces/inputInterfaces";
 
 /** @hidden */
-export class WebDeviceInputSystem implements IDeviceInputSystem {
+export class WebDeviceInputSystemImpl implements IDeviceInputSystem {
     /** onDeviceConnected property */
     public set onDeviceConnected(callback: (deviceType: DeviceType, deviceSlot: number) => void) {
         this._onDeviceConnected = callback;
@@ -209,7 +209,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
      */
     private _addPointerDevice(deviceType: DeviceType, deviceSlot: number, currentX: number, currentY: number) {
         this._pointerActive = true;
-        this._registerDevice(deviceType, deviceSlot, WebDeviceInputSystem.MAX_POINTER_INPUTS);
+        this._registerDevice(deviceType, deviceSlot, WebDeviceInputSystemImpl.MAX_POINTER_INPUTS);
         const pointer = this._inputs[deviceType][deviceSlot]; /* initialize our pointer position immediately after registration */
         pointer[0] = currentX;
         pointer[1] = currentY;
@@ -261,7 +261,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._keyboardDownEvent = ((evt) => {
             if (!this._keyboardActive) {
                 this._keyboardActive = true;
-                this._registerDevice(DeviceType.Keyboard, 0, WebDeviceInputSystem.MAX_KEYCODES);
+                this._registerDevice(DeviceType.Keyboard, 0, WebDeviceInputSystemImpl.MAX_KEYCODES);
             }
 
             const kbKey = this._inputs[DeviceType.Keyboard][0];
@@ -282,7 +282,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._keyboardUpEvent = ((evt) => {
             if (!this._keyboardActive) {
                 this._keyboardActive = true;
-                this._registerDevice(DeviceType.Keyboard, 0, WebDeviceInputSystem.MAX_KEYCODES);
+                this._registerDevice(DeviceType.Keyboard, 0, WebDeviceInputSystemImpl.MAX_KEYCODES);
             }
 
             const kbKey = this._inputs[DeviceType.Keyboard][0];
@@ -635,7 +635,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
             if (!this._inputs[deviceType][deviceSlot]) {
                 this._pointerActive = true;
-                this._registerDevice(deviceType, deviceSlot, WebDeviceInputSystem.MAX_POINTER_INPUTS);
+                this._registerDevice(deviceType, deviceSlot, WebDeviceInputSystemImpl.MAX_POINTER_INPUTS);
             }
 
             const pointer = this._inputs[deviceType][deviceSlot];

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -5,7 +5,7 @@ import { DeviceType } from './deviceEnums';
 import { Nullable } from '../../types';
 import { Observable } from '../../Misc/observable';
 import { DeviceInput } from './deviceTypes';
-import { IDeviceEvent, IDeviceInputSystem } from '../Interfaces/inputInterfaces';
+import { IDeviceEvent } from '../Interfaces/inputInterfaces';
 
 /**
  * Class that handles all input for a specific device
@@ -18,7 +18,7 @@ export class DeviceSource<T extends DeviceType> {
     public readonly onInputChangedObservable = new Observable<IDeviceEvent>();
 
     // Private Members
-    private readonly _deviceInputSystem: IDeviceInputSystem;
+    private readonly _deviceInputSystem: DeviceInputSystem;
 
     /**
      * Default Constructor
@@ -26,7 +26,7 @@ export class DeviceSource<T extends DeviceType> {
      * @param deviceType Type of device
      * @param deviceSlot "Slot" or index that device is referenced in
      */
-    constructor(deviceInputSystem: IDeviceInputSystem,
+    constructor(deviceInputSystem: DeviceInputSystem,
         /** Type of device */
         public readonly deviceType: DeviceType,
         /** "Slot" or index that device is referenced in */
@@ -68,7 +68,7 @@ export class DeviceSourceManager implements IDisposable {
     // Private Members
     private readonly _devices: Array<Array<DeviceSource<DeviceType>>>;
     private readonly _firstDevice: Array<number>;
-    private readonly _deviceInputSystem: IDeviceInputSystem;
+    private readonly _deviceInputSystem: DeviceInputSystem;
 
     /**
      * Default Constructor

--- a/src/DeviceInput/Interfaces/inputInterfaces.ts
+++ b/src/DeviceInput/Interfaces/inputInterfaces.ts
@@ -70,10 +70,19 @@ export interface INativeInput extends IDisposable {
  */
 export interface IDeviceInputSystem extends IDisposable {
     // Callbacks
+    /**
+     * Callback for when a device is connected
+     */
     onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
 
+    /**
+     * Callback for when a device is disconnected
+     */
     onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
 
+    /**
+     * Callback for when an input is changed
+     */
     onInputChanged: (deviceEvent: IDeviceEvent) => void;
 
     /**

--- a/src/DeviceInput/Interfaces/inputInterfaces.ts
+++ b/src/DeviceInput/Interfaces/inputInterfaces.ts
@@ -1,5 +1,4 @@
 import { IEvent } from "../../Events/deviceInputEvents";
-import { Observable } from "../../Misc/observable";
 import { IDisposable } from "../../scene";
 import { Nullable } from "../../types";
 import { DeviceType } from "../InputDevices/deviceEnums";
@@ -70,19 +69,12 @@ export interface INativeInput extends IDisposable {
  * Interface for DeviceInputSystem implementations (JS and Native)
  */
 export interface IDeviceInputSystem extends IDisposable {
-    // Observables
-    /**
-     * Observable for devices being connected
-     */
-    readonly onDeviceConnectedObservable: Observable<{ deviceType: DeviceType, deviceSlot: number }>;
-    /**
-     * Observable for devices being disconnected
-     */
-    readonly onDeviceDisconnectedObservable: Observable<{ deviceType: DeviceType, deviceSlot: number }>;
-    /**
-     * Observable for changes to device input
-     */
-    readonly onInputChangedObservable: Observable<IDeviceEvent>;
+    // Callbacks
+    onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
+
+    onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
+
+    onInputChanged: (deviceEvent: IDeviceEvent) => void;
 
     /**
      * Configures events to work with an engine's active element

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -1,8 +1,10 @@
 import { Engine } from '../Engines/engine';
 import { INative } from '../Engines/Native/nativeInterfaces';
-import { NativeDeviceInputWrapper } from './Implementations/nativeDeviceInputWrapper';
+import { Observable } from '../Misc/observable';
+import { NativeDeviceInputSystem } from './Implementations/nativeDeviceInputSystem';
 import { WebDeviceInputSystem } from './Implementations/webDeviceInputSystem';
-import { IDeviceInputSystem } from './Interfaces/inputInterfaces';
+import { DeviceType } from './InputDevices/deviceEnums';
+import { IDeviceEvent, IDeviceInputSystem } from './Interfaces/inputInterfaces';
 
 declare const _native: INative;
 
@@ -13,22 +15,75 @@ declare const _native: INative;
  * pointer device and one keyboard.
  */
 export class DeviceInputSystem {
+    // Observables
+    /**
+     * Observable for devices being connected
+     */
+    public readonly onDeviceConnectedObservable: Observable<{ deviceType: DeviceType; deviceSlot: number; }>;
+    /**
+     * Observable for devices being disconnected
+     */
+    public readonly onDeviceDisconnectedObservable: Observable<{ deviceType: DeviceType; deviceSlot: number; }>;
+    /**
+     * Observable for changes to device input
+     */
+    public readonly onInputChangedObservable: Observable<IDeviceEvent>;
+
+    private _deviceInputSystem: IDeviceInputSystem;
     /**
      * Creates a new DeviceInputSystem instance or returns existing one in engine
      * @param engine Engine to assign input system to
      * @returns The new instance
      */
-    public static Create(engine: Engine): IDeviceInputSystem {
+    public static Create(engine: Engine): DeviceInputSystem {
         // If running in Babylon Native, then defer to the native input system, which has the same public contract
         if (!engine.deviceInputSystem) {
             if (typeof _native !== 'undefined') {
-                engine.deviceInputSystem = (_native.DeviceInputSystem) ? new NativeDeviceInputWrapper(new _native.DeviceInputSystem()) : new NativeDeviceInputWrapper();
+                engine.deviceInputSystem = new DeviceInputSystem((_native.DeviceInputSystem) ? new NativeDeviceInputSystem(new _native.DeviceInputSystem()) : new NativeDeviceInputSystem());
             }
             else {
-                engine.deviceInputSystem = new WebDeviceInputSystem(engine);
+                engine.deviceInputSystem = new DeviceInputSystem(new WebDeviceInputSystem(engine));
             }
         }
 
         return engine.deviceInputSystem;
+    }
+
+    constructor(deviceInputSystem: IDeviceInputSystem) {
+        this._deviceInputSystem = deviceInputSystem;
+        this.onDeviceConnectedObservable = new Observable();
+        this.onDeviceDisconnectedObservable = new Observable();
+        this.onInputChangedObservable = new Observable<IDeviceEvent>();
+
+        this._deviceInputSystem.onDeviceConnected = (deviceType, deviceSlot) => {
+            this.onDeviceConnectedObservable.notifyObservers({ deviceType, deviceSlot });
+        };
+
+        this._deviceInputSystem.onDeviceDisconnected = (deviceType, deviceSlot) => {
+            this.onDeviceDisconnectedObservable.notifyObservers({ deviceType, deviceSlot });
+        };
+
+        this._deviceInputSystem.onInputChanged = (deviceEvent) => {
+            this.onInputChangedObservable.notifyObservers(deviceEvent);
+        };
+    }
+
+    public configureEvents() {
+        this._deviceInputSystem.configureEvents();
+    }
+
+    public pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): number {
+        return this._deviceInputSystem.pollInput(deviceType, deviceSlot, inputIndex);
+    }
+
+    public isDeviceAvailable(deviceType: DeviceType): boolean {
+        return this._deviceInputSystem.isDeviceAvailable(deviceType);
+    }
+
+    public dispose() {
+        this.onDeviceConnectedObservable.clear();
+        this.onDeviceDisconnectedObservable.clear();
+        this.onInputChangedObservable.clear();
+        this._deviceInputSystem.dispose();
     }
 }

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -38,17 +38,27 @@ export class DeviceInputSystem {
     public static Create(engine: Engine): DeviceInputSystem {
         // If running in Babylon Native, then defer to the native input system, which has the same public contract
         if (!engine.deviceInputSystem) {
+            let selectedDIS;
+
             if (typeof _native !== 'undefined') {
-                engine.deviceInputSystem = new DeviceInputSystem((_native.DeviceInputSystem) ? new NativeDeviceInputSystem(new _native.DeviceInputSystem()) : new NativeDeviceInputSystem());
+                selectedDIS = (_native.DeviceInputSystem) ? new NativeDeviceInputSystem(new _native.DeviceInputSystem()) : new NativeDeviceInputSystem();
             }
             else {
-                engine.deviceInputSystem = new DeviceInputSystem(new WebDeviceInputSystem(engine));
+                selectedDIS = new WebDeviceInputSystem(engine);
+            }
+
+            if (selectedDIS) {
+                engine.deviceInputSystem = new DeviceInputSystem(selectedDIS);
             }
         }
 
         return engine.deviceInputSystem;
     }
 
+    /**
+     * DeviceInputSystem constructor
+     * @param deviceInputSystem Web or Native implementation of DeviceInputSystem
+     */
     constructor(deviceInputSystem: IDeviceInputSystem) {
         this._deviceInputSystem = deviceInputSystem;
         this.onDeviceConnectedObservable = new Observable();
@@ -68,18 +78,36 @@ export class DeviceInputSystem {
         };
     }
 
+    /**
+     * Configure events to talk with DeviceInputSystem
+     */
     public configureEvents() {
         this._deviceInputSystem.configureEvents();
     }
 
+    /**
+     * Checks for current device input value, given an id and input index. Throws exception if requested device not initialized.
+     * @param deviceType Enum specifiying device type
+     * @param deviceSlot "Slot" or index that device is referenced in
+     * @param inputIndex Id of input to be checked
+     * @returns Current value of input
+     */
     public pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): number {
         return this._deviceInputSystem.pollInput(deviceType, deviceSlot, inputIndex);
     }
 
+    /**
+     * Check if there's an instance of device on given DeviceInputSystem
+     * @param deviceType Enum specifiying device type
+     * @returns
+     */
     public isDeviceAvailable(deviceType: DeviceType): boolean {
         return this._deviceInputSystem.isDeviceAvailable(deviceType);
     }
 
+    /**
+     * Dispose of DeviceInputSystem sub-elements
+     */
     public dispose() {
         this.onDeviceConnectedObservable.clear();
         this.onDeviceDisconnectedObservable.clear();

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -1,8 +1,8 @@
 import { Engine } from '../Engines/engine';
 import { INative } from '../Engines/Native/nativeInterfaces';
 import { Observable } from '../Misc/observable';
-import { NativeDeviceInputSystem } from './Implementations/nativeDeviceInputSystem';
-import { WebDeviceInputSystem } from './Implementations/webDeviceInputSystem';
+import { NativeDeviceInputSystemImpl } from './Implementations/nativeDeviceInputSystem';
+import { WebDeviceInputSystemImpl } from './Implementations/webDeviceInputSystem';
 import { DeviceType } from './InputDevices/deviceEnums';
 import { IDeviceEvent, IDeviceInputSystem } from './Interfaces/inputInterfaces';
 
@@ -41,10 +41,10 @@ export class DeviceInputSystem {
             let selectedDIS;
 
             if (typeof _native !== 'undefined') {
-                selectedDIS = (_native.DeviceInputSystem) ? new NativeDeviceInputSystem(new _native.DeviceInputSystem()) : new NativeDeviceInputSystem();
+                selectedDIS = (_native.DeviceInputSystem) ? new NativeDeviceInputSystemImpl(new _native.DeviceInputSystem()) : new NativeDeviceInputSystemImpl();
             }
             else {
-                selectedDIS = new WebDeviceInputSystem(engine);
+                selectedDIS = new WebDeviceInputSystemImpl(engine);
             }
 
             if (selectedDIS) {

--- a/src/DeviceInput/index.ts
+++ b/src/DeviceInput/index.ts
@@ -3,7 +3,7 @@ export * from "./InputDevices/deviceEnums";
 export * from "./InputDevices/deviceTypes";
 
 export * from "./Helpers/eventFactory";
-export * from "./Implementations/nativeDeviceInputWrapper";
+export * from "./Implementations/nativeDeviceInputSystem";
 export * from "./Implementations/webDeviceInputSystem";
 
 import "./InputDevices/deviceSourceManager";

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -27,7 +27,7 @@ import "./Extensions/engine.dynamicBuffer";
 import { IAudioEngine } from '../Audio/Interfaces/IAudioEngine';
 import { IPointerEvent } from "../Events/deviceInputEvents";
 
-declare type IDeviceInputSystem = import("../DeviceInput/Interfaces/inputInterfaces").IDeviceInputSystem;
+declare type DeviceInputSystem = import("../DeviceInput").DeviceInputSystem;
 declare type Material = import("../Materials/material").Material;
 declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
 
@@ -393,7 +393,7 @@ export class Engine extends ThinEngine {
     /**
      * Stores instance of DeviceInputSystem
      */
-    public deviceInputSystem: IDeviceInputSystem;
+    public deviceInputSystem: DeviceInputSystem;
 
     // Observables
 

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -11,7 +11,7 @@ import { KeyboardEventTypes, KeyboardInfoPre, KeyboardInfo } from "../Events/key
 import { DeviceType, PointerInput } from "../DeviceInput/InputDevices/deviceEnums";
 import { IEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from "../Events/deviceInputEvents";
 import { DeviceInputSystem } from "../DeviceInput/deviceInputSystem";
-import { IDeviceEvent, IDeviceInputSystem } from "../DeviceInput/Interfaces/inputInterfaces";
+import { IDeviceEvent } from "../DeviceInput/Interfaces/inputInterfaces";
 
 declare type Scene = import("../scene").Scene;
 
@@ -113,7 +113,7 @@ export class InputManager {
     private _onKeyUp: (evt: IKeyboardEvent) => void;
 
     private _scene: Scene;
-    private _deviceInputSystem: IDeviceInputSystem;
+    private _deviceInputSystem: DeviceInputSystem;
 
     /**
      * Creates a new InputManager


### PR DESCRIPTION
This PR contains changes to remove the connected, disconncted, and input changed observables out of the implemented web and native classes and put them in a universal wrapper that consumes both the web and native versions of the DeviceInputSystem