### PR TITLE
Inspector autopicking is in sync with GimoManager autopicking

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -252,6 +252,7 @@
 - Added constructor parameters to allow turning off `updateScale` on RotationGizmo ([jekelija](https://github.com/jekelija))
 - Dispose `_dragPlane` when detaching in `PointerDragBehavior` ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Log warning when trying to attach a node to a `LightGizmo` ([CedricGuillemet](https://github.com/CedricGuillemet))
+- Inspector autopicking is in sync with `GimoManager` autopicking ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fixed wrong matrix with nodes having pivot point ([CedricGuillemet](https://github.com/CedricGuillemet))
 - `validateDrag` support added to `AxisDragGizmo` ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Gizmos that have draggable components now support near interactions via `WebXRNearInteraction` ([rickfromwork](https://github.com/rickfromwork))

--- a/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -68,7 +68,7 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
                 nextState.isSelected = false;
             }
         }
-        this.updateGizmoAutoPicking(nextState.updateGizmoAutoPicking);
+        this.updateGizmoAutoPicking(nextState.isInPickingMode);
         return true;
     }
 

--- a/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -52,6 +52,8 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
             } else if (manager.boundingBoxGizmoEnabled) {
                 gizmoMode = 4;
             }
+            // autopicking is disable by default
+            manager.enableAutoPicking = false;
         }
 
         this.state = { isSelected: false, isInPickingMode: false, gizmoMode: gizmoMode };
@@ -66,8 +68,16 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
                 nextState.isSelected = false;
             }
         }
-
+        this.updateGizmoAutoPicking(nextState.updateGizmoAutoPicking);
         return true;
+    }
+
+    updateGizmoAutoPicking(isInPickingMode: boolean) {
+        const scene = this.props.scene;
+        if (scene.reservedDataStore && scene.reservedDataStore.gizmoManager) {
+            const manager: GizmoManager = scene.reservedDataStore.gizmoManager;
+            manager.enableAutoPicking = isInPickingMode;
+        }
     }
 
     componentDidMount() {

--- a/src/Gizmos/gizmoManager.ts
+++ b/src/Gizmos/gizmoManager.ts
@@ -26,6 +26,9 @@ export class GizmoManager implements IDisposable {
     /** When true, the gizmo will be detached from the current object when a pointer down occurs with an empty picked mesh */
     public clearGizmoOnEmptyPointerEvent = false;
 
+    /** When true (default), picking to attach a new mesh is enabled. This works in sync with inspector autopicking. */
+    public enableAutoPicking = true;
+
     /** Fires an event when the manager is attached to a mesh */
     public onAttachedToMeshObservable = new Observable<Nullable<AbstractMesh>>();
 
@@ -136,32 +139,34 @@ export class GizmoManager implements IDisposable {
             }
             if (pointerInfo.type == PointerEventTypes.POINTERDOWN) {
                 if (pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh) {
-                    var node: Nullable<Node> = pointerInfo.pickInfo.pickedMesh;
-                    if (this.attachableMeshes == null) {
-                        // Attach to the most parent node
-                        while (node && node.parent != null) {
-                            node = node.parent;
-                        }
-                    } else {
-                        // Attach to the parent node that is an attachableMesh
-                        var found = false;
-                        this.attachableMeshes.forEach((mesh) => {
-                            if (node && (node == mesh || node.isDescendantOf(mesh))) {
-                                node = mesh;
-                                found = true;
+                    if (this.enableAutoPicking) {
+                        var node: Nullable<Node> = pointerInfo.pickInfo.pickedMesh;
+                        if (this.attachableMeshes == null) {
+                            // Attach to the most parent node
+                            while (node && node.parent != null) {
+                                node = node.parent;
                             }
-                        });
-                        if (!found) {
-                            node = null;
+                        } else {
+                            // Attach to the parent node that is an attachableMesh
+                            var found = false;
+                            this.attachableMeshes.forEach((mesh) => {
+                                if (node && (node == mesh || node.isDescendantOf(mesh))) {
+                                    node = mesh;
+                                    found = true;
+                                }
+                            });
+                            if (!found) {
+                                node = null;
+                            }
                         }
-                    }
-                    if (node instanceof AbstractMesh) {
-                        if (this._attachedMesh != node) {
-                            this.attachToMesh(node);
-                        }
-                    } else {
-                        if (this.clearGizmoOnEmptyPointerEvent) {
-                            this.attachToMesh(null);
+                        if (node instanceof AbstractMesh) {
+                            if (this._attachedMesh != node) {
+                                this.attachToMesh(node);
+                            }
+                        } else {
+                            if (this.clearGizmoOnEmptyPointerEvent) {
+                                this.attachToMesh(null);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Follow up to a discussion with @PatrickRyanMS 
In the inspector, when a gizmo is active, autopicking is on in the gizmomanger even if not active in Inspector.
So, clicking to rotate camera will select a mesh. To fix that, gizmomanger autopicking (on by default) is in sync with Inspector.