### PR TITLE
Updated Texture Compression batch script to use new PVRTC settings for PVRTexToolCLI.

### DIFF
--- a/Tools/CompressedTextured/ktx-files.bat
+++ b/Tools/CompressedTextured/ktx-files.bat
@@ -27,8 +27,8 @@ REM - - - - - - - - - - - - - - - PVRTC - - - - - - - - - - - - - - -
 REM PVRTC must be square on iOS
 IF EXIST %2-pvrtc.ktx GOTO DXT
 
-SET format=PVRTC1_2_RGB
-if %3 == 'Y' SET format=PVRTC1_2
+SET format=PVRTCI_2BPP_RGB
+if %3 == 'Y' SET format=PVRTCI_2BPP_RGBA
 
 SET quality=pvrtcfastest
 if %4 == 'Q' SET quality=pvrtcbest


### PR DESCRIPTION
I noticed that the command line too for texture compression using PVRTexTool still works great for everything but PVRTC.

After their own manuals fell short, I asked in their forums and updated the values according to their recommendations.

The new documentation which supports this change will be available soon according to them.

Source: https://forums.imgtec.com/t/pvrtextoolcli-pvrtc-encoding-invalid-valid-values/3483
