### PR TITLE
Removing dispose call and auto-parenting when setting a new collision mesh in TouchButton3D

### DIFF
--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -81,13 +81,9 @@ export class TouchButton3D extends Button3D {
      * @param collisionMesh the new collision mesh for the button
      */
     public set collisionMesh(collisionMesh: Mesh) {
-        if (this._collisionMesh) {
-            this._collisionMesh.dispose();
-        }
-
-        // parent the mesh to sync transforms
-        if (!collisionMesh.parent && this.mesh) {
-            collisionMesh.setParent(this.mesh);
+        // Remove the GUI3DManager's data from the previous collision mesh's reserved data store
+        if (this._collisionMesh?.reservedDataStore?.GUI3D) {
+            this._collisionMesh.reservedDataStore.GUI3D = {};
         }
 
         this._collisionMesh = collisionMesh;


### PR DESCRIPTION
Making it the developer's responsibility to dispose of a mesh created by them, and also leaving parenting the mesh up to them (no more blind assumptions about how the class will be used).

Also updating the reservedDataStore cache to prevent the GUI3DManager from performing collision testing on the mesh, as it's no longer the target for interactions.

Resolves #11807