### PR TITLE
Reverted Code Changes from PR 11697

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -383,7 +383,6 @@
 - Fix Button3D, HolographicButton, TouchHolographicButton and HolographicSlate content when scene is right-handed ([carolhmj](https://github.com/carolhmj))
 - Fix get attachedNode always return null for `PositionGizmo` ([jtcheng](https://github.com/jtcheng))
 - Fix Screen Space Reflections for right-handed scenes ([carolhmj](https://github.com/carolhmj))
-- Fix FreeCameraTouchInput roation when moving ([m1911star](https://github.com/m1911star))
 - Fix camera collisions for right-handed scenes ([carolhmj](https://github.com/carolhmj))
 - Add a null check when setting `imageSrc` on HolographicSlate([carolhmj](https://github.com/carolhmj))
 - Fix issue with physics impostors'unique ID not set correctly if an impostor was disposed ([RaananW](https://github.com/RaananW))

--- a/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -133,9 +133,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             };
         }
 
-        this._observer = this.camera
-            .getScene()
-            .onPointerObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
+        this._observer = this.camera.getScene().onPointerObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
         if (this._onLostFocus) {
             const engine = this.camera.getEngine();
@@ -185,12 +183,12 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         }
 
         var camera = this.camera;
+        camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
 
         const rotateCamera = (this.singleFingerRotate && this._pointerPressed.length === 1) || (!this.singleFingerRotate && this._pointerPressed.length > 1);
 
         if (rotateCamera) {
             camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
-            camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
         } else {
             var speed = camera._computeLocalCameraSpeed();
             var direction = new Vector3(0, 0, (speed * this._offsetY) / this.touchMoveSensibility);


### PR DESCRIPTION
The changes from [this PR](https://github.com/BabylonJS/Babylon.js/pull/11697) are being reverted because there is an unintended side effect.  Original behavior is that the camera would rotate when touch was at edge of screen.  Reverted PR caused this behavior to not occur.