### PR TITLE
[Inspector] Fix checkbox not rendering correctly

### DIFF
--- a/guiEditor/src/components/propertyTab/propertyTab.scss
+++ b/guiEditor/src/components/propertyTab/propertyTab.scss
@@ -893,38 +893,6 @@ hr.ge {
             align-items: center;
             margin-left: auto;
             margin-right: 0px;
-            
-            .lbl {
-                position: relative;
-                display: block;
-                height: 14px;
-                width: 34px;
-                border-radius: 100px;
-                cursor: pointer;
-                transition: all 0.3s ease;
-                border: solid;
-                border-width: thin;
-            }
-
-            .lbl:after {
-                position: absolute;
-                left: 3px;
-                top: 1px;
-                display: block;
-                width: 10px;
-                height: 10px;
-                border-radius: 100px;
-                background: #e2e2e2;
-                box-shadow: 0px 3px 3px rgba(0,0,0,0.05);
-                content: '';
-                transition: all 0.15s ease;
-                border: solid;
-                border-width: thin;
-            }
-
-            .lbl:active:after { 
-                transform: scale(1.15, 0.85); 
-            }
 
             .cbx:checked ~ label { 
                 background: transparent;

--- a/inspector/src/components/actionTabs/actionTabs.scss
+++ b/inspector/src/components/actionTabs/actionTabs.scss
@@ -852,7 +852,11 @@ $line-padding-left: 2px;
 
                         .hidden { 
                             display: none; 
-                        }               
+                        }
+                        
+                        .icon {
+                            display: none;
+                        }
                     }                    
                 }                   
 

--- a/sharedUiComponents/lines/checkBoxLineComponent.tsx
+++ b/sharedUiComponents/lines/checkBoxLineComponent.tsx
@@ -101,7 +101,7 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
                     </div>}
                 {this.props.faIcons && <FontAwesomeIcon className={`cbx ${this.props.disabled ? "disabled" : ""}`} icon={this.state.isSelected ? this.props.faIcons.enabled : this.props.faIcons.disabled} onClick={() => !this.props.disabled && this.onChange()}/>}
                 {!this.props.faIcons && <div className="checkBox">
-                    <label className="container">
+                    <label className={`container lbl${!!this.props.disabled ? " disabled" : ""}`}>
                         <input
                             type="checkbox"
                             className={`cbx hidden ${this.state.isConflict ? "conflict" : ""}`}


### PR DESCRIPTION
Fixes checkbox inputs that were broken by a change to GUI editor. Checkboxes now render the old CSS for the inspector (and no icon), while in the GUI editor they render the new SVG icon instead.