### PR TITLE
Fix native shaders OpenGL

### DIFF
--- a/src/Shaders/depthOfField.fragment.fx
+++ b/src/Shaders/depthOfField.fragment.fx
@@ -172,7 +172,7 @@ void main(void)
 	float coc = abs(aperture * (screen_distance * (inverse_focal_length - 1.0 / distance) - 1.0));
 
 	// disable blur
-	if (dof_enabled == false || coc < 0.07) { coc = 0.0; }
+	if (float(dof_enabled) == 0. || coc < 0.07) { coc = 0.0; }
 
 	// blur from edge blur effect
 	float edge_blur_amount = 0.0;
@@ -193,11 +193,11 @@ void main(void)
 		gl_FragColor = getBlurColor(blur_amount * 1.7);
 
 		// if we have computed highlights: enhance highlights
-		if (highlights) {
+		if (float(highlights) != 0.) {
 			gl_FragColor.rgb += clamp(coc, 0.0, 1.0)*texture2D(highlightsSampler, distorted_coords).rgb;
 		}
 
-		if (blur_noise) {
+		if (float(blur_noise) != 0.) {
 			// we put a slight amount of noise in the blurred color
 			vec2 noise = rand(distorted_coords) * 0.01 * blur_amount;
 			vec2 blurred_coord = vec2(distorted_coords.x + noise.x, distorted_coords.y + noise.y);

--- a/src/Shaders/depthOfField.fragment.fx
+++ b/src/Shaders/depthOfField.fragment.fx
@@ -193,6 +193,7 @@ void main(void)
 		gl_FragColor = getBlurColor(blur_amount * 1.7);
 
 		// if we have computed highlights: enhance highlights
+		// cast explanation : https://github.com/BabylonJS/Babylon.js/pull/12070
 		if (float(highlights) != 0.) {
 			gl_FragColor.rgb += clamp(coc, 0.0, 1.0)*texture2D(highlightsSampler, distorted_coords).rgb;
 		}

--- a/src/Shaders/sprites.fragment.fx
+++ b/src/Shaders/sprites.fragment.fx
@@ -18,7 +18,7 @@ void main(void) {
 
 	vec4 color = texture2D(diffuseSampler, vUV);
 
-	if (alphaTest != 0.) 
+	if (float(alphaTest) != 0.)
 	{
 		if (color.a < 0.95)
 			discard;

--- a/src/Shaders/sprites.fragment.fx
+++ b/src/Shaders/sprites.fragment.fx
@@ -18,6 +18,7 @@ void main(void) {
 
 	vec4 color = texture2D(diffuseSampler, vUV);
 
+	// cast explanation : https://github.com/BabylonJS/Babylon.js/pull/12070
 	if (float(alphaTest) != 0.)
 	{
 		if (color.a < 0.95)

--- a/src/Shaders/sprites.fragment.fx
+++ b/src/Shaders/sprites.fragment.fx
@@ -18,7 +18,7 @@ void main(void) {
 
 	vec4 color = texture2D(diffuseSampler, vUV);
 
-	if (alphaTest) 
+	if (alphaTest != 0.) 
 	{
 		if (color.a < 0.95)
 			discard;


### PR DESCRIPTION
In native, every uniform is converted to a vec4 and usage in shader is updated accordingly. This is done because bgfx only support vec4/mat4, for every rendering backend.
For example, 
`uniform bool alphaTest;` is converted to `uniform vec4 alphaTest;` and usage is changed:
`if (alphaTest)` to `if (alphaTest.x)`
A problem rised with OpenGL (at least it doesn't with Metal and HLSL, don't know for Vulkan): Conversion from a float value to a boolean is not authorized and compiling the shader crashes the app.

The fix here casts alphaTest to a float and compares it with 0.
I fixed it for the DOF postprocess as well. IIRC it crashed on Native ( ping @DarraghBurkeMS )

Tested with D3D11 and OpenGL.