### PR TITLE
WebGPU: Sync with spec

### DIFF
--- a/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -126,7 +126,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             else {
                 location = this.webgpuProcessingContext.getVaryingNextLocation(varyingType, this._getArraySize(name, varyingType, preProcessors)[2]);
                 this.webgpuProcessingContext.availableVaryings[name] = location;
-                this._varyingsWGSL.push(`[[location(${location})]] ${name} : ${varyingType};`);
+                this._varyingsWGSL.push(`@location(${location}) ${name} : ${varyingType};`);
                 this._varyingsDeclWGSL.push(`var<private> ${name} : ${varyingType};`);
                 this._varyingNamesWGSL.push(name);
             }
@@ -147,7 +147,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             this.webgpuProcessingContext.availableAttributes[name] = location;
             this.webgpuProcessingContext.orderedAttributes[location] = name;
 
-            this._attributesWGSL.push(`[[location(${location})]] ${name} : ${attributeType};`);
+            this._attributesWGSL.push(`@location(${location}) ${name} : ${attributeType};`);
             this._attributesDeclWGSL.push(`var<private> ${name} : ${attributeType};`);
             this._attributeNamesWGSL.push(name);
             attribute = "";
@@ -215,7 +215,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
                 const { groupIndex, bindingIndex } = textureInfo.textures[i];
 
                 if (i === 0) {
-                    texture = `[[group(${groupIndex}), binding(${bindingIndex})]] ${texture}`;
+                    texture = `@group(${groupIndex}) @binding(${bindingIndex}) ${texture}`;
                 }
 
                 this._addTextureBindingDescription(name, textureInfo, i, textureDimension, storageTextureFormat, !isFragment);
@@ -259,13 +259,13 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
 
         let vertexAttributesDecl = this._attributesDeclWGSL.join("\n") + "\n";
 
-        let vertexInputs = "struct VertexInputs {\n  [[builtin(vertex_index)]] vertexIndex : u32;\n  [[builtin(instance_index)]] instanceIndex : u32;\n";
+        let vertexInputs = "struct VertexInputs {\n  @builtin(vertex_index) vertexIndex : u32;\n  @builtin(instance_index) instanceIndex : u32;\n";
         if (this._attributesWGSL.length > 0) {
             vertexInputs += this._attributesWGSL.join("\n");
         }
         vertexInputs += "\n};\n";
 
-        let vertexFragmentInputs = "struct FragmentInputs {\n  [[builtin(position)]] position : vec4<f32>;\n";
+        let vertexFragmentInputs = "struct FragmentInputs {\n  @builtin(position) position : vec4<f32>;\n";
         if (this._varyingsWGSL.length > 0) {
             vertexFragmentInputs += this._varyingsWGSL.join("\n");
         }
@@ -297,13 +297,13 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
 
         let fragmentBuiltinDecl = `var<private> ${builtInName_position_frag} : vec4<f32>;\nvar<private> ${builtInName_front_facing} : bool;\nvar<private> ${builtInName_FragColor} : vec4<f32>;\nvar<private> ${builtInName_frag_depth} : f32;\n`;
 
-        let fragmentFragmentInputs = "struct FragmentInputs {\n  [[builtin(position)]] position : vec4<f32>;\n  [[builtin(front_facing)]] frontFacing : bool;\n";
+        let fragmentFragmentInputs = "struct FragmentInputs {\n  @builtin(position) position : vec4<f32>;\n  @builtin(front_facing) frontFacing : bool;\n";
         if (this._varyingsWGSL.length > 0) {
             fragmentFragmentInputs += this._varyingsWGSL.join("\n");
         }
         fragmentFragmentInputs += "\n};\n";
 
-        let fragmentOutputs = "struct FragmentOutputs {\n  [[location(0)]] color : vec4<f32>;\n";
+        let fragmentOutputs = "struct FragmentOutputs {\n  @location(0) color : vec4<f32>;\n";
 
         let hasFragDepth = false;
         let idx = 0;
@@ -325,7 +325,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
         }
 
         if (hasFragDepth) {
-            fragmentOutputs += "  [[builtin(frag_depth)]] fragDepth: f32;\n";
+            fragmentOutputs += "  @builtin(frag_depth) fragDepth: f32;\n";
         }
 
         fragmentOutputs += "};\n";
