### PR TITLE
Fix small ordering issue with HolographicSlate

### DIFF
--- a/gui/src/3D/controls/holographicSlate.ts
+++ b/gui/src/3D/controls/holographicSlate.ts
@@ -214,7 +214,6 @@ export class HolographicSlate extends ContentDisplay3D {
         const titleBarTitle = this._titleBarTitle;
         const contentPlate = this._contentPlate;
         const backPlate = this._backPlate;
-        const rightHandScene = contentPlate.getScene().useRightHandedSystem;
 
         if (followButton && closeButton && titleBar) {
             closeButton.scaling.setAll(this.titleBarHeight);
@@ -235,6 +234,7 @@ export class HolographicSlate extends ContentDisplay3D {
                 .addInPlace(this.origin);
 
             const contentPlateHeight = this.dimensions.y - this.titleBarHeight - this.titleBarMargin;
+            const rightHandScene = contentPlate.getScene().useRightHandedSystem;
 
             titleBar.scaling.set(this.dimensions.x, this.titleBarHeight, Epsilon);
             titleBarTitle.scaling.set(this.dimensions.x - (2 * this.titleBarHeight), this.titleBarHeight, Epsilon);


### PR DESCRIPTION
I missed this check with my last PR. If the dimensions are updated before calling GUI3DManager.addControl(HolographicSlate), then the content plate doesn't exist yet. Putting it inside the conditional check ensures that the content plate exists (it's created alongside the titlebar)