### PR TITLE
[GE] Rename controls from tree view

### DIFF
--- a/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
@@ -28,7 +28,7 @@ export class ControlTreeItemComponent extends React.Component<IControlTreeItemCo
 
         const control = this.props.control;
 
-        this.state = { isActive: control.isHighlighted, isVisible: control.isVisible, isEditing: false };
+        this.state = { isActive: control.isHighlighted, isVisible: control.isVisible, isRenaming: false };
     }
 
     highlight() {

--- a/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
@@ -22,13 +22,13 @@ interface IControlTreeItemComponentProps {
     dragOverLocation: DragOverLocation;
 }
 
-export class ControlTreeItemComponent extends React.Component<IControlTreeItemComponentProps, { isActive: boolean; isVisible: boolean }> {
+export class ControlTreeItemComponent extends React.Component<IControlTreeItemComponentProps, { isActive: boolean; isVisible: boolean, isRenaming: boolean }> {
     constructor(props: IControlTreeItemComponentProps) {
         super(props);
 
         const control = this.props.control;
 
-        this.state = { isActive: control.isHighlighted, isVisible: control.isVisible };
+        this.state = { isActive: control.isHighlighted, isVisible: control.isVisible, isEditing: false };
     }
 
     highlight() {
@@ -44,17 +44,29 @@ export class ControlTreeItemComponent extends React.Component<IControlTreeItemCo
         this.props.control.isVisible = newState;
     }
 
+    onRename(name: string) {
+        this.props.control.name = name;
+        this.forceUpdate();
+    }
+
     render() {
         const control = this.props.control;
 
-        let name = `${control.name || "No name"} [${control.getClassName()}]`;
+        let bracket = "";
         if (control.parent?.typeName === "Grid") {
-            name += ` [${(control.parent as Grid).getChildCellInfo(this.props.control)}]`;
+            bracket = (control.parent as Grid).getChildCellInfo(this.props.control);
         }
         let draggingSelf = this.props.globalState.draggedControl === control;
         return (
             <div className="controlTools">
-                <TreeItemLabelComponent label={name} onClick={() => this.props.onClick()} color="greenyellow" />
+                <TreeItemLabelComponent
+                    label={control.name}
+                    bracket={bracket}
+                    onClick={() => this.props.onClick()}
+                    onChange={name => this.onRename(name)}
+                    setRenaming={renaming => this.setState({isRenaming: renaming})}
+                    renaming={this.state.isRenaming}
+                />
                 {!draggingSelf && this.props.dragOverHover && this.props.dragOverLocation == DragOverLocation.CENTER && control instanceof Container && (
                     <>
                         <div className="makeChild icon" onClick={() => this.highlight()} title="Make Child">
@@ -62,7 +74,7 @@ export class ControlTreeItemComponent extends React.Component<IControlTreeItemCo
                         </div>
                     </>
                 )}
-                {this.props.isHovered && this.props.globalState.draggedControl === null && this.props.dragOverLocation == DragOverLocation.NONE && (
+                {!this.state.isRenaming && this.props.isHovered && this.props.globalState.draggedControl === null && this.props.dragOverLocation == DragOverLocation.NONE && (
                     <>
                         <div className="addComponent icon" onClick={() => this.highlight()} title="Add component (Not Implemented)">
                             <img src={makeComponentIcon} />

--- a/guiEditor/src/components/sceneExplorer/sceneExplorer.scss
+++ b/guiEditor/src/components/sceneExplorer/sceneExplorer.scss
@@ -3,7 +3,9 @@
     left: 0px;
     top:0px;
     bottom: 0px;
-    font-family: "acumin-pro-condensed";
+    * {
+            font-family: "acumin-pro-condensed";
+    }
     &:focus {
         outline: none;
     }
@@ -396,7 +398,6 @@
         .controlTools {
             grid-column: 2;
             display: grid;
-            grid-template-columns: 1fr 30px 30px auto 5px;
             align-items: center;
 
             .highlight {
@@ -430,7 +431,8 @@
                 grid-column: 1;
                 white-space: nowrap;
                 text-overflow: ellipsis;
-                overflow: hidden;          
+                overflow: hidden;
+                outline: none;
             }   
  
         }

--- a/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -145,6 +145,8 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
         if (!this.state.selectedEntity) {
             return;
         }
+        // if typing inside a text box, don't process keys
+        if ((keyEvent.target as HTMLElement).localName === "input") return;
 
         const scene = this.state.scene;
         let search = false;

--- a/guiEditor/src/components/sceneExplorer/treeItemLabelComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/treeItemLabelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 interface ITreeItemLabelComponentProps {
-    label: string | undefined;
+    label?: string;
     onClick?: () => void;
     onChange: (newValue: string) => void;
     bracket: string;
@@ -10,7 +10,7 @@ interface ITreeItemLabelComponentProps {
 }
 
 interface ITreeItemLabelState {
-    value: string | undefined;
+    value: string;
 }
 
 export class TreeItemLabelComponent extends React.Component<ITreeItemLabelComponentProps, ITreeItemLabelState> {
@@ -27,11 +27,6 @@ export class TreeItemLabelComponent extends React.Component<ITreeItemLabelCompon
         }
 
         this.props.onClick();
-    }
-
-    onFocus() {
-        this.props.setRenaming(true);
-        this.setState({value: this.props.label});
     }
 
     onBlur() {
@@ -62,7 +57,10 @@ export class TreeItemLabelComponent extends React.Component<ITreeItemLabelCompon
                 :
                     <div
                         className="titleText"
-                        onDoubleClick={() => this.onFocus()}
+                        onDoubleClick={() => {
+                            this.props.setRenaming(true);
+                            this.setState({value: label});                    
+                        }}
                     >{label}
                     </div>
                 }

--- a/guiEditor/src/components/sceneExplorer/treeItemLabelComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/treeItemLabelComponent.tsx
@@ -1,28 +1,71 @@
 import * as React from "react";
 
 interface ITreeItemLabelComponentProps {
-    label: string;
+    label: string | undefined;
     onClick?: () => void;
-    color: string;
+    onChange: (newValue: string) => void;
+    bracket: string;
+    renaming: boolean;
+    setRenaming: (renaming: boolean) => void;
 }
 
-export class TreeItemLabelComponent extends React.Component<ITreeItemLabelComponentProps> {
+interface ITreeItemLabelState {
+    value: string | undefined;
+}
+
+export class TreeItemLabelComponent extends React.Component<ITreeItemLabelComponentProps, ITreeItemLabelState> {
     constructor(props: ITreeItemLabelComponentProps) {
         super(props);
+        this.state = {
+            value: ""
+        }
     }
 
     onClick() {
-        if (!this.props.onClick) {
+        if (!this.props.onClick || this.props.renaming) {
             return;
         }
 
         this.props.onClick();
     }
 
+    onFocus() {
+        this.props.setRenaming(true);
+        this.setState({value: this.props.label});
+    }
+
+    onBlur() {
+        this.props.setRenaming(false);
+    }
+
     render() {
+        // if editing, overwrite string with local value
+        const label = this.props.renaming ? this.state.value : (this.props.label || "No Name");
         return (
             <div className="title" onClick={() => this.onClick()}>
-                <div className="titleText">{this.props.label || "no name"}</div>
+                {
+                this.props.renaming ?
+                    <input
+                        type="text"
+                        onBlur={() => this.onBlur()}
+                        autoFocus={true}
+                        value={label}
+                        onChange={ev => {
+                            this.props.onChange(ev.target.value);
+                            this.setState({value: ev.target.value})
+                        }}
+                        onKeyDown={(ev) => {
+                            if (ev.key === "Enter") this.onBlur();
+                        }}
+                        className="titleText"
+                    />
+                :
+                    <div
+                        className="titleText"
+                        onDoubleClick={() => this.onFocus()}
+                    >{label}
+                    </div>
+                }
             </div>
         );
     }

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -297,6 +297,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     }
 
     keyEvent = (evt: KeyboardEvent) => {
+        if ((evt.target as HTMLElement).localName === "input") return;
         this._ctrlKeyIsPressed = evt.ctrlKey;
         this._altKeyIsPressed = evt.altKey;
         if (evt.shiftKey) {

--- a/guiEditor/src/workbenchEditor.tsx
+++ b/guiEditor/src/workbenchEditor.tsx
@@ -117,13 +117,15 @@ export class WorkbenchEditor extends React.Component<IGraphEditorProps, IGraphEd
         const deltaX = evt.clientX - this._startX;
         const rootElement = evt.currentTarget.ownerDocument!.getElementById("gui-editor-workbench-root") as HTMLDivElement;
 
+        const maxWidth = this.props.globalState.hostWindow.innerWidth - this._toolBarIconSize - 8;
+
         if (forLeft) {
             this._leftWidth += deltaX;
-            this._leftWidth = Math.max(150, Math.min(400, this._leftWidth));
+            this._leftWidth = Math.max(150, Math.min(maxWidth - this._rightWidth, this._leftWidth));
             DataStorage.WriteNumber("LeftWidth", this._leftWidth);
         } else {
             this._rightWidth -= deltaX;
-            this._rightWidth = Math.max(250, Math.min(500, this._rightWidth));
+            this._rightWidth = Math.max(250, Math.min(maxWidth - this._leftWidth, this._rightWidth));
             DataStorage.WriteNumber("RightWidth", this._rightWidth);
         }
 


### PR DESCRIPTION
Allows you to double click to rename a control from the tree view on the left. Also removes the max width on the left panel, so you can drag it out as big as you need to see all your control names.