### PR TITLE
GetFontOffset Native

### DIFF
--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -2202,7 +2202,7 @@ export class Control {
             this._font = this._fontStyle + " " + this._fontWeight + " " + this.fontSizeInPixels + "px " + this._fontFamily;
         }
 
-        this._fontOffset = Control._GetFontOffset(this._font);
+        this._fontOffset = Control._GetFontOffset(this._font, this._host.getContext());
 
         //children need to be refreshed
         this.getDescendants().forEach((child) => child._markAllAsDirty());
@@ -2321,7 +2321,7 @@ export class Control {
     private static _FontHeightSizes: { [key: string]: { ascent: number; height: number; descent: number } } = {};
 
     /** @hidden */
-    public static _GetFontOffset(font: string): { ascent: number; height: number; descent: number } {
+    public static _GetFontOffset(font: string, context: ICanvasRenderingContext): { ascent: number; height: number; descent: number } {
         if (Control._FontHeightSizes[font]) {
             return Control._FontHeightSizes[font];
         }
@@ -2331,7 +2331,7 @@ export class Control {
             throw new Error("Invalid engine. Unable to create a canvas.");
         }
 
-        var result = engine.getFontOffset(font);
+        var result = engine.getFontOffset(font, context);
         Control._FontHeightSizes[font] = result;
 
         return result;

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -894,7 +894,7 @@ export class InputText extends Control implements IFocusableControl {
         }
 
         if (!this._fontOffset || this._wasDirty) {
-            this._fontOffset = Control._GetFontOffset(context.font);
+            this._fontOffset = Control._GetFontOffset(context.font, context);
         }
 
         // Text

--- a/gui/src/2D/controls/textBlock.ts
+++ b/gui/src/2D/controls/textBlock.ts
@@ -293,7 +293,7 @@ export class TextBlock extends Control {
 
     protected _processMeasures(parentMeasure: Measure, context: ICanvasRenderingContext): void {
         if (!this._fontOffset || this.isDirty) {
-            this._fontOffset = Control._GetFontOffset(context.font);
+            this._fontOffset = Control._GetFontOffset(context.font, context);
         }
         super._processMeasures(parentMeasure, context);
 
@@ -572,7 +572,7 @@ export class TextBlock extends Control {
             if (context) {
                 this._applyStates(context);
                 if (!this._fontOffset) {
-                    this._fontOffset = Control._GetFontOffset(context.font);
+                    this._fontOffset = Control._GetFontOffset(context.font, context);
                 }
                 const lines = this._lines ? this._lines : this._breakLines(this.widthInPixels - this._paddingLeftInPixels - this._paddingRightInPixels, this.heightInPixels - this._paddingTopInPixels - this._paddingBottomInPixels, context);
                 return this._computeHeightForLinesOf(lines.length);

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -2000,9 +2000,10 @@ export class Engine extends ThinEngine {
     /**
      * Get Font size information
      * @param font font name
+     * @param context the Canvas context used for rendering. Might be ignored for Web
      * @return an object containing ascent, height and descent
      */
-    public getFontOffset(font: string, context: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
+    public getFontOffset(font: string, context?: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
         var text = document.createElement("span");
         text.innerHTML = "Hg";
         text.setAttribute('style', `font: ${font} !important`);

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -20,6 +20,7 @@ import { PerfCounter } from '../Misc/perfCounter';
 import { WebGLDataBuffer } from '../Meshes/WebGL/webGLDataBuffer';
 import { Logger } from '../Misc/logger';
 import { RenderTargetWrapper } from "./renderTargetWrapper";
+import { ICanvasRenderingContext } from "./ICanvas";
 
 import "./Extensions/engine.alpha";
 import "./Extensions/engine.readTexture";
@@ -2001,7 +2002,7 @@ export class Engine extends ThinEngine {
      * @param font font name
      * @return an object containing ascent, height and descent
      */
-    public getFontOffset(font: string): { ascent: number, height: number, descent: number } {
+    public getFontOffset(font: string, context: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
         var text = document.createElement("span");
         text.innerHTML = "Hg";
         text.setAttribute('style', `font: ${font} !important`);

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -25,12 +25,11 @@ import { ShaderCodeInliner } from "./Processors/shaderCodeInliner";
 import { WebGL2ShaderProcessor } from '../Engines/WebGL/webGL2ShaderProcessors';
 import { IMaterialContext } from "./IMaterialContext";
 import { IDrawContext } from "./IDrawContext";
-import { ICanvas, IImage } from "./ICanvas";
+import { ICanvas, IImage, ICanvasRenderingContext } from "./ICanvas";
 import { IStencilState } from "../States/IStencilState";
 import { RenderTargetWrapper } from "./renderTargetWrapper";
 import { NativeData, NativeDataStream } from "./Native/nativeDataStream";
 import { INative, INativeCamera, INativeEngine } from "./Native/nativeInterfaces";
-
 declare const _native: INative;
 
 const onNativeObjectInitialized = new Observable<INative>();
@@ -2930,9 +2929,7 @@ export class NativeEngine extends Engine {
         }
     }
 
-    public getFontOffset(font: string): { ascent: number, height: number, descent: number } {
-        // TODO
-        var result = { ascent: 0, height: 0, descent: 0 };
-        return result;
+    public getFontOffset(font: string, context: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
+        return (context as any).getTextMetrics();
     }
 }

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -2929,7 +2929,10 @@ export class NativeEngine extends Engine {
         }
     }
 
-    public getFontOffset(font: string, context: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
-        return (context as any).getTextMetrics();
+    public getFontOffset(font: string, context?: ICanvasRenderingContext): { ascent: number, height: number, descent: number } {
+        if (context) {
+            return (context as any).getTextMetrics();
+        }
+        return { ascent: 0, height: 0, descent: 0 };
     }
 }


### PR DESCRIPTION
`getFontOffset` needed for the space demo. For native, it needs the context. So, it gets forwarded for a few methods.

Native part : https://github.com/BabylonJS/BabylonNative/pull/1002