### PR TITLE
fixed drawbuffer call when the default framebuffer is bound

### DIFF
--- a/src/Rendering/prePassRenderer.ts
+++ b/src/Rendering/prePassRenderer.ts
@@ -273,7 +273,11 @@ export class PrePassRenderer {
             if (effect._multiTarget && isPrePassCapable && !excluded) {
                 this._engine.bindAttachments(this._multiRenderAttachments);
             } else {
-                this._engine.bindAttachments(this._defaultAttachments);
+                if (this._engine._currentRenderTarget) {
+                    this._engine.bindAttachments(this._defaultAttachments);
+                } else {
+                    this._engine.restoreSingleAttachment();
+                }
 
                 if (this._geometryBuffer && this.currentRTisSceneRT && !excluded) {
                     this._geometryBuffer.renderList!.push(subMesh.getRenderingMesh());
@@ -368,7 +372,11 @@ export class PrePassRenderer {
      */
     public restoreAttachments() {
         if (this.enabled && this._currentTarget.enabled && this._defaultAttachments) {
-            this._engine.bindAttachments(this._defaultAttachments);
+            if (this._engine._currentRenderTarget) {
+                this._engine.bindAttachments(this._defaultAttachments);
+            } else {
+                this._engine.restoreSingleAttachment();
+            }
         }
     }
 


### PR DESCRIPTION
Related to webgl errors in https://forum.babylonjs.com/t/transparencies-and-babylon-5-super-improvement/25536/23

We can't use `gl.drawBuffers([gl.COLOR_ATTACHMENT0] `when no framebuffer is bound, we have to use `gl.drawBuffers([gl.BACK])`