### PR TITLE
[GUI] Fire pointer out events on children when a control is disabled

### DIFF
--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1130,7 +1130,7 @@ export class Control {
                     delete control.host._lastControlOver[pointer];
                 }
             }
-            if (control instanceof Container) {
+            if ((control as Container).children !== undefined) {
                 (control as Container).children.forEach(recursivelyFirePointerOut);
             }
         }

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1122,17 +1122,19 @@ export class Control {
 
         this._isEnabled = value;
         this._markAsDirty();
-        // if any child elements are under the pointer, we need to fire a pointerOut event on
-        if (!this._isEnabled) {
-            [this, ...this.getDescendants()].forEach(desc => {
-                for(const pointer in this.host._lastControlOver) {
-                    if (desc === this.host._lastControlOver[pointer]) {
-                        desc._onPointerOut(desc, null, true);
-                        delete this.host._lastControlOver[pointer];
-                    }
+        // if this control or any of it's descendants are under a pointer, we need to fire a pointerOut event
+        const recursivelyFirePointerOut = (control: Control) => {
+            for (const pointer in control.host._lastControlOver) {
+                if (control === this.host._lastControlOver[pointer]) {
+                    control._onPointerOut(control, null, true);
+                    delete control.host._lastControlOver[pointer];
                 }
-            })
+            }
+            if (control instanceof Container) {
+                (control as Container).children.forEach(recursivelyFirePointerOut);
+            }
         }
+        recursivelyFirePointerOut(this);
     }
     /** Gets or sets background color of control if it's disabled */
     @serialize()

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1133,7 +1133,7 @@ export class Control {
             if ((control as Container).children !== undefined) {
                 (control as Container).children.forEach(recursivelyFirePointerOut);
             }
-        }
+        };
         recursivelyFirePointerOut(this);
     }
     /** Gets or sets background color of control if it's disabled */

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1122,6 +1122,17 @@ export class Control {
 
         this._isEnabled = value;
         this._markAsDirty();
+        // if any child elements are under the pointer, we need to fire a pointerOut event on
+        if (!this._isEnabled) {
+            [this, ...this.getDescendants()].forEach(desc => {
+                for(const pointer in this.host._lastControlOver) {
+                    if (desc === this.host._lastControlOver[pointer]) {
+                        desc._onPointerOut(desc, null, true);
+                        delete this.host._lastControlOver[pointer];
+                    }
+                }
+            })
+        }
     }
     /** Gets or sets background color of control if it's disabled */
     @serialize()


### PR DESCRIPTION
If you disable a control, neither it nor its descendants can be hovered by the cursor. Therefore, we should immediately fire pointer events. Playground to demonstrate the new behavior: https://playground.babylonjs.com/#XCPP9Y#10800

Previously, clicking the button wouldn't do anything until you moved the cursor out. Now, it will instantly change the button color to red.

Fixes issue reported by @bghgary 