@@ -363,7 +363,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
 
             if (leftOverUniform.length > 0) {
                 if (size <= 2) {
-                    ubo += ` [[align(16)]] ${leftOverUniform.name} : [[stride(16)]] array<${leftOverUniform.type}, ${leftOverUniform.length}>;\n`;
+                    ubo += ` @align(16) ${leftOverUniform.name} : @stride(16) array<${leftOverUniform.type}, ${leftOverUniform.length}>;\n`;
                 } else {
                     ubo += ` ${leftOverUniform.name} : array<${leftOverUniform.type}, ${leftOverUniform.length}>;\n`;
                 }
@@ -374,7 +374,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
         }
         ubo += "};\n";
 
-        ubo += `[[group(${uniformBufferDescription.binding.groupIndex}), binding(${uniformBufferDescription.binding.bindingIndex})]] var<uniform> ${leftOverVarName} : ${name};\n`;
+        ubo += `@group(${uniformBufferDescription.binding.groupIndex}) @binding(${uniformBufferDescription.binding.bindingIndex}) var<uniform> ${leftOverVarName} : ${name};\n`;
 
         return ubo;
     }
@@ -412,7 +412,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             this._addSamplerBindingDescription(name, samplerInfo, isVertex);
 
             const part1 = code.substring(0, match.index);
-            const insertPart = `[[group(${samplerInfo.binding.groupIndex}), binding(${samplerInfo.binding.bindingIndex})]] `;
+            const insertPart = `@group(${samplerInfo.binding.groupIndex}) @binding(${samplerInfo.binding.bindingIndex}) `;
             const part2 = code.substring(match.index);
 
             code = part1 + insertPart + part2;
@@ -462,7 +462,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             const bindingIndex = bufferInfo.binding.bindingIndex;
 
             const part1 = code.substring(0, match.index);
-            const insertPart = `[[group(${groupIndex}), binding(${bindingIndex})]] `;
+            const insertPart = `@group(${groupIndex}) @binding(${bindingIndex}) `;
             const part2 = code.substring(match.index);
 
             code = part1 + insertPart + part2;

