### PR TITLE
[GUI Editor] fix bug with pointer lock on arrow inputs

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/inputArrowsComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/inputArrowsComponent.tsx
@@ -16,9 +16,15 @@ export class InputArrowsComponent extends React.Component<IInputArrowsComponentP
     private _releaseListener = () => {
         this.props.setDragging(false);
         this._arrowsRef.current?.ownerDocument.exitPointerLock();
-        window.removeEventListener("pointerup", this._releaseListener);
-        this._arrowsRef.current?.ownerDocument.removeEventListener("mousemove", this._drag);
+        this._arrowsRef.current?.ownerDocument.defaultView!.removeEventListener("pointerup", this._releaseListener);
+        this._arrowsRef.current?.ownerDocument.removeEventListener("pointerlockchange", this._lockChangeListener);
+        this._arrowsRef.current?.ownerDocument.defaultView!.removeEventListener("mousemove", this._drag);
     };
+    private _lockChangeListener = () => {
+        if (this._arrowsRef.current?.ownerDocument.pointerLockElement !== this._arrowsRef.current) {
+            this._releaseListener();
+        }
+    }
 
     render() {
         return (
@@ -26,10 +32,11 @@ export class InputArrowsComponent extends React.Component<IInputArrowsComponentP
                 className="arrows"
                 ref={this._arrowsRef}
                 onPointerDown={() => {
+                    this._arrowsRef.current?.ownerDocument.addEventListener("pointerlockchange", this._lockChangeListener);
+                    this._arrowsRef.current?.ownerDocument.defaultView!.addEventListener("pointerup", this._releaseListener);
+                    this._arrowsRef.current?.ownerDocument.defaultView!.addEventListener("mousemove", this._drag);
                     this.props.setDragging(true);
                     this._arrowsRef.current?.requestPointerLock();
-                    window.addEventListener("pointerup", this._releaseListener);
-                    this._arrowsRef.current?.ownerDocument.addEventListener("mousemove", this._drag);
                 }}
                 onDragStart={(evt) => evt.preventDefault()}
             >

--- a/packages/dev/sharedUiComponents/src/lines/inputArrowsComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/inputArrowsComponent.tsx
@@ -24,7 +24,7 @@ export class InputArrowsComponent extends React.Component<IInputArrowsComponentP
         if (this._arrowsRef.current?.ownerDocument.pointerLockElement !== this._arrowsRef.current) {
             this._releaseListener();
         }
-    }
+    };
 
     render() {
         return (


### PR DESCRIPTION
Fixes a bug with pointer lock where event handlers could be added to the wrong window, causing the arrows to get "stuck"