### PR TITLE
[GUI] Make touch inputs open the prompt on inputText and inputPassword

### DIFF
--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -12,7 +12,7 @@ import { RegisterClass } from 'babylonjs/Misc/typeStore';
 import { Measure } from '../measure';
 import { TextWrapper } from './textWrapper';
 import { serialize } from 'babylonjs/Misc/decorators';
-import { IKeyboardEvent } from 'babylonjs/Events/deviceInputEvents';
+import { IKeyboardEvent, IPointerEvent } from 'babylonjs/Events/deviceInputEvents';
 import { ICanvasRenderingContext } from "babylonjs/Engines/ICanvas";
 
 /**
@@ -30,6 +30,7 @@ export class InputText extends Control implements IFocusableControl {
     private _autoStretchWidth = true;
     private _maxWidth = new ValueAndUnit(1, ValueAndUnit.UNITMODE_PERCENTAGE, false);
     private _isFocused = false;
+    private _focusedBy: string;
     private _blinkTimeout: number;
     private _blinkIsEven = false;
     private _cursorOffset = 0;
@@ -396,7 +397,7 @@ export class InputText extends Control implements IFocusableControl {
 
         this.onFocusObservable.notifyObservers(this);
 
-        if (navigator.userAgent.indexOf("Mobile") !== -1 && !this.disableMobilePrompt) {
+        if (this._focusedBy === "touch" && !this.disableMobilePrompt) {
             let value = prompt(this.promptMessage);
 
             if (value !== null) {
@@ -1055,6 +1056,7 @@ export class InputText extends Control implements IFocusableControl {
         this._cursorIndex = -1;
         this._isPointerDown = true;
         this._host._capturingControl[pointerId] = this;
+        this._focusedBy = (pi.event as IPointerEvent).pointerType;
         if (this._host.focusedControl === this) {
             // Move cursor
             clearTimeout(this._blinkTimeout);

--- a/gui/src/2D/controls/inputText.ts
+++ b/gui/src/2D/controls/inputText.ts
@@ -30,6 +30,7 @@ export class InputText extends Control implements IFocusableControl {
     private _autoStretchWidth = true;
     private _maxWidth = new ValueAndUnit(1, ValueAndUnit.UNITMODE_PERCENTAGE, false);
     private _isFocused = false;
+    /** the type of device that most recently focused the input: "mouse", "touch" or "pen" */
     private _focusedBy: string;
     private _blinkTimeout: number;
     private _blinkIsEven = false;


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/inputpassword-gui-bug-on-ipad/27819

Previously, we were deciding whether or not to open an input prompt based on the user agent. This would fail to detect tablet devices which don't have "mobile" in the user agent. I have switched it to open the prompt if the last pointerDown event came from a "touch" device.

As a consequence of this, touching the input even from a touch-enabled laptop will open the prompt. I think this is the right behavior, but not everyone may agree. As far as I can tell, there is no way to detect the presence of a physical keyboard.

We may want to consider doing the same if the input is from a "pen" device? I am not sure.