### PR TITLE
No more hacky fix for CreateForMesh serialization

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -24,6 +24,7 @@ import { Viewport } from "babylonjs/Maths/math.viewport";
 import { Color3 } from "babylonjs/Maths/math.color";
 import { WebRequest } from "babylonjs/Misc/webRequest";
 import { IPointerEvent, IWheelEvent } from "babylonjs/Events/deviceInputEvents";
+import { RandomGUID } from "babylonjs/Misc/guid";
 
 /**
  * Class used to create texture to support 2D GUI elements
@@ -1151,7 +1152,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     public static CreateForMesh(mesh: AbstractMesh, width = 1024, height = 1024, supportPointerMove = true, onlyAlphaTesting = false, invertY?: boolean): AdvancedDynamicTexture {
         // use a unique ID in name so serialization will work even if you create two ADTs for a single mesh
         // TODO: find a better solution for material serialization
-        const uniqueId = mesh.getScene().getUniqueId();
+        const uniqueId = RandomGUID();
         var result = new AdvancedDynamicTexture(`AdvancedDynamicTexture for ${mesh.name} [${uniqueId}]`, width, height, mesh.getScene(), true, Texture.TRILINEAR_SAMPLINGMODE, invertY);
         var material = new StandardMaterial(`AdvancedDynamicTextureMaterial for ${mesh.name} [${uniqueId}]`, mesh.getScene());
         material.backFaceCulling = false;

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -1151,7 +1151,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      */
     public static CreateForMesh(mesh: AbstractMesh, width = 1024, height = 1024, supportPointerMove = true, onlyAlphaTesting = false, invertY?: boolean): AdvancedDynamicTexture {
         // use a unique ID in name so serialization will work even if you create two ADTs for a single mesh
-        // TODO: find a better solution for material serialization
         const uniqueId = RandomGUID();
         var result = new AdvancedDynamicTexture(`AdvancedDynamicTexture for ${mesh.name} [${uniqueId}]`, width, height, mesh.getScene(), true, Texture.TRILINEAR_SAMPLINGMODE, invertY);
         var material = new StandardMaterial(`AdvancedDynamicTextureMaterial for ${mesh.name} [${uniqueId}]`, mesh.getScene());

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -1149,8 +1149,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * @returns a new AdvancedDynamicTexture
      */
     public static CreateForMesh(mesh: AbstractMesh, width = 1024, height = 1024, supportPointerMove = true, onlyAlphaTesting = false, invertY?: boolean): AdvancedDynamicTexture {
-        var result = new AdvancedDynamicTexture(mesh.name + " AdvancedDynamicTexture", width, height, mesh.getScene(), true, Texture.TRILINEAR_SAMPLINGMODE, invertY);
-        var material = new StandardMaterial("AdvancedDynamicTextureMaterial", mesh.getScene());
+        // use a unique ID in name so serialization will work even if you create two ADTs for a single mesh
+        // TODO: find a better solution for material serialization
+        const uniqueId = mesh.getScene().getUniqueId();
+        var result = new AdvancedDynamicTexture(`AdvancedDynamicTexture for ${mesh.name} [${uniqueId}]`, width, height, mesh.getScene(), true, Texture.TRILINEAR_SAMPLINGMODE, invertY);
+        var material = new StandardMaterial(`AdvancedDynamicTextureMaterial for ${mesh.name} [${uniqueId}]`, mesh.getScene());
         material.backFaceCulling = false;
         material.diffuseColor = Color3.Black();
         material.specularColor = Color3.Black();

--- a/src/Misc/index.ts
+++ b/src/Misc/index.ts
@@ -60,3 +60,4 @@ export * from "./domManagement";
 export * from "./computePressure";
 export * from "./PerformanceViewer/index";
 export * from "./coroutine";
+export * from "./guid";

--- a/src/Misc/uniqueIdGenerator.ts
+++ b/src/Misc/uniqueIdGenerator.ts
@@ -3,7 +3,7 @@
  */
 export class UniqueIdGenerator {
     // Statics
-    private static _UniqueIdCounter = 1;
+    private static _UniqueIdCounter = 0;
 
     /**
      * Gets an unique (relatively to the current scene) Id

--- a/src/Misc/uniqueIdGenerator.ts
+++ b/src/Misc/uniqueIdGenerator.ts
@@ -3,7 +3,7 @@
  */
 export class UniqueIdGenerator {
     // Statics
-    private static _UniqueIdCounter = 0;
+    private static _UniqueIdCounter = 1;
 
     /**
      * Gets an unique (relatively to the current scene) Id


### PR DESCRIPTION
Makes CreateForMesh generate textures and materials with unique names, using the mesh name + a unique ID.

Fixes #11605.

In future we should probably make material serialization more name-conflict proof. This is a hotfix for a specific broken behavior, but doesn't address the bigger problem.