### PR TITLE
fix freecamera touch input rotation sensibility and calculation error

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -362,6 +362,7 @@
 - Fix Button3D, HolographicButton, TouchHolographicButton and HolographicSlate content when scene is right-handed ([carolhmj](https://github.com/carolhmj))
 - Fix get attachedNode always return null for `PositionGizmo` ([jtcheng](https://github.com/jtcheng))
 - Fix Screen Space Reflections for right-handed scenes ([carolhmj](https://github.com/carolhmj))
+- Fix FreeCameraTouchInput roation when moving ([m1911star](https://github.com/m1911star))
 
 ## Breaking changes
 

--- a/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -19,14 +19,14 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
 
     /**
      * Defines the touch sensibility for rotation.
-     * The higher the faster.
+     * The lower the faster.
      */
     @serialize()
     public touchAngularSensibility: number = 200000.0;
 
     /**
      * Defines the touch sensibility for move.
-     * The higher the faster.
+     * The lower the faster.
      */
     @serialize()
     public touchMoveSensibility: number = 250.0;
@@ -54,7 +54,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
          * Define if mouse events can be treated as touch events
          */
         public allowMouse = false
-    ) { }
+    ) {}
 
     /**
      * Attach the input controls to a specific dom element to get the input from.
@@ -133,7 +133,9 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             };
         }
 
-        this._observer = this.camera.getScene().onPointerObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
+        this._observer = this.camera
+            .getScene()
+            .onPointerObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
         if (this._onLostFocus) {
             const engine = this.camera.getEngine();
@@ -183,12 +185,12 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         }
 
         var camera = this.camera;
-        camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
 
         const rotateCamera = (this.singleFingerRotate && this._pointerPressed.length === 1) || (!this.singleFingerRotate && this._pointerPressed.length > 1);
 
         if (rotateCamera) {
             camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
+            camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
         } else {
             var speed = camera._computeLocalCameraSpeed();
             var direction = new Vector3(0, 0, (speed * this._offsetY) / this.touchMoveSensibility);


### PR DESCRIPTION
- since *Sensibility is used as a divisor, so it should be `lower & faster`
-  when it's not a rotateCamera, it should not change `cameraRotation.y`