### PR TITLE
Fix problems with RTT when refreshRate is 0

### DIFF
--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -269,6 +269,13 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     }
 
     /**
+     * Gets the current value of the refreshId counter
+     */
+    public get currentRefreshId() {
+        return this._currentRefreshId;
+    }
+
+    /**
      * Sets a specific material to be used to render a mesh/a list of meshes in this render target texture
      * @param mesh mesh or array of meshes
      * @param material material or array of materials to use for this render pass. If undefined is passed, no specific material will be used but the regular material instead (mesh.material). It's possible to provide an array of materials to use a different material for each rendering in the case of a cube texture (6 rendering) and a 2D texture array (as many rendering as the length of the array)

--- a/src/Rendering/depthRenderer.ts
+++ b/src/Rendering/depthRenderer.ts
@@ -123,6 +123,28 @@ export class DepthRenderer {
             engine._debugPopGroup?.(1);
         });
 
+        this._depthMap.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
+            if (!mesh.isReady(false)) {
+                return false;
+            }
+            if (refreshRate === 0 && mesh.subMeshes) {
+                // full check: check that the effects are ready
+                for (let i = 0; i < mesh.subMeshes.length; ++i) {
+                    const subMesh = mesh.subMeshes[i];
+                    const renderingMesh = subMesh.getRenderingMesh();
+
+                    const batch = renderingMesh._getInstancesRenderList(subMesh._id, !!subMesh.getReplacementMesh());
+                    const hardwareInstancedRendering = engine.getCaps().instancedArrays && (batch.visibleInstances[subMesh._id] !== null && batch.visibleInstances[subMesh._id] !== undefined || renderingMesh.hasThinInstances);
+
+                    if (!this.isReady(subMesh, hardwareInstancedRendering)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        };
+
         // Custom render function
         var renderSubMesh = (subMesh: SubMesh): void => {
             var renderingMesh = subMesh.getRenderingMesh();

--- a/src/Rendering/geometryBufferRenderer.ts
+++ b/src/Rendering/geometryBufferRenderer.ts
@@ -737,6 +737,33 @@ export class GeometryBufferRenderer {
             }
         };
 
+        this._multiRenderTarget.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
+            if (!mesh.isReady(false)) {
+                return false;
+            }
+            if (refreshRate === 0 && mesh.subMeshes) {
+                // full check: check that the effects are ready
+                for (let i = 0; i < mesh.subMeshes.length; ++i) {
+                    const subMesh = mesh.subMeshes[i];
+                    const material = subMesh.getMaterial();
+                    const renderingMesh = subMesh.getRenderingMesh();
+
+                    if (!material) {
+                        continue;
+                    }
+
+                    const batch = renderingMesh._getInstancesRenderList(subMesh._id, !!subMesh.getReplacementMesh());
+                    const hardwareInstancedRendering = engine.getCaps().instancedArrays && (batch.visibleInstances[subMesh._id] !== null || renderingMesh.hasThinInstances);
+
+                    if (!this.isReady(subMesh, hardwareInstancedRendering)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        };
+
         this._multiRenderTarget.customRenderFunction = (opaqueSubMeshes: SmartArray<SubMesh>, alphaTestSubMeshes: SmartArray<SubMesh>, transparentSubMeshes: SmartArray<SubMesh>, depthOnlySubMeshes: SmartArray<SubMesh>): void => {
             var index;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/another-water-shader/26319/6

The problem was that when calling `mesh.isReady(refreshRate === 0)` in `RenderTargetTexture._prepareRenderingManager` it is the material of the mesh which is tested for readiness and not the material/effect used to render the mesh in the RTT. So I have added an implementation of `RTT.customIsReadyFunction` in all subsystems that are using a RTT internally which is calling the local `isReady` function.