### PR TITLE
[GUI] Mark as dirty after calls to scale and scaleTo

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -1219,4 +1219,23 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         result.attach();
         return result;
     }
+
+    /**
+     * Scales the texture
+     * @param ratio the scale factor to apply to both width and height
+     */
+     public scale(ratio: number): void {
+        super.scale(ratio);
+        this.markAsDirty();
+    }
+
+    /**
+     * Resizes the texture
+     * @param width the new width
+     * @param height the new height
+     */
+    public scaleTo(width: number, height: number): void {
+        super.scaleTo(width, height);
+        this.markAsDirty();
+    }
 }


### PR DESCRIPTION
Calling scale or scaleTo on an ADT should mark it as dirty, forcing it to re-render. If the GUI does not re-render, you will end up with a blank texture.

Forum thread: https://forum.babylonjs.com/t/gui-advanced-dynamic-texture-scaleto-or-change-the-size-of-the-texture-after-initial-creation/27461/3