### PR TITLE
PG: Start render loop before creating scene

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -149,6 +149,7 @@
 
 ### Playground
 
+- Start render loop before creating scene to make stopping it more convenient([BlakeOne](https://github.com/BlakeOne))
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME


### PR DESCRIPTION
PR for playground to start the default render loop before calling the scene creation function, so that we can stop it and start a new one without having to use setTimeout() to wait for the default to be started.

Basically the current code to start the render loop is moved into a hidden public method which is called after creating the engine, right before calling the user function that creates the scene.

Forum discussion: https://forum.babylonjs.com/t/make-it-easier-to-stop-default-render-loop-on-playground/26749/2