### PR TITLE
Fix type of param clearColor for drawText

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -410,7 +410,6 @@
 - Fix keypoint drag in ACE ([carolhmj](https://github.com/carolhmj))
 - Fix spherical harmonics computation ([Meakk](https://github.com/Meakk))
 - Fix KTX and DDS loading with baked mipmaps ([Meakk](https://github.com/Meakk))
-- Fix type of param `clearColor` to allow null to be passed to drawText` for `DynamicTexture` ([BlakeOne](https://github.com/BlakeOne))
 
 ## Breaking changes
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -291,6 +291,7 @@
 
 ## Bugs
 
+- Fix type of param `clearColor` to allow null to be passed to drawText` for `DynamicTexture` ([BlakeOne](https://github.com/BlakeOne))
 - Fix `WaterMaterial`’s constructor to use `this.getScene()` instead of `scene` parameter ([BlakeOne](https://github.com/BlakeOne))
 - Add missing param `point` to the callback function's type for the methods `registerOnPhysicsCollide` and `unregisterOnPhysicsCollide` of the `PhysicsImpostor` class. ([BlakeOne](https://github.com/BlakeOne))
 - Fix serialization and parsing of `textBlock` and `image` for `Button` class ([BlakeOne](https://github.com/BlakeOne))

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -291,7 +291,6 @@
 
 ## Bugs
 
-- Fix type of param `clearColor` to allow null to be passed to drawText` for `DynamicTexture` ([BlakeOne](https://github.com/BlakeOne))
 - Fix `WaterMaterial`’s constructor to use `this.getScene()` instead of `scene` parameter ([BlakeOne](https://github.com/BlakeOne))
 - Add missing param `point` to the callback function's type for the methods `registerOnPhysicsCollide` and `unregisterOnPhysicsCollide` of the `PhysicsImpostor` class. ([BlakeOne](https://github.com/BlakeOne))
 - Fix serialization and parsing of `textBlock` and `image` for `Button` class ([BlakeOne](https://github.com/BlakeOne))
@@ -411,6 +410,7 @@
 - Fix keypoint drag in ACE ([carolhmj](https://github.com/carolhmj))
 - Fix spherical harmonics computation ([Meakk](https://github.com/Meakk))
 - Fix KTX and DDS loading with baked mipmaps ([Meakk](https://github.com/Meakk))
+- Fix type of param `clearColor` to allow null to be passed to drawText` for `DynamicTexture` ([BlakeOne](https://github.com/BlakeOne))
 
 ## Breaking changes
 

--- a/src/Materials/Textures/dynamicTexture.ts
+++ b/src/Materials/Textures/dynamicTexture.ts
@@ -153,7 +153,7 @@ export class DynamicTexture extends Texture {
      * @param invertY defines the direction for the Y axis (default is true - y increases downwards)
      * @param update defines whether texture is immediately update (default is true)
      */
-    public drawText(text: string, x: number | null | undefined, y: number | null | undefined, font: string, color: string | null, clearColor: string, invertY?: boolean, update = true) {
+    public drawText(text: string, x: number | null | undefined, y: number | null | undefined, font: string, color: string | null, clearColor: string | null, invertY?: boolean, update = true) {
         var size = this.getSize();
         if (clearColor) {
             this._context.fillStyle = clearColor;


### PR DESCRIPTION
When drawing text to a DynamicTexture, null is passed for the clearColor to not clear it. However in Typescript null is not allowed do to incorrect type of this parameter. This PR  just changes the type from "string" to "string | null" (like the param "color").

Forum issue: https://forum.babylonjs.com/t/writing-text-on-top-of-a-cylinder/27591/11