### PR TITLE
[XR] reset AR camera's transformation on XR init

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -229,6 +229,7 @@
 - Add the `WebXRLayers` feature to support rendering to an `XRProjectionLayer` ([#10588](https://github.com/BabylonJS/Babylon.js/issues/10588)) ([rgerd](https://github.com/rgerd))
 - Introduced a new opt-in property to `Gui3DManager`, `useRealisticScaling`, that will automatically scale 3D GUI components like buttons to MRTK standards for better sizing in XR experiences. ([rickfromwork](https://github.com/rickfromwork))
 - Add `NativeXRPlugin` and `NativeXRFrame` to improve XR performance on BabylonNative ([rgerd](https://github.com/rgerd))
+- Reset XR Camera's orientation when entering an AR session for consistent experience ([RaananW](https://github.com/RaananW))
 
 ### Gizmos
 

--- a/src/XR/webXRExperienceHelper.ts
+++ b/src/XR/webXRExperienceHelper.ts
@@ -150,9 +150,16 @@ export class WebXRExperienceHelper implements IDisposable {
                 // Kept here, TODO - check if needed
                 this.scene.autoClear = false;
                 this.camera.compensateOnFirstFrame = false;
+                // reset the camera's position to the origin
+                this.camera.position.set(0, 0, 0);
+                this.camera.rotationQuaternion.set(0, 0, 0, 1);
             }
 
             this.sessionManager.onXRSessionEnded.addOnce(() => {
+                // when using the back button and not the exit button (default on mobile), the session is ending but the EXITING state was not set
+                if (this.state !== WebXRState.EXITING_XR) {
+                    this._setState(WebXRState.EXITING_XR);
+                }
                 // Reset camera rigs output render target to ensure sessions render target is not drawn after it ends
                 this.camera.rigCameras.forEach((c) => {
                     c.outputRenderTarget = null;


### PR DESCRIPTION
This resolves an issue when entering an XR session in AR mode - the camera's orientation was kept and not reset on every session, which caused an issue with model transformation.

Also adding ËXITING XR" state change when not using the exit button (for example when using the browser's back button)