### PR TITLE
Added getCreationOptions on ThinEngine

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -71,6 +71,7 @@
 - Added `onCreateCustomConvexHullImpostor` handler for creating convex hull imposters with custom vertex data. ([MackeyK24](https://github.com/MackeyK24))
 - Modified touch in `WebDeviceInputSystem` to no longer delete touch points after pointer up. ([PolygonalSun](https://github.com/PolygonalSun))
 - Added support for DualSense controllers to DeviceInputSystem. ([PolygonalSun](https://github.com/PolygonalSun))
+- Added `getCreationOptions` on `ThinEngine`. ([carolhmj](https://github.com/carolhmj))
 
 ### Engine
 

--- a/src/Engines/thinEngine.ts
+++ b/src/Engines/thinEngine.ts
@@ -363,6 +363,14 @@ export class ThinEngine {
     protected _audioContext: Nullable<AudioContext>;
     protected _audioDestination: Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode>;
 
+    /**
+     * Gets the options used for engine creation
+     * @returns EngineOptions object
+     */
+    public getCreationOptions() {
+        return this._creationOptions;
+    }
+
     protected _highPrecisionShadersAllowed = true;
     /** @hidden */
     public get _shouldUseHighPrecisionShader(): boolean {


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/there-is-now-way-to-get-the-engineoptions-from-an-engine/26357