### PR TITLE
Prevent exception when glTF has empty joints array

### DIFF
--- a/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1183,6 +1183,10 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _findSkeletonRootNode(context: string, joints: Array<number>): Nullable<INode> {
+        if (joints.length === 0) {
+            return null;
+        }
+
         const paths: { [joint: number]: Array<INode> } = {};
         for (const index of joints) {
             const path = new Array<INode>();


### PR DESCRIPTION
See forum: https://forum.babylonjs.com/t/cannot-save-and-load-skeleton/28182