### PR TITLE
Add public version of AbstractMesh's _getPositionData function

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -130,6 +130,7 @@
 
 ### Meshes
 
+- Added public version of `AbstractMesh` function _getPositionData. ([BlakeOne](https://github.com/BlakeOne))
 - Added default options parameter to Create functions. ([BlakeOne](https://github.com/BlakeOne))
 - `LineMesh` now allows assigning custom material via `material` setter. ([FullStackForger](https://github.com/FullStackForger)
 - `InstancedMesh` can now be sorted from back to front before rendering if the material is transparent ([Popov72](https://github.com/Popov72))

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1440,7 +1440,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
                 }
             }
         }
-        
+
         if (data && applySkeleton && this.skeleton) {
             var matricesIndicesData = this.getVerticesData(VertexBuffer.MatricesIndicesKind);
             var matricesWeightsData = this.getVerticesData(VertexBuffer.MatricesWeightsKind);

--- a/src/Meshes/abstractMesh.ts
+++ b/src/Meshes/abstractMesh.ts
@@ -1406,25 +1406,15 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._updateBoundingInfo();
     }
 
-    /** @hidden */
-    public _getPositionData(applySkeleton: boolean, applyMorph: boolean): Nullable<FloatArray> {
-        let data = this.getVerticesData(VertexBuffer.PositionKind);
-
-        if (this._internalAbstractMeshDataInfo._positions) {
-            this._internalAbstractMeshDataInfo._positions = null;
-        }
-
-        if (data && ((applySkeleton && this.skeleton) || (applyMorph && this.morphTargetManager))) {
-            data = Tools.Slice(data);
-            this._generatePointsArray();
-            if (this._positions) {
-                const pos = this._positions;
-                this._internalAbstractMeshDataInfo._positions = new Array<Vector3>(pos.length);
-                for (let i = 0; i < pos.length; i++) {
-                    this._internalAbstractMeshDataInfo._positions[i] = pos[i]?.clone() || new Vector3();
-                }
-            }
-        }
+    /**
+     * Get the position vertex data and optionally apply skeleton and morphing.
+     * @param applySkeleton defines whether to apply the skeleton
+     * @param applyMorph  defines whether to apply the morph target
+     * @param data defines the position data to apply the skeleton and morph to
+     * @returns the position data
+     */
+    public getPositionData(applySkeleton: boolean, applyMorph: boolean, data?: Nullable<FloatArray>): Nullable<FloatArray> {
+        data = data ?? this.getVerticesData(VertexBuffer.PositionKind);
 
         if (data && applyMorph && this.morphTargetManager) {
             let faceIndexCount = 0;
@@ -1450,6 +1440,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
                 }
             }
         }
+        
         if (data && applySkeleton && this.skeleton) {
             var matricesIndicesData = this.getVerticesData(VertexBuffer.MatricesIndicesKind);
             var matricesWeightsData = this.getVerticesData(VertexBuffer.MatricesWeightsKind);
@@ -1499,6 +1490,29 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         }
 
         return data;
+    }
+
+    /** @hidden */
+    public _getPositionData(applySkeleton: boolean, applyMorph: boolean): Nullable<FloatArray> {
+        let data = this.getVerticesData(VertexBuffer.PositionKind);
+
+        if (this._internalAbstractMeshDataInfo._positions) {
+            this._internalAbstractMeshDataInfo._positions = null;
+        }
+
+        if (data && ((applySkeleton && this.skeleton) || (applyMorph && this.morphTargetManager))) {
+            data = Tools.Slice(data);
+            this._generatePointsArray();
+            if (this._positions) {
+                const pos = this._positions;
+                this._internalAbstractMeshDataInfo._positions = new Array<Vector3>(pos.length);
+                for (let i = 0; i < pos.length; i++) {
+                    this._internalAbstractMeshDataInfo._positions[i] = pos[i]?.clone() || new Vector3();
+                }
+            }
+        }
+
+        return this.getPositionData(applySkeleton, applyMorph, data);
     }
 
     /** @hidden */


### PR DESCRIPTION
PR to add a public version of the _getPositionData function to the AbstractMesh class to allow users to get positions data with skeleton and/or morph applied.

Forum: https://forum.babylonjs.com/t/how-do-i-extract-mesh-vertex-data-properly/27381/9

NOTE: Undid previous commits, started with fresh, up-to-date repo and re-applied the changes. Hopefully it will build and validate successfully, which it is locally now...

Original closed PR for reference: https://github.com/BabylonJS/Babylon.js/pull/11928