### PR TITLE
Ensure instanceColor in sync with instances

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -420,6 +420,7 @@
 - `Mesh.createInstance` no longer make a unique `Geometry` for the Mesh so updating one `Geometry` can affect more meshes than before. Use `Mesh.makeUniqueGeometry` for old behaviour. ([breakin](https://github.com/breakin))
 - Ammo.js needs to be initialized before creating the plugin with `await Ammo();` since Ammo introduced an async init in their library. ([sebavan](https://github.com/sebavan))
 - Recast.js needs to be initialized before creating the plugin with `await Recast();` since Recast introduced an async init in their library. ([CedricGuillemet](https://github.com/CedricGuillemet))
+- Custom shaders using instancing must use `instanceColor` instead of `color` so mesh vertex colors can be used with instancing. ([CedricGuillemet](https://github.com/CedricGuillemet))
 - Fixed spelling of `EventState.initialize` ([seritools](https://github.com/seritools))
 - `SkeletonViewer` is now enabled by default ([Deltakosh](https://github.com/deltakosh))
 - `BindEyePosition` has been moved from `Material` to `Scene` to avoid a circular dependency problem and is now a non-static method (`bindEyePosition`) ([Popov72](https://github.com/Popov72))

--- a/src/Materials/materialHelper.ts
+++ b/src/Materials/materialHelper.ts
@@ -163,6 +163,12 @@ export class MaterialHelper {
             changed = true;
         }
 
+        // ensure defines.INSTANCESCOLOR is not out of sync with instances
+        if (defines["INSTANCESCOLOR"] && !defines["INSTANCES"]) {
+            defines["INSTANCESCOLOR"] = false;
+            changed = true;
+        }
+
         if (defines["THIN_INSTANCES"] !== useThinInstances) {
             defines["THIN_INSTANCES"] = useThinInstances;
             changed = true;


### PR DESCRIPTION
There are some edge cases when instances is not enabled yet and `INSTANCECOLOR` is defined in shaders because data is present in mesh.
When it happens, instanceColor attribute is not declared (because enclosed with `#ifdef INSTANCES`) and `INSTANCECOLOR` allows assignation in VS. And shader compilation fails. This fix ensure that `INSTANCECOLOR` is always disabled when instances are disabled.
I've found this issue in Native Validation tests. I don't think this can happen with Web (at least, I didn't find a valid) version because of a combination of engine caps difference between Native and Web.

Also updated breaking change for custom shaders

