### PR TITLE
optional scene parameter (part 1)

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -356,7 +356,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * @param samplingMode defines the texture sampling mode (Texture.NEAREST_SAMPLINGMODE by default)
      * @param invertY defines if the texture needs to be inverted on the y axis during loading (true by default)
      */
-    constructor(name: string, width = 0, height = 0, scene: Nullable<Scene>, generateMipMaps = false, samplingMode = Texture.NEAREST_SAMPLINGMODE, invertY = true) {
+    constructor(name: string, width = 0, height = 0, scene?: Nullable<Scene>, generateMipMaps = false, samplingMode = Texture.NEAREST_SAMPLINGMODE, invertY = true) {
         super(name, { width: width, height: height }, scene, generateMipMaps, samplingMode, Constants.TEXTUREFORMAT_RGBA, invertY);
         scene = this.getScene();
         if (!scene || !this._texture) {

--- a/gui/src/3D/materials/fluent/fluentMaterial.ts
+++ b/gui/src/3D/materials/fluent/fluentMaterial.ts
@@ -116,7 +116,7 @@ export class FluentMaterial extends PushMaterial {
      * @param name defines the name of the material
      * @param scene defines the hosting scene
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -217,13 +217,13 @@ export class FluentBackplateMaterial extends PushMaterial {
     public globalRightIndexTipPosition = Vector3.Zero();
     private _globalRightIndexTipPosition4 = Vector4.Zero();
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
 
-        this._blobTexture = new Texture(FluentBackplateMaterial.BLOB_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
-        this._iridescentMap = new Texture(FluentBackplateMaterial.IM_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._blobTexture = new Texture(FluentBackplateMaterial.BLOB_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._iridescentMap = new Texture(FluentBackplateMaterial.IM_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public needAlphaBlending(): boolean {

--- a/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
+++ b/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
@@ -268,13 +268,13 @@ export class FluentButtonMaterial extends PushMaterial {
 
     private _blobTexture: Texture;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_ADD;
         this.disableDepthWrite = true;
         this.backFaceCulling = false;
 
-        this._blobTexture = new Texture(FluentButtonMaterial.BLOB_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._blobTexture = new Texture(FluentButtonMaterial.BLOB_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public needAlphaBlending(): boolean {

--- a/gui/src/3D/materials/handle/handleMaterial.ts
+++ b/gui/src/3D/materials/handle/handleMaterial.ts
@@ -87,7 +87,7 @@ export class HandleMaterial extends ShaderMaterial {
      * @param name Name of the material
      * @param scene Scene
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene, "handle", {
             attributes: ["position"],
             uniforms: ["worldViewProjection", "color", "scale", "positionOffset"],

--- a/gui/src/3D/materials/handle/handleMaterial.ts
+++ b/gui/src/3D/materials/handle/handleMaterial.ts
@@ -87,7 +87,7 @@ export class HandleMaterial extends ShaderMaterial {
      * @param name Name of the material
      * @param scene Scene
      */
-    constructor(name: string, scene?: Scene) {
+    constructor(name: string, scene: Scene) {
         super(name, scene, "handle", {
             attributes: ["position"],
             uniforms: ["worldViewProjection", "color", "scale", "positionOffset"],

--- a/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
+++ b/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
@@ -209,12 +209,12 @@ export class MRDLBackplateMaterial extends PushMaterial {
     @serialize()
     public edgeLineGradientBlend = 0.5;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
 
-        this._iridescentMapTexture = new Texture(MRDLBackplateMaterial.IRIDESCENT_MAP_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._iridescentMapTexture = new Texture(MRDLBackplateMaterial.IRIDESCENT_MAP_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public needAlphaBlending(): boolean {

--- a/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
+++ b/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
@@ -477,11 +477,11 @@ export class MRDLSliderBarMaterial extends PushMaterial {
      */
     public globalRightIndexMiddlePosition =  new Vector4(0.0, 0.0, 0.0, 1.0);
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
-        this._blueGradientTexture = new Texture(MRDLSliderBarMaterial.BLUE_GRADIENT_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._blueGradientTexture = new Texture(MRDLSliderBarMaterial.BLUE_GRADIENT_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public needAlphaBlending(): boolean {

--- a/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
+++ b/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
@@ -478,7 +478,7 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
      */
     public globalRightIndexMiddlePosition = new Vector4(0.0, 0.0, 0.0, 1.0);
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;

--- a/materialsLibrary/src/cell/cellMaterial.ts
+++ b/materialsLibrary/src/cell/cellMaterial.ts
@@ -76,7 +76,7 @@ export class CellMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/custom/customMaterial.ts
+++ b/materialsLibrary/src/custom/customMaterial.ts
@@ -173,7 +173,7 @@ export class CustomMaterial extends StandardMaterial {
         return name;
     }
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.CustomParts = new ShaderSpecialParts();
         this.customShaderNameResolve = this.Builder;

--- a/materialsLibrary/src/custom/pbrCustomMaterial.ts
+++ b/materialsLibrary/src/custom/pbrCustomMaterial.ts
@@ -188,7 +188,7 @@ export class PBRCustomMaterial extends PBRMaterial {
         return name;
     }
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this.CustomParts = new ShaderAlebdoParts();
         this.customShaderNameResolve = this.Builder;

--- a/materialsLibrary/src/fire/fireMaterial.ts
+++ b/materialsLibrary/src/fire/fireMaterial.ts
@@ -73,7 +73,7 @@ export class FireMaterial extends PushMaterial {
     private _scaledDiffuse = new Color3();
     private _lastTime: number = 0;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/fur/furMaterial.ts
+++ b/materialsLibrary/src/fur/furMaterial.ts
@@ -115,7 +115,7 @@ export class FurMaterial extends PushMaterial {
 
     private _furTime: number = 0;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/gradient/gradientMaterial.ts
+++ b/materialsLibrary/src/gradient/gradientMaterial.ts
@@ -84,7 +84,7 @@ export class GradientMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public disableLighting: boolean;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/grid/gridMaterial.ts
+++ b/materialsLibrary/src/grid/gridMaterial.ts
@@ -107,7 +107,7 @@ export class GridMaterial extends PushMaterial {
      * @param name The name given to the material in order to identify it afterwards.
      * @param scene The scene the material is used in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/lava/lavaMaterial.ts
+++ b/materialsLibrary/src/lava/lavaMaterial.ts
@@ -137,7 +137,7 @@ export class LavaMaterial extends PushMaterial {
 
     private _scaledDiffuse = new Color3();
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -134,7 +134,7 @@ export class MixMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/normal/normalMaterial.ts
+++ b/materialsLibrary/src/normal/normalMaterial.ts
@@ -108,7 +108,7 @@ export class NormalMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/materialsLibrary/src/shadowOnly/shadowOnlyMaterial.ts
@@ -46,7 +46,7 @@ export class ShadowOnlyMaterial extends PushMaterial {
     private _activeLight: IShadowLight;
     private _needAlphaBlending = true;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/simple/simpleMaterial.ts
+++ b/materialsLibrary/src/simple/simpleMaterial.ts
@@ -68,7 +68,7 @@ export class SimpleMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/sky/skyMaterial.ts
+++ b/materialsLibrary/src/sky/skyMaterial.ts
@@ -132,7 +132,7 @@ export class SkyMaterial extends PushMaterial {
      * @param name Define the name of the material in the scene
      * @param scene Define the scene the material belong to
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/terrain/terrainMaterial.ts
+++ b/materialsLibrary/src/terrain/terrainMaterial.ts
@@ -107,7 +107,7 @@ export class TerrainMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
+++ b/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
@@ -112,7 +112,7 @@ export class TriPlanarMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -225,7 +225,7 @@ export class WaterMaterial extends PushMaterial {
     /**
     * Constructor
     */
-    constructor(name: string, scene: Scene, public renderTargetSize: Vector2 = new Vector2(512, 512)) {
+    constructor(name: string, scene?: Scene, public renderTargetSize: Vector2 = new Vector2(512, 512)) {
         super(name, scene);
 
         this._createRenderTargets(this.getScene(), renderTargetSize);

--- a/proceduralTexturesLibrary/src/brick/brickProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/brick/brickProceduralTexture.ts
@@ -4,6 +4,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
+import { Nullable } from "babylonjs/types";
 
 import "./brickProceduralTexture.fragment";
 
@@ -13,7 +14,7 @@ export class BrickProceduralTexture extends ProceduralTexture {
     private _jointColor = new Color3(0.72, 0.72, 0.72);
     private _brickColor = new Color3(0.77, 0.47, 0.40);
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "brickProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/cloud/cloudProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/cloud/cloudProceduralTexture.ts
@@ -4,6 +4,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
+import { Nullable } from "babylonjs/types";
 
 import "./cloudProceduralTexture.fragment";
 
@@ -13,7 +14,7 @@ export class CloudProceduralTexture extends ProceduralTexture {
     private _amplitude = 1;
     private _numOctaves = 4;
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "cloudProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/fire/fireProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/fire/fireProceduralTexture.ts
@@ -5,6 +5,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
+import { Nullable } from "babylonjs/types";
 
 import "./fireProceduralTexture.fragment";
 
@@ -15,7 +16,7 @@ export class FireProceduralTexture extends ProceduralTexture {
     private _fireColors: Color3[];
     private _alphaThreshold: number = 0.5;
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "fireProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this._fireColors = FireProceduralTexture.RedFireColors;
         this.updateShaderUniforms();

--- a/proceduralTexturesLibrary/src/grass/grassProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/grass/grassProceduralTexture.ts
@@ -4,6 +4,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
+import { Nullable } from "babylonjs/types";
 
 import "./grassProceduralTexture.fragment";
 
@@ -11,7 +12,7 @@ export class GrassProceduralTexture extends ProceduralTexture {
     private _grassColors: Color3[];
     private _groundColor = new Color3(1, 1, 1);
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "grassProceduralTexture", scene, fallbackTexture, generateMipMaps);
 
         this._grassColors = [

--- a/proceduralTexturesLibrary/src/marble/marbleProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/marble/marbleProceduralTexture.ts
@@ -4,6 +4,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
+import { Nullable } from "babylonjs/types";
 
 import "./marbleProceduralTexture.fragment";
 
@@ -13,7 +14,7 @@ export class MarbleProceduralTexture extends ProceduralTexture {
     private _amplitude: number = 9.0;
     private _jointColor = new Color3(0.72, 0.72, 0.72);
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "marbleProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/normalMap/normalMapProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/normalMap/normalMapProceduralTexture.ts
@@ -3,13 +3,13 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
-
+import { Nullable } from "babylonjs/types";
 import "./normalMapProceduralTexture.fragment";
 
 export class NormalMapProceduralTexture extends ProceduralTexture {
     private _baseTexture: Texture;
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "normalMapProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/perlinNoise/perlinNoiseProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/perlinNoise/perlinNoiseProceduralTexture.ts
@@ -3,7 +3,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
-
+import { Nullable } from "babylonjs/types";
 import "./perlinNoiseProceduralTexture.fragment";
 
 export class PerlinNoiseProceduralTexture extends ProceduralTexture {
@@ -18,7 +18,7 @@ export class PerlinNoiseProceduralTexture extends ProceduralTexture {
 
     private _currentTranslation: number = 0;
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "perlinNoiseProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/road/roadProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/road/roadProceduralTexture.ts
@@ -4,13 +4,13 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
-
+import { Nullable } from "babylonjs/types";
 import "./roadProceduralTexture.fragment";
 
 export class RoadProceduralTexture extends ProceduralTexture {
     private _roadColor = new Color3(0.53, 0.53, 0.53);
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "roadProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/starfield/starfieldProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/starfield/starfieldProceduralTexture.ts
@@ -3,7 +3,7 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
-
+import { Nullable } from "babylonjs/types";
 import "./starfieldProceduralTexture.fragment";
 
 export class StarfieldProceduralTexture extends ProceduralTexture {
@@ -19,7 +19,7 @@ export class StarfieldProceduralTexture extends ProceduralTexture {
     private _distfading = 0.730;
     private _saturation = 0.850;
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "starfieldProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/proceduralTexturesLibrary/src/wood/woodProceduralTexture.ts
+++ b/proceduralTexturesLibrary/src/wood/woodProceduralTexture.ts
@@ -4,14 +4,14 @@ import { Texture } from "babylonjs/Materials/Textures/texture";
 import { ProceduralTexture } from "babylonjs/Materials/Textures/Procedurals/proceduralTexture";
 import { Scene } from "babylonjs/scene";
 import { RegisterClass } from 'babylonjs/Misc/typeStore';
-
+import { Nullable } from "babylonjs/types";
 import "./woodProceduralTexture.fragment";
 
 export class WoodProceduralTexture extends ProceduralTexture {
     private _ampScale: number = 100.0;
     private _woodColor: Color3 = new Color3(0.32, 0.17, 0.09);
 
-    constructor(name: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene: Nullable<Scene> = null, fallbackTexture?: Texture, generateMipMaps?: boolean) {
         super(name, size, "woodProceduralTexture", scene, fallbackTexture, generateMipMaps);
         this.updateShaderUniforms();
     }

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -292,7 +292,7 @@ export class _Exporter {
         this._glTF = {
             asset: { generator: "BabylonJS", version: "2.0" }
         };
-        babylonScene = babylonScene || Engine.LastCreatedScene
+        babylonScene = babylonScene || Engine.LastCreatedScene;
         if (!babylonScene) {
             return;
         }

--- a/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/serializers/src/glTF/2.0/glTFExporter.ts
@@ -288,10 +288,14 @@ export class _Exporter {
      * @param babylonScene Babylon scene object
      * @param options Options to modify the behavior of the exporter
      */
-    public constructor(babylonScene: Scene, options?: IExportOptions) {
+    public constructor(babylonScene?: Nullable<Scene>, options?: IExportOptions) {
         this._glTF = {
             asset: { generator: "BabylonJS", version: "2.0" }
         };
+        babylonScene = babylonScene || Engine.LastCreatedScene
+        if (!babylonScene) {
+            return;
+        }
         this._babylonScene = babylonScene;
         this._bufferViews = [];
         this._accessors = [];
@@ -1871,7 +1875,7 @@ export class _Exporter {
      * @param binaryWriter Buffer to write binary data to
      * @returns Node mapping of unique id to index
      */
-    private createNodeMapAndAnimationsAsync(babylonScene: Scene, nodes: Node[], binaryWriter: _BinaryWriter): Promise<{ [key: number]: number }>  {
+    private createNodeMapAndAnimationsAsync(babylonScene: Scene, nodes: Node[], binaryWriter: _BinaryWriter): Promise<{ [key: number]: number }> {
         let promiseChain = Promise.resolve();
         const nodeMap: { [key: number]: number } = {};
         let nodeIndex: number;

--- a/src/Actions/actionManager.ts
+++ b/src/Actions/actionManager.ts
@@ -129,9 +129,13 @@ export class ActionManager extends AbstractActionManager {
      * Creates a new action manager
      * @param scene defines the hosting scene
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Nullable<Scene>) {
         super();
-        this._scene = scene || EngineStore.LastCreatedScene;
+        scene = scene || EngineStore.LastCreatedScene
+        if (!scene) {
+            return;
+        }
+        this._scene = scene;
 
         scene.actionManagers.push(this);
     }

--- a/src/Actions/actionManager.ts
+++ b/src/Actions/actionManager.ts
@@ -131,7 +131,7 @@ export class ActionManager extends AbstractActionManager {
      */
     constructor(scene?: Nullable<Scene>) {
         super();
-        scene = scene || EngineStore.LastCreatedScene
+        scene = scene || EngineStore.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Audio/analyser.ts
+++ b/src/Audio/analyser.ts
@@ -49,7 +49,11 @@ export class Analyser {
      * Creates a new analyser
      * @param scene defines hosting scene
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Nullable<Scene>) {
+        scene = scene || Engine.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this._scene = scene;
         if (!Engine.audioEngine) {
             Tools.Warn("No audio engine initialized, failed to create an audio analyser");

--- a/src/Audio/analyser.ts
+++ b/src/Audio/analyser.ts
@@ -50,7 +50,7 @@ export class Analyser {
      * @param scene defines hosting scene
      */
     constructor(scene?: Nullable<Scene>) {
-        scene = scene || Engine.LastCreatedScene
+        scene = scene || Engine.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Audio/audioSceneComponent.ts
+++ b/src/Audio/audioSceneComponent.ts
@@ -303,7 +303,11 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
      * Creates a new instance of the component for the given scene
      * @param scene Defines the scene to register the component in
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Nullable<Scene>) {
+        scene = scene || Engine.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this.scene = scene;
 
         scene.soundTracks = new Array<SoundTrack>();

--- a/src/Audio/audioSceneComponent.ts
+++ b/src/Audio/audioSceneComponent.ts
@@ -304,7 +304,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
      * @param scene Defines the scene to register the component in
      */
     constructor(scene?: Nullable<Scene>) {
-        scene = scene || Engine.LastCreatedScene
+        scene = scene || Engine.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -163,7 +163,7 @@ export class Sound {
      */
     constructor(name: string, urlOrArrayBuffer: any, scene?: Nullable<Scene>, readyToPlayCallback: Nullable<() => void> = null, options?: ISoundOptions) {
         this.name = name;
-        scene = scene || Engine.LastCreatedScene
+        scene = scene || Engine.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Audio/sound.ts
+++ b/src/Audio/sound.ts
@@ -161,8 +161,12 @@ export class Sound {
      * @param readyToPlayCallback Provide a callback function if you'd like to load your code once the sound is ready to be played
      * @param options Objects to provide with the current available options: autoplay, loop, volume, spatialSound, maxDistance, rolloffFactor, refDistance, distanceModel, panningModel, streaming
      */
-    constructor(name: string, urlOrArrayBuffer: any, scene: Scene, readyToPlayCallback: Nullable<() => void> = null, options?: ISoundOptions) {
+    constructor(name: string, urlOrArrayBuffer: any, scene?: Nullable<Scene>, readyToPlayCallback: Nullable<() => void> = null, options?: ISoundOptions) {
         this.name = name;
+        scene = scene || Engine.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this._scene = scene;
         Sound._SceneComponentInitialization(scene);
 

--- a/src/Audio/soundTrack.ts
+++ b/src/Audio/soundTrack.ts
@@ -45,7 +45,11 @@ export class SoundTrack {
      * @param scene Define the scene the sound track belongs to
      * @param options
      */
-    constructor(scene: Scene, options: ISoundTrackOptions = {}) {
+    constructor(scene?: Nullable<Scene>, options: ISoundTrackOptions = {}) {
+        scene = scene || Engine.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this._scene = scene;
         this.soundCollection = new Array();
         this._options = options;

--- a/src/Audio/soundTrack.ts
+++ b/src/Audio/soundTrack.ts
@@ -46,7 +46,7 @@ export class SoundTrack {
      * @param options
      */
     constructor(scene?: Nullable<Scene>, options: ISoundTrackOptions = {}) {
-        scene = scene || Engine.LastCreatedScene
+        scene = scene || Engine.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/BakedVertexAnimation/bakedVertexAnimationManager.ts
+++ b/src/BakedVertexAnimation/bakedVertexAnimationManager.ts
@@ -4,6 +4,7 @@ import { serialize, expandToProperty, serializeAsTexture, SerializationHelper } 
 import { BaseTexture } from '../Materials/Textures/baseTexture';
 import { Vector4 } from "../Maths/math.vector";
 import { Effect } from "../Materials/effect";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Interface for baked vertex animation texture, see BakedVertexAnimationManager
@@ -104,7 +105,11 @@ export class BakedVertexAnimationManager implements IBakedVertexAnimationManager
      * Creates a new BakedVertexAnimationManager
      * @param scene defines the current scene
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Nullable<Scene>) {
+        scene = scene || EngineStore.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this._scene = scene;
         this.animationParameters = new Vector4(0, 0, 0, 30);
     }

--- a/src/BakedVertexAnimation/bakedVertexAnimationManager.ts
+++ b/src/BakedVertexAnimation/bakedVertexAnimationManager.ts
@@ -106,7 +106,7 @@ export class BakedVertexAnimationManager implements IBakedVertexAnimationManager
      * @param scene defines the current scene
      */
     constructor(scene?: Nullable<Scene>) {
-        scene = scene || EngineStore.LastCreatedScene
+        scene = scene || EngineStore.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
@@ -25,7 +25,7 @@ export class AnaglyphArcRotateCamera extends ArcRotateCamera {
      * @param interaxialDistance defines distance between each color axis
      * @param scene defines the hosting scene
      */
-    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, interaxialDistance: number, scene: Scene) {
+    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, interaxialDistance: number, scene?: Scene) {
         super(name, alpha, beta, radius, target, scene);
         this.interaxialDistance = interaxialDistance;
         this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_ANAGLYPH, { interaxialDistance: interaxialDistance });

--- a/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
@@ -21,7 +21,7 @@ export class AnaglyphFreeCamera extends FreeCamera {
      * @param interaxialDistance defines distance between each color axis
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_ANAGLYPH, { interaxialDistance: interaxialDistance });

--- a/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
@@ -21,7 +21,7 @@ export class AnaglyphGamepadCamera extends GamepadCamera {
      * @param interaxialDistance defines distance between each color axis
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_ANAGLYPH, { interaxialDistance: interaxialDistance });

--- a/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
@@ -22,7 +22,7 @@ export class AnaglyphUniversalCamera extends UniversalCamera {
      * @param interaxialDistance defines distance between each color axis
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.setCameraRigMode(Camera.RIG_MODE_STEREOSCOPIC_ANAGLYPH, { interaxialDistance: interaxialDistance });

--- a/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
@@ -25,7 +25,7 @@ export class StereoscopicArcRotateCamera extends ArcRotateCamera {
      * @param isStereoscopicSideBySide defines is stereoscopic is done side by side or over under
      * @param scene defines the hosting scene
      */
-    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene: Scene) {
+    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene?: Scene) {
         super(name, alpha, beta, radius, target, scene);
         this.interaxialDistance = interaxialDistance;
         this.isStereoscopicSideBySide = isStereoscopicSideBySide;

--- a/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
@@ -22,7 +22,7 @@ export class StereoscopicFreeCamera extends FreeCamera {
      * @param isStereoscopicSideBySide defines is stereoscopic is done side by side or over under
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.isStereoscopicSideBySide = isStereoscopicSideBySide;

--- a/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
@@ -22,7 +22,7 @@ export class StereoscopicGamepadCamera extends GamepadCamera {
      * @param isStereoscopicSideBySide defines is stereoscopic is done side by side or over under
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.isStereoscopicSideBySide = isStereoscopicSideBySide;

--- a/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicScreenUniversalCamera.ts
@@ -44,7 +44,7 @@ export class StereoscopicScreenUniversalCamera extends UniversalCamera {
      * @param distanceToProjectionPlane defines distance between each color axis. The rig cameras will receive this as their negative z position!
      * @param distanceBetweenEyes defines is stereoscopic is done side by side or over under
      */
-    constructor(name: string, position: Vector3, scene: Scene, distanceToProjectionPlane: number = 1, distanceBetweenEyes: number = 0.065) {
+    constructor(name: string, position: Vector3, scene?: Scene, distanceToProjectionPlane: number = 1, distanceBetweenEyes: number = 0.065) {
         super(name, position, scene);
         this._distanceBetweenEyes = distanceBetweenEyes;
         this._distanceToProjectionPlane = distanceToProjectionPlane;

--- a/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
+++ b/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
@@ -21,7 +21,7 @@ export class StereoscopicUniversalCamera extends UniversalCamera {
      * @param isStereoscopicSideBySide defines is stereoscopic is done side by side or over under
      * @param scene defines the hosting scene
      */
-    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene: Scene) {
+    constructor(name: string, position: Vector3, interaxialDistance: number, isStereoscopicSideBySide: boolean, scene?: Scene) {
         super(name, position, scene);
         this.interaxialDistance = interaxialDistance;
         this.isStereoscopicSideBySide = isStereoscopicSideBySide;

--- a/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
@@ -29,7 +29,7 @@ export class VRDeviceOrientationArcRotateCamera extends ArcRotateCamera {
      * @param compensateDistortion defines if the camera needs to compensate the lens distortion
      * @param vrCameraMetrics defines the vr metrics associated to the camera
      */
-    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
+    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene?: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
         super(name, alpha, beta, radius, target, scene);
 
         vrCameraMetrics.compensateDistortion = compensateDistortion;

--- a/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
@@ -24,7 +24,7 @@ export class VRDeviceOrientationFreeCamera extends DeviceOrientationCamera {
      * @param compensateDistortion defines if the camera needs to compensate the lens distortion
      * @param vrCameraMetrics defines the vr metrics associated to the camera
      */
-    constructor(name: string, position: Vector3, scene: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
+    constructor(name: string, position: Vector3, scene?: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
         super(name, position, scene);
 
         vrCameraMetrics.compensateDistortion = compensateDistortion;

--- a/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
+++ b/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
@@ -25,7 +25,7 @@ export class VRDeviceOrientationGamepadCamera extends VRDeviceOrientationFreeCam
      * @param compensateDistortion defines if the camera needs to compensate the lens distortion
      * @param vrCameraMetrics defines the vr metrics associated to the camera
      */
-    constructor(name: string, position: Vector3, scene: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
+    constructor(name: string, position: Vector3, scene?: Scene, compensateDistortion = true, vrCameraMetrics: VRCameraMetrics = VRCameraMetrics.GetDefault()) {
         super(name, position, scene, compensateDistortion, vrCameraMetrics);
 
         this.inputs.addGamepad();

--- a/src/Cameras/VR/webVRCamera.ts
+++ b/src/Cameras/VR/webVRCamera.ts
@@ -230,7 +230,7 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
      * @param scene The scene the camera belongs to
      * @param webVROptions a set of customizable options for the webVRCamera
      */
-    constructor(name: string, position: Vector3, scene: Scene, private webVROptions: WebVROptions = {}) {
+    constructor(name: string, position: Vector3, scene?: Scene, private webVROptions: WebVROptions = {}) {
         super(name, position, scene);
         this._cache.position = Vector3.Zero();
         if (webVROptions.defaultHeight) {
@@ -306,7 +306,7 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
          * This way, the right camera will be used as a parent, and the mesh will be rendered correctly.
          * Amazing!
          */
-        scene.onBeforeCameraRenderObservable.add((camera) => {
+        this.getScene().onBeforeCameraRenderObservable.add((camera) => {
             if (camera.parent === this && this.rigParenting) {
                 this._descendants = this.getDescendants(true, (n) => {
                     // don't take the cameras or the controllers!
@@ -320,7 +320,7 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
             }
         });
 
-        scene.onAfterCameraRenderObservable.add((camera) => {
+        this.getScene().onAfterCameraRenderObservable.add((camera) => {
             if (camera.parent === this && this.rigParenting) {
                 this._descendants.forEach((node) => {
                     node.parent = this;

--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -694,7 +694,7 @@ export class ArcRotateCamera extends TargetCamera {
      * @param scene Defines the scene the camera belongs to
      * @param setActiveOnSceneIfNoneActive Defines whether the camera should be marked as active if not other active cameras have been defined
      */
-    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene: Scene, setActiveOnSceneIfNoneActive = true) {
+    constructor(name: string, alpha: number, beta: number, radius: number, target: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, Vector3.Zero(), scene, setActiveOnSceneIfNoneActive);
 
         this._target = Vector3.Zero();

--- a/src/Cameras/camera.ts
+++ b/src/Cameras/camera.ts
@@ -365,7 +365,7 @@ export class Camera extends Node {
      * @param scene Defines the scene the camera belongs too
      * @param setActiveOnSceneIfNoneActive Defines if the camera should be set as active after creation if no other camera have been defined in the scene
      */
-    constructor(name: string, position: Vector3, scene: Scene, setActiveOnSceneIfNoneActive = true) {
+    constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, scene);
 
         this.getScene().addCamera(this);

--- a/src/Cameras/deviceOrientationCamera.ts
+++ b/src/Cameras/deviceOrientationCamera.ts
@@ -28,7 +28,7 @@ export class DeviceOrientationCamera extends FreeCamera {
      * @param position The start position camera
      * @param scene The scene the camera belongs to
      */
-    constructor(name: string, position: Vector3, scene: Scene) {
+    constructor(name: string, position: Vector3, scene?: Scene) {
         super(name, position, scene);
         this._quaternionCache = new Quaternion();
         this.inputs.addDeviceOrientation();

--- a/src/Cameras/flyCamera.ts
+++ b/src/Cameras/flyCamera.ts
@@ -266,7 +266,7 @@ export class FlyCamera extends TargetCamera {
      * @param scene Define the scene the camera belongs to.
      * @param setActiveOnSceneIfNoneActive Defines whether the camera should be marked as active, if no other camera has been defined as active.
     */
-    constructor(name: string, position: Vector3, scene: Scene, setActiveOnSceneIfNoneActive = true) {
+    constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, position, scene, setActiveOnSceneIfNoneActive);
         this.inputs = new FlyCameraInputsManager(this);
         this.inputs.addKeyboard().addMouse();

--- a/src/Cameras/followCamera.ts
+++ b/src/Cameras/followCamera.ts
@@ -115,7 +115,7 @@ export class FollowCamera extends TargetCamera {
      * @param scene Define the scene the camera belong to
      * @param lockedTarget Define the target of the camera
      */
-    constructor(name: string, position: Vector3, scene: Scene, lockedTarget: Nullable<AbstractMesh> = null) {
+    constructor(name: string, position: Vector3, scene?: Scene, lockedTarget: Nullable<AbstractMesh> = null) {
         super(name, position, scene);
 
         this.lockedTarget = lockedTarget;

--- a/src/Cameras/freeCamera.ts
+++ b/src/Cameras/freeCamera.ts
@@ -253,7 +253,7 @@ export class FreeCamera extends TargetCamera {
      * @param scene Define the scene the camera belongs to
      * @param setActiveOnSceneIfNoneActive Defines whether the camera should be marked as active if not other active cameras have been defined
      */
-    constructor(name: string, position: Vector3, scene: Scene, setActiveOnSceneIfNoneActive = true) {
+    constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, position, scene, setActiveOnSceneIfNoneActive);
         this.inputs = new FreeCameraInputsManager(this);
         this.inputs.addKeyboard().addMouse();

--- a/src/Cameras/gamepadCamera.ts
+++ b/src/Cameras/gamepadCamera.ts
@@ -21,7 +21,7 @@ export class GamepadCamera extends UniversalCamera {
      * @param position Define the start position of the camera in the scene
      * @param scene Define the scene the camera belongs to
      */
-    constructor(name: string, position: Vector3, scene: Scene) {
+    constructor(name: string, position: Vector3, scene?: Scene) {
         super(name, position, scene);
     }
 

--- a/src/Cameras/targetCamera.ts
+++ b/src/Cameras/targetCamera.ts
@@ -108,7 +108,7 @@ export class TargetCamera extends Camera {
      * @param scene Defines the scene the camera belongs to
      * @param setActiveOnSceneIfNoneActive Defines whether the camera should be marked as active if not other active cameras have been defined
      */
-    constructor(name: string, position: Vector3, scene: Scene, setActiveOnSceneIfNoneActive = true) {
+    constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, position, scene, setActiveOnSceneIfNoneActive);
     }
 

--- a/src/Cameras/touchCamera.ts
+++ b/src/Cameras/touchCamera.ts
@@ -64,7 +64,7 @@ export class TouchCamera extends FreeCamera {
      * @param position Define the start position of the camera in the scene
      * @param scene Define the scene the camera belongs to
      */
-    constructor(name: string, position: Vector3, scene: Scene) {
+    constructor(name: string, position: Vector3, scene?: Scene) {
         super(name, position, scene);
         this.inputs.addTouch();
 

--- a/src/Cameras/universalCamera.ts
+++ b/src/Cameras/universalCamera.ts
@@ -66,7 +66,7 @@ export class UniversalCamera extends TouchCamera {
      * @param position Define the start position of the camera in the scene
      * @param scene Define the scene the camera belongs to
      */
-    constructor(name: string, position: Vector3, scene: Scene) {
+    constructor(name: string, position: Vector3, scene?: Scene) {
         super(name, position, scene);
         this.inputs.addGamepad();
     }

--- a/src/Cameras/virtualJoysticksCamera.ts
+++ b/src/Cameras/virtualJoysticksCamera.ts
@@ -26,7 +26,7 @@ export class VirtualJoysticksCamera extends FreeCamera {
      * @param position Define the start position of the camera in the scene
      * @param scene Define the scene the camera belongs to
      */
-    constructor(name: string, position: Vector3, scene: Scene) {
+    constructor(name: string, position: Vector3, scene?: Scene) {
         super(name, position, scene);
         this.inputs.addVirtualJoystick();
     }

--- a/src/Culling/Octrees/octreeSceneComponent.ts
+++ b/src/Culling/Octrees/octreeSceneComponent.ts
@@ -7,6 +7,7 @@ import { Ray } from "../../Culling/ray";
 import { SceneComponentConstants } from "../../sceneComponent";
 
 import { Octree } from "./octree";
+import { EngineStore } from "../../Engines/engineStore";
 
 declare type Collider = import("../../Collisions/collider").Collider;
 
@@ -139,7 +140,11 @@ export class OctreeSceneComponent {
      * Creates a new instance of the component for the given scene
      * @param scene Defines the scene to register the component in
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Scene) {
+        scene = scene || <Scene>EngineStore.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this.scene = scene;
 
         this.scene.getActiveMeshCandidates = this.getActiveMeshCandidates.bind(this);

--- a/src/Culling/Octrees/octreeSceneComponent.ts
+++ b/src/Culling/Octrees/octreeSceneComponent.ts
@@ -141,7 +141,7 @@ export class OctreeSceneComponent {
      * @param scene Defines the scene to register the component in
      */
     constructor(scene?: Scene) {
-        scene = scene || <Scene>EngineStore.LastCreatedScene
+        scene = scene || <Scene>EngineStore.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Debug/axesViewer.ts
+++ b/src/Debug/axesViewer.ts
@@ -53,7 +53,7 @@ export class AxesViewer {
      * @param zAxis defines the node hierarchy used to render the z-axis
      */
     constructor(scene?: Scene, scaleLines = 1, renderingGroupId: Nullable<number> = 2, xAxis?: TransformNode, yAxis?: TransformNode, zAxis?: TransformNode) {
-        scene = scene || <Scene>EngineStore.LastCreatedScene
+        scene = scene || <Scene>EngineStore.LastCreatedScene;
         if (!scene) {
             return;
         }

--- a/src/Debug/axesViewer.ts
+++ b/src/Debug/axesViewer.ts
@@ -5,6 +5,7 @@ import { TransformNode } from "../Meshes/transformNode";
 import { StandardMaterial } from "../Materials/standardMaterial";
 import { AxisDragGizmo } from "../Gizmos/axisDragGizmo";
 import { Color3 } from '../Maths/math.color';
+import { EngineStore } from "../Engines/engineStore";
 
 /**
      * The Axes viewer will show 3 axes in a specific point in space
@@ -51,7 +52,11 @@ export class AxesViewer {
      * @param yAxis defines the node hierarchy used to render the y-axis
      * @param zAxis defines the node hierarchy used to render the z-axis
      */
-    constructor(scene: Scene, scaleLines = 1, renderingGroupId: Nullable<number> = 2, xAxis?: TransformNode, yAxis?: TransformNode, zAxis?: TransformNode) {
+    constructor(scene?: Scene, scaleLines = 1, renderingGroupId: Nullable<number> = 2, xAxis?: TransformNode, yAxis?: TransformNode, zAxis?: TransformNode) {
+        scene = scene || <Scene>EngineStore.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this.scaleLines = scaleLines;
 
         if (!xAxis) {

--- a/src/Debug/debugLayer.ts
+++ b/src/Debug/debugLayer.ts
@@ -2,6 +2,7 @@ import { Tools } from "../Misc/tools";
 import { Observable } from "../Misc/observable";
 import { Scene } from "../scene";
 import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 // declare INSPECTOR namespace for compilation issue
 declare var INSPECTOR: any;
@@ -178,8 +179,11 @@ export class DebugLayer {
      * @see https://doc.babylonjs.com/features/playground_debuglayer
      * @param scene Defines the scene to inspect
      */
-    constructor(scene: Scene) {
-        this._scene = scene;
+    constructor(scene?: Scene) {
+        this._scene = scene || <Scene>EngineStore.LastCreatedScene;
+        if (!this._scene) {
+            return;
+        }
         this._scene.onDisposeObservable.add(() => {
             // Debug layer
             if (this._scene._debugLayer) {

--- a/src/Debug/physicsViewer.ts
+++ b/src/Debug/physicsViewer.ts
@@ -44,8 +44,11 @@ export class PhysicsViewer {
      * Creates a new PhysicsViewer
      * @param scene defines the hosting scene
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Scene) {
         this._scene = scene || EngineStore.LastCreatedScene;
+        if (!this._scene) {
+            return;
+        }
         let physicEngine = this._scene.getPhysicsEngine();
 
         if (physicEngine) {

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -12,6 +12,7 @@ import { DeviceType, PointerInput } from "../DeviceInput/InputDevices/deviceEnum
 import { IEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from "../Events/deviceInputEvents";
 import { IDeviceEvent } from "../DeviceInput/InputDevices/inputInterfaces";
 import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
+import { EngineStore } from "../Engines/engineStore";
 
 declare type Scene = import("../scene").Scene;
 
@@ -119,8 +120,11 @@ export class InputManager {
      * Creates a new InputManager
      * @param scene defines the hosting scene
      */
-    public constructor(scene: Scene) {
-        this._scene = scene;
+    constructor(scene?: Scene) {
+        this._scene = scene || <Scene>EngineStore.LastCreatedScene;
+        if (!this._scene) {
+            return;
+        }
     }
 
     /**

--- a/src/Layers/effectLayer.ts
+++ b/src/Layers/effectLayer.ts
@@ -193,10 +193,10 @@ export abstract class EffectLayer {
     constructor(
         /** The Friendly of the effect in the scene */
         name: string,
-        scene: Scene) {
+        scene?: Scene) {
         this.name = name;
 
-        this._scene = scene || EngineStore.LastCreatedScene;
+        this._scene = scene || <Scene>EngineStore.LastCreatedScene;
         EffectLayer._SceneComponentInitialization(this._scene);
 
         this._engine = this._scene.getEngine();

--- a/src/Layers/effectLayerSceneComponent.ts
+++ b/src/Layers/effectLayerSceneComponent.ts
@@ -7,6 +7,7 @@ import { SceneComponentConstants, ISceneSerializableComponent } from "../sceneCo
 import { EffectLayer } from "./effectLayer";
 import { AbstractScene } from "../abstractScene";
 import { AssetContainer } from "../assetContainer";
+import { EngineStore } from "../Engines/engineStore";
 // Adds the parser to the scene parsers.
 AbstractScene.AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
     if (parsedData.effectLayers) {
@@ -82,10 +83,13 @@ export class EffectLayerSceneComponent implements ISceneSerializableComponent {
      * Creates a new instance of the component for the given scene
      * @param scene Defines the scene to register the component in
      */
-    constructor(scene: Scene) {
-        this.scene = scene;
-        this._engine = scene.getEngine();
-        scene.effectLayers = new Array<EffectLayer>();
+    constructor(scene?: Scene) {
+        this.scene = scene || <Scene>EngineStore.LastCreatedScene;
+        if (!this.scene) {
+            return;
+        }
+        this._engine = this.scene.getEngine();
+        this.scene.effectLayers = new Array<EffectLayer>();
     }
 
     /**

--- a/src/Layers/glowLayer.ts
+++ b/src/Layers/glowLayer.ts
@@ -90,7 +90,7 @@ export interface IGlowLayerOptions {
     /**
      * Defines the blend mode used by the merge
      */
-     alphaBlendingMode?: number;
+    alphaBlendingMode?: number;
 }
 
 /**
@@ -181,7 +181,7 @@ export class GlowLayer extends EffectLayer {
      * @param scene The scene to use the layer in
      * @param options Sets of none mandatory options to use with the layer (see IGlowLayerOptions for more information)
      */
-    constructor(name: string, scene: Scene, options?: Partial<IGlowLayerOptions>) {
+    constructor(name: string, scene?: Scene, options?: Partial<IGlowLayerOptions>) {
         super(name, scene);
         this.neutralColor = new Color4(0, 0, 0, 1);
 

--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -264,7 +264,7 @@ export class HighlightLayer extends EffectLayer {
      * @param scene The scene to use the layer in
      * @param options Sets of none mandatory options to use with the layer (see IHighlightLayerOptions for more information)
      */
-    constructor(public name: string, scene: Scene, options?: Partial<IHighlightLayerOptions>) {
+    constructor(public name: string, scene?: Scene, options?: Partial<IHighlightLayerOptions>) {
         super(name, scene);
         this.neutralColor = HighlightLayer.NeutralColor;
 

--- a/src/Layers/layerSceneComponent.ts
+++ b/src/Layers/layerSceneComponent.ts
@@ -5,6 +5,7 @@ import { SceneComponentConstants, ISceneComponent } from "../sceneComponent";
 import { Layer } from "./layer";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { AbstractScene } from '../abstractScene';
+import { EngineStore } from "../Engines/engineStore";
 
 declare module "../abstractScene" {
     export interface AbstractScene {
@@ -36,10 +37,13 @@ export class LayerSceneComponent implements ISceneComponent {
      * Creates a new instance of the component for the given scene
      * @param scene Defines the scene to register the component in
      */
-    constructor(scene: Scene) {
-        this.scene = scene;
-        this._engine = scene.getEngine();
-        scene.layers = new Array<Layer>();
+    constructor(scene?: Scene) {
+        this.scene = scene || <Scene>EngineStore.LastCreatedScene;
+        if (!this.scene) {
+            return;
+        }
+        this._engine = this.scene.getEngine();
+        this.scene.layers = new Array<Layer>();
     }
 
     /**

--- a/src/Materials/Background/backgroundMaterial.ts
+++ b/src/Materials/Background/backgroundMaterial.ts
@@ -610,7 +610,7 @@ export class BackgroundMaterial extends PushMaterial {
      * @param name The friendly name of the material
      * @param scene The scene to add the material to
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
 
         // Setup the default processing configuration to the scene.

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -913,7 +913,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             return this._renderTargets;
         };
 
-        this._environmentBRDFTexture = GetEnvironmentBRDFTexture(scene);
+        this._environmentBRDFTexture = GetEnvironmentBRDFTexture(this.getScene());
         this.prePassConfiguration = new PrePassConfiguration();
     }
 

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -887,7 +887,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      * @param name The material name
      * @param scene The scene the material will be use in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
 
         this.brdf = new PBRBRDFConfiguration(this);

--- a/src/Materials/PBR/pbrBaseSimpleMaterial.ts
+++ b/src/Materials/PBR/pbrBaseSimpleMaterial.ts
@@ -127,7 +127,7 @@ export abstract class PBRBaseSimpleMaterial extends PBRBaseMaterial {
      * @param name The material name
      * @param scene The scene the material will be use in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
 
         this._useAlphaFromAlbedoTexture = true;

--- a/src/Materials/PBR/pbrMaterial.ts
+++ b/src/Materials/PBR/pbrMaterial.ts
@@ -749,10 +749,10 @@ export class PBRMaterial extends PBRBaseMaterial {
      * @param name The material name
      * @param scene The scene the material will be use in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
 
-        this._environmentBRDFTexture = GetEnvironmentBRDFTexture(scene);
+        this._environmentBRDFTexture = GetEnvironmentBRDFTexture(this.getScene());
     }
 
     /**

--- a/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
+++ b/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
@@ -61,7 +61,7 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
      * @param name The material name
      * @param scene The scene the material will be use in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this._useRoughnessFromMetallicTextureAlpha = false;
         this._useRoughnessFromMetallicTextureGreen = true;

--- a/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
+++ b/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
@@ -62,7 +62,7 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
      * @param name The material name
      * @param scene The scene the material will be use in.
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
         this._useMicroSurfaceFromReflectivityMapAlpha = true;
     }

--- a/src/Materials/Textures/MultiviewRenderTarget.ts
+++ b/src/Materials/Textures/MultiviewRenderTarget.ts
@@ -17,9 +17,9 @@ export class MultiviewRenderTarget extends RenderTargetTexture {
      * @param scene scene used with the render target
      * @param size the size of the render target (used for each view)
      */
-    constructor(scene: Scene, size: number | { width: number, height: number } | { ratio: number } = 512) {
+    constructor(scene?: Scene, size: number | { width: number, height: number } | { ratio: number } = 512) {
         super("multiview rtt", size, scene, false, true, Constants.TEXTURETYPE_UNSIGNED_INT, false, undefined, false, false, true, undefined, true);
-        this._renderTarget = scene.getEngine().createMultiviewRenderTargetTexture(this.getRenderWidth(), this.getRenderHeight());
+        this._renderTarget = this.getScene()!.getEngine().createMultiviewRenderTargetTexture(this.getRenderWidth(), this.getRenderHeight());
         this._texture = this._renderTarget.texture!;
         this._texture.isMultiview = true;
         this._texture.format = Constants.TEXTUREFORMAT_RGBA;

--- a/src/Materials/Textures/baseTexture.ts
+++ b/src/Materials/Textures/baseTexture.ts
@@ -490,7 +490,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
      * in order to make a correct use of the texture.
      * @param sceneOrEngine Define the scene or engine the texture belongs to
      */
-    constructor(sceneOrEngine: Nullable<Scene | ThinEngine>) {
+    constructor(sceneOrEngine?: Nullable<Scene | ThinEngine>) {
         super(null);
 
         if (sceneOrEngine) {

--- a/src/Materials/Textures/mirrorTexture.ts
+++ b/src/Materials/Textures/mirrorTexture.ts
@@ -116,7 +116,7 @@ export class MirrorTexture extends RenderTargetTexture {
     }
 
     private _updateGammaSpace() {
-        this.gammaSpace = !this.scene.imageProcessingConfiguration.isEnabled || !this.scene.imageProcessingConfiguration.applyByPostProcess;
+        this.gammaSpace = !this.scene!.imageProcessingConfiguration.isEnabled || !this.scene!.imageProcessingConfiguration.applyByPostProcess;
     }
 
     private _imageProcessingConfigChangeObserver: Nullable<Observer<ImageProcessingConfiguration>>;
@@ -148,9 +148,14 @@ export class MirrorTexture extends RenderTargetTexture {
      * @param samplingMode
      * @param generateDepthBuffer
      */
-    constructor(name: string, size: number | { width: number, height: number } | { ratio: number }, private scene: Scene, generateMipMaps?: boolean, type: number = Constants.TEXTURETYPE_UNSIGNED_INT, samplingMode = Texture.BILINEAR_SAMPLINGMODE, generateDepthBuffer = true) {
+    constructor(name: string, size: number | { width: number, height: number } | { ratio: number }, private scene?: Scene, generateMipMaps?: boolean, type: number = Constants.TEXTURETYPE_UNSIGNED_INT, samplingMode = Texture.BILINEAR_SAMPLINGMODE, generateDepthBuffer = true) {
         super(name, size, scene, generateMipMaps, true, type, false, samplingMode, generateDepthBuffer);
 
+        this.scene = <Scene>this.getScene();
+
+        if (!scene) {
+            return this;
+        }
         this.ignoreCameraViewport = true;
 
         this._updateGammaSpace();
@@ -158,7 +163,7 @@ export class MirrorTexture extends RenderTargetTexture {
             this._updateGammaSpace();
         });
 
-        const engine = this.getScene()!.getEngine();
+        const engine = scene.getEngine();
 
         if (engine.supportsUniformBuffers) {
             this._sceneUBO = scene.createSceneUniformBuffer(`Scene for Mirror Texture (name "${name}")`);
@@ -300,7 +305,7 @@ export class MirrorTexture extends RenderTargetTexture {
      */
     public dispose() {
         super.dispose();
-        this.scene.imageProcessingConfiguration.onUpdateParameters.remove(this._imageProcessingConfigChangeObserver);
+        this.scene!.imageProcessingConfiguration.onUpdateParameters.remove(this._imageProcessingConfigChangeObserver);
         this._sceneUBO?.dispose();
     }
 }

--- a/src/Materials/Textures/multiRenderTarget.ts
+++ b/src/Materials/Textures/multiRenderTarget.ts
@@ -135,7 +135,7 @@ export class MultiRenderTarget extends RenderTargetTexture {
      * @param options Define the options used to create the multi render target
      * @param textureNames Define the names to set to the textures (if count > 0 - optional)
      */
-    constructor(name: string, size: any, count: number, scene: Scene, options?: IMultiRenderTargetOptions, textureNames?: string[]) {
+    constructor(name: string, size: any, count: number, scene?: Scene, options?: IMultiRenderTargetOptions, textureNames?: string[]) {
         var generateMipMaps = options && options.generateMipMaps ? options.generateMipMaps : false;
         var generateDepthTexture = options && options.generateDepthTexture ? options.generateDepthTexture : false;
         var depthTextureFormat = options && options.depthTextureFormat ? options.depthTextureFormat : Constants.TEXTUREFORMAT_DEPTH16;

--- a/src/Materials/Textures/prePassRenderTarget.ts
+++ b/src/Materials/Textures/prePassRenderTarget.ts
@@ -56,7 +56,7 @@ export class PrePassRenderTarget extends MultiRenderTarget {
       */
     public renderTargetTexture: Nullable<RenderTargetTexture> = null;
 
-    public constructor(name: string, renderTargetTexture: Nullable<RenderTargetTexture>, size: any, count: number, scene: Scene, options?: IMultiRenderTargetOptions | undefined) {
+    public constructor(name: string, renderTargetTexture: Nullable<RenderTargetTexture>, size: any, count: number, scene?: Scene, options?: IMultiRenderTargetOptions | undefined) {
         super(name, size, count, scene, options);
 
         this.renderTargetTexture = renderTargetTexture;

--- a/src/Materials/Textures/refractionTexture.ts
+++ b/src/Materials/Textures/refractionTexture.ts
@@ -28,15 +28,15 @@ export class RefractionTexture extends RenderTargetTexture {
      * @param scene Define the scene the refraction belongs to
      * @param generateMipMaps Define if we need to generate mips level for the refraction
      */
-    constructor(name: string, size: number, scene: Scene, generateMipMaps?: boolean) {
+    constructor(name: string, size: number, scene?: Scene, generateMipMaps?: boolean) {
         super(name, size, scene, generateMipMaps, true);
 
         this.onBeforeRenderObservable.add(() => {
-            scene.clipPlane = this.refractionPlane;
+            this.getScene()!.clipPlane = this.refractionPlane;
         });
 
         this.onAfterRenderObservable.add(() => {
-            scene.clipPlane = null;
+            this.getScene()!.clipPlane = null;
         });
     }
 

--- a/src/Materials/Textures/renderTargetTexture.ts
+++ b/src/Materials/Textures/renderTargetTexture.ts
@@ -371,7 +371,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * @param samples sample count to use when creating the RTT
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      */
-    constructor(name: string, size: number | { width: number, height: number, layers?: number } | { ratio: number }, scene: Nullable<Scene>, generateMipMaps?: boolean, doNotChangeAspectRatio: boolean = true, type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    constructor(name: string, size: number | { width: number, height: number, layers?: number } | { ratio: number }, scene?: Nullable<Scene>, generateMipMaps?: boolean, doNotChangeAspectRatio: boolean = true, type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
         isCube = false, samplingMode = Texture.TRILINEAR_SAMPLINGMODE, generateDepthBuffer = true, generateStencilBuffer = false, isMulti = false, format = Constants.TEXTUREFORMAT_RGBA, delayAllocation = false, samples?: number, creationFlags?: number) {
         super(null, scene, !generateMipMaps, undefined, samplingMode, undefined, undefined, undefined, undefined, format);
         scene = this.getScene();

--- a/src/Materials/Textures/texture.ts
+++ b/src/Materials/Textures/texture.ts
@@ -339,7 +339,7 @@ export class Texture extends BaseTexture {
      * @param loaderOptions options to be passed to the loader
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      */
-    constructor(url: Nullable<string>, sceneOrEngine: Nullable<Scene | ThinEngine>, noMipmapOrOptions?: boolean | ITextureCreationOptions, invertY: boolean = true, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
+    constructor(url: Nullable<string>, sceneOrEngine?: Nullable<Scene | ThinEngine>, noMipmapOrOptions?: boolean | ITextureCreationOptions, invertY: boolean = true, samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
         onLoad: Nullable<() => void> = null, onError: Nullable<(message?: string, exception?: any) => void> = null, buffer: Nullable<string | ArrayBuffer | ArrayBufferView | HTMLImageElement | Blob | ImageBitmap> = null,
         deleteBuffer: boolean = false, format?: number, mimeType?: string, loaderOptions?: any, creationFlags?: number) {
         super(sceneOrEngine);

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -25,8 +25,10 @@ import { DrawWrapper } from "./drawWrapper";
 import { MaterialStencilState } from "./materialStencilState";
 import { Scene } from "../scene";
 import { AbstractScene } from "../abstractScene";
-import { MaterialPluginEvent,
-    MaterialPluginDisposed, MaterialPluginIsReadyForSubMesh, MaterialPluginGetDefineNames, MaterialPluginBindForSubMesh, MaterialPluginGetActiveTextures, MaterialPluginHasTexture, MaterialPluginGetAnimatables, MaterialPluginPrepareDefines, MaterialPluginPrepareEffect, MaterialPluginPrepareUniformBuffer, MaterialPluginCreated, MaterialPluginFillRenderTargetTextures, MaterialPluginHasRenderTargetTextures, MaterialPluginHardBindForSubMesh } from "./materialPluginEvent";
+import {
+    MaterialPluginEvent,
+    MaterialPluginDisposed, MaterialPluginIsReadyForSubMesh, MaterialPluginGetDefineNames, MaterialPluginBindForSubMesh, MaterialPluginGetActiveTextures, MaterialPluginHasTexture, MaterialPluginGetAnimatables, MaterialPluginPrepareDefines, MaterialPluginPrepareEffect, MaterialPluginPrepareUniformBuffer, MaterialPluginCreated, MaterialPluginFillRenderTargetTextures, MaterialPluginHasRenderTargetTextures, MaterialPluginHardBindForSubMesh
+} from "./materialPluginEvent";
 import { ShaderCustomProcessingFunction } from "../Engines/Processors/shaderProcessingOptions";
 
 declare type PrePassRenderer = import("../Rendering/prePassRenderer").PrePassRenderer;
@@ -598,8 +600,8 @@ export class Material implements IAnimatable {
     /**
      * Stores the z offset Units value
      */
-     @serialize()
-     public zOffsetUnits = 0;
+    @serialize()
+    public zOffsetUnits = 0;
 
     public get wireframe(): boolean {
         switch (this._fillMode) {
@@ -735,36 +737,36 @@ export class Material implements IAnimatable {
     public _uniformBufferLayoutBuilt = false;
 
     protected _eventInfo:
-            MaterialPluginCreated &
-            MaterialPluginDisposed &
-            MaterialPluginHasTexture &
-            MaterialPluginIsReadyForSubMesh &
-            MaterialPluginGetDefineNames &
-            MaterialPluginPrepareEffect &
-            MaterialPluginPrepareDefines &
-            MaterialPluginPrepareUniformBuffer &
-            MaterialPluginBindForSubMesh &
-            MaterialPluginGetAnimatables &
-            MaterialPluginGetActiveTextures &
-            MaterialPluginFillRenderTargetTextures &
-            MaterialPluginHasRenderTargetTextures &
-            MaterialPluginHardBindForSubMesh
-    = { } as any; // will be initialized before each event notification
+        MaterialPluginCreated &
+        MaterialPluginDisposed &
+        MaterialPluginHasTexture &
+        MaterialPluginIsReadyForSubMesh &
+        MaterialPluginGetDefineNames &
+        MaterialPluginPrepareEffect &
+        MaterialPluginPrepareDefines &
+        MaterialPluginPrepareUniformBuffer &
+        MaterialPluginBindForSubMesh &
+        MaterialPluginGetAnimatables &
+        MaterialPluginGetActiveTextures &
+        MaterialPluginFillRenderTargetTextures &
+        MaterialPluginHasRenderTargetTextures &
+        MaterialPluginHardBindForSubMesh
+        = {} as any; // will be initialized before each event notification
 
     /** @hidden */
-    public _callbackPluginEventGeneric: (id: number, info: MaterialPluginGetActiveTextures | MaterialPluginGetAnimatables | MaterialPluginHasTexture | MaterialPluginDisposed | MaterialPluginGetDefineNames | MaterialPluginPrepareEffect | MaterialPluginPrepareUniformBuffer) => void = () => void(0);
+    public _callbackPluginEventGeneric: (id: number, info: MaterialPluginGetActiveTextures | MaterialPluginGetAnimatables | MaterialPluginHasTexture | MaterialPluginDisposed | MaterialPluginGetDefineNames | MaterialPluginPrepareEffect | MaterialPluginPrepareUniformBuffer) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventIsReadyForSubMesh: (eventData: MaterialPluginIsReadyForSubMesh) => void = () => void(0);
+    public _callbackPluginEventIsReadyForSubMesh: (eventData: MaterialPluginIsReadyForSubMesh) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventPrepareDefines: (eventData: MaterialPluginPrepareDefines) => void = () => void(0);
+    public _callbackPluginEventPrepareDefines: (eventData: MaterialPluginPrepareDefines) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventHardBindForSubMesh: (eventData: MaterialPluginHardBindForSubMesh) => void = () => void(0);
+    public _callbackPluginEventHardBindForSubMesh: (eventData: MaterialPluginHardBindForSubMesh) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventBindForSubMesh: (eventData: MaterialPluginBindForSubMesh) => void = () => void(0);
+    public _callbackPluginEventBindForSubMesh: (eventData: MaterialPluginBindForSubMesh) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventHasRenderTargetTextures: (eventData: MaterialPluginHasRenderTargetTextures) => void = () => void(0);
+    public _callbackPluginEventHasRenderTargetTextures: (eventData: MaterialPluginHasRenderTargetTextures) => void = () => void (0);
     /** @hidden */
-    public _callbackPluginEventFillRenderTargetTextures: (eventData: MaterialPluginFillRenderTargetTextures) => void = () => void(0);
+    public _callbackPluginEventFillRenderTargetTextures: (eventData: MaterialPluginFillRenderTargetTextures) => void = () => void (0);
 
     /**
      * Creates a material instance
@@ -775,7 +777,7 @@ export class Material implements IAnimatable {
     constructor(name: string, scene?: Nullable<Scene>, doNotAdd?: boolean) {
         this.name = name;
         const setScene = scene || EngineStore.LastCreatedScene;
-        if(!setScene) {
+        if (!setScene) {
             return;
         }
         this._scene = setScene;
@@ -1684,7 +1686,7 @@ export class Material implements IAnimatable {
         }
 
         var materialType = Tools.Instantiate(parsedMaterial.customType);
-        const material =  materialType.Parse(parsedMaterial, scene, rootUrl);
+        const material = materialType.Parse(parsedMaterial, scene, rootUrl);
         material._loadedUniqueId = parsedMaterial.uniqueId;
         return material;
     }

--- a/src/Materials/material.ts
+++ b/src/Materials/material.ts
@@ -772,9 +772,13 @@ export class Material implements IAnimatable {
      * @param scene defines the scene to reference
      * @param doNotAdd specifies if the material should be added to the scene
      */
-    constructor(name: string, scene: Scene, doNotAdd?: boolean) {
+    constructor(name: string, scene?: Nullable<Scene>, doNotAdd?: boolean) {
         this.name = name;
-        this._scene = scene || EngineStore.LastCreatedScene;
+        const setScene = scene || EngineStore.LastCreatedScene;
+        if(!setScene) {
+            return;
+        }
+        this._scene = setScene;
         this._dirtyCallbacks = {};
 
         this._dirtyCallbacks[Constants.MATERIAL_TextureDirtyFlag] = this._markAllSubMeshesAsTexturesDirty.bind(this);

--- a/src/Materials/multiMaterial.ts
+++ b/src/Materials/multiMaterial.ts
@@ -46,10 +46,10 @@ export class MultiMaterial extends Material {
      * @param name Define the name in the scene
      * @param scene Define the scene the material belongs to
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene, true);
 
-        scene.multiMaterials.push(this);
+        this.getScene().multiMaterials.push(this);
 
         this.subMaterials = new Array<Material>();
 

--- a/src/Materials/pushMaterial.ts
+++ b/src/Materials/pushMaterial.ts
@@ -16,7 +16,7 @@ export class PushMaterial extends Material {
 
     protected _normalMatrix: Matrix = new Matrix();
 
-    constructor(name: string, scene: Scene, storeEffectOnSubMeshes = true) {
+    constructor(name: string, scene?: Scene, storeEffectOnSubMeshes = true) {
         super(name, scene);
         this._storeEffectOnSubMeshes = storeEffectOnSubMeshes;
     }

--- a/src/Materials/shadowDepthWrapper.ts
+++ b/src/Materials/shadowDepthWrapper.ts
@@ -80,9 +80,9 @@ export class ShadowDepthWrapper {
      * @param scene Define the scene the material belongs to
      * @param options Options used to create the wrapper
      */
-    constructor(baseMaterial: Material, scene: Scene, options?: IIOptionShadowDepthMaterial) {
+    constructor(baseMaterial: Material, scene?: Scene, options?: IIOptionShadowDepthMaterial) {
         this._baseMaterial = baseMaterial;
-        this._scene = scene ?? Engine.LastCreatedScene;
+        this._scene = scene ?? <Scene>Engine.LastCreatedScene;
         this._options = options;
 
         this._subMeshToEffect = new Map();

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -750,7 +750,7 @@ export class StandardMaterial extends PushMaterial {
      * @param name Define the name of the material in the scene
      * @param scene Define the scene the material belong to
      */
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
 
         this.detailMap = new DetailMapConfiguration(this);

--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -16,6 +16,7 @@ import { Tags } from "../Misc/tags";
 import { DataBuffer } from "../Buffers/dataBuffer";
 import { extractMinAndMax } from "../Maths/math.functions";
 import { AbstractScene } from "../abstractScene";
+import { EngineStore } from "../Engines/engineStore";
 
 declare type Mesh = import("../Meshes/mesh").Mesh;
 
@@ -132,12 +133,15 @@ export class Geometry implements IGetSetVerticesData {
      * @param updatable defines if geometry must be updatable (false by default)
      * @param mesh defines the mesh that will be associated with the geometry
      */
-    constructor(id: string, scene: Scene, vertexData?: VertexData, updatable: boolean = false, mesh: Nullable<Mesh> = null) {
+    constructor(id: string, scene?: Scene, vertexData?: VertexData, updatable: boolean = false, mesh: Nullable<Mesh> = null) {
+        this._scene = scene || <Scene>EngineStore.LastCreatedScene;
+        if (!this._scene) {
+            return;
+        }
         this.id = id;
-        this.uniqueId = scene.getUniqueId();
-        this._engine = scene.getEngine();
+        this.uniqueId = this._scene.getUniqueId();
+        this._engine = this._scene.getEngine();
         this._meshes = [];
-        this._scene = scene;
         //Init vertex buffer cache
         this._vertexBuffers = {};
         this._indices = [];

--- a/src/Meshes/groundMesh.ts
+++ b/src/Meshes/groundMesh.ts
@@ -33,7 +33,7 @@ export class GroundMesh extends Mesh {
     /** @hidden */
     public _maxZ: number;
 
-    constructor(name: string, scene: Scene) {
+    constructor(name: string, scene?: Scene) {
         super(name, scene);
     }
 

--- a/src/Meshes/trailMesh.ts
+++ b/src/Meshes/trailMesh.ts
@@ -31,7 +31,7 @@ export class TrailMesh extends Mesh {
      * @param length Length of trailing mesh. Default is 60.
      * @param autoStart Automatically start trailing mesh. Default true.
      */
-    constructor(name: string, generator: TransformNode, scene: Scene, diameter: number = 1, length: number = 60, autoStart: boolean = true) {
+    constructor(name: string, generator: TransformNode, scene?: Scene, diameter: number = 1, length: number = 60, autoStart: boolean = true) {
         super(name, scene);
 
         this._running = false;

--- a/src/Misc/assetsManager.ts
+++ b/src/Misc/assetsManager.ts
@@ -13,6 +13,7 @@ import { EquiRectangularCubeTexture } from "../Materials/Textures/equiRectangula
 import { Logger } from "../Misc/logger";
 import { AnimationGroup } from '../Animations/animationGroup';
 import { AssetContainer } from "../assetContainer";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Defines the list of states available for a task inside a AssetsManager
@@ -919,8 +920,8 @@ export class AssetsManager {
      * Creates a new AssetsManager
      * @param scene defines the scene to work on
      */
-    constructor(scene: Scene) {
-        this._scene = scene;
+    constructor(scene?: Scene) {
+        this._scene = scene || <Scene>EngineStore.LastCreatedScene;
     }
 
     /**

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -14,6 +14,7 @@ import { Nullable } from './types';
 import { Node } from './node';
 import { Observer } from "./Misc/observable";
 import { ThinEngine } from "./Engines/thinEngine";
+import { Engine } from "./Engines/engine";
 
 /**
  * Set of assets to keep when moving a scene into an asset container.
@@ -56,8 +57,12 @@ export class AssetContainer extends AbstractScene {
      * Instantiates an AssetContainer.
      * @param scene The scene the AssetContainer belongs to.
      */
-    constructor(scene: Scene) {
+    constructor(scene?: Nullable<Scene>) {
         super();
+        scene = scene || Engine.LastCreatedScene
+        if (!scene) {
+            return;
+        }
         this.scene = scene;
         this["sounds"] = [];
         this["effectLayers"] = [];

--- a/src/assetContainer.ts
+++ b/src/assetContainer.ts
@@ -59,7 +59,7 @@ export class AssetContainer extends AbstractScene {
      */
     constructor(scene?: Nullable<Scene>) {
         super();
-        scene = scene || Engine.LastCreatedScene
+        scene = scene || Engine.LastCreatedScene;
         if (!scene) {
             return;
         }


### PR DESCRIPTION
Making the scene an optional parameter where possible.
We have a few annotations for the optional scene. One is making it nullable and setting it to null, the other is making it optional in typescript.
This PR doesn't choose one or the other, it inherites from related components.

This is part 1, there are a few other places where we can benefit from that.

Note that in certain cases it is impossible, as the scene is not the last not-optional parameter in the constructor.