### PR TITLE
fixing pointer exit bug and exposing more info about near touch state

### DIFF
--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -168,6 +168,7 @@ export class TouchButton3D extends Button3D {
     /**
      * Get the height of the touchPoint from the collidable part of the button
      * @param touchPoint the point to compare to the button, in absolute position
+     * @returns the depth of the touch point into the front of the button
      */
     public getPressDepth(touchPoint: Vector3) {
         if (!this._isNearPressed) {

--- a/gui/src/3D/controls/touchButton3D.ts
+++ b/gui/src/3D/controls/touchButton3D.ts
@@ -18,7 +18,8 @@ export class TouchButton3D extends Button3D {
 
     // 'front' direction. If Vector3.Zero, there is no front and all directions of interaction are accepted
     private _collidableFrontDirection: Vector3;
-    protected _isNearPressed = false;
+    private _isNearPressed = false;
+    private _interactionSurfaceHeight = 0;
 
     private _isToggleButton = false;
     private _toggleState = false;
@@ -42,6 +43,13 @@ export class TouchButton3D extends Button3D {
         if (collisionMesh) {
             this.collisionMesh = collisionMesh;
         }
+    }
+
+    /**
+     * Whether the current interaction is caused by near interaction or not
+     */
+    public get isActiveNearInteraction() {
+        return this._isNearPressed;
     }
 
     /**
@@ -157,6 +165,18 @@ export class TouchButton3D extends Button3D {
         return this._getInteractionHeight(collidablePos, this._collisionMesh.getAbsolutePosition()) > 0;
     }
 
+    /**
+     * Get the height of the touchPoint from the collidable part of the button
+     * @param touchPoint the point to compare to the button, in absolute position
+     */
+    public getPressDepth(touchPoint: Vector3) {
+        if (!this._isNearPressed) {
+            return 0;
+        }
+        var interactionHeight = this._getInteractionHeight(touchPoint, this._collisionMesh.getAbsolutePosition());
+        return this._interactionSurfaceHeight - interactionHeight;
+    }
+
     // Returns true if the collidable is in front of the button, or if the button has no front direction
     protected _getInteractionHeight(interactionPos: Vector3, basePos: Vector3) {
         const frontDir = this.collidableFrontDirection;
@@ -179,6 +199,7 @@ export class TouchButton3D extends Button3D {
             }
             else {
                 this._isNearPressed = true;
+                this._interactionSurfaceHeight = this._getInteractionHeight(nearMeshPosition, this._collisionMesh.getAbsolutePosition());
             }
         }
         if (providedType === PointerEventTypes.POINTERUP) {

--- a/gui/src/3D/controls/touchHolographicButton.ts
+++ b/gui/src/3D/controls/touchHolographicButton.ts
@@ -254,7 +254,7 @@ export class TouchHolographicButton extends TouchButton3D {
         };
 
         this.pointerDownAnimation = () => {
-            if (this._frontPlate && !this._isNearPressed) {
+            if (this._frontPlate && !this.isActiveNearInteraction) {
                 this._frontPlate.scaling.z = this._frontPlateDepth * 0.2;
                 this._frontPlate.position = Vector3.Forward(this._frontPlate._scene.useRightHandedSystem).scale((this._frontPlateDepth - (0.2 * this._frontPlateDepth)) / 2);
                 this._textPlate.position = Vector3.Forward(this._textPlate._scene.useRightHandedSystem).scale(-(this._backPlateDepth + (0.2 * this._frontPlateDepth)) / 2);
@@ -269,7 +269,7 @@ export class TouchHolographicButton extends TouchButton3D {
         };
 
         this.onPointerMoveObservable.add((position) => {
-            if (this._frontPlate && this._isNearPressed) {
+            if (this._frontPlate && this.isActiveNearInteraction) {
                 const scale = Vector3.Zero();
                 if (this._backPlate.getWorldMatrix().decompose(scale, undefined, undefined)) {
                     let interactionHeight = this._getInteractionHeight(position, this._backPlate.getAbsolutePosition()) / scale.z;

--- a/src/XR/features/WebXRNearInteraction.ts
+++ b/src/XR/features/WebXRNearInteraction.ts
@@ -36,6 +36,7 @@ type ControllerData = {
     meshUnderPointer: Nullable<AbstractMesh>;
     nearInteractionTargetMesh: Nullable<AbstractMesh>;
     pick: Nullable<PickingInfo>;
+    stalePick: Nullable<PickingInfo>;
     id: number;
     touchCollisionMesh: AbstractMesh;
     touchCollisionMeshFunction: (isTouch: boolean) => void;
@@ -153,6 +154,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
             meshUnderPointer: null,
             nearInteractionTargetMesh: null,
             pick: null,
+            stalePick: null,
             touchCollisionMesh,
             touchCollisionMeshFunction: touchCollisionMeshFunction,
             hydrateCollisionMeshFunction: hydrateCollisionMeshFunction,
@@ -532,6 +534,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                     }
                 }
 
+                controllerData.stalePick = controllerData.pick;
                 controllerData.pick = pick;
 
                 // Update mesh under pointer
@@ -624,8 +627,8 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                     this._scene.simulatePointerDown(controllerData.pick, pointerEventInit);
                     controllerData.nearInteractionTargetMesh = controllerData.meshUnderPointer;
                 }
-            } else if (controllerData.nearInteractionTargetMesh && controllerData.pick) {
-                this._scene.simulatePointerUp(controllerData.pick, pointerEventInit);
+            } else if (controllerData.nearInteractionTargetMesh && controllerData.stalePick) {
+                this._scene.simulatePointerUp(controllerData.stalePick, pointerEventInit);
                 controllerData.nearInteractionTargetMesh = null;
             }
         });


### PR DESCRIPTION
I noticed while testing controls that the pointer up event isn't being fired for near interaction, due to the pick data being null (as the near interactor is no longer colliding with the target. This change saves the previous pick data for use one frame past the end of the collision so that a pointer up can be sent to the correct target.

Also I expose two new components of the TouchButton3D class for developer access, namely isActiveNearInteraction and getPressDepth(position).
- isActiveNearInteraction returns true if there is an active near interaction on that button
- getPressDepth(position) returns how far into the button the near interaction is
These two additions allow developers to easily perform different actions based on the interaction type used to press the button, and tie in components to react based on press depth.