### PR TITLE
[Playground] Fix monaco manager issues with deprecated members

### DIFF
--- a/Playground/src/tools/monacoManager.ts
+++ b/Playground/src/tools/monacoManager.ts
@@ -202,7 +202,7 @@ class Playground {
 
         this._editor.onDidChangeModelContent(() => {
             let newCode = this._editor.getValue();
-            const analyzeCodeDebounced = debounce(() => this._analyzeCodeAsync());
+            const analyzeCodeDebounced = debounce(() => this._analyzeCodeAsync(), 500);
             if (this.globalState.currentCode !== newCode) {
                 this.globalState.currentCode = newCode;
                 this._isDirty = true;

--- a/Playground/src/tools/monacoManager.ts
+++ b/Playground/src/tools/monacoManager.ts
@@ -8,6 +8,7 @@ import * as languageFeatures from "monaco-editor/esm/vs/language/typescript/lang
 import { GlobalState } from "../globalState";
 import { Utilities } from "./utilities";
 import { CompilationError } from "../components/errorDisplayComponent";
+import { debounce } from "ts-debounce";
 
 declare type IStandaloneCodeEditor = import("monaco-editor/esm/vs/editor/editor.api").editor.IStandaloneCodeEditor;
 declare type IStandaloneEditorConstructionOptions = import("monaco-editor/esm/vs/editor/editor.api").editor.IStandaloneEditorConstructionOptions;
@@ -201,9 +202,11 @@ class Playground {
 
         this._editor.onDidChangeModelContent(() => {
             let newCode = this._editor.getValue();
+            const analyzeCodeDebounced = debounce(() => this._analyzeCodeAsync());
             if (this.globalState.currentCode !== newCode) {
                 this.globalState.currentCode = newCode;
                 this._isDirty = true;
+                analyzeCodeDebounced();
             }
         });
 
@@ -460,6 +463,10 @@ class Playground {
             return;
         }
 
+        if (!this._deprecatedCandidates) {
+            return;
+        }
+
         const model = this._editor.getModel();
         if (!model) {
             return;
@@ -517,7 +524,7 @@ class Playground {
                         endLineNumber: match.range.endLineNumber,
                         startColumn: wordInfo.startColumn,
                         endColumn: wordInfo.endColumn,
-                        message: deprecatedInfo.text,
+                        message: this._getTagMessage(deprecatedInfo),
                         severity: monaco.MarkerSeverity.Warning,
                         source: source,
                     });
@@ -526,6 +533,19 @@ class Playground {
         }
 
         monaco.editor.setModelMarkers(model, source, markers);
+    }
+
+    private _getTagMessage(tag: any) {
+        if (tag?.text instanceof String)
+            return tag.text;
+
+        if (tag?.text instanceof Array)
+            return tag.text
+                .filter((i: { kind: string}) => i.kind === "text")
+                .map((i: { text: any; }) => i.text)
+                .join(', ');
+
+        return '';
     }
 
     // This is our hook in the Monaco suggest adapter, we are called everytime a completion UI is displayed
@@ -543,22 +563,8 @@ class Playground {
                 return result;
             }
 
+            // filter non public members
             const suggestions = result.suggestions.filter((item: any) => !item.label.startsWith("_"));
-
-            for (const suggestion of suggestions) {
-                if (owner._deprecatedCandidates.includes(suggestion.label)) {
-                    // the following is time consuming on all suggestions, that's why we precompute deprecated candidate names in the definition worker to filter calls
-                    // @see setupDefinitionWorker
-                    const uri = suggestion.uri;
-                    const worker = await this._worker(uri);
-                    const model = monaco.editor.getModel(uri);
-                    const details = await worker.getCompletionEntryDetails(uri.toString(), model!.getOffsetAt(position), suggestion.label);
-
-                    if (owner._isDeprecatedEntry(details)) {
-                        suggestion.tags = [monaco.languages.CompletionItemTag.Deprecated];
-                    }
-                }
-            }
 
             // add our own templates when invoked without context
             if (context.triggerKind == monaco.languages.CompletionTriggerKind.Invoke) {

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -159,6 +159,9 @@
 
 - Start render loop before creating scene to make stopping it more convenient ([BlakeOne](https://github.com/BlakeOne))
 - Added tooltips for menubar buttons ([darraghjburke](https://github.com/darraghjburke))
+- Fixed squiggles not working for deprecated members ([sailro](https://github.com/sailro))
+- Removed legacy code for formatting deprecated members display ([sailro](https://github.com/sailro))
+- Fixed deprecated members info display ([sailro](https://github.com/sailro))
 
 ### NME
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
         "svg-url-loader": "^6.0.0",
         "symlink-dir": "^4.2.0",
         "through2": "~3.0.1",
+        "ts-debounce": "4.0.0",
         "ts-loader": "^8.3.0",
         "ts-node": "^9.1.1",
         "tslib": "^2.3.1",


### PR DESCRIPTION
Several fixes here:

- Fixed squiggles not working for deprecated members.
_This was initially done [here](https://github.com/BabylonJS/Babylon.js/pull/7223) but was lost during the Playground migration. As a result if you try this [sample](https://playground.babylonjs.com/#PRQU53#7) and remove `Mesh.` line 9, you'll see that yellow squiggles are not updated. We need a debounced call to `_analyzeCodeAsync` after every keystroke._

- Removed legacy code for formatting deprecated members display.
_Monaco `0.21` (21.09.2020) and `0.25` (11.06.2021), added and optimized native support for deprecated tag.
So we can remove our custom processing (doing the exact same thing) that we have in place since 2019._

- Fixed deprecated members info display
Probably a breaking change in Monaco, but a `Tag.text` from `CompletionEntryDetails.Tags[]` is now an `array` and not a `string` anymore.