### PR TITLE
Update TextureDome after setting halfMode or crossEye

### DIFF
--- a/packages/dev/core/src/Helpers/textureDome.ts
+++ b/packages/dev/core/src/Helpers/textureDome.ts
@@ -137,6 +137,7 @@ export abstract class TextureDome<T extends Texture> extends TransformNode {
     public set halfDome(enabled: boolean) {
         this._halfDome = enabled;
         this._halfDomeMask.setEnabled(enabled);
+        this._changeTextureMode(this._textureMode);
     }
 
     /**
@@ -144,6 +145,7 @@ export abstract class TextureDome<T extends Texture> extends TransformNode {
      */
     public set crossEye(enabled: boolean) {
         this._crossEye = enabled;
+        this._changeTextureMode(this._textureMode);
     }
 
     /**


### PR DESCRIPTION
Changing `TextureDome.halfDome` property after setting `videoMode` does not work. It does work if the sequence is reversed. Here’s a PG showing the issue:

 - [BJS Playground - VideoDome.halfMode issue](https://playground.babylonjs.com/#5I9YRP#1)

The fix is to recalculate the texture coordinates after setting the property.  Same for `crossEye`. This was already being being done when setting the `textureMode`.

Related forum post:
 - https://forum.babylonjs.com/t/videodome-halfdome-and-videomode-order-shouldnt-matter/28551