### PR TITLE
Documentation

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraGamepadInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraGamepadInput.ts
@@ -20,14 +20,14 @@ export class ArcRotateCameraGamepadInput implements ICameraInput<ArcRotateCamera
     public gamepad: Nullable<Gamepad>;
 
     /**
-     * Defines the gamepad rotation sensiblity.
+     * Defines the gamepad rotation sensibility.
      * This is the threshold from when rotation starts to be accounted for to prevent jittering.
      */
     @serialize()
     public gamepadRotationSensibility = 80;
 
     /**
-     * Defines the gamepad move sensiblity.
+     * Defines the gamepad move sensibility.
      * This is the threshold from when moving starts to be accounted for for to prevent jittering.
      */
     @serialize()

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -233,7 +233,7 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Defines the value of the inertia used during panning.
-     * 0 would mean stop inertia and one would mean no decelleration at all.
+     * 0 would mean stop inertia and one would mean no deceleration at all.
      */
     @serialize()
     public panningInertia = 0.9;

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -261,7 +261,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this._internalAbstractMeshDataInfo._facetData.facetDepthSortFrom = location;
     }
 
-    /** number of collision detection tries. Change this value if not all colisions are detected and handled properly */
+    /** number of collision detection tries. Change this value if not all collisions are detected and handled properly */
     public get collisionRetryCount(): number {
         return this._internalAbstractMeshDataInfo._collisionRetryCount;
     }

--- a/packages/dev/core/src/abstractScene.ts
+++ b/packages/dev/core/src/abstractScene.ts
@@ -57,7 +57,7 @@ export abstract class AbstractScene {
     }
 
     /**
-     * Gets a general parser from the list of avaialble ones
+     * Gets a general parser from the list of available ones
      * @param name Defines the name of the parser
      * @returns the requested parser or null
      */
@@ -79,7 +79,7 @@ export abstract class AbstractScene {
     }
 
     /**
-     * Gets an individual parser from the list of avaialble ones
+     * Gets an individual parser from the list of available ones
      * @param name Defines the name of the parser
      * @returns the requested parser or null
      */
@@ -177,10 +177,10 @@ export abstract class AbstractScene {
     public geometries = new Array<Geometry>();
 
     /**
-     * All of the tranform nodes added to this scene
+     * All of the transform nodes added to this scene
      * In the context of a Scene, it is not supposed to be modified manually.
      * Any addition or removal should be done using the addTransformNode and removeTransformNode Scene methods.
-     * Note also that the order of the TransformNode wihin the array is not significant and might change.
+     * Note also that the order of the TransformNode within the array is not significant and might change.
      * @see https://doc.babylonjs.com/how_to/transformnode
      */
     public transformNodes = new Array<TransformNode>();

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -100,9 +100,9 @@ export class AssetContainer extends AbstractScene {
      * Skeletons and animation groups will all be cloned
      * @param nameFunction defines an optional function used to get new names for clones
      * @param cloneMaterials defines an optional boolean that defines if materials must be cloned as well (false by default)
-     * @param options defines an optional list of options to control how to instanciate / clone models
+     * @param options defines an optional list of options to control how to instantiate / clone models
      * @param options.doNotInstantiate
-     * @returns a list of rootNodes, skeletons and aniamtion groups that were duplicated
+     * @returns a list of rootNodes, skeletons and animation groups that were duplicated
      */
     public instantiateModelsToScene(nameFunction?: (sourceName: string) => string, cloneMaterials = false, options?: { doNotInstantiate: boolean }): InstantiatedEntries {
         const convertionMap: { [key: number]: number } = {};

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1226,7 +1226,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * @param supportPointerMove defines a boolean indicating if the texture must capture move events (true by default)
      * @param onlyAlphaTesting defines a boolean indicating that alpha blending will not be used (only alpha testing) (false by default)
      * @param invertY defines if the texture needs to be inverted on the y axis during loading (true by default)
-     * @param materialSetupCallback defines a custom way of creating and seting up the material on the mesh
+     * @param materialSetupCallback defines a custom way of creating and setting up the material on the mesh
      * @returns a new AdvancedDynamicTexture
      */
     public static CreateForMesh(


### PR DESCRIPTION
Minor documentation typos in code comments:

- `aniamtion` => `animation`
- `avaialble` => `available`
- `colisions` => `collisions`
- `decelleration` => `deceleration`
- `instanciate` => `instantiate`
- `sensiblity` => `sensibility`
- `seting` => `setting`
- `tranform` => `transform`
- `wihin` => `within`