### PR TITLE
GUI Editor: Fix scaling gizmos and dragging jitter in popup

### DIFF
--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -306,7 +306,7 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps> {
 
     createBaseGizmo() {
         // Get the canvas element from the DOM.
-        const canvas = document.getElementById("workbench-canvas") as HTMLCanvasElement;
+        const canvas = this.props.globalState.hostDocument.getElementById("workbench-canvas") as HTMLCanvasElement;
 
         const scalePointCursors = [
             "nesw-resize",
@@ -392,6 +392,7 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps> {
                 if (this._responsive) {
                     this.props.globalState.workbench.convertToPercentage(node, false);
                 }
+                this.props.globalState.workbench._liveGuiTextureRerender = false;
                 this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
             }
         }

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -73,6 +73,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     private _selectionDepth = 0;
     private _doubleClick: Nullable<Control> = null;
     private _lockMainSelection: boolean = false;
+    public _liveGuiTextureRerender: boolean = true;
     public get globalState() {
         return this.props.globalState;
     }
@@ -670,6 +671,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     public clicked: boolean;
 
     public _onMove(guiControl: Control, evt: Vector2, startPos: Vector2, ignorClick: boolean = false) {
+        this._liveGuiTextureRerender = false;
         let newX = evt.x - startPos.x;
         let newY = evt.y - startPos.y;
 
@@ -860,16 +862,15 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         // also, every time *we* re-render (due to a change in the GUI), we must re-render the original ADT
         // to prevent an infite loop, we flip a boolean flag
         if (this.globalState.liveGuiTexture) {
-            let doRerender = true;
             this._guiRenderObserver = this.globalState.guiTexture.onBeginRenderObservable.add(() => {
-                if (doRerender) {
+                if (this._liveGuiTextureRerender) {
                     this.globalState.liveGuiTexture?.markAsDirty();
                 }
-                doRerender = true;
+                this._liveGuiTextureRerender = true;
             });
             this._liveRenderObserver = this.globalState.liveGuiTexture.onEndRenderObservable.add(() => {
                 this.globalState.guiTexture?.markAsDirty();
-                doRerender = false;
+                this._liveGuiTextureRerender = false;
             });
         }
 


### PR DESCRIPTION
Fixes issue where scalepoints would not be added to canvas. Also, disables re-rendering the original ADT when you are dragging or scaling a control, which was causing jitter/bugginess.