### PR TITLE
Avoid extra vertex data copies during Mesh.MergeMeshes

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -139,7 +139,7 @@
 - Added `mesh.onMeshReadyObservable` to get notified when a mesh is ready ([RaananW](https://github.com/RaananW))
 - Added support for morph targets to the mesh `BoundingInfo` refresh. ([EricBeetsOfficial-Opuscope](https://github.com/EricBeetsOfficial-Opuscope))
 - Added support for screen coverage in addition to distance for LOds. ([CraigFeldspar](https://github.com/CraigFeldspar))
-- Decreated memory usage and improved performance of `Mesh.MergeMeshes`. ([ryantrem](https://github.com/ryantrem))
+- Decreased memory usage and improved performance of `Mesh.MergeMeshes`. ([ryantrem](https://github.com/ryantrem))
 
 ### Inspector
 

--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -139,6 +139,7 @@
 - Added `mesh.onMeshReadyObservable` to get notified when a mesh is ready ([RaananW](https://github.com/RaananW))
 - Added support for morph targets to the mesh `BoundingInfo` refresh. ([EricBeetsOfficial-Opuscope](https://github.com/EricBeetsOfficial-Opuscope))
 - Added support for screen coverage in addition to distance for LOds. ([CraigFeldspar](https://github.com/CraigFeldspar))
+- Decreated memory usage and improved performance of `Mesh.MergeMeshes`. ([ryantrem](https://github.com/ryantrem))
 
 ### Inspector
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -763,7 +763,7 @@ class CommandBufferEncoder {
 /** @hidden */
 export class NativeEngine extends Engine {
     // This must match the protocol version in NativeEngine.cpp
-    private static readonly PROTOCOL_VERSION = 2;
+    private static readonly PROTOCOL_VERSION = 3;
 
     private readonly _engine: INativeEngine = new _native.Engine();
     private readonly _camera: Nullable<INativeCamera> = _native.Camera ? new _native.Camera() : null;

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -4437,11 +4437,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         const getVertexDataFromMesh = (mesh: Mesh) => {
             const wm = mesh.computeWorldMatrix(true);
             const vertexData = VertexData.ExtractFromMesh(mesh, false, false);
-            //vertexData.transform(wm);
             return [vertexData, wm] as const;
         };
 
-        Tools.StartPerformanceCounter(`getVertexDataFromMesh`);
         const [sourceVertexData, sourceTransform] = getVertexDataFromMesh(source);
         if (isAsync) { yield; }
 
@@ -4450,7 +4448,6 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             meshVertexDatas[i - 1] = getVertexDataFromMesh(meshes[i]);
             if (isAsync) { yield; }
         }
-        Tools.EndPerformanceCounter(`getVertexDataFromMesh`);
 
         const mergeCoroutine = sourceVertexData._mergeCoroutine(sourceTransform, meshVertexDatas, allow32BitsIndices, isAsync);
         let mergeCoroutineStep = mergeCoroutine.next();

--- a/src/Meshes/mesh.ts
+++ b/src/Meshes/mesh.ts
@@ -4442,7 +4442,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         };
 
         Tools.StartPerformanceCounter(`getVertexDataFromMesh`);
-        const sourceVertexData = getVertexDataFromMesh(source);
+        const [sourceVertexData, sourceTransform] = getVertexDataFromMesh(source);
         if (isAsync) { yield; }
 
         const meshVertexDatas = new Array<readonly [VertexData, Matrix]>(meshes.length - 1);
@@ -4452,7 +4452,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
         Tools.EndPerformanceCounter(`getVertexDataFromMesh`);
 
-        const mergeCoroutine = sourceVertexData[0]._mergeCoroutine(sourceVertexData[1], meshVertexDatas, allow32BitsIndices, isAsync);
+        const mergeCoroutine = sourceVertexData._mergeCoroutine(sourceTransform, meshVertexDatas, allow32BitsIndices, isAsync);
         let mergeCoroutineStep = mergeCoroutine.next();
         while (!mergeCoroutineStep.done) {
             if (isAsync) { yield; }

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -622,7 +622,7 @@ export class VertexData {
             return this._mergeElement(kind, nonNullOthers[0][0], nonNullOthers[0][1], nonNullOthers.slice(1));
         }
 
-        const len = nonNullOthers.reduce((sumLen, elements) => sumLen + elements.length, source.length);
+        const len = nonNullOthers.reduce((sumLen, elements) => sumLen + elements[0].length, source.length);
 
         const transformRange = (element: FloatArray, matrix: Matrix | undefined, offset: number, length: number) => {
             if (matrix) {

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -621,28 +621,22 @@ export class VertexData {
 
         const len = nonNullOthers.reduce((sumLen, elements) => sumLen + elements[0].length, source.length);
 
-        const transformRange = (element: FloatArray, matrix: Matrix | undefined, offset: number, length: number) => {
-            if (matrix) {
-                if (kind === VertexBuffer.PositionKind) {
-                    VertexData._TransformVector3Coordinates(element, matrix, offset, length);
-                } else if (kind === VertexBuffer.NormalKind) {
-                    VertexData._TransformVector3Normals(element, matrix, offset, length);
-                } else if (kind === VertexBuffer.TangentKind) {
-                    VertexData._TransformVector4Normals(element, matrix, offset, length);
-                }
-            }
-        };
+        const transformRange =
+            kind === VertexBuffer.PositionKind ? VertexData._TransformVector3Coordinates :
+            kind === VertexBuffer.NormalKind ? VertexData._TransformVector3Normals :
+            kind === VertexBuffer.TangentKind ? VertexData._TransformVector4Normals :
+            () => {};
 
         if (source instanceof Float32Array) {
             // use non-loop method when the source is Float32Array
             const ret32 = new Float32Array(len);
             ret32.set(source);
-            transformRange(ret32, transform, 0, source.length);
+            transform && transformRange(ret32, transform, 0, source.length);
 
             let offset = source.length;
             for (const [vertexData, transform] of nonNullOthers) {
                 ret32.set(vertexData, offset);
-                transformRange(ret32, transform, offset, vertexData.length);
+                transform && transformRange(ret32, transform, offset, vertexData.length);
                 offset += vertexData.length;
             }
             return ret32;
@@ -652,14 +646,14 @@ export class VertexData {
             for (let i = 0; i < source.length; i++) {
                 ret[i] = source[i];
             }
-            transformRange(ret, transform, 0, source.length);
+            transform && transformRange(ret, transform, 0, source.length);
 
             let offset = source.length;
             for (const [vertexData, transform] of nonNullOthers) {
                 for (let i = 0; i < vertexData.length; i++) {
                     ret[offset + i] = vertexData[i];
                 }
-                transformRange(ret, transform, offset, vertexData.length);
+                transform && transformRange(ret, transform, offset, vertexData.length);
                 offset += vertexData.length;
             }
             return ret;

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -443,9 +443,9 @@ export class VertexData {
         for (let index = offset; index < offset + length; index += 3) {
             Vector3.FromArrayToRef(normals, index, normal);
             Vector3.TransformNormalToRef(normal, transformation, transformedNormal);
-            normals[index + offset] = transformedNormal.x;
-            normals[index + offset + 1] = transformedNormal.y;
-            normals[index + offset + 2] = transformedNormal.z;
+            normals[index] = transformedNormal.x;
+            normals[index + 1] = transformedNormal.y;
+            normals[index + 2] = transformedNormal.z;
         }
     }
 
@@ -456,10 +456,10 @@ export class VertexData {
         for (let index = offset; index < offset + length; index += 4) {
             Vector4.FromArrayToRef(normals, index, normal);
             Vector4.TransformNormalToRef(normal, transformation, transformedNormal);
-            normals[index + offset] = transformedNormal.x;
-            normals[index + offset + 1] = transformedNormal.y;
-            normals[index + offset + 2] = transformedNormal.z;
-            normals[index + offset + 3] = transformedNormal.w;
+            normals[index] = transformedNormal.x;
+            normals[index + 1] = transformedNormal.y;
+            normals[index + 2] = transformedNormal.z;
+            normals[index + 3] = transformedNormal.w;
         }
     }
 
@@ -467,8 +467,8 @@ export class VertexData {
     private static _FlipFaces(indices: IndicesArray, offset = 0, length = indices.length) {
         for (let index = offset; index < offset + length; index += 3) {
             const tmp = indices[index + 1];
-            indices[index + offset + 1] = indices[index + 2];
-            indices[index + offset + 2] = tmp;
+            indices[index + 1] = indices[index + 2];
+            indices[index + 2] = tmp;
         }
     }
 
@@ -514,7 +514,6 @@ export class VertexData {
         this._validate();
 
         const others = vertexDatas.map(vertexData => vertexData[0]);
-        //const transforms = vertexDatas.map(vertexData => vertexData[1]);
 
         for (const other of others) {
             other._validate();
@@ -560,8 +559,7 @@ export class VertexData {
             }
 
             let positionsOffset = this.positions ? this.positions.length / 3 : 0;
-            for (const vertexData of vertexDatas) {
-                const [other, transform] = vertexData;
+            for (const [other, transform] of vertexDatas) {
                 if (other.indices) {
                     for (let index = 0; index < other.indices.length; index++) {
                         this.indices[indicesOffset + index] = other.indices[index] + positionsOffset;
@@ -645,8 +643,7 @@ export class VertexData {
             transformRange(ret32, transform, 0, source.length);
 
             let offset = source.length;
-            for (const other of nonNullOthers) {
-                const [vertexData, transform] = other;
+            for (const [vertexData, transform] of nonNullOthers) {
                 ret32.set(vertexData, offset);
                 transformRange(ret32, transform, offset, vertexData.length);
                 offset += vertexData.length;
@@ -661,13 +658,12 @@ export class VertexData {
             transformRange(ret, transform, 0, source.length);
 
             let offset = source.length;
-            for (const other of nonNullOthers) {
-                const [vertexData, transform] = other;
+            for (const [vertexData, transform] of nonNullOthers) {
                 for (let i = 0; i < vertexData.length; i++) {
                     ret[offset + i] = vertexData[i];
                 }
                 transformRange(ret, transform, offset, vertexData.length);
-                offset += other.length;
+                offset += vertexData.length;
             }
             return ret;
         }

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -11,7 +11,6 @@ declare type Geometry = import("../Meshes/geometry").Geometry;
 declare type Mesh = import("../Meshes/mesh").Mesh;
 
 import { ICreateCapsuleOptions } from "./Builders/capsuleBuilder";
-import { Tools } from "../Misc/tools";
 declare type PolyhedronData= import("./geodesicMesh").PolyhedronData;
 
 /**
@@ -578,7 +577,6 @@ export class VertexData {
             }
         }
 
-        Tools.StartPerformanceCounter(`VertexData._mergeElement`);
         this.positions = VertexData._mergeElement(VertexBuffer.PositionKind, this.positions, transform, vertexDatas.map((other) => [other[0].positions, other[1]]));
         if (isAsync) { yield; }
         this.normals = VertexData._mergeElement(VertexBuffer.NormalKind, this.normals, transform, vertexDatas.map((other) => [other[0].normals, other[1]]));
@@ -606,7 +604,6 @@ export class VertexData {
         this.matricesIndicesExtra = VertexData._mergeElement(VertexBuffer.MatricesIndicesExtraKind, this.matricesIndicesExtra, transform, vertexDatas.map((other) => [other[0].matricesIndicesExtra, other[1]]));
         if (isAsync) { yield; }
         this.matricesWeightsExtra = VertexData._mergeElement(VertexBuffer.MatricesWeightsExtraKind, this.matricesWeightsExtra, transform, vertexDatas.map((other) => [other[0].matricesWeightsExtra, other[1]]));
-        Tools.EndPerformanceCounter(`VertexData._mergeElement`);
 
         return this;
     }

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -608,8 +608,8 @@ export class VertexData {
         return this;
     }
 
-    private static _mergeElement(kind: string, source: Nullable<FloatArray>, transform: Matrix | undefined, others: readonly (readonly [element: Nullable<FloatArray>, transform: Matrix | undefined])[]): Nullable<FloatArray> {
-        const nonNullOthers = others.filter((other): other is [element: FloatArray, transform: Matrix | undefined] => other[0] !== null && other[0] !== undefined);
+    private static _mergeElement(kind: string, source: Nullable<FloatArray>, transform: Matrix | undefined, others: readonly (readonly [element: Nullable<FloatArray>, transform?: Matrix])[]): Nullable<FloatArray> {
+        const nonNullOthers = others.filter((other): other is [element: FloatArray, transform?: Matrix] => other[0] !== null && other[0] !== undefined);
 
         if (nonNullOthers.length === 0) {
             return source;

--- a/src/Meshes/mesh.vertexData.ts
+++ b/src/Meshes/mesh.vertexData.ts
@@ -504,7 +504,7 @@ export class VertexData {
      * @returns the modified VertexData
      */
     public merge(others: VertexData | VertexData[], use32BitsIndices = false) {
-        const vertexDatas: [vertexData: VertexData, transform?: Matrix][] = Array.isArray(others) ? others.map(other => [other, undefined]) : [[others, undefined]];
+        const vertexDatas: [vertexData: VertexData, transform?: Matrix][] = Array.isArray(others) ? others.map((other) => [other, undefined]) : [[others, undefined]];
         return runCoroutineSync(this._mergeCoroutine(undefined, vertexDatas, use32BitsIndices, false));
     }
 
@@ -512,7 +512,7 @@ export class VertexData {
     public *_mergeCoroutine(transform: Matrix | undefined, vertexDatas: (readonly [vertexData: VertexData, transform?: Matrix])[], use32BitsIndices = false, isAsync: boolean): Coroutine<VertexData> {
         this._validate();
 
-        const others = vertexDatas.map(vertexData => vertexData[0]);
+        const others = vertexDatas.map((vertexData) => vertexData[0]);
 
         for (const other of others) {
             other._validate();
@@ -631,7 +631,7 @@ export class VertexData {
                     VertexData._TransformVector4Normals(element, matrix, offset, length);
                 }
             }
-        }
+        };
 
         if (source instanceof Float32Array) {
             // use non-loop method when the source is Float32Array


### PR DESCRIPTION
Previously, `MergeMeshes` would call `VertexData.ExtractFromMesh(mesh, true, true);` which would make a copies of the vertex buffers so they could be transformed prior to merge. With these changes, `MergeMeshes` calls `VertexData.ExtractFromMesh(mesh, false, false);` which does not make copies of the vertex buffers, and instead passes the transform matrix down to lower layers of the merge so the transform can be done "in place" on the final buffers. For the large model I'm testing with (7.5M verts), this reduces peak memory during the merge process by about 140mb. It also makes the merge operation faster, particularly in Babylon Native where for the same model this change reduces the merge time from 1470ms to 845ms.