### PR TITLE
Native Thin Instances

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -30,6 +30,7 @@
 - Added ability to enable/disable `ArcRotateCamera` zoom on multiTouch event ([NicolasBuecher](https://github.com/NicolasBuecher))
 - Moving button to shared uI folder.([msDestiny14](https://github.com/msDestiny14))
 - Added `collisionRetryCount` to improved collision detection ([CedricGuillemet](https://github.com/CedricGuillemet))
+- Added color/instance color differenciation in shaders for thin instances ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Added sleepBody support for ammojs ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Moved sharedUI component to shared UI folder. ([msDestiny14](https://github.com/msDestiny14))
 - Added `encapsulate` and `encapsulateBoundingInfo` methods to `BoundingInfo`. ([Tolo789](https://github.com/Tolo789))

--- a/materialsLibrary/src/cell/cell.vertex.fx
+++ b/materialsLibrary/src/cell/cell.vertex.fx
@@ -100,7 +100,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/cell/cell.vertex.fx
+++ b/materialsLibrary/src/cell/cell.vertex.fx
@@ -100,11 +100,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/cell/cellMaterial.ts
+++ b/materialsLibrary/src/cell/cellMaterial.ts
@@ -39,6 +39,7 @@ class CellMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public NDOTL = true;
     public CUSTOMUSERLIGHTING = true;
     public CELLBASIC = true;

--- a/materialsLibrary/src/fire/fire.vertex.fx
+++ b/materialsLibrary/src/fire/fire.vertex.fx
@@ -81,7 +81,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/fire/fire.vertex.fx
+++ b/materialsLibrary/src/fire/fire.vertex.fx
@@ -81,11 +81,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/fire/fireMaterial.ts
+++ b/materialsLibrary/src/fire/fireMaterial.ts
@@ -39,6 +39,7 @@ class FireMaterialDefines extends MaterialDefines {
     public BonesPerMesh = 0;
     public NUM_BONE_INFLUENCERS = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/materialsLibrary/src/fur/fur.vertex.fx
+++ b/materialsLibrary/src/fur/fur.vertex.fx
@@ -168,7 +168,11 @@ float r = Rand(position);
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/fur/fur.vertex.fx
+++ b/materialsLibrary/src/fur/fur.vertex.fx
@@ -168,11 +168,9 @@ float r = Rand(position);
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/fur/furMaterial.ts
+++ b/materialsLibrary/src/fur/furMaterial.ts
@@ -44,6 +44,7 @@ class FurMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public HIGHLEVEL = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;

--- a/materialsLibrary/src/gradient/gradient.vertex.fx
+++ b/materialsLibrary/src/gradient/gradient.vertex.fx
@@ -83,11 +83,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/gradient/gradient.vertex.fx
+++ b/materialsLibrary/src/gradient/gradient.vertex.fx
@@ -83,7 +83,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/gradient/gradientMaterial.ts
+++ b/materialsLibrary/src/gradient/gradientMaterial.ts
@@ -39,6 +39,7 @@ class GradientMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/materialsLibrary/src/lava/lava.vertex.fx
+++ b/materialsLibrary/src/lava/lava.vertex.fx
@@ -221,7 +221,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/lava/lava.vertex.fx
+++ b/materialsLibrary/src/lava/lava.vertex.fx
@@ -221,11 +221,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/lava/lavaMaterial.ts
+++ b/materialsLibrary/src/lava/lavaMaterial.ts
@@ -81,6 +81,7 @@ class LavaMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public UNLIT = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;

--- a/materialsLibrary/src/mix/mix.vertex.fx
+++ b/materialsLibrary/src/mix/mix.vertex.fx
@@ -99,11 +99,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/mix/mix.vertex.fx
+++ b/materialsLibrary/src/mix/mix.vertex.fx
@@ -99,7 +99,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/mix/mixMaterial.ts
+++ b/materialsLibrary/src/mix/mixMaterial.ts
@@ -42,6 +42,7 @@ class MixMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public MIXMAP2 = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;

--- a/materialsLibrary/src/simple/simple.fragment.fx
+++ b/materialsLibrary/src/simple/simple.fragment.fx
@@ -13,6 +13,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 // Helper functions
@@ -68,6 +70,8 @@ void main(void) {
 #endif
 
 #ifdef VERTEXCOLOR
+	baseColor.rgb *= vColor.rgb;
+#elif INSTANCESCOLOR
 	baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/materialsLibrary/src/simple/simple.fragment.fx
+++ b/materialsLibrary/src/simple/simple.fragment.fx
@@ -11,9 +11,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 
@@ -69,9 +67,7 @@ void main(void) {
 	baseColor.rgb *= vDiffuseInfos.y;
 #endif
 
-#ifdef VERTEXCOLOR
-	baseColor.rgb *= vColor.rgb;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 	baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/materialsLibrary/src/simple/simple.vertex.fx
+++ b/materialsLibrary/src/simple/simple.vertex.fx
@@ -40,9 +40,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/materialsLibrary/src/simple/simple.vertex.fx
+++ b/materialsLibrary/src/simple/simple.vertex.fx
@@ -99,11 +99,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/simple/simple.vertex.fx
+++ b/materialsLibrary/src/simple/simple.vertex.fx
@@ -99,7 +99,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/simple/simple.vertex.fx
+++ b/materialsLibrary/src/simple/simple.vertex.fx
@@ -42,6 +42,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 

--- a/materialsLibrary/src/simple/simpleMaterial.ts
+++ b/materialsLibrary/src/simple/simpleMaterial.ts
@@ -40,6 +40,7 @@ class SimpleMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/materialsLibrary/src/sky/sky.vertex.fx
+++ b/materialsLibrary/src/sky/sky.vertex.fx
@@ -47,8 +47,6 @@ void main(void) {
 	// Vertex color
 #ifdef VERTEXCOLOR
 	vColor = color;
-#elif INSTANCESCOLOR
-	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/sky/sky.vertex.fx
+++ b/materialsLibrary/src/sky/sky.vertex.fx
@@ -46,11 +46,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/sky/sky.vertex.fx
+++ b/materialsLibrary/src/sky/sky.vertex.fx
@@ -46,7 +46,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/terrain/terrain.fragment.fx
+++ b/materialsLibrary/src/terrain/terrain.fragment.fx
@@ -17,6 +17,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 // Helper functions
@@ -156,6 +158,8 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	baseColor.rgb *= vColor.rgb;
+#elif INSTANCESCOLOR
+    baseColor.rgb *= vColor.rgb;
 #endif
 
 	// Lighting

--- a/materialsLibrary/src/terrain/terrain.fragment.fx
+++ b/materialsLibrary/src/terrain/terrain.fragment.fx
@@ -15,9 +15,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 
@@ -156,9 +154,7 @@ void main(void) {
 	
 #endif
 
-#ifdef VERTEXCOLOR
-	baseColor.rgb *= vColor.rgb;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
     baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/materialsLibrary/src/terrain/terrain.vertex.fx
+++ b/materialsLibrary/src/terrain/terrain.vertex.fx
@@ -40,9 +40,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/materialsLibrary/src/terrain/terrain.vertex.fx
+++ b/materialsLibrary/src/terrain/terrain.vertex.fx
@@ -42,6 +42,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<clipPlaneVertexDeclaration>

--- a/materialsLibrary/src/terrain/terrain.vertex.fx
+++ b/materialsLibrary/src/terrain/terrain.vertex.fx
@@ -99,11 +99,9 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/terrain/terrain.vertex.fx
+++ b/materialsLibrary/src/terrain/terrain.vertex.fx
@@ -99,7 +99,11 @@ void main(void) {
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/terrain/terrainMaterial.ts
+++ b/materialsLibrary/src/terrain/terrainMaterial.ts
@@ -43,6 +43,7 @@ class TerrainMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
+++ b/materialsLibrary/src/triPlanar/triPlanarMaterial.ts
@@ -47,6 +47,7 @@ class TriPlanarMaterialDefines extends MaterialDefines {
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/materialsLibrary/src/triPlanar/triplanar.fragment.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.fragment.fx
@@ -11,9 +11,7 @@ uniform vec4 vSpecularColor;
 // Input
 varying vec3 vPositionW;
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 
@@ -118,9 +116,7 @@ void main(void) {
 
 #include<depthPrePass>
 
-#ifdef VERTEXCOLOR
-	baseColor.rgb *= vColor.rgb;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
     baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/materialsLibrary/src/triPlanar/triplanar.fragment.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.fragment.fx
@@ -13,6 +13,8 @@ varying vec3 vPositionW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 // Helper functions
@@ -118,6 +120,8 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	baseColor.rgb *= vColor.rgb;
+#elif INSTANCESCOLOR
+    baseColor.rgb *= vColor.rgb;
 #endif
 
 	// Lighting

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -118,7 +118,11 @@ void main(void)
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -42,9 +42,7 @@ varying vec3 vPositionW;
 varying mat3 tangentSpace;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -118,11 +118,9 @@ void main(void)
 
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -44,6 +44,8 @@ varying mat3 tangentSpace;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<clipPlaneVertexDeclaration>

--- a/materialsLibrary/src/water/water.fragment.fx
+++ b/materialsLibrary/src/water/water.fragment.fx
@@ -19,9 +19,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 
@@ -113,9 +111,7 @@ void main(void) {
 	vec3 bumpColor = vec3(1.0);
 #endif
 
-#ifdef VERTEXCOLOR
-	baseColor.rgb *= vColor.rgb;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
     baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/materialsLibrary/src/water/water.fragment.fx
+++ b/materialsLibrary/src/water/water.fragment.fx
@@ -21,6 +21,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 // Helper functions
@@ -113,6 +115,8 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	baseColor.rgb *= vColor.rgb;
+#elif INSTANCESCOLOR
+    baseColor.rgb *= vColor.rgb;
 #endif
 
 	// Bump

--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -45,6 +45,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<clipPlaneVertexDeclaration>

--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -125,11 +125,9 @@ void main(void) {
     
 	// Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 	// Point size

--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -125,7 +125,11 @@ void main(void) {
     
 	// Vertex color
 #ifdef VERTEXCOLOR
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 	// Point size

--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -43,9 +43,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/materialsLibrary/src/water/waterMaterial.ts
+++ b/materialsLibrary/src/water/waterMaterial.ts
@@ -49,6 +49,7 @@ class WaterMaterialDefines extends MaterialDefines implements IImageProcessingCo
     public NUM_BONE_INFLUENCERS = 0;
     public BonesPerMesh = 0;
     public INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public SPECULARTERM = false;
     public LOGARITHMICDEPTH = false;
     public USE_REVERSE_DEPTHBUFFER = false;

--- a/src/Buffers/buffer.ts
+++ b/src/Buffers/buffer.ts
@@ -621,6 +621,10 @@ export class VertexBuffer {
      */
     public static readonly ColorKind = "color";
     /**
+     * Instance Colors
+     */
+     public static readonly ColorInstanceKind = "instanceColor";
+    /**
      * Matrix indices (for bones)
      */
     public static readonly MatricesIndicesKind = "matricesIndices";

--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -17,7 +17,7 @@ export interface INativeEngine {
     updateDynamicIndexBuffer(buffer: NativeData, bytes: ArrayBuffer, byteOffset: number, byteLength: number, startIndex: number): void;
 
     createVertexBuffer(bytes: ArrayBuffer, byteOffset: number, byteLength: number, dynamic: boolean): NativeData;
-    recordVertexBuffer(vertexArray: NativeData, vertexBuffer: NativeData, location: number, byteOffset: number, byteStride: number, numElements: number, type: number, normalized: boolean): void;
+    recordVertexBuffer(vertexArray: NativeData, vertexBuffer: NativeData, location: number, byteOffset: number, byteStride: number, numElements: number, type: number, normalized: boolean, instanceDivisor: number): void;
     updateDynamicVertexBuffer(vertexBuffer: NativeData, bytes: ArrayBuffer, byteOffset: number, byteLength: number): void;
 
     createProgram(vertexShader: string, fragmentShader: string): any;

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -1048,7 +1048,8 @@ export class NativeEngine extends Engine {
                             vertexBuffer.byteStride,
                             vertexBuffer.getSize(),
                             this._getNativeAttribType(vertexBuffer.type),
-                            vertexBuffer.normalized);
+                            vertexBuffer.normalized,
+                            vertexBuffer.getInstanceDivisor());
                     }
                 }
             }

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -2123,10 +2123,17 @@ export class ThinEngine {
 
                 if (overrideVertexBuffers) {
                     vertexBuffer = overrideVertexBuffers[ai];
+                    if (!vertexBuffer && ai === VertexBuffer.ColorInstanceKind) {
+                        vertexBuffer = overrideVertexBuffers[VertexBuffer.ColorKind];
+                    }
                 }
 
                 if (!vertexBuffer) {
                     vertexBuffer = vertexBuffers[ai];
+                }
+
+                if (!vertexBuffer && ai === VertexBuffer.ColorInstanceKind) {
+                    vertexBuffer = vertexBuffers[VertexBuffer.ColorKind];
                 }
 
                 if (!vertexBuffer) {

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -2123,17 +2123,10 @@ export class ThinEngine {
 
                 if (overrideVertexBuffers) {
                     vertexBuffer = overrideVertexBuffers[ai];
-                    if (!vertexBuffer && ai === VertexBuffer.ColorInstanceKind) {
-                        vertexBuffer = overrideVertexBuffers[VertexBuffer.ColorKind];
-                    }
                 }
 
                 if (!vertexBuffer) {
                     vertexBuffer = vertexBuffers[ai];
-                }
-
-                if (!vertexBuffer && ai === VertexBuffer.ColorInstanceKind) {
-                    vertexBuffer = vertexBuffers[VertexBuffer.ColorKind];
                 }
 
                 if (!vertexBuffer) {

--- a/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/src/Materials/PBR/pbrBaseMaterial.ts
@@ -170,6 +170,7 @@ export class PBRMaterialDefines extends MaterialDefines
 
     public INSTANCES = false;
     public THIN_INSTANCES = false;
+    public INSTANCESCOLOR = false;
 
     public PREPASS = false;
     public PREPASS_IRRADIANCE = false;

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -266,9 +266,13 @@ export class MaterialHelper {
         }
 
         if (useVertexColor) {
-            var hasVertexColors = mesh.useVertexColors && (mesh.isVerticesDataPresent(VertexBuffer.ColorKind) || mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind));
+            var hasVertexColors = mesh.useVertexColors && mesh.isVerticesDataPresent(VertexBuffer.ColorKind);
             defines["VERTEXCOLOR"] = hasVertexColors;
             defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
+        }
+
+        if (mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind)) {
+            defines["INSTANCESCOLOR"] = true;
         }
 
         if (useBones) {

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -266,7 +266,7 @@ export class MaterialHelper {
         }
 
         if (useVertexColor) {
-            var hasVertexColors = mesh.useVertexColors && mesh.isVerticesDataPresent(VertexBuffer.ColorKind);
+            var hasVertexColors = mesh.useVertexColors && (mesh.isVerticesDataPresent(VertexBuffer.ColorKind) || mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind));
             defines["VERTEXCOLOR"] = hasVertexColors;
             defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
         }

--- a/src/Materials/shaderMaterial.ts
+++ b/src/Materials/shaderMaterial.ts
@@ -632,6 +632,10 @@ export class ShaderMaterial extends PushMaterial {
             MaterialHelper.PushAttributesForInstances(attribs);
             if (mesh?.hasThinInstances) {
                 defines.push("#define THIN_INSTANCES");
+                if (mesh && mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind)) {
+                    attribs.push(VertexBuffer.ColorInstanceKind);
+                    defines.push("#define INSTANCESCOLOR");
+                }
             }
         }
 

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -1244,7 +1244,11 @@ export class StandardMaterial extends PushMaterial {
             }
 
             if (defines.VERTEXCOLOR) {
-                attribs.push(VertexBuffer.ColorKind);
+                if (defines.INSTANCES) {
+                    attribs.push(VertexBuffer.ColorInstanceKind);
+                } else {
+                    attribs.push(VertexBuffer.ColorKind);
+                }
             }
 
             MaterialHelper.PrepareAttributesForBones(attribs, mesh, defines, fallbacks);

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -99,6 +99,7 @@ export class StandardMaterialDefines extends MaterialDefines
     public BONES_VELOCITY_ENABLED = false;
     public INSTANCES = false;
     public THIN_INSTANCES = false;
+    public INSTANCESCOLOR = false;
     public GLOSSINESS = false;
     public ROUGHNESS = false;
     public EMISSIVEASILLUMINATION = false;

--- a/src/Materials/standardMaterial.ts
+++ b/src/Materials/standardMaterial.ts
@@ -1244,11 +1244,11 @@ export class StandardMaterial extends PushMaterial {
             }
 
             if (defines.VERTEXCOLOR) {
-                if (defines.INSTANCES) {
-                    attribs.push(VertexBuffer.ColorInstanceKind);
-                } else {
-                    attribs.push(VertexBuffer.ColorKind);
-                }
+                attribs.push(VertexBuffer.ColorKind);
+            }
+
+            if (defines.INSTANCESCOLOR) {
+                attribs.push(VertexBuffer.ColorInstanceKind);
             }
 
             MaterialHelper.PrepareAttributesForBones(attribs, mesh, defines, fallbacks);

--- a/src/Meshes/thinInstanceMesh.ts
+++ b/src/Meshes/thinInstanceMesh.ts
@@ -240,6 +240,12 @@ Mesh.prototype.thinInstanceSetBuffer = function (kind: string, buffer: Nullable<
             this._thinInstanceDataStorage.previousMatrixBuffer = this._thinInstanceCreateMatrixBuffer("previousWorld", buffer, staticBuffer);
         }
     } else {
+        // color for instanced mesh is ColorInstanceKind and not ColorKind because of native that needs to do the differenciation
+        // hot switching kind here to preserve backward compatibility
+        if (kind === VertexBuffer.ColorKind) {
+            kind = VertexBuffer.ColorInstanceKind;
+        }
+
         if (buffer === null) {
             if (this._userThinInstanceBuffersStorage?.data[kind]) {
                 this.removeVerticesData(kind);

--- a/src/Shaders/ShadersInclude/instancesDeclaration.fx
+++ b/src/Shaders/ShadersInclude/instancesDeclaration.fx
@@ -3,6 +3,7 @@
 	attribute vec4 world1;
 	attribute vec4 world2;
 	attribute vec4 world3;
+    attribute vec4 instanceColor;
     #if defined(THIN_INSTANCES) && !defined(WORLD_UBO)
         uniform mat4 world;
     #endif

--- a/src/Shaders/ShadersInclude/instancesDeclaration.fx
+++ b/src/Shaders/ShadersInclude/instancesDeclaration.fx
@@ -3,7 +3,9 @@
 	attribute vec4 world1;
 	attribute vec4 world2;
 	attribute vec4 world3;
-    attribute vec4 instanceColor;
+    #ifdef INSTANCESCOLOR
+        attribute vec4 instanceColor;
+    #endif
     #if defined(THIN_INSTANCES) && !defined(WORLD_UBO)
         uniform mat4 world;
     #endif

--- a/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
@@ -40,9 +40,7 @@ void albedoOpacityBlock(
         surfaceAlbedo *= albedoInfos.y;
     #endif
 
-    #ifdef VERTEXCOLOR
-        surfaceAlbedo *= vColor.rgb;
-    #elif INSTANCESCOLOR
+    #if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
         surfaceAlbedo *= vColor.rgb;
     #endif
 

--- a/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
+++ b/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
@@ -42,6 +42,8 @@ void albedoOpacityBlock(
 
     #ifdef VERTEXCOLOR
         surfaceAlbedo *= vColor.rgb;
+    #elif INSTANCESCOLOR
+        surfaceAlbedo *= vColor.rgb;
     #endif
 
     #ifdef DETAIL

--- a/src/Shaders/ShadersInclude/pbrFragmentExtraDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrFragmentExtraDeclaration.fx
@@ -16,4 +16,6 @@ varying vec3 vPositionW;
 
 #ifdef VERTEXCOLOR
     varying vec4 vColor;
+#elif INSTANCESCOLOR
+    varying vec4 vColor;
 #endif

--- a/src/Shaders/ShadersInclude/pbrFragmentExtraDeclaration.fx
+++ b/src/Shaders/ShadersInclude/pbrFragmentExtraDeclaration.fx
@@ -14,8 +14,6 @@ varying vec3 vPositionW;
     #endif
 #endif
 
-#ifdef VERTEXCOLOR
-    varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
     varying vec4 vColor;
 #endif

--- a/src/Shaders/color.fragment.fx
+++ b/src/Shaders/color.fragment.fx
@@ -1,6 +1,8 @@
 ﻿
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #else
 uniform vec4 color;
 #endif
@@ -18,6 +20,8 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	gl_FragColor = vColor;
+#elif INSTANCESCOLOR
+    gl_FragColor = vColor;
 #else
 	gl_FragColor = color;
 #endif

--- a/src/Shaders/color.fragment.fx
+++ b/src/Shaders/color.fragment.fx
@@ -1,7 +1,5 @@
 ﻿
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #else
 uniform vec4 color;
@@ -18,9 +16,7 @@ void main(void) {
 
 #include<clipPlaneFragment>
 
-#ifdef VERTEXCOLOR
-	gl_FragColor = vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
     gl_FragColor = vColor;
 #else
 	gl_FragColor = color;

--- a/src/Shaders/color.vertex.fx
+++ b/src/Shaders/color.vertex.fx
@@ -21,6 +21,8 @@ uniform mat4 viewProjection;
 // Output
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 

--- a/src/Shaders/color.vertex.fx
+++ b/src/Shaders/color.vertex.fx
@@ -19,9 +19,7 @@ uniform mat4 viewProjection;
 #endif
 
 // Output
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/src/Shaders/color.vertex.fx
+++ b/src/Shaders/color.vertex.fx
@@ -48,12 +48,9 @@ void main(void) {
 #include<clipPlaneVertex>
 
 #ifdef VERTEXCOLOR
-	// Vertex color
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 #define CUSTOM_VERTEX_MAIN_END

--- a/src/Shaders/color.vertex.fx
+++ b/src/Shaders/color.vertex.fx
@@ -49,7 +49,11 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	// Vertex color
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 #define CUSTOM_VERTEX_MAIN_END

--- a/src/Shaders/default.fragment.fx
+++ b/src/Shaders/default.fragment.fx
@@ -25,6 +25,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<mainUVVaryingDeclaration>[1..7]
@@ -151,6 +153,8 @@ void main(void) {
 #include<depthPrePass>
 
 #ifdef VERTEXCOLOR
+	baseColor.rgb *= vColor.rgb;
+#elif INSTANCESCOLOR
 	baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/src/Shaders/default.fragment.fx
+++ b/src/Shaders/default.fragment.fx
@@ -23,9 +23,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 
@@ -152,9 +150,7 @@ void main(void) {
 
 #include<depthPrePass>
 
-#ifdef VERTEXCOLOR
-	baseColor.rgb *= vColor.rgb;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 	baseColor.rgb *= vColor.rgb;
 #endif
 

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -171,12 +171,9 @@ void main(void) {
 #include<shadowsVertex>[0..maxSimultaneousLights]
 
 #ifdef VERTEXCOLOR
-	// Vertex color
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
 #include<pointCloudVertex>

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -46,9 +46,7 @@ varying vec3 vPositionW;
 varying vec3 vNormalW;
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -48,6 +48,8 @@ varying vec3 vNormalW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<bumpVertexDeclaration>

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -172,7 +172,11 @@ void main(void) {
 
 #ifdef VERTEXCOLOR
 	// Vertex color
-	vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
 #include<pointCloudVertex>

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -78,6 +78,8 @@ varying vec3 vPositionW;
 
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
+#elif INSTANCESCOLOR
+varying vec4 vColor;
 #endif
 
 #include<bumpVertexDeclaration>

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -243,7 +243,11 @@ void main(void) {
 
     // Vertex color
 #ifdef VERTEXCOLOR
-    vColor = color;
+    #ifdef INSTANCES
+        vColor = instanceColor;
+    #else
+	    vColor = color;
+    #endif
 #endif
 
     // Point size

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -243,11 +243,9 @@ void main(void) {
 
     // Vertex color
 #ifdef VERTEXCOLOR
-    #ifdef INSTANCES
-        vColor = instanceColor;
-    #else
-	    vColor = color;
-    #endif
+	vColor = color;
+#elif INSTANCESCOLOR
+	vColor = instanceColor;
 #endif
 
     // Point size

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -76,9 +76,7 @@ varying vec3 vPositionW;
     #endif
 #endif
 
-#ifdef VERTEXCOLOR
-varying vec4 vColor;
-#elif INSTANCESCOLOR
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 varying vec4 vColor;
 #endif
 

--- a/src/ShadersWGSL/ShadersInclude/instancesDeclaration.fx
+++ b/src/ShadersWGSL/ShadersInclude/instancesDeclaration.fx
@@ -3,6 +3,7 @@
 	attribute world1 : vec4<f32>;
 	attribute world2 : vec4<f32>;
 	attribute world3 : vec4<f32>;
+    attribute instanceColor : vec4<f32>;
     #if defined(THIN_INSTANCES) && !defined(WORLD_UBO)
         uniform world : mat4x4<f32>;
     #endif

--- a/src/ShadersWGSL/ShadersInclude/instancesDeclaration.fx
+++ b/src/ShadersWGSL/ShadersInclude/instancesDeclaration.fx
@@ -3,7 +3,9 @@
 	attribute world1 : vec4<f32>;
 	attribute world2 : vec4<f32>;
 	attribute world3 : vec4<f32>;
-    attribute instanceColor : vec4<f32>;
+    #ifdef INSTANCESCOLOR
+        attribute instanceColor : vec4<f32>;
+    #endif
     #if defined(THIN_INSTANCES) && !defined(WORLD_UBO)
         uniform world : mat4x4<f32>;
     #endif


### PR DESCRIPTION
This is the JS part for this Native PR : https://github.com/BabylonJS/BabylonNative/pull/990
See the comment there for implication on Native/bgfx

Because Native needs to differenciate color attribute coming from the mesh and instanceColor, this PR adds a new attribute `instanceColor` while preserving backward compatibility.
As `world0..1` are new attribute for instancing, `instanceColor` is added and used in Vertex shaders. A vertex attribute kind switch is done for compatibility. Setting an instance buffer with 'color' will change it to 'instanceColor' under the hood.

Also, vertex buffer instance divisor is forwarded to Native buffer recording.

There are 6 cases in shaders:
- no instances, no vertex color, no instance color
- no instances, vertex color, no instance color
- instances, no vertex color, no instance color => https://playground.babylonjs.com/#V1JE4Z#1 with comment line 41
- instances, no vertex color, instance color => https://playground.babylonjs.com/#V1JE4Z#1
- instances, vertex color, no instance color => https://playground.babylonjs.com/#UAIZCS#0
- instances, vertex color, instance color

So, a new define `INSTANCESCOLOR` is added and forwarded to the shaders.