### PR TITLE
HolographicSlate clean-up

### DIFF
--- a/gui/src/3D/controls/contentDisplay3D.ts
+++ b/gui/src/3D/controls/contentDisplay3D.ts
@@ -23,7 +23,7 @@ export class ContentDisplay3D extends Control3D {
     public set content(value: Control) {
         this._content = value;
 
-        if (!this._host || !this._host.utilityLayer) {
+        if (!value || !this._host || !this._host.utilityLayer) {
             return;
         }
 

--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -11,7 +11,6 @@ import { Matrix, Quaternion, Vector2, Vector3 } from "babylonjs/Maths/math.vecto
 import { Control3D } from "./control3D";
 import { ContentDisplay3D } from "./contentDisplay3D";
 import { AdvancedDynamicTexture } from "../../2D/advancedDynamicTexture";
-import { Image } from "../../2D/controls/image";
 import { SlateGizmo } from "../gizmos/slateGizmo";
 import { DefaultBehavior } from "../behaviors/defaultBehavior";
 import { Viewport } from "babylonjs/Maths/math.viewport";
@@ -19,7 +18,6 @@ import { PointerDragBehavior } from "babylonjs/Behaviors/Meshes/pointerDragBehav
 import { Scalar } from "babylonjs/Maths/math.scalar";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { FluentBackplateMaterial } from "../materials/fluentBackplate/fluentBackplateMaterial";
-import { DomManagement } from "babylonjs/Misc/domManagement";
 import { Vector4 } from "babylonjs/Maths/math";
 
 /**
@@ -40,15 +38,17 @@ export class HolographicSlate extends ContentDisplay3D {
      */
     public static FOLLOW_ICON_FILENAME: string = "IconFollowMe.png";
 
+    private static SLATE_DEPTH: number = 0.001;
+
     /**
-     * Dimensions of the slate
+     * 2D dimensions of the slate
      */
-    public dimensions = new Vector3(21.875, 12.5, 0.001);
+    public dimensions = new Vector2(21.875, 12.5);
 
     /**
      * Minimum dimensions of the slate
      */
-    public minDimensions = new Vector3(15.625, 6.25, 0.001);
+    public minDimensions = new Vector2(15.625, 6.25);
 
     /**
      * Default dimensions of the slate
@@ -56,25 +56,24 @@ export class HolographicSlate extends ContentDisplay3D {
     public readonly defaultDimensions = this.dimensions.clone();
 
     /**
-     * Dimensions of the backplate
+     * Height of the title bar component
      */
-    public backplateDimensions = new Vector3(21.875, 0.625, 0.001);
+    public titleBarHeight = 0.625;
 
     /**
-     * Margin between backplate and contentplate
+     * Margin between title bar and contentplate
      */
-    public backPlateMargin = 0.005;
+    public titleBarMargin = 0.005;
 
     /**
      * Origin in local coordinates (top left corner)
      */
     public origin = new Vector3(0, 0, 0);
 
-    private _backPlateMaterial: FluentBackplateMaterial;
+    private _titleBarMaterial: FluentBackplateMaterial;
     private _contentMaterial: FluentMaterial;
     private _pickedPointObserver: Nullable<Observer<Nullable<Vector3>>>;
     private _positionChangedObserver: Nullable<Observer<{ position: Vector3 }>>;
-    private _imageUrl: string;
 
     private _contentViewport: Viewport;
     private _contentDragBehavior: PointerDragBehavior;
@@ -90,7 +89,7 @@ export class HolographicSlate extends ContentDisplay3D {
     /** @hidden */
     public _gizmo: SlateGizmo;
 
-    protected _backPlate: Mesh;
+    protected _titleBar: Mesh;
     protected _contentPlate: Mesh;
     protected _followButton: TouchHolographicButton;
     protected _closeButton: TouchHolographicButton;
@@ -100,29 +99,11 @@ export class HolographicSlate extends ContentDisplay3D {
      * Rendering ground id of all the mesh in the button
      */
     public set renderingGroupId(id: number) {
-        this._backPlate.renderingGroupId = id;
+        this._titleBar.renderingGroupId = id;
         this._contentPlate.renderingGroupId = id;
     }
     public get renderingGroupId(): number {
-        return this._backPlate.renderingGroupId;
-    }
-
-    /**
-     * Gets or sets the image url for the button
-     */
-    public get imageUrl(): string {
-        return this._imageUrl;
-    }
-
-    public set imageUrl(value: string) {
-        if (this._imageUrl === value) {
-            return;
-        }
-
-        this._imageUrl = value;
-        this._rebuildContent();
-        this._resetContentPositionAndZoom();
-        this._applyContentViewport();
+        return this._titleBar.renderingGroupId;
     }
 
     /**
@@ -148,26 +129,10 @@ export class HolographicSlate extends ContentDisplay3D {
      */
     protected _applyFacade(facadeTexture: AdvancedDynamicTexture) {
         this._contentMaterial.albedoTexture = facadeTexture;
+        this._resetContentPositionAndZoom();
+        this._applyContentViewport();
 
-        // We should have a content plate by this point, but check for safety
-        if (this._contentPlate) {
-            facadeTexture.attachToMesh(this._contentPlate, true);
-        }
-    }
-
-    private _rebuildContent(): void {
-        this._disposeFacadeTexture();
-
-        if (DomManagement.IsDocumentAvailable() && !!document.createElement) {
-            if (this._imageUrl) {
-                let image = new Image();
-                image.source = this._imageUrl;
-
-                if (this._contentPlate) {
-                    this.content = image;
-                }
-            }
-        }
+        facadeTexture.attachToMesh(this._contentPlate, true);
     }
 
     private _addControl(control: Control3D): void {
@@ -187,38 +152,38 @@ export class HolographicSlate extends ContentDisplay3D {
     public _positionElements() {
         const followButtonMesh = this._followButton.mesh;
         const closeButtonMesh = this._closeButton.mesh;
-        const backPlate = this._backPlate;
+        const titleBar = this._titleBar;
         const contentPlate = this._contentPlate;
 
-        if (followButtonMesh && closeButtonMesh && backPlate) {
+        if (followButtonMesh && closeButtonMesh && titleBar) {
             // World size of a button with 1 scaling
             const buttonBaseSize = 1;
 
-            // Buttons take full backPlate on Y axis
-            const backPlateYScale = this.backplateDimensions.y / buttonBaseSize;
+            // Buttons take full titleBar on Y axis
+            const titleBarYScale = this.titleBarHeight / buttonBaseSize;
 
-            closeButtonMesh.scaling.setAll(backPlateYScale);
-            followButtonMesh.scaling.setAll(backPlateYScale);
+            closeButtonMesh.scaling.setAll(titleBarYScale);
+            followButtonMesh.scaling.setAll(titleBarYScale);
             closeButtonMesh.position
                 .copyFromFloats(
-                    this.backplateDimensions.x - backPlateYScale / 2,
-                    -this.backplateDimensions.y / 2,
-                    (-this.backplateDimensions.z / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
+                    this.dimensions.x - titleBarYScale / 2,
+                    -this.titleBarHeight / 2,
+                    (-HolographicSlate.SLATE_DEPTH / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
                 )
                 .addInPlace(this.origin);
             followButtonMesh.position
                 .copyFromFloats(
-                    this.backplateDimensions.x - (3 * backPlateYScale) / 2,
-                    -this.backplateDimensions.y / 2,
-                    (-this.backplateDimensions.z / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
+                    this.dimensions.x - (3 * titleBarYScale) / 2,
+                    -this.titleBarHeight / 2,
+                    (-HolographicSlate.SLATE_DEPTH / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
                 )
                 .addInPlace(this.origin);
 
-            const contentPlateHeight = this.dimensions.y - this.backplateDimensions.y - this.backPlateMargin;
-            backPlate.scaling.copyFrom(this.backplateDimensions);
-            contentPlate.scaling.copyFromFloats(this.dimensions.x, contentPlateHeight, this.dimensions.z);
-            backPlate.position.copyFromFloats(this.backplateDimensions.x / 2, -(this.backplateDimensions.y / 2), 0).addInPlace(this.origin);
-            contentPlate.position.copyFromFloats(this.dimensions.x / 2, -(this.backplateDimensions.y + this.backPlateMargin + contentPlateHeight / 2), 0).addInPlace(this.origin);
+            const contentPlateHeight = this.dimensions.y - this.titleBarHeight - this.titleBarMargin;
+            titleBar.scaling.set(this.dimensions.x, this.titleBarHeight, HolographicSlate.SLATE_DEPTH);
+            contentPlate.scaling.copyFromFloats(this.dimensions.x, contentPlateHeight, HolographicSlate.SLATE_DEPTH);
+            titleBar.position.copyFromFloats(this.dimensions.x / 2, -(this.titleBarHeight / 2), 0).addInPlace(this.origin);
+            contentPlate.position.copyFromFloats(this.dimensions.x / 2, -(this.titleBarHeight + this.titleBarMargin + contentPlateHeight / 2), 0).addInPlace(this.origin);
 
             const aspectRatio = this.dimensions.x / contentPlateHeight;
             this._contentViewport.width = this._contentScaleRatio;
@@ -253,9 +218,8 @@ export class HolographicSlate extends ContentDisplay3D {
         }
 
         // Update pivot point so it is at the center of geometry
-        const center = this.dimensions.scale(0.5);
         // As origin is topleft corner in 2D, dimensions are calculated towards bottom right corner, thus y axis is downwards
-        center.y *= -1;
+        const center = new Vector3(this.dimensions.x * 0.5, -this.dimensions.y * 0.5, HolographicSlate.SLATE_DEPTH);
         center.addInPlace(this.origin);
         center.z = 0;
 
@@ -269,17 +233,17 @@ export class HolographicSlate extends ContentDisplay3D {
 
     // Mesh association
     protected _createNode(scene: Scene): TransformNode {
-        const node = new Mesh("slate" + this.name, scene);
+        const node = new Mesh("slate_" + this.name, scene);
 
-        this._backPlate = CreateBox("backPlate" + this.name, { size: 1 }, scene);
+        this._titleBar = CreateBox("titleBar_" + this.name, { size: 1 }, scene);
         const faceUV = new Array(6).fill(new Vector4(0, 0, 1, 1));
         if (scene.useRightHandedSystem) {
             faceUV[0].copyFromFloats(0, 1, 1, 0);
         }
-        this._contentPlate = CreateBox("contentPlate" + this.name, { size: 1, faceUV }, scene);
+        this._contentPlate = CreateBox("contentPlate_" + this.name, { size: 1, faceUV }, scene);
 
-        this._backPlate.parent = node;
-        this._backPlate.isNearGrabbable = true;
+        this._titleBar.parent = node;
+        this._titleBar.isNearGrabbable = true;
         this._contentPlate.parent = node;
         this._attachContentPlateBehavior();
 
@@ -338,8 +302,8 @@ export class HolographicSlate extends ContentDisplay3D {
             worldMatrix = this.node.computeWorldMatrix(true);
 
             origin.copyFrom(event.dragPlanePoint);
-            worldDimensions.copyFrom(this.dimensions);
-            worldDimensions.y -= this.backplateDimensions.y + this.backPlateMargin;
+            worldDimensions.set(this.dimensions.x, this.dimensions.y, HolographicSlate.SLATE_DEPTH);
+            worldDimensions.y -= this.titleBarHeight + this.titleBarMargin;
             Vector3.TransformNormalToRef(worldDimensions, worldMatrix, worldDimensions);
             upWorld.copyFromFloats(0, 1, 0);
             Vector3.TransformNormalToRef(upWorld, worldMatrix, upWorld);
@@ -366,24 +330,24 @@ export class HolographicSlate extends ContentDisplay3D {
 
     protected _affectMaterial(mesh: AbstractMesh) {
         // TODO share materials
-        this._backPlateMaterial = new FluentBackplateMaterial(`${this.name} plateMaterial`, mesh.getScene());
+        this._titleBarMaterial = new FluentBackplateMaterial(`${this.name} plateMaterial`, mesh.getScene());
 
         this._pickedPointObserver = this._host.onPickedPointChangedObservable.add((pickedPoint) => {
             // if (pickedPoint) {
-            //     this._backPlateMaterial. = pickedPoint;
-            //     this._backPlateMaterial.hoverColor.a = 1.0;
+            //     this._titleBarMaterial.globalLeftIndexTipPosition = pickedPoint;
+            //     this._titleBarMaterial.hoverColor.a = 1.0;
             // } else {
-            //     this._backPlateMaterial.hoverColor.a = 0;
+            //     this._titleBarMaterial.hoverColor.a = 0;
             // }
         });
 
         this._contentMaterial = new FluentMaterial(this.name + "contentMaterial", mesh.getScene());
         this._contentMaterial.renderBorders = true;
 
-        this._backPlate.material = this._backPlateMaterial;
+        this._titleBar.material = this._titleBarMaterial;
         this._contentPlate.material = this._contentMaterial;
 
-        this._rebuildContent();
+        this._resetContent();
         this._applyContentViewport();
     }
 
@@ -393,7 +357,7 @@ export class HolographicSlate extends ContentDisplay3D {
         this._gizmo = new SlateGizmo(this._host.utilityLayer!);
         this._gizmo.attachedSlate = this;
         this._defaultBehavior = new DefaultBehavior();
-        this._defaultBehavior.attach(this.node as Mesh, [this._backPlate]);
+        this._defaultBehavior.attach(this.node as Mesh, [this._titleBar]);
 
         this._positionChangedObserver = this._defaultBehavior.sixDofDragBehavior.onPositionChangedObservable.add(() => {
             this._gizmo.updateBoundingBox();
@@ -429,10 +393,10 @@ export class HolographicSlate extends ContentDisplay3D {
      */
     public dispose() {
         super.dispose();
-        this._backPlateMaterial.dispose();
+        this._titleBarMaterial.dispose();
         this._contentMaterial.dispose();
 
-        this._backPlate.dispose();
+        this._titleBar.dispose();
         this._contentPlate.dispose();
 
         this._followButton.dispose();

--- a/gui/src/3D/gizmos/slateGizmo.ts
+++ b/gui/src/3D/gizmos/slateGizmo.ts
@@ -209,8 +209,7 @@ export class SlateGizmo extends Gizmo {
         offsetDimensionsMasked.copyFrom(offset).multiplyInPlace(masks.dimensions);
 
         this._attachedSlate.origin.copyFrom(originStart).addInPlace(offsetOriginMasked);
-        this._attachedSlate.dimensions.copyFrom(dimensionsStart).addInPlace(offsetDimensionsMasked);
-        this._attachedSlate.backplateDimensions.x = this._attachedSlate.dimensions.x;
+        this._attachedSlate.dimensions.set(dimensionsStart.x + offsetDimensionsMasked.x, dimensionsStart.y + offsetDimensionsMasked.y);
     }
 
     private _assignDragBehaviorCorners(
@@ -236,7 +235,7 @@ export class SlateGizmo extends Gizmo {
 
         const dragStart = (event: { position: Vector3 }) => {
             if (this.attachedSlate && this.attachedMesh) {
-                dimensionsStart.copyFrom(this.attachedSlate.dimensions);
+                dimensionsStart.set(this.attachedSlate.dimensions.x, this.attachedSlate.dimensions.y, 0.001);
                 originStart.copyFrom(this.attachedSlate.origin);
                 dragOrigin.copyFrom(event.position);
                 toObjectFrame.copyFrom(this.attachedMesh.computeWorldMatrix(true));


### PR DESCRIPTION
This change updates the HolographicSlate to not center around holding an image. Instead, an image can be set by setting the .content variable. This variable is also used to assign other controls/content (unchanged). Previously, setting the image URL variable would overwrite any content added via the aforementioned variable.

Other changes include cleaning up the public vectors to avoid mismatch issues (updating the slate size without updating the title bar size), and renaming public variables for more clarity (backplate -> titleBar).