### PR TITLE
Fix wrong values used for horiz/vert blur when resizing

### DIFF
--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -209,6 +209,7 @@ export class HighlightLayer extends EffectLayer {
      */
     public set blurHorizontalSize(value: number) {
         this._horizontalBlurPostprocess.kernel = value;
+        this._options.blurHorizontalSize = value;
     }
 
     /**
@@ -216,6 +217,7 @@ export class HighlightLayer extends EffectLayer {
      */
     public set blurVerticalSize(value: number) {
         this._verticalBlurPostprocess.kernel = value;
+        this._options.blurVerticalSize = value;
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/low-quality-rendering-in-canvas-until-the-inspector-is-opened/21804/10