### PR TITLE
Make quaternion animations non editable and less prominent on the ACE.

### DIFF
--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/context.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/context.ts
@@ -315,4 +315,11 @@ export class Context {
         }
         return null;
     }
+
+    public hasActiveQuaternionAnimationKeyPoints() {
+        const activeAnimData = this.activeKeyPoints?.map(keyPointComponent => keyPointComponent.props.curve.animation.dataType);
+        const quaternionAnimData = activeAnimData?.filter(type => (type === Animation.ANIMATIONTYPE_QUATERNION));
+        const hasActiveQuaternionAnimation = (quaternionAnimData?.length || 0) > 0;
+        return hasActiveQuaternionAnimation;
+    }   
 }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curve.ts
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curve.ts
@@ -40,6 +40,7 @@ export class Curve {
         }
         let pathData = `M${convertX(keys[0].frame)} ${convertY(keys[0].value)}`;
 
+        const dataType = this.animation.dataType;
         for (var keyIndex = 1; keyIndex < keys.length; keyIndex++) {
             const outTangent = keys[keyIndex - 1].outTangent;
             const inTangent = keys[keyIndex].inTangent;
@@ -56,7 +57,7 @@ export class Curve {
                 continue;
             }
 
-            if (outTangent === undefined && inTangent === undefined) { // Draw a straight line
+            if (outTangent === undefined && inTangent === undefined && dataType !== Animation.ANIMATIONTYPE_QUATERNION) { // Draw a straight line
                 pathData += ` L${convertX(currentFrame)} ${convertY(currentValue)}`;
                 continue;
             }

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curveComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curveComponent.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Context, IActiveAnimationChangedOptions } from "../context";
 import { Curve } from "./curve";
 import { AnimationKeyInterpolation } from "babylonjs/Animations/animationKey";
+import { Animation } from "babylonjs/Animations/animation";
 
 interface ICurveComponentProps {
     curve: Curve;
@@ -67,16 +68,22 @@ export class CurveComponent extends React.Component<ICurveComponentProps, ICurve
         if (!this.props.context.isChannelEnabled(this.props.curve.animation, this.props.curve.color)) {
             return null;
         }
+        const pathStyle : any = {
+            stroke: this.props.curve.color,
+            fill: "none",
+            strokeWidth: "1",
+        };
+
+        if (this.props.curve.animation.dataType === Animation.ANIMATIONTYPE_QUATERNION) {
+            pathStyle['stroke-dasharray'] = '5';
+            pathStyle['stroke-opacity'] = '0.5';
+        }
 
         return (
             <svg style={{ cursor: "pointer", overflow: "auto" }}>
                 <path
                     d={this.props.curve.getPathData(this.props.convertX, this.props.convertY)}
-                    style={{
-                        stroke: this.props.curve.color,
-                        fill: "none",
-                        strokeWidth: "1",
-                    }}
+                    style={pathStyle}
                 ></path>
             </svg>
         );

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/graphComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/graphComponent.tsx
@@ -138,6 +138,9 @@ export class GraphComponent extends React.Component<IGraphComponentProps, IGraph
             }
 
             for (const currentAnimation of this.props.context.activeAnimations) {
+                if (currentAnimation.dataType === Animation.ANIMATIONTYPE_QUATERNION) {
+                    continue;
+                }
                 let keys = currentAnimation.getKeys();
 
                 const currentFrame = this.props.context.activeFrame;
@@ -212,16 +215,6 @@ export class GraphComponent extends React.Component<IGraphComponentProps, IGraph
                             }
                             case Animation.ANIMATIONTYPE_VECTOR3: {
                                 derivative = Vector3.Hermite1stDerivative(
-                                    leftKey.value.scale(invFrameDelta),
-                                    leftKey.outTangent,
-                                    rightKey.value.scale(invFrameDelta),
-                                    rightKey.inTangent,
-                                    cutTime
-                                );
-                                break;
-                            }
-                            case Animation.ANIMATIONTYPE_QUATERNION: {
-                                derivative = Quaternion.Hermite1stDerivative(
                                     leftKey.value.scale(invFrameDelta),
                                     leftKey.outTangent,
                                     rightKey.value.scale(invFrameDelta),

--- a/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
+++ b/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
@@ -58,8 +58,10 @@ export class TopBarComponent extends React.Component<ITopBarComponentProps, ITop
             
             const frameControlEnabled = (numKeys === 1 && numAnims === 1) || (numKeys > 1 && numAnims > 1);
             const valueControlEnabled = numKeys > 0;
+
+            const hasActiveQuaternionAnimation = this.props.context.hasActiveQuaternionAnimationKeyPoints();
             
-            this.setState({ keyFrameValue: "", keyValue: "", frameControlEnabled, valueControlEnabled });
+            this.setState({ keyFrameValue: "", keyValue: "", frameControlEnabled: frameControlEnabled && !hasActiveQuaternionAnimation, valueControlEnabled: valueControlEnabled && !hasActiveQuaternionAnimation });
         });
     }
 


### PR DESCRIPTION
A visual of how they look:
![image](https://user-images.githubusercontent.com/6002144/154557173-b0a550e2-4b57-4a20-b2fc-157f24b54832.png)
Compared to a "normal" animation:
![image](https://user-images.githubusercontent.com/6002144/154557238-66a3901f-6bac-48cb-8fdf-bd456698368f.png)
