### PR TITLE
feat: OBJ loader bump map multiplier

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -107,6 +107,7 @@
 - Added support for normalized attributes ([#11685](https://github.com/BabylonJS/Babylon.js/issues/11685)) ([RaananW](https://github.com/RaananW))
 - Added fallback error logging on mesh loading tasks if no error handler is defined. ([carolhmj](https://github.com/carolhmj))
 - Updated the glTF loader to place the skinned mesh as a sibling of the skeleton root node instead of using `skeleton.overrideMesh`. ([bghgary](https://github.com/bghgary))
+- Added support for `--bm` bump multiplier to OBJ loader ([brianzinn](https://github.com/brianzinn))
 
 ### Navigation
 

--- a/loaders/src/OBJ/mtlFileLoader.ts
+++ b/loaders/src/OBJ/mtlFileLoader.ts
@@ -37,7 +37,7 @@ export class MTLFileLoader {
 
         //Split the lines from the file
         var lines = data.split('\n');
-        //Space char
+        // whitespace char ie: [ \t\r\n\f]
         var delimiter_pattern = /\s+/;
         //Array with RGB colors
         var color: number[];
@@ -135,7 +135,19 @@ export class MTLFileLoader {
                 //    continue;
             } else if (key === "map_bump" && material) {
                 //The bump texture
-                material.bumpTexture = MTLFileLoader._getTexture(rootUrl, value, scene);
+                const values = value.split(delimiter_pattern);
+                const bumpMultiplierIndex = values.indexOf('-bm');
+                let bumpMultiplier: Nullable<string> = null;
+
+                if (bumpMultiplierIndex >= 0) {
+                    bumpMultiplier = values[bumpMultiplierIndex + 1];
+                    values.splice(bumpMultiplierIndex, 2); // remove
+                }
+
+                material.bumpTexture = MTLFileLoader._getTexture(rootUrl, values.join(' '), scene);
+                if (material.bumpTexture && bumpMultiplier !== null) {
+                    material.bumpTexture.level = parseFloat(bumpMultiplier);
+                }
             } else if (key === "map_d" && material) {
                 // The dissolve of the material
                 material.opacityTexture = MTLFileLoader._getTexture(rootUrl, value, scene);


### PR DESCRIPTION
Should be same effect as #641

The parameter `-bm` is defined in MTL spec here:
http://www.paulbourke.net/dataformats/mtl/

Bump scale is passed in MTL loader.  Forum post:
https://forum.babylonjs.com/t/how-to-import-obj-file-with-mtl-that-contains-multiple-material/27909

Was expecting `level` to be a multiplier for the size of the height map, while it appears to impact intensity.