### PR TITLE
fix function _internalPick's return 

### DIFF
--- a/src/Culling/ray.ts
+++ b/src/Culling/ray.ts
@@ -730,7 +730,7 @@ Scene.prototype._internalPick = function (rayFunction: (world: Matrix, enableDis
             if (result) {
                 if (onlyBoundingInfo) {
                     // the user only asked for a bounding info check so we can return
-                    return pickingInfo;
+                    return result;
                 }
                 const tmpMatrix = TmpVectors.Matrix[1];
                 let thinMatrices = (mesh as Mesh).thinInstanceGetWorldMatrices();


### PR DESCRIPTION
when using thinInstanceEnablePicking and pickWithBoundingInfo, '_internalPick' function will always return null. It seems it is not expected.
PG: https://playground.babylonjs.com/#RC2IAH#38