### PR TITLE
When moving a GUI element's pivot point on the editor, keep the element in the same place

### DIFF
--- a/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -71,7 +71,6 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
 
         this._onPropertyChangedObserver = this.props.onPropertyChangedObservable?.add((event) => {
             const isTransformEvent = event.property === "transformCenterX" || event.property === "transformCenterY";
-            console.log('on observer for event', event.property);
             for (let control of controls) {
                 let transformed = this._getTransformedReferenceCoordinate(control);
                 if (isTransformEvent && control.metadata._previousCenter) {
@@ -214,30 +213,6 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                 this.forceUpdate();
             }
         }
-        /*const updateTransformCentersAndPositions = () => {
-            for (let control of controls) {
-                let transformed = this._getTransformedReferenceCoordinate(control);
-                if (control.metadata._previousCenter) {
-                    // transform
-                    const diff = transformed.subtract(control.metadata._previousCenter);
-                    control.leftInPixels -= diff.x;
-                    control.topInPixels -= diff.y;
-
-                    transformed = this._getTransformedReferenceCoordinate(control);
-                }
-
-                control.metadata._previousCenter = transformed;
-            }
-            this.forceUpdate();
-        };
-
-        const updateTransformCenters = () => {
-            for (let control of controls) {
-                let transformed = this._getTransformedReferenceCoordinate(control);
-
-                control.metadata._previousCenter = transformed;
-            }
-        };*/
 
         return (
             <div>

--- a/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -59,7 +59,6 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
         const controls = this.props.controls;
         for (let control of controls) {
             const transformed = this._getTransformedReferenceCoordinate(control);
-            console.log('transformed', transformed);
             if (!control.metadata) {
                 control.metadata = {};
             }
@@ -185,6 +184,30 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                 this.forceUpdate();
             }
         }
+        const updateTransformCentersAndPositions = () => {
+            for (let control of controls) {
+                let transformed = this._getTransformedReferenceCoordinate(control);
+                if (control.metadata._previousCenter) {
+                    // transform
+                    const diff = transformed.subtract(control.metadata._previousCenter);
+                    control.leftInPixels -= diff.x;
+                    control.topInPixels -= diff.y;
+
+                    transformed = this._getTransformedReferenceCoordinate(control);
+                }
+
+                control.metadata._previousCenter = transformed;
+            }
+            this.forceUpdate();
+        };
+
+        const updateTransformCenters = () => {
+            for (let control of controls) {
+                let transformed = this._getTransformedReferenceCoordinate(control);
+
+                control.metadata._previousCenter = transformed;
+            }
+        };
 
         return (
             <div>
@@ -253,7 +276,10 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         label="X"
                         delayInput={true}
                         value={getValue("_left")}
-                        onChange={(newValue) => this._checkAndUpdateValues("left", newValue)}
+                        onChange={(newValue) => {
+                            this._checkAndUpdateValues("left", newValue);
+                            updateTransformCenters();
+                        }}
                         unit={getUnitString("_left")}
                         onUnitClicked={unit => convertUnits(unit, "left")}
                     />
@@ -263,7 +289,10 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         label="Y"
                         delayInput={true}
                         value={getValue("_top")}
-                        onChange={(newValue) => this._checkAndUpdateValues("top", newValue)}
+                        onChange={(newValue) => {
+                            this._checkAndUpdateValues("top", newValue);
+                            updateTransformCenters();
+                        }}
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                         unit={getUnitString("_top")}
                         onUnitClicked={unit => convertUnits(unit, "top")}
@@ -294,6 +323,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 }
                             }
                             this._checkAndUpdateValues("width", newValue);
+                            updateTransformCenters();
                         }}
                         unit={getUnitString("_width")}
                         onUnitClicked={unit => convertUnits(unit, "width")}
@@ -320,6 +350,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 }
                             }
                             this._checkAndUpdateValues("height", newValue);
+                            updateTransformCenters();
                         }}
                         unit={getUnitString("_height")}
                         onUnitClicked={unit => convertUnits(unit, "height")}
@@ -408,22 +439,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         target={proxy}
                         propertyName="transformCenterX"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                        onChange={() => {
-                            for (let control of controls) {
-                                let transformed = this._getTransformedReferenceCoordinate(control);
-                                if (control.metadata._previousCenter) {
-                                    // transform
-                                    const diff = transformed.subtract(control.metadata._previousCenter);
-                                    control.leftInPixels -= diff.x;
-                                    control.topInPixels -= diff.y;
-
-                                    transformed = this._getTransformedReferenceCoordinate(control);
-                                }
-
-                                control.metadata._previousCenter = transformed;
-                            }
-                            this.forceUpdate();
-                        }}
+                        onChange={updateTransformCentersAndPositions}
                     />
                     <FloatLineComponent
                         lockObject={this.props.lockObject}
