### PR TITLE
Added a new flag for checking double sided mesh in collision

### DIFF
--- a/packages/dev/core/src/Collisions/collider.ts
+++ b/packages/dev/core/src/Collisions/collider.ts
@@ -85,6 +85,11 @@ export class Collider {
      */
     public collidedMesh: Nullable<AbstractMesh>;
 
+    /**
+     * If true, it check for double sided faces and only returns 1 collision instead of 2
+     */
+    public static DoubleSidedCheck = false;
+
     private _collisionPoint = Vector3.Zero();
     private _planeIntersectionPoint = Vector3.Zero();
     private _tempVector = Vector3.Zero();
@@ -247,6 +252,12 @@ export class Collider {
 
         const signedDistToTrianglePlane = trianglePlane.signedDistanceTo(this._basePoint);
         const normalDotVelocity = Vector3.Dot(trianglePlane.normal, this._velocity);
+
+        // if DoubleSidedCheck is false(default), a double sided face will be consided 2 times. 
+        // if true, it discard the faces having normal not facing velocity
+        if (Collider.DoubleSidedCheck && normalDotVelocity > 0.0001) {
+            return;
+        }
 
         if (normalDotVelocity == 0) {
             if (Math.abs(signedDistToTrianglePlane) >= 1.0) {

--- a/packages/dev/core/src/Collisions/collider.ts
+++ b/packages/dev/core/src/Collisions/collider.ts
@@ -253,7 +253,7 @@ export class Collider {
         const signedDistToTrianglePlane = trianglePlane.signedDistanceTo(this._basePoint);
         const normalDotVelocity = Vector3.Dot(trianglePlane.normal, this._velocity);
 
-        // if DoubleSidedCheck is false(default), a double sided face will be consided 2 times. 
+        // if DoubleSidedCheck is false(default), a double sided face will be consided 2 times.
         // if true, it discard the faces having normal not facing velocity
         if (Collider.DoubleSidedCheck && normalDotVelocity > 0.0001) {
             return;


### PR DESCRIPTION
Added a new flag for checking double sided mesh in collision detection (disable by default)

follow up https://forum.babylonjs.com/t/movewithcollisions-cant-handle-doublesided-meshes/28928
double sided face are evaluated 2 times, by design. With this change, they are only evaluated once.
To not break back compat, it's hidden behind a flag.
To enable it :
```
BABYLON.Collider.DoubleSidedCheck = true;
```