### PR TITLE
Parent find by (empty) id

### DIFF
--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -736,7 +736,7 @@ SceneLoader.RegisterPlugin({
                 var currentMesh: AbstractMesh;
                 for (index = 0, cache = scene.meshes.length; index < cache; index++) {
                     currentMesh = scene.meshes[index];
-                    if (currentMesh._waitingParentId !== null && currentMesh._waitingParentId.length) {
+                    if (currentMesh._waitingParentId) {
                         currentMesh.parent = scene.getLastEntryById(currentMesh._waitingParentId);
                         if (currentMesh.parent?.getClassName() === "TransformNode") {
                             const loadedTransformNodeIndex = loadedTransformNodes.indexOf(currentMesh.parent as TransformNode);

--- a/src/Loading/Plugins/babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylonFileLoader.ts
@@ -736,7 +736,7 @@ SceneLoader.RegisterPlugin({
                 var currentMesh: AbstractMesh;
                 for (index = 0, cache = scene.meshes.length; index < cache; index++) {
                     currentMesh = scene.meshes[index];
-                    if (currentMesh._waitingParentId !== null) {
+                    if (currentMesh._waitingParentId !== null && currentMesh._waitingParentId.length) {
                         currentMesh.parent = scene.getLastEntryById(currentMesh._waitingParentId);
                         if (currentMesh.parent?.getClassName() === "TransformNode") {
                             const loadedTransformNodeIndex = loadedTransformNodes.indexOf(currentMesh.parent as TransformNode);


### PR DESCRIPTION
Follow up on https://forum.babylonjs.com/t/bonelookcontroller-and-bone-orientation/27042/10

When loading a .babylon scene, there is a parent attachment per id. But when the scene already has a mesh with an empty name, the first mesh in the .babylon is attached to it. I fixed it by checking parent name is not empty and is not zero length.