### PR TITLE
Fix PG download

### DIFF
--- a/Playground/src/components/rendererComponent.tsx
+++ b/Playground/src/components/rendererComponent.tsx
@@ -100,32 +100,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         });
     }
 
-    /** @hidden */
-    public _startRenderLoop(engine: Engine, canvas: HTMLCanvasElement) {
-        engine.runRenderLoop(() => {
-            if (!this._scene || !this._engine) {
-                return;
-            }            
-
-            if (this.props.globalState.runtimeMode === RuntimeMode.Editor && window.innerWidth > this.props.globalState.MobileSizeTrigger) {
-                if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
-                    this._engine.resize();
-                }
-            }
-
-            if (this._scene.activeCamera || (this._scene.activeCameras && this._scene.activeCameras.length > 0)) {
-                this._scene.render();
-            }
-
-            // Update FPS if camera is not a webxr camera
-            if (!(this._scene.activeCamera && this._scene.activeCamera.getClassName && this._scene.activeCamera.getClassName() === "WebXRCamera")) {
-                if (this.props.globalState.runtimeMode !== RuntimeMode.Full) {
-                    this.props.globalState.fpsElement.innerHTML = this._engine.getFps().toFixed() + " fps";
-                }
-            }
-        });
-    }
-
     private async _compileAndRunAsync() {
         this.props.globalState.onDisplayWaitRingObservable.notifyObservers(false);
         this.props.globalState.onErrorObservable.notifyObservers(null);
@@ -287,8 +261,31 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     window.engine = await asyncEngineCreation();`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";
 
-                globalObject.engineHost = this;
-                code += "\r\nengineHost._startRenderLoop(engine, canvas);";
+                globalObject.startRenderLoop = (engine: Engine, canvas: HTMLCanvasElement) => {
+                    engine.runRenderLoop(() => {
+                        if (!this._scene || !this._engine) {
+                            return;
+                        }
+
+                        if (this.props.globalState.runtimeMode === RuntimeMode.Editor && window.innerWidth > this.props.globalState.MobileSizeTrigger) {
+                            if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
+                                this._engine.resize();
+                            }
+                        }
+
+                        if (this._scene.activeCamera || (this._scene.activeCameras && this._scene.activeCameras.length > 0)) {
+                            this._scene.render();
+                        }
+
+                        // Update FPS if camera is not a webxr camera
+                        if (!(this._scene.activeCamera && this._scene.activeCamera.getClassName && this._scene.activeCamera.getClassName() === "WebXRCamera")) {
+                            if (this.props.globalState.runtimeMode !== RuntimeMode.Full) {
+                                this.props.globalState.fpsElement.innerHTML = this._engine.getFps().toFixed() + " fps";
+                            }
+                        }
+                    });
+                };
+                code += "\r\nstartRenderLoop(engine, canvas);";
 
                 if (this.props.globalState.language === "JS") {
                     code += "\r\n" + "window.scene = " + createSceneFunction + "();";
@@ -348,7 +345,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 });
             } else {
                 this._scene = globalObject.scene as Scene;
-            }            
+            }
 
             if (checkSceneCount && this._engine.scenes.length === 0) {
                 this.props.globalState.onErrorObservable.notifyObservers({

--- a/Playground/zipContent/index.html
+++ b/Playground/zipContent/index.html
@@ -41,7 +41,7 @@
     <script>
         var canvas = document.getElementById("renderCanvas");
 
-        function startRenderLoop(engine, canvas) {
+        var startRenderLoop = function (engine, canvas) {
             engine.runRenderLoop(function () {
                 if (sceneToRender && sceneToRender.activeCamera) {
                     sceneToRender.render();

--- a/Playground/zipContent/index.html
+++ b/Playground/zipContent/index.html
@@ -41,12 +41,15 @@
     <script>
         var canvas = document.getElementById("renderCanvas");
 
-####INJECT####        
+        function startRenderLoop(engine, canvas) {
             engine.runRenderLoop(function () {
                 if (sceneToRender && sceneToRender.activeCamera) {
                     sceneToRender.render();
                 }
             });
+        }
+
+####INJECT####                    
         });
 
         // Resize

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -155,7 +155,7 @@
 
 ### Playground
 
-- Start render loop before creating scene to make stopping it more convenient([BlakeOne](https://github.com/BlakeOne))
+- Start render loop before creating scene to make stopping it more convenient on the PG website and PG dowloads([BlakeOne](https://github.com/BlakeOne))
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -155,7 +155,7 @@
 
 ### Playground
 
-- Start render loop before creating scene to make stopping it more convenient. ([BlakeOne](https://github.com/BlakeOne))
+- Start render loop before creating scene to make stopping it more convenient ([BlakeOne](https://github.com/BlakeOne))
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -155,7 +155,7 @@
 
 ### Playground
 
-- Start render loop before creating scene to make stopping it more convenient on the PG website and PG dowloads([BlakeOne](https://github.com/BlakeOne))
+- Start render loop before creating scene to make stopping it more convenient. ([BlakeOne](https://github.com/BlakeOne))
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
 
 ### NME


### PR DESCRIPTION
Fixes a bug introduced to downloaded playgrounds by my previous PR, in which I overlooked handling and testing PG downloads. With this bug fix and improvement, both PG's running on the PG website and PG's downloaded will work the same, with the default render loop started before the scene is created so that the scene creation function can stop it without using setTimeout to wait for it to be created.

Forum discussion / bug report: https://forum.babylonjs.com/t/playground-sample-zip-stops-to-work/27004

Original PR for reference: https://github.com/BabylonJS/Babylon.js/pull/11783