### PR TITLE
Support Custom Mesh Colliders

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -62,6 +62,8 @@
 - Added `mapPanning` on `ArcRotateCamera` ([Hypnosss](https://github.com/Hypnosss))
 - Added resetLastInteractionTime() to the auto rotate behavior ([RaananW](https://github.com/RaananW))
 - Update `addContainerTask` and `addMeshTask` signatures on `AssetsManager` to allow receiving a File as the sceneFilename argument. ([carolhmj](https://github.com/carolhmj))
+- Added `onCreateCustomMeshCollider` handler to support cureating custom mesh colliders like Ammo.btSmoothTriangleMesh. ([MackeyK24](https://github.com/MackeyK24))
+
 
 ### Engine
 

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -160,9 +160,9 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
     public onCreateCustomShape: (impostor: PhysicsImpostor) => any;
 
     /**
-     * The create custom mesh collider handler function to support building custom mesh collider vertex data
+     * The create custom mesh impostor handler function to support building custom mesh impostor vertex data (Ex: Ammo.btSmoothTriangleMesh)
      */
-     public onCreateCustomMeshCollider: (impostor: PhysicsImpostor) => any;
+     public onCreateCustomMeshImpostor: (impostor: PhysicsImpostor) => any;
 
     // Ammo's contactTest and contactPairTest take a callback that runs synchronously, wrap them so that they are easier to consume
     private _isImpostorInContact(impostor: PhysicsImpostor) {
@@ -1006,8 +1006,8 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 if (impostor.getParam("mass") == 0) {
                     // Only create btBvhTriangleMeshShape impostor is static
                     // See https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=7283
-                    if (this.onCreateCustomMeshCollider) {
-                        returnValue = this.onCreateCustomMeshCollider(impostor);
+                    if (this.onCreateCustomMeshImpostor) {
+                        returnValue = this.onCreateCustomMeshImpostor(impostor);
                     } else {
                         var tetraMesh = new this.bjsAMMO.btTriangleMesh();
                         impostor._pluginData.toDispose.push(tetraMesh);

--- a/src/Physics/Plugins/ammoJSPlugin.ts
+++ b/src/Physics/Plugins/ammoJSPlugin.ts
@@ -159,6 +159,11 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
      */
     public onCreateCustomShape: (impostor: PhysicsImpostor) => any;
 
+    /**
+     * The create custom mesh collider handler function to support building custom mesh collider vertex data
+     */
+     public onCreateCustomMeshCollider: (impostor: PhysicsImpostor) => any;
+
     // Ammo's contactTest and contactPairTest take a callback that runs synchronously, wrap them so that they are easier to consume
     private _isImpostorInContact(impostor: PhysicsImpostor) {
         this._tmpContactCallbackResult = false;
@@ -1001,13 +1006,17 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 if (impostor.getParam("mass") == 0) {
                     // Only create btBvhTriangleMeshShape impostor is static
                     // See https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=7283
-                    var tetraMesh = new this.bjsAMMO.btTriangleMesh();
-                    impostor._pluginData.toDispose.push(tetraMesh);
-                    var triangeCount = this._addMeshVerts(tetraMesh, object, object);
-                    if (triangeCount == 0) {
-                        returnValue = new this.bjsAMMO.btCompoundShape();
+                    if (this.onCreateCustomMeshCollider) {
+                        returnValue = this.onCreateCustomMeshCollider(impostor);
                     } else {
-                        returnValue = new this.bjsAMMO.btBvhTriangleMeshShape(tetraMesh);
+                        var tetraMesh = new this.bjsAMMO.btTriangleMesh();
+                        impostor._pluginData.toDispose.push(tetraMesh);
+                        var triangeCount = this._addMeshVerts(tetraMesh, object, object);
+                        if (triangeCount == 0) {
+                            returnValue = new this.bjsAMMO.btCompoundShape();
+                        } else {
+                            returnValue = new this.bjsAMMO.btBvhTriangleMeshShape(tetraMesh);
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
Add support for custom mesh colliders. (Different from custom shapes)

Add onCreateCustomMeshCollider handler to support creating custom mesh collider.

Example: Can use the hook to add support for Ammo.btSmoothTriangleMesh instead of Ammo.btTriangleMesh to help smooth out mesh collider contacts where the impostor type has to be a **MeshImposter** and not a **CustomImpostor**. Especially for high speed driving simulations