### PR TITLE
Fallback error logging on mesh loading tasks

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -102,6 +102,7 @@
 - Fixed an issue where errors for loading certain assets (e.g. <20-byte GLBs) are not catchable. ([bghgary](https://github.com/bghgary))
 - Added support for `KHR_materials_emissive_strength` for glTF loader. ([sebavan](https://github.com/sebavan))
 - Added support for normalized attributes ([#11685](https://github.com/BabylonJS/Babylon.js/issues/11685)) ([RaananW](https://github.com/RaananW))
+- Added fallback error logging on mesh loading tasks if no error handler is defined. ([carolhmj](https://github.com/carolhmj))
 
 ### Navigation
 

--- a/src/Misc/assetsManager.ts
+++ b/src/Misc/assetsManager.ts
@@ -1151,12 +1151,27 @@ export class AssetsManager {
 
             if (this.onTaskError) {
                 this.onTaskError(task);
+            } else if (!task.onError) {
+                Logger.Error(this._formatTaskErrorMessage(task));
             }
             this.onTaskErrorObservable.notifyObservers(task);
             this._decreaseWaitingTasksCount(task);
         };
 
         task.run(this._scene, done, error);
+    }
+
+    private _formatTaskErrorMessage(task: AbstractAssetTask) {
+        let errorMessage = "Unable to complete task " + task.name;
+
+        if (task.errorObject.message) {
+            errorMessage += `: ${task.errorObject.message}`;
+        }
+        if (task.errorObject.exception) {
+            errorMessage += `: ${task.errorObject.exception}`;
+        }
+
+        return errorMessage;
     }
 
     /**


### PR DESCRIPTION
With this, the mesh loading tasks will have the same behavior as the SceneLoader tasks: if no error handler is defined, print an error message with errors on loading.
Example on playground showing that tasks don't log, but SceneLoaders do: https://playground.babylonjs.com/#ZJYNY#987