### PR TITLE
Change cursor on hover GUI gizmo scale points

### DIFF
--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -308,6 +308,17 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps> {
         // Get the canvas element from the DOM.
         const canvas = document.getElementById("workbench-canvas") as HTMLCanvasElement;
 
+        const scalePointCursors = [
+            "nesw-resize",
+            "nwse-resize",
+            "nesw-resize",
+            "nwse-resize",
+            "ew-resize",
+            "ns-resize",
+            "ew-resize",
+            "ns-resize"
+        ];
+
         for (let i = 0; i < 8; ++i) {
             let scalePoint = canvas.ownerDocument!.createElement("div");
             scalePoint.className = "ge-scalePoint";
@@ -317,6 +328,7 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps> {
             scalePoint.style.left = i * 100 + "px";
             scalePoint.style.top = i * 100 + "px";
             scalePoint.style.transform = "translate(-50%, -50%)";
+            scalePoint.style.cursor = scalePointCursors[i];
             scalePoint.addEventListener("pointerdown", () => {
                 this._setMousePosition(i);
             });


### PR DESCRIPTION
Tiny QoL improvement, changes the cursor when you hover over a scale point in the GUI editor. The cursor icon used will reflect the direction you are scaling in.