### PR TITLE
get attachedNode in PositionGizmo always return null

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -351,6 +351,7 @@
 - Fix glTF exporter exports unused materials from excluded meshes ([daoshengmu](https://github.com/daoshengmu))
 - Fix glTFLoader 2.0 when dealing with glTF files that contain no meshes ([simonihmig](https://github.com/simonihmig))
 - Fix issue with setParent and meshes with a pivot ([RaananW](https://github.com/RaananW))
+- Fix get attachedNode always return null for `PositionGizmo` ([jtcheng](https://github.com/jtcheng))
 
 ## Breaking changes
 

--- a/src/Gizmos/positionGizmo.ts
+++ b/src/Gizmos/positionGizmo.ts
@@ -83,7 +83,7 @@ export class PositionGizmo extends Gizmo {
     }
     public set attachedNode(node: Nullable<Node>) {
         this._meshAttached = null;
-        this._nodeAttached = null;
+        this._nodeAttached = node;
         [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
             if (gizmo.isEnabled) {
                 gizmo.attachedNode = node;


### PR DESCRIPTION
get attachedNode in PositionGizmo always return null.

Playground:
https://playground.babylonjs.com/#31M2AP#243