### PR TITLE
Implementing near interaction for motion controllers

### DIFF
--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -208,7 +208,10 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
     constructor(_xrSessionManager: WebXRSessionManager, private readonly _options: IWebXRNearInteractionOptions) {
         super(_xrSessionManager);
         this._scene = this._xrSessionManager.scene;
-        this._options.nearInteractionControllerMode = WebXRNearControllerMode.CENTERED_IN_FRONT;
+        if (this._options.nearInteractionControllerMode === undefined) {
+            this._options.nearInteractionControllerMode = WebXRNearControllerMode.CENTERED_IN_FRONT;
+        }
+
         if (this._options.farInteractionFeature) {
             this._farInteractionFeature = this._options.farInteractionFeature;
         }

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -20,7 +20,7 @@ import { TransformNode } from "../../Meshes/transformNode";
 import { StandardMaterial } from "../../Materials/standardMaterial";
 import { Color3 } from "../../Maths/math.color";
 import { NodeMaterial } from "../../Materials/Node/nodeMaterial";
-import { Material } from "../../Materials/Material";
+import { Material } from "../../Materials/material";
 import { Animation } from "../../Animations/animation";
 import { QuadraticEase, EasingFunction } from "../../Animations/easing";
 // side effects

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -769,7 +769,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
         touchCollisionMesh.isVisible = false;
 
         // Generate the material for the touch mesh visuals
-        NodeMaterial.ParseFromSnippetAsync("8RUNKL#3", meshCreationScene).then(nodeMaterial => {
+        NodeMaterial.ParseFromSnippetAsync("8RUNKL#3", meshCreationScene).then((nodeMaterial) => {
             touchCollisionMesh.material = nodeMaterial;
         });
 

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -66,6 +66,9 @@ enum ControllerOrbAnimationState {
     TOUCH
 }
 
+/**
+ * Where should the near interaction mesh be attached to when using a motion controller for near interaction 
+ */
 export enum WebXRNearControllerMode {
     /**
      * Motion controllers will not support near interaction
@@ -355,7 +358,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
         // Don't always break to allow for animation fallthrough on rare cases of multi-transitions
         if (newState > controllerData.currentAnimationState) {
-            switch(controllerData.currentAnimationState) {
+            switch (controllerData.currentAnimationState) {
                 case ControllerOrbAnimationState.DEHYDRATED: {
                     controllerData.hydrateCollisionMeshFunction(true);
                     if (newState === ControllerOrbAnimationState.HOVER) {
@@ -371,7 +374,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
             }
         }
         else {
-            switch(controllerData.currentAnimationState) {
+            switch (controllerData.currentAnimationState) {
                 case ControllerOrbAnimationState.TOUCH: {
                     controllerData.touchCollisionMeshFunction(false);
                     if (newState === ControllerOrbAnimationState.HOVER) {
@@ -401,7 +404,6 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
         controllerData.grabRay.origin.copyFrom(position);
         orientation.toEulerAnglesToRef(TmpVectors.Vector3[0]);
         controllerData.grabRay.direction.copyFrom(TmpVectors.Vector3[0]);
-
 
         if (this._options.nearInteractionControllerMode === WebXRNearControllerMode.CENTERED_IN_FRONT && !(controllerData.xrController?.inputSource.hand)) {
             // offset the touch point in the direction the transform is facing

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -742,8 +742,6 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                 }
                 let result = WebXRNearInteraction.PickMeshWithSphere(mesh, sphere);
 
-                console.log(result.hit);
-
                 if (result && result.hit && result.distance < pickingInfo.distance) {
                     pickingInfo.hit = result.hit;
                     pickingInfo.pickedMesh = mesh;

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -19,7 +19,7 @@ import { BoundingSphere } from "../../Culling/boundingSphere";
 import { TransformNode } from "../../Meshes/transformNode";
 import { StandardMaterial } from "../../Materials/standardMaterial";
 import { Color3 } from "../../Maths/math.color";
-import { FresnelParameters } from "../../Materials/FresnelParameters";
+import { FresnelParameters } from "../../Materials/fresnelParameters";
 // side effects
 import "../../Meshes/subMesh.project";
 
@@ -98,7 +98,7 @@ export interface IWebXRNearInteractionOptions {
     /**
      * Near interaction mode for motion controllers
      */
-    nearInteractionControllerMode?: WebXRNearControllerMode
+    nearInteractionControllerMode?: WebXRNearControllerMode;
 }
 
 /**

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -51,9 +51,17 @@ type ControllerData = {
 
 // Tracks the interaction animation state when using a motion controller with a near interaction orb
 enum ControllerOrbAnimationState {
+    /**
+     * Orb is invisible
+     */
     DEHYDRATED,
-    HYDRATED,
+    /**
+     * Orb is visible and inside the hover range
+     */
     HOVER,
+    /**
+     * Orb is visible and touching a near interaction target
+     */
     TOUCH
 }
 
@@ -554,7 +562,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                 this._handleTransitionAnimation(controllerData, ControllerOrbAnimationState.TOUCH);
             }
             else if (controllerData.hoverInteraction) {
-                this._handleTransitionAnimation(controllerData, ControllerOrbAnimationState.HYDRATED);
+                this._handleTransitionAnimation(controllerData, ControllerOrbAnimationState.HOVER);
             }
             else {
                 this._handleTransitionAnimation(controllerData, ControllerOrbAnimationState.DEHYDRATED);

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -67,7 +67,7 @@ enum ControllerOrbAnimationState {
 }
 
 /**
- * Where should the near interaction mesh be attached to when using a motion controller for near interaction 
+ * Where should the near interaction mesh be attached to when using a motion controller for near interaction
  */
 export enum WebXRNearControllerMode {
     /**


### PR DESCRIPTION
This change updates the near interaction logic to work with motion controllers in addition to the existing hand joint functionality. An orb is added to the front of the motion controller to dictate the touch point, and this orb comes into view only when near an object that can be interacted with.

Also added an enum to determine how near interaction is handled for controllers - Near interaction is either disabled, enabled at the center of the controller, or enabled in front of the controller along the raycast line for far interaction (enabled by default).

Resolves #10493



https://user-images.githubusercontent.com/70608380/151047413-6e60967a-c98f-4b50-b4e8-b7e01d09b9a0.mp4



