### PR TITLE
update CreatePolygon

### DIFF
--- a/src/Meshes/Builders/polygonBuilder.ts
+++ b/src/Meshes/Builders/polygonBuilder.ts
@@ -171,7 +171,8 @@ export function CreatePolygon(name: string, options: { shape: Vector3[], holes?:
         }
         polygonTriangulation.addHole(hole);
     }
-    var polygon = polygonTriangulation.build(options.updatable, depth, smoothingThreshold);
+    //updatability is set during applyToMesh; setting to true in triangulation build produces errors
+    var polygon = polygonTriangulation.build(false, depth, smoothingThreshold);
     polygon._originalBuilderSideOrientation = options.sideOrientation;
     var vertexData = CreatePolygonVertexData(polygon, options.sideOrientation, options.faceUV, options.faceColors, options.frontUVs, options.backUVs, options.wrap);
     vertexData.applyToMesh(polygon, options.updatable);


### PR DESCRIPTION
Ref https://forum.babylonjs.com/t/any-bugs-on-updatable-field/27756/2?u=johnk

Why there were no problems in 4.2 and there is now in 5.0 I cannot figure out, however there have been a number of changes to how the building of meshes take place since then.

What I found is that when the first parameter of 

```
var polygon = polygonTriangulation.build(options.updatable, depth, smoothingThreshold);
```

is true the side orientation for the polygon seems to be built the wrong way round (???). Setting it to false stops this problem.

Since only the triangulation function of 'PolygonMeshBuilder' is used to obtain the data for the triangles and `CreatePolygonVertexData` is used to build the mesh rather than the functions of 'PolygonMeshBuilder' then the change to

```
var polygon = polygonTriangulation.build(false, depth, smoothingThreshold);

returns the correct data.
```