### PR TITLE
DeviceInputSystem: Updated touch logic to be more GC efficient

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -61,6 +61,7 @@
 - Added `mapPanning` on `ArcRotateCamera` ([Hypnosss](https://github.com/Hypnosss))
 - Added resetLastInteractionTime() to the auto rotate behavior ([RaananW](https://github.com/RaananW))
 - Update `addContainerTask` and `addMeshTask` signatures on `AssetsManager` to allow receiving a File as the sceneFilename argument. ([carolhmj](https://github.com/carolhmj))
+- Modified touch in `WebDeviceInputSystem` to no longer delete touch points after pointer up. ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 

--- a/src/DeviceInput/Implementations/webDeviceInputSystem.ts
+++ b/src/DeviceInput/Implementations/webDeviceInputSystem.ts
@@ -331,7 +331,9 @@ export class WebDeviceInputSystemImpl implements IDeviceInputSystem {
      */
     private _handlePointerActions() {
         this._maxTouchPoints = navigator.maxTouchPoints || 0;
-        this._activeTouchIds = new Array<number>(this._maxTouchPoints);
+        if (!this._activeTouchIds) {
+            this._activeTouchIds = new Array<number>(this._maxTouchPoints);
+        }
 
         for (let i = 0; i < this._maxTouchPoints; i++) {
             this._activeTouchIds[i] = -1;


### PR DESCRIPTION
In this PR, I've modified how touch points are handled by the DeviceInputSystem.  When assigning event handling, an array of pointer ids for touch (of size maxTouchPoints) will be created and any touches performed will have their pointerIds stored in them.  On pointerup, the reference will be cleared out but nothing will be deleted.  Any pointerdown calls over the max number will be ignored.