### PR TITLE
Set WebXRSessionManager._engine to null on dispose

### DIFF
--- a/src/XR/webXRSessionManager.ts
+++ b/src/XR/webXRSessionManager.ts
@@ -130,6 +130,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         this.onXRReferenceSpaceChanged.clear();
         this.onXRSessionInit.clear();
         this._engine?.onDisposeObservable.remove(this._onEngineDisposedObserver);
+        this._engine = null;
     }
 
     /**


### PR DESCRIPTION
In a recent commit (https://github.com/BabylonJS/Babylon.js/commit/1a1c274b36ebf57259c39ce91112d17a182fdcf0), the following line was added to `webXRSessionManager.ts`:
```typescript
this._engine?.onDisposeObservable.remove(this._onEngineDisposedObserver);
```
The result of this however is that there can be a period of time where the `WebXRSessionManager` has been disposed and the `Engine` has been disposed but the `this._engine` property has not been cleared, and code in `WebXRSessionManager` still tries to operate on it (such as in the session `end` event handler). In the case of the Babylon Native, this can mean that we actually try to call into a disposed engine, which breaks things (this is an actual regression we're seeing in Babylon Native). So the change here is to set the `this._engine` property to null during `dispose` to ensure we don't continue to try to interact with it under any circumstances.