### PR TITLE
Add and use AutoReleaseWorkerPool for auto cleanup

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -74,6 +74,7 @@
 - Added `getCreationOptions` on `ThinEngine`. ([carolhmj](https://github.com/carolhmj))
 - Added `CompatibilityOptions.UseOpenGLOrientationForUV` to define if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default) ([Deltakosh](https://github.com/deltakosh))
 - Added RuntimeError and errorCodes for runtime errors. ([jp833](https://github.com/jp833))
+- Added `AutoReleaseWorkerPool` which will automatically terminate idle workers after a specified amount of time and use them in KTX2 and Draco decoders. ([bghgary](https://github.com/bghgary))
 
 ### Engine
 

--- a/loaders/src/glTF/glTFValidation.ts
+++ b/loaders/src/glTF/glTFValidation.ts
@@ -117,12 +117,14 @@ export class GLTFValidation {
                             worker.removeEventListener("error", onError);
                             worker.removeEventListener("message", onMessage);
                             resolve(data.value);
+                            worker.terminate();
                             break;
                         }
                         case "validate.reject": {
                             worker.removeEventListener("error", onError);
                             worker.removeEventListener("message", onMessage);
                             reject(data.reason);
+                            worker.terminate();
                         }
                     }
                 };

--- a/src/Misc/workerPool.ts
+++ b/src/Misc/workerPool.ts
@@ -1,16 +1,17 @@
 import { IDisposable } from "../scene";
 
 interface WorkerInfo {
-    worker: Worker;
-    active: boolean;
+    workerPromise: Promise<Worker>;
+    idle: boolean;
+    timeoutId?: number;
 }
 
 /**
  * Helper class to push actions to a pool of workers.
  */
 export class WorkerPool implements IDisposable {
-    private _workerInfos: Array<WorkerInfo>;
-    private _pendingActions = new Array<(worker: Worker, onComplete: () => void) => void>();
+    protected _workerInfos: Array<WorkerInfo>;
+    protected _pendingActions = new Array<(worker: Worker, onComplete: () => void) => void>();
 
     /**
      * Constructor
@@ -18,8 +19,8 @@ export class WorkerPool implements IDisposable {
      */
     constructor(workers: Array<Worker>) {
         this._workerInfos = workers.map((worker) => ({
-            worker: worker,
-            active: false
+            workerPromise: Promise.resolve(worker),
+            idle: true
         }));
     }
 
@@ -28,11 +29,13 @@ export class WorkerPool implements IDisposable {
      */
     public dispose(): void {
         for (const workerInfo of this._workerInfos) {
-            workerInfo.worker.terminate();
+            workerInfo.workerPromise.then((worker) => {
+                worker.terminate();
+            });
         }
 
-        this._workerInfos = [];
-        this._pendingActions = [];
+        this._workerInfos.length = 0;
+        this._pendingActions.length = 0;
     }
 
     /**
@@ -41,24 +44,98 @@ export class WorkerPool implements IDisposable {
      * @param action The action to perform. Call onComplete when the action is complete.
      */
     public push(action: (worker: Worker, onComplete: () => void) => void): void {
+        if (!this._executeOnIdleWorker(action)) {
+            this._pendingActions.push(action);
+        }
+    }
+
+    protected _executeOnIdleWorker(action: (worker: Worker, onComplete: () => void) => void): boolean {
         for (const workerInfo of this._workerInfos) {
-            if (!workerInfo.active) {
+            if (workerInfo.idle) {
                 this._execute(workerInfo, action);
-                return;
+                return true;
             }
         }
 
-        this._pendingActions.push(action);
+        return false;
     }
 
-    private _execute(workerInfo: WorkerInfo, action: (worker: Worker, onComplete: () => void) => void): void {
-        workerInfo.active = true;
-        action(workerInfo.worker, () => {
-            workerInfo.active = false;
-            const nextAction = this._pendingActions.shift();
-            if (nextAction) {
-                this._execute(workerInfo, nextAction);
+    protected _execute(workerInfo: WorkerInfo, action: (worker: Worker, onComplete: () => void) => void): void {
+        workerInfo.idle = false;
+        workerInfo.workerPromise.then((worker) => {
+            action(worker, () => {
+                const nextAction = this._pendingActions.shift();
+                if (nextAction) {
+                    this._execute(workerInfo, nextAction);
+                } else {
+                    workerInfo.idle = true;
+                }
+            });
+        });
+    }
+}
+
+export interface AutoReleaseWorkPoolOptions {
+    idleTimeElapsedBeforeRelease: number;
+}
+
+export class AutoReleaseWorkerPool extends WorkerPool {
+    public static DefaultOptions: AutoReleaseWorkPoolOptions = {
+        idleTimeElapsedBeforeRelease: 1000
+    };
+
+    private readonly _maxWorkers: number;
+    private readonly _createWorkerAsync: () => Promise<Worker>;
+    private readonly _options: AutoReleaseWorkPoolOptions;
+
+    constructor(maxWorkers: number, createWorkerAsync: () => Promise<Worker>, options = AutoReleaseWorkerPool.DefaultOptions) {
+        super([]);
+
+        this._maxWorkers = maxWorkers;
+        this._createWorkerAsync = createWorkerAsync;
+        this._options = options;
+    }
+
+    public push(action: (worker: Worker, onComplete: () => void) => void): void {
+        if (!this._executeOnIdleWorker(action)) {
+            if (this._workerInfos.length < this._maxWorkers) {
+                const workerInfo: WorkerInfo = {
+                    workerPromise: this._createWorkerAsync(),
+                    idle: false
+                };
+                this._workerInfos.push(workerInfo);
+                this._execute(workerInfo, action);
+            } else {
+                this._pendingActions.push(action);
             }
+        }
+    }
+
+    protected _execute(workerInfo: WorkerInfo, action: (worker: Worker, onComplete: () => void) => void): void {
+        // Reset the idle timeout.
+        if (workerInfo.timeoutId) {
+            clearTimeout(workerInfo.timeoutId);
+            delete workerInfo.timeoutId;
+        }
+
+        super._execute(workerInfo, (worker, onComplete) => {
+            action(worker, () => {
+                onComplete();
+
+                if (workerInfo.idle) {
+                    // Schedule the worker to be terminated after the elapsed time.
+                    workerInfo.timeoutId = setTimeout(() => {
+                        workerInfo.workerPromise.then((worker) => {
+                            worker.terminate();
+                        });
+
+                        const indexOf = this._workerInfos.indexOf(workerInfo);
+                        if (indexOf !== -1) {
+                            this._workerInfos.splice(indexOf, 1);
+                        }
+                    }, this._options.idleTimeElapsedBeforeRelease);
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
See forum issue: https://forum.babylonjs.com/t/workers-of-ktx2-loader-are-never-closed/28119

This change adds an `AutoReleaseWorkerPool` class that derives from `WorkerPool`. It will automatically terminate workers that have been idle for a specified timeout (1 second by default). This is used by KTX2 and Draco so that the workers can release the memory.