### PR TITLE
Add null check on holographic slate

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -373,6 +373,7 @@
 - Fix Screen Space Reflections for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 - Fix FreeCameraTouchInput roation when moving ([m1911star](https://github.com/m1911star))
 - Fix camera collisions for right-handed scenes ([carolhmj](https://github.com/carolhmj))
+- Add a null check when setting `imageSrc` on HolographicSlate([carolhmj](https://github.com/carolhmj))
 
 ## Breaking changes
 

--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -224,7 +224,7 @@ export class HolographicSlate extends ContentDisplay3D {
     }
 
     private _applyContentViewport() {
-        if (this._contentPlate.material && (this._contentPlate.material as FluentMaterial).albedoTexture) {
+        if (this._contentPlate?.material && (this._contentPlate.material as FluentMaterial).albedoTexture) {
             const tex = (this._contentPlate.material as FluentMaterial).albedoTexture as Texture;
             tex.uScale = this._contentScaleRatio;
             tex.vScale = (this._contentScaleRatio / this._contentViewport.width) * this._contentViewport.height;


### PR DESCRIPTION
Without the fix, setting the imageSrc property on a HolographicButton before adding it to the control would crash:
![image](https://user-images.githubusercontent.com/6002144/148820554-17df2090-3818-466b-8003-53b3cd94f23b.png)
https://playground.babylonjs.com/#1N1VGL

With the fix, there is no crash, and the image appears.