### PR TITLE
[XR] Ability to add a QuadLayer

### DIFF
--- a/src/LibDeclarations/webxr.d.ts
+++ b/src/LibDeclarations/webxr.d.ts
@@ -54,7 +54,7 @@ type XRDOMOverlayInit = {
 };
 
 type XRLightProbeInit = {
-     reflectionFormat: XRReflectionFormat;
+    reflectionFormat: XRReflectionFormat;
 };
 
 interface XRSessionInit {
@@ -100,6 +100,7 @@ declare class XRWebGLBinding {
     // https://immersive-web.github.io/layers/#XRWebGLBindingtype
     createProjectionLayer(init: XRProjectionLayerInit): XRProjectionLayer;
     getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    createQuadLayer(init: XRQuadLayerInit): XRQuadLayer;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
@@ -151,6 +152,35 @@ interface XRProjectionLayer extends XRCompositionLayer {
 
     ignoreDepthValues: boolean;
     fixedFoveation?: number;
+}
+
+interface XRLayerInit {
+    space: XRSpace;
+    colorFormat?: GLenum;        //  Default 0x1908, RGBA
+    depthFormat?: GLenum;
+    mipLevels?: number; // default = 1
+    viewPixelWidth: number;
+    viewPixelHeight: number;
+    layout?: XRLayerLayout; // defaults - mono
+    isStatic?: boolean; // false
+}
+
+interface XRQuadLayerInit extends XRLayerInit {
+    textureType?: XRTextureType; //  Default  "texture";
+    transform?: XRRigidTransform;
+    width?: number; // default 1.0
+    height?: number; // default 1.0
+}
+
+interface XRQuadLayer extends XRCompositionLayer {
+    space: XRSpace;
+    transform: XRRigidTransform;
+
+    width: number;
+    height: number;
+
+    // Events
+    onredraw: XREventHandler;
 }
 
 interface XRSubImage {
@@ -263,9 +293,9 @@ type XRDOMOverlayState = {
 };
 
 interface XRLightProbe extends EventTarget {
-    readonly probeSpace: XRSpace ;
-    onreflectionchange: XREventHandler ;
-  }
+    readonly probeSpace: XRSpace;
+    onreflectionchange: XREventHandler;
+}
 
 interface XRSession {
     addEventListener(type: XREventType, listener: XREventHandler, options?: boolean | AddEventListenerOptions): void;

--- a/src/XR/features/WebXRLayers.ts
+++ b/src/XR/features/WebXRLayers.ts
@@ -69,7 +69,10 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
         }
 
         this._lastSubImages.set(eye, subImage);
-
+        // don't skip clear for the first rtt. skip for all others
+        if (subImageIndex === 0) {
+            this._renderTargetTextures[subImageIndex].skipInitialClear = false;
+        }
         return this._renderTargetTextures[subImageIndex];
     }
 
@@ -127,6 +130,23 @@ export class WebXRProjectionLayerWrapper extends WebXRCompositionLayerWrapper {
             layer,
             'XRProjectionLayer',
             (sessionManager) => new WebXRProjectionLayerRenderTargetTextureProvider(sessionManager, xrGLBinding, this));
+    }
+}
+
+/**
+ * Wraps xr quad layers.
+ * @hidden
+ */
+export class WebXRQuadLayerWrapper extends WebXRCompositionLayerWrapper {
+    constructor(
+        public readonly layer: XRQuadLayer,
+        xrGLBinding: XRWebGLBinding) {
+        super(
+            () => layer.width,
+            () => layer.height,
+            layer,
+            'XRQuadLayer',
+            (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, xrGLBinding, this));
     }
 }
 
@@ -253,6 +273,17 @@ export class WebXRLayers extends WebXRAbstractFeature {
     public createProjectionLayer(params = defaultXRProjectionLayerInit): WebXRProjectionLayerWrapper {
         const projLayer = this._xrWebGLBinding.createProjectionLayer(params);
         return new WebXRProjectionLayerWrapper(projLayer, this._xrWebGLBinding);
+    }
+
+    /**
+     * Create a new quad layer (wrapper).
+     * Note - this is not yet added to the layers list. @see addXRSessionLayer
+     * @param params parameters for the quad layer initialization
+     * @returns a new quad layer wrapper
+     */
+    public createQuadLayer(params: XRQuadLayerInit = { space: this._xrSessionManager.referenceSpace, viewPixelHeight: 1, viewPixelWidth: 1 }): WebXRQuadLayerWrapper {
+        const quadLayer = this._xrWebGLBinding.createQuadLayer(params);
+        return new WebXRQuadLayerWrapper(quadLayer, this._xrWebGLBinding);
     }
 
     /**

--- a/src/XR/webXRLayerWrapper.ts
+++ b/src/XR/webXRLayerWrapper.ts
@@ -4,7 +4,7 @@ import { WebXRSessionManager } from "./webXRSessionManager";
 
 /** Covers all supported subclasses of WebXR's XRCompositionLayer */
 // TODO (rgerd): Extend for all other subclasses of XRCompositionLayer.
-export type WebXRCompositionLayerType = 'XRProjectionLayer';
+export type WebXRCompositionLayerType = 'XRProjectionLayer' | 'XRQuadLayer';
 
 /** Covers all supported subclasses of WebXR's XRLayer */
 export type WebXRLayerType = 'XRWebGLLayer' | WebXRCompositionLayerType;

--- a/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/src/XR/webXRRenderTargetTextureProvider.ts
@@ -63,19 +63,22 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         // Create render target texture from the internal texture
         const renderTargetTexture = new RenderTargetTexture("XR renderTargetTexture", { width, height }, this._scene);
         const renderTargetWrapper = renderTargetTexture.renderTarget!;
-        (renderTargetWrapper as WebGLRenderTargetWrapper)._framebuffer = framebuffer;
+        // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
+        if (framebuffer || !colorTexture) {
+            (renderTargetWrapper as WebGLRenderTargetWrapper)._framebuffer = framebuffer;
+        }
 
         // Create internal texture
         const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
         internalTexture.width = width;
         internalTexture.height = height;
-        if (!!colorTexture) {
+        if (colorTexture) {
             internalTexture._hardwareTexture = colorTexture;
         }
         renderTargetWrapper.setTexture(internalTexture, 0);
         renderTargetTexture._texture = internalTexture;
 
-        if (!!depthStencilTexture) {
+        if (depthStencilTexture) {
             const internalDSTexture = new InternalTexture(engine, InternalTextureSource.DepthStencil, true);
             internalDSTexture.width = width;
             internalDSTexture.height = height;


### PR DESCRIPTION
This is step one in supporting fullscreen UI in XR.

It's now possible to create a quad layer, get its texture and render anything needed to it. It's technically the same as adding a plane with a texture, but accelerated by the underlying system. It also supports XR's reference spaces which make it more usable in different XR scenarios.