### PR TITLE
Change GLB export from inspector to exclude disabled nodes

### DIFF
--- a/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -222,7 +222,12 @@ export class ToolsTabComponent extends PaneComponent {
     }
 
     shouldExport(node: Node): boolean {
-        // No skybox
+        // Exclude disabled
+        if (!node.isEnabled()) {
+            return false;
+        }
+
+        // Exclude skybox
         if (node instanceof Mesh) {
             if (node.material) {
                 const material = node.material as PBRMaterial | StandardMaterial | BackgroundMaterial;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/exported-gltf-scene-does-not-have-material-color-in-blender/27235