### PR TITLE
Fixing 2D control interactions on the HolographicSlate

### DIFF
--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -148,6 +148,11 @@ export class HolographicSlate extends ContentDisplay3D {
      */
     protected _applyFacade(facadeTexture: AdvancedDynamicTexture) {
         this._contentMaterial.albedoTexture = facadeTexture;
+
+        // We should have a content plate by this point, but check for safety
+        if (this._contentPlate) {
+            facadeTexture.attachToMesh(this._contentPlate, true);
+        }
     }
 
     private _rebuildContent(): void {


### PR DESCRIPTION
The HolographicSlate is a 3D control with an embedded AdvancedDynamicTexture on it, but any 2D controls placed on it could not be interacted with. This boiled down to it missing the attachToMesh call connecting the texture to the backplate.

Playground used to test: https://www.babylonjs-playground.com/#XHZWI1#9