### PR TITLE
Fix screen space reflections on right handed scenes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -357,6 +357,7 @@
 - Fix issue with setParent and meshes with a pivot ([RaananW](https://github.com/RaananW))
 - Fix Button3D, HolographicButton, TouchHolographicButton and HolographicSlate content when scene is right-handed ([carolhmj](https://github.com/carolhmj))
 - Fix get attachedNode always return null for `PositionGizmo` ([jtcheng](https://github.com/jtcheng))
+- Fix Screen Space Reflections for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 
 ## Breaking changes
 

--- a/src/PostProcesses/screenSpaceReflectionPostProcess.ts
+++ b/src/PostProcesses/screenSpaceReflectionPostProcess.ts
@@ -65,6 +65,7 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
     private _enableSmoothReflections: boolean = false;
     private _reflectionSamples: number = 64;
     private _smoothSteps: number = 5;
+    private _isSceneRightHanded: boolean;
 
     /**
      * Gets a string identifying the name of the class
@@ -160,6 +161,8 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
             effect.setFloat("stepSize", this.step);
             effect.setFloat("roughnessFactor", this.roughnessFactor);
         };
+
+        this._isSceneRightHanded = scene.useRightHandedSystem;
     }
 
     /**
@@ -237,6 +240,9 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
         }
         if (this._enableSmoothReflections) {
             defines.push("#define ENABLE_SMOOTH_REFLECTIONS");
+        }
+        if (this._isSceneRightHanded) {
+            defines.push("#define RIGHT_HANDED_SCENE");
         }
 
         defines.push("#define REFLECTION_SAMPLES " + (this._reflectionSamples >> 0));

--- a/src/Shaders/screenSpaceReflection.fragment.fx
+++ b/src/Shaders/screenSpaceReflection.fragment.fx
@@ -101,6 +101,9 @@ ReflectionInfo getReflectionInfo(vec3 dir, vec3 hitCoord)
         sampledDepth = (view * texture2D(positionSampler, projectedCoord.xy)).z;
  
         float depth = sampledDepth - hitCoord.z;
+        #ifdef RIGHT_HANDED_SCENE
+            depth *= -1.0;
+        #endif
 
         if(((depth - dir.z) < threshold) && depth <= 0.0)
         {
@@ -152,12 +155,15 @@ void main()
 
         vec2 dCoords = smoothstep(0.2, 0.6, abs(vec2(0.5, 0.5) - info.coords.xy));
         float screenEdgefactor = clamp(1.0 - (dCoords.x + dCoords.y), 0.0, 1.0);
-
+        
         // Fresnel
         vec3 F0 = vec3(0.04);
         F0      = mix(F0, albedo, spec);
         vec3 fresnel = fresnelSchlick(max(dot(normalize(normal), normalize(position)), 0.0), F0);
 
+        #ifdef RIGHT_HANDED_SCENE
+            reflected.z *= -1.0;
+        #endif
         // Apply
         float reflectionMultiplier = clamp(pow(spec * strength, reflectionSpecularFalloffExponent) * screenEdgefactor * reflected.z, 0.0, 0.9);
         float albedoMultiplier = 1.0 - reflectionMultiplier;


### PR DESCRIPTION
From https://forum.babylonjs.com/t/ssr-with-right-handled-system/26079

With the fix, example https://playground.babylonjs.com/#PIZ1GK#331 properly displays SSRs.