### PR TITLE
Added check to ArcRotateCamera for non-y axis panning

### DIFF
--- a/src/Cameras/arcRotateCamera.ts
+++ b/src/Cameras/arcRotateCamera.ts
@@ -939,7 +939,7 @@ export class ArcRotateCamera extends TargetCamera {
             localDirection.multiplyInPlace(this.panningAxis);
             Vector3.TransformNormalToRef(localDirection, this._cameraTransformMatrix, this._transformedDirection);
             // Eliminate y if mapPanning is enabled
-            if (this.mapPanning) {
+            if (this.mapPanning || !this.panningAxis.y) {
                 this._transformedDirection.y = 0;
             }
 


### PR DESCRIPTION
This PR contains a simple fix for a regression with the ArcRotateCamera's behavior.  This fix was provided by forum user Oscar and adds a check to see if the panning axis includes the y-axis.  If not, the transformedDirection information is then ignored (in the same manner as if mapPanning was true.  This should put the current behavior inline with the previous behavior from 4.2