### PR TITLE
Updated ThinEngine resize to optionally take device pixel ratio into account

### DIFF
--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1663,7 +1663,7 @@ export class ThinEngine {
         let height: number;
 
         // Requery hardware scaling level to handle zoomed-in resizing.
-        if(this._adaptToDeviceRatio) {
+        if (this._adaptToDeviceRatio) {
             const devicePixelRatio = IsWindowObjectExist() ? (window.devicePixelRatio || 1.0) : 1.0;
             var limitDeviceRatio = this._creationOptions.limitDeviceRatio || devicePixelRatio;
             this._hardwareScalingLevel = this._adaptToDeviceRatio ? 1.0 / Math.min(limitDeviceRatio, devicePixelRatio) : 1.0;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -527,6 +527,9 @@ export class ThinEngine {
     private _activeRequests = new Array<IFileRequest>();
 
     /** @hidden */
+    private _adaptToDeviceRatio: boolean = false;
+
+    /** @hidden */
     public _transformTextureUrl: Nullable<(url: string) => string> = null;
 
     /**
@@ -707,6 +710,9 @@ export class ThinEngine {
         options = options || {};
 
         this._creationOptions = options;
+
+        // Save this off for use in resize().
+        this._adaptToDeviceRatio = adaptToDeviceRatio ?? false;
 
         this._stencilStateComposer.stencilGlobal = this._stencilState;
 
@@ -1655,6 +1661,13 @@ export class ThinEngine {
     public resize(forceSetSize = false): void {
         let width: number;
         let height: number;
+
+        // Requery hardware scaling level to handle zoomed-in resizing.
+        if(this._adaptToDeviceRatio){
+            const devicePixelRatio = IsWindowObjectExist() ? (window.devicePixelRatio || 1.0) : 1.0;
+            var limitDeviceRatio = this._creationOptions.limitDeviceRatio || devicePixelRatio;
+            this._hardwareScalingLevel = this._adaptToDeviceRatio ? 1.0 / Math.min(limitDeviceRatio, devicePixelRatio) : 1.0;
+        }
 
         if (IsWindowObjectExist()) {
             width = this._renderingCanvas ? (this._renderingCanvas.clientWidth || this._renderingCanvas.width) : window.innerWidth;

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -1663,7 +1663,7 @@ export class ThinEngine {
         let height: number;
 
         // Requery hardware scaling level to handle zoomed-in resizing.
-        if(this._adaptToDeviceRatio){
+        if(this._adaptToDeviceRatio) {
             const devicePixelRatio = IsWindowObjectExist() ? (window.devicePixelRatio || 1.0) : 1.0;
             var limitDeviceRatio = this._creationOptions.limitDeviceRatio || devicePixelRatio;
             this._hardwareScalingLevel = this._adaptToDeviceRatio ? 1.0 / Math.min(limitDeviceRatio, devicePixelRatio) : 1.0;


### PR DESCRIPTION
When creating an `Engine` object, one of the constructor's parameters is `adaptToDeviceRatio`, which properly sets `_hardwareScalingLevel` during creation. This part works well.

The issue arises if the user then zooms their browser. This triggers a call to `resize()` (as it should), but `resize()` no longer takes the device pixel ratio into account. This presents in poor aliasing the more you zoom out. Here is an example, zoomed in 200%:
![image](https://user-images.githubusercontent.com/3525861/152420620-83f9e013-25b3-49bb-9b0f-39f71a4bf6b0.png)

One such workaround is to call `setHardwareScalingLevel` and pass the inverse of the window.devicePixelRatio (so something like `1.0 / (window.devicePixelRatio || 1)`, which then calls resize and accomplishes the same thing, but this feels somewhat clunky.

This solution adds a new private `_adaptToDeviceRatio` in order to maintain this setting. Then, in `resize()`, if this property is set to true, it performs the same calculations as in the constructor to re-query the device pixel ratio at that time and automatically assign it for that resize. This way the user can use the same API to resize as normal, and the `adaptToDeviceRatio` actually persists (as one might assume it does on creation).

Here is the same scene (still zoomed in to 200%), using this change:
![image](https://user-images.githubusercontent.com/3525861/152421436-a6dba199-d419-4a62-bba0-e0d39b12b154.png)
