### PR TITLE
[GUI Editor] fix delete from tree view

### DIFF
--- a/packages/tools/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/tools/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -181,15 +181,8 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
                 return;
             case "Delete":
             case "Backspace":
-                if (this.state.selectedEntity !== this.props.globalState.guiTexture.getChildren()[0]) {
-                    this.state.selectedEntity.dispose();
-                    this.props.globalState.selectedControls.forEach((node) => {
-                        if (node !== this.props.globalState.guiTexture.getChildren()[0]) {
-                            node.dispose();
-                        }
-                        this.forceUpdate();
-                    });
-                }
+                this.props.globalState.deleteSelectedNodes();
+                this.forceUpdate();
                 break;
         }
 

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -269,7 +269,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
         if (evt.key === "Delete" || evt.key === "Backspace") {
             if (!this.props.globalState.lockObject.lock) {
-                this._deleteSelectedNodes();
+                this.props.globalState.deleteSelectedNodes();
             }
         }
 
@@ -283,15 +283,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
             this._canvas.style.cursor = this._altKeyIsPressed ? "zoom-out" : "zoom-in";
         }
     };
-
-    private _deleteSelectedNodes() {
-        for (const control of this.props.globalState.selectedControls) {
-            this.props.globalState.guiTexture.removeControl(control);
-            this.props.globalState.liveGuiTexture?.removeControl(control);
-            control.dispose();
-        }
-        this.props.globalState.setSelection([]);
-    }
 
     public copyToClipboard(copyFn: (content: string) => void) {
         const controlList: any[] = [];
@@ -310,7 +301,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
     public cutToClipboard(copyFn: (content: string) => void) {
         this.copyToClipboard(copyFn);
-        this._deleteSelectedNodes();
+        this.props.globalState.deleteSelectedNodes();
     }
 
     public pasteFromClipboard(clipboardContents: string) {

--- a/packages/tools/guiEditor/src/globalState.ts
+++ b/packages/tools/guiEditor/src/globalState.ts
@@ -163,6 +163,15 @@ export class GlobalState {
         this.onSelectionChangedObservable.notifyObservers();
     }
 
+    public deleteSelectedNodes() {
+        for (const control of this.selectedControls) {
+            this.guiTexture.removeControl(control);
+            this.liveGuiTexture?.removeControl(control);
+            control.dispose();
+        }
+        this.setSelection([]);
+    }
+
     public isMultiSelectable(control: Control): boolean {
         if (this.selectedControls.length === 0) return true;
         if (this.selectedControls[0].parent === control.parent) return true;


### PR DESCRIPTION
Fixes an issue where pressing delete with the tree view focused would not properly delete controls. Moves the delete function to the global state so we can call it from anywhere and get consistent results.