### PR TITLE
Fix for ParticleSystem being disposed before _subEmitters is created

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -251,6 +251,7 @@
 
 ## Bugs
 
+- Fix issue when `ParticleSystem` is disposed before `_subEmitters` is created ([BlakeOne](https://github.com/BlakeOne))
 - Fix incorrect GUI.TextBlock width when resizeToFit is true & fontStyle is italic ([Kalkut](https://github.com/Kalkut))
 - Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))
 - Fix issue with the Promise polyfill where a return value was expected from resolve() ([Deltakosh](https://github.com/deltakosh))

--- a/src/Particles/particleSystem.ts
+++ b/src/Particles/particleSystem.ts
@@ -2129,7 +2129,7 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
         if (this.subEmitters && !this._subEmitters) {
             this._prepareSubEmitterInternalArray();
         }
-        
+
         if (this._subEmitters && this._subEmitters.length) {
             for (var index = 0; index < this._subEmitters.length; index++) {
                 for (var subEmitter of this._subEmitters[index]) {

--- a/src/Particles/particleSystem.ts
+++ b/src/Particles/particleSystem.ts
@@ -2126,6 +2126,10 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
 
         this._removeFromRoot();
 
+        if (this.subEmitters && !this._subEmitters) {
+            this._prepareSubEmitterInternalArray();
+        }
+        
         if (this._subEmitters && this._subEmitters.length) {
             for (var index = 0; index < this._subEmitters.length; index++) {
                 for (var subEmitter of this._subEmitters[index]) {


### PR DESCRIPTION
Fixes the issue where if a ParticleSystem is disposed before _subEmitters has been created & populated internally then the sub emitters are not disposed.

Here is the playground that demonstrates this issue: https://playground.babylonjs.com/#GXTHL9#50

Forum: https://forum.babylonjs.com/t/particle-system-dispose-leak-with-nested-subemitter/25952/2