### PR TITLE
Early return from InstancedMesh.getLOD if there are no LODs

### DIFF
--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -390,15 +390,9 @@ export class InstancedMesh extends AbstractMesh {
         const sourceMeshLODLevels = this.sourceMesh.getLODLevels();
         if(!sourceMeshLODLevels || sourceMeshLODLevels.length === 0) {
             this._currentLOD = this.sourceMesh;
-            return this.sourceMesh;
-        }
-
-        let boundingInfo = this.getBoundingInfo();
-
-        this._currentLOD = <Mesh>this.sourceMesh.getLOD(camera, boundingInfo.boundingSphere);
-
-        if (this._currentLOD === this.sourceMesh) {
-            return this.sourceMesh;
+        } else {
+            let boundingInfo = this.getBoundingInfo();
+            this._currentLOD = <Mesh>this.sourceMesh.getLOD(camera, boundingInfo.boundingSphere);
         }
 
         return this._currentLOD;

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -388,7 +388,7 @@ export class InstancedMesh extends AbstractMesh {
         }
 
         const sourceMeshLODLevels = this.sourceMesh.getLODLevels();
-        if(!sourceMeshLODLevels || sourceMeshLODLevels.length === 0) {
+        if (!sourceMeshLODLevels || sourceMeshLODLevels.length === 0) {
             this._currentLOD = this.sourceMesh;
         } else {
             let boundingInfo = this.getBoundingInfo();

--- a/src/Meshes/instancedMesh.ts
+++ b/src/Meshes/instancedMesh.ts
@@ -387,6 +387,12 @@ export class InstancedMesh extends AbstractMesh {
             return this;
         }
 
+        const sourceMeshLODLevels = this.sourceMesh.getLODLevels();
+        if(!sourceMeshLODLevels || sourceMeshLODLevels.length === 0) {
+            this._currentLOD = this.sourceMesh;
+            return this.sourceMesh;
+        }
+
         let boundingInfo = this.getBoundingInfo();
 
         this._currentLOD = <Mesh>this.sourceMesh.getLOD(camera, boundingInfo.boundingSphere);


### PR DESCRIPTION
`Mesh.getLOD` has this nice thing where it returns early in case there are no LODs. `InstancedMesh.getLOD` uses `Mesh.getLOD` underneath, but not before it calls off to a `AbstractMesh.getBoundingInfo`: https://github.com/BabylonJS/Babylon.js/blob/087deb584b40fc5fe8543d54b3e3eed60d1cc121/src/Meshes/instancedMesh.ts#L390

So even if there are no LODs, a whole lot happens to figure out which one would be the right one:
<img width="682" alt="Screenshot 2022-02-23 at 01 05 02" src="https://user-images.githubusercontent.com/238667/155240741-6831c75c-e2dc-4d22-8a61-7ae7c66f12ec.png">

I assume LODs are not used very often, especially in combination with `InstancedMesh`es, so this PR includes a significant early return optimisation for that common case.