### PR TITLE
Cameras: Removed redundant detachControl calls

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
@@ -104,11 +104,6 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._observer) {
             this.camera.getScene().onPointerObservable.remove(this._observer);

--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -242,11 +242,6 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._onLostFocus) {
             const hostWindow = this.camera.getScene().getEngine().getHostWindow();

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraGamepadInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraGamepadInput.ts
@@ -76,11 +76,6 @@ export class ArcRotateCameraGamepadInput implements ICameraInput<ArcRotateCamera
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.camera.getScene().gamepadManager.onGamepadConnectedObservable.remove(this._onGamepadConnectedObserver);
         this.camera.getScene().gamepadManager.onGamepadDisconnectedObservable.remove(this._onGamepadDisconnectedObserver);

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
@@ -160,11 +160,6 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._scene) {
             if (this._onKeyboardObserver) {

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -149,11 +149,6 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._observer) {
             this.camera.getScene().onPointerObservable.remove(this._observer);

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraVRDeviceOrientationInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraVRDeviceOrientationInput.ts
@@ -125,11 +125,6 @@ export class ArcRotateCameraVRDeviceOrientationInput implements ICameraInput<Arc
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         window.removeEventListener("deviceorientation", this._deviceOrientationHandler);
     }

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
@@ -127,11 +127,6 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._scene) {
             if (this._onKeyboardObserver) {

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
@@ -99,11 +99,6 @@ export class FlyCameraMouseInput implements ICameraInput<FlyCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._observer) {
             this.camera.getScene().onPointerObservable.remove(this._observer);

--- a/packages/dev/core/src/Cameras/Inputs/followCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraKeyboardMoveInput.ts
@@ -212,11 +212,6 @@ export class FollowCameraKeyboardMoveInput implements ICameraInput<FollowCamera>
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._scene) {
             if (this._onKeyboardObserver) {

--- a/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -121,11 +121,6 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._observer) {
             this.camera.getScene().onPointerObservable.remove(this._observer);

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraDeviceOrientationInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraDeviceOrientationInput.ts
@@ -183,11 +183,6 @@ export class FreeCameraDeviceOrientationInput implements ICameraInput<FreeCamera
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         window.removeEventListener("orientationchange", this._orientationChanged);
         window.removeEventListener("deviceorientation", this._deviceOrientation);

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraGamepadInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraGamepadInput.ts
@@ -94,11 +94,6 @@ export class FreeCameraGamepadInput implements ICameraInput<FreeCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.camera.getScene().gamepadManager.onGamepadConnectedObservable.remove(this._onGamepadConnectedObserver);
         this.camera.getScene().gamepadManager.onGamepadDisconnectedObservable.remove(this._onGamepadDisconnectedObserver);

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
@@ -149,11 +149,6 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._scene) {
             if (this._onKeyboardObserver) {

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -210,11 +210,6 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._observer) {
             this.camera.getScene().onPointerObservable.remove(this._observer);

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -150,11 +150,6 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         if (this._pointerInput) {
             if (this._observer) {

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraVirtualJoystickInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraVirtualJoystickInput.ts
@@ -98,11 +98,6 @@ export class FreeCameraVirtualJoystickInput implements ICameraInput<FreeCamera> 
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this._leftjoystick.releaseCanvas();
         this._rightjoystick.releaseCanvas();

--- a/packages/dev/core/src/Cameras/VR/webVRCamera.ts
+++ b/packages/dev/core/src/Cameras/VR/webVRCamera.ts
@@ -530,11 +530,6 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.getScene().gamepadManager.onGamepadConnectedObservable.remove(this._onGamepadConnectedObserver);
         this.getScene().gamepadManager.onGamepadDisconnectedObservable.remove(this._onGamepadDisconnectedObserver);

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -886,15 +886,6 @@ export class ArcRotateCamera extends TargetCamera {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-    /**
-     * Detach the current controls from the specified dom element.
-     * @param ignored defines an ignored parameter kept for backward compatibility.
-     */
-    public detachControl(ignored: any): void;
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.inputs.detachElement();
 

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -597,13 +597,9 @@ export class Camera extends Node {
 
     /**
      * Detach the current controls from the specified dom element.
-     */
-    public detachControl(): void;
-    /**
-     * Detach the current controls from the specified dom element.
      * @param ignored defines an ignored parameter kept for backward compatibility.
      */
-    public detachControl(ignored: any): void;
+    public detachControl(): void;
     /**
      * Detach the current controls from the specified dom element.
      * @param ignored defines an ignored parameter kept for backward compatibility.

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -183,11 +183,6 @@ export class FollowCamera extends TargetCamera {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.inputs.detachElement();
 

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -285,15 +285,6 @@ export class FreeCamera extends TargetCamera {
     /**
      * Detach the current controls from the specified dom element.
      */
-    public detachControl(): void;
-    /**
-     * Detach the current controls from the specified dom element.
-     * @param ignored defines an ignored parameter kept for backward compatibility.
-     */
-    public detachControl(ignored: any): void;
-    /**
-     * Detach the current controls from the specified dom element.
-     */
     public detachControl(): void {
         this.inputs.detachElement();
 


### PR DESCRIPTION
This PR removes any redundant detachControl() calls and unused detachControl(ignored) calls from our cameras and camera inputs.