### PR TITLE
[XR] fix rendering in Firefox

### DIFF
--- a/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/src/XR/webXRRenderTargetTextureProvider.ts
@@ -47,7 +47,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
 
     constructor(
         private readonly _scene: Scene,
-        public readonly layerWrapper: WebXRLayerWrapper) {}
+        public readonly layerWrapper: WebXRLayerWrapper) { }
 
     protected _createRenderTargetTexture(
         width: number,
@@ -86,8 +86,11 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         }
 
         renderTargetTexture.disableRescaling();
-        // WebXR pre-clears textures
-        renderTargetTexture.skipInitialClear = true;
+        // Firefox reality fails if skipInitialClear is set to true, so make sure only modern XR implementations set it.
+        if (typeof XRWebGLBinding !== "undefined") {
+            // WebXR pre-clears textures
+            renderTargetTexture.skipInitialClear = true;
+        }
 
         this._renderTargetTextures.push(renderTargetTexture);
 


### PR DESCRIPTION
Firefox has an rendering issue if we set skipInitialClear to true on the XR RTT.

As FF-Reality has not updated the XR implementation, it is missing key object from XR (like the XRWebGLBinding - https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLBinding).