### PR TITLE
Make decorations use "equals" if available

### DIFF
--- a/src/Animations/animation.ts
+++ b/src/Animations/animation.ts
@@ -65,7 +65,7 @@ export class Animation {
     /**
      * Stores the easing function of the animation
      */
-    private _easingFunction: IEasingFunction;
+    private _easingFunction: Nullable<IEasingFunction>;
 
     /**
      * @hidden Internal use only
@@ -669,7 +669,7 @@ export class Animation {
      * Gets the easing function of the animation
      * @returns Easing function of the animation
      */
-    public getEasingFunction(): IEasingFunction {
+    public getEasingFunction(): Nullable<IEasingFunction> {
         return this._easingFunction;
     }
 
@@ -677,7 +677,7 @@ export class Animation {
      * Sets the easing function of the animation
      * @param easingFunction A custom mathematical formula for animation
      */
-    public setEasingFunction(easingFunction: IEasingFunction): void {
+    public setEasingFunction(easingFunction: Nullable<IEasingFunction>): void {
         this._easingFunction = easingFunction;
     }
 
@@ -905,7 +905,7 @@ export class Animation {
 
                 // check for easingFunction and correction of gradient
                 let easingFunction = this.getEasingFunction();
-                if (easingFunction != null) {
+                if (easingFunction !== null) {
                     gradient = easingFunction.ease(gradient);
                 }
 

--- a/src/Animations/animation.ts
+++ b/src/Animations/animation.ts
@@ -65,7 +65,7 @@ export class Animation {
     /**
      * Stores the easing function of the animation
      */
-    private _easingFunction: Nullable<IEasingFunction>;
+    private _easingFunction: Nullable<IEasingFunction> = null;
 
     /**
      * @hidden Internal use only

--- a/src/Misc/decorators.ts
+++ b/src/Misc/decorators.ts
@@ -137,6 +137,13 @@ function generateExpandMember(setCallback: string, targetKey: Nullable<string> =
                 return this[key];
             },
             set: function (this: any, value) {
+                // does this object (i.e. vector3) has an equals function? use it!
+                // Note - not using "with epsilon" here, it is expected te behave like the internal cache does.
+                if (typeof this.equals === "function") {
+                    if (this.equals(value)) {
+                        return;
+                    }
+                }
                 if (this[key] === value) {
                     return;
                 }


### PR DESCRIPTION
Then setting certain properties with decorators we are checking for "this === value" which doesn't work for vectors or quaternions. It is now checking if the function "equals" exist and then use it instead.

This PR also adds the ability to reset the easing function