### PR TITLE
Fix WaterMaterial constructor

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -281,6 +281,7 @@
 
 ## Bugs
 
+- Fix `WaterMaterial`’s constructor to use `this.getScene()` instead of `scene` parameter ([BlakeOne](https://github.com/BlakeOne))
 - Add missing param `point` to the callback function's type for the methods `registerOnPhysicsCollide` and `unregisterOnPhysicsCollide` of the `PhysicsImpostor` class. ([BlakeOne](https://github.com/BlakeOne))
 - Fix serialization and parsing of `textBlock` and `image` for `Button` class ([BlakeOne](https://github.com/BlakeOne))
 - Fix for `AdvancedTimer` ignoring `timeout` option ([BlakeOne](https://github.com/BlakeOne))

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -228,7 +228,7 @@ export class WaterMaterial extends PushMaterial {
     constructor(name: string, scene: Scene, public renderTargetSize: Vector2 = new Vector2(512, 512)) {
         super(name, scene);
 
-        this._createRenderTargets(scene, renderTargetSize);
+        this._createRenderTargets(this.getScene(), renderTargetSize);
 
         // Create render targets
         this.getRenderTargetTextures = (): SmartArray<RenderTargetTexture> => {


### PR DESCRIPTION
Fixes WaterMaterial’s constructor to use this.getScene() instead of scene parameter to avoid the error repro’ed in below playground that doesn’t pass a scene.

Playground: https://playground.babylonjs.com/#1SLLOJ#2029
Forum: https://forum.babylonjs.com/t/babylon-watermaterial-scene-parameter-required/27015