### PR TITLE
Fix WebGPU Compute on Meshes

### DIFF
--- a/src/Meshes/geometry.ts
+++ b/src/Meshes/geometry.ts
@@ -692,6 +692,11 @@ export class Geometry implements IGetSetVerticesData {
         } else {
             if (!data) {
                 data = this.getVerticesData(VertexBuffer.PositionKind)!;
+                // This can happen if the buffer comes from a Hardware Buffer where
+                // The data have not been uploaded by Babylon. (ex: Compute Shaders and Storage Buffers)
+                if (!data) {
+                    return;
+                }
             }
 
             this._extend = extractMinAndMax(data, 0, this._totalVertices, this.boundingBias, 3);


### PR DESCRIPTION
Trying to fix https://playground.babylonjs.com/#3URR7V#142 I noticed data may not be available for storage buffers