### PR TITLE
SubSurfaceConfiguration: Fix name in exception message

### DIFF
--- a/src/Rendering/subSurfaceConfiguration.ts
+++ b/src/Rendering/subSurfaceConfiguration.ts
@@ -14,7 +14,7 @@ import { Constants } from "../Engines/constants";
 export class SubSurfaceConfiguration implements PrePassEffectConfiguration {
     /** @hidden */
     public static _SceneComponentInitialization: (scene: Scene) => void = (_) => {
-        throw _WarnImport("PrePassRendererSceneComponent");
+        throw _WarnImport("SubSurfaceSceneComponent");
     }
 
     private _ssDiffusionS: number[] = [];


### PR DESCRIPTION
Also, why not having:
```javascript
import "./SubSurfaceSceneComponent";
```
directly in `SubSurfaceConfiguration` instead of relying on the user not forgetting to add it themself? This import is always required for  the `SubSurfaceConfiguration` object to work as expected, so it would be easier to just have the import done by this class.

Same thing for the pre pass renderer, the depth renderer, and more generally all the scene components that are all built the same way.

[...] Ah, it seems there's a problem with the order of the module initializations when doing this. There's an error on:
```typescript
SubSurfaceConfiguration._SceneComponentInitialization = (scene: Scene) => {
    // Register the G Buffer component to the scene.
    let component = scene._getComponent(SceneComponentConstants.NAME_SUBSURFACE) as SubSurfaceSceneComponent;
    if (!component) {
        component = new SubSurfaceSceneComponent(scene);
        scene._addComponent(component);
    }
};
```
which says "Cannot access 'SubSurfaceConfiguration' before initialization"...
