### PR TITLE
scene picking precision with huge values in world matrices

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -47,6 +47,7 @@
 - Spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the corresponding `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))
+- Improved scene picking precision with huge values in world matrices ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Added `applyVerticalCorrection` and `projectionPlaneTilt` to perspective cameras to correct perspective projections ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Support rotation keys in universal camera ([Sebavan](https://github.com/sebavan))
 - Added flag to allow users to swap between rotation and movement for single touch on FreeCameraTouchInput ([PolygonalSun](https://github.com/PolygonalSun))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -47,7 +47,7 @@
 - Spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the corresponding `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))
-- Improved scene picking precision with huge values in world matrices ([CedricGuillemet](https://github.com/CedricGuillemet)
+- Improved scene picking precision with huge values in world matrices when `Ray.EnableDistantPicking` flag is true ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Added `applyVerticalCorrection` and `projectionPlaneTilt` to perspective cameras to correct perspective projections ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Support rotation keys in universal camera ([Sebavan](https://github.com/sebavan))
 - Added flag to allow users to swap between rotation and movement for single touch on FreeCameraTouchInput ([PolygonalSun](https://github.com/PolygonalSun))

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -468,7 +468,7 @@ export class Ray {
         if (Ray.EnableDistantPicking) {
             // With world matrices having great values (like 8000000000 on 1 or more scaling or position axis),
             // multiplying view/projection/world and doing invert will result in loss of float precision in the matrix.
-            // One way to fix it is to compute the ray with world at identity then transform the ray in object space. 
+            // One way to fix it is to compute the ray with world at identity then transform the ray in object space.
             // This is slower (2 matrix inverts instead of 1) but precision is preserved.
             // This is hidden behind `EnableDistantPicking` flag (default is false)
             if (!Ray._rayDistant) {
@@ -477,11 +477,9 @@ export class Ray {
 
             Ray._rayDistant.unprojectRayToRef(x, y, viewportWidth, viewportHeight, Matrix.IdentityReadOnly, view, projection);
 
-            if (world) {
-                var tm = TmpVectors.Matrix[0];
-                world.invertToRef(tm);
-                Ray.TransformToRef(Ray._rayDistant, tm, this);
-            }
+            var tm = TmpVectors.Matrix[0];
+            world.invertToRef(tm);
+            Ray.TransformToRef(Ray._rayDistant, tm, this);
         } else {
             this.unprojectRayToRef(x, y, viewportWidth, viewportHeight, world, view, projection);
         }

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -17,6 +17,7 @@ declare type Mesh = import("../Meshes/mesh").Mesh;
  */
 export class Ray {
     private static readonly _TmpVector3 = ArrayTools.BuildArray(6, Vector3.Zero);
+    /** When enabled, decompose picking matrices for better precision with large values for mesh position and scling */
     public static EnableDistantPicking = false;
     private static _rayDistant = Ray.Zero();
     private _tmpRay: Ray;
@@ -483,7 +484,7 @@ export class Ray {
         } else {
             this.unprojectRayToRef(x, y, viewportWidth, viewportHeight, world, view, projection);
         }
-        
+
         return this;
     }
 

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -682,7 +682,6 @@ Scene.prototype.createPickingRayInCameraSpaceToRef = function (x: number, y: num
 
 Scene.prototype._internalPickForMesh = function (pickingInfo: Nullable<PickingInfo>, rayFunction: (world: Matrix) => Ray, mesh: AbstractMesh, world: Matrix, fastCheck?: boolean, onlyBoundingInfo?: boolean, trianglePredicate?: TrianglePickingPredicate, skipBoundingInfo?: boolean) {
     let ray = rayFunction(world);
-    //console.log("Got Ray fn ", ray);
 
     let result = mesh.intersects(ray, fastCheck, trianglePredicate, onlyBoundingInfo, world, skipBoundingInfo);
     if (!result || !result.hit) {

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -585,7 +585,7 @@ export class Ray {
         nearScreenSource.y = -((sourceY / viewportHeight) * 2 - 1);
         nearScreenSource.z = -1.0;
         // far Z need to be close but < to 1 or camera projection matrix with maxZ = 0 will NaN
-        var farScreenSource = TmpVectors.Vector3[1].copyFromFloats(nearScreenSource.x, nearScreenSource.y, 1.0 - 1e-16);
+        var farScreenSource = TmpVectors.Vector3[1].copyFromFloats(nearScreenSource.x, nearScreenSource.y, 1.0 - 1e-8);
         const nearVec3 = TmpVectors.Vector3[2];
         const farVec3 = TmpVectors.Vector3[3];
         Vector3._UnprojectFromInvertedMatrixToRef(nearScreenSource, matrix, nearVec3);


### PR DESCRIPTION
Reported by @sebavan 
with (really) high values in mesh world matrix, picking doesn't work.
https://playground.babylonjs.com/#KNE0O#1171

This is caused by float precisions. In this method:
https://github.com/BabylonJS/Babylon.js/blob/cc9d16b2b2867bd783f0d20d6cfac17e55e17e6e/src/Culling/ray.ts#L560

world matrix is multiplied by view and projection, then inverted. Matrix is using float and precision loss makes it impossible to pick mesh later in the code.

To improve precision, view ray is computed then transformed back into the mesh coordinates system. It's not bullet proof. With even higher values, picking will have 'holes' in resolution.


This decomposition is disabled by default. To enable it:
```
BABYLON.Ray.EnableDistantPicking = true;
```