### PR TITLE
[GE] Renaming control should update it everywhere

### DIFF
--- a/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
+++ b/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
@@ -46,7 +46,7 @@ export class ControlTreeItemComponent extends React.Component<IControlTreeItemCo
 
     onRename(name: string) {
         this.props.control.name = name;
-        this.forceUpdate();
+        this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
     }
 
     render() {


### PR DESCRIPTION
Renaming a control in the tree view should trigger an update in the right-hand panel as well as the tree view