### PR TITLE
DeviceInputSystem: Fixed Gamepad caching issue and added DualSense support

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -69,6 +69,7 @@
 - Added `onCreateCustomMeshImpostor` handler for creating mesh impostors with custom vertex data. ([MackeyK24](https://github.com/MackeyK24))
 - Added `onCreateCustomConvexHullImpostor` handler for creating convex hull imposters with custom vertex data. ([MackeyK24](https://github.com/MackeyK24))
 - Modified touch in `WebDeviceInputSystem` to no longer delete touch points after pointer up. ([PolygonalSun](https://github.com/PolygonalSun))
+- Added support for DualSense controllers to DeviceInputSystem. ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -15,7 +15,9 @@ export enum DeviceType {
     /** Xbox */
     Xbox = 5,
     /** Switch Controller */
-    Switch = 6
+    Switch = 6,
+    /** PS5 DualSense */
+    DualSense = 7,
 }
 
 // Device Enums
@@ -71,6 +73,56 @@ export enum DualShockInput {
     R2 = 7,
     /** Share */
     Share = 8,
+    /** Options */
+    Options = 9,
+    /** L3 */
+    L3 = 10,
+    /** R3 */
+    R3 = 11,
+    /** DPadUp */
+    DPadUp = 12,
+    /** DPadDown */
+    DPadDown = 13,
+    /** DPadLeft */
+    DPadLeft = 14,
+    /** DRight */
+    DPadRight = 15,
+    /** Home */
+    Home = 16,
+    /** TouchPad */
+    TouchPad = 17,
+    /** LStickXAxis */
+    LStickXAxis = 18,
+    /** LStickYAxis */
+    LStickYAxis = 19,
+    /** RStickXAxis */
+    RStickXAxis = 20,
+    /** RStickYAxis */
+    RStickYAxis = 21
+}
+
+/**
+ * Enum for Dual Shock Gamepad
+ */
+ export enum DualSenseInput {
+    /** Cross */
+    Cross = 0,
+    /** Circle */
+    Circle = 1,
+    /** Square */
+    Square = 2,
+    /** Triangle */
+    Triangle = 3,
+    /** L1 */
+    L1 = 4,
+    /** R1 */
+    R1 = 5,
+    /** L2 */
+    L2 = 6,
+    /** R2 */
+    R2 = 7,
+    /** Create */
+    Create  = 8,
     /** Options */
     Options = 9,
     /** L3 */

--- a/src/DeviceInput/InputDevices/deviceTypes.ts
+++ b/src/DeviceInput/InputDevices/deviceTypes.ts
@@ -1,4 +1,4 @@
-import { DeviceType, PointerInput, DualShockInput, XboxInput, SwitchInput } from './deviceEnums';
+import { DeviceType, PointerInput, DualShockInput, XboxInput, SwitchInput, DualSenseInput } from './deviceEnums';
 
 /**
  * Type to handle enforcement of inputs
@@ -9,4 +9,5 @@ export type DeviceInput<T extends DeviceType> =
     T extends DeviceType.DualShock ? DualShockInput :
     T extends DeviceType.Xbox ? XboxInput :
     T extends DeviceType.Switch ? SwitchInput :
+    T extends DeviceType.DualSense ? DualSenseInput :
     never;

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -162,6 +162,7 @@ export class InternalDeviceSourceManager implements IDisposable {
                 this._firstDevice[type] = 0;
                 break;
             case DeviceType.Touch:
+            case DeviceType.DualSense:
             case DeviceType.DualShock:
             case DeviceType.Xbox:
             case DeviceType.Switch:

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -100,7 +100,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             throw `Unable to find device ${DeviceType[deviceType]}`;
         }
 
-        if (deviceType >= DeviceType.Xbox && deviceType <= DeviceType.Switch && navigator.getGamepads) {
+        if (deviceType >= DeviceType.DualShock && deviceType <= DeviceType.DualSense && navigator.getGamepads) {
             this._updateDevice(deviceType, deviceSlot, inputIndex);
         }
 
@@ -194,8 +194,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         const deviceType = this._getGamepadDeviceType(gamepad.id);
         const deviceSlot = gamepad.index;
 
-        this._registerDevice(deviceType, deviceSlot, gamepad.buttons.length + gamepad.axes.length);
         this._gamepads = this._gamepads || new Array<DeviceType>(gamepad.index + 1);
+        this._registerDevice(deviceType, deviceSlot, gamepad.buttons.length + gamepad.axes.length);
+
         this._gamepads[deviceSlot] = deviceType;
     }
 
@@ -768,8 +769,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
      * @returns DeviceType enum value
      */
     private _getGamepadDeviceType(deviceName: string): DeviceType {
-        if (deviceName.indexOf("054c") !== -1 && deviceName.indexOf("0ce6") === -1) { // DualShock 4 Gamepad
-            return DeviceType.DualShock;
+        if (deviceName.indexOf("054c") !== -1) { // DualShock 4 Gamepad
+            return (deviceName.indexOf("0ce6") !== -1 ? DeviceType.DualSense : DeviceType.DualShock);
         }
         else if (deviceName.indexOf("Xbox One") !== -1 || deviceName.search("Xbox 360") !== -1 || deviceName.search("xinput") !== -1) { // Xbox Gamepad
             return DeviceType.Xbox;


### PR DESCRIPTION
This PR contains a fix and compatibility enhancement.  There was a scenario where the DeviceInputSystem could check for input on gamepads before they were properly cached.  This has been fixed.  Basic PS5 DualSense support has been added to the DeviceInputSystem/DeviceSourceManager.  It will be detected and interacted with in the same manner as any other gamepad.