### PR TITLE
[GUI Editor] Units refactor

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -27,10 +27,8 @@ interface IFloatLineComponentProps {
     icon?: string;
     iconLabel?: string;
     defaultValue?: number;
-    unit?: string;
-    onUnitClicked?: (unit: string) => void;
-    unitLocked?: boolean;
     arrows?: boolean;
+    unit?: React.ReactNode;
 }
 
 export class FloatLineComponent extends React.Component<IFloatLineComponentProps, { value: string; dragging: boolean }> {
@@ -230,16 +228,7 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
                                 <InputArrowsComponent incrementValue={(amount) => this.incrementValue(amount)} setDragging={(dragging) => this.setState({ dragging })} />
                             )}
                         </div>
-                        {this.props.unit && (
-                            <button
-                                className={this.props.unitLocked ? "unit disabled" : "unit"}
-                                onClick={() => {
-                                    if (this.props.onUnitClicked && !this.props.unitLocked) this.props.onUnitClicked(this.props.unit || "");
-                                }}
-                            >
-                                {this.props.unit}
-                            </button>
-                        )}
+                        {this.props.unit}
                     </div>
                 )}
                 {this.props.useEuler && (

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -22,6 +22,7 @@ interface ISliderLineComponentProps {
     icon?: string;
     iconLabel?: string;
     lockObject?: LockObject;
+    unit?: React.ReactNode;
 }
 
 export class SliderLineComponent extends React.Component<ISliderLineComponentProps, { value: number }> {
@@ -138,6 +139,7 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
                         this.onChange(changed);
                     }}
                     onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    unit={this.props.unit}
                 />
                 <div className="slider">
                     <input

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -18,9 +18,6 @@ export interface ITextInputLineComponentProps {
     noUnderline?: boolean;
     numbersOnly?: boolean;
     delayInput?: boolean;
-    unit?: string;
-    onUnitClicked?: (unit: string) => void;
-    unitLocked?: boolean;
     arrows?: boolean;
     arrowsIncrement?: (amount: number) => void;
     step?: number;
@@ -29,6 +26,7 @@ export interface ITextInputLineComponentProps {
     min?: number;
     max?: number;
     placeholder?: string;
+    unit?: React.ReactNode;
 }
 
 export class TextInputLineComponent extends React.Component<ITextInputLineComponentProps, { value: string; dragging: boolean }> {
@@ -199,16 +197,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                     />
                     {this.props.arrows && <InputArrowsComponent incrementValue={(amount) => this.incrementValue(amount)} setDragging={(dragging) => this.setState({ dragging })} />}
                 </div>
-                {this.props.unit !== undefined && (
-                    <button
-                        className={this.props.unitLocked ? "unit disabled" : "unit"}
-                        onClick={() => {
-                            if (this.props.onUnitClicked && !this.props.unitLocked) this.props.onUnitClicked(this.props.unit || "");
-                        }}
-                    >
-                        {this.props.unit}
-                    </button>
-                )}
+                {this.props.unit}
             </div>
         );
     }

--- a/packages/dev/sharedUiComponents/src/lines/unitButton.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/unitButton.tsx
@@ -5,13 +5,15 @@ interface IUnitButtonProps {
 }
 
 export function UnitButton(props: IUnitButtonProps) {
-    return <button
-            className={props.locked ? "unit disabled" : "unit"}
+    return (
+        <button
+            className={"unit"}
             onClick={() => {
                 if (props.onClick && !props.locked) props.onClick(props.unit || "");
             }}
             disabled={props.locked}
         >
             {props.unit}
-        </button>;
+        </button>
+    );
 }

--- a/packages/dev/sharedUiComponents/src/lines/unitButton.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/unitButton.tsx
@@ -1,0 +1,17 @@
+interface IUnitButtonProps {
+    unit: string;
+    locked?: boolean;
+    onClick?: (unit: string) => void;
+}
+
+export function UnitButton(props: IUnitButtonProps) {
+    return <button
+            className={props.locked ? "unit disabled" : "unit"}
+            onClick={() => {
+                if (props.onClick && !props.locked) props.onClick(props.unit || "");
+            }}
+            disabled={props.locked}
+        >
+            {props.unit}
+        </button>;
+}

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/buttonPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/buttonPropertyGridComponent.tsx
@@ -6,6 +6,7 @@ import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObj
 import type { Rectangle } from "gui/2D/controls/rectangle";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { TextLineComponent } from "shared-ui-components/lines/textLineComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 import { CommandButtonComponent } from "../../../commandButtonComponent";
 import { makeTargetsProxy } from "shared-ui-components/lines/targetsProxy";
 import { ContainerPropertyGridComponent } from "./containerPropertyGridComponent";
@@ -64,16 +65,23 @@ export class ButtonPropertyGridComponent extends React.Component<IButtonProperty
                         label=""
                         target={proxy}
                         propertyName="thickness"
-                        unit="PX"
-                        unitLocked={true}
-                        arrows={true}
+                        unit={<UnitButton unit="PX" locked />}
                         min={0}
                         digits={2}
                     />
                 </div>
                 <div className="ge-divider double">
                     <IconComponent icon={cornerRadiusIcon} label={"Corner Radius"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="cornerRadius" unit="PX" unitLocked={true} arrows={true} min={0} digits={2} />
+                    <FloatLineComponent
+                        lockObject={lockObject}
+                        label=""
+                        target={proxy}
+                        propertyName="cornerRadius"
+                        unit={<UnitButton unit="PX" locked />}
+                        arrows={true}
+                        min={0}
+                        digits={2}
+                    />
                 </div>
                 <ContainerPropertyGridComponent containers={rectangles} onPropertyChangedObservable={onPropertyChangedObservable} />
             </div>

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/checkboxPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/checkboxPropertyGridComponent.tsx
@@ -13,6 +13,7 @@ import checkBoxIconDark from "shared-ui-components/imgs/checkboxIconDark.svg";
 import sizeIcon from "shared-ui-components/imgs/sizeIcon.svg";
 import strokeWeightIcon from "shared-ui-components/imgs/strokeWeightIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface ICheckboxPropertyGridComponentProps {
     checkboxes: Checkbox[];
@@ -62,9 +63,8 @@ export class CheckboxPropertyGridComponent extends React.Component<ICheckboxProp
                         lockObject={this.props.lockObject}
                         target={makeTargetsProxy(checkboxes, this.props.onPropertyChangedObservable)}
                         propertyName="thickness"
-                        unit="PX"
                         label=""
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked/>}
                         arrows={true}
                         min={0}
                         digits={2}

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/checkboxPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/checkboxPropertyGridComponent.tsx
@@ -64,7 +64,7 @@ export class CheckboxPropertyGridComponent extends React.Component<ICheckboxProp
                         target={makeTargetsProxy(checkboxes, this.props.onPropertyChangedObservable)}
                         propertyName="thickness"
                         label=""
-                        unit={<UnitButton unit="PX" locked/>}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         min={0}
                         digits={2}

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -49,6 +49,7 @@ import vAlignBottomIcon from "shared-ui-components/imgs/vAlignBottomIcon.svg";
 import descendantsOnlyPaddingIcon from "shared-ui-components/imgs/descendantsOnlyPaddingIcon.svg";
 import { StackPanel } from "gui/2D/controls/stackPanel";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface ICommonControlPropertyGridComponentProps {
     controls: Control[];
@@ -342,8 +343,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 delayInput={true}
                                 value={getValue("_left")}
                                 onChange={(newValue) => this._checkAndUpdateValues("left", newValue)}
-                                unit={getUnitString("_left")}
-                                onUnitClicked={(unit) => convertUnits(unit, "left")}
+                                unit={<UnitButton unit={getUnitString("_left")} onClick={(unit) => convertUnits(unit, "left")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("left", amount)}
                             />
@@ -354,8 +354,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 delayInput={true}
                                 value={getValue("_top")}
                                 onChange={(newValue) => this._checkAndUpdateValues("top", newValue)}
-                                unit={getUnitString("_top")}
-                                onUnitClicked={(unit) => convertUnits(unit, "top")}
+                                unit={<UnitButton unit={getUnitString("_top")} onClick={(unit) => convertUnits(unit, "top")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("top", amount)}
                             />
@@ -382,9 +381,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     }
                                     this._checkAndUpdateValues("width", newValue);
                                 }}
-                                unit={getUnitString("_width")}
-                                unitLocked={widthUnitsLocked}
-                                onUnitClicked={(unit) => !widthUnitsLocked && convertUnits(unit, "width")}
+                                unit={<UnitButton unit={getUnitString("_width")} locked={widthUnitsLocked} onClick={(unit) => convertUnits(unit, "width")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("width", amount)}
                             />
@@ -408,9 +405,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     }
                                     this._checkAndUpdateValues("height", newValue);
                                 }}
