### PR TITLE
[Draco] normalize attributes if required

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -100,6 +100,7 @@
 - Added an observable for when loader state changed. ([bghgary](https://github.com/bghgary))
 - Fixed an issue where errors for loading certain assets (e.g. <20-byte GLBs) are not catchable. ([bghgary](https://github.com/bghgary))
 - Added support for `KHR_materials_emissive_strength` for glTF loader. ([sebavan](https://github.com/sebavan))
+- Added support for normalized attributes ([#11685](https://github.com/BabylonJS/Babylon.js/issues/11685)) ([RaananW](https://github.com/RaananW))
 
 ### Navigation
 

--- a/src/Meshes/Compression/dracoCompression.ts
+++ b/src/Meshes/Compression/dracoCompression.ts
@@ -86,7 +86,7 @@ function decodeMesh(decoderModule: any, dataView: ArrayBufferView, attributes: {
                 else {
                     const babylonData = new Float32Array(numValues);
                     babylonData.set(new Float32Array(decoderModule.HEAPF32.buffer, ptr, numValues));
-                    if(divider !== 1) {
+                    if (divider !== 1) {
                         for (let i = 0; i < babylonData.length; i++) {
                             babylonData[i] = babylonData[i] / divider;
                         }
@@ -386,6 +386,7 @@ export class DracoCompression implements IDisposable {
       * Decode Draco compressed mesh data to vertex data.
       * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
       * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
+      * @param dividers a list of optional dividers for normalization
       * @returns A promise that resolves with the decoded vertex data
       */
     public decodeMeshAsync(data: ArrayBuffer | ArrayBufferView, attributes?: { [kind: string]: number }, dividers?: { [kind: string]: number }): Promise<VertexData> {
@@ -417,7 +418,7 @@ export class DracoCompression implements IDisposable {
                             else {
                                 // check normalization
                                 const divider = dividers && dividers[message.data.id] ? dividers[message.data.id] : 1;
-                                if(divider !== 1) {
+                                if (divider !== 1) {
                                     // normalize
                                     for (let i = 0; i < message.data.value.length; i++) {
                                         message.data.value[i] = message.data.value[i] / divider;


### PR DESCRIPTION
Fixes #11685

Pass optional dividers in case the attributes are normalized, based on their types.

The chosen architecture is set this way because dracoCompression is part of Core and not the loaders and therefore has access only to primitives passed to it by the loader. Since dracoCompression is the component responsible for setting the vertex data there is no way out of normalizing the attributes there.