### PR TITLE
[3D GUI] HolographicSlate bugfixes

### DIFF
--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -456,6 +456,7 @@ export class HolographicSlate extends ContentDisplay3D {
 
     /**
      * Resets the aspect and pose of the slate so it is right in front of the active camera, facing towards it.
+     * @param resetAspect Should the slate's dimensions/aspect ratio be reset as well
      */
     public resetDefaultAspectAndPose(resetAspect: boolean = true) {
         if (!this._host || !this._host.utilityLayer || !this.node) {

--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -89,7 +89,7 @@ export class HolographicSlate extends ContentDisplay3D {
     public _followButton: TouchHolographicButton;
     protected _closeButton: TouchHolographicButton;
     protected _contentScaleRatio = 1;
-    
+
     /**
      * 2D dimensions of the slate
      */
@@ -317,12 +317,12 @@ export class HolographicSlate extends ContentDisplay3D {
         adt.addControl(this._titleTextComponent);
 
         if (scene.useRightHandedSystem) {
-            const faceUV = new Vector4(0,0,1,1);
+            const faceUV = new Vector4(0, 0, 1, 1);
             this._contentPlate = CreatePlane("contentPlate_" + this.name, { size: 1, sideOrientation: VertexData.BACKSIDE, frontUVs: faceUV }, scene);
             this._backPlate = CreatePlane("backPlate_" + this.name, { size: 1, sideOrientation: VertexData.FRONTSIDE }, scene);
         }
         else {
-            const faceUV = new Vector4(0,0,1,1);
+            const faceUV = new Vector4(0, 0, 1, 1);
             this._contentPlate = CreatePlane("contentPlate_" + this.name, { size: 1, sideOrientation: VertexData.FRONTSIDE, frontUVs: faceUV }, scene);
             this._backPlate = CreatePlane("backPlate_" + this.name, { size: 1, sideOrientation: VertexData.BACKSIDE }, scene);
         }

--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -10,7 +10,6 @@ import { FluentMaterial } from "../materials/fluent/fluentMaterial";
 import { FluentBackplateMaterial } from "../materials/fluentBackplate/fluentBackplateMaterial";
 import { PointerDragBehavior } from "babylonjs/Behaviors/Meshes/pointerDragBehavior";
 import { Texture } from "babylonjs/Materials/Textures/texture";
-import { Vector4 } from "babylonjs/Maths/math";
 import { Epsilon } from "babylonjs/Maths/math.constants";
 import { Scalar } from "babylonjs/Maths/math.scalar";
 import { Matrix, Quaternion, Vector2, Vector3 } from "babylonjs/Maths/math.vector";
@@ -20,6 +19,7 @@ import { CreateBox } from "babylonjs/Meshes/Builders/boxBuilder";
 import { CreatePlane } from "babylonjs/Meshes/Builders/planeBuilder";
 import { TransformNode } from "babylonjs/Meshes/transformNode";
 import { Mesh } from "babylonjs/Meshes/mesh";
+import { VertexData } from "babylonjs/Meshes/mesh.vertexData";
 import { Observer } from "babylonjs/Misc/observable";
 import { Scene } from "babylonjs/scene";
 import { Nullable } from "babylonjs/types";
@@ -45,26 +45,6 @@ export class HolographicSlate extends ContentDisplay3D {
     private static DEFAULT_TEXT_RESOLUTION_Y = 102.4;
 
     /**
-     * 2D dimensions of the slate
-     */
-    public dimensions = new Vector2(21.875, 12.5);
-
-    /**
-     * Minimum dimensions of the slate
-     */
-    public minDimensions = new Vector2(15.625, 6.25);
-
-    /**
-     * Default dimensions of the slate
-     */
-    public readonly defaultDimensions = this.dimensions.clone();
-
-    /**
-     * Height of the title bar component
-     */
-    public titleBarHeight = 0.625;
-
-    /**
      * Margin between title bar and contentplate
      */
     public titleBarMargin = 0.005;
@@ -74,7 +54,11 @@ export class HolographicSlate extends ContentDisplay3D {
      */
     public origin = new Vector3(0, 0, 0);
 
+    private _dimensions = new Vector2(21.875, 12.5);
+    private _titleBarHeight = 0.625;
+
     private _titleBarMaterial: FluentBackplateMaterial;
+    private _backMaterial: FluentBackplateMaterial;
     private _contentMaterial: FluentMaterial;
     private _pickedPointObserver: Nullable<Observer<Nullable<Vector3>>>;
     private _positionChangedObserver: Nullable<Observer<{ position: Vector3 }>>;
@@ -99,9 +83,58 @@ export class HolographicSlate extends ContentDisplay3D {
     protected _titleBar: Mesh;
     protected _titleBarTitle: Mesh;
     protected _contentPlate: Mesh;
-    protected _followButton: TouchHolographicButton;
+    protected _backPlate: Mesh;
+    /** @hidden */
+    public _followButton: TouchHolographicButton;
     protected _closeButton: TouchHolographicButton;
     protected _contentScaleRatio = 1;
+    
+    /**
+     * 2D dimensions of the slate
+     */
+    public get dimensions() {
+        return this._dimensions;
+    }
+    public set dimensions(value) {
+        //clamp, respecting ratios
+        let scale = 1.0;
+        if (value.x < this.minDimensions.x || value.y < this.minDimensions.y) {
+            const newRatio = value.x / value.y;
+            const minRatio = this.minDimensions.x / this.minDimensions.y;
+            if (minRatio > newRatio) {
+                // We just need to make sure the x-val is greater than the min
+                scale = this.minDimensions.x / value.x;
+            }
+            else {
+                // We just need to make sure the y-val is greater than the min
+                scale = this.minDimensions.y / value.y;
+            }
+        }
+
+        this._dimensions.copyFrom(value).scaleInPlace(scale);
+        this._updatePivot();
+        this._positionElements();
+    }
+
+    /**
+     * Minimum dimensions of the slate
+     */
+    public minDimensions = new Vector2(15.625, 6.25);
+
+    /**
+     * Default dimensions of the slate
+     */
+    public readonly defaultDimensions = this._dimensions.clone();
+
+    /**
+     * Height of the title bar component
+     */
+    public get titleBarHeight() {
+        return this._titleBarHeight;
+    }
+    public set titleBarHeight(value) {
+        this._titleBarHeight = value;
+    }
 
     /**
      * Rendering ground id of all the meshes
@@ -110,6 +143,7 @@ export class HolographicSlate extends ContentDisplay3D {
         this._titleBar.renderingGroupId = id;
         this._titleBarTitle.renderingGroupId = id;
         this._contentPlate.renderingGroupId = id;
+        this._backPlate.renderingGroupId = id;
     }
     public get renderingGroupId(): number {
         return this._titleBar.renderingGroupId;
@@ -136,6 +170,7 @@ export class HolographicSlate extends ContentDisplay3D {
         super(name);
 
         this._followButton = new TouchHolographicButton("followButton" + this.name);
+        this._followButton.isToggleButton = true;
         this._closeButton = new TouchHolographicButton("closeButton" + this.name);
 
         this._contentViewport = new Viewport(0, 0, 1, 1);
@@ -172,27 +207,28 @@ export class HolographicSlate extends ContentDisplay3D {
      * @hidden
      */
     public _positionElements() {
-        const followButtonMesh = this._followButton.mesh;
-        const closeButtonMesh = this._closeButton.mesh;
+        const followButton = this._followButton;
+        const closeButton = this._closeButton;
         const titleBar = this._titleBar;
         const titleBarTitle = this._titleBarTitle;
         const contentPlate = this._contentPlate;
+        const backPlate = this._backPlate;
 
-        if (followButtonMesh && closeButtonMesh && titleBar) {
-            closeButtonMesh.scaling.setAll(this.titleBarHeight);
-            followButtonMesh.scaling.setAll(this.titleBarHeight);
-            closeButtonMesh.position
+        if (followButton && closeButton && titleBar) {
+            closeButton.scaling.setAll(this.titleBarHeight);
+            followButton.scaling.setAll(this.titleBarHeight);
+            closeButton.position
                 .copyFromFloats(
                     this.dimensions.x - this.titleBarHeight / 2,
                     -this.titleBarHeight / 2,
-                    (-Epsilon / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
+                    0
                 )
                 .addInPlace(this.origin);
-            followButtonMesh.position
+            followButton.position
                 .copyFromFloats(
                     this.dimensions.x - (3 * this.titleBarHeight) / 2,
                     -this.titleBarHeight / 2,
-                    (-Epsilon / 2) * (this._host.scene.useRightHandedSystem ? -1 : 1)
+                    0
                 )
                 .addInPlace(this.origin);
 
@@ -201,10 +237,12 @@ export class HolographicSlate extends ContentDisplay3D {
             titleBar.scaling.set(this.dimensions.x, this.titleBarHeight, Epsilon);
             titleBarTitle.scaling.set(this.dimensions.x - (2 * this.titleBarHeight), this.titleBarHeight, Epsilon);
             contentPlate.scaling.copyFromFloats(this.dimensions.x, contentPlateHeight, Epsilon);
+            backPlate.scaling.copyFromFloats(this.dimensions.x, contentPlateHeight, Epsilon);
 
             titleBar.position.copyFromFloats(this.dimensions.x / 2, -(this.titleBarHeight / 2), 0).addInPlace(this.origin);
             titleBarTitle.position.copyFromFloats((this.dimensions.x / 2) - this.titleBarHeight, -(this.titleBarHeight / 2), -Epsilon).addInPlace(this.origin);
             contentPlate.position.copyFromFloats(this.dimensions.x / 2, -(this.titleBarHeight + this.titleBarMargin + contentPlateHeight / 2), 0).addInPlace(this.origin);
+            backPlate.position.copyFromFloats(this.dimensions.x / 2, -(this.titleBarHeight + this.titleBarMargin + contentPlateHeight / 2), Epsilon).addInPlace(this.origin);
 
             // Update the title's AdvancedDynamicTexture scale to avoid visual stretching
             this._titleTextComponent.host.scaleTo(HolographicSlate.DEFAULT_TEXT_RESOLUTION_Y * titleBarTitle.scaling.x / titleBarTitle.scaling.y, HolographicSlate.DEFAULT_TEXT_RESOLUTION_Y);
@@ -214,6 +252,9 @@ export class HolographicSlate extends ContentDisplay3D {
             this._contentViewport.height = this._contentScaleRatio / aspectRatio;
 
             this._applyContentViewport();
+            if (this._gizmo) {
+                this._gizmo.updateBoundingBox();
+            }
         }
     }
 
@@ -273,24 +314,23 @@ export class HolographicSlate extends ContentDisplay3D {
         this._titleTextComponent.paddingLeft = HolographicSlate.DEFAULT_TEXT_RESOLUTION_Y / 4;
         adt.addControl(this._titleTextComponent);
 
-        const faceUV = new Array(6).fill(new Vector4(0, 0, 1, 1));
-        if (scene.useRightHandedSystem) {
-            faceUV[0].copyFromFloats(0, 1, 1, 0);
-        }
-        this._contentPlate = CreateBox("contentPlate_" + this.name, { size: 1, faceUV }, scene);
+        this._contentPlate = CreatePlane("contentPlate_" + this.name, { size: 1, sideOrientation: VertexData.FRONTSIDE }, scene);
+        this._backPlate = CreatePlane("backPlate_" + this.name, { size: 1, sideOrientation: VertexData.BACKSIDE }, scene);
 
         this._titleBar.parent = node;
         this._titleBar.isNearGrabbable = true;
         this._contentPlate.parent = node;
+        this._backPlate.parent = node;
         this._attachContentPlateBehavior();
 
         this._addControl(this._followButton);
         this._addControl(this._closeButton);
 
-        const followButtonMesh = this._followButton.mesh!;
-        const closeButtonMesh = this._closeButton.mesh!;
-        followButtonMesh.parent = node;
-        closeButtonMesh.parent = node;
+        const followButton = this._followButton;
+        const closeButton = this._closeButton;
+
+        followButton.node!.parent = node;
+        closeButton.node!.parent = node;
 
         this._positionElements();
 
@@ -300,8 +340,8 @@ export class HolographicSlate extends ContentDisplay3D {
         this._followButton.isBackplateVisible = false;
         this._closeButton.isBackplateVisible = false;
 
-        this._followButton.onPointerClickObservable.add(() => {
-            this._defaultBehavior.followBehaviorEnabled = !this._defaultBehavior.followBehaviorEnabled;
+        this._followButton.onToggleObservable.add((isToggled) => {
+            this._defaultBehavior.followBehaviorEnabled = isToggled;
             if (this._defaultBehavior.followBehaviorEnabled) {
                 this._defaultBehavior.followBehavior.recenter();
             }
@@ -369,20 +409,17 @@ export class HolographicSlate extends ContentDisplay3D {
         // TODO share materials
         this._titleBarMaterial = new FluentBackplateMaterial(`${this.name} plateMaterial`, mesh.getScene());
 
-       // this._pickedPointObserver = this._host.onPickedPointChangedObservable.add((pickedPoint) => {
-       //     if (pickedPoint) {
-       //         this._titleBarMaterial.globalLeftIndexTipPosition = pickedPoint;
-       //         this._titleBarMaterial.hoverColor.a = 1.0;
-       //     } else {
-       //         this._titleBarMaterial.hoverColor.a = 0;
-       //     }
-       // });
-
-        this._contentMaterial = new FluentMaterial(this.name + "contentMaterial", mesh.getScene());
+        this._contentMaterial = new FluentMaterial(`${this.name} contentMaterial`, mesh.getScene());
         this._contentMaterial.renderBorders = true;
+
+        this._backMaterial = new FluentBackplateMaterial(`${this.name} backPlate`, mesh.getScene());
+        this._backMaterial.lineWidth = Epsilon;
+        this._backMaterial.radius = 0.005;
+        this._backMaterial.backFaceCulling = true;
 
         this._titleBar.material = this._titleBarMaterial;
         this._contentPlate.material = this._contentMaterial;
+        this._backPlate.material = this._backMaterial;
 
         this._resetContent();
         this._applyContentViewport();
@@ -395,19 +432,22 @@ export class HolographicSlate extends ContentDisplay3D {
         this._gizmo.attachedSlate = this;
         this._defaultBehavior = new DefaultBehavior();
         this._defaultBehavior.attach(this.node as Mesh, [this._titleBar]);
+        this._defaultBehavior.sixDofDragBehavior.onDragStartObservable.add(() => {
+            this._followButton.isToggled = false;
+        });
 
         this._positionChangedObserver = this._defaultBehavior.sixDofDragBehavior.onPositionChangedObservable.add(() => {
             this._gizmo.updateBoundingBox();
         });
 
         this._updatePivot();
-        this.resetDefaultAspectAndPose();
+        this.resetDefaultAspectAndPose(false);
     }
 
     /**
      * Resets the aspect and pose of the slate so it is right in front of the active camera, facing towards it.
      */
-    public resetDefaultAspectAndPose() {
+    public resetDefaultAspectAndPose(resetAspect: boolean = true) {
         if (!this._host || !this._host.utilityLayer || !this.node) {
             return;
         }
@@ -415,13 +455,16 @@ export class HolographicSlate extends ContentDisplay3D {
         const camera = scene.activeCamera;
         if (camera) {
             const worldMatrix = camera.getWorldMatrix();
-            const backward = Vector3.TransformNormal(Vector3.Backward(scene.useRightHandedSystem), worldMatrix);
-            this.dimensions.copyFrom(this.defaultDimensions);
+            const backward = Vector3.TransformNormal(Vector3.Backward(false), worldMatrix);
             this.origin.setAll(0);
             this._gizmo.updateBoundingBox();
             const pivot = this.node.getAbsolutePivotPoint();
             this.node.position.copyFrom(camera.position).subtractInPlace(backward).subtractInPlace(pivot);
             this.node.rotationQuaternion = Quaternion.FromLookDirectionLH(backward, new Vector3(0, 1, 0));
+
+            if (resetAspect) {
+                this.dimensions = this.defaultDimensions;
+            }
         }
     }
 
@@ -436,6 +479,7 @@ export class HolographicSlate extends ContentDisplay3D {
         this._titleBar.dispose();
         this._titleBarTitle.dispose();
         this._contentPlate.dispose();
+        this._backPlate.dispose();
 
         this._followButton.dispose();
         this._closeButton.dispose();

--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -93,6 +93,13 @@ export class TouchHolographicButton extends TouchButton3D {
     }
 
     /**
+     * Gets the mesh used to render this control
+     */
+    public get mesh(): Nullable<AbstractMesh> {
+        return this._backPlate as AbstractMesh;
+    }
+
+    /**
      * Text to be displayed on the tooltip shown when hovering on the button. When set to null tooltip is disabled. (Default: null)
      */
     public set tooltipText(text: Nullable<string>) {
@@ -364,7 +371,7 @@ export class TouchHolographicButton extends TouchButton3D {
             scene
         );
 
-        this._backPlate.position = Vector3.Forward(scene.useRightHandedSystem).scale(-this._backPlateDepth / 2);
+        this._backPlate.position = Vector3.Forward(scene.useRightHandedSystem).scale(this._backPlateDepth / 2);
         this._backPlate.isPickable = false;
 
         this._textPlate = <Mesh>super._createNode(scene);
@@ -375,10 +382,13 @@ export class TouchHolographicButton extends TouchButton3D {
         this._backPlate.addChild(collisionMesh);
         this._backPlate.addChild(this._textPlate);
 
+        let tn = new TransformNode(`{this.name}_root`, scene);
+        this._backPlate.setParent(tn);
+
         this.collisionMesh = collisionMesh;
         this.collidableFrontDirection = this._backPlate.forward.negate(); // Mesh is facing the wrong way
 
-        return this._backPlate;
+        return tn;
     }
 
     protected _applyFacade(facadeTexture: AdvancedDynamicTexture) {


### PR DESCRIPTION
This change fixes the following issues.

**HolographicSlate:**
- Slate dimensions don't respect minimum dimensions
- Slate contents visible upside-down on back of slate
- Making the follow behavior button a proper toggle button
- Follow behavior is properly cancelled when manipulating the slate (it no longer resumes following the user after the user manually adjusts its position, for example)
- Changed slate content plate to be a panel instead of a box, removed unnecessary uv assignment
- No longer reset dimensions of slate when adding it to the manager

**SlateGizmo:**
- Slate manipulation handles don't respect slate scaling (only properly sized in using GUI3DManager.useRealisticScaling)
- Attempting to resize a slate that is less than the minimum results in slate/texture distortion
- Fixed slate gizmo bars not adjusting to new slate size
- SlateGizmo side handles weren't being updated when using fixedScreenSize logic

**TouchHolographicButton:**
- Fixing TouchHolographicButton backplate offset to no longer clip though slate title bar