### PR TITLE
[GE] Use browser clipboard API

### DIFF
--- a/guiEditor/src/components/commandBarComponent.tsx
+++ b/guiEditor/src/components/commandBarComponent.tsx
@@ -88,14 +88,14 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                             {
                                 label: "Copy Selected",
                                 onClick: () => {
-                                    this.props.globalState.workbench.copyToClipboard();
+                                    this.props.globalState.onCopyObservable.notifyObservers(content => this.props.globalState.hostWindow.navigator.clipboard.writeText(content));
 
                                 },
                             },
                             {
                                 label: "Paste",
-                                onClick: () => {
-                                    this.props.globalState.workbench.pasteFromClipboard();
+                                onClick: async () => {
+                                    this.props.globalState.onPasteObservable.notifyObservers(await this.props.globalState.hostWindow.navigator.clipboard.readText());
                                 }
                             },
                             {

--- a/guiEditor/src/guiEditor.ts
+++ b/guiEditor/src/guiEditor.ts
@@ -59,6 +59,7 @@ export class GUIEditor {
         globalState.customSave = options.customSave;
         globalState.customLoad = options.customLoad;
         globalState.hostWindow = hostElement.ownerDocument!.defaultView!;
+        globalState.registerEventListeners();
 
         const graphEditor = React.createElement(WorkbenchEditor, {
             globalState: globalState,


### PR DESCRIPTION
Detects browser copy, cut and paste events and uses the native clipboard to store data, rather than a custom clipboard.

The advantages of this approach:
- Can copy and paste between GUI editor windows
- Behaves as expected cross-platform (previously used Ctrl+C, Ctrl+V even on MacOS)
- Can take advantage of clipboard history systems