### PR TITLE
Add multiview support for XRProjectionLayer

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -246,6 +246,7 @@
 - Introduced a new opt-in property to `Gui3DManager`, `useRealisticScaling`, that will automatically scale 3D GUI components like buttons to MRTK standards for better sizing in XR experiences. ([rickfromwork](https://github.com/rickfromwork))
 - Add `NativeXRPlugin` and `NativeXRFrame` to improve XR performance on BabylonNative ([rgerd](https://github.com/rgerd))
 - Reset XR Camera's orientation when entering an AR session for consistent experience ([RaananW](https://github.com/RaananW))
+- Enable multiview rendering to `XRProjectionLayer` with texture type "texture-array" ([#10767](https://github.com/BabylonJS/Babylon.js/issues/10767)) ([rgerd](https://github.com/rgerd))
 
 ### Gizmos
 

--- a/src/Engines/Extensions/engine.multiview.ts
+++ b/src/Engines/Extensions/engine.multiview.ts
@@ -99,7 +99,7 @@ declare module "../../Cameras/camera" {
          * @hidden
          * For WebXR cameras that are rendering to multiview texture arrays.
          */
-        _renderingMultiview(): boolean;
+        _renderingMultiview: boolean;
 
         /**
          * @hidden
@@ -114,10 +114,6 @@ declare module "../../Cameras/camera" {
 Camera.prototype._useMultiviewToSingleView = false;
 
 Camera.prototype._multiviewTexture = null;
-
-Camera.prototype._renderingMultiview = function() {
-    return this.outputRenderTarget && this.outputRenderTarget.getViewCount() > 1 && this.getEngine().getCaps().multiview;
-};
 
 Camera.prototype._resizeOrCreateMultiviewTexture = function (width: number, height: number) {
     if (!this._multiviewTexture) {

--- a/src/Materials/Textures/MultiviewRenderTarget.ts
+++ b/src/Materials/Textures/MultiviewRenderTarget.ts
@@ -7,6 +7,11 @@ import { Constants } from '../../Engines/constants';
  * @see https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/
  */
 export class MultiviewRenderTarget extends RenderTargetTexture {
+    public set samples(value: number) {
+        // We override this setter because multisampling is handled by framebufferTextureMultisampleMultiviewOVR
+        this._samples = value;
+    }
+
     /**
      * Creates a multiview render target
      * @param scene scene used with the render target
@@ -14,8 +19,8 @@ export class MultiviewRenderTarget extends RenderTargetTexture {
      */
     constructor(scene: Scene, size: number | { width: number, height: number } | { ratio: number } = 512) {
         super("multiview rtt", size, scene, false, true, Constants.TEXTURETYPE_UNSIGNED_INT, false, undefined, false, false, true, undefined, true);
-        var rtWrapper = scene.getEngine().createMultiviewRenderTargetTexture(this.getRenderWidth(), this.getRenderHeight());
-        this._texture = rtWrapper.texture!;
+        this._renderTarget = scene.getEngine().createMultiviewRenderTargetTexture(this.getRenderWidth(), this.getRenderHeight());
+        this._texture = this._renderTarget.texture!;
         this._texture.isMultiview = true;
         this._texture.format = Constants.TEXTUREFORMAT_RGBA;
         this.samples = this._getEngine()!.getCaps().maxSamples || this.samples;

--- a/src/XR/features/WebXRLayers.ts
+++ b/src/XR/features/WebXRLayers.ts
@@ -234,7 +234,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
         this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
         this._existingLayers = [];
 
-        const projectionLayerInit = defaultXRProjectionLayerInit;
+        const projectionLayerInit = { ...defaultXRProjectionLayerInit };
         const projectionLayerMultiview = this._options.preferMultiviewOnInit && engine.getCaps().multiview;
         if (projectionLayerMultiview) {
             projectionLayerInit.textureType = 'texture-array';

--- a/src/XR/features/WebXRLayers.ts
+++ b/src/XR/features/WebXRLayers.ts
@@ -3,7 +3,6 @@ import { WebXRSessionManager } from "../webXRSessionManager";
 import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import { Nullable } from "../../types";
 import { WebXRLayerRenderTargetTextureProvider } from "../webXRRenderTargetTextureProvider";
-import { WebGLHardwareTexture } from "../../Engines/WebGL/webGLHardwareTexture";
 import { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
 import { WebXRLayerType, WebXRLayerWrapper } from "../webXRLayerWrapper";
 import { Viewport } from "../../Maths/math.viewport";
@@ -19,6 +18,7 @@ export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
         public getHeight: () => number,
         public readonly layer: XRCompositionLayer,
         public readonly layerType: WebXRLayerType,
+        public readonly isMultiview: boolean,
         public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider) {
         super(
             getWidth,
@@ -35,7 +35,6 @@ export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
  */
 class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
     protected _lastSubImages = new Map<XREye, XRWebGLSubImage>();
-    private _glContext: WebGLRenderingContext;
     private _compositionLayer: XRCompositionLayer;
 
     constructor(
@@ -43,7 +42,6 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
         protected readonly _xrWebGLBinding: XRWebGLBinding,
         public readonly layerWrapper: WebXRCompositionLayerWrapper) {
         super(_xrSessionManager.scene, layerWrapper);
-        this._glContext = this._xrSessionManager.scene.getEngine()._gl;
         this._compositionLayer = layerWrapper.layer;
     }
 
@@ -53,14 +51,13 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
         if (!this._renderTargetTextures[subImageIndex] ||
             lastSubImage?.textureWidth !== subImage.textureWidth ||
             lastSubImage?.textureHeight != subImage.textureHeight) {
-            const colorTexture = new WebGLHardwareTexture(subImage.colorTexture, this._glContext);
-            const depthStencilTexture = new WebGLHardwareTexture(subImage.depthStencilTexture, this._glContext);
             this._renderTargetTextures[subImageIndex] = this._createRenderTargetTexture(
                 subImage.textureWidth,
                 subImage.textureHeight,
                 null,
-                colorTexture,
-                depthStencilTexture);
+                subImage.colorTexture,
+                subImage.depthStencilTexture,
+                this.layerWrapper.isMultiview);
 
             this._framebufferDimensions = {
                 framebufferWidth: subImage.textureWidth,
@@ -120,12 +117,14 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
 export class WebXRProjectionLayerWrapper extends WebXRCompositionLayerWrapper {
     constructor(
         public readonly layer: XRProjectionLayer,
+        isMultiview: boolean,
         xrGLBinding: XRWebGLBinding) {
         super(
             () => layer.textureWidth,
             () => layer.textureHeight,
             layer,
             'XRProjectionLayer',
+            isMultiview,
             (sessionManager) => new WebXRProjectionLayerRenderTargetTextureProvider(sessionManager, xrGLBinding, this));
     }
 }
@@ -177,7 +176,14 @@ const defaultXRWebGLLayerInit: XRWebGLLayerInit = {
 const defaultXRProjectionLayerInit: XRProjectionLayerInit = {
     textureType: "texture",
     colorFormat: 0x1908, /* WebGLRenderingContext.RGBA */
-    depthFormat: 0x1902, /* WebGLRenderingContext.DEPTH_COMPONENT */
+    depthFormat: 0x88F0, /* WebGLRenderingContext.DEPTH24_STENCIL8 */
+    scaleFactor: 1.0,
+};
+
+const defaultMultiviewXRProjectionLayerInit: XRProjectionLayerInit = {
+    textureType: "texture-array",
+    colorFormat: 0x1908,
+    depthFormat: 0x88F0,
     scaleFactor: 1.0,
 };
 
@@ -219,10 +225,15 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return false;
         }
 
-        this._glContext = this._xrSessionManager.scene.getEngine()._gl;
+        const engine = this._xrSessionManager.scene.getEngine();
+        this._glContext = engine._gl;
         this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
         this._existingLayers = [];
-        this.addXRSessionLayer(this.createProjectionLayer());
+
+        const projectionLayerParams = engine.getCaps().multiview
+            ? defaultMultiviewXRProjectionLayerInit
+            : defaultXRProjectionLayerInit;
+        this.addXRSessionLayer(this.createProjectionLayer(projectionLayerParams));
 
         return true;
     }
@@ -247,12 +258,13 @@ export class WebXRLayers extends WebXRAbstractFeature {
 
     /**
      * Creates a new XRProjectionLayer.
-     * @param params an object providing configuration options for the new XRProjectionLayer
+     * @param params an object providing configuration options for the new XRProjectionLayer.
+     * If the texture type is set to 'texture-array', multiview rendering will be used.
      * @returns the projection layer
      */
     public createProjectionLayer(params = defaultXRProjectionLayerInit): WebXRProjectionLayerWrapper {
         const projLayer = this._xrWebGLBinding.createProjectionLayer(params);
-        return new WebXRProjectionLayerWrapper(projLayer, this._xrWebGLBinding);
+        return new WebXRProjectionLayerWrapper(projLayer, params.textureType === 'texture-array', this._xrWebGLBinding);
     }
 
     /**

--- a/src/XR/features/WebXRLayers.ts
+++ b/src/XR/features/WebXRLayers.ts
@@ -259,12 +259,15 @@ export class WebXRLayers extends WebXRAbstractFeature {
     /**
      * Creates a new XRProjectionLayer.
      * @param params an object providing configuration options for the new XRProjectionLayer.
-     * If the texture type is set to 'texture-array', multiview rendering will be used.
+     * @param multiview whether the projection layer should render with multiview.
      * @returns the projection layer
      */
-    public createProjectionLayer(params = defaultXRProjectionLayerInit): WebXRProjectionLayerWrapper {
+    public createProjectionLayer(params = defaultXRProjectionLayerInit, multiview = false): WebXRProjectionLayerWrapper {
+        if (multiview && params.textureType !== 'texture-array') {
+            throw new Error("Projection layers can only be made multiview if they use texture arrays. Set the textureType parameter to 'texture-array'.");
+        }
         const projLayer = this._xrWebGLBinding.createProjectionLayer(params);
-        return new WebXRProjectionLayerWrapper(projLayer, params.textureType === 'texture-array', this._xrWebGLBinding);
+        return new WebXRProjectionLayerWrapper(projLayer, multiview, this._xrWebGLBinding);
     }
 
     /**

--- a/src/XR/features/WebXRLayers.ts
+++ b/src/XR/features/WebXRLayers.ts
@@ -47,11 +47,11 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
 
     protected _getRenderTargetForSubImage(subImage: XRWebGLSubImage, eye: XREye) {
         const lastSubImage = this._lastSubImages.get(eye);
-        const subImageIndex = eye == 'left' ? 0 : 1;
-        if (!this._renderTargetTextures[subImageIndex] ||
+        const eyeIndex = eye == 'left' ? 0 : 1;
+        if (!this._renderTargetTextures[eyeIndex] ||
             lastSubImage?.textureWidth !== subImage.textureWidth ||
             lastSubImage?.textureHeight != subImage.textureHeight) {
-            this._renderTargetTextures[subImageIndex] = this._createRenderTargetTexture(
+            this._renderTargetTextures[eyeIndex] = this._createRenderTargetTexture(
                 subImage.textureWidth,
                 subImage.textureHeight,
                 null,
@@ -67,7 +67,7 @@ class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderT
 
         this._lastSubImages.set(eye, subImage);
 
-        return this._renderTargetTextures[subImageIndex];
+        return this._renderTargetTextures[eyeIndex];
     }
 
     private _getSubImageForEye(eye: XREye): Nullable<XRWebGLSubImage> {
@@ -186,6 +186,7 @@ const defaultXRProjectionLayerInit: XRProjectionLayerInit = {
 export interface IWebXRLayersOptions {
     /**
      * Whether to try initializing the base projection layer as a multiview render target, if multiview is supported.
+     * Defaults to false.
      */
     preferMultiviewOnInit?: boolean;
 }
@@ -271,6 +272,12 @@ export class WebXRLayers extends WebXRAbstractFeature {
         if (multiview && params.textureType !== 'texture-array') {
             throw new Error("Projection layers can only be made multiview if they use texture arrays. Set the textureType parameter to 'texture-array'.");
         }
+
+        // TODO (rgerd): Support RTT's that are bound to sub-images in the texture array.
+        if (!multiview && params.textureType === 'texture-array') {
+            throw new Error("We currently only support multiview rendering when the textureType parameter is set to 'texture-array'.");
+        }
+
         const projLayer = this._xrWebGLBinding.createProjectionLayer(params);
         return new WebXRProjectionLayerWrapper(projLayer, multiview, this._xrWebGLBinding);
     }

--- a/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/src/XR/webXRRenderTargetTextureProvider.ts
@@ -1,3 +1,4 @@
+import { Engine } from "../Engines/engine";
 import { WebGLHardwareTexture } from "../Engines/WebGL/webGLHardwareTexture";
 import { WebGLRenderTargetWrapper } from "../Engines/WebGL/webGLRenderTargetWrapper";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
@@ -46,12 +47,21 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
     protected _renderTargetTextures = new Array<RenderTargetTexture>();
     protected _framebufferDimensions: Nullable<{ framebufferWidth: number, framebufferHeight: number }>;
 
-    private _glContext: WebGLRenderingContext;
+    private _engine: Engine;
 
     constructor(
         private readonly _scene: Scene,
         public readonly layerWrapper: WebXRLayerWrapper) {
-        this._glContext = _scene.getEngine()._gl;
+        this._engine = _scene.getEngine();
+    }
+
+    private _createInternalTexture(textureSize: { width: number, height: number }, texture: WebGLTexture): InternalTexture {
+        const internalTexture = new InternalTexture(this._engine, InternalTextureSource.Unknown, true);
+        internalTexture.width = textureSize.width;
+        internalTexture.height = textureSize.height;
+        internalTexture._hardwareTexture = new WebGLHardwareTexture(texture, this._engine._gl);
+        internalTexture.isReady = true;
+        return internalTexture;
     }
 
     protected _createRenderTargetTexture(
@@ -61,15 +71,16 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         colorTexture?: WebGLTexture,
         depthStencilTexture?: WebGLTexture,
         multiview?: boolean): RenderTargetTexture {
-        const engine = this._scene.getEngine();
-        if (!engine) {
+        if (!this._engine) {
             throw new Error("Engine is disposed");
         }
 
+        const textureSize = { width, height };
+
         // Create render target texture from the internal texture
         const renderTargetTexture = multiview
-            ? new MultiviewRenderTarget(this._scene, { width, height })
-            : new RenderTargetTexture("XR renderTargetTexture", { width, height }, this._scene);
+            ? new MultiviewRenderTarget(this._scene, textureSize)
+            : new RenderTargetTexture("XR renderTargetTexture", textureSize, this._scene);
         const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
         // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
         if (framebuffer || !colorTexture) {
@@ -81,12 +92,8 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
             if (multiview) {
                 renderTargetWrapper._colorTextureArray = colorTexture;
             } else {
-                const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
-                internalTexture.width = width;
-                internalTexture.height = height;
-                internalTexture._hardwareTexture = new WebGLHardwareTexture(colorTexture, this._glContext);
+                const internalTexture = this._createInternalTexture(textureSize, colorTexture);
                 renderTargetWrapper.setTexture(internalTexture, 0);
-                internalTexture.isReady = true;
                 renderTargetTexture._texture = internalTexture;
             }
         }
@@ -95,12 +102,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
             if (multiview) {
                 renderTargetWrapper._depthStencilTextureArray = depthStencilTexture;
             } else {
-                const internalDSTexture = new InternalTexture(engine, InternalTextureSource.DepthStencil, true);
-                internalDSTexture.width = width;
-                internalDSTexture.height = height;
-                internalDSTexture._hardwareTexture = new WebGLHardwareTexture(depthStencilTexture, this._glContext);
-                internalDSTexture.isReady = true;
-                renderTargetWrapper._depthStencilTexture = internalDSTexture;
+                renderTargetWrapper._depthStencilTexture = this._createInternalTexture(textureSize, depthStencilTexture);
             }
         }
 

--- a/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/src/XR/webXRRenderTargetTextureProvider.ts
@@ -1,6 +1,7 @@
 import { WebGLHardwareTexture } from "../Engines/WebGL/webGLHardwareTexture";
 import { WebGLRenderTargetWrapper } from "../Engines/WebGL/webGLRenderTargetWrapper";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
+import { MultiviewRenderTarget } from "../Materials/Textures/MultiviewRenderTarget";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { Viewport } from "../Maths/math.viewport";
 import { IDisposable, Scene } from "../scene";
@@ -45,42 +46,62 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
     protected _renderTargetTextures = new Array<RenderTargetTexture>();
     protected _framebufferDimensions: Nullable<{ framebufferWidth: number, framebufferHeight: number }>;
 
+    private _glContext: WebGLRenderingContext;
+
     constructor(
         private readonly _scene: Scene,
-        public readonly layerWrapper: WebXRLayerWrapper) { }
+        public readonly layerWrapper: WebXRLayerWrapper) {
+        this._glContext = _scene.getEngine()._gl;
+    }
 
     protected _createRenderTargetTexture(
         width: number,
         height: number,
         framebuffer: Nullable<WebGLFramebuffer>,
-        colorTexture?: WebGLHardwareTexture,
-        depthStencilTexture?: WebGLHardwareTexture): RenderTargetTexture {
+        colorTexture?: WebGLTexture,
+        depthStencilTexture?: WebGLTexture,
+        multiview?: boolean): RenderTargetTexture {
         const engine = this._scene.getEngine();
         if (!engine) {
             throw new Error("Engine is disposed");
         }
 
         // Create render target texture from the internal texture
-        const renderTargetTexture = new RenderTargetTexture("XR renderTargetTexture", { width, height }, this._scene);
-        const renderTargetWrapper = renderTargetTexture.renderTarget!;
-        (renderTargetWrapper as WebGLRenderTargetWrapper)._framebuffer = framebuffer;
+        const renderTargetTexture = multiview
+            ? new MultiviewRenderTarget(this._scene, { width, height })
+            : new RenderTargetTexture("XR renderTargetTexture", { width, height }, this._scene);
+        const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
+        // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
+        if (framebuffer || !colorTexture) {
+            renderTargetWrapper._framebuffer = framebuffer;
+        }
 
         // Create internal texture
-        const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
-        internalTexture.width = width;
-        internalTexture.height = height;
-        if (!!colorTexture) {
-            internalTexture._hardwareTexture = colorTexture;
+        if (colorTexture) {
+            if (multiview) {
+                renderTargetWrapper._colorTextureArray = colorTexture;
+            } else {
+                const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
+                internalTexture.width = width;
+                internalTexture.height = height;
+                internalTexture._hardwareTexture = new WebGLHardwareTexture(colorTexture, this._glContext);
+                renderTargetWrapper.setTexture(internalTexture, 0);
+                internalTexture.isReady = true;
+                renderTargetTexture._texture = internalTexture;
+            }
         }
-        renderTargetWrapper.setTexture(internalTexture, 0);
-        renderTargetTexture._texture = internalTexture;
 
-        if (!!depthStencilTexture) {
-            const internalDSTexture = new InternalTexture(engine, InternalTextureSource.DepthStencil, true);
-            internalDSTexture.width = width;
-            internalDSTexture.height = height;
-            internalDSTexture._hardwareTexture = depthStencilTexture;
-            renderTargetWrapper._depthStencilTexture = internalDSTexture;
+        if (depthStencilTexture) {
+            if (multiview) {
+                renderTargetWrapper._depthStencilTextureArray = depthStencilTexture;
+            } else {
+                const internalDSTexture = new InternalTexture(engine, InternalTextureSource.DepthStencil, true);
+                internalDSTexture.width = width;
+                internalDSTexture.height = height;
+                internalDSTexture._hardwareTexture = new WebGLHardwareTexture(depthStencilTexture, this._glContext);
+                internalDSTexture.isReady = true;
+                renderTargetWrapper._depthStencilTexture = internalDSTexture;
+            }
         }
 
         renderTargetTexture.disableRescaling();

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3932,7 +3932,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             this._bindFrameBuffer(this._activeCamera);
         }
 
-        var useMultiview = this.getEngine().getCaps().multiview && camera.outputRenderTarget && camera.outputRenderTarget.getViewCount() > 1;
+        var useMultiview = camera._renderingMultiview;
         if (useMultiview) {
             this.setTransformMatrix(camera._rigCameras[0].getViewMatrix(), camera._rigCameras[0].getProjectionMatrix(), camera._rigCameras[1].getViewMatrix(), camera._rigCameras[1].getProjectionMatrix());
         } else {
@@ -4045,8 +4045,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     }
 
     private _processSubCameras(camera: Camera, bindFrameBuffer = true): void {
-        if (camera.cameraRigMode === Constants.RIG_MODE_NONE || camera._renderingMultiview()) {
-            if (camera._renderingMultiview() && !this._multiviewSceneUbo) {
+        if (camera.cameraRigMode === Constants.RIG_MODE_NONE || camera._renderingMultiview) {
+            if (camera._renderingMultiview && !this._multiviewSceneUbo) {
                 this._createMultiviewUbo();
             }
             this._renderForCamera(camera, undefined, bindFrameBuffer);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -4045,7 +4045,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     }
 
     private _processSubCameras(camera: Camera, bindFrameBuffer = true): void {
-        if (camera.cameraRigMode === Constants.RIG_MODE_NONE || (camera.outputRenderTarget && camera.outputRenderTarget.getViewCount() > 1 && this.getEngine().getCaps().multiview)) {
+        if (camera.cameraRigMode === Constants.RIG_MODE_NONE || camera._renderingMultiview()) {
+            if (camera._renderingMultiview() && !this._multiviewSceneUbo) {
+                this._createMultiviewUbo();
+            }
             this._renderForCamera(camera, undefined, bindFrameBuffer);
             this.onAfterRenderCameraObservable.notifyObservers(camera);
             return;
@@ -4360,7 +4363,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 throw new Error("No camera defined");
             }
 
-            this._processSubCameras(this.activeCamera, false);
+            this._processSubCameras(this.activeCamera, !!this.activeCamera.outputRenderTarget);
         }
 
         // Intersection checks


### PR DESCRIPTION
This change hooks up the `XRProjectionLayer` to our existing xr multiview rendering implementation. The `"texture-array"` texture type in `XRProjectionLayerInit` is designed to be used with the multiview WebGL extension, and so we use multiview rendering whenever `"texture-array"` is specified as the texture type.

Before:
<img height="300" alt="scene-render-no-mv" src="https://user-images.githubusercontent.com/4724014/151077741-3f9e842b-9aec-437d-89a5-665e53daef11.png">

After:
<img height="300" alt="scene-render-mv" src="https://user-images.githubusercontent.com/4724014/151077735-1ec81825-c3bd-4ec8-919e-5ae1acc1518a.png">

Taking performance profiles on an Oculus quest with a playground rendering 400 default-fidelity spheres (https://playground.babylonjs.com/#F41V6N#705), I got the following per-frame times for multiview turned off and on:

Multiview off
 - scene.render: 59-62ms
 - GPU time: 5ms
 - renderFunction (the entire frame): 61-72ms

Multiview on
 - scene.render: 30-32ms
 - GPU time: 3ms
 - renderFunction: 32-40ms

Exported profiles from Chrome DevTools:
[xr-multiview-profiles.zip](https://github.com/BabylonJS/Babylon.js/files/7937993/xr-multiview-profiles.zip)

So we got some significant performance wins on both the CPU and GPU, as would be expected. With scene.render taking up around 95% of the entire time for the frame, cutting the time for that function down in half just about doubled the overall FPS.

Even with one sphere, I'm still seeing around a 10% decrease in frame time (40% in scene.render) and about a 20% decrease in GPU time.

fixes #10767 
