### PR TITLE
fix: typo

### DIFF
--- a/src/Meshes/Builders/cylinderBuilder.ts
+++ b/src/Meshes/Builders/cylinderBuilder.ts
@@ -18,7 +18,7 @@ import { Axis } from '../../Maths/math.axis';
   * * arc a number from 0 to 1, to create an unclosed cylinder based on the fraction of the circumference given by the arc value, optional, default 1
   * * faceColors an array of Color3 elements used to set different colors to the top, rings and bottom respectively
   * * faceUV an array of Vector4 elements used to set different images to the top, rings and bottom respectively
-  * * hasRings when true makes each subdivision independantly treated as a face for faceUV and faceColors, optional, default false
+  * * hasRings when true makes each subdivision independently treated as a face for faceUV and faceColors, optional, default false
   * * enclose when true closes an open cylinder by adding extra flat faces between the height axis and vertical edges, think cut cake
   * * sideOrientation optional and takes the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
   * * frontUvs only usable when you create a double-sided mesh, used to choose what parts of the texture image to crop and apply on the front side, optional, default vector4 (0, 0, 1, 1)

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -936,7 +936,7 @@ export class VertexData {
       * * arc a number from 0 to 1, to create an unclosed cylinder based on the fraction of the circumference given by the arc value, optional, default 1
       * * faceColors an array of Color3 elements used to set different colors to the top, rings and bottom respectively
       * * faceUV an array of Vector4 elements used to set different images to the top, rings and bottom respectively
-      * * hasRings when true makes each subdivision independantly treated as a face for faceUV and faceColors, optional, default false
+      * * hasRings when true makes each subdivision independently treated as a face for faceUV and faceColors, optional, default false
       * * enclose when true closes an open cylinder by adding extra flat faces between the height axis and vertical edges, think cut cake
       * * sideOrientation optional and takes the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
       * * frontUvs only usable when you create a double-sided mesh, used to choose what parts of the texture image to crop and apply on the front side, optional, default vector4 (0, 0, 1, 1)


### PR DESCRIPTION
Small typo in comments (`independantly` => `independently`)