### PR TITLE
[Viewer] add a 3d-commerce-certified flag to the viewer

### DIFF
--- a/Viewer/dist/3dCommerceCertifiedExample.html
+++ b/Viewer/dist/3dCommerceCertifiedExample.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>BabylonJS Viewer - UFO</title>
+    </head>
+
+    <body>
+        <babylon 3d-commerce-certified="true" extends="default, shadowDirectionalLight, environmentMap" templates.nav-bar.params.hide-logo="true" templates.main.params.fill-screen="true">
+            <scene glow="true">
+            </scene>
+            <lab>
+                <environment-main-color r="0.5" g="0.2" b="0.2"></environment-main-color>
+            </lab>
+            <model url="https://models.babylonjs.com/ufo.glb">
+                <animation auto-start="true"></animation>
+            </model>
+            <camera beta="0.8"></camera>
+        </babylon>
+        <script src="viewer.js"></script>
+    </body>
+
+</html>

--- a/Viewer/src/configuration/configuration.ts
+++ b/Viewer/src/configuration/configuration.ts
@@ -94,6 +94,7 @@ export interface ViewerConfiguration {
     environmentMap?: IEnvironmentMapConfiguration;
 
     vr?: IVRConfiguration;
+    "3dCommerceCertified"?: boolean;
 
     // features that are being tested.
     // those features' syntax will change and move out!

--- a/Viewer/src/viewer/viewer.ts
+++ b/Viewer/src/viewer/viewer.ts
@@ -1,5 +1,5 @@
 import { Engine } from 'babylonjs/Engines/engine';
-import { ISceneLoaderPlugin, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent } from 'babylonjs/Loading/sceneLoader';
+import { ISceneLoaderPlugin, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent, SceneLoader } from 'babylonjs/Loading/sceneLoader';
 import { Observable } from 'babylonjs/Misc/observable';
 import { Scene } from 'babylonjs/scene';
 import { RenderingManager } from 'babylonjs/Rendering/renderingManager';
@@ -20,6 +20,7 @@ import { viewerManager } from './viewerManager';
 import { ViewerConfiguration } from '../configuration/configuration';
 import { IObserversConfiguration } from '../configuration/interfaces/observersConfiguration';
 import { IModelConfiguration } from '../configuration/interfaces/modelConfiguration';
+import { GLTFFileLoader } from 'babylonjs-loaders/glTF/glTFFileLoader';
 
 /**
  * The AbstractViewer is the center of Babylon's viewer.
@@ -648,6 +649,21 @@ export abstract class AbstractViewer {
         if (viewerGlobals.disableWebGL2Support) {
             config.engineOptions = config.engineOptions || {};
             config.engineOptions.disableWebGL2Support = true;
+        }
+
+        if(this.configuration["3dCommerceCertified"]) {
+            config.engineOptions = config.engineOptions || {};
+            config.engineOptions.forceSRGBBufferSupportState = true;
+            const loader = SceneLoader.GetPluginForExtension(".gltf");
+            if(loader) {
+                (loader as GLTFFileLoader).transparencyAsCoverage = true;
+            }
+            SceneLoader.OnPluginActivatedObservable.add((plugin) => {
+                if (plugin.name === "gltf") {
+                    const loader = plugin as GLTFFileLoader;
+                    loader.transparencyAsCoverage = true;
+                }
+            });
         }
 
         this.engine = new Engine(this.canvas, !!config.antialiasing, config.engineOptions);


### PR DESCRIPTION
a new flag was added to the configuration - 3dCommerceCertified. When set to true, it sets the following flags automatically:

https://doc.babylonjs.com/divingDeeper/3D_commerce_certif#certified-viewer-version-based-on-babylonjs-engine