### PR TITLE
[GE] Let Backspace key delete nodes

### DIFF
--- a/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -175,6 +175,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
                 return;
                 break;
             case "Delete":
+            case "Backspace":
                 if (this.state.selectedEntity !== this.props.globalState.guiTexture.getChildren()[0]) {
                     this.state.selectedEntity.dispose();
                     this.forceUpdate();

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -252,7 +252,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
             this._constraintDirection = ConstraintDirection.NONE;
         }
 
-        if (evt.key === "Delete") {
+        if (evt.key === "Delete" || evt.key === "Backspace") {
             if (!this.props.globalState.lockObject.lock) {
                 this._selectedGuiNodes.forEach((guiNode) => {
                     if (guiNode !== this.globalState.guiTexture.getChildren()[0]) {


### PR DESCRIPTION
Adds the backspace key as an additional key to delete nodes. Particularly helpful for Mac users, who don't have a delete key.