### PR TITLE
[GUI] Add checkPointerEveryFrame property

### DIFF
--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -45,9 +45,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _resizeObserver: Nullable<Observer<Engine>>;
     private _preKeyboardObserver: Nullable<Observer<KeyboardInfoPre>>;
     private _pointerMoveObserver: Nullable<Observer<PointerInfoPre>>;
-    // private _cameraViewMatrixChangedObserver: Nullable<Observer<Camera>>;
-    // private _cameraChangedObserver: Nullable<Observer<Scene>>;
-    // private _camera: Nullable<Camera>;
     private _sceneRenderObserver: Nullable<Observer<Scene>>;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _canvasPointerOutObserver: Nullable<Observer<IPointerEvent>>;
@@ -552,12 +549,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (this._sceneRenderObserver) {
             scene.onBeforeRenderObservable.remove(this._sceneRenderObserver);
         }
-        // if (this._camera && this._cameraViewMatrixChangedObserver) {
-        //     this._camera?.onViewMatrixChangedObservable.remove(this._cameraViewMatrixChangedObserver);
-        // }
-        // if (this._cameraChangedObserver) {
-        //     scene.onActiveCameraChanged.remove(this._cameraChangedObserver);
-        // }
         if (this._pointerObserver) {
             scene.onPointerObservable.remove(this._pointerObserver);
         }
@@ -856,7 +847,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 pi.skipOnPointerObservable = this._shouldBlockPointer;
             }
         } else {
-            this._doPicking(x, y, null, PointerEventTypes.POINTERMOVE, 0, this._defaultMousePointerId);
+            this._doPicking(x, y, null, PointerEventTypes.POINTERMOVE, this._defaultMousePointerId, 0);
         }
         // if overridden by a rig camera - reset back to the original value
         scene.cameraToUseForPointers = originalCameraToUseForPointers;
@@ -890,7 +881,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
 
             this._translateToPicking(scene, tempViewport, pi);
         });
-        this._attachToCameraView(scene, () => this._translateToPicking(scene, tempViewport, null), false);
+        this._attachPickingToSceneRender(scene, () => this._translateToPicking(scene, tempViewport, null), false);
         this._attachToOnPointerOut(scene);
         this._attachToOnBlur(scene);
     }
@@ -1006,7 +997,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             }
         });
         mesh.enablePointerMoveEvents = supportPointerMove;
-        this._attachToCameraView(scene, () => {
+        this._attachPickingToSceneRender(scene, () => {
             const pointerId = this._defaultMousePointerId;
             const pick = scene?.pick(scene.pointerX, scene.pointerY);
             if (pick && pick.hit && pick.pickedMesh === mesh) {
@@ -1020,8 +1011,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                         PointerEventTypes.POINTERMOVE,
                         pointerId,
                         0,
-                        0,
-                        0
                     );
                 }
             } else {
@@ -1059,7 +1048,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             }
         }
     }
