### PR TITLE
Turn picking on when gizmo is enabled (Inspector)

### DIFF
--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -121,6 +121,8 @@
 - Added more functionality and options to the skeleton debug panel. ([Pryme8](https://github.com/Pryme8))
 - Along with bone index it is now possible to select a bone using its name when viewing bone weights ([#9117](https://github.com/BabylonJS/Babylon.js/issues/9117)) ([RaananW](https://github.com/RaananW))
 - Gradient nodes from NME can now be set to be visible in the inspector ([msDestiny14](https://github.com/msDestiny14))
+- Automatically turn picking on when gizmo is enabled (Inspector) (BlakeOne](https://github.com/BlakeOne))
+
 
 ### Cameras
 

--- a/dist/what's new.md
+++ b/dist/what's new.md
@@ -123,7 +123,6 @@
 - Gradient nodes from NME can now be set to be visible in the inspector ([msDestiny14](https://github.com/msDestiny14))
 - Automatically turn picking on when gizmo is enabled (Inspector) (BlakeOne](https://github.com/BlakeOne))
 
-
 ### Cameras
 
 - Fixed up vector not correctly handled with stereoscopic rig ([cedricguillemet](https://github.com/cedricguillemet))

--- a/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -263,6 +263,9 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
             manager.dispose();
             scene.reservedDataStore.gizmoManager = null;
         } else {
+            if (mode !== 0 && !this.state.isInPickingMode) {
+                this.onPickingMode();
+            }
             switch (mode) {
                 case 1:
                     manager.positionGizmoEnabled = true;


### PR DESCRIPTION
For the Inspector automatically turn picking on when gizmo is turned on so that we don't have to click an extra button to start using the gizmo.

https://forum.babylonjs.com/t/can-inspector-turn-on-picking-when-gizmo-is-enabled/27939/3