### PR TITLE
Refresh Light direction instead of resetting it

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -356,8 +356,7 @@ export class Gizmo implements IDisposable {
                     }
                     // setter doesn't copy values. Need a new Vector3
                     light.position = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
-                    Vector3.Backward(false).rotateByQuaternionToRef(this._tempQuaternion, this._tempVector);
-                    light.direction = new Vector3(this._tempVector.x, this._tempVector.y, this._tempVector.z);
+                    light.direction = new Vector3(light.direction.x, light.direction.y, light.direction.z);
                 }
             }
         }


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/create-spotlight-with-a-positiongizmo-will-change-the-spotlight-direction/28725/13
and https://github.com/BabylonJS/Babylon.js/issues/11075

Light direction needs to be refresh (see #11075) but instead of forcing it to be (0,0,1), keep its value so it's not reset when moving it.