### PR TITLE
Documentation

### DIFF
--- a/packages/dev/core/src/Bones/boneIKController.ts
+++ b/packages/dev/core/src/Bones/boneIKController.ts
@@ -15,7 +15,7 @@ export class BoneIKController {
 
     /**
      * Gets or sets the target TransformNode
-     * Name kept as mesh for back compability
+     * Name kept as mesh for back compatibility
      */
     public targetMesh: TransformNode;
 
@@ -49,7 +49,7 @@ export class BoneIKController {
 
     /**
      * Gets or sets the TransformNode associated with the controller
-     * Name kept as mesh for back compability
+     * Name kept as mesh for back compatibility
      */
     public mesh: TransformNode;
 

--- a/packages/dev/core/src/Bones/boneLookController.ts
+++ b/packages/dev/core/src/Bones/boneLookController.ts
@@ -21,7 +21,7 @@ export class BoneLookController {
 
     /**
      * The TransformNode that the bone is attached to
-     * Name kept as mesh for back compability
+     * Name kept as mesh for back compatibility
      */
     public mesh: TransformNode;
 

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
@@ -146,7 +146,7 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
     }
 
     /**
-     * Gets the class name of the current intput.
+     * Gets the class name of the current input.
      * @returns the class name
      */
     public getClassName(): string {

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraGamepadInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraGamepadInput.ts
@@ -22,14 +22,14 @@ export class FreeCameraGamepadInput implements ICameraInput<FreeCamera> {
     public gamepad: Nullable<Gamepad>;
 
     /**
-     * Defines the gamepad rotation sensiblity.
+     * Defines the gamepad rotation sensibility.
      * This is the threshold from when rotation starts to be accounted for to prevent jittering.
      */
     @serialize()
     public gamepadAngularSensibility = 200;
 
     /**
-     * Defines the gamepad move sensiblity.
+     * Defines the gamepad move sensibility.
      * This is the threshold from when moving starts to be accounted for for to prevent jittering.
      */
     @serialize()

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -432,7 +432,7 @@ export class Camera extends Node {
 
     /**
      * Gets a string representation of the camera useful for debug purpose.
-     * @param fullDetails Defines that a more verboe level of logging is required
+     * @param fullDetails Defines that a more verbose level of logging is required
      * @returns the string representation
      */
     public toString(fullDetails?: boolean): string {

--- a/packages/dev/core/src/Compute/computeEffect.ts
+++ b/packages/dev/core/src/Compute/computeEffect.ts
@@ -19,7 +19,7 @@ export interface IComputeEffectCreationOptions {
      */
     defines: any;
     /**
-     * The name of the entry point in the shader source (defaut: "main")
+     * The name of the entry point in the shader source (default: "main")
      */
     entryPoint?: string;
     /**

--- a/packages/dev/core/src/Compute/computeShader.ts
+++ b/packages/dev/core/src/Compute/computeShader.ts
@@ -31,7 +31,7 @@ export interface IComputeShaderOptions {
     defines?: string[];
 
     /**
-     * The name of the entry point in the shader source (defaut: "main")
+     * The name of the entry point in the shader source (default: "main")
      */
     entryPoint?: string;
 

--- a/packages/dev/core/src/DeviceInput/InputDevices/inputInterfaces.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/inputInterfaces.ts
@@ -7,7 +7,7 @@ import { DeviceType } from "./deviceEnums";
 export interface IDeviceInputSystem extends IDisposable {
     /**
      * Checks for current device input value, given an id and input index. Throws exception if requested device not initialized.
-     * @param deviceType Enum specifiying device type
+     * @param deviceType Enum specifying device type
      * @param deviceSlot "Slot" or index that device is referenced in
      * @param inputIndex Id of input to be checked
      * @returns Current value of input

--- a/packages/dev/core/src/Engines/Extensions/engine.query.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.query.ts
@@ -361,7 +361,7 @@ declare module "../../Meshes/abstractMesh" {
         _occlusionDataStorage: _OcclusionDataStorage;
 
         /**
-         * This number indicates the number of allowed retries before stop the occlusion query, this is useful if the occlusion query is taking long time before to the query result is retireved, the query result indicates if the object is visible within the scene or not and based on that Babylon.Js engine decides to show or hide the object.
+         * This number indicates the number of allowed retries before stop the occlusion query, this is useful if the occlusion query is taking long time before to the query result is retrieved, the query result indicates if the object is visible within the scene or not and based on that Babylon.Js engine decides to show or hide the object.
          * The default value is -1 which means don't break the query and wait till the result
          * @see https://doc.babylonjs.com/features/occlusionquery
          */

--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -212,7 +212,7 @@ export interface ICanvasRenderingContext {
     rotate(angle: number): void;
 
     /**
-     * Adds a translation transformation by moving the canvas and its origin x horzontally and y vertically on the grid.
+     * Adds a translation transformation by moving the canvas and its origin x horizontally and y vertically on the grid.
      * @param x Distance to move in the horizontal direction. Positive values are to the right, and negative to the left.
      * @param y Distance to move in the vertical direction. Positive values are down, and negative are up.
      */

--- a/packages/dev/core/src/Gamepads/gamepadSceneComponent.ts
+++ b/packages/dev/core/src/Gamepads/gamepadSceneComponent.ts
@@ -118,7 +118,7 @@ export class GamepadSystemSceneComponent implements ISceneComponent {
     }
 
     /**
-     * Disposes the component and the associated ressources
+     * Disposes the component and the associated resources
      */
     public dispose(): void {
         const gamepadManager = this.scene._gamepadManager;

--- a/packages/dev/core/src/Gizmos/lightGizmo.ts
+++ b/packages/dev/core/src/Gizmos/lightGizmo.ts
@@ -154,8 +154,8 @@ export class LightGizmo extends Gizmo {
             this._attachedMeshParent.freezeWorldMatrix(this._light.parent.getWorldMatrix());
         }
 
-        // For light positon and direction, a dirty flag is set to true in the setter
-        // It means setting values individualy or copying values willl not call setter and
+        // For light position and direction, a dirty flag is set to true in the setter
+        // It means setting values individually or copying values will not call setter and
         // dirty flag will not be set to true. Hence creating a new Vector3.
         if ((this._light as any).position) {
             // If the gizmo is moved update the light otherwise update the gizmo to match the light

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -472,7 +472,7 @@ export class HighlightLayer extends EffectLayer {
     /**
      * Checks for the readiness of the element composing the layer.
      * @param subMesh the mesh to check for
-     * @param useInstances specify wether or not to use instances to render the mesh
+     * @param useInstances specify whether or not to use instances to render the mesh
      * @param emissiveTexture the associated emissive texture used to generate the glow
      * @return true if ready otherwise, false
      */

--- a/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
@@ -11,19 +11,19 @@ import { Scene } from "../../../scene";
  */
 export class ColorMergerBlock extends NodeMaterialBlock {
     /**
-     * Gets or sets the swizzle for r (meaning which compoent to affect to the output.r)
+     * Gets or sets the swizzle for r (meaning which component to affect to the output.r)
      */
     public rSwizzle: "r" | "g" | "b" | "a" = "r";
     /**
-     * Gets or sets the swizzle for g (meaning which compoent to affect to the output.g)
+     * Gets or sets the swizzle for g (meaning which component to affect to the output.g)
      */
     public gSwizzle: "r" | "g" | "b" | "a" = "g";
     /**
-     * Gets or sets the swizzle for b (meaning which compoent to affect to the output.b)
+     * Gets or sets the swizzle for b (meaning which component to affect to the output.b)
      */
     public bSwizzle: "r" | "g" | "b" | "a" = "b";
     /**
-     * Gets or sets the swizzle for a (meaning which compoent to affect to the output.a)
+     * Gets or sets the swizzle for a (meaning which component to affect to the output.a)
      */
     public aSwizzle: "r" | "g" | "b" | "a" = "a";
 

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -152,7 +152,7 @@ export class InstancedMesh extends AbstractMesh {
 
     /**
      * Returns a positive integer : the total number of indices in this mesh geometry.
-     * @returns the numner of indices or zero if the mesh has no geometry.
+     * @returns the number of indices or zero if the mesh has no geometry.
      */
     public getTotalIndices(): number {
         return this._sourceMesh.getTotalIndices();

--- a/packages/dev/core/src/Misc/assetsManager.ts
+++ b/packages/dev/core/src/Misc/assetsManager.ts
@@ -462,7 +462,7 @@ export class TextFileAssetTask extends AbstractAssetTask {
  */
 export class BinaryFileAssetTask extends AbstractAssetTask {
     /**
-     * Gets the lodaded data (as an array buffer)
+     * Gets the loaded data (as an array buffer)
      */
     public data: ArrayBuffer;
 
@@ -1142,7 +1142,7 @@ export class AssetsManager {
                     this.onFinish(currentTasks);
                 }
 
-                // Let's remove successfull tasks
+                // Let's remove successful tasks
                 for (var task of currentTasks) {
                     if (task.taskState === AssetTaskState.DONE) {
                         const index = this._tasks.indexOf(task);

--- a/packages/dev/core/src/Misc/interfaces/iPerfViewer.ts
+++ b/packages/dev/core/src/Misc/interfaces/iPerfViewer.ts
@@ -49,7 +49,7 @@ export interface IPerfCustomEvent {
      */
     name: string;
     /**
-     * The value for the event, if set we will use it as the value, otherwise we will count the number of occurences.
+     * The value for the event, if set we will use it as the value, otherwise we will count the number of occurrences.
      */
     value?: number;
 }

--- a/packages/dev/core/src/Particles/IParticleSystem.ts
+++ b/packages/dev/core/src/Particles/IParticleSystem.ts
@@ -190,7 +190,7 @@ export interface IParticleSystem {
      */
     endSpriteCellID: number;
     /**
-     * If using a spritesheet (isAnimationSheetEnabled), defines wether the sprite animation is looping
+     * If using a spritesheet (isAnimationSheetEnabled), defines whether the sprite animation is looping
      */
     spriteCellLoop: boolean;
     /**

--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -227,7 +227,7 @@ export class BlurPostProcess extends PostProcess {
         let defines = "";
         defines += this._staticDefines;
 
-        // The DOF fragment should ignore the center pixel when looping as it is handled manualy in the fragment shader.
+        // The DOF fragment should ignore the center pixel when looping as it is handled manually in the fragment shader.
         if (this._staticDefines.indexOf("DOF") != -1) {
             defines += `#define CENTER_WEIGHT ${this._glslFloat(weights[varyingCount - 1])}\r\n`;
             varyingCount--;

--- a/packages/dev/core/src/Rendering/depthPeelingSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingSceneComponent.ts
@@ -14,7 +14,7 @@ declare module "../scene" {
         _depthPeelingRenderer: Nullable<DepthPeelingRenderer>;
 
         /**
-         * Flag to indicate if we want to use order independant transparency, despite the performance hit
+         * Flag to indicate if we want to use order independent transparency, despite the performance hit
          */
         useOrderIndependentTransparency: boolean;
         /** @hidden */
@@ -58,7 +58,7 @@ Object.defineProperty(Scene.prototype, "useOrderIndependentTransparency", {
 });
 
 /**
- * Scene component to render order independant transparency with depth peeling
+ * Scene component to render order independent transparency with depth peeling
  */
 export class DepthPeelingSceneComponent implements ISceneComponent {
     /**

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1373,7 +1373,7 @@ export class Control {
     }
 
     /**
-     * Shorthand funtion to set the top, right, bottom, and left padding values on the control.
+     * Shorthand function to set the top, right, bottom, and left padding values on the control.
      * @param { string | number} paddingTop - The value of the top padding.
      * @param { string | number} paddingRight - The value of the right padding. If omitted, top is used.
      * @param { string | number} paddingBottom - The value of the bottom padding. If omitted, top is used.

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -67,7 +67,7 @@ export class Image extends Control {
 
     /**
      * Gets or sets a boolean indicating if pointers should only be validated on pixels with alpha > 0.
-     * Beware using this as this will comsume more memory as the image has to be stored twice
+     * Beware using this as this will consume more memory as the image has to be stored twice
      */
     @serialize()
     public get detectPointerOnOpaqueOnly(): boolean {
@@ -291,7 +291,7 @@ export class Image extends Control {
         }
     }
 
-    /** Gets or sets the streching mode used by the image */
+    /** Gets or sets the stretching mode used by the image */
     @serialize()
     public get stretch(): number {
         return this._stretch;

--- a/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
@@ -32,7 +32,7 @@ export class BaseSlider extends Control {
     protected _backgroundBoxThickness: number;
     protected _effectiveThumbThickness: number;
 
-    /** Observable raised when the sldier value changes */
+    /** Observable raised when the slider value changes */
     public onValueChangedObservable = new Observable<number>();
 
     /** Gets or sets a boolean indicating if the thumb must be rendered */

--- a/packages/dev/gui/src/3D/controls/control3D.ts
+++ b/packages/dev/gui/src/3D/controls/control3D.ts
@@ -288,7 +288,7 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
      * Node creation.
      * Can be overriden by children
      * @param scene defines the scene where the node must be attached
-     * @returns the attached node or null if none. Must return a Mesh or AbstractMesh if there is an atttached visible object
+     * @returns the attached node or null if none. Must return a Mesh or AbstractMesh if there is an attached visible object
      */
     protected _createNode(scene: Scene): Nullable<TransformNode> {
         // Do nothing by default

--- a/packages/dev/gui/src/3D/gizmos/gizmoHandle.ts
+++ b/packages/dev/gui/src/3D/gizmos/gizmoHandle.ts
@@ -149,7 +149,7 @@ export abstract class GizmoHandle {
 
     /**
      * Creates the meshes and parent node of the handle
-     * Should be overriden by child classes
+     * Should be overridden by child classes
      * @returns created node
      */
     public abstract createNode(): TransformNode;

--- a/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
@@ -31,7 +31,7 @@ export class FluentMaterialDefines extends MaterialDefines {
 }
 
 /**
- * Class used to render controls with fluent desgin
+ * Class used to render controls with fluent design
  */
 export class FluentMaterial extends PushMaterial {
     /**

--- a/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -36,7 +36,7 @@ class FluentBackplateMaterialDefines extends MaterialDefines {
 }
 
 /**
- * Class used to render square buttons with fluent desgin
+ * Class used to render square buttons with fluent design
  */
 export class FluentBackplateMaterial extends PushMaterial {
     /**

--- a/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
@@ -35,7 +35,7 @@ class FluentButtonMaterialDefines extends MaterialDefines {
 }
 
 /**
- * Class used to render square buttons with fluent desgin
+ * Class used to render square buttons with fluent design
  * @since 5.0.0
  */
 export class FluentButtonMaterial extends PushMaterial {

--- a/packages/dev/materials/src/grid/gridMaterial.ts
+++ b/packages/dev/materials/src/grid/gridMaterial.ts
@@ -111,7 +111,7 @@ export class GridMaterial extends PushMaterial {
     }
 
     /**
-     * Returns wehter or not the grid requires alpha blending.
+     * Returns whether or not the grid requires alpha blending.
      */
     public needAlphaBlending(): boolean {
         return this.opacity < 1.0 || (this._opacityTexture && this._opacityTexture.isReady());


### PR DESCRIPTION
Minor documentation typos, reviewing A through M of packages:

- `atttached` => `attached`
- `compability` => `compatibility`
- `compoent` => `component`
- `comsume` => `consume`
- `defaut` => `default`
- `desgin` => `design`
- `funtion` => `function`
- `horzontally` => `horizontally`
- `independant` => `independent`
- `individualy` => `individually`
- `intput` => `input`
- `lodaded` => `loaded`
- `manualy` => `manually`
- `numner` => `number`
- `occurences` => `occurrences`
- `overriden` => `overridden`
- `positon` => `position`
- `ressources` => `resources`
- `retireved` => `retrieved`
- `sensiblity` => `sensibility`
- `sldier` => `slider`
- `specifiying` => `specifying`
- `streching` => `stretching`
- `successfull` => `successful`
- `verboe` => `verbose`
- `wether` => `whether`
- `willl` => `will`