### PR TITLE
[GUI Editor] Fix unit switching when value is 0

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -79,7 +79,7 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
         if (nextState.dragging != this.state.dragging || nextProps.unit !== this.props.unit || nextProps.unitLocked !== this.props.unitLocked) {
             return true;
         }
-        
+
         return false;
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -76,9 +76,10 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
             return true;
         }
 
-        if (nextState.dragging != this.state.dragging) {
+        if (nextState.dragging != this.state.dragging || nextProps.unit !== this.props.unit || nextProps.unitLocked !== this.props.unitLocked) {
             return true;
         }
+        
         return false;
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -63,7 +63,9 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
             return true;
         }
 
-        if (nextState.dragging != this.state.dragging) return true;
+        if (nextState.dragging != this.state.dragging || nextProps.unit !== this.props.unit || nextProps.unitLocked !== this.props.unitLocked) {
+            return true;
+        ]
 
         return false;
     }

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -65,7 +65,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
 
         if (nextState.dragging != this.state.dragging || nextProps.unit !== this.props.unit || nextProps.unitLocked !== this.props.unitLocked) {
             return true;
-        ]
+        }
 
         return false;
     }


### PR DESCRIPTION
Lets float and text inputs update when the unit changes. Fixes an issue where converting a 0px value to a 0% value would not show the updated unit.