### PR TITLE
Add a forceRenderingWhenOccluded property when doing occlusion queries

### DIFF
--- a/src/Engines/Extensions/engine.query.ts
+++ b/src/Engines/Extensions/engine.query.ts
@@ -27,6 +27,9 @@ export class _OcclusionDataStorage {
 
     /** @hidden */
     public occlusionQueryAlgorithmType = AbstractMesh.OCCLUSION_ALGORITHM_TYPE_CONSERVATIVE;
+
+    /** @hidden */
+    public forceRenderingWhenOccluded = false;
 }
 
 declare module "../../Engines/engine" {
@@ -392,6 +395,12 @@ declare module "../../Meshes/abstractMesh" {
          * @see https://doc.babylonjs.com/features/occlusionquery
          */
         isOcclusionQueryInProgress: boolean;
+
+        /**
+         * Flag to force rendering the mesh even if occluded
+         * @see https://doc.babylonjs.com/features/occlusionquery
+         */
+        forceRenderingWhenOccluded: boolean;
     }
 }
 Object.defineProperty(AbstractMesh.prototype, "isOcclusionQueryInProgress", {
@@ -455,6 +464,17 @@ Object.defineProperty(AbstractMesh.prototype, "occlusionRetryCount", {
     },
     set: function (this: AbstractMesh, value: number) {
         this._occlusionDataStorage.occlusionRetryCount = value;
+    },
+    enumerable: true,
+    configurable: true
+});
+
+Object.defineProperty(AbstractMesh.prototype, "forceRenderingWhenOccluded", {
+    get: function (this: AbstractMesh) {
+        return this._occlusionDataStorage.forceRenderingWhenOccluded;
+    },
+    set: function (this: AbstractMesh, value: boolean) {
+        this._occlusionDataStorage.forceRenderingWhenOccluded = value;
     },
     enumerable: true,
     configurable: true

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -2129,7 +2129,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this._internalAbstractMeshDataInfo._isActive = false;
         }
 
-        if (this._checkOcclusionQuery()) {
+        if (this._checkOcclusionQuery() && !this._occlusionDataStorage.forceRenderingWhenOccluded) {
             return this;
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/showing-highlighted-silhouette-of-mesh-only-when-it-is-occluded/27783/22.

Sometimes we may need to still have a mesh rendered even if the occlusion query says it is hidden (`isOccluded=true`): basically, we only need `isOccluded` to be updated correctly based on the mesh visibility but the mesh must still be rendered.

See the thread above. To do it, I needed to override `_checkOcclusionQuery`, which prevents to make this behaviour available on a per-mesh basis. In this PR, I added a property to enable this on a per-mesh basis.

So, instead of doing: https://playground.babylonjs.com/#JXYGLT#14

We can simply do: https://playground.babylonjs.com/#JXYGLT#15
