### PR TITLE
[XR] scene.clearColor is ignored within XR mode on Quest2 when using multiview

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -3936,7 +3936,17 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this._renderId++;
 
         if (!this.prePass && bindFrameBuffer) {
+            let skipInitialClear = true;
+            if (camera._renderingMultiview && camera.outputRenderTarget) {
+                skipInitialClear = camera.outputRenderTarget.skipInitialClear;
+                if (this.autoClear) {
+                    camera.outputRenderTarget.skipInitialClear = false;
+                }
+            }
             this._bindFrameBuffer(this._activeCamera);
+            if (camera._renderingMultiview && camera.outputRenderTarget) {
+                camera.outputRenderTarget.skipInitialClear = skipInitialClear;
+            }
         }
 
         this.updateTransformMatrix();


### PR DESCRIPTION
Fixes #12068

If scene's autoclear is set to true and in multiview, prevent the skipInitialClear flag from not clearing (i.e. force clear once in multiview)