### PR TITLE
[GUI Editor] Fix saving to snippet server from within popout window

### DIFF
--- a/guiEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/guiEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -189,7 +189,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                         if (windowAsAny.Playground && oldId) {
                             windowAsAny.Playground.onRequestCodeChangeObservable.notifyObservers({
                                 regex: new RegExp(oldId, "g"),
-                                replace: `parseFromSnippetAsync("${adt.snippetId}`,
+                                replace: `parseFromSnippetAsync("${adt.snippetId})`,
                             });
                         }
                         resolve(adt.snippetId);
@@ -222,8 +222,8 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
             .then((snippetId: string) => {
                 adt.snippetId = snippetId;
                 const alertMessage = `GUI saved with ID:  ${adt.snippetId}`;
-                if (navigator.clipboard) {
-                    navigator.clipboard
+                if (this.props.globalState.hostWindow.navigator.clipboard) {
+                    this.props.globalState.hostWindow.navigator.clipboard
                         .writeText(adt.snippetId)
                         .then(() => {
                             this.props.globalState.hostWindow.alert(`${alertMessage}. The ID was copied to your clipboard.`);

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -886,11 +886,12 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     // removes all controls from both GUIs, and re-adds the controls from the original to the GUI editor
     synchronizeLiveGUI() {
         if (this.globalState.liveGuiTexture) {
-            this.props.globalState.guiTexture._rootContainer.getDescendants().filter(desc => desc.name !== "Art-Board-Background").forEach(desc => desc.dispose());
+            this.globalState.guiTexture._rootContainer.getDescendants().filter(desc => desc.name !== "Art-Board-Background").forEach(desc => desc.dispose());
             this.globalState.liveGuiTexture.rootContainer.getDescendants(true).forEach(desc => {
                 this.globalState.liveGuiTexture?.removeControl(desc);
                 this.appendBlock(desc);
             })
+            this.globalState.guiTexture.snippetId = this.globalState.liveGuiTexture.snippetId;
         }
     }
 


### PR DESCRIPTION
1. Fixes a bug where the new snippet server URL wasn't copied to your clipboard on save
2. If the GUI editor was opened from the playground, scans your code for the old snippet ID and replaces it with the newly saved one