### PR TITLE
MergeMeshes - Preserve vertex transform data if only a single mesh is "merged"

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -766,7 +766,8 @@ export class VertexData {
     ): Nullable<FloatArray> {
         const nonNullOthers = others.filter((other): other is [element: FloatArray, transform?: Matrix] => other[0] !== null && other[0] !== undefined);
 
-        if (nonNullOthers.length === 0) {
+        // If there is no source to copy and no other non-null sources then skip this element.
+        if (!source && nonNullOthers.length == 0) {
             return source;
         }
 


### PR DESCRIPTION
This PR addresses a small regression in MergeMeshes from https://github.com/BabylonJS/Babylon.js/pull/12046.  This change held off on copying vertex data immediately to save the cost of an intermediate copy and instead copied directly into the final buffer later in the operation.  However the code to copy the transform data in _MergeElement was only triggering if we had at least two non-empty vertex buffers for the element type. If called on a single mesh, we skip copying and vertex transform information is lost.

To fix this I'm changing the logic in MergeElement to run even if only one element is non-null.