### PR TITLE
[GUI Editor] Major Gizmo Refactor

### DIFF
--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -55,7 +55,7 @@ class Rect {
     public get width() {
         return this.right - this.left;
     }
-    
+
     public get height() {
         return this.bottom - this.top;
     }
@@ -140,7 +140,6 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
      */
     updateGizmo(force?: boolean) {
         const selectedGuiNodes = this.props.globalState.workbench.selectedGuiNodes;
-        console.log("update gizmo");
         if (selectedGuiNodes.length > 0 && (force || this.state.scalePointDragging != -1)) {
             // Calculating the offsets for each scale point.
             const half = 1 / 2;
@@ -543,7 +542,7 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
 
     private _beginDraggingScalePoint = (scalePointIndex: number) => {
         const selectedGuiNodes = this.props.globalState.workbench.selectedGuiNodes;
-        this.setState({scalePointDragging: scalePointIndex});
+        this.setState({ scalePointDragging: scalePointIndex });
         if (selectedGuiNodes.length > 0) {
             const node = selectedGuiNodes[0];
             this._localBounds = this._computeLocalBounds(node);

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -215,7 +215,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         this.props.globalState.hostDocument!.defaultView!.addEventListener("blur", this.blurEvent, false);
 
         props.globalState.onWindowResizeObservable.add(() => {
-            //this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
+            this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
             this._engine.resize();
         });
 
@@ -912,7 +912,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         const panningFn = () => {
             const pos = this.getPosition(scene, camera, plane);
             this.panning(pos, initialPos, camera.inertia, inertialPanning);
-            //this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
         };
 
         const inertialPanningFn = () => {
@@ -920,6 +919,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
                 camera.target.addInPlace(inertialPanning);
                 inertialPanning.scaleInPlace(camera.inertia);
                 this.zeroIfClose(inertialPanning);
+                this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
             }
         };
 
@@ -989,7 +989,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
             }
         }, KeyboardEventTypes.KEYDOWN);
 
-        scene.onAfterRenderObservable.add(() => { this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers() });
+        scene.onAfterRenderObservable.add(() => { if (this._camera.inertialRadiusOffset != 0) this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers() });
         scene.onPointerObservable.add(zoomFnScrollWheel, PointerEventTypes.POINTERWHEEL);
         scene.onBeforeRenderObservable.add(inertialPanningFn);
         scene.onBeforeRenderObservable.add(wheelPrecisionFn);
@@ -1065,7 +1065,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         ref.addInPlace(offset);
 
         camera.inertialRadiusOffset += delta;
-        //this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
     }
 
     //Sets x y or z of passed in vector to zero if less than Epsilon

--- a/guiEditor/src/guiEditor.ts
+++ b/guiEditor/src/guiEditor.ts
@@ -68,7 +68,6 @@ export class GUIEditor {
         // create the middle workbench canvas
         if (!globalState.guiTexture) {
             globalState.workbench.createGUICanvas();
-            globalState.guiGizmo.createBaseGizmo();
             if (options.currentSnippetToken) {
                 try {
                     await globalState.workbench.loadFromSnippet(options.currentSnippetToken);

--- a/guiEditor/src/main.scss
+++ b/guiEditor/src/main.scss
@@ -95,19 +95,6 @@
         width: 100%;
         height: 100%;
     }
-
-    .ge-scalePoint {
-        width: 10px;
-        height: 10px;
-        background: transparent;
-        outline: rgb(125, 125, 125) 2px solid;
-    }
-
-    .ge-pivotPoint {
-        width: 30px;
-        height: 30px;
-        background: transparent;
-    }
 }
 
 .right-panel {
@@ -238,5 +225,32 @@
                 }
             }
         }
+    }
+}
+.gizmo {
+    width: 0;
+    height: 0;
+    .bounding-box-line {
+        background-color: black;
+        position: absolute;
+        line-height: 1px;
+        height: 1px;
+        pointer-events: none;
+    }
+    .scale-point {
+        position: absolute;
+        transform: "translate(-50%,-50%)";
+        top: 20px;
+        left: 20px;
+        width: 10px;
+        height: 10px;
+        background: transparent;
+        outline: rgb(125, 125, 125) 2px solid;
+    }
+    .pivot-point {
+        width: 30px;
+        height: 30px;
+        background: transparent;
+        position: absolute;
     }
 }


### PR DESCRIPTION
Significantly refactors the guiGizmo class, making the following changes:
* Uses React's render() function rather than direct DOM manipulation to display the selection box and scale points
* Supports drawing a selection box around multiple controls if you have more than one selected
* Uses DOM elements to render the selection box rather than GUI outlines. This gives us more flexibility over the appearance of the box, and allows us to use outlines for other things (displaying grid cells)
* Scale points are now represented using clearly named interfaces and enums, rather than just being an array. Removes the need for code like `index = index % 4`, so should be more readable now

Still unimplemented:
* Rotating using the gizmo
* Scaling multiple controls simultaneously

Wanted to open a PR though as this PR is already growing quite large. I will try to keep future PRs smaller, but I needed to significantly refactor this code to make the changes I wanted to make.