### PR TITLE
Fix issue when AssetContainer is added to Scene multiple times

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -252,6 +252,7 @@
 
 ## Bugs
 
+- Fix issue when `AssetContainer` is added to `Scene` multiple times ([BlakeOne](https://github.com/BlakeOne))
 - Fix issue when `ParticleSystem` is disposed before `_subEmitters` is created ([BlakeOne](https://github.com/BlakeOne))
 - Fix incorrect GUI.TextBlock width when resizeToFit is true & fontStyle is italic ([Kalkut](https://github.com/Kalkut))
 - Fix CubeTexture extension detection when rootUrl has a query string ([civa86](https://github.com/civa86))

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -260,6 +260,10 @@ export class AssetContainer extends AbstractScene {
      * Adds all the assets from the container to the scene.
      */
     public addAllToScene() {
+        if (this._wasAddedToScene) {
+            return;
+        }
+
         this._wasAddedToScene = true;
 
         this.cameras.forEach((o) => {


### PR DESCRIPTION
Add check for _wasAddedToScene to method addAllToScene and return early if AssetContainer has already been added.

This fixes an issue which can be reproduced by opening this simple playground - which calls addAllToScene twice - and then pressing the run button, which causes the page to become unresponsive.

Playground: https://playground.babylonjs.com/#99WCUQ#12
Forum: https://forum.babylonjs.com/t/calling-assetcontainer-addalltoscene-multiple-times-freezes-page/26100