### PR TITLE
Improvements to tick distance on ACE

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -154,6 +154,7 @@
 - Let users edit multiple ACE key frame/values at the same time ([carolhmj](https://github.com/carolhmj))
 - Set default tangents for new keys on ACE and fix their behavior ([carolhmj](https://github.com/carolhmj))
 - Let the playhead move past the last animation key on ACE ([carolhmj](https://github.com/carolhmj))
+- Improve zooming on ACE ([carolhmj](https://github.com/carolhmj))
 
 ### Playground
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/frameBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/frameBarComponent.tsx
@@ -4,6 +4,10 @@ import { GlobalState } from "../../../../../../globalState";
 import { Context } from "../context";
 import { Observer } from "babylonjs/Misc/observable";
 
+// x distance between consecutive ticks on the frame
+const baseTickDistance = 25;
+const minTickDistance = 35;
+
 interface IFrameBarComponentProps {
     globalState: GlobalState;
     context: Context;
@@ -72,7 +76,7 @@ export class FrameBarComponent extends React.Component<IFrameBarComponentProps, 
 
         let range = maxFrame - minFrame;
         let convertRatio = range / this._GraphAbsoluteWidth;
-        let dist = Math.max(25 * this._viewScale, 35) ; // x distance between consecutive ticks
+        const dist = Math.max(baseTickDistance * this._viewScale, minTickDistance) ; // x distance between consecutive ticks
         let offset = Math.floor(dist * convertRatio);
 
         let steps = [];

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/frameBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/frameBarComponent.tsx
@@ -70,10 +70,10 @@ export class FrameBarComponent extends React.Component<IFrameBarComponentProps, 
         let minFrame = this.props.context.referenceMinFrame;
         let maxFrame = this.props.context.referenceMaxFrame;
 
-        let stepCounts = 20;
         let range = maxFrame - minFrame;
-        let offset = (range / stepCounts) | 0;
         let convertRatio = range / this._GraphAbsoluteWidth;
+        let dist = Math.max(25 * this._viewScale, 35) ; // x distance between consecutive ticks
+        let offset = Math.floor(dist * convertRatio);
 
         let steps = [];
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/graphComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/graphComponent.tsx
@@ -21,7 +21,7 @@ interface IGraphComponentState {}
 
 export class GraphComponent extends React.Component<IGraphComponentProps, IGraphComponentState> {
     private readonly _MinScale = 0.5;
-    private readonly _MaxScale = 4;
+    private readonly _MaxScale = 5;
     private readonly _GraphAbsoluteWidth = 788;
     private readonly _GraphAbsoluteHeight = 357;
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
@@ -5,6 +5,8 @@ import { Context } from "../context";
 import { Animation } from "babylonjs/Animations/animation";
 import { Observer } from "babylonjs/Misc/observable";
 
+const tickDistance = 25; // x distance between consecutive ticks
+
 interface IRangeFrameBarComponentProps {
     globalState: GlobalState;
     context: Context;
@@ -114,8 +116,8 @@ export class RangeFrameBarComponent extends React.Component<IRangeFrameBarCompon
 
         let range = to - from;
         let convertRatio = range / this._viewWidth;
-        let dist = 25; // x distance between consecutive ticks
-        let offset = Math.max(Math.floor(dist * convertRatio), 1);
+        const dist = tickDistance; 
+        const offset = Math.max(Math.floor(dist * convertRatio), 1);
 
         let steps = [];
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
@@ -113,9 +113,9 @@ export class RangeFrameBarComponent extends React.Component<IRangeFrameBarCompon
         const to = this.props.context.toKey;
 
         let range = to - from;
-        let stepCounts = Math.min(20, to - from);
-        let offset = (range / stepCounts) | 0;
         let convertRatio = range / this._viewWidth;
+        let dist = 25; // x distance between consecutive ticks
+        let offset = Math.floor(dist * convertRatio);
 
         let steps = [];
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
@@ -115,7 +115,7 @@ export class RangeFrameBarComponent extends React.Component<IRangeFrameBarCompon
         let range = to - from;
         let convertRatio = range / this._viewWidth;
         let dist = 25; // x distance between consecutive ticks
-        let offset = Math.floor(dist * convertRatio);
+        let offset = Math.max(Math.floor(dist * convertRatio), 1);
 
         let steps = [];
 

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
@@ -56,7 +56,7 @@ export class TopBarComponent extends React.Component<ITopBarComponentProps, ITop
             const numKeys = this.props.context.activeKeyPoints?.length || 0;
             const numAnims = new Set(this.props.context.activeKeyPoints?.map(keyPointComponent => keyPointComponent.props.curve.animation.uniqueId)).size;
             
-            const frameControlEnabled = numKeys > 0 && numAnims > 1;
+            const frameControlEnabled = (numKeys === 1 && numAnims === 1) || (numKeys > 1 && numAnims > 1);
             const valueControlEnabled = numKeys > 0;
             
             this.setState({ keyFrameValue: "", keyValue: "", frameControlEnabled, valueControlEnabled });


### PR DESCRIPTION
Changed a bit how the calculation of the ticks works so that it adapts to smaller screen sizes:
![image](https://user-images.githubusercontent.com/6002144/151048868-697b10ce-6d64-43f4-a1a7-213a621a788c.png)

And also works better with zoomed out views:
![image](https://user-images.githubusercontent.com/6002144/151048997-06f72b57-fdde-491e-acf3-38addd19e45d.png)

Also increased the max zoom level by a bit