### PR TITLE
chore: update main and types paths in UMD babylonjs-materials package

### DIFF
--- a/packages/public/umd/babylonjs-materials/package.json
+++ b/packages/public/umd/babylonjs-materials/package.json
@@ -1,8 +1,8 @@
 {
     "name": "babylonjs-materials",
     "version": "5.0.0-rc.10",
-    "main": "babylon.materials.js",
-    "types": "babylon.materials.module.d.ts",
+    "main": "babylonjs.materials.js",
+    "types": "babylonjs.materials.module.d.ts",
     "files": [
         "*"
     ],


### PR DESCRIPTION
Paths to main & types missed "js" in the package.json of the "babylonjs-materials" UMD package.

Here is a preview of what the package contains where setting "babylonjs.materials.js" instead of "babylon.materials.js" fixed the links.

Setting these real paths avoids errors when requiring the package and compilation errors such as "babylonjs-material is not a module".

<img width="286" alt="Capture d’écran 2022-03-25 à 13 03 58" src="https://user-images.githubusercontent.com/2620127/160117575-93d6c45c-b8e8-4789-b607-01ad2125b4d0.png">

Do you confirm that this is the only file that need to be changed ?
