### PR TITLE
 Add missing param "point" to the type of the callback func for PhysicsImpostor collisions

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -278,6 +278,7 @@
 
 ## Bugs
 
+- Add missing param `point` to the callback function's type for the methods `registerOnPhysicsCollide` and `unregisterOnPhysicsCollide` of the `PhysicsImpostor` class. ([BlakeOne](https://github.com/BlakeOne))
 - Fix serialization and parsing of `textBlock` and `image` for `Button` class ([BlakeOne](https://github.com/BlakeOne))
 - Fix for `AdvancedTimer` ignoring `timeout` option ([BlakeOne](https://github.com/BlakeOne))
 - Fix issue when `AssetContainer` is added to `Scene` multiple times ([BlakeOne](https://github.com/BlakeOne))

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -776,7 +776,7 @@ export class PhysicsImpostor {
      * @param collideAgainst Physics imposter, or array of physics imposters to collide against
      * @param func Callback that is executed on collision
      */
-    public registerOnPhysicsCollide(collideAgainst: PhysicsImpostor | Array<PhysicsImpostor>, func: (collider: PhysicsImpostor, collidedAgainst: PhysicsImpostor) => void): void {
+    public registerOnPhysicsCollide(collideAgainst: PhysicsImpostor | Array<PhysicsImpostor>, func: (collider: PhysicsImpostor, collidedAgainst: PhysicsImpostor, point: Nullable<Vector3>) => void): void {
         var collidedAgainstList: Array<PhysicsImpostor> = collideAgainst instanceof Array ? <Array<PhysicsImpostor>>collideAgainst : [<PhysicsImpostor>collideAgainst];
         this._onPhysicsCollideCallbacks.push({ callback: func, otherImpostors: collidedAgainstList });
     }
@@ -786,7 +786,7 @@ export class PhysicsImpostor {
      * @param collideAgainst The physics object to collide against
      * @param func Callback to execute on collision
      */
-    public unregisterOnPhysicsCollide(collideAgainst: PhysicsImpostor | Array<PhysicsImpostor>, func: (collider: PhysicsImpostor, collidedAgainst: PhysicsImpostor | Array<PhysicsImpostor>) => void): void {
+    public unregisterOnPhysicsCollide(collideAgainst: PhysicsImpostor | Array<PhysicsImpostor>, func: (collider: PhysicsImpostor, collidedAgainst: PhysicsImpostor | Array<PhysicsImpostor>, point: Nullable<Vector3>) => void): void {
         var collidedAgainstList: Array<PhysicsImpostor> = collideAgainst instanceof Array ? <Array<PhysicsImpostor>>collideAgainst : [<PhysicsImpostor>collideAgainst];
         var index = -1;
         let found = this._onPhysicsCollideCallbacks.some((cbDef, idx) => {


### PR DESCRIPTION
The type of the callback function for PhysicsImpostor's methods registerOnPhysicsCollide and unregisterOnPhysicsCollide is missing the third parameter point. This PR just adds that missing parameter for proper typing, code-completion, and API-documentation. :)

Forum issue/discussion: https://forum.babylonjs.com/t/point-of-collision/26862/7