### PR TITLE
Fix - Unique ID for physics impostor

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -375,6 +375,7 @@
 - Fix FreeCameraTouchInput roation when moving ([m1911star](https://github.com/m1911star))
 - Fix camera collisions for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 - Add a null check when setting `imageSrc` on HolographicSlate([carolhmj](https://github.com/carolhmj))
+- Fix issue with physics impostors'unique ID not set correctly if an impostor was disposed ([RaananW](https://github.com/RaananW))
 
 ## Breaking changes
 

--- a/src/Physics/physicsEngine.ts
+++ b/src/Physics/physicsEngine.ts
@@ -19,6 +19,7 @@ export class PhysicsEngine implements IPhysicsEngine {
     private _impostors: Array<PhysicsImpostor> = [];
     private _joints: Array<PhysicsImpostorJoint> = [];
     private _subTimeStep: number = 0;
+    private _uniqueIdCounter = 0;
 
     /**
      * Gets the gravity vector used by the simulation
@@ -118,7 +119,8 @@ export class PhysicsEngine implements IPhysicsEngine {
      * @param impostor the impostor to add
      */
     public addImpostor(impostor: PhysicsImpostor) {
-        impostor.uniqueId = this._impostors.push(impostor);
+        this._impostors.push(impostor);
+        impostor.uniqueId = this._uniqueIdCounter++;
         //if no parent, generate the body
         if (!impostor.parent) {
             this._physicsPlugin.generatePhysicsBody(impostor);


### PR DESCRIPTION
Unqieu IDs were set using the index position of the impostor.
This means that if an impostor was removed, the next unqieu ID will be incorrect.

Just in case this arrises - the physics engine has no reference to the scene (deliberatly), so there is no way of using the scene's unique ID mechanism.

Reported on the forum: https://forum.babylonjs.com/t/physics-imposter-unique-ids/26612