### PR TITLE
Cameras: Reset current active button when controls are detached

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -272,6 +272,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         this._metaKey = false;
         this._shiftKey = false;
         this._buttonsPressed = 0;
+        this._currentActiveButton = -1;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -233,6 +233,8 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
             this._onMouseMove = null;
             this._previousPosition = null;
         }
+
+        this._currentActiveButton = -1;
     }
 
     /**


### PR DESCRIPTION
This PR contains a simple fix that resets _currentActiveButton to -1 in our cameras.  This addresses an a potential scenario where the controls are detached before a pointerup is handled.