-    private _attachToCameraView(scene: Scene, pickFunction: () => void, forcePicking: boolean) {
+    private _attachPickingToSceneRender(scene: Scene, pickFunction: () => void, forcePicking: boolean) {
         this._sceneRenderObserver = scene.onBeforeRenderObservable.add(() => {
             if (!this.checkPointerEveryFrame) return;
             if (this._linkedControls.length > 0 || forcePicking) {

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -45,6 +45,10 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _resizeObserver: Nullable<Observer<Engine>>;
     private _preKeyboardObserver: Nullable<Observer<KeyboardInfoPre>>;
     private _pointerMoveObserver: Nullable<Observer<PointerInfoPre>>;
+    // private _cameraViewMatrixChangedObserver: Nullable<Observer<Camera>>;
+    // private _cameraChangedObserver: Nullable<Observer<Scene>>;
+    // private _camera: Nullable<Camera>;
+    private _sceneRenderObserver: Nullable<Observer<Scene>>;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _canvasPointerOutObserver: Nullable<Observer<IPointerEvent>>;
     private _canvasBlurObserver: Nullable<Observer<Engine>>;
@@ -346,6 +350,14 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     public set clipboardData(value: string) {
         this._clipboardData = value;
     }
+
+    /**
+     * If set to true, every scene render will trigger a pointer event for the GUI
+     * if it is linked to a mesh or has controls linked to a mesh. This will allow
+     * you to catch the pointer moving around the GUI due to camera or mesh movements,
+     * but it has a performance cost.
+     */
+    public checkPointerEveryFrame = false;
     /**
      * Creates a new AdvancedDynamicTexture
      * @param name defines the name of the texture
@@ -537,6 +549,15 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (this._pointerMoveObserver) {
             scene.onPrePointerObservable.remove(this._pointerMoveObserver);
         }
+        if (this._sceneRenderObserver) {
+            scene.onBeforeRenderObservable.remove(this._sceneRenderObserver);
+        }
+        // if (this._camera && this._cameraViewMatrixChangedObserver) {
+        //     this._camera?.onViewMatrixChangedObservable.remove(this._cameraViewMatrixChangedObserver);
+        // }
+        // if (this._cameraChangedObserver) {
+        //     scene.onActiveCameraChanged.remove(this._cameraChangedObserver);
+        // }
         if (this._pointerObserver) {
             scene.onPointerObservable.remove(this._pointerObserver);
         }
@@ -729,7 +750,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._lastControlDown[pointerId] = control;
         this.onControlPickedObservable.notifyObservers(control);
     }
-    private _doPicking(x: number, y: number, pi: PointerInfoBase, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): void {
+    private _doPicking(x: number, y: number, pi: Nullable<PointerInfoBase>, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): void {
         var scene = this.getScene();
         if (!scene) {
             return;
@@ -785,6 +806,62 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._cleanControlAfterRemovalFromList(this._lastControlDown, control);
         this._cleanControlAfterRemovalFromList(this._lastControlOver, control);
     }
+
+    private _translateToPicking(scene: Scene, tempViewport: Viewport, pi: Nullable<PointerInfoPre>) {
+        const camera = scene.cameraToUseForPointers || scene.activeCamera;
+        const engine = scene.getEngine();
+        const originalCameraToUseForPointers = scene.cameraToUseForPointers;
+
+        if (!camera) {
+            tempViewport.x = 0;
+            tempViewport.y = 0;
+            tempViewport.width = engine.getRenderWidth();
+            tempViewport.height = engine.getRenderHeight();
+        } else {
+            if (camera.rigCameras.length) {
+                // rig camera - we need to find the camera to use for this event
+                let rigViewport = new Viewport(0, 0, 1, 1);
+                camera.rigCameras.forEach((rigCamera) => {
+                    // generate the viewport of this camera
+                    rigCamera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), rigViewport);
+                    let x = scene.pointerX / engine.getHardwareScalingLevel() - rigViewport.x;
+                    let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - rigViewport.y - rigViewport.height);
+                    // check if the pointer is in the camera's viewport
+                    if (x < 0 || y < 0 || x > rigViewport.width || y > rigViewport.height) {
+                        // out of viewport - don't use this camera
+                        return;
+                    }
+                    // set the camera to use for pointers until this pointer loop is over
+                    scene.cameraToUseForPointers = rigCamera;
+                    // set the viewport
+                    tempViewport.x = rigViewport.x;
+                    tempViewport.y = rigViewport.y;
+                    tempViewport.width = rigViewport.width;
+                    tempViewport.height = rigViewport.height;
+                });
+            } else {
+                camera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), tempViewport);
+            }
+        }
+
+        let x = scene.pointerX / engine.getHardwareScalingLevel() - tempViewport.x;
+        let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - tempViewport.y - tempViewport.height);
+        this._shouldBlockPointer = false;
+        // Do picking modifies _shouldBlockPointer
+        if (pi) {
+            let pointerId = (pi.event as IPointerEvent).pointerId || this._defaultMousePointerId;
+            this._doPicking(x, y, pi, pi.type, pointerId, pi.event.button, (<IWheelEvent>pi.event).deltaX, (<IWheelEvent>pi.event).deltaY);
+            // Avoid overwriting a true skipOnPointerObservable to false
+            if (this._shouldBlockPointer) {
+                pi.skipOnPointerObservable = this._shouldBlockPointer;
+            }
+        } else {
+            this._doPicking(x, y, null, PointerEventTypes.POINTERMOVE, 0, this._defaultMousePointerId);
+        }
+        // if overridden by a rig camera - reset back to the original value
+        scene.cameraToUseForPointers = originalCameraToUseForPointers;
+    }
+
     /** Attach to all scene events required to support pointer events */
     public attach(): void {
         const scene = this.getScene();
@@ -811,55 +888,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 this._defaultMousePointerId = (pi.event as IPointerEvent).pointerId; // This is required to make sure we have the correct pointer ID for wheel
             }
 
-            const camera = scene.cameraToUseForPointers || scene.activeCamera;
-            const engine = scene.getEngine();
-            const originalCameraToUseForPointers = scene.cameraToUseForPointers;
-
-            if (!camera) {
-                tempViewport.x = 0;
-                tempViewport.y = 0;
-                tempViewport.width = engine.getRenderWidth();
-                tempViewport.height = engine.getRenderHeight();
-            } else {
-                if (camera.rigCameras.length) {
-                    // rig camera - we need to find the camera to use for this event
-                    let rigViewport = new Viewport(0, 0, 1, 1);
-                    camera.rigCameras.forEach((rigCamera) => {
-                        // generate the viewport of this camera
-                        rigCamera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), rigViewport);
-                        let x = scene.pointerX / engine.getHardwareScalingLevel() - rigViewport.x;
-                        let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - rigViewport.y - rigViewport.height);
-                        // check if the pointer is in the camera's viewport
-                        if (x < 0 || y < 0 || x > rigViewport.width || y > rigViewport.height) {
-                            // out of viewport - don't use this camera
-                            return;
-                        }
-                        // set the camera to use for pointers until this pointer loop is over
-                        scene.cameraToUseForPointers = rigCamera;
-                        // set the viewport
-                        tempViewport.x = rigViewport.x;
-                        tempViewport.y = rigViewport.y;
-                        tempViewport.width = rigViewport.width;
-                        tempViewport.height = rigViewport.height;
-                    });
-                } else {
-                    camera.viewport.toGlobalToRef(engine.getRenderWidth(), engine.getRenderHeight(), tempViewport);
-                }
-            }
-
-            let x = scene.pointerX / engine.getHardwareScalingLevel() - tempViewport.x;
-            let y = scene.pointerY / engine.getHardwareScalingLevel() - (engine.getRenderHeight() - tempViewport.y - tempViewport.height);
-            this._shouldBlockPointer = false;
-            // Do picking modifies _shouldBlockPointer
-            let pointerId = (pi.event as IPointerEvent).pointerId || this._defaultMousePointerId;
-            this._doPicking(x, y, pi, pi.type, pointerId, pi.event.button, (<IWheelEvent>pi.event).deltaX, (<IWheelEvent>pi.event).deltaY);
-            // Avoid overwriting a true skipOnPointerObservable to false
-            if (this._shouldBlockPointer) {
-                pi.skipOnPointerObservable = this._shouldBlockPointer;
-            }
-            // if overridden by a rig camera - reset back to the original value
-            scene.cameraToUseForPointers = originalCameraToUseForPointers;
+            this._translateToPicking(scene, tempViewport, pi);
         });
