### PR TITLE
Perf recording fixes

### DIFF
--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -70,9 +70,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
         if (window) {
             window.close();
         }
-        // if (isLoadedFromCsv) {
         setIsLoadedFromCsv(false);
-        // }
         setIsOpen(false);
     };
 

--- a/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/performanceViewer/performanceViewerComponent.tsx
@@ -78,7 +78,7 @@ export const PerformanceViewerComponent: React.FC<IPerformanceViewerComponentPro
         if (!isLoadedFromCsv) {
             if (performanceCollector) {
                 performanceCollector.stop();
-                performanceCollector.clear(false, false);
+                performanceCollector.clear(false);
                 addStrategies(performanceCollector);
             }
         }

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -355,6 +355,7 @@ export class PerformanceViewerCollector {
      * Given a string containing file data, this function parses the file data into the datasets object.
      * It returns a boolean to indicate if this object was successfully loaded with the data.
      * @param data string content representing the file data.
+     * @param keepDatasetMeta if it should use reuse the existing dataset metadata
      * @returns true if the data was successfully loaded, false otherwise.
      */
     public loadFromFileData(data: string, keepDatasetMeta?: boolean): boolean {

--- a/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -51,6 +51,7 @@ export class PerformanceViewerCollector {
     private _strategies: Map<string, IPerfViewerCollectionStrategy>;
     private _startingTimestamp: number;
     private _hasLoadedData: boolean;
+    private _isStarted: boolean;
     private readonly _customEventObservable: Observable<IPerfCustomEvent>;
     private readonly _eventRestoreSet: Set<string>;
 
@@ -356,7 +357,7 @@ export class PerformanceViewerCollector {
      * @param data string content representing the file data.
      * @returns true if the data was successfully loaded, false otherwise.
      */
-    public loadFromFileData(data: string): boolean {
+    public loadFromFileData(data: string, keepDatasetMeta?: boolean): boolean {
         const lines =
             data.replace(carriageReturnRegex, '').split('\n')
                 .map((line) => (
@@ -423,13 +424,17 @@ export class PerformanceViewerCollector {
         this.datasets.ids = parsedDatasets.ids;
         this.datasets.data = parsedDatasets.data;
         this.datasets.startingIndices = parsedDatasets.startingIndices;
-        this._datasetMeta.clear();
+        if (!keepDatasetMeta) {
+            this._datasetMeta.clear();
+        }
         this._strategies.forEach((strategy) => strategy.dispose());
         this._strategies.clear();
 
         // populate metadata.
-        for (const id of this.datasets.ids) {
-            this._datasetMeta.set(id, {color: this._getHexColorFromId(id)});
+        if (!keepDatasetMeta) {
+            for (const id of this.datasets.ids) {
+                this._datasetMeta.set(id, {color: this._getHexColorFromId(id)});
+            }
         }
         this.metadataObservable.notifyObservers(this._datasetMeta);
         this._hasLoadedData = true;
@@ -484,6 +489,7 @@ export class PerformanceViewerCollector {
         }
         this._scene.onAfterRenderObservable.add(this._collectDataAtFrame);
         this._restoreStringEvents();
+        this._isStarted = true;
     }
 
     /**
@@ -491,6 +497,14 @@ export class PerformanceViewerCollector {
      */
     public stop() {
         this._scene.onAfterRenderObservable.removeCallback(this._collectDataAtFrame);
+        this._isStarted = false;
+    }
+
+    /**
+     * Returns if the perf collector has been started or not.
+     */
+    public get isStarted() : boolean {
+        return this._isStarted;
     }
 
     /**
@@ -504,6 +518,7 @@ export class PerformanceViewerCollector {
         });
         this.datasetObservable.clear();
         this.metadataObservable.clear();
+        this._isStarted = false;
         (<any>this.datasets) = null;
     }
 }


### PR DESCRIPTION
Fix some issues when loading the performance profiler from a CSV then opening a live performance profiler. As part of this, I hid the buttons to open the profiler while the popup is open, so the user has to close it before opening another.