### PR TITLE
Added option to force sRGB Buffer support state

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -75,6 +75,7 @@
 - Added `IAudioEngineOptions` interface to provide the audio engine with a pre-defined Audio Context and audio destination node. ([Vandy](https://github.com/svanderbeck11))
 - Added support for cannon-es method `world.removeBody()`. Falls back to cannon method `remove()`. ([Faber](https://https://github.com/Faber-smythe))
 - Added support for ZOffset Unit as we currently only supported factor. ([Sebavan](https://github.com/sebavan/)
+- Added the option to force the state of sRGB Buffer support ([RaananW](https://github.com/RaananW))
 
 ### Loaders
 

--- a/sandbox/src/components/renderingZone.tsx
+++ b/sandbox/src/components/renderingZone.tsx
@@ -74,7 +74,7 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             });
             await (this._engine as WebGPUEngine).initAsync();
         } else {
-            this._engine = new Engine(this._canvas, antialias, { premultipliedAlpha: false, preserveDrawingBuffer: true, antialias: antialias });
+            this._engine = new Engine(this._canvas, antialias, { premultipliedAlpha: false, preserveDrawingBuffer: true, antialias: antialias, forceSRGBBufferSupportState: this.props.globalState.commerceMode });
         }
 
         this._engine.loadingUIBackgroundColor = "#2A2342";

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1271,7 +1271,6 @@ export class ThinEngine {
             // When the issue in angle/chrome is fixed the flag should be taken into account only when it is explicitly defined
             this._caps.supportSRGBBuffers = this._caps.supportSRGBBuffers && !!(this._creationOptions && this._creationOptions.forceSRGBBufferSupportState);
         }
-        console.log(this._caps.supportSRGBBuffers);
 
         // Depth buffer
         this._depthCullingState.depthTest = true;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -161,7 +161,7 @@ export interface EngineOptions extends WebGLContextAttributes {
     /**
      * If sRGB Buffer support is not set during construction, use this value to force a specific state
      * This is added due to an issue when processing textures in chrome/edge/firefox
-     * This will not influence NativeEngine and WebGPUEngine which sets the behavior to true during construction.
+     * This will not influence NativeEngine and WebGPUEngine which set the behavior to true during construction.
      */
     forceSRGBBufferSupportState?: boolean;
 }
@@ -706,6 +706,8 @@ export class ThinEngine {
 
         options = options || {};
 
+        this._creationOptions = options;
+
         this._stencilStateComposer.stencilGlobal = this._stencilState;
 
         PerformanceConfigurator.SetMatrixPrecision(!!options.useHighPrecisionMatrix);
@@ -935,7 +937,6 @@ export class ThinEngine {
         //     }
         // }
 
-        this._creationOptions = options;
         const versionToLog = `Babylon.js v${ThinEngine.Version}`;
         console.log(versionToLog + ` - ${this.description}`);
 

--- a/tests/validation/validation.js
+++ b/tests/validation/validation.js
@@ -531,7 +531,7 @@ function init(_engineName, useReverseDepthBuffer, useNonCompatibilityMode) {
             engine.initAsync(glslangOptions, twgslOptions).then(() => resolve());
         });
     } else {
-        engine = new BABYLON.Engine(canvas, false, { useHighPrecisionFloats: true, disableWebGL2Support: engineName === "webgl1" ? true : false });
+        engine = new BABYLON.Engine(canvas, false, { useHighPrecisionFloats: true, disableWebGL2Support: engineName === "webgl1" ? true : false, forceSRGBBufferSupportState: true });
         engine.enableOfflineSupport = false;
         engine.setDitheringState(false);
         engine.useReverseDepthBuffer = forceUseReverseDepthBuffer;


### PR DESCRIPTION
Turned on by default in tests and 3dcommerce sandbox

This is done due to an error in chrome (or angle?) :

https://bugs.chromium.org/p/chromium/issues/detail?id=1256340&q=SRGB8_ALPHA8&can=4

If set during construction (like in native or webgpu) this flag is ignored. 

Fixes #11747

Points for discussion:

- Should we also support this flag in native and webgpu (i.e. - if defined, set it to this value?)? Is there a reason for that?
- The way I see it - when the error is fixed we can still support this flag (back-compat) by making sure it is defined when setting it (in thinEngine) instead of just treating it as default = false. Any other views on that?
- Any other place this needs to be turned on by default? At the moment the sandbox and the visualization tests use this flag, setting it to true.