### PR TITLE
Fix "Trasnsform" tooltip typo in GUI Editor properties panel

### DIFF
--- a/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -307,7 +307,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                 <TextLineComponent tooltip="" label="TRANSFORMATION" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider">
                     <FloatLineComponent
-                        iconLabel={"Trasnsform Center"}
+                        iconLabel={"Transform Center"}
                         icon={positionIcon}
                         lockObject={this.props.lockObject}
                         label="X"


### PR DESCRIPTION
Fixes the tooltip displayed when mouse pointer hovers over the "transformation center" icon in the property panel.