### PR TITLE
Fix GUI editor save to snippet server

### DIFF
--- a/guiEditor/src/guiEditor.ts
+++ b/guiEditor/src/guiEditor.ts
@@ -40,6 +40,10 @@ export class GUIEditor {
                     //swallow and continue
                 }
             }
+            if (options.liveGuiTexture) {
+                this._CurrentState.liveGuiTexture = options.liveGuiTexture;
+            }
+            return;
         }
 
         let hostElement = options.hostElement;


### PR DESCRIPTION
We shouldn't re-initialize the GUI editor if it's already loaded. But we do need to set the liveGuiTexture. This PR does that.

Fixes crash on saving to snippet server (really crash caused by hash changing, triggering reload)