### PR TITLE
Fix for AdvancedTimer to support the timeout option

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -253,6 +253,7 @@
 
 ## Bugs
 
+- Fix for `AdvancedTimer` ignoring `timeout` option ([BlakeOne](https://github.com/BlakeOne))
 - Fix issue when `AssetContainer` is added to `Scene` multiple times ([BlakeOne](https://github.com/BlakeOne))
 - Fix issue when `ParticleSystem` is disposed before `_subEmitters` is created ([BlakeOne](https://github.com/BlakeOne))
 - Fix incorrect GUI.TextBlock width when resizeToFit is true & fontStyle is italic ([Kalkut](https://github.com/Kalkut))

--- a/src/Misc/timer.ts
+++ b/src/Misc/timer.ts
@@ -164,6 +164,7 @@ export class AdvancedTimer<T = any> implements IDisposable {
         this._contextObservable = options.contextObservable;
         this._observableParameters = options.observableParameters ?? {};
         this._breakCondition = options.breakCondition ?? (() => false);
+        this._timeToEnd = options.timeout;
         if (options.onEnded) {
             this.onTimerEndedObservable.add(options.onEnded);
         }


### PR DESCRIPTION
The property "timeout", which is part of the ITimerOptions interface, is currently ignored by AdvancedTimer.

This PR adds support for it by initialing _timeToEnd in the constructor to the value options.timeout. This value will be used unless a new timeToEnd value is passed to the start method.

Forum post that flagged the issue: https://forum.babylonjs.com/t/advanced-timer-function-does-not-run/26173