### PR TITLE
Fix ssao utility layer

### DIFF
--- a/src/Rendering/utilityLayerRenderer.ts
+++ b/src/Rendering/utilityLayerRenderer.ts
@@ -159,6 +159,9 @@ export class UtilityLayerRenderer implements IDisposable {
         this.utilityLayerScene.useRightHandedSystem = originalScene.useRightHandedSystem;
         this.utilityLayerScene._allowPostProcessClearColor = false;
 
+        // Deactivate post processes
+        this.utilityLayerScene.postProcessesEnabled = false;
+
         // Detach controls on utility scene, events will be fired by logic below to handle picking priority
         this.utilityLayerScene.detachControl();
 


### PR DESCRIPTION
Disables all post processes on the utility layer scene, so SSAO is not applied twice (ssao is a render pipeline linked to a camera, not the scene)