### PR TITLE
Fix camera collisions for RHS scenes with GLTF models

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -369,6 +369,7 @@
 - Fix get attachedNode always return null for `PositionGizmo` ([jtcheng](https://github.com/jtcheng))
 - Fix Screen Space Reflections for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 - Fix FreeCameraTouchInput roation when moving ([m1911star](https://github.com/m1911star))
+- Fix camera collisions for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 
 ## Breaking changes
 

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -394,14 +394,18 @@ export class Collider {
     }
 
     /** @hidden */
-    public _collide(trianglePlaneArray: Array<Plane>, pts: Vector3[], indices: IndicesArray, indexStart: number, indexEnd: number, decal: number, hasMaterial: boolean, hostMesh: AbstractMesh): void {
+    public _collide(trianglePlaneArray: Array<Plane>, pts: Vector3[], indices: IndicesArray, indexStart: number, indexEnd: number, decal: number, hasMaterial: boolean, hostMesh: AbstractMesh, invertTriangles?: boolean): void {
         if (!indices || indices.length === 0) {
             for (let i = 0; i < pts.length; i += 3) {
                 const p1 = pts[i];
                 const p2 = pts[i + 1];
                 const p3 = pts[i + 2];
-
-                this._testTriangle(i, trianglePlaneArray, p3, p2, p1, hasMaterial, hostMesh);
+                
+                if (invertTriangles) {
+                    this._testTriangle(i, trianglePlaneArray, p1, p2, p3, hasMaterial, hostMesh);
+                } else {
+                    this._testTriangle(i, trianglePlaneArray, p3, p2, p1, hasMaterial, hostMesh);
+                }
             }
         } else {
             for (let i = indexStart; i < indexEnd; i += 3) {
@@ -409,7 +413,11 @@ export class Collider {
                 const p2 = pts[indices[i + 1] - decal];
                 const p3 = pts[indices[i + 2] - decal];
 
-                this._testTriangle(i, trianglePlaneArray, p3, p2, p1, hasMaterial, hostMesh);
+                if (invertTriangles) {
+                    this._testTriangle(i, trianglePlaneArray, p1, p2, p3, hasMaterial, hostMesh);
+                } else {
+                    this._testTriangle(i, trianglePlaneArray, p3, p2, p1, hasMaterial, hostMesh);
+                }
             }
         }
     }
@@ -418,7 +426,7 @@ export class Collider {
     public _getResponse(pos: Vector3, vel: Vector3): void {
         pos.addToRef(vel, this._destinationPoint);
         vel.scaleInPlace((this._nearestDistance / vel.length()));
-
+    
         this._basePoint.addToRef(vel, pos);
         pos.subtractToRef(this.intersectionPoint, this._slidePlaneNormal);
         this._slidePlaneNormal.normalize();
@@ -426,7 +434,7 @@ export class Collider {
 
         pos.addInPlace(this._displacementVector);
         this.intersectionPoint.addInPlace(this._displacementVector);
-
+        
         this._slidePlaneNormal.scaleInPlace(Plane.SignedDistanceToPlaneFromPositionAndNormal(this.intersectionPoint, this._slidePlaneNormal, this._destinationPoint));
         this._destinationPoint.subtractInPlace(this._slidePlaneNormal);
 

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -426,7 +426,7 @@ export class Collider {
     public _getResponse(pos: Vector3, vel: Vector3): void {
         pos.addToRef(vel, this._destinationPoint);
         vel.scaleInPlace((this._nearestDistance / vel.length()));
-    
+
         this._basePoint.addToRef(vel, pos);
         pos.subtractToRef(this.intersectionPoint, this._slidePlaneNormal);
         this._slidePlaneNormal.normalize();

--- a/src/Collisions/collider.ts
+++ b/src/Collisions/collider.ts
@@ -434,7 +434,7 @@ export class Collider {
 
         pos.addInPlace(this._displacementVector);
         this.intersectionPoint.addInPlace(this._displacementVector);
-        
+
         this._slidePlaneNormal.scaleInPlace(Plane.SignedDistanceToPlaneFromPositionAndNormal(this.intersectionPoint, this._slidePlaneNormal, this._destinationPoint));
         this._destinationPoint.subtractInPlace(this._slidePlaneNormal);
 

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1685,7 +1685,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             subMesh.indexStart + subMesh.indexCount,
             subMesh.verticesStart,
             !!subMesh.getMaterial(),
-            this
+            this,
+            this._shouldConvertRHS()
         );
         return this;
     }
@@ -1709,6 +1710,11 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     }
 
     /** @hidden */
+    public _shouldConvertRHS() {
+        return false;
+    }
+
+    /** @hidden */
     public _checkCollision(collider: Collider): AbstractMesh {
         // Bounding box test
         if (!this.getBoundingInfo()._checkCollision(collider)) {
@@ -1718,7 +1724,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         // Transformation matrix
         const collisionsScalingMatrix = TmpVectors.Matrix[0];
         const collisionsTransformMatrix = TmpVectors.Matrix[1];
-        Matrix.ScalingToRef(1.0 / collider._radius.x, 1.0 / collider._radius.y, 1.0 / collider._radius.z, collisionsScalingMatrix);
+        Matrix.ScalingToRef(1.0 / collider._radius.x, 1.0 / collider._radius.y, 1.0 / collider._radius.z, collisionsScalingMatrix);     
         this.worldMatrixFromCache.multiplyToRef(collisionsScalingMatrix, collisionsTransformMatrix);
         this._processCollisionsForSubMeshes(collider, collisionsTransformMatrix);
         return this;

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1724,7 +1724,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         // Transformation matrix
         const collisionsScalingMatrix = TmpVectors.Matrix[0];
         const collisionsTransformMatrix = TmpVectors.Matrix[1];
-        Matrix.ScalingToRef(1.0 / collider._radius.x, 1.0 / collider._radius.y, 1.0 / collider._radius.z, collisionsScalingMatrix);     
+        Matrix.ScalingToRef(1.0 / collider._radius.x, 1.0 / collider._radius.y, 1.0 / collider._radius.z, collisionsScalingMatrix);
         this.worldMatrixFromCache.multiplyToRef(collisionsScalingMatrix, collisionsTransformMatrix);
         this._processCollisionsForSubMeshes(collider, collisionsTransformMatrix);
         return this;

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -4501,6 +4501,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this.instances.pop();
         }
     }
+
+    /** @hidden */
+    public _shouldConvertRHS() {
+        return this.overrideMaterialSideOrientation === Material.CounterClockWiseSideOrientation;
+    }
 }
 
 RegisterClass("BABYLON.Mesh", Mesh);


### PR DESCRIPTION
Fix #11688

With the fix, collisions happen normally on the example playground: https://www.babylonjs-playground.com/#I6J7UZ#47