--- a/src/Rendering/depthPeelingRenderer.ts
+++ b/src/Rendering/depthPeelingRenderer.ts
@@ -428,7 +428,7 @@ export class DepthPeelingRenderer {
         this._engine.bindFramebuffer(this._depthMrts[0].renderTarget!);
         this._engine.bindAttachments(this._layoutCache[0]);
 
-        this._engine.setAlphaMode(Constants.ALPHA_ONEONE); // the value does not matter (as MAX operation does not use them) but the src and dst color factors should not use SRC_ALPHA else WebGPU will throw a validation error
+        this._engine.setAlphaMode(Constants.ALPHA_ONEONE_ONEONE); // in WebGPU, when using MIN or MAX equation, the src / dst color factors should not use SRC_ALPHA and the src / dst alpha factors must be 1 else WebGPU will throw a validation error
         this._engine.setAlphaEquation(Constants.ALPHA_EQUATION_MAX);
         this._engine.depthCullingState.depthMask = false;
         this._engine.depthCullingState.depthTest = true;
@@ -465,7 +465,7 @@ export class DepthPeelingRenderer {
             this._engine.bindFramebuffer(this._depthMrts[writeId].renderTarget!);
             this._engine.bindAttachments(this._layoutCache[2]);
 
-            this._engine.setAlphaMode(Constants.ALPHA_ONEONE); // the value does not matter (as MAX operation does not use them) but the src and dst color factors should not use SRC_ALPHA else WebGPU will throw a validation error
+            this._engine.setAlphaMode(Constants.ALPHA_ONEONE_ONEONE); // the value does not matter (as MAX operation does not use them) but the src and dst color factors should not use SRC_ALPHA else WebGPU will throw a validation error
             this._engine.setAlphaEquation(Constants.ALPHA_EQUATION_MAX);
             this._engine.depthCullingState.depthTest = false;
             this._engine.applyStates();

--- a/src/ShadersWGSL/gpuUpdateParticles.compute.fx
+++ b/src/ShadersWGSL/gpuUpdateParticles.compute.fx
@@ -125,40 +125,40 @@ struct SimParams {
     #endif
 };
 
-[[binding(0), group(0)]] var<uniform> params : SimParams;
-[[binding(1), group(0)]] var<storage, read> particlesIn : Particles;
-[[binding(2), group(0)]] var<storage, read_write> particlesOut : Particles;
-[[binding(3), group(0)]] var randomTexture : texture_2d<f32>;
-[[binding(4), group(0)]] var randomTexture2 : texture_2d<f32>;
+@binding(0) @group(0) var<uniform> params : SimParams;
+@binding(1) @group(0) var<storage, read> particlesIn : Particles;
+@binding(2) @group(0) var<storage, read_write> particlesOut : Particles;
+@binding(3) @group(0) var randomTexture : texture_2d<f32>;
+@binding(4) @group(0) var randomTexture2 : texture_2d<f32>;
 
 #ifdef SIZEGRADIENTS
-    [[binding(0), group(1)]] var sizeGradientSampler : sampler;
-    [[binding(1), group(1)]] var sizeGradientTexture : texture_2d<f32>;
+    @binding(0) @group(1) var sizeGradientSampler : sampler;
+    @binding(1) @group(1) var sizeGradientTexture : texture_2d<f32>;
 #endif 
 
 #ifdef ANGULARSPEEDGRADIENTS
-    [[binding(2), group(1)]] var angularSpeedGradientSampler : sampler;
-    [[binding(3), group(1)]] var angularSpeedGradientTexture : texture_2d<f32>;
+    @binding(2) @group(1) var angularSpeedGradientSampler : sampler;
+    @binding(3) @group(1) var angularSpeedGradientTexture : texture_2d<f32>;
 #endif 
 
 #ifdef VELOCITYGRADIENTS
-    [[binding(4), group(1)]] var velocityGradientSampler : sampler;
-    [[binding(5), group(1)]] var velocityGradientTexture : texture_2d<f32>;
+    @binding(4) @group(1) var velocityGradientSampler : sampler;
+    @binding(5) @group(1) var velocityGradientTexture : texture_2d<f32>;
 #endif
 
 #ifdef LIMITVELOCITYGRADIENTS
-    [[binding(6), group(1)]] var limitVelocityGradientSampler : sampler;
-    [[binding(7), group(1)]] var limitVelocityGradientTexture : texture_2d<f32>;
+    @binding(6) @group(1) var limitVelocityGradientSampler : sampler;
+    @binding(7) @group(1) var limitVelocityGradientTexture : texture_2d<f32>;
 #endif
 
 #ifdef DRAGGRADIENTS
-    [[binding(8), group(1)]] var dragGradientSampler : sampler;
-    [[binding(9), group(1)]] var dragGradientTexture : texture_2d<f32>;
+    @binding(8) @group(1) var dragGradientSampler : sampler;
+    @binding(9) @group(1) var dragGradientTexture : texture_2d<f32>;
 #endif
 
 #ifdef NOISE
-    [[binding(10), group(1)]] var noiseSampler : sampler;
-    [[binding(11), group(1)]] var noiseTexture : texture_2d<f32>;
+    @binding(10) @group(1) var noiseSampler : sampler;
+    @binding(11) @group(1) var noiseTexture : texture_2d<f32>;
 #endif
 
 fn getRandomVec3(offset : f32, vertexID : f32) -> vec3<f32> {
@@ -169,8 +169,8 @@ fn getRandomVec4(offset : f32, vertexID : f32) -> vec4<f32> {
     return textureLoad(randomTexture, vec2<i32>(i32(vertexID * offset / params.currentCount * f32(params.randomTextureSize)) % params.randomTextureSize, 0), 0);
 }
 
-[[stage(compute), workgroup_size(64)]]
-fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
+@stage(compute) @workgroup_size(64)
+fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
     let index : u32 = GlobalInvocationID.x;
     let vertexID : f32 = f32(index);
 

--- a/tests/validation/config.json
+++ b/tests/validation/config.json
@@ -1356,7 +1356,7 @@
         {
             "title": "Sample depth texture",
             "renderCount": 5,
-            "playgroundId": "#8RU8Q3#81",
+            "playgroundId": "#8RU8Q3#108",
             "excludedEngines": ["webgl1"],
             "referenceImage": "sampleDepthTexture.png"
         },

--- a/tests/validation/webgpu.json
+++ b/tests/validation/webgpu.json
@@ -155,7 +155,7 @@
         {
             "title": "wgsl in shadermaterial",
             "renderCount": 30,
-            "playgroundId": "#8RU8Q3#79",
+            "playgroundId": "#8RU8Q3#104",
             "excludedEngines": ["webgl1", "webgl2"]
         },
         {


### PR DESCRIPTION
Replace the `[[...]]` decorations by `@`.

There are still a lot of deprecated warnings (because of old decoration formats + [[block]] should be removed) because TintWASM should be recompiled with the newest source code (providing Tint is up to date regarding those deprecation warnings...).