### PR TITLE
Roll back change that broke nativeOverride

### DIFF
--- a/src/Misc/decorators.ts
+++ b/src/Misc/decorators.ts
@@ -445,7 +445,7 @@ declare const _native: any;
  * Decorator used to redirect a function to a native implementation if available.
  * @hidden
  */
-export function nativeOverride<T extends (...params: any[]) => boolean>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<(...params: Parameters<T>) => unknown>, predicate?: T) {
+export function nativeOverride<T extends (...params: any) => boolean>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<(...params: Parameters<T>) => unknown>, predicate?: T) {
     // Cache the original JS function for later.
     const jsFunc = descriptor.value!;
 
@@ -460,7 +460,7 @@ export function nativeOverride<T extends (...params: any[]) => boolean>(target: 
             // If a predicate was provided, then we'll need to invoke the predicate on each invocation of the underlying function to determine whether to call the native function or the JS function.
             if (predicate) {
                 // The resolved function will execute the predicate and then either execute the native function or the JS function.
-                func = (...params: Parameters<T>) => (predicate(params) ? nativeFunc(...params) : jsFunc(...params));
+                func = (...params: Parameters<T>) => predicate(...params) ? nativeFunc(...params) : jsFunc(...params);
             } else {
                 // The resolved function will directly execute the native function.
                 func = nativeFunc;


### PR DESCRIPTION
A recent [change](https://github.com/BabylonJS/Babylon.js/pull/11989/files#diff-cc077f3b29e3f852d03820acd8ccc536b87ff54bc63cd1b324097c69196ef7f9) broken the `@nativeOverride` decorator. A spread operator was removed that semantically changed the code. This change rolls back that change to fix the broken functionality. I already talked with @RaananW about this and he will investigate other ways to change the code and make the newest versions of TS happy with it.