### PR TITLE
DeviceInputSystem: Combine handling of all movement into single Move

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -70,7 +70,6 @@
 - Added `onCreateCustomConvexHullImpostor` handler for creating convex hull imposters with custom vertex data. ([MackeyK24](https://github.com/MackeyK24))
 - Modified touch in `WebDeviceInputSystem` to no longer delete touch points after pointer up. ([PolygonalSun](https://github.com/PolygonalSun))
 - Added support for DualSense controllers to DeviceInputSystem. ([PolygonalSun](https://github.com/PolygonalSun))
-- Modifed movement changes in DeviceInputSystem to use `PointerInput.Move` for all movement ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -70,6 +70,7 @@
 - Added `onCreateCustomConvexHullImpostor` handler for creating convex hull imposters with custom vertex data. ([MackeyK24](https://github.com/MackeyK24))
 - Modified touch in `WebDeviceInputSystem` to no longer delete touch points after pointer up. ([PolygonalSun](https://github.com/PolygonalSun))
 - Added support for DualSense controllers to DeviceInputSystem. ([PolygonalSun](https://github.com/PolygonalSun))
+- Modifed movement changes in DeviceInputSystem to use `PointerInput.Move` for all movement ([PolygonalSun](https://github.com/PolygonalSun))
 
 ### Engine
 

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -50,12 +50,7 @@ export class DeviceEventFactory {
 
         evt.pointerId = deviceType === DeviceType.Mouse ? 1 : deviceSlot;
 
-        if (
-            inputIndex === PointerInput.Horizontal ||
-            inputIndex === PointerInput.Vertical ||
-            inputIndex === PointerInput.DeltaHorizontal ||
-            inputIndex === PointerInput.DeltaVertical
-        ) {
+        if (inputIndex === PointerInput.Move) {
             evt.type = "pointermove";
         }
         else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -104,7 +104,7 @@ export enum DualShockInput {
 }
 
 /**
- * Enum for Dual Shock Gamepad
+ * Enum for Dual Sense Gamepad
  */
  export enum DualSenseInput {
     /** Cross */

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -49,6 +49,8 @@ export enum PointerInput {
     DeltaHorizontal = 10,
     /** Delta Y */
     DeltaVertical = 11,
+    /** Move Catch-all */
+    Move = 12,
 }
 
 /**

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,6 +1,6 @@
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
-import { DeviceType } from "./deviceEnums";
+import { DeviceType, PointerInput } from "./deviceEnums";
 import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "./inputInterfaces";
 
 /** @hidden */
@@ -23,12 +23,13 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
         };
 
         this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState, eventData) => {
+            const idx = (inputIndex === PointerInput.Horizontal || inputIndex === PointerInput.Vertical || inputIndex === PointerInput.DeltaHorizontal || inputIndex === PointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
             const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
 
             let deviceEvent = evt as IDeviceEvent;
             deviceEvent.deviceType = deviceType;
             deviceEvent.deviceSlot = deviceSlot;
-            deviceEvent.inputIndex = inputIndex;
+            deviceEvent.inputIndex = idx;
             deviceEvent.previousState = previousState;
             deviceEvent.currentState = currentState;
 

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -353,12 +353,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
             const pointer = this._inputs[deviceType][deviceSlot];
             if (pointer) {
-                // Store previous values for event
-                const previousHorizontal = pointer[PointerInput.Horizontal];
-                const previousVertical = pointer[PointerInput.Vertical];
-                const previousDeltaHorizontal = pointer[PointerInput.DeltaHorizontal];
-                const previousDeltaVertical = pointer[PointerInput.DeltaVertical];
-
                 pointer[PointerInput.Horizontal] = evt.clientX;
                 pointer[PointerInput.Vertical] = evt.clientY;
                 pointer[PointerInput.DeltaHorizontal] = evt.movementX;
@@ -367,38 +361,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 let deviceEvent = evt as IDeviceEvent;
                 deviceEvent.deviceType = deviceType;
                 deviceEvent.deviceSlot = deviceSlot;
+                deviceEvent.inputIndex = PointerInput.Move;
 
-                // The browser might use a move event in case
-                // of simultaneous mouse buttons click for instance. So
-                // in this case we stil need to propagate it.
-                if (previousHorizontal !== evt.clientX) {
-                    deviceEvent.inputIndex = PointerInput.Horizontal;
-                    deviceEvent.previousState = previousHorizontal;
-                    deviceEvent.currentState = pointer[PointerInput.Horizontal];
+                this.onInputChanged(deviceEvent);
 
-                    this.onInputChanged(deviceEvent);
-                }
-                if (previousVertical !== evt.clientY) {
-                    deviceEvent.inputIndex = PointerInput.Vertical;
-                    deviceEvent.previousState = previousVertical;
-                    deviceEvent.currentState = pointer[PointerInput.Vertical];
-
-                    this.onInputChanged(deviceEvent);
-                }
-                if (pointer[PointerInput.DeltaHorizontal] !== 0) {
-                    deviceEvent.inputIndex = PointerInput.DeltaHorizontal;
-                    deviceEvent.previousState = previousDeltaHorizontal;
-                    deviceEvent.currentState = pointer[PointerInput.DeltaHorizontal];
-
-                    this.onInputChanged(deviceEvent);
-                }
-                if (pointer[PointerInput.DeltaVertical] !== 0) {
-                    deviceEvent.inputIndex = PointerInput.DeltaVertical;
-                    deviceEvent.previousState = previousDeltaVertical;
-                    deviceEvent.currentState = pointer[PointerInput.DeltaVertical];
-
-                    this.onInputChanged(deviceEvent);
-                }
                 // Lets Propagate the event for move with same position.
                 if (!this._usingSafari && evt.button !== -1) {
                     deviceEvent.inputIndex = evt.button + 2;
@@ -491,17 +457,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.currentState = pointer[deviceEvent.inputIndex];
                 this.onInputChanged(deviceEvent);
 
-                if (previousHorizontal !== evt.clientX) {
-                    deviceEvent.inputIndex = PointerInput.Horizontal;
-                    deviceEvent.previousState = previousHorizontal;
-                    deviceEvent.currentState = pointer[PointerInput.Horizontal];
-
-                    this.onInputChanged(deviceEvent);
-                }
-                if (previousVertical !== evt.clientY) {
-                    deviceEvent.inputIndex = PointerInput.Vertical;
-                    deviceEvent.previousState = previousVertical;
-                    deviceEvent.currentState = pointer[PointerInput.Vertical];
+                if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
+                    deviceEvent.inputIndex = PointerInput.Move;
 
                     this.onInputChanged(deviceEvent);
                 }
@@ -535,17 +492,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceType = deviceType;
                 deviceEvent.deviceSlot = deviceSlot;
 
-                if (previousHorizontal !== evt.clientX) {
-                    deviceEvent.inputIndex = PointerInput.Horizontal;
-                    deviceEvent.previousState = previousHorizontal;
-                    deviceEvent.currentState = pointer[PointerInput.Horizontal];
-
-                    this.onInputChanged(deviceEvent);
-                }
-                if (previousVertical !== evt.clientY) {
-                    deviceEvent.inputIndex = PointerInput.Vertical;
-                    deviceEvent.previousState = previousVertical;
-                    deviceEvent.currentState = pointer[PointerInput.Vertical];
+                if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
+                    deviceEvent.inputIndex = PointerInput.Move;
 
                     this.onInputChanged(deviceEvent);
                 }

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -876,12 +876,7 @@ export class InputManager {
                 }
 
                 if (attachMove) {
-                    if (
-                        eventData.inputIndex === PointerInput.Horizontal ||
-                        eventData.inputIndex === PointerInput.Vertical ||
-                        eventData.inputIndex === PointerInput.DeltaHorizontal ||
-                        eventData.inputIndex === PointerInput.DeltaVertical
-                    ) {
+                    if (eventData.inputIndex === PointerInput.Move) {
                         this._onPointerMove(evt as IPointerEvent);
                     } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
                         this._onPointerMove(evt as IWheelEvent);


### PR DESCRIPTION
This PR contains a change that combines all changes to axes into single move when processing movement in the InputManager.  Additionally, there is a small fix to a typo in the device enums.