### PR TITLE
Fix passing rootUrl when loading NodeMaterial and nested asset URL

### DIFF
--- a/dist/preview release/what's new.md
+++ b/dist/preview release/what's new.md
@@ -310,6 +310,7 @@
 - Fix issue when scaling is reapplied with BoundingBoxGizmo and GizmoManager ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Fix direct loading of a glTF string that has base64-encoded URI. ([bghgary](https://github.com/bghgary))
 - Fix capsule impostor size computation for ammojs ([CedricGuillemet](https://github.com/CedricGuillemet)
+- Fix passing rootUrl when loading NodeMaterial and nested asset URL ([CedricGuillemet](https://github.com/CedricGuillemet)
 - Fix compound shapes for CannonJS plugin ([cedricguillemet](https://github.com/cedricguillemet))
 - Fix crash of some node materials using instances on iOS ([Popov72](https://github.com/Popov72))
 - Fix the code generated for the NME gradient block ([Popov72](https://github.com/Popov72))

--- a/src/Materials/Node/nodeMaterial.ts
+++ b/src/Materials/Node/nodeMaterial.ts
@@ -1639,12 +1639,13 @@ export class NodeMaterial extends PushMaterial {
     /**
      * Loads the current Node Material from a url pointing to a file save by the Node Material Editor
      * @param url defines the url to load from
+     * @param rootUrl defines the root URL for nested url in the node material
      * @returns a promise that will fulfil when the material is fully loaded
      */
-    public loadAsync(url: string) {
+    public loadAsync(url: string, rootUrl: string = "") {
         return this.getScene()._loadFileAsync(url).then((data) => {
             const serializationObject = JSON.parse(data as string);
-            this.loadFromSerialization(serializationObject, "");
+            this.loadFromSerialization(serializationObject, rootUrl);
         });
     }
 
@@ -1934,13 +1935,14 @@ export class NodeMaterial extends PushMaterial {
      * @param name defines the name of the material to create
      * @param url defines the url to load from
      * @param scene defines the hosting scene
+     * @param rootUrl defines the root URL for nested url in the node material
      * @returns a promise that will resolve to the new node material
      */
-    public static ParseFromFileAsync(name: string, url: string, scene: Scene): Promise<NodeMaterial> {
+    public static ParseFromFileAsync(name: string, url: string, scene: Scene, rootUrl: string = ""): Promise<NodeMaterial> {
         var material = new NodeMaterial(name, scene);
 
         return new Promise((resolve, reject) => {
-            return material.loadAsync(url).then(() => {
+            return material.loadAsync(url, rootUrl).then(() => {
                 material.build();
                 resolve(material);
             }).catch(reject);


### PR DESCRIPTION
RootURL was not used when loading NodeMaterial. When nested URL assets are present (textureBlock with reference to URL), it could not load the asset if the default root is not the same as the browser.
Not much of an issue with BJS web but on native, some assets could not be loaded because BN has no default root.