### PR TITLE
[Build] make jest-screenshot optional to support M1 development

### DIFF
--- a/buildSystem.md
+++ b/buildSystem.md
@@ -843,6 +843,8 @@ This will run all tests that have the word "material" in their name.
 
 Run visualization tests using `npm run test:visualization` in the main directory.
 
+Note - a dependency needed to run the test does not currently support OSX using M1 processors. Running the tests on theses machines will fail.
+
 #### Configuring the visualization tests
 
 Visualization tests are running using puppeteer, which is an interface to control chrome or firefox on node. The test will run in a browser and will generate a report if any test fails. The browser selected is the local chromium installed together with puppeteer. If you want the tests to run in a different browser you can customize the puppeteer configuration at `jest-puppeteer.config.js` in the main directory. Some of the options are:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4444,7 +4444,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -4563,7 +4563,7 @@
         },
         "node_modules/asn1": {
             "version": "0.2.6",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
@@ -4571,7 +4571,7 @@
         },
         "node_modules/assert-plus": {
             "version": "1.0.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8"
@@ -4591,7 +4591,7 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/at-least-node": {
@@ -4604,7 +4604,7 @@
         },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "*"
@@ -4612,7 +4612,7 @@
         },
         "node_modules/aws4": {
             "version": "1.11.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/axios": {
@@ -4868,7 +4868,7 @@
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
@@ -5225,7 +5225,7 @@
         },
         "node_modules/caseless": {
             "version": "0.12.0",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/chalk": {
@@ -5388,7 +5388,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -5399,7 +5399,7 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/color-support": {
@@ -5417,7 +5417,7 @@
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -5753,7 +5753,7 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
@@ -5944,7 +5944,7 @@
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
@@ -6124,7 +6124,7 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -6341,7 +6341,7 @@
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "jsbn": "~0.1.0",
@@ -7340,7 +7340,7 @@
         },
         "node_modules/extend": {
             "version": "3.0.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/extract-zip": {
@@ -7378,7 +7378,7 @@
         },
         "node_modules/extsprintf": {
             "version": "1.3.0",
-            "dev": true,
+            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -7386,7 +7386,7 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-diff": {
@@ -7411,7 +7411,7 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -7726,7 +7726,7 @@
         },
         "node_modules/forever-agent": {
             "version": "0.6.1",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "*"
@@ -7921,7 +7921,7 @@
         },
         "node_modules/getpass": {
             "version": "0.1.7",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
@@ -8104,7 +8104,7 @@
         },
         "node_modules/har-schema": {
             "version": "2.0.0",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "engines": {
                 "node": ">=4"
@@ -8112,7 +8112,7 @@
         },
         "node_modules/har-validator": {
             "version": "5.1.5",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.3",
@@ -8124,7 +8124,7 @@
         },
         "node_modules/har-validator/node_modules/ajv": {
             "version": "6.12.6",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -8139,7 +8139,7 @@
         },
         "node_modules/har-validator/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/hard-rejection": {
@@ -8176,7 +8176,7 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8483,7 +8483,7 @@
         },
         "node_modules/http-signature": {
             "version": "1.2.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
@@ -9016,7 +9016,7 @@
         },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/is-weakref": {
@@ -9069,7 +9069,7 @@
         },
         "node_modules/isstream": {
             "version": "0.1.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/istanbul-lib-coverage": {
@@ -10064,8 +10064,8 @@
         },
         "node_modules/jest-screenshot": {
             "version": "0.3.5",
-            "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "chalk": "^3.0.0",
                 "lodash.kebabcase": "^4.1.1",
@@ -10076,8 +10076,8 @@
         },
         "node_modules/jest-screenshot/node_modules/chalk": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -10303,7 +10303,7 @@
         },
         "node_modules/jsbn": {
             "version": "0.1.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/jsdoc-type-pratt-parser": {
@@ -10382,7 +10382,7 @@
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
-            "dev": true,
+            "devOptional": true,
             "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
@@ -10397,7 +10397,7 @@
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/json5": {
@@ -10429,7 +10429,7 @@
         },
         "node_modules/jsprim": {
             "version": "1.4.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "1.0.0",
@@ -10542,8 +10542,8 @@
         },
         "node_modules/lodash.kebabcase": {
             "version": "4.1.1",
-            "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -10881,7 +10881,7 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -10889,7 +10889,7 @@
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -11089,7 +11089,7 @@
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "mkdirp": "bin/cmd.js"
@@ -11210,9 +11210,9 @@
         },
         "node_modules/native-image-diff": {
             "version": "0.1.14",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "request": "^2.88.2"
             }
@@ -11399,9 +11399,9 @@
         },
         "node_modules/node-libpng": {
             "version": "0.2.20",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "request": "^2.88.2"
             }
@@ -11588,7 +11588,7 @@
         },
         "node_modules/oauth-sign": {
             "version": "0.9.0",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "*"
@@ -11938,7 +11938,7 @@
         },
         "node_modules/performance-now": {
             "version": "2.1.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -12261,7 +12261,7 @@
         },
         "node_modules/psl": {
             "version": "1.8.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/pump": {
@@ -12275,7 +12275,7 @@
         },
         "node_modules/punycode": {
             "version": "2.1.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -12342,7 +12342,7 @@
         },
         "node_modules/qs": {
             "version": "6.5.3",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.6"
@@ -12700,7 +12700,7 @@
         },
         "node_modules/request": {
             "version": "2.88.2",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-sign2": "~0.7.0",
@@ -12730,7 +12730,7 @@
         },
         "node_modules/request/node_modules/form-data": {
             "version": "2.3.3",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -12743,7 +12743,7 @@
         },
         "node_modules/request/node_modules/tough-cookie": {
             "version": "2.5.0",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "psl": "^1.1.28",
@@ -12755,7 +12755,7 @@
         },
         "node_modules/request/node_modules/uuid": {
             "version": "3.4.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
@@ -12968,12 +12968,12 @@
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/sass-graph": {
@@ -13589,7 +13589,7 @@
         },
         "node_modules/sshpk": {
             "version": "1.17.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "asn1": "~0.2.3",
@@ -13831,7 +13831,7 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -14416,7 +14416,7 @@
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -14427,7 +14427,7 @@
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
-            "dev": true,
+            "devOptional": true,
             "license": "Unlicense"
         },
         "node_modules/type-check": {
@@ -14596,7 +14596,7 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -14760,7 +14760,7 @@
         },
         "node_modules/verror": {
             "version": "1.10.0",
-            "dev": true,
+            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -15652,12 +15652,11 @@
             "version": "5.0.0-rc.10",
             "dependencies": {
                 "@babylonjs/core": "^5.0.0-rc.10",
-                "@babylonjs/gui": "^5.0.0-rc.10",
-                "react": "^17.0.2",
-                "react-dom": "^17.0.2",
-                "tslib": "^2.3.1"
+                "@babylonjs/gui": "^5.0.0-rc.10"
             },
             "devDependencies": {
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
             },
@@ -15671,12 +15670,14 @@
             "dependencies": {
                 "@babylonjs/core": "^5.0.0-rc.10",
                 "@babylonjs/gui": "^5.0.0-rc.10",
-                "react": "^17.0.2",
-                "react-dom": "^17.0.2",
-                "tslib": "^2.3.1"
+                "@babylonjs/loaders": "^5.0.0-rc.10",
+                "@babylonjs/materials": "^5.0.0-rc.10",
+                "@babylonjs/serializers": "^5.0.0-rc.10"
             },
             "devDependencies": {
                 "@lts/gui": "1.0.0",
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
             },
@@ -15715,13 +15716,11 @@
         "packages/public/@babylonjs/node-editor": {
             "version": "5.0.0-rc.10",
             "dependencies": {
-                "@babylonjs/core": "^5.0.0-rc.10",
-                "@babylonjs/gui": "^5.0.0-rc.10",
-                "react": "^17.0.2",
-                "react-dom": "^17.0.2",
-                "tslib": "^2.3.1"
+                "@babylonjs/core": "^5.0.0-rc.10"
             },
             "devDependencies": {
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
             },
@@ -15854,7 +15853,11 @@
         "packages/public/umd/babylonjs-inspector": {
             "version": "5.0.0-rc.10",
             "dependencies": {
-                "babylonjs": "^5.0.0-rc.10"
+                "babylonjs": "^5.0.0-rc.10",
+                "babylonjs-gui": "^5.0.0-rc.10",
+                "babylonjs-loaders": "^5.0.0-rc.10",
+                "babylonjs-materials": "^5.0.0-rc.10",
+                "babylonjs-serializers": "^5.0.0-rc.10"
             },
             "devDependencies": {
                 "@dev/build-tools": "1.0.0",
@@ -16248,11 +16251,13 @@
                 "@types/react-dom": "^17.0.10",
                 "jest": "^27.4.7",
                 "jest-puppeteer": "^6.0.3",
-                "jest-screenshot": "^0.3.5",
                 "node-sass": "^7.0.1",
                 "puppeteer": "^13.1.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
+            },
+            "optionalDependencies": {
+                "jest-screenshot": "^0.3.5"
             }
         },
         "packages/tools/testTools": {
@@ -17390,7 +17395,6 @@
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
-                "tslib": "^2.3.1",
                 "typescript": "^4.4.4"
             }
         },
@@ -17399,11 +17403,13 @@
             "requires": {
                 "@babylonjs/core": "^5.0.0-rc.10",
                 "@babylonjs/gui": "^5.0.0-rc.10",
+                "@babylonjs/loaders": "^5.0.0-rc.10",
+                "@babylonjs/materials": "^5.0.0-rc.10",
+                "@babylonjs/serializers": "^5.0.0-rc.10",
                 "@lts/gui": "1.0.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
-                "tslib": "^2.3.1",
                 "typescript": "^4.4.4"
             }
         },
@@ -17434,11 +17440,9 @@
             "version": "file:packages/public/@babylonjs/node-editor",
             "requires": {
                 "@babylonjs/core": "^5.0.0-rc.10",
-                "@babylonjs/gui": "^5.0.0-rc.10",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
-                "tslib": "^2.3.1",
                 "typescript": "^4.4.4"
             }
         },
@@ -19611,7 +19615,7 @@
         },
         "ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -19685,14 +19689,14 @@
         },
         "asn1": {
             "version": "0.2.6",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
             "version": "1.0.0",
-            "dev": true
+            "devOptional": true
         },
         "async": {
             "version": "0.9.2",
@@ -19704,7 +19708,7 @@
         },
         "asynckit": {
             "version": "0.4.0",
-            "dev": true
+            "devOptional": true
         },
         "at-least-node": {
             "version": "1.0.0",
@@ -19712,11 +19716,11 @@
         },
         "aws-sign2": {
             "version": "0.7.0",
-            "dev": true
+            "devOptional": true
         },
         "aws4": {
             "version": "1.11.0",
-            "dev": true
+            "devOptional": true
         },
         "axios": {
             "version": "0.25.0",
@@ -19909,6 +19913,10 @@
                 "@types/react": "^17.0.30",
                 "@types/react-dom": "^17.0.10",
                 "babylonjs": "^5.0.0-rc.10",
+                "babylonjs-gui": "^5.0.0-rc.10",
+                "babylonjs-loaders": "^5.0.0-rc.10",
+                "babylonjs-materials": "^5.0.0-rc.10",
+                "babylonjs-serializers": "^5.0.0-rc.10",
                 "css-loader": "^6.4.0",
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
@@ -20064,7 +20072,7 @@
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -20289,7 +20297,7 @@
         },
         "caseless": {
             "version": "0.12.0",
-            "dev": true
+            "devOptional": true
         },
         "chalk": {
             "version": "4.1.0",
@@ -20387,14 +20395,14 @@
         },
         "color-convert": {
             "version": "2.0.1",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
         },
         "color-name": {
             "version": "1.1.4",
-            "dev": true
+            "devOptional": true
         },
         "color-support": {
             "version": "1.1.3",
@@ -20406,7 +20414,7 @@
         },
         "combined-stream": {
             "version": "1.0.8",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -20623,7 +20631,7 @@
         },
         "core-util-is": {
             "version": "1.0.2",
-            "dev": true
+            "devOptional": true
         },
         "cosmiconfig": {
             "version": "7.0.1",
@@ -20751,7 +20759,7 @@
         },
         "dashdash": {
             "version": "1.14.1",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -20862,7 +20870,7 @@
         },
         "delayed-stream": {
             "version": "1.0.0",
-            "dev": true
+            "devOptional": true
         },
         "delegates": {
             "version": "1.0.0",
@@ -21001,7 +21009,7 @@
         },
         "ecc-jsbn": {
             "version": "0.1.2",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -21649,7 +21657,7 @@
         },
         "extend": {
             "version": "3.0.2",
-            "dev": true
+            "devOptional": true
         },
         "extract-zip": {
             "version": "2.0.1",
@@ -21672,11 +21680,11 @@
         },
         "extsprintf": {
             "version": "1.3.0",
-            "dev": true
+            "devOptional": true
         },
         "fast-deep-equal": {
             "version": "3.1.3",
-            "dev": true
+            "devOptional": true
         },
         "fast-diff": {
             "version": "1.2.0",
@@ -21695,7 +21703,7 @@
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true
+            "devOptional": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -21902,7 +21910,7 @@
         },
         "forever-agent": {
             "version": "0.6.1",
-            "dev": true
+            "devOptional": true
         },
         "form-data": {
             "version": "3.0.1",
@@ -22022,7 +22030,7 @@
         },
         "getpass": {
             "version": "0.1.7",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -22151,11 +22159,11 @@
         },
         "har-schema": {
             "version": "2.0.0",
-            "dev": true
+            "devOptional": true
         },
         "har-validator": {
             "version": "5.1.5",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -22163,7 +22171,7 @@
             "dependencies": {
                 "ajv": {
                     "version": "6.12.6",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -22173,7 +22181,7 @@
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -22198,7 +22206,7 @@
         },
         "has-flag": {
             "version": "4.0.0",
-            "dev": true
+            "devOptional": true
         },
         "has-symbols": {
             "version": "1.0.3",
@@ -22394,7 +22402,7 @@
         },
         "http-signature": {
             "version": "1.2.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -22690,7 +22698,7 @@
         },
         "is-typedarray": {
             "version": "1.0.0",
-            "dev": true
+            "devOptional": true
         },
         "is-weakref": {
             "version": "1.0.2",
@@ -22724,7 +22732,7 @@
         },
         "isstream": {
             "version": "0.1.2",
-            "dev": true
+            "devOptional": true
         },
         "istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -23456,7 +23464,7 @@
         },
         "jest-screenshot": {
             "version": "0.3.5",
-            "dev": true,
+            "optional": true,
             "requires": {
                 "chalk": "^3.0.0",
                 "lodash.kebabcase": "^4.1.1",
@@ -23467,7 +23475,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "3.0.0",
-                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -23642,7 +23650,7 @@
         },
         "jsbn": {
             "version": "0.1.1",
-            "dev": true
+            "devOptional": true
         },
         "jsdoc-type-pratt-parser": {
             "version": "2.2.5",
@@ -23695,7 +23703,7 @@
         },
         "json-schema": {
             "version": "0.4.0",
-            "dev": true
+            "devOptional": true
         },
         "json-schema-traverse": {
             "version": "1.0.0",
@@ -23707,7 +23715,7 @@
         },
         "json-stringify-safe": {
             "version": "5.0.1",
-            "dev": true
+            "devOptional": true
         },
         "json5": {
             "version": "2.2.1",
@@ -23727,7 +23735,7 @@
         },
         "jsprim": {
             "version": "1.4.2",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -23797,7 +23805,7 @@
         },
         "lodash.kebabcase": {
             "version": "4.1.1",
-            "dev": true
+            "optional": true
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -24024,11 +24032,11 @@
         },
         "mime-db": {
             "version": "1.52.0",
-            "dev": true
+            "devOptional": true
         },
         "mime-types": {
             "version": "2.1.35",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "mime-db": "1.52.0"
             }
@@ -24148,7 +24156,7 @@
         },
         "mkdirp": {
             "version": "1.0.4",
-            "dev": true
+            "devOptional": true
         },
         "mkdirp-classic": {
             "version": "0.5.3",
@@ -24227,7 +24235,7 @@
         },
         "native-image-diff": {
             "version": "0.1.14",
-            "dev": true,
+            "optional": true,
             "requires": {
                 "request": "^2.88.2"
             }
@@ -24354,7 +24362,7 @@
         },
         "node-libpng": {
             "version": "0.2.20",
-            "dev": true,
+            "optional": true,
             "requires": {
                 "request": "^2.88.2"
             }
@@ -24492,7 +24500,7 @@
         },
         "oauth-sign": {
             "version": "0.9.0",
-            "dev": true
+            "devOptional": true
         },
         "object-assign": {
             "version": "4.1.1"
@@ -24703,7 +24711,7 @@
         },
         "performance-now": {
             "version": "2.1.0",
-            "dev": true
+            "devOptional": true
         },
         "picocolors": {
             "version": "1.0.0",
@@ -24906,7 +24914,7 @@
         },
         "psl": {
             "version": "1.8.0",
-            "dev": true
+            "devOptional": true
         },
         "pump": {
             "version": "3.0.0",
@@ -24918,7 +24926,7 @@
         },
         "punycode": {
             "version": "2.1.1",
-            "dev": true
+            "devOptional": true
         },
         "puppeteer": {
             "version": "13.5.1",
@@ -24954,7 +24962,7 @@
         },
         "qs": {
             "version": "6.5.3",
-            "dev": true
+            "devOptional": true
         },
         "queue-microtask": {
             "version": "1.2.3",
@@ -25186,7 +25194,7 @@
         },
         "request": {
             "version": "2.88.2",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -25212,7 +25220,7 @@
             "dependencies": {
                 "form-data": {
                     "version": "2.3.3",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.6",
@@ -25221,7 +25229,7 @@
                 },
                 "tough-cookie": {
                     "version": "2.5.0",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "psl": "^1.1.28",
                         "punycode": "^2.1.1"
@@ -25229,7 +25237,7 @@
                 },
                 "uuid": {
                     "version": "3.4.0",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -25358,11 +25366,11 @@
         },
         "safe-buffer": {
             "version": "5.1.2",
-            "dev": true
+            "devOptional": true
         },
         "safer-buffer": {
             "version": "2.1.2",
-            "dev": true
+            "devOptional": true
         },
         "sass-graph": {
             "version": "4.0.0",
@@ -25780,7 +25788,7 @@
         },
         "sshpk": {
             "version": "1.17.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -25933,7 +25941,7 @@
         },
         "supports-color": {
             "version": "7.2.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }
@@ -26294,14 +26302,14 @@
         },
         "tunnel-agent": {
             "version": "0.6.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
             "version": "0.14.5",
-            "dev": true
+            "devOptional": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -26403,7 +26411,7 @@
         },
         "uri-js": {
             "version": "4.4.1",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -26506,7 +26514,7 @@
         },
         "verror": {
             "version": "1.10.0",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "prepare-snapshot": "npm run build:snapshot -w @tools/babylon-server && build-tools -c ps"
     },
     "engines": {
-        "node": ">=12.0.0",
+        "node": ">=12.0.0 <17.0.0",
         "npm": ">=7.0.0"
     },
     "changelog": {

--- a/packages/tools/tests/package.json
+++ b/packages/tools/tests/package.json
@@ -28,11 +28,13 @@
         "@types/react-dom": "^17.0.10",
         "jest": "^27.4.7",
         "jest-puppeteer": "^6.0.3",
-        "jest-screenshot": "^0.3.5",
         "node-sass": "^7.0.1",
         "puppeteer": "^13.1.2",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "optionalDependencies": {
+        "jest-screenshot": "^0.3.5"
     },
     "sideEffects": false
 }


### PR DESCRIPTION
jest-screenshot has a dependency that only works on node 12 to 16 and on all OSs except for OSX with M1 processor. This makes the dependency optional, meaning the installation will not fail completely if the OS can't manage to install it.

This, however, also means that M1 users will not be able to run validation tests locally.