### PR TITLE
Allow custom node material blocks with custom object connections

### DIFF
--- a/packages/dev/core/src/Materials/Node/index.ts
+++ b/packages/dev/core/src/Materials/Node/index.ts
@@ -1,4 +1,5 @@
 export * from "./Enums/index";
+export * from "./nodeMaterialConnectionPointCustomObject";
 export * from "./nodeMaterialBlockConnectionPoint";
 export * from "./nodeMaterialBlock";
 export * from "./nodeMaterial";


### PR DESCRIPTION
Hi, 

we're trying to create a custom block for the node material system (a custom illumination model), using the PBRMetallicRoughnessBlock as a starting point.

I don't know if it is the best way to do it but the nodeMaterialConnectionPointCustomObject is not exported in the Node index.ts so i did a PR for that.