### PR TITLE
[Inspector] Display linear texture previews correctly

### DIFF
--- a/inspector/src/lod.ts
+++ b/inspector/src/lod.ts
@@ -6,13 +6,19 @@ let shader = `
 
 precision highp float;
 
+const float GammaEncodePowerApprox = 1.0 / 2.2;
+
 varying vec2 vUV;
 uniform sampler2D textureSampler;
 uniform float lod;
 uniform vec2 texSize;
+uniform bool gamma;
 void main(void)
 {
     gl_FragColor = textureLod(textureSampler,vUV,lod);
+    if (!gamma) {
+        gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(GammaEncodePowerApprox));
+    }
 }`;
 
 Effect.ShadersStore[name] = shader;

--- a/inspector/src/lodCube.ts
+++ b/inspector/src/lodCube.ts
@@ -4,9 +4,12 @@ let name = 'lodCubePixelShader';
 let shader = `
 precision highp float;
 
+const float GammaEncodePowerApprox = 1.0 / 2.2;
+
 varying vec2 vUV;
 uniform samplerCube textureSampler;
 uniform float lod;
+uniform bool gamma;
 void main(void)
 {
     vec2 uv=vUV*2.0-1.0;
@@ -28,6 +31,9 @@ void main(void)
     #ifdef NEGATIVEZ
     gl_FragColor=textureCube(textureSampler,vec3(uv,-1.001),lod);
     #endif
+    if (!gamma) {
+        gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(GammaEncodePowerApprox));
+    }
 }`;
 
 Effect.ShadersStore[name] = shader;

--- a/inspector/src/textureHelper.ts
+++ b/inspector/src/textureHelper.ts
@@ -24,7 +24,7 @@ export class TextureHelper {
         let lodPostProcess: PostProcess;
 
         if (!texture.isCube) {
-            lodPostProcess = new PostProcess("lod", "lod", ["lod"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine);
+            lodPostProcess = new PostProcess("lod", "lod", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine);
         } else {
             const faceDefines = [
                 "#define POSITIVEX",
@@ -34,7 +34,7 @@ export class TextureHelper {
                 "#define POSITIVEZ",
                 "#define NEGATIVEZ",
             ];
-            lodPostProcess = new PostProcess("lodCube", "lodCube", ["lod"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine, false, faceDefines[face]);
+            lodPostProcess = new PostProcess("lodCube", "lodCube", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine, false, faceDefines[face]);
         }
 
         if (!lodPostProcess.getEffect().isReady()) {
@@ -60,6 +60,7 @@ export class TextureHelper {
         lodPostProcess.onApply = function (effect) {
             effect.setTexture("textureSampler", texture);
             effect.setFloat("lod", lod);
+            effect.setBool("gamma", texture.gammaSpace)
         };
 
         const internalTexture = texture.getInternalTexture();


### PR DESCRIPTION
The texture preview in the inspector uses canvas, which is always sRGB. We need to convert linear space textures to sRGB when we are rendering them out.