### PR TITLE
[Viewer] load from the right path

### DIFF
--- a/Viewer/src/configuration/mappers.ts
+++ b/Viewer/src/configuration/mappers.ts
@@ -1,7 +1,7 @@
 import { Tools } from 'babylonjs/Misc/tools';
 import { ViewerConfiguration } from './configuration';
 
-import { kebabToCamel } from '../helper/';
+import { kebabToCamel } from '../helper/index';
 
 /**
  * This is the mapper's interface. Implement this function to create your own mapper and register it at the mapper manager

--- a/Viewer/src/configuration/renderOnlyLoader.ts
+++ b/Viewer/src/configuration/renderOnlyLoader.ts
@@ -2,7 +2,7 @@ import { mapperManager } from './mappers';
 import { ViewerConfiguration } from './configuration';
 import { processConfigurationCompatibility } from './configurationCompatibility';
 
-import { deepmerge } from '../helper';
+import { deepmerge } from '../helper/index';
 import { Tools } from 'babylonjs/Misc/tools';
 import { extendedConfiguration } from './types/extended';
 import { renderOnlyDefaultConfiguration } from './types/renderOnlyDefault';

--- a/Viewer/src/configuration/types/default.ts
+++ b/Viewer/src/configuration/types/default.ts
@@ -2,7 +2,7 @@ import { ViewerConfiguration } from '../configuration';
 import { babylonFont, defaultTemplate, fillContainer, loadingScreen, defaultViewer, navbar, overlay, help, share, error } from 'babylonjs-viewer-assets';
 import * as images from 'babylonjs-viewer-assets';
 import { renderOnlyDefaultConfiguration } from './renderOnlyDefault';
-import { deepmerge } from '../../helper';
+import { deepmerge } from '../../helper/index';
 
 /**
  * The default configuration of the viewer, including templates (canvas, overly, loading screen)

--- a/Viewer/src/configuration/types/index.ts
+++ b/Viewer/src/configuration/types/index.ts
@@ -4,7 +4,7 @@ import { extendedConfiguration } from './extended';
 import { ViewerConfiguration } from '../configuration';
 import { shadowDirectionalLightConfiguration, shadowSpotlLightConfiguration } from './shadowLight';
 import { environmentMapConfiguration } from './environmentMap';
-import { deepmerge } from '../../helper/';
+import { deepmerge } from '../../helper/index';
 
 /**
  * Get the configuration type you need to use as the base for your viewer.

--- a/Viewer/src/managers/sceneManager.ts
+++ b/Viewer/src/managers/sceneManager.ts
@@ -1,12 +1,12 @@
-import { ILightConfiguration, ISceneConfiguration, ISceneOptimizerConfiguration, ICameraConfiguration, ISkyboxConfiguration, ViewerConfiguration, IGroundConfiguration, IModelConfiguration, getConfigurationKey, IDefaultRenderingPipelineConfiguration, IVRConfiguration } from '../configuration';
+import { ILightConfiguration, ISceneConfiguration, ISceneOptimizerConfiguration, ICameraConfiguration, ISkyboxConfiguration, IGroundConfiguration, IModelConfiguration, IDefaultRenderingPipelineConfiguration, IVRConfiguration } from '../configuration/interfaces/index';
+import { getConfigurationKey, ViewerConfiguration } from '../configuration/configuration';
 import { ViewerModel, ModelState } from '../model/viewerModel';
-import { extendClassWithConfig } from '../helper';
+import { extendClassWithConfig, deepmerge } from '../helper/index';
 import { CameraBehavior } from '../interfaces';
 import { ViewerLabs } from '../labs/viewerLabs';
-import { getCustomOptimizerByName } from '../optimizer/custom/';
+import { getCustomOptimizerByName } from '../optimizer/custom/index';
 import { ObservablesManager } from '../managers/observablesManager';
 import { ConfigurationContainer } from '../configuration/configurationContainer';
-import { deepmerge } from '../helper';
 import { IEnvironmentMapConfiguration } from '../configuration/interfaces/environmentMapConfiguration';
 import { Observable } from 'babylonjs/Misc/observable';
 import { SceneOptimizer, SceneOptimizerOptions } from 'babylonjs/Misc/sceneOptimizer';

--- a/Viewer/src/model/viewerModel.ts
+++ b/Viewer/src/model/viewerModel.ts
@@ -19,8 +19,7 @@ import { IAsset } from "babylonjs-gltf2interface";
 import { IModelConfiguration } from "../configuration/interfaces/modelConfiguration";
 import { IModelAnimationConfiguration } from "../configuration/interfaces/modelAnimationConfiguration";
 import { IModelAnimation, GroupModelAnimation, AnimationPlayMode, ModelAnimationConfiguration, EasingFunction, AnimationState } from "./modelAnimation";
-
-import { deepmerge, extendClassWithConfig } from '../helper/';
+import { deepmerge, extendClassWithConfig } from '../helper/index';
 import { ObservablesManager } from "../managers/observablesManager";
 import { ConfigurationContainer } from "../configuration/configurationContainer";
 

--- a/Viewer/src/templating/templateManager.ts
+++ b/Viewer/src/templating/templateManager.ts
@@ -1,11 +1,10 @@
 import { Observable } from 'babylonjs/Misc/observable';
 import { Tools } from 'babylonjs/Misc/tools';
-import { isUrl, camelToKebab, kebabToCamel } from '../helper';
+import { isUrl, camelToKebab, kebabToCamel, deepmerge } from '../helper/index';
 
 import * as Handlebars from 'handlebars/dist/handlebars';
 import { EventManager } from './eventManager';
-import { ITemplateConfiguration } from '../configuration/interfaces';
-import { deepmerge } from '../helper/';
+import { ITemplateConfiguration } from '../configuration/interfaces/templateConfiguration';
 import { IFileRequest } from 'babylonjs/Misc/fileRequest';
 
 /**

--- a/Viewer/src/viewer/defaultViewer.ts
+++ b/Viewer/src/viewer/defaultViewer.ts
@@ -1,5 +1,4 @@
 
-import { ViewerConfiguration, IModelConfiguration, ILightConfiguration, ISceneConfiguration } from './../configuration';
 import { Template, EventCallback } from '../templating/templateManager';
 import { FilesInput } from 'babylonjs/Misc/filesInput';
 import { SpotLight } from 'babylonjs/Lights/spotLight';
@@ -8,12 +7,15 @@ import { TemplateManager } from '../templating/templateManager';
 import { AbstractViewerWithTemplate } from './viewerWithTemplate';
 import { StandardMaterial } from 'babylonjs/Materials/standardMaterial';
 import { PBRMaterial } from 'babylonjs/Materials/PBR/pbrMaterial';
-import { extendClassWithConfig } from '../helper';
+import { extendClassWithConfig } from '../helper/index';
 import { ViewerModel } from '../model/viewerModel';
 import { IModelAnimation, AnimationState } from '../model/modelAnimation';
 import { IViewerTemplatePlugin } from '../templating/viewerTemplatePlugin';
 import { HDButtonPlugin } from '../templating/plugins/hdButtonPlugin';
 import { PrintButtonPlugin } from '../templating/plugins/printButton';
+import { ViewerConfiguration } from '../configuration/configuration';
+import { ISceneConfiguration } from '../configuration/interfaces/sceneConfiguration';
+import { IModelConfiguration } from '../configuration/interfaces/modelConfiguration';
 
 /**
  * The Default viewer is the default implementation of the AbstractViewer.

--- a/Viewer/src/viewer/renderOnlyViewer.ts
+++ b/Viewer/src/viewer/renderOnlyViewer.ts
@@ -1,5 +1,5 @@
 
-import { ViewerConfiguration } from '../configuration';
+import { ViewerConfiguration } from '../configuration/configuration';
 import { AbstractViewer } from './viewer';
 
 export class RenderOnlyViewer extends AbstractViewer {

--- a/Viewer/src/viewer/viewer.ts
+++ b/Viewer/src/viewer/viewer.ts
@@ -3,23 +3,23 @@ import { ISceneLoaderPlugin, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent 
 import { Observable } from 'babylonjs/Misc/observable';
 import { Scene } from 'babylonjs/scene';
 import { RenderingManager } from 'babylonjs/Rendering/renderingManager';
-import { Vector3 } from 'babylonjs/Maths/math';
 import { TargetCamera } from 'babylonjs/Cameras/targetCamera';
 import { Tools } from 'babylonjs/Misc/tools';
 import { Effect } from 'babylonjs/Materials/effect';
-import { ConfigurationLoader } from '../configuration/loader';
-import { IModelConfiguration, IObserversConfiguration, ViewerConfiguration } from '../configuration/';
 import { processConfigurationCompatibility } from '../configuration/configurationCompatibility';
 import { ConfigurationContainer } from '../configuration/configurationContainer';
 import { viewerGlobals } from '../configuration/globals';
 import { RenderOnlyConfigurationLoader } from '../configuration/renderOnlyLoader';
-import { deepmerge } from '../helper/';
+import { deepmerge } from '../helper/index';
 import { ModelLoader } from '../loader/modelLoader';
 import { ObservablesManager } from '../managers/observablesManager';
 import { SceneManager } from '../managers/sceneManager';
 import { telemetryManager } from '../managers/telemetryManager';
 import { ViewerModel } from '../model/viewerModel';
 import { viewerManager } from './viewerManager';
+import { ViewerConfiguration } from '../configuration/configuration';
+import { IObserversConfiguration } from '../configuration/interfaces/observersConfiguration';
+import { IModelConfiguration } from '../configuration/interfaces/modelConfiguration';
 
 /**
  * The AbstractViewer is the center of Babylon's viewer.


### PR DESCRIPTION
We had a few imports from index instead of directly from the corresponding file, which lead to an issue when the .js to imports during build phase.