### PR TITLE
[Playground] Add support for experimental/beta members

### DIFF
--- a/Playground/src/tools/monacoManager.ts
+++ b/Playground/src/tools/monacoManager.ts
@@ -553,7 +553,7 @@ class Playground {
     private _getCandidateCompletionSuffix(candidate: {tagName: string}) {
         switch(candidate.tagName) {
             case "deprecated":
-                return "⚠️";
+                return "";
             default:
                 return "🧪";
         }


### PR DESCRIPTION
Previously discussed with @deltakosh, here is a working support for `experimental` or `beta` members:

It works exactly like `@deprecated`

```typescript
            /**
             * @experimental Easy money, keep this one secret
             */
            function CreateAAAGameForMePlease();
```

Completion provider with a distinct icon for `experimental` or `beta`
![Screenshot 2022-01-27 14 36 21](https://user-images.githubusercontent.com/638167/151369819-34d26d52-19dd-4df3-8183-9ee9ed434aae.png)

Squiggles:
![image](https://user-images.githubusercontent.com/638167/151367101-3ec66dda-8422-44aa-b2fe-21d4818a7bd7.png)

Completion tooltip:
![Screenshot 2022-01-27 14 21 46](https://user-images.githubusercontent.com/638167/151367324-66a28e48-1399-4d18-965e-8b2eb47db92e.png)

![image](https://user-images.githubusercontent.com/638167/151367648-c6cda222-e012-4516-95db-12f87aa195cd.png)

