### PR TITLE
DeviceInputSystem: Adjust order of operations on pointerdown

### DIFF
--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -482,9 +482,12 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceType = deviceType;
                 deviceEvent.deviceSlot = deviceSlot;
 
+                // NOTE: The +2 used here to is because PointerInput has the same value progression for its mouse buttons as PointerEvent.button
+                // However, we have our X and Y values front-loaded to group together the touch inputs but not break this progression
+                // EG. ([X, Y, Left-click], Middle-click, etc...)
                 deviceEvent.inputIndex = evt.button + 2;
                 deviceEvent.previousState = previousButton;
-                deviceEvent.currentState = pointer[evt.button + 2];
+                deviceEvent.currentState = pointer[deviceEvent.inputIndex];
                 this.onInputChanged(deviceEvent);
 
                 if (previousHorizontal !== evt.clientX) {
@@ -546,9 +549,12 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     this.onInputChanged(deviceEvent);
                 }
 
+                // NOTE: The +2 used here to is because PointerInput has the same value progression for its mouse buttons as PointerEvent.button
+                // However, we have our X and Y values front-loaded to group together the touch inputs but not break this progression
+                // EG. ([X, Y, Left-click], Middle-click, etc...)
                 deviceEvent.inputIndex = evt.button + 2;
                 deviceEvent.previousState = previousButton;
-                deviceEvent.currentState = pointer[evt.button + 2];
+                deviceEvent.currentState = pointer[deviceEvent.inputIndex];
 
                 if (deviceType === DeviceType.Mouse && this._mouseId >= 0 && this._elementToAttachTo.hasPointerCapture?.(this._mouseId)) {
                     this._elementToAttachTo.releasePointerCapture(this._mouseId);

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -482,6 +482,11 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceType = deviceType;
                 deviceEvent.deviceSlot = deviceSlot;
 
+                deviceEvent.inputIndex = evt.button + 2;
+                deviceEvent.previousState = previousButton;
+                deviceEvent.currentState = pointer[evt.button + 2];
+                this.onInputChanged(deviceEvent);
+
                 if (previousHorizontal !== evt.clientX) {
                     deviceEvent.inputIndex = PointerInput.Horizontal;
                     deviceEvent.previousState = previousHorizontal;
@@ -496,11 +501,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                     this.onInputChanged(deviceEvent);
                 }
-
-                deviceEvent.inputIndex = evt.button + 2;
-                deviceEvent.previousState = previousButton;
-                deviceEvent.currentState = pointer[evt.button + 2];
-                this.onInputChanged(deviceEvent);
             }
         });
 


### PR DESCRIPTION
When a `pointerdown` event was being addressed, changes to X and Y were being handled before the actual button press so move events were being fired before the button events.  This PR changes that order to handle the button first.  This is to address an issue with the ArcRotateCamera that was causing an unnecessary rotation before allowing for pan/pinch actions.