### PR TITLE
Weaken restriction on Texture Types

### DIFF
--- a/src/Layers/layer.ts
+++ b/src/Layers/layer.ts
@@ -7,6 +7,7 @@ import { EngineStore } from "../Engines/engineStore";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Material } from "../Materials/material";
 import { Texture } from "../Materials/Textures/texture";
+import { BaseTexture } from "../Materials/Textures/baseTexture";
 import { SceneComponentConstants } from "../sceneComponent";
 import { LayerSceneComponent } from "./layerSceneComponent";
 import { Constants } from "../Engines/constants";
@@ -26,7 +27,7 @@ export class Layer {
     /**
      * Define the texture the layer should display.
      */
-    public texture: Nullable<Texture>;
+    public texture: Nullable<BaseTexture>;
 
     /**
      * Is the layer in background or foreground.


### PR DESCRIPTION
The texture allowed for layers was constrained to only allow `Texture` assignments. However `BaseTexture` would have sufficed. 

Motivation was driven by getting the  `export class AnimatedGifTexture extends BaseTexture` to work with a Layer.

Forum Reference: https://forum.babylonjs.com/t/make-a-background-with-basetexture/27116/3?u=asdf989

Testing I've done:...
Not amazing. I force cast my `AnimatedGifTexture` into the `layer.texture = animatedGif as unknown as Texture` and it worked pretty well thank you very much.


https://github.com/sebavan/BabylonjsAnimatedGifSample