### PR TITLE
DeviceSourceManager: Add mouse to list of already connected items

### DIFF
--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -94,6 +94,11 @@ export class DeviceSourceManager implements IDisposable {
         this._deviceInputSystem.onInputChangedObservable.add((eventData) => {
             this.getDeviceSource(eventData.deviceType, eventData.deviceSlot)?.onInputChangedObservable.notifyObservers(eventData);
         });
+
+        // Since the mouse is already added in the DeviceInputSystem for some scenarios, add it here automatically
+        if (this._deviceInputSystem.isDeviceAvailable(DeviceType.Mouse)) {
+            this._addDevice(DeviceType.Mouse, 0);
+        }
     }
 
     // Public Functions

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -58,12 +58,7 @@ export class DeviceInputSystem {
      */
     constructor(deviceInputSystem: IDeviceInputSystem) {
         this._deviceInputSystem = deviceInputSystem;
-        // Adds a callback that reassigns onDeviceConnected's callback to trigger the observable's observers for already connected devices
-        this.onDeviceConnectedObservable = new Observable((observer) => {
-            this._deviceInputSystem.onDeviceConnected = (deviceType, deviceSlot) => {
-                this.onDeviceConnectedObservable.notifyObservers({ deviceType, deviceSlot });
-            };
-        });
+        this.onDeviceConnectedObservable = new Observable();
         this.onDeviceDisconnectedObservable = new Observable();
         this.onInputChangedObservable = new Observable<IDeviceEvent>();
 

--- a/src/DeviceInput/deviceInputSystem.ts
+++ b/src/DeviceInput/deviceInputSystem.ts
@@ -58,7 +58,12 @@ export class DeviceInputSystem {
      */
     constructor(deviceInputSystem: IDeviceInputSystem) {
         this._deviceInputSystem = deviceInputSystem;
-        this.onDeviceConnectedObservable = new Observable();
+        // Adds a callback that reassigns onDeviceConnected's callback to trigger the observable's observers for already connected devices
+        this.onDeviceConnectedObservable = new Observable((observer) => {
+            this._deviceInputSystem.onDeviceConnected = (deviceType, deviceSlot) => {
+                this.onDeviceConnectedObservable.notifyObservers({ deviceType, deviceSlot });
+            };
+        });
         this.onDeviceDisconnectedObservable = new Observable();
         this.onInputChangedObservable = new Observable<IDeviceEvent>();
 


### PR DESCRIPTION
This PR adds a line to automatically add the mouse to the DeviceSourceManager's list of items because the mouse is already connected in the DeviceInputSystem.