### PR TITLE
[XR] Refactor plane removal logic for perf

### DIFF
--- a/src/XR/features/WebXRPlaneDetector.ts
+++ b/src/XR/features/WebXRPlaneDetector.ts
@@ -150,21 +150,18 @@ export class WebXRPlaneDetector extends WebXRAbstractFeature {
         if (!this.attached || !this._enabled || !frame) {
             return;
         }
-        // const timestamp = this.xrSessionManager.currentTimestamp;
 
         const detectedPlanes = frame.detectedPlanes || frame.worldInformation?.detectedPlanes;
         if (detectedPlanes) {
-            const toRemove = this._detectedPlanes
-                .filter((plane) => !detectedPlanes.has(plane.xrPlane))
-                .map((plane) => {
-                    return this._detectedPlanes.indexOf(plane);
-                });
-            let idxTracker = 0;
-            toRemove.forEach((index) => {
-                const plane = this._detectedPlanes.splice(index - idxTracker, 1)[0];
-                this.onPlaneRemovedObservable.notifyObservers(plane);
-                idxTracker++;
-            });
+            // remove all planes that are not currently detected in the frame
+            for (let planeIdx = 0; planeIdx < this._detectedPlanes.length; planeIdx++) {
+                const plane = this._detectedPlanes[planeIdx];
+                if (!detectedPlanes.has(plane.xrPlane)) {
+                    this._detectedPlanes.splice(planeIdx--, 1);
+                    this.onPlaneRemovedObservable.notifyObservers(plane);
+                }
+            }
+
             // now check for new ones
             detectedPlanes.forEach((xrPlane) => {
                 if (!this._lastFrameDetected.has(xrPlane)) {


### PR DESCRIPTION
A small refactor of logic in the plane detector to make the code slightly more readable and performant.
Anecdotally, on BabylonNative/HoloLens, I was seeing about 16.93% of JS runtime going to `WebXRPlaneDetector._onXRFrame`, and after this change it's 16.27%. 