-                                unit={getUnitString("_height")}
-                                unitLocked={heightUnitsLocked}
-                                onUnitClicked={(unit) => !heightUnitsLocked && convertUnits(unit, "height")}
+                                unit={<UnitButton unit={getUnitString("_height")} locked={heightUnitsLocked} onClick={(unit) => convertUnits(unit, "height")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("height", amount)}
                             />
@@ -427,8 +422,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     this._checkAndUpdateValues("paddingTop", newValue);
                                     this._markChildrenAsDirty();
                                 }}
-                                unit={getUnitString("_paddingTop")}
-                                onUnitClicked={(unit) => convertUnits(unit, "paddingTop")}
+                                unit={<UnitButton unit={getUnitString("_paddingTop")} onClick={(unit) => convertUnits(unit, "paddingTop")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("paddingTop", amount, 0)}
                             />
@@ -442,8 +436,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     this._checkAndUpdateValues("paddingBottom", newValue);
                                     this._markChildrenAsDirty();
                                 }}
-                                unit={getUnitString("_paddingBottom")}
-                                onUnitClicked={(unit) => convertUnits(unit, "paddingBottom")}
+                                unit={<UnitButton unit={getUnitString("_paddingBottom")} onClick={(unit) => convertUnits(unit, "paddingBottom")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("paddingBottom", amount, 0)}
                             />
@@ -460,8 +453,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     this._checkAndUpdateValues("paddingLeft", newValue);
                                     this._markChildrenAsDirty();
                                 }}
