### PR TITLE
[NME] fix color picker zindex

### DIFF
--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTab.scss
@@ -285,6 +285,7 @@
                 right: 0px;
                 bottom: 0px;
                 left: 0px;
+                z-index: 1;
             }
 
             .color-picker-float {


### PR DESCRIPTION
Fixes an issue where the color picker could render below certain other UI elements. reported by @PatrickRyanMS 