### PR TITLE
[XR] utility layer clear in xr scenarios

### DIFF
--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -322,7 +322,16 @@ export class UtilityLayerRenderer implements IDisposable {
         this._afterRenderObserver = this.originalScene.onAfterCameraRenderObservable.add((camera) => {
             // Only render when the render camera finishes rendering
             if (this.shouldRender && camera == this.getRenderCamera()) {
+                let currentState;
+                if (camera.outputRenderTarget && camera.isRigCamera && camera.isLeftCamera) {
+                    // first camera in this webxr rig. don't skip clear
+                    currentState = camera.outputRenderTarget.skipInitialClear;
+                    camera.outputRenderTarget.skipInitialClear = false;
+                }
                 this.render();
+                if (camera.outputRenderTarget && currentState !== undefined) {
+                    camera.outputRenderTarget.skipInitialClear = currentState;
+                }
             }
         });
 


### PR DESCRIPTION
Utility layers are rendered after the scene was rendered.
If skipInitialClear is set to true, the utility layer doesn't render on top of the scene, but as part of the scene.

This fixes the issues mentioned here: https://forum.babylonjs.com/t/position-gizmo-is-hidden-behind-a-mesh-in-xr-gizmo-webxr/25998