### PR TITLE
update hoverRadius for fluentMaterial

### DIFF
--- a/gui/src/3D/materials/fluent/fluentMaterial.ts
+++ b/gui/src/3D/materials/fluent/fluentMaterial.ts
@@ -90,7 +90,7 @@ export class FluentMaterial extends PushMaterial {
      * Gets or sets the radius used to render the hover light (default is 1.0)
      */
     @serialize()
-    public hoverRadius = 1.0;
+    public hoverRadius = 0.01;
 
     /**
      * Gets or sets the color used to render the hover light (default is Color4(0.3, 0.3, 0.3, 1.0))


### PR DESCRIPTION
This PR updates the hoverRadius for fluent material so that the hover glow doesn't extend past the bounds of the active element.

Before:
![flutentMaterialHoverRadiusBefore](https://user-images.githubusercontent.com/15232740/152149511-72b52710-69d9-4605-80bc-1be44ff37a57.gif)

After:
![flutentMaterialHoverRadiusAfter](https://user-images.githubusercontent.com/15232740/152149554-8fea9f73-b145-4d45-8435-0ff6bdad4f2b.gif)

