### PR TITLE
DeviceSourceManager: Fix discrepancy with onInputChangedObservable contract

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -447,3 +447,5 @@
 - Cloning and creating instances of a mesh now refreshes the bounding box applying skins and morph targets. ([bghgary](https://github.com/bghgary))
 - `KeyboardInfoPre.skipOnPointerObservable` is now correctly renamed to `KeyboardInfoPre.skipOnKeyboardObservable`. ([bghgary](https://github.com/bghgary))
 - GLTF Animations are loaded at 60 FPS by default. ([carolhmj](https://github.com/carolhmj))
+- `currentState` and `previousState` have been removed from use in `onInputChangedObservable` in the `DeviceSourceManager` ([PolygonalSun](https://github.com/PolygonalSun))
+- `PointerInput` movement enums are no longer being used in any movement event handling in the `DeviceInputSystem` and `InputManager` ([PolygonalSun](https://github.com/PolygonalSun))

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -46,7 +46,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _preKeyboardObserver: Nullable<Observer<KeyboardInfoPre>>;
     private _pointerMoveObserver: Nullable<Observer<PointerInfoPre>>;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
-    private _canvasPointerOutObserver: Nullable<Observer<IPointerEvent>>;
+    private _canvasPointerOutObserver: Nullable<Observer<PointerEvent>>;
     private _canvasBlurObserver: Nullable<Observer<Engine>>;
     private _background: string;
     /** @hidden */

--- a/gui/src/3D/gui3DManager.ts
+++ b/gui/src/3D/gui3DManager.ts
@@ -11,6 +11,7 @@ import { IDisposable, Scene } from "babylonjs/scene";
 
 import { Container3D } from "./controls/container3D";
 import { Control3D } from "./controls/control3D";
+import { IPointerEvent } from "babylonjs/Events/deviceInputEvents";
 
 /**
  * Class used to manage 3D user interface
@@ -152,7 +153,7 @@ export class GUI3DManager implements IDisposable {
             return false;
         }
 
-        let pointerEvent = <PointerEvent>pi.event;
+        let pointerEvent = <IPointerEvent>pi.event;
 
         let pointerId = pointerEvent.pointerId || 0;
         let buttonIndex = pointerEvent.button;

--- a/guiEditor/src/diagram/workbench.tsx
+++ b/guiEditor/src/diagram/workbench.tsx
@@ -11,7 +11,6 @@ import { ArcRotateCamera } from "babylonjs/Cameras/arcRotateCamera";
 import { HemisphericLight } from "babylonjs/Lights/hemisphericLight";
 import { Axis } from "babylonjs/Maths/math.axis";
 import { PointerEventTypes } from "babylonjs/Events/pointerEvents";
-import { IWheelEvent } from "babylonjs/Events/deviceInputEvents";
 import { Epsilon } from "babylonjs/Maths/math.constants";
 import { Container } from "babylonjs-gui/2D/controls/container";
 import { KeyboardEventTypes, KeyboardInfo } from "babylonjs/Events/keyboardEvents";
@@ -24,7 +23,6 @@ import { ISize } from "babylonjs/Maths/math";
 import { Texture } from "babylonjs/Materials/Textures/texture";
 import { CoordinateHelper } from "./coordinateHelper";
 import { Logger } from "babylonjs/Misc/logger";
-import { DeviceType, PointerInput } from "babylonjs/DeviceInput/InputDevices/deviceEnums";
 require("./workbenchCanvas.scss");
 
 export interface IWorkbenchComponentProps {
@@ -854,16 +852,8 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     //Add zoom and pan controls
     addControls(scene: Scene) {
 
-        const zoomFnScrollWheel = (e: IWheelEvent | WheelEvent) => {
-            let ev: any = e;
-
-            if (!ev.deviceType) {
-                ev.deviceType = DeviceType.Mouse;
-                ev.deviceSlot = 0;
-                ev.inputIndex = PointerInput.MouseWheelY;
-            }
-
-            const delta = this.zoomWheel(ev);
+        const zoomFnScrollWheel = (e: WheelEvent) => {
+            const delta = this.zoomWheel(e);
             this.zooming(1 + (delta / 1000));
         };
 
@@ -984,7 +974,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     }
 
     //Get the wheel delta
-    zoomWheel(event: IWheelEvent) {
+    zoomWheel(event: WheelEvent) {
 
         event.preventDefault();
         let delta = 0;

--- a/src/Actions/actionEvent.ts
+++ b/src/Actions/actionEvent.ts
@@ -3,7 +3,7 @@ import { Nullable } from "../types";
 import { Sprite } from "../Sprites/sprite";
 import { Scene } from "../scene";
 import { Vector2 } from "../Maths/math.vector";
-import { IEvent } from "../Events/deviceInputEvents";
+import { IUIEvent } from "../Events/deviceInputEvents";
 
 /**
  * Interface used to define ActionEvent
@@ -58,7 +58,7 @@ export class ActionEvent implements IActionEvent {
      * @param additionalData additional data for the event
      * @returns the new ActionEvent
      */
-    public static CreateNew(source: AbstractMesh, evt?: IEvent, additionalData?: any): ActionEvent {
+    public static CreateNew(source: AbstractMesh, evt?: IUIEvent, additionalData?: any): ActionEvent {
         var scene = source.getScene();
         return new ActionEvent(source, scene.pointerX, scene.pointerY, scene.meshUnderPointer || source, evt, additionalData);
     }
@@ -71,7 +71,7 @@ export class ActionEvent implements IActionEvent {
      * @param additionalData additional data for the event
      * @returns the new ActionEvent
      */
-    public static CreateNewFromSprite(source: Sprite, scene: Scene, evt?: IEvent, additionalData?: any): ActionEvent {
+    public static CreateNewFromSprite(source: Sprite, scene: Scene, evt?: IUIEvent, additionalData?: any): ActionEvent {
         return new ActionEvent(source, scene.pointerX, scene.pointerY, scene.meshUnderPointer, evt, additionalData);
     }
 
@@ -81,7 +81,7 @@ export class ActionEvent implements IActionEvent {
      * @param evt The original (browser) event
      * @returns the new ActionEvent
      */
-    public static CreateNewFromScene(scene: Scene, evt: IEvent): ActionEvent {
+    public static CreateNewFromScene(scene: Scene, evt: IUIEvent): ActionEvent {
         return new ActionEvent(null, scene.pointerX, scene.pointerY, scene.meshUnderPointer, evt);
     }
 

--- a/src/Actions/actionEvent.ts
+++ b/src/Actions/actionEvent.ts
@@ -3,7 +3,6 @@ import { Nullable } from "../types";
 import { Sprite } from "../Sprites/sprite";
 import { Scene } from "../scene";
 import { Vector2 } from "../Maths/math.vector";
-import { IUIEvent } from "../Events/deviceInputEvents";
 
 /**
  * Interface used to define ActionEvent
@@ -58,7 +57,7 @@ export class ActionEvent implements IActionEvent {
      * @param additionalData additional data for the event
      * @returns the new ActionEvent
      */
-    public static CreateNew(source: AbstractMesh, evt?: IUIEvent, additionalData?: any): ActionEvent {
+    public static CreateNew(source: AbstractMesh, evt?: any, additionalData?: any): ActionEvent {
         var scene = source.getScene();
         return new ActionEvent(source, scene.pointerX, scene.pointerY, scene.meshUnderPointer || source, evt, additionalData);
     }
@@ -71,7 +70,7 @@ export class ActionEvent implements IActionEvent {
      * @param additionalData additional data for the event
      * @returns the new ActionEvent
      */
-    public static CreateNewFromSprite(source: Sprite, scene: Scene, evt?: IUIEvent, additionalData?: any): ActionEvent {
+    public static CreateNewFromSprite(source: Sprite, scene: Scene, evt?: any, additionalData?: any): ActionEvent {
         return new ActionEvent(source, scene.pointerX, scene.pointerY, scene.meshUnderPointer, evt, additionalData);
     }
 
@@ -81,7 +80,7 @@ export class ActionEvent implements IActionEvent {
      * @param evt The original (browser) event
      * @returns the new ActionEvent
      */
-    public static CreateNewFromScene(scene: Scene, evt: IUIEvent): ActionEvent {
+    public static CreateNewFromScene(scene: Scene, evt: any): ActionEvent {
         return new ActionEvent(null, scene.pointerX, scene.pointerY, scene.meshUnderPointer, evt);
     }
 

--- a/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
+++ b/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
@@ -10,6 +10,7 @@ import { TransformNode } from "../../Meshes/transformNode";
 import { PickingInfo } from "../../Collisions/pickingInfo";
 import { Camera } from "../../Cameras/camera";
 import { Ray } from "../../Culling/ray";
+import { IPointerEvent } from "../../Events/deviceInputEvents";
 
 /**
  * Data store to track virtual pointers movement
@@ -292,12 +293,12 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
         };
 
         this._pointerObserver = this._scene.onPointerObservable.add((pointerInfo, eventState) => {
-            const pointerId = (<PointerEvent>pointerInfo.event).pointerId;
+            const pointerId = (<IPointerEvent>pointerInfo.event).pointerId;
             if (!this._virtualMeshesInfo[pointerId]) {
                 this._virtualMeshesInfo[pointerId] = this._createVirtualMeshInfo();
             }
             const virtualMeshesInfo = this._virtualMeshesInfo[pointerId];
-            const isXRPointer = (<PointerEvent>pointerInfo.event).pointerType === "xr";
+            const isXRPointer = (<IPointerEvent>pointerInfo.event).pointerType === "xr";
 
             if (pointerInfo.type == PointerEventTypes.POINTERDOWN) {
                 if (

--- a/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -11,6 +11,7 @@ import { PivotTools } from '../../Misc/pivotTools';
 import { ArcRotateCamera } from '../../Cameras/arcRotateCamera';
 import "../../Meshes/Builders/planeBuilder";
 import { CreatePlane } from "../../Meshes/Builders/planeBuilder";
+import { IPointerEvent } from "../../Events/deviceInputEvents";
 
 /**
  * A behavior that when attached to a mesh will allow the mesh to be dragged around the screen based on pointer events
@@ -225,18 +226,18 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             if (pointerInfo.type == PointerEventTypes.POINTERDOWN) {
 
                 if (this.startAndReleaseDragOnPointerEvents && !this.dragging && pointerInfo.pickInfo && pointerInfo.pickInfo.hit && pointerInfo.pickInfo.pickedMesh && pointerInfo.pickInfo.pickedPoint && pointerInfo.pickInfo.ray && pickPredicate(pointerInfo.pickInfo.pickedMesh)) {
-                    this._startDrag((<PointerEvent>pointerInfo.event).pointerId, pointerInfo.pickInfo.ray, pointerInfo.pickInfo.pickedPoint);
+                    this._startDrag((<IPointerEvent>pointerInfo.event).pointerId, pointerInfo.pickInfo.ray, pointerInfo.pickInfo.pickedPoint);
                 }
             } else if (pointerInfo.type == PointerEventTypes.POINTERUP) {
-                if (this.startAndReleaseDragOnPointerEvents && this.currentDraggingPointerId == (<PointerEvent>pointerInfo.event).pointerId) {
+                if (this.startAndReleaseDragOnPointerEvents && this.currentDraggingPointerId == (<IPointerEvent>pointerInfo.event).pointerId) {
                     this.releaseDrag();
                 }
             } else if (pointerInfo.type == PointerEventTypes.POINTERMOVE) {
-                var pointerId = (<PointerEvent>pointerInfo.event).pointerId;
+                var pointerId = (<IPointerEvent>pointerInfo.event).pointerId;
 
                 // If drag was started with anyMouseID specified, set pointerID to the next mouse that moved
                 if (this.currentDraggingPointerId === PointerDragBehavior._AnyMouseId && pointerId !== PointerDragBehavior._AnyMouseId) {
-                    const evt = <PointerEvent>pointerInfo.event;
+                    const evt = <IPointerEvent>pointerInfo.event;
                     const isMouseEvent = evt.pointerType === "mouse" || (!this._scene.getEngine().hostInformation.isMobile && evt instanceof MouseEvent);
                     if (isMouseEvent) {
                         if (this._lastPointerRay[this.currentDraggingPointerId]) {

--- a/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -68,7 +68,7 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
             // IE: event.wheelDelta
             // Firefox: event.detail (inverted)
             var wheelDelta = Math.max(-1, Math.min(1,
-                (event.deltaY || (<any>event).wheelDelta || -event.detail)));
+                (event.deltaY || (<any>event).wheelDelta || -(<any>event).detail)));
             if (this.wheelDeltaPercentage) {
                 console.assert((<number>(<unknown>this.axisControlRadius) +
                     <number>(<unknown>this.axisControlHeight) +

--- a/src/Cameras/VR/vrExperienceHelper.ts
+++ b/src/Cameras/VR/vrExperienceHelper.ts
@@ -37,6 +37,7 @@ import { WebXRState } from '../../XR/webXRTypes';
 import { CreateCylinder } from "../../Meshes/Builders/cylinderBuilder";
 import { CreateTorus } from "../../Meshes/Builders/torusBuilder";
 import { CreateGround } from "../../Meshes/Builders/groundBuilder";
+import { IPointerEvent } from "../../Events/deviceInputEvents";
 
 /**
  * Options to modify the vr teleportation behavior.
@@ -985,7 +986,7 @@ export class VRExperienceHelper {
         // Allow clicking in the vrDeviceOrientationCamera
         scene.onPointerObservable.add((e) => {
             if (this._interactionsEnabled) {
-                if (scene.activeCamera === this.vrDeviceOrientationCamera && (e.event as PointerEvent).pointerType === "mouse") {
+                if (scene.activeCamera === this.vrDeviceOrientationCamera && (e.event as IPointerEvent).pointerType === "mouse") {
                     if (e.type === PointerEventTypes.POINTERDOWN) {
                         this._cameraGazer._selectionPointerDown();
                     } else if (e.type === PointerEventTypes.POINTERUP) {

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -1,9 +1,8 @@
 import { Constants } from "../../Engines/constants";
 import { EventConstants, IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
-import { DeviceType, PointerInput } from "../InputDevices/deviceEnums";
+import { DeviceType, NativePointerInput, PointerInput } from "../InputDevices/deviceEnums";
 import { IDeviceInputSystem } from "../InputDevices/inputInterfaces";
-import { NativePointerInput } from "../InputDevices/nativeDeviceInputSystem";
 
 /**
  * Class to wrap DeviceInputSystem data into an event object

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -106,20 +106,24 @@ export class DeviceEventFactory {
         const evt = this._createEvent(elementToAttachTo);
         const pointerX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Horizontal);
         const pointerY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Vertical);
-        // If dealing with a change to the delta, grab values for event init
-        const movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.DeltaHorizontal);
-        const movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.DeltaVertical);
-        // Get offsets from container
-        const offsetX = inputIndex === PointerInput.DeltaHorizontal && elementToAttachTo ? movementX! - elementToAttachTo.getBoundingClientRect().x : 0;
-        const offsetY = inputIndex === PointerInput.DeltaVertical && elementToAttachTo ? movementY! - elementToAttachTo.getBoundingClientRect().y : 0;
+
+        // Handle offsets/deltas based on existence of HTMLElement
+        if (elementToAttachTo) {
+            evt.movementX = 0;
+            evt.movementY = 0;
+            evt.offsetX = evt.movementX - elementToAttachTo.getBoundingClientRect().x;
+            evt.offsetY = evt.movementY - elementToAttachTo.getBoundingClientRect().y;
+        }
+        else {
+            evt.movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, 10); // DeltaHorizontal
+            evt.movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, 11); // DeltaVertical
+            evt.offsetX = 0;
+            evt.offsetY = 0;
+        }
         this._checkNonCharacterKeys(evt, deviceInputSystem);
 
         evt.clientX = pointerX;
         evt.clientY = pointerY;
-        evt.movementX = movementX;
-        evt.movementY = movementY;
-        evt.offsetX = offsetX;
-        evt.offsetY = offsetY;
         evt.x = pointerX;
         evt.y = pointerY;
 

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -3,6 +3,7 @@ import { EventConstants, IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceType, PointerInput } from "../InputDevices/deviceEnums";
 import { IDeviceInputSystem } from "../InputDevices/inputInterfaces";
+import { NativePointerInput } from "../InputDevices/nativeDeviceInputSystem";
 
 /**
  * Class to wrap DeviceInputSystem data into an event object
@@ -115,8 +116,8 @@ export class DeviceEventFactory {
             evt.offsetY = evt.movementY - elementToAttachTo.getBoundingClientRect().y;
         }
         else {
-            evt.movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, 10); // DeltaHorizontal
-            evt.movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, 11); // DeltaVertical
+            evt.movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaHorizontal); // DeltaHorizontal
+            evt.movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaVertical); // DeltaVertical
             evt.offsetX = 0;
             evt.offsetY = 0;
         }

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -1,5 +1,5 @@
 import { Constants } from "../../Engines/constants";
-import { EventConstants, IEvent } from "../../Events/deviceInputEvents";
+import { EventConstants, IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceType, PointerInput } from "../InputDevices/deviceEnums";
 import { IDeviceInputSystem } from "../InputDevices/inputInterfaces";
@@ -19,7 +19,7 @@ export class DeviceEventFactory {
      * @param elementToAttachTo HTMLElement to reference as target for inputs
      * @returns IEvent object
      */
-    public static CreateDeviceEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): IEvent {
+    public static CreateDeviceEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): IUIEvent {
         switch (deviceType) {
             case DeviceType.Keyboard:
                 return this._createKeyboardEvent(inputIndex, currentState, deviceInputSystem, elementToAttachTo);
@@ -49,10 +49,12 @@ export class DeviceEventFactory {
         const evt = this._createMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
 
         if (deviceType === DeviceType.Mouse) {
+            evt.deviceType = DeviceType.Mouse;
             evt.pointerId = 1;
             evt.pointerType = "mouse";
         }
         else {
+            evt.deviceType = DeviceType.Touch;
             evt.pointerId = deviceSlot;
             evt.pointerType = "touch";
         }
@@ -135,6 +137,7 @@ export class DeviceEventFactory {
     private static _createKeyboardEvent(inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): any {
         const evt = this._createEvent(elementToAttachTo);
         this._checkNonCharacterKeys(evt, deviceInputSystem);
+        evt.deviceType = DeviceType.Keyboard;
 
         evt.type = currentState === 1 ? "keydown" : "keyup";
         evt.key = String.fromCharCode(inputIndex);

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -17,7 +17,7 @@ export class DeviceEventFactory {
      * @param currentState Current value for given input
      * @param deviceInputSystem Reference to DeviceInputSystem
      * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IEvent object
+     * @returns IUIEvent object
      */
     public static CreateDeviceEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): IUIEvent {
         switch (deviceType) {
@@ -43,7 +43,7 @@ export class DeviceEventFactory {
      * @param currentState Current value for given input
      * @param deviceInputSystem Reference to DeviceInputSystem
      * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IEvent object (Pointer)
+     * @returns IUIEvent object (Pointer)
      */
     private static _createPointerEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): any {
         const evt = this._createMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
@@ -78,7 +78,7 @@ export class DeviceEventFactory {
      * @param currentState Current value for given input
      * @param deviceInputSystem Reference to DeviceInputSystem
      * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IEvent object (Wheel)
+     * @returns IUIEvent object (Wheel)
      */
     private static _createWheelEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo: any): any {
         const evt = this._createMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
@@ -100,7 +100,7 @@ export class DeviceEventFactory {
      * @param currentState Current value for given input
      * @param deviceInputSystem Reference to DeviceInputSystem
      * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IEvent object (Mouse)
+     * @returns IUIEvent object (Mouse)
      */
     private static _createMouseEvent(deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): any {
         const evt = this._createEvent(elementToAttachTo);
@@ -123,6 +123,10 @@ export class DeviceEventFactory {
         evt.x = pointerX;
         evt.y = pointerY;
 
+        evt.deviceType = deviceType;
+        evt.deviceSlot = deviceSlot;
+        evt.inputIndex = inputIndex;
+
         return evt;
     }
 
@@ -138,6 +142,8 @@ export class DeviceEventFactory {
         const evt = this._createEvent(elementToAttachTo);
         this._checkNonCharacterKeys(evt, deviceInputSystem);
         evt.deviceType = DeviceType.Keyboard;
+        evt.deviceSlot = 0;
+        evt.inputIndex = inputIndex;
 
         evt.type = currentState === 1 ? "keydown" : "keyup";
         evt.key = String.fromCharCode(inputIndex);

--- a/src/DeviceInput/Helpers/eventFactory.ts
+++ b/src/DeviceInput/Helpers/eventFactory.ts
@@ -107,8 +107,8 @@ export class DeviceEventFactory {
         const pointerX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Horizontal);
         const pointerY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Vertical);
         // If dealing with a change to the delta, grab values for event init
-        const movementX = inputIndex === PointerInput.DeltaHorizontal ? currentState : 0;
-        const movementY = inputIndex === PointerInput.DeltaVertical ? currentState : 0;
+        const movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.DeltaHorizontal);
+        const movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.DeltaVertical);
         // Get offsets from container
         const offsetX = inputIndex === PointerInput.DeltaHorizontal && elementToAttachTo ? movementX! - elementToAttachTo.getBoundingClientRect().x : 0;
         const offsetY = inputIndex === PointerInput.DeltaVertical && elementToAttachTo ? movementY! - elementToAttachTo.getBoundingClientRect().y : 0;

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -49,6 +49,34 @@ export enum PointerInput {
     Move = 12,
 }
 
+/** @hidden */
+export enum NativePointerInput {
+    /** Horizontal Axis */
+    Horizontal = PointerInput.Horizontal,
+    /** Vertical Axis */
+    Vertical = 1,
+    /** Left Click or Touch */
+    LeftClick = 2,
+    /** Middle Click */
+    MiddleClick = 3,
+    /** Right Click */
+    RightClick = 4,
+    /** Browser Back */
+    BrowserBack = 5,
+    /** Browser Forward */
+    BrowserForward = 6,
+    /** Mouse Wheel X */
+    MouseWheelX = 7,
+    /** Mouse Wheel Y */
+    MouseWheelY = 8,
+    /** Mouse Wheel Z */
+    MouseWheelZ = 9,
+    /** Delta X */
+    DeltaHorizontal = 10,
+    /** Delta Y */
+    DeltaVertical = 11,
+}
+
 /**
  * Enum for Dual Shock Gamepad
  */

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -25,9 +25,9 @@ export enum DeviceType {
  * Enum for All Pointers (Touch/Mouse)
  */
 export enum PointerInput {
-    /** Horizontal Axis */
+    /** Horizontal Axis (Not used in events/observables; only in polling) */
     Horizontal = 0,
-    /** Vertical Axis */
+    /** Vertical Axis (Not used in events/observables; only in polling) */
     Vertical = 1,
     /** Left Click or Touch */
     LeftClick = 2,
@@ -45,7 +45,7 @@ export enum PointerInput {
     MouseWheelY = 8,
     /** Mouse Wheel Z */
     MouseWheelZ = 9,
-    /** Move Catch-all (Only used in Observable) */
+    /** Used in events/observables to identify if x/y changes occurred */
     Move = 12,
 }
 

--- a/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -45,11 +45,7 @@ export enum PointerInput {
     MouseWheelY = 8,
     /** Mouse Wheel Z */
     MouseWheelZ = 9,
-    /** Delta X */
-    DeltaHorizontal = 10,
-    /** Delta Y */
-    DeltaVertical = 11,
-    /** Move Catch-all */
+    /** Move Catch-all (Only used in Observable) */
     Move = 12,
 }
 

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -4,7 +4,6 @@ import { DeviceInput } from './deviceTypes';
 import { IDeviceInputSystem } from './inputInterfaces';
 import { IUIEvent } from '../../Events/deviceInputEvents';
 
-/** @hidden */
 type DeviceEventInput<T extends DeviceType> =
     T extends DeviceType.Keyboard | DeviceType.Generic ? number :
     T extends DeviceType.Mouse | DeviceType.Touch ? Exclude<PointerInput, PointerInput.Horizontal | PointerInput.Vertical> :

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -1,8 +1,14 @@
-import { DeviceType } from './deviceEnums';
+import { DeviceType, PointerInput } from './deviceEnums';
 import { Observable } from '../../Misc/observable';
 import { DeviceInput } from './deviceTypes';
 import { IDeviceInputSystem } from './inputInterfaces';
 import { IUIEvent } from '../../Events/deviceInputEvents';
+
+/** @hidden */
+export type DeviceEventInput<T extends DeviceType> =
+    T extends DeviceType.Keyboard | DeviceType.Generic ? number :
+    T extends DeviceType.Mouse | DeviceType.Touch ? Exclude<PointerInput, PointerInput.Horizontal | PointerInput.Vertical> :
+    never;
 
 /**
  * Class that handles all input for a specific device
@@ -12,7 +18,7 @@ export class DeviceSource<T extends DeviceType> {
     /**
      * Observable to handle device input changes per device
      */
-    public readonly onInputChangedObservable = new Observable<IUIEvent>();
+    public readonly onInputChangedObservable = new Observable<IUIEvent & { inputIndex: DeviceEventInput<T> }>();
 
     // Private Members
     private readonly _deviceInputSystem: IDeviceInputSystem;

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -5,7 +5,7 @@ import { IDeviceInputSystem } from './inputInterfaces';
 import { IUIEvent } from '../../Events/deviceInputEvents';
 
 /** @hidden */
-export type DeviceEventInput<T extends DeviceType> =
+type DeviceEventInput<T extends DeviceType> =
     T extends DeviceType.Keyboard | DeviceType.Generic ? number :
     T extends DeviceType.Mouse | DeviceType.Touch ? Exclude<PointerInput, PointerInput.Horizontal | PointerInput.Vertical> :
     never;

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -1,7 +1,8 @@
 import { DeviceType } from './deviceEnums';
 import { Observable } from '../../Misc/observable';
 import { DeviceInput } from './deviceTypes';
-import { IDeviceEvent, IDeviceInputSystem } from './inputInterfaces';
+import { IDeviceInputSystem } from './inputInterfaces';
+import { IUIEvent } from '../../Events/deviceInputEvents';
 
 /**
  * Class that handles all input for a specific device
@@ -11,7 +12,7 @@ import { IDeviceEvent, IDeviceInputSystem } from './inputInterfaces';
     /**
      * Observable to handle device input changes per device
      */
-    public readonly onInputChangedObservable = new Observable<IDeviceEvent>();
+    public readonly onInputChangedObservable = new Observable<IUIEvent>();
 
     // Private Members
     private readonly _deviceInputSystem: IDeviceInputSystem;

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -7,7 +7,7 @@ import { IUIEvent } from '../../Events/deviceInputEvents';
 /**
  * Class that handles all input for a specific device
  */
- export class DeviceSource<T extends DeviceType> {
+export class DeviceSource<T extends DeviceType> {
     // Public Members
     /**
      * Observable to handle device input changes per device

--- a/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/src/DeviceInput/InputDevices/deviceSource.ts
@@ -4,6 +4,9 @@ import { DeviceInput } from './deviceTypes';
 import { IDeviceInputSystem } from './inputInterfaces';
 import { IUIEvent } from '../../Events/deviceInputEvents';
 
+/**
+ * Subset of DeviceInput that only handles pointers and keyboard
+ */
 type DeviceEventInput<T extends DeviceType> =
     T extends DeviceType.Keyboard | DeviceType.Generic ? number :
     T extends DeviceType.Mouse | DeviceType.Touch ? Exclude<PointerInput, PointerInput.Horizontal | PointerInput.Vertical> :

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -3,7 +3,7 @@ import { DeviceType } from './deviceEnums';
 import { Nullable } from '../../types';
 import { Observable, Observer } from '../../Misc/observable';
 import { DeviceSource } from './deviceSource';
-import { InternalDeviceSourceManager } from './internalDeviceSourceManager';
+import { InternalDeviceSourceManager, IObservableManager } from './internalDeviceSourceManager';
 import { IDisposable } from '../../scene';
 import { ThinEngine } from '../../Engines/thinEngine';
 import { IUIEvent } from '../../Events/deviceInputEvents';
@@ -11,7 +11,7 @@ import { IUIEvent } from '../../Events/deviceInputEvents';
 /**
  * Class to keep track of devices
  */
-export class DeviceSourceManager implements IDisposable {
+export class DeviceSourceManager implements IDisposable, IObservableManager {
     // Public Members
     /**
      * Observable to be triggered when after a device is connected, any new observers added will be triggered against already connected devices

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -88,7 +88,7 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
 
         this._onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => {
             this._devices[deviceType][deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
-        }
+        };
 
         if (!this._engine._deviceSourceManager) {
             this._engine._deviceSourceManager = new InternalDeviceSourceManager(engine);

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -149,7 +149,7 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
 
     /** @hidden */
     public _onInputChanged(deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void {
-        this._devices[deviceType][deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
+        this._devices[deviceType]?.[deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
     }
 
     // Private Functions

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -17,10 +17,7 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      * Observable to be triggered when after a device is connected, any new observers added will be triggered against already connected devices
      */
     public readonly onDeviceConnectedObservable: Observable<DeviceSource<DeviceType>>;
-    /**
-     * Observable to be triggered when a device's input is changed
-     */
-    public readonly onInputChangedObservable: Observable<IUIEvent>;
+
     /**
      * Observable to be triggered when after a device is disconnected
      */
@@ -29,10 +26,8 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
     // Private Members
     private _engine: Engine;
     private _onDisposeObserver: Nullable<Observer<ThinEngine>>;
-
-    private _getDeviceSource: <T extends DeviceType>(deviceType: T, deviceSlot?: number) => Nullable<DeviceSource<T>>;
-    private _getDeviceSources: <T extends DeviceType>(deviceType: T) => ReadonlyArray<DeviceSource<T>>;
-    private _getDevices: () => ReadonlyArray<DeviceSource<DeviceType>>;
+    private readonly _devices: Array<Array<DeviceSource<DeviceType>>>;
+    private readonly _firstDevice: Array<number>;
 
     // Public Functions
     /**
@@ -42,16 +37,27 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      * @returns DeviceSource
      */
     public getDeviceSource<T extends DeviceType>(deviceType: T, deviceSlot?: number): Nullable<DeviceSource<T>> {
-        return this._getDeviceSource(deviceType, deviceSlot);
-    }
+        if (deviceSlot === undefined) {
+            if (this._firstDevice[deviceType] === undefined) {
+                return null;
+            }
 
+            deviceSlot = this._firstDevice[deviceType];
+        }
+
+        if (!this._devices[deviceType] || this._devices[deviceType][deviceSlot] === undefined) {
+            return null;
+        }
+
+        return this._devices[deviceType][deviceSlot];
+    }
     /**
      * Gets an array of DeviceSource objects for a given device type
      * @param deviceType Type of Device
      * @returns All available DeviceSources of a given type
      */
     public getDeviceSources<T extends DeviceType>(deviceType: T): ReadonlyArray<DeviceSource<T>> {
-        return this._getDeviceSources(deviceType);
+        return this._devices[deviceType].filter((source) => { return !!source; });
     }
 
     /**
@@ -59,7 +65,12 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      * @returns All available DeviceSources
      */
     public getDevices(): ReadonlyArray<DeviceSource<DeviceType>> {
-        return this._getDevices();
+        const deviceArray = new Array<DeviceSource<DeviceType>>();
+        this._devices.forEach((deviceSet) => {
+            deviceArray.push.apply(deviceArray, deviceSet);
+        });
+
+        return deviceArray;
     }
 
     /**
@@ -67,7 +78,11 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      * @param engine Used to get canvas (if applicable)
      */
     constructor(engine: Engine) {
+        const numberOfDeviceTypes = Object.keys(DeviceType).length / 2;
+        this._devices = new Array<Array<DeviceSource<DeviceType>>>(numberOfDeviceTypes);
+        this._firstDevice = new Array<number>(numberOfDeviceTypes);
         this._engine = engine;
+
         if (!this._engine._deviceSourceManager) {
             this._engine._deviceSourceManager = new InternalDeviceSourceManager(engine);
         }
@@ -79,14 +94,9 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
                 this.onDeviceConnectedObservable.notifyObserver(observer, device);
             });
         });
-        this.onInputChangedObservable = new Observable<IUIEvent>();
         this.onDeviceDisconnectedObservable = new Observable<DeviceSource<DeviceType>>();
 
         this._engine._deviceSourceManager.registerManager(this);
-
-        this._getDeviceSource = this._engine._deviceSourceManager.getDeviceSource;
-        this._getDeviceSources = this._engine._deviceSourceManager.getDeviceSources;
-        this._getDevices = this._engine._deviceSourceManager.getDevices;
 
         this._onDisposeObserver = engine.onDisposeObservable.add(() => {
             this.dispose();
@@ -99,12 +109,7 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
     public dispose(): void {
         // Null out observable refs
         this.onDeviceConnectedObservable.clear();
-        this.onInputChangedObservable.clear();
         this.onDeviceDisconnectedObservable.clear();
-        // Null out function refs
-        this._getDeviceSource = () => { return null; };
-        this._getDeviceSources = () => { return []; };
-        this._getDevices = () => { return []; };
 
         if (this._engine._deviceSourceManager) {
             this._engine._deviceSourceManager.unregisterManager(this);
@@ -114,5 +119,63 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
             }
         }
         this._engine.onDisposeObservable.remove(this._onDisposeObserver);
+    }
+
+    // Hidden Functions
+    /** @hidden */
+    public _onInputChanged (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void {
+        this._devices[deviceType][deviceSlot].onInputChangedObservable.notifyObservers(eventData);
+    }
+
+    /** @hidden */
+    public _addDevice(deviceSource: DeviceSource<DeviceType>): void {
+        if (!this._devices[deviceSource.deviceType]) {
+            this._devices[deviceSource.deviceType] = new Array<DeviceSource<DeviceType>>();
+        }
+
+        if (!this._devices[deviceSource.deviceType][deviceSource.deviceSlot]) {
+            this._devices[deviceSource.deviceType][deviceSource.deviceSlot] = deviceSource;
+            this._updateFirstDevices(deviceSource.deviceType);
+        }
+
+        this.onDeviceConnectedObservable.notifyObservers(deviceSource);
+    }
+
+    /** @hidden */
+    public _removeDevice(deviceType: DeviceType, deviceSlot: number): void {
+        const deviceSource = this._devices[deviceType]?.[deviceSlot]; // Grab local reference to use before removing from devices
+        this.onDeviceDisconnectedObservable.notifyObservers(deviceSource);
+        if (this._devices[deviceType]?.[deviceSlot]) {
+            delete this._devices[deviceType][deviceSlot];
+        }
+        // Even if we don't delete a device, we should still check for the first device as things may have gotten out of sync.
+        this._updateFirstDevices(deviceType);
+    }
+
+    // Private Functions
+    private _updateFirstDevices(type: DeviceType): void {
+        switch (type) {
+            case DeviceType.Keyboard:
+            case DeviceType.Mouse:
+                this._firstDevice[type] = 0;
+                break;
+            case DeviceType.Touch:
+            case DeviceType.DualSense:
+            case DeviceType.DualShock:
+            case DeviceType.Xbox:
+            case DeviceType.Switch:
+            case DeviceType.Generic:
+                delete this._firstDevice[type];
+                const devices = this._devices[type];
+                if (devices) {
+                    for (let i = 0; i < devices.length; i++) {
+                        if (devices[i]) {
+                            this._firstDevice[type] = i;
+                            break;
+                        }
+                    }
+                }
+                break;
+        }
     }
 }

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -2,11 +2,11 @@ import { Engine } from '../../Engines/engine';
 import { DeviceType } from './deviceEnums';
 import { Nullable } from '../../types';
 import { Observable, Observer } from '../../Misc/observable';
-import { IDeviceEvent } from './inputInterfaces';
 import { DeviceSource } from './deviceSource';
 import { InternalDeviceSourceManager } from './internalDeviceSourceManager';
 import { IDisposable } from '../../scene';
 import { ThinEngine } from '../../Engines/thinEngine';
+import { IUIEvent } from '../../Events/deviceInputEvents';
 
 /**
  * Class to keep track of devices
@@ -20,7 +20,7 @@ export class DeviceSourceManager implements IDisposable {
     /**
      * Observable to be triggered when a device's input is changed
      */
-    public readonly onInputChangedObservable: Observable<IDeviceEvent>;
+    public readonly onInputChangedObservable: Observable<IUIEvent>;
     /**
      * Observable to be triggered when after a device is disconnected
      */
@@ -79,7 +79,7 @@ export class DeviceSourceManager implements IDisposable {
                 this.onDeviceConnectedObservable.notifyObserver(observer, device);
             });
         });
-        this.onInputChangedObservable = new Observable<IDeviceEvent>();
+        this.onInputChangedObservable = new Observable<IUIEvent>();
         this.onDeviceDisconnectedObservable = new Observable<DeviceSource<DeviceType>>();
 
         this._engine._deviceSourceManager.registerManager(this);

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -23,6 +23,9 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      */
     public readonly onDeviceDisconnectedObservable: Observable<DeviceSource<DeviceType>>;
 
+    /** @hidden */
+    public readonly _onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => void;
+
     // Private Members
     private _engine: Engine;
     private _onDisposeObserver: Nullable<Observer<ThinEngine>>;
@@ -83,6 +86,10 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
         this._firstDevice = new Array<number>(numberOfDeviceTypes);
         this._engine = engine;
 
+        this._onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => {
+            this._devices[deviceType][deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
+        }
+
         if (!this._engine._deviceSourceManager) {
             this._engine._deviceSourceManager = new InternalDeviceSourceManager(engine);
         }
@@ -122,11 +129,6 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
     }
 
     // Hidden Functions
-    /** @hidden */
-    public _onInputChanged (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void {
-        this._devices[deviceType][deviceSlot].onInputChangedObservable.notifyObservers(eventData);
-    }
-
     /** @hidden */
     public _addDevice(deviceSource: DeviceSource<DeviceType>): void {
         if (!this._devices[deviceSource.deviceType]) {

--- a/src/DeviceInput/InputDevices/deviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/deviceSourceManager.ts
@@ -23,9 +23,6 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      */
     public readonly onDeviceDisconnectedObservable: Observable<DeviceSource<DeviceType>>;
 
-    /** @hidden */
-    public readonly _onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => void;
-
     // Private Members
     private _engine: Engine;
     private _onDisposeObserver: Nullable<Observer<ThinEngine>>;
@@ -69,9 +66,9 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
      */
     public getDevices(): ReadonlyArray<DeviceSource<DeviceType>> {
         const deviceArray = new Array<DeviceSource<DeviceType>>();
-        this._devices.forEach((deviceSet) => {
+        for (const deviceSet of this._devices) {
             deviceArray.push.apply(deviceArray, deviceSet);
-        });
+        }
 
         return deviceArray;
     }
@@ -85,10 +82,6 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
         this._devices = new Array<Array<DeviceSource<DeviceType>>>(numberOfDeviceTypes);
         this._firstDevice = new Array<number>(numberOfDeviceTypes);
         this._engine = engine;
-
-        this._onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => {
-            this._devices[deviceType][deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
-        };
 
         if (!this._engine._deviceSourceManager) {
             this._engine._deviceSourceManager = new InternalDeviceSourceManager(engine);
@@ -152,6 +145,11 @@ export class DeviceSourceManager implements IDisposable, IObservableManager {
         }
         // Even if we don't delete a device, we should still check for the first device as things may have gotten out of sync.
         this._updateFirstDevices(deviceType);
+    }
+
+    /** @hidden */
+    public _onInputChanged(deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void {
+        this._devices[deviceType][deviceSlot]?.onInputChangedObservable.notifyObservers(eventData);
     }
 
     // Private Functions

--- a/src/DeviceInput/InputDevices/deviceTypes.ts
+++ b/src/DeviceInput/InputDevices/deviceTypes.ts
@@ -5,7 +5,7 @@ import { DeviceType, PointerInput, DualShockInput, XboxInput, SwitchInput, DualS
  */
 export type DeviceInput<T extends DeviceType> =
     T extends DeviceType.Keyboard | DeviceType.Generic ? number :
-    T extends DeviceType.Mouse | DeviceType.Touch ? PointerInput :
+    T extends DeviceType.Mouse | DeviceType.Touch ? Exclude<PointerInput, PointerInput.Move> :
     T extends DeviceType.DualShock ? DualShockInput :
     T extends DeviceType.Xbox ? XboxInput :
     T extends DeviceType.Switch ? SwitchInput :

--- a/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -20,7 +20,7 @@ export interface INativeInput extends IDisposable {
     /**
      * Callback for when input is changed on a device
      */
-    onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>) => void;
+    onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>) => void;
 
     /**
      * Checks for current device input value, given an id and input index.

--- a/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -1,69 +1,7 @@
-import { IEvent } from "../../Events/deviceInputEvents";
+import { IUIEvent } from "../../Events/deviceInputEvents";
 import { IDisposable } from "../../scene";
 import { Nullable } from "../../types";
 import { DeviceType } from "./deviceEnums";
-
-/**
- * Interface for Observables in DeviceInputSystem
- */
-export interface IDeviceEvent extends IEvent {
-    /**
-     * Device type
-     */
-    deviceType: DeviceType;
-    /**
-     * Device slot
-     */
-    deviceSlot: number;
-    /**
-     * Input array index
-     */
-    inputIndex: number;
-    /**
-     * Previous state of given input
-     */
-    previousState: Nullable<number>;
-    /**
-     * Current state of given input
-     */
-    currentState: Nullable<number>;
-}
-
-/**
- * Interface for NativeInput object
- */
-export interface INativeInput extends IDisposable {
-    /**
-     * Callback for when a device is connected
-     */
-    onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
-
-    /**
-     * Callback for when a device is disconnected
-     */
-    onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
-
-    /**
-     * Callback for when input is changed on a device
-     */
-    onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: any) => void;
-
-    /**
-     * Checks for current device input value, given an id and input index.
-     * @param deviceType Type of device
-     * @param deviceSlot "Slot" or index that device is referenced in
-     * @param inputIndex Id of input to be checked
-     * @returns Current value of input
-     */
-    pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): number;
-
-    /**
-     * Check for a specific device in the DeviceInputSystem
-     * @param deviceType Type of device to check for
-     * @returns bool with status of device's existence
-     */
-    isDeviceAvailable(deviceType: DeviceType): boolean;
-}
 
 /**
  * Interface for DeviceInputSystem implementations (JS and Native)
@@ -83,7 +21,7 @@ export interface IDeviceInputSystem extends IDisposable {
     /**
      * Callback for when an input is changed
      */
-    onInputChanged: (deviceEvent: IDeviceEvent) => void;
+     onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => void;
 
     // Functions
     /**

--- a/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -1,4 +1,3 @@
-import { IUIEvent } from "../../Events/deviceInputEvents";
 import { IDisposable } from "../../scene";
 import { Nullable } from "../../types";
 import { DeviceType } from "./deviceEnums";
@@ -6,7 +5,7 @@ import { DeviceType } from "./deviceEnums";
 /**
  * Interface for NativeInput object
  */
- export interface INativeInput extends IDisposable {
+export interface INativeInput extends IDisposable {
     /**
      * Callback for when a device is connected
      */
@@ -39,6 +38,42 @@ import { DeviceType } from "./deviceEnums";
     isDeviceAvailable(deviceType: DeviceType): boolean;
 }
 
+export interface IDeviceEvent {
+    // Properties
+
+    /**
+     * Input array index
+     */
+    inputIndex: number;
+
+    /**
+     * Current target for an event
+     */
+    currentTarget?: any;
+
+    /**
+     * Alias for target
+     * @deprecated
+     */
+    srcElement?: any;
+
+    /**
+     * Type of event
+     */
+    type: string;
+
+    /**
+     * Reference to object where object was dispatched
+     */
+    target: any;
+
+    // Methods
+    /**
+     * Tells user agent what to do when not explicitly handled
+     */
+    preventDefault: () => void;
+}
+
 /**
  * Interface for DeviceInputSystem implementations (JS and Native)
  */
@@ -57,7 +92,7 @@ export interface IDeviceInputSystem extends IDisposable {
     /**
      * Callback for when an input is changed
      */
-     onInputChanged: (eventData: IUIEvent) => void;
+    onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => void;
 
     // Functions
     /**

--- a/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -1,3 +1,4 @@
+import { IUIEvent } from "../../Events/deviceInputEvents";
 import { IDisposable } from "../../scene";
 import { Nullable } from "../../types";
 import { DeviceType } from "./deviceEnums";
@@ -38,42 +39,6 @@ export interface INativeInput extends IDisposable {
     isDeviceAvailable(deviceType: DeviceType): boolean;
 }
 
-export interface IDeviceEvent {
-    // Properties
-
-    /**
-     * Input array index
-     */
-    inputIndex: number;
-
-    /**
-     * Current target for an event
-     */
-    currentTarget?: any;
-
-    /**
-     * Alias for target
-     * @deprecated
-     */
-    srcElement?: any;
-
-    /**
-     * Type of event
-     */
-    type: string;
-
-    /**
-     * Reference to object where object was dispatched
-     */
-    target: any;
-
-    // Methods
-    /**
-     * Tells user agent what to do when not explicitly handled
-     */
-    preventDefault: () => void;
-}
-
 /**
  * Interface for DeviceInputSystem implementations (JS and Native)
  */
@@ -92,7 +57,7 @@ export interface IDeviceInputSystem extends IDisposable {
     /**
      * Callback for when an input is changed
      */
-    onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => void;
+    onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => void;
 
     // Functions
     /**

--- a/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -4,6 +4,42 @@ import { Nullable } from "../../types";
 import { DeviceType } from "./deviceEnums";
 
 /**
+ * Interface for NativeInput object
+ */
+ export interface INativeInput extends IDisposable {
+    /**
+     * Callback for when a device is connected
+     */
+    onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void;
+
+    /**
+     * Callback for when a device is disconnected
+     */
+    onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
+
+    /**
+     * Callback for when input is changed on a device
+     */
+    onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>) => void;
+
+    /**
+     * Checks for current device input value, given an id and input index.
+     * @param deviceType Type of device
+     * @param deviceSlot "Slot" or index that device is referenced in
+     * @param inputIndex Id of input to be checked
+     * @returns Current value of input
+     */
+    pollInput(deviceType: DeviceType, deviceSlot: number, inputIndex: number): number;
+
+    /**
+     * Check for a specific device in the DeviceInputSystem
+     * @param deviceType Type of device to check for
+     * @returns bool with status of device's existence
+     */
+    isDeviceAvailable(deviceType: DeviceType): boolean;
+}
+
+/**
  * Interface for DeviceInputSystem implementations (JS and Native)
  */
 export interface IDeviceInputSystem extends IDisposable {
@@ -21,7 +57,7 @@ export interface IDeviceInputSystem extends IDisposable {
     /**
      * Callback for when an input is changed
      */
-     onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => void;
+     onInputChanged: (eventData: IUIEvent) => void;
 
     // Functions
     /**

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -70,6 +70,8 @@ export class InternalDeviceSourceManager implements IDisposable {
                 for (const manager of this._registeredManagers) {
                     manager.onInputChangedObservable.notifyObservers(eventData);
                 }
+
+                this._devices[eventData.deviceType][eventData.deviceSlot].onInputChangedObservable.notifyObservers(eventData);
             }
         };
     }

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -65,7 +65,7 @@ export class InternalDeviceSourceManager implements IDisposable {
             }
         };
 
-        this._deviceInputSystem.onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => {
+        this._deviceInputSystem.onInputChanged = (eventData: IUIEvent) => {
             if (eventData) {
                 for (const manager of this._registeredManagers) {
                     manager.onInputChangedObservable.notifyObservers(eventData);

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -2,12 +2,13 @@ import { IDisposable } from '../../scene';
 import { DeviceType } from './deviceEnums';
 import { Nullable } from '../../types';
 import { Observable } from '../../Misc/observable';
-import { IDeviceEvent, IDeviceInputSystem } from './inputInterfaces';
+import { IDeviceInputSystem } from './inputInterfaces';
 import { NativeDeviceInputSystem } from './nativeDeviceInputSystem';
 import { WebDeviceInputSystem } from './webDeviceInputSystem';
 import { DeviceSource } from './deviceSource';
 import { INative } from '../../Engines/Native/nativeInterfaces';
 import { Engine } from '../../Engines/engine';
+import { IUIEvent } from '../../Events/deviceInputEvents';
 
 declare const _native: INative;
 
@@ -21,7 +22,7 @@ declare module "../../Engines/engine" {
 /** @hidden */
 export interface IObservableManager {
     onDeviceConnectedObservable: Observable<DeviceSource<DeviceType>>;
-    onInputChangedObservable: Observable<IDeviceEvent>;
+    onInputChangedObservable: Observable<IUIEvent>;
     onDeviceDisconnectedObservable: Observable<DeviceSource<DeviceType>>;
 }
 
@@ -64,9 +65,11 @@ export class InternalDeviceSourceManager implements IDisposable {
             }
         };
 
-        this._deviceInputSystem.onInputChanged = (deviceEvent) => {
-            for (const manager of this._registeredManagers) {
-                manager.onInputChangedObservable.notifyObservers(deviceEvent);
+        this._deviceInputSystem.onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => {
+            if (eventData) {
+                for (const manager of this._registeredManagers) {
+                    manager.onInputChangedObservable.notifyObservers(eventData);
+                }
             }
         };
     }

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -24,7 +24,7 @@ export interface IObservableManager {
     onDeviceDisconnectedObservable: Observable<DeviceSource<DeviceType>>;
 
     // Functions
-    _onInputChanged (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void;
+    _onInputChanged(deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent): void;
     _addDevice(deviceSource: DeviceSource<DeviceType>): void;
     _removeDevice(deviceType: DeviceType, deviceSlot: number): void;
 }

--- a/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
+++ b/src/DeviceInput/InputDevices/internalDeviceSourceManager.ts
@@ -2,7 +2,7 @@ import { IDisposable } from '../../scene';
 import { DeviceType } from './deviceEnums';
 import { Nullable } from '../../types';
 import { Observable } from '../../Misc/observable';
-import { IDeviceInputSystem } from './inputInterfaces';
+import { IDeviceEvent, IDeviceInputSystem } from './inputInterfaces';
 import { NativeDeviceInputSystem } from './nativeDeviceInputSystem';
 import { WebDeviceInputSystem } from './webDeviceInputSystem';
 import { DeviceSource } from './deviceSource';
@@ -65,13 +65,13 @@ export class InternalDeviceSourceManager implements IDisposable {
             }
         };
 
-        this._deviceInputSystem.onInputChanged = (eventData: IUIEvent) => {
+        this._deviceInputSystem.onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => {
             if (eventData) {
                 for (const manager of this._registeredManagers) {
                     manager.onInputChangedObservable.notifyObservers(eventData);
                 }
 
-                this._devices[eventData.deviceType][eventData.deviceSlot].onInputChangedObservable.notifyObservers(eventData);
+                this._devices[deviceType][deviceSlot].onInputChangedObservable.notifyObservers(eventData);
             }
         };
     }

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,17 +1,18 @@
+import { IUIEvent } from "../..";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
-import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "./inputInterfaces";
+import { IDeviceInputSystem } from "./inputInterfaces";
 
 /** @hidden */
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-    public onInputChanged = (deviceEvent: IDeviceEvent) => { };
+    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: any) => { };
 
-    private readonly _nativeInput: INativeInput;
+    private readonly _nativeInput: IDeviceInputSystem;
 
-    public constructor(nativeInput?: INativeInput) {
+    public constructor(nativeInput?: IDeviceInputSystem) {
         this._nativeInput = nativeInput || this._createDummyNativeInput();
 
         this._nativeInput.onDeviceConnected = (deviceType, deviceSlot) => {
@@ -26,14 +27,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
             const idx = (inputIndex === PointerInput.Horizontal || inputIndex === PointerInput.Vertical || inputIndex === PointerInput.DeltaHorizontal || inputIndex === PointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
             const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
 
-            let deviceEvent = evt as IDeviceEvent;
-            deviceEvent.deviceType = deviceType;
-            deviceEvent.deviceSlot = deviceSlot;
-            deviceEvent.inputIndex = idx;
-            deviceEvent.previousState = previousState;
-            deviceEvent.currentState = currentState;
-
-            this.onInputChanged(deviceEvent);
+            this.onInputChanged(deviceType, deviceSlot, idx, previousState, currentState, evt);
         };
     }
 
@@ -76,7 +70,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
         let nativeInput = {
             onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => { },
             onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => { },
-            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: any) => { },
+            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => { },
             pollInput: () => { return 0; },
             isDeviceAvailable: () => { return false; },
             dispose: () => { },

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,14 +1,41 @@
-import { IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
-import { IDeviceInputSystem, INativeInput } from "./inputInterfaces";
+import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "./inputInterfaces";
+
+/** @hidden */
+enum NativePointerInput {
+    /** Horizontal Axis */
+    Horizontal = PointerInput.Horizontal,
+    /** Vertical Axis */
+    Vertical = 1,
+    /** Left Click or Touch */
+    LeftClick = 2,
+    /** Middle Click */
+    MiddleClick = 3,
+    /** Right Click */
+    RightClick = 4,
+    /** Browser Back */
+    BrowserBack = 5,
+    /** Browser Forward */
+    BrowserForward = 6,
+    /** Mouse Wheel X */
+    MouseWheelX = 7,
+    /** Mouse Wheel Y */
+    MouseWheelY = 8,
+    /** Mouse Wheel Z */
+    MouseWheelZ = 9,
+    /** Delta X */
+    DeltaHorizontal = 10,
+    /** Delta Y */
+    DeltaVertical = 11,
+}
 
 /** @hidden */
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-    public onInputChanged = (eventData: IUIEvent) => { };
+    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => { };
 
     private readonly _nativeInput: INativeInput;
 
@@ -24,10 +51,10 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
         };
 
         this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState) => {
-            const idx = (inputIndex === PointerInput.Horizontal || inputIndex === PointerInput.Vertical || inputIndex === PointerInput.DeltaHorizontal || inputIndex === PointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
+            const idx = (inputIndex === NativePointerInput.Horizontal || inputIndex === NativePointerInput.Vertical || inputIndex === NativePointerInput.DeltaHorizontal || inputIndex === NativePointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
             const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, idx, currentState, this);
 
-            this.onInputChanged(evt);
+            this.onInputChanged(deviceType, deviceSlot, evt);
         };
     }
 

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -25,7 +25,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
 
         this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState, eventData) => {
             const idx = (inputIndex === PointerInput.Horizontal || inputIndex === PointerInput.Vertical || inputIndex === PointerInput.DeltaHorizontal || inputIndex === PointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
-            const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
+            const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, idx, currentState, this);
 
             this.onInputChanged(deviceType, deviceSlot, idx, previousState, currentState, evt);
         };

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,7 +1,8 @@
+import { IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
-import { IDeviceEvent, IDeviceInputSystem, INativeInput } from "./inputInterfaces";
+import { IDeviceInputSystem, INativeInput } from "./inputInterfaces";
 
 /** @hidden */
 enum NativePointerInput {
@@ -35,7 +36,7 @@ enum NativePointerInput {
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => { };
+    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => { };
 
     private readonly _nativeInput: INativeInput;
 

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -5,7 +5,7 @@ import { DeviceType, PointerInput } from "./deviceEnums";
 import { IDeviceInputSystem, INativeInput } from "./inputInterfaces";
 
 /** @hidden */
-enum NativePointerInput {
+export enum NativePointerInput {
     /** Horizontal Axis */
     Horizontal = PointerInput.Horizontal,
     /** Vertical Axis */
@@ -51,7 +51,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
             this.onDeviceDisconnected(deviceType, deviceSlot);
         };
 
-        this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState) => {
+        this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, currentState) => {
             const idx = (inputIndex === NativePointerInput.Horizontal || inputIndex === NativePointerInput.Vertical || inputIndex === NativePointerInput.DeltaHorizontal || inputIndex === NativePointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
             const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, idx, currentState, this);
 
@@ -98,7 +98,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
         let nativeInput = {
             onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => { },
             onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => { },
-            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>) => { },
+            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, currentState: Nullable<number>) => { },
             pollInput: () => { return 0; },
             isDeviceAvailable: () => { return false; },
             dispose: () => { },

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -2,17 +2,17 @@ import { IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
-import { IDeviceInputSystem } from "./inputInterfaces";
+import { IDeviceInputSystem, INativeInput } from "./inputInterfaces";
 
 /** @hidden */
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => { };
+    public onInputChanged = (eventData: IUIEvent) => { };
 
-    private readonly _nativeInput: IDeviceInputSystem;
+    private readonly _nativeInput: INativeInput;
 
-    public constructor(nativeInput?: IDeviceInputSystem) {
+    public constructor(nativeInput?: INativeInput) {
         this._nativeInput = nativeInput || this._createDummyNativeInput();
 
         this._nativeInput.onDeviceConnected = (deviceType, deviceSlot) => {
@@ -23,11 +23,11 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
             this.onDeviceDisconnected(deviceType, deviceSlot);
         };
 
-        this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState, eventData) => {
+        this._nativeInput.onInputChanged = (deviceType, deviceSlot, inputIndex, previousState, currentState) => {
             const idx = (inputIndex === PointerInput.Horizontal || inputIndex === PointerInput.Vertical || inputIndex === PointerInput.DeltaHorizontal || inputIndex === PointerInput.DeltaVertical) ? PointerInput.Move : inputIndex;
             const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, idx, currentState, this);
 
-            this.onInputChanged(deviceType, deviceSlot, idx, previousState, currentState, evt);
+            this.onInputChanged(evt);
         };
     }
 
@@ -70,7 +70,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
         let nativeInput = {
             onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => { },
             onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => { },
-            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => { },
+            onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>) => { },
             pollInput: () => { return 0; },
             isDeviceAvailable: () => { return false; },
             dispose: () => { },

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,4 +1,4 @@
-import { IUIEvent } from "../..";
+import { IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
@@ -8,7 +8,7 @@ import { IDeviceInputSystem } from "./inputInterfaces";
 export class NativeDeviceInputSystem implements IDeviceInputSystem {
     public onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
     public onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: any) => { };
+    public onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => { };
 
     private readonly _nativeInput: IDeviceInputSystem;
 

--- a/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,36 +1,8 @@
 import { IUIEvent } from "../../Events/deviceInputEvents";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
-import { DeviceType, PointerInput } from "./deviceEnums";
+import { DeviceType, NativePointerInput, PointerInput } from "./deviceEnums";
 import { IDeviceInputSystem, INativeInput } from "./inputInterfaces";
-
-/** @hidden */
-export enum NativePointerInput {
-    /** Horizontal Axis */
-    Horizontal = PointerInput.Horizontal,
-    /** Vertical Axis */
-    Vertical = 1,
-    /** Left Click or Touch */
-    LeftClick = 2,
-    /** Middle Click */
-    MiddleClick = 3,
-    /** Right Click */
-    RightClick = 4,
-    /** Browser Back */
-    BrowserBack = 5,
-    /** Browser Forward */
-    BrowserForward = 6,
-    /** Mouse Wheel X */
-    MouseWheelX = 7,
-    /** Mouse Wheel Y */
-    MouseWheelY = 8,
-    /** Mouse Wheel Z */
-    MouseWheelZ = 9,
-    /** Delta X */
-    DeltaHorizontal = 10,
-    /** Delta Y */
-    DeltaVertical = 11,
-}
 
 /** @hidden */
 export class NativeDeviceInputSystem implements IDeviceInputSystem {

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -6,7 +6,7 @@ import { Tools } from "../../Misc/tools";
 import { Nullable } from "../../types";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
 import { DeviceType, PointerInput } from "./deviceEnums";
-import { IDeviceEvent, IDeviceInputSystem } from "./inputInterfaces";
+import { IDeviceInputSystem } from "./inputInterfaces";
 
 const MAX_KEYCODES = 255;
 const MAX_POINTER_INPUTS = Object.keys(PointerInput).length / 2;
@@ -36,7 +36,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     }
 
     public onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
-    public onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => void;
+    public onInputChanged: (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => void;
 
     // Private Members
     private _inputs: Array<{ [deviceSlot: number]: Array<number> }> = [];
@@ -82,7 +82,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
         this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
         this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IDeviceEvent) => { };
+        this.onInputChanged = (deviceType: DeviceType, deviceSlot: number, eventData: IUIEvent) => { };
 
         this._enableEvents();
 
@@ -116,6 +116,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         const currentValue = device[inputIndex];
         if (currentValue === undefined) {
             throw `Unable to find input ${inputIndex} for device ${DeviceType[deviceType]} in slot ${deviceSlot}`;
+        }
+
+        if (inputIndex === PointerInput.Move) {
+            Tools.Warn(`Unable to provide information for PointerInput.Move.  Try using PointerInput.Horizontal or PointerInput.Vertical for move data.`);
         }
 
         return currentValue;

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -36,7 +36,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     }
 
     public onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
-    public onInputChanged: (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: any) => void;
+    public onInputChanged: (eventData: any) => void;
 
     // Private Members
     private _inputs: Array<{ [deviceSlot: number]: Array<number> }> = [];
@@ -82,7 +82,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
         this.onDeviceConnected = (deviceType: DeviceType, deviceSlot: number) => { };
         this.onDeviceDisconnected = (deviceType: DeviceType, deviceSlot: number) => { };
-        this.onInputChanged = (deviceType: DeviceType, deviceSlot: number, inputIndex: number, previousState: Nullable<number>, currentState: Nullable<number>, eventData?: IUIEvent) => { };
+        this.onInputChanged = (eventData: IUIEvent) => { };
 
         this._enableEvents();
 
@@ -329,7 +329,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceSlot = 0;
                 deviceEvent.inputIndex = evt.keyCode;
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 0, 1, deviceEvent);
+                this.onInputChanged(deviceEvent);
             }
         });
 
@@ -348,7 +348,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceSlot = 0;
                 deviceEvent.inputIndex = evt.keyCode;
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                this.onInputChanged(deviceEvent);
             }
         });
 
@@ -362,7 +362,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                         const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, i, 0, this, this._elementToAttachTo);
 
-                        this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                        this.onInputChanged(deviceEvent);
                     }
                 }
             }
@@ -411,15 +411,14 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceSlot = deviceSlot;
                 deviceEvent.inputIndex = PointerInput.Move;
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 0, 1, deviceEvent);
+                this.onInputChanged(deviceEvent);
 
                 // Lets Propagate the event for move with same position.
                 if (!this._usingSafari && evt.button !== -1) {
                     deviceEvent.inputIndex = evt.button + 2;
-                    let previousButton = pointer[evt.button + 2];
                     pointer[evt.button + 2] = (pointer[evt.button + 2] ? 0 : 1); // Reverse state of button if evt.button has value
 
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousButton, pointer[evt.button + 2], deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
             }
         });
@@ -457,7 +456,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             if (pointer) {
                 const previousHorizontal = pointer[PointerInput.Horizontal];
                 const previousVertical = pointer[PointerInput.Vertical];
-                const previousButton = pointer[evt.button + 2];
 
                 if (deviceType === DeviceType.Mouse) { // Mouse; Among supported browsers, value is either 1 or 0 for mouse
                     if (this._mouseId === -1) {
@@ -502,11 +500,11 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 // EG. ([X, Y, Left-click], Middle-click, etc...)
                 deviceEvent.inputIndex = evt.button + 2;
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousButton, pointer[evt.button + 2], deviceEvent);
+                this.onInputChanged(deviceEvent);
 
                 if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
                     deviceEvent.inputIndex = PointerInput.Move;
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 0, 1, deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
             }
         });
@@ -528,7 +526,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             if (pointer && pointer[evt.button + 2] !== 0) {
                 const previousHorizontal = pointer[PointerInput.Horizontal];
                 const previousVertical = pointer[PointerInput.Vertical];
-                const previousButton = pointer[evt.button + 2];
 
                 pointer[PointerInput.Horizontal] = evt.clientX;
                 pointer[PointerInput.Vertical] = evt.clientY;
@@ -540,7 +537,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
                     deviceEvent.inputIndex = PointerInput.Move;
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 0, 1, deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
 
                 // NOTE: The +2 used here to is because PointerInput has the same value progression for its mouse buttons as PointerEvent.button
@@ -555,7 +552,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     this._elementToAttachTo.releasePointerCapture(evt.pointerId);
                 }
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousButton, pointer[deviceEvent.inputIndex], deviceEvent);
+                this.onInputChanged(deviceEvent);
 
                 if (deviceType === DeviceType.Touch) {
                     this.onDeviceDisconnected(deviceType, deviceSlot);
@@ -577,7 +574,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                         const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
-                        this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                        this.onInputChanged(deviceEvent);
                     }
                 }
             }
@@ -592,7 +589,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
 
-                this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                this.onInputChanged(deviceEvent);
 
                 this._activeTouchIds[deviceSlot] = -1;
                 this.onDeviceDisconnected(DeviceType.Touch, deviceSlot);
@@ -642,7 +639,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                         const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
-                        this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                        this.onInputChanged(deviceEvent);
                     }
                 }
             }
@@ -663,7 +660,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                         const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
 
-                        this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
+                        this.onInputChanged(deviceEvent);
 
                         this._activeTouchIds[deviceSlot] = -1;
                         this.onDeviceDisconnected(DeviceType.Touch, deviceSlot);
@@ -687,11 +684,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
             const pointer = this._inputs[deviceType][deviceSlot];
             if (pointer) {
-                // Store previous values for event
-                let previousWheelScrollX = pointer[PointerInput.MouseWheelX];
-                let previousWheelScrollY = pointer[PointerInput.MouseWheelY];
-                let previousWheelScrollZ = pointer[PointerInput.MouseWheelZ];
-
                 pointer[PointerInput.MouseWheelX] = evt.deltaX || 0;
                 pointer[PointerInput.MouseWheelY] = evt.deltaY || evt.wheelDelta || 0;
                 pointer[PointerInput.MouseWheelZ] = evt.deltaZ || 0;
@@ -702,15 +694,15 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 if (pointer[PointerInput.MouseWheelX] !== 0) {
                     deviceEvent.inputIndex = PointerInput.MouseWheelX;
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousWheelScrollX, pointer[PointerInput.MouseWheelX], deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
                 if (pointer[PointerInput.MouseWheelY] !== 0) {
                     deviceEvent.inputIndex = PointerInput.MouseWheelY;
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousWheelScrollY, pointer[PointerInput.MouseWheelY], deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
                 if (pointer[PointerInput.MouseWheelZ] !== 0) {
                     deviceEvent.inputIndex = PointerInput.MouseWheelZ;
-                    this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, previousWheelScrollZ, pointer[PointerInput.MouseWheelZ], deviceEvent);
+                    this.onInputChanged(deviceEvent);
                 }
             }
         });

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -411,10 +411,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 // Lets Propagate the event for move with same position.
                 if (!this._usingSafari && evt.button !== -1) {
-                    const inputIndex = evt.button + 2;
+                    deviceEvent.inputIndex = evt.button + 2;
                     pointer[evt.button + 2] = (pointer[evt.button + 2] ? 0 : 1); // Reverse state of button if evt.button has value
-                    const ev: IUIEvent = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, pointer[evt.button + 2], this, this._elementToAttachTo);
-                    this.onInputChanged(deviceType, deviceSlot, ev);
+                    this.onInputChanged(deviceType, deviceSlot, deviceEvent);
                 }
             }
         });

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -347,7 +347,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.deviceType = DeviceType.Keyboard;
                 deviceEvent.deviceSlot = 0;
                 deviceEvent.inputIndex = evt.keyCode;
-                
+
                 this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
             }
         });
@@ -360,11 +360,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (kbKey[i] !== 0) {
                         kbKey[i] = 0;
 
-                        const evt: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, i, 0, this, this._elementToAttachTo);
-                        const deviceEvent = evt;
-                        deviceEvent.deviceType = DeviceType.Keyboard;
-                        deviceEvent.deviceSlot = 0;
-                        deviceEvent.inputIndex = i;
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, i, 0, this, this._elementToAttachTo);
 
                         this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
                     }
@@ -579,11 +575,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointer[inputIndex] === 1) {
                         pointer[inputIndex] = 0;
 
-                        const evt: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
-                        const deviceEvent = evt;
-                        deviceEvent.deviceType = DeviceType.Mouse;
-                        deviceEvent.deviceSlot = 0;
-                        deviceEvent.inputIndex = inputIndex;
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
                         this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
                     }
@@ -598,11 +590,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 this._inputs[DeviceType.Touch][deviceSlot][PointerInput.LeftClick] = 0;
 
-                const upEvt: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
-                const deviceEvent = upEvt as IUIEvent;
-                deviceEvent.deviceType = DeviceType.Touch;
-                deviceEvent.deviceSlot = deviceSlot;
-                deviceEvent.inputIndex = PointerInput.LeftClick;
+                const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
 
                 this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
 
@@ -652,11 +640,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointer[inputIndex] === 1) {
                         pointer[inputIndex] = 0;
 
-                        const evt: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
-                        const deviceEvent = evt;
-                        deviceEvent.deviceType = DeviceType.Mouse;
-                        deviceEvent.deviceSlot = 0;
-                        deviceEvent.inputIndex = inputIndex;
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
                         this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
                     }
@@ -677,11 +661,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointerId !== -1 && pointer[deviceSlot]?.[PointerInput.LeftClick] === 1) {
                         pointer[deviceSlot][PointerInput.LeftClick] = 0;
 
-                        const evt: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
-                        const deviceEvent = evt;
-                        deviceEvent.deviceType = DeviceType.Touch;
-                        deviceEvent.deviceSlot = deviceSlot;
-                        deviceEvent.inputIndex = PointerInput.LeftClick;
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
 
                         this.onInputChanged(deviceEvent.deviceType, deviceEvent.deviceSlot, deviceEvent.inputIndex, 1, 0, deviceEvent);
 

--- a/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -36,7 +36,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     }
 
     public onDeviceDisconnected: (deviceType: DeviceType, deviceSlot: number) => void;
-    public onInputChanged: (eventData: any) => void;
+    public onInputChanged: (eventData: IUIEvent) => void;
 
     // Private Members
     private _inputs: Array<{ [deviceSlot: number]: Array<number> }> = [];

--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -1,4 +1,4 @@
-import { IDeviceInputSystem } from "../../DeviceInput/InputDevices/inputInterfaces";
+import { INativeInput } from "../../DeviceInput/InputDevices/inputInterfaces";
 import { InternalTexture } from "../../Materials/Textures/internalTexture";
 import { Nullable } from "../../types";
 import { ICanvas, IImage } from "../ICanvas";
@@ -215,8 +215,8 @@ interface INativeImageConstructor {
 
 /** @hidden */
 interface IDeviceInputSystemConstructor {
-    prototype: IDeviceInputSystem;
-    new(): IDeviceInputSystem;
+    prototype: INativeInput;
+    new(): INativeInput;
 }
 
 /** @hidden */

--- a/src/Engines/Native/nativeInterfaces.ts
+++ b/src/Engines/Native/nativeInterfaces.ts
@@ -1,4 +1,4 @@
-import { INativeInput } from "../../DeviceInput/InputDevices/inputInterfaces";
+import { IDeviceInputSystem } from "../../DeviceInput/InputDevices/inputInterfaces";
 import { InternalTexture } from "../../Materials/Textures/internalTexture";
 import { Nullable } from "../../types";
 import { ICanvas, IImage } from "../ICanvas";
@@ -215,8 +215,8 @@ interface INativeImageConstructor {
 
 /** @hidden */
 interface IDeviceInputSystemConstructor {
-    prototype: INativeInput;
-    new(): INativeInput;
+    prototype: IDeviceInputSystem;
+    new(): IDeviceInputSystem;
 }
 
 /** @hidden */

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -26,6 +26,7 @@ import "./Extensions/engine.readTexture";
 import "./Extensions/engine.dynamicBuffer";
 import { IAudioEngine } from '../Audio/Interfaces/IAudioEngine';
 import { IPointerEvent } from "../Events/deviceInputEvents";
+import { DeviceType, PointerInput } from "../DeviceInput/InputDevices/deviceEnums";
 
 declare type Material = import("../Materials/material").Material;
 declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
@@ -654,7 +655,11 @@ export class Engine extends ThinEngine {
             // Check that the element at the point of the pointer out isn't the canvas and if it isn't, notify observers
             // Note: This is a workaround for a bug with Safari
             if (document.elementFromPoint(ev.clientX, ev.clientY) !== canvas) {
-                this.onCanvasPointerOutObservable.notifyObservers(ev);
+                let evt: any = ev;
+                evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
+                evt.deviceSlot = evt.pointerId || 0;
+                evt.inputIndex = PointerInput.Move;
+                this.onCanvasPointerOutObservable.notifyObservers(evt);
             }
         };
 

--- a/src/Engines/engine.ts
+++ b/src/Engines/engine.ts
@@ -25,8 +25,6 @@ import "./Extensions/engine.alpha";
 import "./Extensions/engine.readTexture";
 import "./Extensions/engine.dynamicBuffer";
 import { IAudioEngine } from '../Audio/Interfaces/IAudioEngine';
-import { IPointerEvent } from "../Events/deviceInputEvents";
-import { DeviceType, PointerInput } from "../DeviceInput/InputDevices/deviceEnums";
 
 declare type Material = import("../Materials/material").Material;
 declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
@@ -410,7 +408,7 @@ export class Engine extends ThinEngine {
     /**
      * Observable event triggered each time the canvas receives pointerout event
      */
-    public onCanvasPointerOutObservable = new Observable<IPointerEvent>();
+    public onCanvasPointerOutObservable = new Observable<PointerEvent>();
 
     /**
      * Observable raised when the engine begins a new frame
@@ -655,11 +653,7 @@ export class Engine extends ThinEngine {
             // Check that the element at the point of the pointer out isn't the canvas and if it isn't, notify observers
             // Note: This is a workaround for a bug with Safari
             if (document.elementFromPoint(ev.clientX, ev.clientY) !== canvas) {
-                let evt: any = ev;
-                evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
-                evt.deviceSlot = evt.pointerId || 0;
-                evt.inputIndex = PointerInput.Move;
-                this.onCanvasPointerOutObservable.notifyObservers(evt);
+                this.onCanvasPointerOutObservable.notifyObservers(ev);
             }
         };
 

--- a/src/Engines/nativeEngine.ts
+++ b/src/Engines/nativeEngine.ts
@@ -764,7 +764,7 @@ class CommandBufferEncoder {
 /** @hidden */
 export class NativeEngine extends Engine {
     // This must match the protocol version in NativeEngine.cpp
-    private static readonly PROTOCOL_VERSION = 3;
+    private static readonly PROTOCOL_VERSION = 4;
 
     private readonly _engine: INativeEngine = new _native.Engine();
     private readonly _camera: Nullable<INativeCamera> = _native.Camera ? new _native.Camera() : null;

--- a/src/Events/deviceInputEvents.ts
+++ b/src/Events/deviceInputEvents.ts
@@ -1,5 +1,3 @@
-import { DeviceType } from "../DeviceInput/InputDevices/deviceEnums";
-
 /**
  * Event Types
  */
@@ -18,14 +16,6 @@ export enum DeviceInputEventType {
  */
 export interface IUIEvent {
     // Properties
-    /**
-     * Device type
-     */
-    deviceType: DeviceType;
-    /**
-     * Device slot
-     */
-    deviceSlot: number;
     /**
      * Input array index
      */
@@ -64,11 +54,6 @@ export interface IUIEvent {
  */
 export interface IKeyboardEvent extends IUIEvent {
     // Properties
-    /**
-     * DeviceType
-     */
-    deviceType: DeviceType.Keyboard;
-
     /**
      * Status of Alt key being pressed
      */
@@ -253,11 +238,6 @@ export interface IPointerEvent extends IMouseEvent {
  */
 export interface IWheelEvent extends IMouseEvent {
     // Properties
-    /**
-     * DeviceType
-     */
-    deviceType: DeviceType.Mouse;
-
     /**
      * Units for delta value
      */

--- a/src/Events/deviceInputEvents.ts
+++ b/src/Events/deviceInputEvents.ts
@@ -1,3 +1,5 @@
+import { DeviceType } from "../DeviceInput/InputDevices/deviceEnums";
+
 /**
  * Event Types
  */
@@ -14,8 +16,21 @@ export enum DeviceInputEventType {
 /**
  * Native friendly interface for Event Object
  */
-export interface IEvent {
+export interface IUIEvent {
     // Properties
+    /**
+     * Device type
+     */
+    deviceType: DeviceType;
+    /**
+     * Device slot
+     */
+    deviceSlot: number;
+    /**
+     * Input array index
+     */
+    inputIndex: number;
+
     /**
      * Current target for an event
      */
@@ -45,31 +60,15 @@ export interface IEvent {
 }
 
 /**
- * Native friendly interface for UIEvent Object
- */
-export interface IUIEvent extends IEvent {
-    // Properties
-    /**
-     * Provides current click count
-     */
-    detail: number;
-
-    /**
-     * Horizontal coordinate of event
-     */
-    pageX: number;
-
-    /**
-     * Vertical coordinate of event
-     */
-    pageY: number;
-}
-
-/**
  * Native friendly interface for KeyboardEvent Object
  */
 export interface IKeyboardEvent extends IUIEvent {
     // Properties
+    /**
+     * DeviceType
+     */
+    deviceType: DeviceType.Keyboard;
+
     /**
      * Status of Alt key being pressed
      */
@@ -118,6 +117,11 @@ export interface IKeyboardEvent extends IUIEvent {
 export interface IMouseEvent extends IUIEvent {
     // Properties
     /**
+     * DeviceType
+     */
+    deviceType: DeviceType.Mouse | DeviceType.Touch;
+
+    /**
      * Status of Alt key being pressed
      */
     altKey: boolean;
@@ -146,6 +150,11 @@ export interface IMouseEvent extends IUIEvent {
      * Status of Ctrl key being pressed
      */
     ctrlKey: boolean;
+
+    /**
+     * Provides current click count
+     */
+    detail?: number;
 
     /**
      * Status of Meta key (eg. Windows key) being pressed
@@ -193,6 +202,16 @@ export interface IMouseEvent extends IUIEvent {
     offsetY: number;
 
     /**
+     * Horizontal coordinate of event
+     */
+    pageX: number;
+
+    /**
+     * Vertical coordinate of event
+     */
+    pageY: number;
+
+    /**
      * Status of Shift key being pressed
      */
     shiftKey: boolean;
@@ -224,6 +243,11 @@ export interface IMouseEvent extends IUIEvent {
 export interface IPointerEvent extends IMouseEvent {
     // Properties
     /**
+     * DeviceType
+     */
+    deviceType: DeviceType.Mouse | DeviceType.Touch;
+
+    /**
      * Pointer Event ID
      */
     pointerId: number;
@@ -239,6 +263,11 @@ export interface IPointerEvent extends IMouseEvent {
  */
 export interface IWheelEvent extends IMouseEvent {
     // Properties
+    /**
+     * DeviceType
+     */
+    deviceType: DeviceType.Mouse;
+
     /**
      * Units for delta value
      */

--- a/src/Events/deviceInputEvents.ts
+++ b/src/Events/deviceInputEvents.ts
@@ -117,11 +117,6 @@ export interface IKeyboardEvent extends IUIEvent {
 export interface IMouseEvent extends IUIEvent {
     // Properties
     /**
-     * DeviceType
-     */
-    deviceType: DeviceType.Mouse | DeviceType.Touch;
-
-    /**
      * Status of Alt key being pressed
      */
     altKey: boolean;
@@ -242,11 +237,6 @@ export interface IMouseEvent extends IUIEvent {
  */
 export interface IPointerEvent extends IMouseEvent {
     // Properties
-    /**
-     * DeviceType
-     */
-    deviceType: DeviceType.Mouse | DeviceType.Touch;
-
     /**
      * Pointer Event ID
      */

--- a/src/Gizmos/boundingBoxGizmo.ts
+++ b/src/Gizmos/boundingBoxGizmo.ts
@@ -19,6 +19,7 @@ import { Color3 } from '../Maths/math.color';
 import "../Meshes/Builders/boxBuilder";
 import { LinesMesh } from '../Meshes/linesMesh';
 import { Epsilon } from '../Maths/math.constants';
+import { IPointerEvent } from "../Events/deviceInputEvents";
 
 /**
  * Bounding box gizmo
@@ -396,17 +397,17 @@ export class BoundingBoxGizmo extends Gizmo {
         // Hover color change
         var pointerIds = new Array<AbstractMesh>();
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
-            if (!pointerIds[(<PointerEvent>pointerInfo.event).pointerId]) {
+            if (!pointerIds[(<IPointerEvent>pointerInfo.event).pointerId]) {
                 this._rotateSpheresParent.getChildMeshes().concat(this._scaleBoxesParent.getChildMeshes()).forEach((mesh) => {
                     if (pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh == mesh) {
-                        pointerIds[(<PointerEvent>pointerInfo.event).pointerId] = mesh;
+                        pointerIds[(<IPointerEvent>pointerInfo.event).pointerId] = mesh;
                         mesh.material = this.hoverColoredMaterial;
                     }
                 });
             } else {
-                if (pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh != pointerIds[(<PointerEvent>pointerInfo.event).pointerId]) {
-                    pointerIds[(<PointerEvent>pointerInfo.event).pointerId].material = this.coloredMaterial;
-                    delete pointerIds[(<PointerEvent>pointerInfo.event).pointerId];
+                if (pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh != pointerIds[(<IPointerEvent>pointerInfo.event).pointerId]) {
+                    pointerIds[(<IPointerEvent>pointerInfo.event).pointerId].material = this.coloredMaterial;
+                    delete pointerIds[(<IPointerEvent>pointerInfo.event).pointerId];
                 }
             }
         });

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -878,12 +878,13 @@ export class InputManager {
             }
             else if (deviceSource.deviceType === DeviceType.Touch) {
                 deviceSource.onInputChangedObservable.add((eventData) => {
-                    if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
-                        if (attachDown) {
+                    const evt = eventData as IPointerEvent;
+                    if ((eventData.inputIndex === PointerInput.LeftClick)) {
+                        if (attachDown && evt.type === "pointerdown") {
                             this._onPointerDown(eventData as IPointerEvent);
 
                         }
-                        else if (attachUp) {
+                        else if (attachUp && evt.type === "pointerup") {
                             this._onPointerUp(eventData as IPointerEvent);
                         }
                     }

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -267,7 +267,7 @@ export class InputManager {
      * @param pointerEventInit pointer event state to be used when simulating the pointer event (eg. pointer id for multitouch)
      */
     public simulatePointerMove(pickResult: PickingInfo, pointerEventInit?: PointerEventInit): void {
-        let evt: any = new PointerEvent("pointermove", pointerEventInit);
+        const evt = new PointerEvent("pointermove", pointerEventInit);
         evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
         evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = PointerInput.Move;
@@ -285,7 +285,7 @@ export class InputManager {
      * @param pointerEventInit pointer event state to be used when simulating the pointer event (eg. pointer id for multitouch)
      */
     public simulatePointerDown(pickResult: PickingInfo, pointerEventInit?: PointerEventInit): void {
-        let evt: any = new PointerEvent("pointerdown", pointerEventInit);
+        const evt = new PointerEvent("pointerdown", pointerEventInit);
         evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
         evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = evt.button + 2;
@@ -382,7 +382,7 @@ export class InputManager {
      * @param doubleTap indicates that the pointer up event should be considered as part of a double click (false by default)
      */
     public simulatePointerUp(pickResult: PickingInfo, pointerEventInit?: PointerEventInit, doubleTap?: boolean): void {
-        let evt: any = new PointerEvent("pointerup", pointerEventInit);
+        let evt = new PointerEvent("pointerup", pointerEventInit);
         evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
         evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = PointerInput.Move;

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -268,8 +268,6 @@ export class InputManager {
      */
     public simulatePointerMove(pickResult: PickingInfo, pointerEventInit?: PointerEventInit): void {
         const evt = new PointerEvent("pointermove", pointerEventInit);
-        evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
-        evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = PointerInput.Move;
 
         if (this._checkPrePointerObservable(pickResult, evt, PointerEventTypes.POINTERMOVE)) {
@@ -286,8 +284,6 @@ export class InputManager {
      */
     public simulatePointerDown(pickResult: PickingInfo, pointerEventInit?: PointerEventInit): void {
         const evt = new PointerEvent("pointerdown", pointerEventInit);
-        evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
-        evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = evt.button + 2;
 
         if (this._checkPrePointerObservable(pickResult, evt, PointerEventTypes.POINTERDOWN)) {
@@ -383,8 +379,6 @@ export class InputManager {
      */
     public simulatePointerUp(pickResult: PickingInfo, pointerEventInit?: PointerEventInit, doubleTap?: boolean): void {
         let evt = new PointerEvent("pointerup", pointerEventInit);
-        evt.deviceType = evt.pointerType === "mouse" ? DeviceType.Mouse : DeviceType.Touch;
-        evt.deviceSlot = evt.pointerId || 0;
         evt.inputIndex = PointerInput.Move;
         let clickInfo = new _ClickInfo();
 
@@ -858,36 +852,80 @@ export class InputManager {
             }
         };
 
-        this._deviceSourceManager.onInputChangedObservable.add((eventData) => {
-            // Keyboard Events
-            if (eventData.deviceType === DeviceType.Keyboard) {
-                if (eventData.type === "keydown") {
-                    this._onKeyDown(eventData as IKeyboardEvent);
-                }
+        /*const mouse = this._deviceSourceManager.getDeviceSource(DeviceType.Mouse);
 
-                if (eventData.type === "keyup") {
-                    this._onKeyUp(eventData as IKeyboardEvent);
+        mouse!.onInputChangedObservable.add((eventData) => {
+            if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
+                const evt = eventData as IPointerEvent;
+                if (attachDown && evt.type === "pointerdown") {
+                    this._onPointerDown(evt);
+
+                }
+                else if (attachUp && evt.type === "pointerup") {
+                    this._onPointerUp(evt);
                 }
             }
 
-            // Pointer Events
-            if (eventData.deviceType === DeviceType.Mouse || eventData.deviceType === DeviceType.Touch) {
-                let pointer = this._deviceSourceManager?.getDeviceSource(eventData.deviceType, eventData.deviceSlot);
-                if (attachDown && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && pointer?.getInput(eventData.inputIndex) === 1) {
-                    this._onPointerDown(eventData as IPointerEvent);
+            if (attachMove) {
+                if (eventData.inputIndex === PointerInput.Move) {
+                    this._onPointerMove(eventData as IPointerEvent);
+                } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
+                    this._onPointerMove(eventData as IWheelEvent);
                 }
+            }
+        });*/
 
-                if (attachUp && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && pointer?.getInput(eventData.inputIndex) === 0) {
-                    this._onPointerUp(eventData as IPointerEvent);
-                }
-
-                if (attachMove) {
-                    if (eventData.inputIndex === PointerInput.Move) {
-                        this._onPointerMove(eventData as IPointerEvent);
-                    } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
-                        this._onPointerMove(eventData as IWheelEvent);
+        // TODO: Decide if these should be connected at same time as mouse
+        this._deviceSourceManager.onDeviceConnectedObservable.add((deviceSource) => {
+            if (deviceSource.deviceType === DeviceType.Mouse) {
+                deviceSource.onInputChangedObservable.add((eventData) => {
+                    if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
+                        const evt = eventData as IPointerEvent;
+                        if (attachDown && evt.type === "pointerdown") {
+                            this._onPointerDown(evt);
+        
+                        }
+                        else if (attachUp && evt.type === "pointerup") {
+                            this._onPointerUp(evt);
+                        }
                     }
-                }
+        
+                    if (attachMove) {
+                        if (eventData.inputIndex === PointerInput.Move) {
+                            this._onPointerMove(eventData as IPointerEvent);
+                        } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
+                            this._onPointerMove(eventData as IWheelEvent);
+                        }
+                    }
+                });
+            }
+            else if (deviceSource.deviceType === DeviceType.Touch) {
+                deviceSource.onInputChangedObservable.add((eventData) => {
+                    if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
+                        if (attachDown) {
+                            this._onPointerDown(eventData as IPointerEvent);
+
+                        }
+                        else if (attachUp) {
+                            this._onPointerUp(eventData as IPointerEvent);
+                        }
+                    }
+
+                    if (attachMove && eventData.inputIndex === PointerInput.Move) {
+                        this._onPointerMove(eventData as IPointerEvent);
+                    }
+                });
+            }
+            else if (deviceSource.deviceType === DeviceType.Keyboard) {
+                deviceSource.onInputChangedObservable.add((eventData) => {
+                    const evt = eventData as IKeyboardEvent;
+                    if (evt.type === "keydown") {
+                        this._onKeyDown(evt);
+                    }
+                    else if (evt.type === "keyup") {
+                        this._onKeyUp(evt);
+                    }
+                });
             }
         });
 

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -9,7 +9,7 @@ import { Constants } from "../Engines/constants";
 import { ActionEvent } from "../Actions/actionEvent";
 import { KeyboardEventTypes, KeyboardInfoPre, KeyboardInfo } from "../Events/keyboardEvents";
 import { DeviceType, PointerInput } from "../DeviceInput/InputDevices/deviceEnums";
-import { IUIEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from "../Events/deviceInputEvents";
+import { IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from "../Events/deviceInputEvents";
 import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 import { EngineStore } from "../Engines/engineStore";
 
@@ -859,33 +859,33 @@ export class InputManager {
         };
 
         this._deviceSourceManager.onInputChangedObservable.add((eventData) => {
-            const evt: IUIEvent = eventData;
             // Keyboard Events
             if (eventData.deviceType === DeviceType.Keyboard) {
                 if (eventData.type === "keydown") {
-                    this._onKeyDown(evt as IKeyboardEvent);
+                    this._onKeyDown(eventData as IKeyboardEvent);
                 }
 
                 if (eventData.type === "keyup") {
-                    this._onKeyUp(evt as IKeyboardEvent);
+                    this._onKeyUp(eventData as IKeyboardEvent);
                 }
             }
 
             // Pointer Events
             if (eventData.deviceType === DeviceType.Mouse || eventData.deviceType === DeviceType.Touch) {
-                if (attachDown && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && eventData.type.indexOf("down") !== -1) {
-                    this._onPointerDown(evt as IPointerEvent);
+                let pointer = this._deviceSourceManager?.getDeviceSource(eventData.deviceType, eventData.deviceSlot);
+                if (attachDown && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && pointer?.getInput(eventData.inputIndex) === 1) {
+                    this._onPointerDown(eventData as IPointerEvent);
                 }
 
-                if (attachUp && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && eventData.type.indexOf("up") !== -1) {
-                    this._onPointerUp(evt as IPointerEvent);
+                if (attachUp && eventData.inputIndex >= PointerInput.LeftClick && eventData.inputIndex <= PointerInput.RightClick && pointer?.getInput(eventData.inputIndex) === 0) {
+                    this._onPointerUp(eventData as IPointerEvent);
                 }
 
                 if (attachMove) {
                     if (eventData.inputIndex === PointerInput.Move) {
-                        this._onPointerMove(evt as IPointerEvent);
+                        this._onPointerMove(eventData as IPointerEvent);
                     } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
-                        this._onPointerMove(evt as IWheelEvent);
+                        this._onPointerMove(eventData as IWheelEvent);
                     }
                 }
             }

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -852,30 +852,7 @@ export class InputManager {
             }
         };
 
-        /*const mouse = this._deviceSourceManager.getDeviceSource(DeviceType.Mouse);
-
-        mouse!.onInputChangedObservable.add((eventData) => {
-            if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
-                const evt = eventData as IPointerEvent;
-                if (attachDown && evt.type === "pointerdown") {
-                    this._onPointerDown(evt);
-
-                }
-                else if (attachUp && evt.type === "pointerup") {
-                    this._onPointerUp(evt);
-                }
-            }
-
-            if (attachMove) {
-                if (eventData.inputIndex === PointerInput.Move) {
-                    this._onPointerMove(eventData as IPointerEvent);
-                } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
-                    this._onPointerMove(eventData as IWheelEvent);
-                }
-            }
-        });*/
-
-        // TODO: Decide if these should be connected at same time as mouse
+        // If a device connects that we can handle, wire up the observable
         this._deviceSourceManager.onDeviceConnectedObservable.add((deviceSource) => {
             if (deviceSource.deviceType === DeviceType.Mouse) {
                 deviceSource.onInputChangedObservable.add((eventData) => {
@@ -883,13 +860,13 @@ export class InputManager {
                         const evt = eventData as IPointerEvent;
                         if (attachDown && evt.type === "pointerdown") {
                             this._onPointerDown(evt);
-        
+
                         }
                         else if (attachUp && evt.type === "pointerup") {
                             this._onPointerUp(evt);
                         }
                     }
-        
+
                     if (attachMove) {
                         if (eventData.inputIndex === PointerInput.Move) {
                             this._onPointerMove(eventData as IPointerEvent);

--- a/src/Inputs/scene.inputManager.ts
+++ b/src/Inputs/scene.inputManager.ts
@@ -858,16 +858,16 @@ export class InputManager {
                 deviceSource.onInputChangedObservable.add((eventData) => {
                     if ((eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick)) {
                         const evt = eventData as IPointerEvent;
-                        if (attachDown && evt.type === "pointerdown") {
+                        if (attachDown && deviceSource.getInput(evt.inputIndex) === 1) {
                             this._onPointerDown(evt);
 
                         }
-                        else if (attachUp && evt.type === "pointerup") {
+                        else if (attachUp && deviceSource.getInput(evt.inputIndex) === 0) {
                             this._onPointerUp(evt);
                         }
                     }
 
-                    if (attachMove) {
+                    else if (attachMove) {
                         if (eventData.inputIndex === PointerInput.Move) {
                             this._onPointerMove(eventData as IPointerEvent);
                         } else if (eventData.inputIndex === PointerInput.MouseWheelX || eventData.inputIndex === PointerInput.MouseWheelY || eventData.inputIndex === PointerInput.MouseWheelZ) {
@@ -880,11 +880,11 @@ export class InputManager {
                 deviceSource.onInputChangedObservable.add((eventData) => {
                     const evt = eventData as IPointerEvent;
                     if ((eventData.inputIndex === PointerInput.LeftClick)) {
-                        if (attachDown && evt.type === "pointerdown") {
+                        if (attachDown && deviceSource.getInput(evt.inputIndex) === 1) {
                             this._onPointerDown(eventData as IPointerEvent);
 
                         }
-                        else if (attachUp && evt.type === "pointerup") {
+                        else if (attachUp && deviceSource.getInput(evt.inputIndex) === 0) {
                             this._onPointerUp(eventData as IPointerEvent);
                         }
                     }

--- a/src/LibDeclarations/browser.d.ts
+++ b/src/LibDeclarations/browser.d.ts
@@ -36,6 +36,13 @@ interface CanvasRenderingContext2D {
     msImageSmoothingEnabled: boolean;
 }
 
+// Babylon Extension to enable Native compatibility
+interface UIEvent {
+    deviceType: number;
+    deviceSlot: number;
+    inputIndex: number;
+}
+
 interface MouseEvent {
     mozMovementX: number;
     mozMovementY: number;

--- a/src/LibDeclarations/browser.d.ts
+++ b/src/LibDeclarations/browser.d.ts
@@ -36,7 +36,7 @@ interface CanvasRenderingContext2D {
     msImageSmoothingEnabled: boolean;
 }
 
-// Babylon Extension to enable Native compatibility
+// Babylon Extension to enable UIEvents to work with our IUIEvents
 interface UIEvent {
     deviceType: number;
     deviceSlot: number;

--- a/src/LibDeclarations/browser.d.ts
+++ b/src/LibDeclarations/browser.d.ts
@@ -38,8 +38,6 @@ interface CanvasRenderingContext2D {
 
 // Babylon Extension to enable UIEvents to work with our IUIEvents
 interface UIEvent {
-    deviceType: number;
-    deviceSlot: number;
     inputIndex: number;
 }
 

--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -9,6 +9,7 @@ import { HemisphericLight } from "../Lights/hemisphericLight";
 import { Vector3 } from "../Maths/math.vector";
 import { Camera } from "../Cameras/camera";
 import { Color3 } from "../Maths/math.color";
+import { IPointerEvent } from "../Events/deviceInputEvents";
 
 /**
  * Renders a layer on top of an existing scene
@@ -183,7 +184,7 @@ export class UtilityLayerRenderer implements IDisposable {
                 }
                 this.utilityLayerScene.pointerX = originalScene.pointerX;
                 this.utilityLayerScene.pointerY = originalScene.pointerY;
-                let pointerEvent = <PointerEvent>prePointerInfo.event;
+                let pointerEvent = <IPointerEvent>prePointerInfo.event;
                 if (originalScene!.isPointerCaptured(pointerEvent.pointerId)) {
                     this._pointerCaptures[pointerEvent.pointerId] = false;
                     return;
@@ -259,7 +260,7 @@ export class UtilityLayerRenderer implements IDisposable {
                     }
                 } else {
                     let originalScenePick = getNearPickDataForScene(originalScene);
-                    let pointerEvent = <PointerEvent>prePointerInfo.event;
+                    let pointerEvent = <IPointerEvent>prePointerInfo.event;
 
                     // If the layer can be occluded by the original scene, only fire pointer events to the first layer that hit they ray
                     if (originalScenePick && utilityScenePick) {
@@ -337,7 +338,7 @@ export class UtilityLayerRenderer implements IDisposable {
         this._updateCamera();
     }
 
-    private _notifyObservers(prePointerInfo: PointerInfoPre, pickInfo: PickingInfo, pointerEvent: PointerEvent) {
+    private _notifyObservers(prePointerInfo: PointerInfoPre, pickInfo: PickingInfo, pointerEvent: IPointerEvent) {
         if (!prePointerInfo.skipOnPointerObservable) {
             this.utilityLayerScene.onPointerObservable.notifyObservers(new PointerInfo(prePointerInfo.type, prePointerInfo.event, pickInfo), prePointerInfo.type);
             this._lastPointerEvents[pointerEvent.pointerId] = true;


### PR DESCRIPTION
With the changes made for 5.0, there was a change made to some parts of the DeviceSourceManager that changed the contract for onInputChangedObservable.  This PR contains changes to fix that discrepancy and remove IDeviceEvent and INativeInput.

This PR also changes the DeviceSourceManager to keep track of its sources, rather than referencing ones on the InternalDeviceSourceManager.  This should prevent observers from staying when a specific DeviceSourceManager instance is disposed of.