### PR TITLE
Fix caching of parented node

### DIFF
--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -1019,6 +1019,7 @@ export class TransformNode extends Node {
         cache.pivotMatrixUpdated = false;
         cache.billboardMode = this.billboardMode;
         cache.infiniteDistance = this.infiniteDistance;
+        cache.parent = this._parentNode;
 
         this._currentRenderId = currentRenderId;
         this._childUpdateId += 1;

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -517,7 +517,7 @@ export class Node implements IBehaviorAware<Node> {
 
     /** @hidden */
     public isSynchronized(): boolean {
-        if (this._cache.parent != this._parentNode) {
+        if (this._cache.parent !== this._parentNode) {
             this._cache.parent = this._parentNode;
             return false;
         }

--- a/what's new.md
+++ b/what's new.md
@@ -417,6 +417,7 @@
 - Fix spherical harmonics computation ([Meakk](https://github.com/Meakk))
 - Fix KTX and DDS loading with baked mipmaps ([Meakk](https://github.com/Meakk))
 - Fix text rendering speed when `TextWrapping.Ellipsis` is used ([carolhmj](https://github.com/carolhmj))
+- Fix caching of parented node ([carolhmj](https://github.com/carolhmj))
 
 ## Breaking changes
 


### PR DESCRIPTION
When setting a node's parent to null/undefined, its cached parent wouldn't be properly updated, causing some issues, such as instanced meshes not having reduced draw calls. 
A playground example can be seen in:
https://playground.babylonjs.com/#6JCJHZ

Without the fix, we have 11 draw calls:
![image](https://user-images.githubusercontent.com/6002144/159566263-2d177f8a-9153-403b-9d57-b16fb59a3afe.png)

With it, we have 1 draw call:
![image](https://user-images.githubusercontent.com/6002144/159566313-f2bf98ba-f2b9-424a-b820-9204cfb8a383.png)
