### PR TITLE
WebGPU: fix usage of gl_PointSize

### DIFF
--- a/materialsLibrary/src/cell/cell.vertex.fx
+++ b/materialsLibrary/src/cell/cell.vertex.fx
@@ -106,7 +106,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/fire/fire.vertex.fx
+++ b/materialsLibrary/src/fire/fire.vertex.fx
@@ -87,7 +87,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/fur/fur.vertex.fx
+++ b/materialsLibrary/src/fur/fur.vertex.fx
@@ -174,7 +174,7 @@ float r = Rand(position);
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/gradient/gradient.vertex.fx
+++ b/materialsLibrary/src/gradient/gradient.vertex.fx
@@ -89,7 +89,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/lava/lava.vertex.fx
+++ b/materialsLibrary/src/lava/lava.vertex.fx
@@ -227,7 +227,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/mix/mix.vertex.fx
+++ b/materialsLibrary/src/mix/mix.vertex.fx
@@ -105,7 +105,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/normal/normal.vertex.fx
+++ b/materialsLibrary/src/normal/normal.vertex.fx
@@ -93,7 +93,7 @@ void main(void) {
 #include<shadowsVertex>[0..maxSimultaneousLights]
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/shadowOnly/shadowOnly.vertex.fx
+++ b/materialsLibrary/src/shadowOnly/shadowOnly.vertex.fx
@@ -64,7 +64,7 @@ void main(void) {
 #include<shadowsVertex>[0..maxSimultaneousLights]
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/simple/simple.vertex.fx
+++ b/materialsLibrary/src/simple/simple.vertex.fx
@@ -105,7 +105,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/sky/sky.vertex.fx
+++ b/materialsLibrary/src/sky/sky.vertex.fx
@@ -50,7 +50,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/terrain/terrain.vertex.fx
+++ b/materialsLibrary/src/terrain/terrain.vertex.fx
@@ -105,7 +105,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/triPlanar/triplanar.vertex.fx
+++ b/materialsLibrary/src/triPlanar/triplanar.vertex.fx
@@ -124,7 +124,7 @@ void main(void)
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/materialsLibrary/src/water/water.vertex.fx
+++ b/materialsLibrary/src/water/water.vertex.fx
@@ -131,7 +131,7 @@ void main(void) {
 #endif
 
 	// Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
 	gl_PointSize = pointSize;
 #endif
 

--- a/src/Shaders/ShadersInclude/pointCloudVertex.fx
+++ b/src/Shaders/ShadersInclude/pointCloudVertex.fx
@@ -1,3 +1,3 @@
-﻿#ifdef POINTSIZE
-	gl_PointSize = pointSize;
+﻿#if defined(POINTSIZE) && !defined(WEBGPU)
+    gl_PointSize = pointSize;
 #endif

--- a/src/Shaders/background.vertex.fx
+++ b/src/Shaders/background.vertex.fx
@@ -146,7 +146,7 @@ void main(void) {
 #endif
 
     // Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
     gl_PointSize = pointSize;
 #endif
 

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -249,7 +249,7 @@ void main(void) {
 #endif
 
     // Point size
-#ifdef POINTSIZE
+#if defined(POINTSIZE) && !defined(WEBGPU)
     gl_PointSize = pointSize;
 #endif
 

--- a/tests/validation/webgpu.json
+++ b/tests/validation/webgpu.json
@@ -100,7 +100,7 @@
         {
             "title": "custom handling of materials for render target pass",
             "renderCount": 30,
-            "playgroundId": "#FIVL25#17"
+            "playgroundId": "#FIVL25#20"
         },
         {
             "title": "dissolve effect with node material and glow layer",


### PR DESCRIPTION
It seems Tint does not generate valid WGSL code when using `gl_PointSize`. As this property is not supported in WebGPU anyway, just avoid setting `gl_PointSize` in WebGPU.

See https://forum.babylonjs.com/t/simple-point-cloud-system-not-working-on-webgpu/27848