### PR TITLE
child-of-child clipping issue

### DIFF
--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -1467,22 +1467,22 @@ export class Control {
     }
 
     /** @hidden */
-    public _intersectsRect(rect: Measure) {
-        // Rotate the control's current measure into local space and check if it intersects the passed in rectangle
-        this._currentMeasure.transformToRef(this._transformMatrix, this._tmpMeasureA);
-        if (this._tmpMeasureA.left >= rect.left + rect.width) {
+    public _intersectsRect(rect: Measure, context?: ICanvasRenderingContext) {
+        // make sure we are transformed correctly before checking intersections. no-op if nothing is dirty.
+        this._transform(context);
+        if (this._evaluatedMeasure.left >= rect.left + rect.width) {
             return false;
         }
 
-        if (this._tmpMeasureA.top >= rect.top + rect.height) {
+        if (this._evaluatedMeasure.top >= rect.top + rect.height) {
             return false;
         }
 
-        if (this._tmpMeasureA.left + this._tmpMeasureA.width <= rect.left) {
+        if (this._evaluatedMeasure.left + this._evaluatedMeasure.width <= rect.left) {
             return false;
         }
 
-        if (this._tmpMeasureA.top + this._tmpMeasureA.height <= rect.top) {
+        if (this._evaluatedMeasure.top + this._evaluatedMeasure.height <= rect.top) {
             return false;
         }
 
@@ -1538,6 +1538,7 @@ export class Control {
         }
 
         this._isDirty = true;
+        this._markMatrixAsDirty();
 
         // Redraw only this rectangle
         if (this._host) {
@@ -1593,6 +1594,7 @@ export class Control {
             Matrix2D.ComposeToRef(-offsetX, -offsetY, this._rotation, this._scaleX, this._scaleY, this.parent ? this.parent._transformMatrix : null, this._transformMatrix);
 
             this._transformMatrix.invertToRef(this._invertTransformMatrix);
+            this._currentMeasure.transformToRef(this._transformMatrix, this._evaluatedMeasure);
         }
     }
 


### PR DESCRIPTION
Under specific conditions there was a chance to clip children of a child component but not clip the child. This lead to (for example) a button to render correctly, but its internal components to be clipped. The issue is hard to reproduce, but can be seen in this playground:

https://www.babylonjs-playground.com/#F6XWSQ#6

Scroll around, try to get the red button out of the viewing pane and bring it back in. when the right conditions apply (button is dirty, not clippe, matrix not marked as dirty, button content clipped) you will see that though the button renders its child doesn't.

This PR solves this issue, maintaining performance as much as possible. The extra call to _transform is not redundant but needed in order to calculate the clipping correctly (before actually running transform for the component itself).

When you mange to reproduce it will look like this:

![image](https://user-images.githubusercontent.com/1381702/154988476-a74f65cf-34f5-4972-bf27-3b958351b949.png)