-                                unit={getUnitString("_paddingLeft")}
-                                onUnitClicked={(unit) => convertUnits(unit, "paddingLeft")}
+                                unit={<UnitButton unit={getUnitString("_paddingLeft")} onClick={(unit) => convertUnits(unit, "paddingLeft")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("paddingLeft", amount)}
                             />
@@ -476,8 +468,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                     this._markChildrenAsDirty();
                                 }}
                                 onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                                unit={getUnitString("_paddingRight")}
-                                onUnitClicked={(unit) => convertUnits(unit, "paddingRight")}
+                                unit={<UnitButton unit={getUnitString("_paddingRight")} onClick={(unit) => convertUnits(unit, "paddingRight")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("paddingRight", amount)}
                             />
@@ -512,6 +503,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         minimum={0}
                         maximum={2 * Math.PI}
                         step={0.01}
+                        unit={<UnitButton unit="RAD" locked />}
                     />
                 </div>
                 <hr className="ge" />
@@ -545,8 +537,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         label="X"
                         target={proxy}
                         propertyName="shadowOffsetX"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         step="0.1"
                         digits={2}
@@ -556,8 +547,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         label="Y"
                         target={proxy}
                         propertyName="shadowOffsetY"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         step="0.1"
                         digits={2}
@@ -609,8 +599,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 numbersOnly={true}
                                 value={getValue("_fontSize")}
                                 onChange={(newValue) => this._checkAndUpdateValues("fontSize", newValue)}
-                                unit={getUnitString("_fontSize")}
-                                onUnitClicked={(unit) => convertUnits(unit, "fontSize")}
+                                unit={<UnitButton unit={getUnitString("_fontSize")} onClick={(unit) => convertUnits(unit, "fontSize")} />}
                                 arrows={true}
                                 arrowsIncrement={(amount) => increment("fontSize", amount, 0)}
                             />

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/ellipsePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/ellipsePropertyGridComponent.tsx
@@ -35,7 +35,16 @@ export class EllipsePropertyGridComponent extends React.Component<IEllipseProper
                 <TextLineComponent label="ELLIPSE" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label={"Stroke Weight"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="thickness" unit={<UnitButton unit="PX" locked/>} arrows={true} min={0} digits={2} />
+                    <FloatLineComponent
+                        lockObject={lockObject}
+                        label=""
+                        target={proxy}
+                        propertyName="thickness"
+                        unit={<UnitButton unit="PX" locked />}
+                        arrows={true}
+                        min={0}
+                        digits={2}
+                    />
                 </div>
                 <ContainerPropertyGridComponent containers={ellipses} onPropertyChangedObservable={onPropertyChangedObservable} />
             </div>

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/ellipsePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/ellipsePropertyGridComponent.tsx
@@ -11,6 +11,7 @@ import { ContainerPropertyGridComponent } from "./containerPropertyGridComponent
 
 import strokeWeightIcon from "shared-ui-components/imgs/strokeWeightIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IEllipsePropertyGridComponentProps {
     ellipses: Ellipse[];
@@ -34,7 +35,7 @@ export class EllipsePropertyGridComponent extends React.Component<IEllipseProper
                 <TextLineComponent label="ELLIPSE" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label={"Stroke Weight"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="thickness" unit={"PX"} unitLocked={true} arrows={true} min={0} digits={2} />
+                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="thickness" unit={<UnitButton unit="PX" locked/>} arrows={true} min={0} digits={2} />
                 </div>
                 <ContainerPropertyGridComponent containers={ellipses} onPropertyChangedObservable={onPropertyChangedObservable} />
             </div>

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/imagePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/imagePropertyGridComponent.tsx
@@ -19,6 +19,7 @@ import autoResizeIcon from "shared-ui-components/imgs/autoResizeIcon.svg";
 import sizeIcon from "shared-ui-components/imgs/sizeIcon.svg";
 import animationSheetIcon from "shared-ui-components/imgs/animationSheetIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IImagePropertyGridComponentProps {
     images: Image[];
@@ -129,8 +130,7 @@ export class ImagePropertyGridComponent extends React.Component<IImagePropertyGr
                         arrows={true}
                         min={0}
                         placeholder="0"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                     />
                     <TextInputLineComponent
                         lockObject={this.props.lockObject}
@@ -141,8 +141,7 @@ export class ImagePropertyGridComponent extends React.Component<IImagePropertyGr
                         arrows={true}
                         min={0}
                         placeholder="0"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                     />
                 </div>
                 <div className="ge-divider double">
@@ -156,8 +155,7 @@ export class ImagePropertyGridComponent extends React.Component<IImagePropertyGr
                         arrows={true}
                         min={0}
                         placeholder={Math.max(...images.map((image) => image.imageWidth)).toString()}
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                     />
                     <TextInputLineComponent
                         lockObject={this.props.lockObject}
@@ -168,8 +166,7 @@ export class ImagePropertyGridComponent extends React.Component<IImagePropertyGr
                         arrows={true}
                         min={0}
                         placeholder={Math.max(...images.map((image) => image.imageHeight)).toString()}
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                     />
                 </div>
                 <div className="ge-divider">

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/inputTextPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/inputTextPropertyGridComponent.tsx
@@ -25,6 +25,7 @@ import selectAllIcon from "shared-ui-components/imgs/selectAllIcon.svg";
 import highlightIcon from "shared-ui-components/imgs/highlightIcon.svg";
 import textPlaceholderIcon from "shared-ui-components/imgs/textPlaceholderIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IInputTextPropertyGridComponentProps {
     inputTexts: InputText[];
@@ -64,7 +65,7 @@ export class InputTextPropertyGridComponent extends React.Component<IInputTextPr
                 </div>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label="Border Thickness" />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="thickness" unit="PX" unitLocked arrows min={0} digits={2} />
+                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="thickness" unit={<UnitButton unit="PX" locked />} arrows min={0} digits={2} />
                 </div>
                 <div className="ge-divider">
                     <IconComponent icon={autoStretchWidthIcon} label="Automatically Stretch Width" />

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/linePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/linePropertyGridComponent.tsx
@@ -14,6 +14,7 @@ import linePoint1Icon from "shared-ui-components/imgs/linePoint1Icon.svg";
 import linePoint2Icon from "shared-ui-components/imgs/linePoint2Icon.svg";
 import lineDashIcon from "shared-ui-components/imgs/lineDashIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface ILinePropertyGridComponentProps {
     lines: Line[];
@@ -76,7 +77,7 @@ export class LinePropertyGridComponent extends React.Component<ILinePropertyGrid
                 </div>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label={"Line Width"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="lineWidth" unit="PX" unitLocked={true} min={0} arrows={true} />
+                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="lineWidth" unit={<UnitButton unit="PX" locked />} min={0} arrows={true} />
                 </div>
                 <div className="ge-divider">
                     <IconComponent icon={lineDashIcon} label={"Dash Pattern"} />

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/radioButtonPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/radioButtonPropertyGridComponent.tsx
@@ -14,6 +14,7 @@ import strokeWeightIcon from "shared-ui-components/imgs/strokeWeightIcon.svg";
 import checkboxIcon from "shared-ui-components/imgs/checkboxIconDark.svg";
 import scaleIcon from "shared-ui-components/imgs/scaleIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IRadioButtonPropertyGridComponentProps {
     radioButtons: RadioButton[];
@@ -45,8 +46,7 @@ export class RadioButtonPropertyGridComponent extends React.Component<IRadioButt
                         label=""
                         target={makeTargetsProxy(radioButtons, this.props.onPropertyChangedObservable)}
                         propertyName="thickness"
-                        unit="PX"
-                        unitLocked
+                        unit={<UnitButton unit="PX" locked />}
                         arrows
                         min={0}
                         digits={2}
@@ -59,8 +59,7 @@ export class RadioButtonPropertyGridComponent extends React.Component<IRadioButt
                         label=""
                         target={makeTargetsProxy(radioButtons, this.props.onPropertyChangedObservable)}
                         propertyName="checkSizeRatio"
-                        unit="PX"
-                        unitLocked
+                        unit={<UnitButton unit="PX" locked />}
                         arrows
                         min={0}
                         digits={2}

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/rectanglePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/rectanglePropertyGridComponent.tsx
@@ -36,11 +36,29 @@ export class RectanglePropertyGridComponent extends React.Component<IRectanglePr
                 <TextLineComponent label="RECTANGLE" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label={"Stroke Weight"} />
-                    <FloatLineComponent lockObject={this.props.lockObject} label="" target={proxy} propertyName="thickness" unit={<UnitButton unit="PX" locked/>} arrows min={0} digits={2} />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label=""
+                        target={proxy}
+                        propertyName="thickness"
+                        unit={<UnitButton unit="PX" locked />}
+                        arrows
+                        min={0}
+                        digits={2}
+                    />
                 </div>
                 <div className="ge-divider double">
                     <IconComponent icon={cornerRadiusIcon} label={"Corner Radius"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="cornerRadius" unit={<UnitButton unit="PX" locked/>} arrows min={0} digits={2} />
+                    <FloatLineComponent
+                        lockObject={lockObject}
+                        label=""
+                        target={proxy}
+                        propertyName="cornerRadius"
+                        unit={<UnitButton unit="PX" locked />}
+                        arrows
+                        min={0}
+                        digits={2}
+                    />
                 </div>
                 <ContainerPropertyGridComponent containers={rectangles} onPropertyChangedObservable={onPropertyChangedObservable} />
             </div>

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/rectanglePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/rectanglePropertyGridComponent.tsx
@@ -12,6 +12,7 @@ import { ContainerPropertyGridComponent } from "./containerPropertyGridComponent
 import cornerRadiusIcon from "shared-ui-components/imgs/conerRadiusIcon.svg";
 import strokeWeightIcon from "shared-ui-components/imgs/strokeWeightIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IRectanglePropertyGridComponentProps {
     rectangles: Rectangle[];
@@ -35,11 +36,11 @@ export class RectanglePropertyGridComponent extends React.Component<IRectanglePr
                 <TextLineComponent label="RECTANGLE" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label={"Stroke Weight"} />
-                    <FloatLineComponent lockObject={this.props.lockObject} label="" target={proxy} propertyName="thickness" unit="PX" unitLocked arrows min={0} digits={2} />
+                    <FloatLineComponent lockObject={this.props.lockObject} label="" target={proxy} propertyName="thickness" unit={<UnitButton unit="PX" locked/>} arrows min={0} digits={2} />
                 </div>
                 <div className="ge-divider double">
                     <IconComponent icon={cornerRadiusIcon} label={"Corner Radius"} />
-                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="cornerRadius" unit="PX" unitLocked arrows min={0} digits={2} />
+                    <FloatLineComponent lockObject={lockObject} label="" target={proxy} propertyName="cornerRadius" unit={<UnitButton unit="PX" locked/>} arrows min={0} digits={2} />
                 </div>
                 <ContainerPropertyGridComponent containers={rectangles} onPropertyChangedObservable={onPropertyChangedObservable} />
             </div>

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/scrollViewerPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/scrollViewerPropertyGridComponent.tsx
@@ -16,6 +16,7 @@ import cornerRadiusIcon from "shared-ui-components/imgs/conerRadiusIcon.svg";
 import strokeWeightIcon from "shared-ui-components/imgs/strokeWeightIcon.svg";
 import scrollViewerPrecisionIcon from "shared-ui-components/imgs/scrollViewerPrecisionIcon.svg"; // TODO: replace
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IScrollViewerPropertyGridComponentProps {
     scrollViewers: ScrollViewer[];
@@ -43,7 +44,16 @@ export class ScrollViewerPropertyGridComponent extends React.Component<IScrollVi
                 </div>
                 <div className="ge-divider">
                     <IconComponent icon={widthIcon} label={"Bar Size"} />
-                    <FloatLineComponent lockObject={this.props.lockObject} label="" target={proxy} propertyName="barSize" unit="PX" unitLocked arrows min={0} digits={2} />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label=""
+                        target={proxy}
+                        propertyName="barSize"
+                        unit={<UnitButton unit="PX" locked />}
+                        arrows
+                        min={0}
+                        digits={2}
+                    />
                 </div>
                 <div className="e-divider">
                     <IconComponent icon={colorIcon} label="Bar Color" />
@@ -60,8 +70,7 @@ export class ScrollViewerPropertyGridComponent extends React.Component<IScrollVi
                         label=""
                         target={proxy}
                         propertyName="thickness"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         min={0}
                         digits={2}
@@ -74,8 +83,7 @@ export class ScrollViewerPropertyGridComponent extends React.Component<IScrollVi
                         label=""
                         target={makeTargetsProxy(scrollViewers, onPropertyChangedObservable)}
                         propertyName="cornerRadius"
-                        unit="PX"
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         min={0}
                         digits={2}

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/stackPanelPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/stackPanelPropertyGridComponent.tsx
@@ -15,6 +15,7 @@ import stackPanelSpacingIcon from "shared-ui-components/imgs/stackPanelSpacingIc
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
 import { ValueAndUnit } from "gui/2D/valueAndUnit";
 import { CoordinateHelper } from "../../../../diagram/coordinateHelper";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 interface IStackPanelPropertyGridComponentProps {
     stackPanels: StackPanel[];
@@ -72,8 +73,7 @@ export class StackPanelPropertyGridComponent extends React.Component<IStackPanel
                         target={proxy}
                         propertyName="spacing"
                         onChange={() => stackPanels.forEach((panel) => panel._markAsDirty())}
-                        unit={"PX"}
-                        unitLocked={true}
+                        unit={<UnitButton unit="PX" locked />}
                         arrows={true}
                         min={0}
                     />

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/textBlockPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/textBlockPropertyGridComponent.tsx
@@ -26,6 +26,7 @@ import wordWrapIcon from "shared-ui-components/imgs/wordWrapIcon.svg";
 import lineSpacingIcon from "shared-ui-components/imgs/LineSpacingIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import { UnitButton } from "shared-ui-components/lines/unitButton";
 
 export class TextBlockPropertyGridComponent extends React.Component<ITextBlockPropertyGridComponentProps> {
     constructor(props: ITextBlockPropertyGridComponentProps) {
@@ -68,7 +69,16 @@ export class TextBlockPropertyGridComponent extends React.Component<ITextBlockPr
                 <TextLineComponent label="OUTLINE" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={strokeWeightIcon} label="Outline Width" />
-                    <FloatLineComponent lockObject={this.props.lockObject} label=" " target={proxy} propertyName="outlineWidth" arrows min={0} unit="PX" unitLocked step="0.01" />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label=" "
+                        target={proxy}
+                        propertyName="outlineWidth"
+                        arrows
+                        min={0}
+                        unit={<UnitButton unit="PX" locked />}
+                        step="0.01"
+                    />
                 </div>
                 <div className="ge-divider">
                     <IconComponent icon={fillColorIcon} label="Outline Color" />

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
@@ -134,16 +134,16 @@
         align-items: center;
     }
 
-    .unit.disabled {
+    .unit:disabled {
         background-color: var(--buttonDisabledBackground);
         cursor: not-allowed;
     }
 
-    .unit:not(.disabled):hover {
+    .unit:not(:disabled):hover {
         background-color: var(--buttonHoverBackground);
     }
 
-    .unit:not(.disabled):active {
+    .unit:not(:disabled):active {
         color: var(--buttonPressed);
         background-color: var(--buttonPressedBackground);
     }

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
@@ -67,6 +67,7 @@
         opacity: 0.7;
         -webkit-transition: 0.2s;
         transition: opacity 0.2s;
+        padding: 0;
     }
 
     .range:hover {
@@ -128,6 +129,9 @@
         font-family: "atten-round-new", sans-serif;
         font-weight: 500;
         font-style: normal;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .unit.disabled {
@@ -174,7 +178,7 @@
         height: var(--spacingHeight);
         display: grid;
         grid-template-rows: 100%;
-        grid-template-columns: auto 1fr 75px 1fr;
+        grid-template-columns: auto 1fr 20px 1fr;
         flex-grow: 1;
 
         .label {
@@ -203,7 +207,7 @@
         .floatLine {
             grid-column: 2;
             padding-left: 0px;
-            grid-template-columns: auto;
+            grid-template-columns: 1fr auto;
 
             .label {
                 grid-column: 1;
@@ -220,7 +224,7 @@
                 input {
                     width: 100%;
                     background-color: white;
-                    height: 26px;
+                    height: 24px;
                 }
 
                 input::-webkit-outer-spin-button,


### PR DESCRIPTION
Refactors units inside text/float inputs to be a separate component. Now you simply pass a UnitButton into the unit prop of the input component. This reduces code duplication and made it easy to add units to the slider component.

Also:
* makes units use "disabled" HTML attribute rather than a "disabled" class, for increasing accesibility
* fixes minor CSS issues with the slider component.