### PR TITLE
Added load texture2D array capability to native engine

### DIFF
--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -27,7 +27,7 @@ export interface INativeEngine {
     createTexture(): WebGLTexture;
     loadTexture(texture: WebGLTexture, data: ArrayBufferView, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadRawTexture(texture: WebGLTexture, data: ArrayBufferView, width: number, height: number, format: number, generateMips: boolean, invertY: boolean): void;
-    loadRawTexture2DArray(texture: WebGLTexture, data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean, samplingMode: number, compression: Nullable<string>, textureType : number) : void;
+    loadRawTexture2DArray(texture: WebGLTexture, data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean) : void;
     loadCubeTexture(texture: WebGLTexture, data: Array<ArrayBufferView>, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadCubeTextureWithMips(texture: WebGLTexture, data: Array<Array<ArrayBufferView>>, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     getTextureWidth(texture: WebGLTexture): number;

--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -27,6 +27,7 @@ export interface INativeEngine {
     createTexture(): WebGLTexture;
     loadTexture(texture: WebGLTexture, data: ArrayBufferView, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadRawTexture(texture: WebGLTexture, data: ArrayBufferView, width: number, height: number, format: number, generateMips: boolean, invertY: boolean): void;
+    loadRawTexture2DArray(texture: WebGLTexture, data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean, samplingMode: number, compression: Nullable<string>, textureType : number) : void;
     loadCubeTexture(texture: WebGLTexture, data: Array<ArrayBufferView>, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadCubeTextureWithMips(texture: WebGLTexture, data: Array<Array<ArrayBufferView>>, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     getTextureWidth(texture: WebGLTexture): number;

--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -27,7 +27,7 @@ export interface INativeEngine {
     createTexture(): WebGLTexture;
     loadTexture(texture: WebGLTexture, data: ArrayBufferView, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadRawTexture(texture: WebGLTexture, data: ArrayBufferView, width: number, height: number, format: number, generateMips: boolean, invertY: boolean): void;
-    loadRawTexture2DArray(texture: WebGLTexture, data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean) : void;
+    loadRawTexture2DArray(texture: WebGLTexture, data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean): void;
     loadCubeTexture(texture: WebGLTexture, data: Array<ArrayBufferView>, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadCubeTextureWithMips(texture: WebGLTexture, data: Array<Array<ArrayBufferView>>, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     getTextureWidth(texture: WebGLTexture): number;

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -2046,9 +2046,13 @@ export class NativeEngine extends Engine {
         texture.is3D = false;
         texture.depth = depth;
 
-        if (texture._hardwareTexture) {
+        if (texture._hardwareTexture) 
+        {
             var webGLTexture = texture._hardwareTexture.underlyingResource;
-            this._engine.loadRawTexture2DArray(webGLTexture, data, width, height, depth, this._getNativeTextureFormat(format, textureType), generateMipMaps, invertY, samplingMode, compression, textureType);
+            this._engine.loadRawTexture2DArray(webGLTexture, data, width, height, depth, this._getNativeTextureFormat(format, textureType), generateMipMaps, invertY);
+        
+            var filter = this._getNativeSamplingMode(samplingMode);
+            this._setTextureSampling(webGLTexture, filter);
         }
 
         return texture;

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -2046,8 +2046,7 @@ export class NativeEngine extends Engine {
         texture.is3D = false;
         texture.depth = depth;
 
-        if (texture._hardwareTexture) 
-        {
+        if (texture._hardwareTexture) {
             var webGLTexture = texture._hardwareTexture.underlyingResource;
             this._engine.loadRawTexture2DArray(webGLTexture, data, width, height, depth, this._getNativeTextureFormat(format, textureType), generateMipMaps, invertY, samplingMode, compression, textureType);
         }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1317,7 +1317,7 @@ export class NativeEngine extends Engine {
             width: this.getRenderWidth(),
             x: 0,
             y: 0,
-            toJSON: () => {}
+            toJSON: () => { }
         };
         return rect;
     }
@@ -2046,11 +2046,10 @@ export class NativeEngine extends Engine {
         texture.is3D = false;
         texture.depth = depth;
 
-        if (texture._hardwareTexture) 
-        {
+        if (texture._hardwareTexture) {
             var webGLTexture = texture._hardwareTexture.underlyingResource;
             this._engine.loadRawTexture2DArray(webGLTexture, data, width, height, depth, this._getNativeTextureFormat(format, textureType), generateMipMaps, invertY);
-        
+
             var filter = this._getNativeSamplingMode(samplingMode);
             this._setTextureSampling(webGLTexture, filter);
         }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -2029,6 +2029,32 @@ export class NativeEngine extends Engine {
         return texture;
     }
 
+    public createRawTexture2DArray(data: Nullable<ArrayBufferView>, width: number, height: number, depth: number, format: number, generateMipMaps: boolean, invertY: boolean, samplingMode: number, compression: Nullable<string> = null, textureType = Constants.TEXTURETYPE_UNSIGNED_INT): InternalTexture {
+        let texture = new InternalTexture(this, InternalTextureSource.Raw2DArray);
+
+        texture.format = format;
+        texture.generateMipMaps = generateMipMaps;
+        texture.samplingMode = samplingMode;
+        texture.invertY = invertY;
+        texture.baseWidth = width;
+        texture.baseHeight = height;
+        texture.width = texture.baseWidth;
+        texture.height = texture.baseHeight;
+        texture._compression = compression;
+        texture.type = textureType;
+        texture.is2DArray = true;
+        texture.is3D = false;
+        texture.depth = depth;
+
+        if (texture._hardwareTexture) 
+        {
+            var webGLTexture = texture._hardwareTexture.underlyingResource;
+            this._engine.loadRawTexture2DArray(webGLTexture, data, width, height, depth, this._getNativeTextureFormat(format, textureType), generateMipMaps, invertY, samplingMode, compression, textureType);
+        }
+
+        return texture;
+    }
+
     public updateRawTexture(texture: Nullable<InternalTexture>, bufferView: Nullable<ArrayBufferView>, format: number, invertY: boolean, compression: Nullable<string> = null, type: number = Constants.TEXTURETYPE_UNSIGNED_INT): void {
         if (!texture) {
             return;


### PR DESCRIPTION
Added the capability for the native engine to handle texture2D arrays in order to enable morph targets to use texture arrays on Babylon Native. 