### PR TITLE
[GUI] Fix scrollbar in ScrollViewer clipping incorrectly

### DIFF
--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1698,6 +1698,7 @@ export class Control {
     }
 
     protected _evaluateClippingState(parentMeasure: Measure) {
+        this._currentMeasure.transformToRef(this._transformMatrix, this._evaluatedMeasure);
         if (this.parent && this.parent.clipChildren) {
             parentMeasure.transformToRef(this.parent._transformMatrix, this._evaluatedParentMeasure);
             // Early clip


### PR DESCRIPTION
Fixes an issue where the scrollbar in a ScrollViewer will not initially render, as its bounds are not being updated before _evaluateClippingState occurs, causing that to erroneously set _isClipped to true on the first frame.

Relevant forum post: https://forum.babylonjs.com/t/scroll-viewer-not-appearing-until-clicked/26322/6

This line used to be here and was removed at some point. I am not sure why yet; possibly for performance reasons? Whatever the reasoning, adding it back in fixes the issue.

I will follow up with @RaananW tomorrow on the correct behavior here.