### PR TITLE
Fix non initialized matrix when setting orientation for bones

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -331,6 +331,7 @@
 - Fix the `StandardMaterial` not using the tangent attribute when available ([Popov72](https://github.com/Popov72))
 - Fix code for handling getting DeviceType/DeviceSlot in DeviceInputSystem to work better with MouseEvents ([PolygonalSun](https://github.com/PolygonalSun))
 - Fix vector2/3/4 and quaternion toString formatting ([rgerd](https://github.com/rgerd))
+- Fix non initialized matrix when setting orientation for bones ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fix cloning skeleton when mesh is an instanced mesh ([Popov72](https://github.com/Popov72))
 - Fix a bug where pointer up/move events were not sent to 3D controls when no mesh in the `UtilityLayerRenderer` is hit by the picking ray. ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Fix issue with DeviceInputSystem where Mouse was being deregistered on Safari/MacOS ([PolygonalSun](https://github.com/PolygonalSun))

--- a/src/Bones/bone.ts
+++ b/src/Bones/bone.ts
@@ -803,6 +803,8 @@ export class Bone extends Node {
         if (tNode) {
             rotMatInv.multiplyToRef(tNode.getWorldMatrix(), rotMatInv);
             Matrix.ScalingToRef(tNode.scaling.x, tNode.scaling.y, tNode.scaling.z, scaleMatrix);
+        } else {
+            Matrix.IdentityToRef(scaleMatrix);
         }
 
         rotMatInv.invert();


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/setting-rotation-quaternion-to-0-1-0-0-leads-to-the-bone-keep-flipping-180-degrees/25719

scaleMatrix is using a private matrix that is not initialized. Its value at index 0 is multiplied by -1 (determinant) giving a flip each frame. 

@carolhmj Can you please take some time to test this fix. Because I could not repro the issue reliably before the fix.