### PR TITLE
[GUI] Fix lagging 

### DIFF
--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1417,11 +1417,9 @@ export class Control {
         let oldLeft = this._left.getValue(this._host);
         let oldTop = this._top.getValue(this._host);
 
-        if (this._currentMeasure.width === 0 && this._currentMeasure.height === 0) {
-            let parentMeasure = this.parent?._currentMeasure;
-            if (parentMeasure) {
-                this._processMeasures(parentMeasure, this._host.getContext());
-            }
+        let parentMeasure = this.parent?._currentMeasure;
+        if (parentMeasure) {
+            this._processMeasures(parentMeasure, this._host.getContext());
         }
 
         var newLeft = projectedPosition.x + this._linkOffsetX.getValue(this._host) - this._currentMeasure.width / 2;


### PR DESCRIPTION
Forum thread: https://forum.babylonjs.com/t/any-way-to-make-gui-resize-more-exact-and-faster/27387
Broken PG: https://playground.babylonjs.com/#XCPP9Y#11059

Forum users reported an issue where a GUI control attached to a mesh would lag one frame behind when rendering. The issue is that Control._moveToProjectedPosition is called before _layout(), so it uses last frame's _currentMeasure instead of the latest one. The fix is simply to call _processMeasure() before every _moveToProjectedPosition to make sure we are always using the latest width and height.