### PR TITLE
fix getHighlightLayerByName no null check

### DIFF
--- a/src/Layers/highlightLayer.ts
+++ b/src/Layers/highlightLayer.ts
@@ -39,7 +39,7 @@ declare module "../abstractScene" {
 }
 
 AbstractScene.prototype.getHighlightLayerByName = function (name: string): Nullable<HighlightLayer> {
-    for (var index = 0; index < this.effectLayers.length; index++) {
+    for (var index = 0; index < this.effectLayers?.length; index++) {
         if (this.effectLayers[index].name === name && this.effectLayers[index].getEffectName() === HighlightLayer.EffectName) {
             return (<any>this.effectLayers[index]) as HighlightLayer;
         }


### PR DESCRIPTION
if no effect layers on scene then this method throws effectLayers is undefined error