### PR TITLE
Remove extra uniform from multiview ubo

### DIFF
--- a/src/Engines/Extensions/engine.multiview.ts
+++ b/src/Engines/Extensions/engine.multiview.ts
@@ -145,7 +145,6 @@ function createMultiviewUbo(engine: Engine, name?: string) {
     ubo.addUniform("viewProjectionR", 16);
     ubo.addUniform("view", 16);
     ubo.addUniform("projection", 16);
-    ubo.addUniform("viewPosition", 4);
     ubo.addUniform("vEyePosition", 4);
     return ubo;
 }


### PR DESCRIPTION
Somehow this fixes #11947

It seems the extra uniform was causing vEyePosition to not get sent to the shader properly. Maybe it was alignment issues?
`viewPosition` is not used as a uniform anywhere in our codebase so I've removed it because it seems to be deprecated.