### PR TITLE
[GE] fix grid outlines and live sync

### DIFF
--- a/guiEditor/src/components/commandBarComponent.tsx
+++ b/guiEditor/src/components/commandBarComponent.tsx
@@ -1,5 +1,3 @@
-import { Container } from "babylonjs-gui/2D/controls/container";
-import { Control } from "babylonjs-gui/2D/controls/control";
 import * as React from "react";
 import { GlobalState } from "../globalState";
 import { CommandButtonComponent } from "./commandButtonComponent";
@@ -25,7 +23,6 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
     private _panning: boolean = false;
     private _zooming: boolean = false;
     private _selecting: boolean = true;
-    private _outlines: boolean;
     public constructor(props: ICommandBarComponentProps) {
         super(props);
 
@@ -50,24 +47,9 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
             this.forceUpdate();
         });
 
-        props.globalState.onOutlinesObservable.add(() => {
-            this._outlines = !this._outlines;
-            const nodes = this.props.globalState.workbench.nodes;
-            nodes.forEach((node) => {
-                this.updateNodeOutline(node);
-            });
+        props.globalState.onOutlineChangedObservable.add(() => {
             this.forceUpdate();
         });
-    }
-
-    private updateNodeOutline(guiControl: Control) {
-        guiControl.isHighlighted = this._outlines;
-        guiControl.highlightLineWidth = 5;
-        if (guiControl instanceof Container) {
-            (guiControl as Container).children.forEach((child) => {
-                this.updateNodeOutline(child);
-            });
-        }
     }
 
     public render() {
@@ -184,10 +166,8 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                         tooltip="Toggle Guides"
                         shortcut="G"
                         icon={guidesIcon}
-                        isActive={this._outlines}
-                        onClick={() => {
-                            this.props.globalState.onOutlinesObservable.notifyObservers();
-                        }}
+                        isActive={this.props.globalState.outlines}
+                        onClick={() => this.props.globalState.outlines = !this.props.globalState.outlines}
                     />
                 </div>
                 <div className="commands-right"></div>

--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -204,7 +204,6 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
             const inNodeSpace = CoordinateHelper.rttToLocalNodeSpace(node, inRTT.x, inRTT.y, undefined, this._storedValues);
             this._dragLocalBounds(inNodeSpace);
             this._updateNodeFromLocalBounds();
-            this.props.globalState.workbench._liveGuiTextureRerender = false;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
         }
         if (this.state.isRotating) {

--- a/guiEditor/src/globalState.ts
+++ b/guiEditor/src/globalState.ts
@@ -38,7 +38,9 @@ export class GlobalState {
     onNewSceneObservable = new Observable<Nullable<Scene>>();
     onGuiNodeRemovalObservable = new Observable<Control>();
     onPopupClosedObservable = new Observable<void>();
-    _backgroundColor: Color3;
+    private _backgroundColor: Color3;
+    private _outlines: boolean = false;
+    onOutlineChangedObservable = new Observable<void>();
     blockKeyboardEvents = false;
     controlCamera: boolean;
     selectionLock: boolean;
@@ -53,7 +55,6 @@ export class GlobalState {
     onSaveObservable = new Observable<void>();
     onSnippetLoadObservable = new Observable<void>();
     onSnippetSaveObservable = new Observable<void>();
-    onOutlinesObservable = new Observable<void>();
     onResponsiveChangeObservable = new Observable<boolean>();
     onParentingChangeObservable = new Observable<Nullable<Control>>();
     onPropertyGridUpdateRequiredObservable = new Observable<void>();
@@ -96,5 +97,14 @@ export class GlobalState {
         DataStorage.WriteNumber("BackgroundColorR", value.r);
         DataStorage.WriteNumber("BackgroundColorG", value.g);
         DataStorage.WriteNumber("BackgroundColorB", value.b);
+    }
+
+    public get outlines() {
+        return this._outlines;
+    }
+
+    public set outlines(value: boolean) {
+        this._outlines = value;
+        this.onOutlineChangedObservable.notifyObservers();
     }
 }

--- a/guiEditor/src/guiNodeTools.ts
+++ b/guiEditor/src/guiNodeTools.ts
@@ -122,7 +122,6 @@ export class GUINodeTools {
                 return element;
             case "Grid":
                 element = new Grid("Grid");
-                element.isHighlighted = true;
                 element.addColumnDefinition(1.0, false);
                 element.addRowDefinition(1.0, false);
                 element.isPointerBlocker = true;
@@ -132,7 +131,6 @@ export class GUINodeTools {
                 return element;
             case "StackPanel":
                 element = new StackPanel("StackPanel");
-                element.isHighlighted = true;
                 element.width = "100%";
                 element.height = "100%";
                 return element;


### PR DESCRIPTION
This PR addresses two separate issues:
1. Fixes grid outline behavior. Now, only grids will ever be outlined, and they will only be outlined if: 1. "guides" is on or 2. the grid is selected.
2. Fixes sync issue between GUI editor and engine where dragging or rescaling controls was not causing an update in the original scene. also, adjusts the delay to 60ms to get a more responsive update. we may want to make this even faster, will have to look into perf considerations more.