### PR TITLE
[Tooling] Fix color picker linear bug

### DIFF
--- a/sharedUiComponents/lines/colorLineComponent.tsx
+++ b/sharedUiComponents/lines/colorLineComponent.tsx
@@ -79,7 +79,7 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
             }
             return this.convertToColor(property);
         } else {
-            return property;
+            return property.clone();
         }
     }
  


### PR DESCRIPTION
Fixes an issue where the color picker would convert the original color it's examining to gamma space, rather than just it's own internal display state. The original color is now cloned.