### PR TITLE
[GUI Editor] Keep units in percentage when dragging controls

### DIFF
--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -17,15 +17,15 @@ import { Container } from "gui/2D/controls/container";
 import type { KeyboardInfo } from "core/Events/keyboardEvents";
 import { KeyboardEventTypes } from "core/Events/keyboardEvents";
 import type { Line } from "gui/2D/controls/line";
-import { DataStorage } from "core/Misc/dataStorage";
 import type { Grid } from "gui/2D/controls/grid";
 import { Tools } from "../tools";
 import type { Observer } from "core/Misc/observable";
 import type { ISize } from "core/Maths/math";
 import { Texture } from "core/Materials/Textures/texture";
-import { CoordinateHelper } from "./coordinateHelper";
+import { CoordinateHelper, DimensionProperties } from "./coordinateHelper";
 import { Logger } from "core/Misc/logger";
 import "./workbenchCanvas.scss";
+import { ValueAndUnit } from "gui/2D/valueAndUnit";
 
 export interface IWorkbenchComponentProps {
     globalState: GlobalState;
@@ -49,7 +49,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     public _scene: Scene;
     private _constraintDirection = ConstraintDirection.NONE;
     private _panning: boolean;
-    private _responsive: boolean;
     private _isOverGUINode: Control[] = [];
     private _engine: Engine;
     private _liveRenderObserver: Nullable<Observer<AdvancedDynamicTexture>>;
@@ -131,7 +130,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         super(props);
         const { globalState } = props;
         this._rootContainer = React.createRef();
-        this._responsive = DataStorage.ReadBoolean("Responsive", true);
 
         globalState.onSelectionChangedObservable.add(() => this.updateNodeOutlines());
 
@@ -201,10 +199,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
         globalState.onParentingChangeObservable.add((control) => {
             this.parent(control);
-        });
-
-        globalState.onResponsiveChangeObservable.add((value) => {
-            this._responsive = value;
         });
 
         globalState.hostDocument!.addEventListener("keyup", this.keyEvent, false);
@@ -585,6 +579,13 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     public clicked: boolean;
 
     public _onMove(guiControl: Control, evt: Vector2, startPos: Vector2) {
+        const toConvert: DimensionProperties[] = [];
+        if (guiControl._top.unit === ValueAndUnit.UNITMODE_PERCENTAGE) {
+            toConvert.push("top");
+        }
+        if (guiControl._left.unit === ValueAndUnit.UNITMODE_PERCENTAGE) {
+            toConvert.push("left");
+        }
         let newX = evt.x - startPos.x;
         let newY = evt.y - startPos.y;
 
@@ -632,10 +633,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         guiControl.leftInPixels += rotatedReferenceAxis.x;
         guiControl.topInPixels += rotatedReferenceAxis.y;
 
-        //convert to percentage
-        if (this._responsive) {
-            CoordinateHelper.ConvertToPercentage(guiControl, ["left", "top"]);
-        }
+        CoordinateHelper.ConvertToPercentage(guiControl, toConvert);
         this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
         return true;
     }


### PR DESCRIPTION
When dragging a control whose left or top is specified in %, it should remain in %. We just need to convert it back.

Also removes some weird behavior where responsive mode would convert controls to percentage values, which should not have been there.