### PR TITLE
Moved EnableDistantPicking flag from Ray to abstractMesh

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -47,7 +47,7 @@
 - Spelling of function/variables `xxxByID` renamed to `xxxById` to be consistent over the project. Old `xxxByID` reamain as deprecated that forward to the corresponding `xxxById` ([barroij](https://github.com/barroij))
 - Added new reflector tool that enable remote inspection of scenes. ([bghgary](https://github.com/bghgary))
 - Update `createPickingRay` and `createPickingRayToRef` matrix parameter to be nullable. ([jlivak](https://github.com/jlivak))
-- Improved scene picking precision with huge values in world matrices when `Ray.EnableDistantPicking` flag is true ([CedricGuillemet](https://github.com/CedricGuillemet)
+- Improved scene picking precision with huge values in world matrices when `Mesh.EnableDistantPicking` flag is true ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Added `applyVerticalCorrection` and `projectionPlaneTilt` to perspective cameras to correct perspective projections ([CraigFeldspar](https://github.com/CraigFeldspar))
 - Support rotation keys in universal camera ([Sebavan](https://github.com/sebavan))
 - Added flag to allow users to swap between rotation and movement for single touch on FreeCameraTouchInput ([PolygonalSun](https://github.com/PolygonalSun))

--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -461,6 +461,7 @@ export class Ray {
      * @param world world matrix
      * @param view view matrix
      * @param projection projection matrix
+     * @param enableDistantPicking defines if picking should handle large values for mesh position/scaling (false by default)
      * @returns this ray updated
      */
     public update(x: number, y: number, viewportWidth: number, viewportHeight: number, world: DeepImmutable<Matrix>, view: DeepImmutable<Matrix>, projection: DeepImmutable<Matrix>, enableDistantPicking: boolean = false): Ray {

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -102,6 +102,7 @@ class _InternalAbstractMeshDataInfo {
     public _positions: Nullable<Vector3[]> = null;
     // Collisions
     public _meshCollisionData = new _MeshCollisionData();
+    public _enableDistantPicking = false;
 }
 
 /**
@@ -583,14 +584,20 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._markSubMeshesAsMiscDirty();
     }
 
+    /** When enabled, decompose picking matrices for better precision with large values for mesh position and scling */
+    public get enableDistantPicking(): boolean {
+        return this._internalAbstractMeshDataInfo._enableDistantPicking;
+    }
+    public set enableDistantPicking(value: boolean) {
+        this._internalAbstractMeshDataInfo._enableDistantPicking = value;
+    }
+
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes selection (true by default) */
     public useOctreeForRenderingSelection = true;
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes picking (true by default) */
     public useOctreeForPicking = true;
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes collision (true by default) */
     public useOctreeForCollisions = true;
-    /** When enabled, decompose picking matrices for better precision with large values for mesh position and scling */
-    public enableDistantPicking = false;
     /**
      * Gets or sets the current layer mask (default is 0x0FFFFFFF)
      * @see https://doc.babylonjs.com/divingDeeper/cameras/layerMasksAndMultiCam

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -589,7 +589,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     public useOctreeForPicking = true;
     /** Gets or sets a boolean indicating that internal octree (if available) can be used to boost submeshes collision (true by default) */
     public useOctreeForCollisions = true;
-
+    /** When enabled, decompose picking matrices for better precision with large values for mesh position and scling */
+    public enableDistantPicking = false;
     /**
      * Gets or sets the current layer mask (default is 0x0FFFFFFF)
      * @see https://doc.babylonjs.com/divingDeeper/cameras/layerMasksAndMultiCam

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4728,9 +4728,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param result defines the ray where to store the picking ray
      * @param camera defines the camera to use for the picking
      * @param cameraViewSpace defines if picking will be done in view space (false by default)
+     * @param enableDistantPicking defines if picking should handle large values for mesh position/scaling (false by default)
      * @returns the current scene
      */
-    public createPickingRayToRef(x: number, y: number, world: Nullable<Matrix>, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false): Scene {
+    public createPickingRayToRef(x: number, y: number, world: Nullable<Matrix>, result: Ray, camera: Nullable<Camera>, cameraViewSpace = false, enableDistantPicking = false): Scene {
         throw _WarnImport("Ray");
     }
 


### PR DESCRIPTION
followup to https://github.com/BabylonJS/Babylon.js/pull/11757
Instead of a static flag in Ray, move the flag as a member of AbstractMesh for fine grained selection of mesh needing matrix decomposition for picking.