### PR TITLE
Preview texture in Inspector: Fix crash when texture ratio is too small

### DIFF
--- a/inspector/src/components/actionTabs/lines/textureLineComponent.tsx
+++ b/inspector/src/components/actionTabs/lines/textureLineComponent.tsx
@@ -55,6 +55,13 @@ export class TextureLineComponent extends React.Component<ITextureLineComponentP
         var ratio = size.width / size.height;
         var width = this.props.width;
         var height = (width / ratio) | 1;
+        var engine = this.props.texture.getScene()?.getEngine();
+
+        if (engine && height > engine.getCaps().maxTextureSize) {
+            // the texture.width/texture.height ratio is too small, so use the real width/height dimensions of the texture instead of the canvas width/computed height
+            width = this.props.texture.getSize().width;
+            height = this.props.texture.getSize().height;
+        }
 
         try {
             const data = await TextureHelper.GetTextureDataAsync(texture, width, height, this.state.face, this.state.channels, this.props.globalState);


### PR DESCRIPTION
Try to preview one of the "noname" texture from this PG: https://playground.babylonjs.com/#PX1VV2#6

It will crash because texture width = 1 and texture height = 256. For the preview we use a fixed width=256, so height is recomputed as 256/(1/256) = 65536 which is too big.