+        this._attachToCameraView(scene, () => this._translateToPicking(scene, tempViewport, null), false);
         this._attachToOnPointerOut(scene);
         this._attachToOnBlur(scene);
     }
@@ -975,6 +1006,31 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             }
         });
         mesh.enablePointerMoveEvents = supportPointerMove;
+        this._attachToCameraView(scene, () => {
+            const pointerId = this._defaultMousePointerId;
+            const pick = scene?.pick(scene.pointerX, scene.pointerY);
+            if (pick && pick.hit && pick.pickedMesh === mesh) {
+                var uv = pick.getTextureCoordinates();
+                if (uv) {
+                    let size = this.getSize();
+                    this._doPicking(
+                        uv.x * size.width,
+                        (this.applyYInversionOnUpdate ? 1.0 - uv.y : uv.y) * size.height,
+                        null,
+                        PointerEventTypes.POINTERMOVE,
+                        pointerId,
+                        0,
+                        0,
+                        0
+                    );
+                }
+            } else {
+                if (this._lastControlOver[pointerId]) {
+                    this._lastControlOver[pointerId]._onPointerOut(this._lastControlOver[pointerId], null, true);
+                }
+                delete this._lastControlOver[pointerId];
+            }
+        }, true);
         this._attachToOnPointerOut(scene);
         this._attachToOnBlur(scene);
     }