@@ -431,6 +447,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         target={proxy}
                         propertyName="transformCenterY"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        onChange={updateTransformCentersAndPositions}
                     />
                 </div>
                 <div className="ge-divider">
@@ -442,6 +459,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         target={proxy}
                         propertyName="scaleX"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        onChange={updateTransformCenters}
                     />
                     <FloatLineComponent
                         lockObject={this.props.lockObject}
@@ -449,6 +467,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         target={proxy}
                         propertyName="scaleY"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        onChange={updateTransformCenters}
                     />
                 </div>
                 <SliderLineComponent
@@ -463,13 +482,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                     maximum={2 * Math.PI}
                     step={0.01}
                     onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                    onChange={() => {
-                        for (let control of controls) {
-                            let transformed = this._getTransformedReferenceCoordinate(control);
-
-                            control.metadata._previousCenter = transformed;
-                        }
-                    }}
+                    onChange={updateTransformCenters}
                 />
                 <hr className="ge" />
                 <TextLineComponent tooltip="" label="APPEARANCE" value=" " color="grey"></TextLineComponent>

--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -206,6 +206,12 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
             this._updateNodeFromLocalBounds();
             this.props.globalState.workbench._liveGuiTextureRerender = false;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
+            this.props.globalState.onPropertyChangedObservable.notifyObservers({
+                object: node,
+                property: 'test',
+                value: 'test',
+                initialValue: 'test'
+            });
         }
         if (this.state.isRotating) {
             const angle = Math.atan2(scene.pointerY - this._rotation.pivot.y, scene.pointerX - this._rotation.pivot.x);
@@ -214,6 +220,12 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
             }
             this._rotation.initialAngleToPivot = angle;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
+            this.props.globalState.onPropertyChangedObservable.notifyObservers({
+                object: null,
+                property: 'test',
+                value: 'test',
+                initialValue: 'test'
+            });
         }
     };
 

--- a/guiEditor/src/diagram/guiGizmo.tsx
+++ b/guiEditor/src/diagram/guiGizmo.tsx
@@ -206,26 +206,21 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
             this._updateNodeFromLocalBounds();
             this.props.globalState.workbench._liveGuiTextureRerender = false;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
-            this.props.globalState.onPropertyChangedObservable.notifyObservers({
-                object: node,
-                property: 'test',
-                value: 'test',
-                initialValue: 'test'
-            });
         }
         if (this.state.isRotating) {
             const angle = Math.atan2(scene.pointerY - this._rotation.pivot.y, scene.pointerX - this._rotation.pivot.x);
             for(const control of this.props.globalState.workbench.selectedGuiNodes) {
+                const oldRotation = control.rotation;
                 control.rotation += (angle - this._rotation.initialAngleToPivot);
+                this.props.globalState.onPropertyChangedObservable.notifyObservers({
+                    object: control,
+                    property: 'rotation',
+                    value: control.rotation,
+                    initialValue: oldRotation
+                })
             }
             this._rotation.initialAngleToPivot = angle;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
-            this.props.globalState.onPropertyChangedObservable.notifyObservers({
-                object: null,
-                property: 'test',
-                value: 'test',
-                initialValue: 'test'
-            });
         }
     };
 
@@ -342,7 +337,14 @@ export class GuiGizmoComponent extends React.Component<IGuiGizmoProps, IGuiGizmo
                 }
                 // compute real change in property
                 const initialUnit = (selectedControl as any)[`_${property}`].unit;
+                const oldPixels = (selectedControl as any)[`${property}InPixels`];
                 (selectedControl as any)[`${property}InPixels`] = newPixels;
+                this.props.globalState.onPropertyChangedObservable.notifyObservers({
+                    object: selectedControl,
+                    property: `${property}InPixels`,
+                    value: newPixels,
+                    initialValue: oldPixels
+                });
                 if (initialUnit === ValueAndUnit.UNITMODE_PERCENTAGE) {
                     CoordinateHelper.convertToPercentage(selectedControl, [property]);
                 }


### PR DESCRIPTION
Without the change:
![gui-editor-pivot-master](https://user-images.githubusercontent.com/6002144/155318474-ddab4c20-3288-4654-bdd9-e690f11d9ea6.gif)
With the change:
![gui-editor-pivot-changed](https://user-images.githubusercontent.com/6002144/155318499-e94021d2-cdb2-4a83-957c-98b96799b56e.gif)

