### PR TITLE
gltf2interface package description

### DIFF
--- a/packages/public/glTF2Interface/package.json
+++ b/packages/public/glTF2Interface/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylonjs-gltf2interface",
-    "description": "A typescript declaration of babylon's gltf2 inteface.",
+    "description": "A typescript declaration of babylon's gltf2 interface.",
     "version": "5.0.0-rc.4",
     "repository": {
         "type": "git",


### PR DESCRIPTION
If I may recommend changing the package description:

From: 
> A typescript declaration of babylon's gltf2 inteface

To:
> A typescript declaration of babylon's gltf2 interface


Typo:
- `inteface` => `interface`