@@ -1002,6 +1058,14 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 this.focusedControl = null;
             }
         }
+    }
+    private _attachToCameraView(scene: Scene, pickFunction: () => void, forcePicking: boolean) {
+        this._sceneRenderObserver = scene.onBeforeRenderObservable.add(() => {
+            if (!this.checkPointerEveryFrame) return;
+            if (this._linkedControls.length > 0 || forcePicking) {
+                pickFunction();
+            }
+        });
     }
     private _attachToOnPointerOut(scene: Scene): void {
         this._canvasPointerOutObserver = scene.getEngine().onCanvasPointerOutObservable.add((pointerEvent) => {

--- a/gui/src/2D/advancedDynamicTexture.ts
+++ b/gui/src/2D/advancedDynamicTexture.ts
@@ -1050,7 +1050,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     }
     private _attachPickingToSceneRender(scene: Scene, pickFunction: () => void, forcePicking: boolean) {
         this._sceneRenderObserver = scene.onBeforeRenderObservable.add(() => {
-            if (!this.checkPointerEveryFrame) return;
+            if (!this.checkPointerEveryFrame) {
+                return;
+            }
             if (this._linkedControls.length > 0 || forcePicking) {
                 pickFunction();
             }

--- a/gui/src/2D/controls/container.ts
+++ b/gui/src/2D/controls/container.ts
@@ -496,7 +496,7 @@ export class Container extends Control {
     }
 
     /** @hidden */
-    public _processPicking(x: number, y: number, pi: PointerInfoBase, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
+    public _processPicking(x: number, y: number, pi: Nullable<PointerInfoBase>, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
         if (!this._isEnabled || !this.isVisible || this.notRenderable) {
             return false;
         }

--- a/gui/src/2D/controls/control.ts
+++ b/gui/src/2D/controls/control.ts
@@ -2007,7 +2007,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _processPicking(x: number, y: number, pi: PointerInfoBase, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
+    public _processPicking(x: number, y: number, pi: Nullable<PointerInfoBase>, type: number, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
         if (!this._isEnabled) {
             return false;
         }
@@ -2025,7 +2025,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _onPointerMove(target: Control, coordinates: Vector2, pointerId: number, pi: PointerInfoBase): void {
+    public _onPointerMove(target: Control, coordinates: Vector2, pointerId: number, pi: Nullable<PointerInfoBase>): void {
         var canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, -1, target, this, pi);
 
         if (canNotify && this.parent != null) {
@@ -2034,7 +2034,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _onPointerEnter(target: Control, pi: PointerInfoBase): boolean {
+    public _onPointerEnter(target: Control, pi: Nullable<PointerInfoBase>): boolean {
         if (!this._isEnabled) {
             return false;
         }
@@ -2076,7 +2076,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _onPointerDown(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, pi: PointerInfoBase): boolean {
+    public _onPointerDown(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, pi: Nullable<PointerInfoBase>): boolean {
         // Prevent pointerout to lose control context.
         // Event redundancy is checked inside the function.
         this._onPointerEnter(this, pi);
@@ -2099,7 +2099,7 @@ export class Control {
     }
 
     /** @hidden */
-    public _onPointerUp(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, notifyClick: boolean, pi?: PointerInfoBase): void {
+    public _onPointerUp(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, notifyClick: boolean, pi?: Nullable<PointerInfoBase>): void {
         if (!this._isEnabled) {
             return;
         }
@@ -2145,7 +2145,7 @@ export class Control {
     public _onCanvasBlur(): void { }
 
     /** @hidden */
-    public _processObservables(type: number, x: number, y: number, pi: PointerInfoBase, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
+    public _processObservables(type: number, x: number, y: number, pi: Nullable<PointerInfoBase>, pointerId: number, buttonIndex: number, deltaX?: number, deltaY?: number): boolean {
         if (!this._isEnabled) {
             return false;
         }


### PR DESCRIPTION
Adds a "checkPointerEveryFrame" property to AdvancedDynamicTexture. If true, and if the ADT is linked to a mesh or there are any controls linked to a mesh, every scene render will call doPicking, which has the potential to trigger POINTERMOVE events.

Test playground: https://playground.babylonjs.com/#ZI9AK7#2027

Makes PointerInfo nullable, as ew don't have any pointerinfo if there was no real pointer signal.

Closes #12027.
