### PR TITLE
Add warnings and early return when trying to create a mesh impostor i…

### DIFF
--- a/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/src/Physics/Plugins/cannonJSPlugin.ts
@@ -114,6 +114,10 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
         //should a new body be created for this impostor?
         if (impostor.isBodyInitRequired()) {
             var shape = this._createShape(impostor);
+            if (!shape) {
+                Logger.Warn("It was not possible to create a physics body for this object.");
+                return;
+            }
 
             //unregister events, if body is being changed
             var oldBody = impostor.physicsBody;
@@ -350,6 +354,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
                 var rawVerts = object.getVerticesData ? object.getVerticesData(VertexBuffer.PositionKind) : [];
                 var rawFaces = object.getIndices ? object.getIndices() : [];
                 if (!rawVerts) {
+                    Logger.Warn("Tried to create a MeshImpostor for an object without vertices. This will fail.");
                     return;
                 }
                 // get only scale! so the object could transform correctly.

--- a/src/Physics/physicsImpostor.ts
+++ b/src/Physics/physicsImpostor.ts
@@ -427,7 +427,7 @@ export class PhysicsImpostor {
     /**
      * Initializes the physics imposter
      * @param object The physics-enabled object used as the physics imposter
-     * @param type The type of the physics imposter
+     * @param type The type of the physics imposter. Types are available as static members of this class.
      * @param _options The options for the physics imposter
      * @param _scene The Babylon scene
      */
@@ -1250,7 +1250,7 @@ export class PhysicsImpostor {
      */
     public static PlaneImpostor = 3;
     /**
-     * Mesh-imposter type
+     * Mesh-imposter type (Only available to objects with vertices data)
      */
     public static MeshImpostor = 4;
     /**


### PR DESCRIPTION
…n an object without vertices. Currently, when doing just this, we end up with an undefined use exception, which isn't informative to users:
![image](https://user-images.githubusercontent.com/6002144/158173804-31e0a6bc-33a9-4b15-9a43-51e579c012eb.png)

This will make easier to understand the usage error:
![image](https://user-images.githubusercontent.com/6002144/158173697-fdaeedfe-9357-4d1e-a16f-08343154a2e4.png)
