### PR TITLE
[Build] make sure externals are only the public dev packages

### DIFF
--- a/packages/dev/buildTools/src/packageMapping.ts
+++ b/packages/dev/buildTools/src/packageMapping.ts
@@ -266,7 +266,7 @@ export function getAllBuildTypes(): BuildType[] {
     return Object.keys(packageMapping) as BuildType[];
 }
 
-export function isValidPackageMap(packageMap: { [key: string]: string | ((data?: any) => string) }): packageMap is PackageMap {
+export function isValidPackageMap(packageMap: { [key: string]: string | ((data?: any) => string) }, publicOnly?: boolean): packageMap is PackageMap {
     const packageNames = Object.keys(packageMap);
     const buildTypes = getAllBuildTypes();
 
@@ -309,7 +309,10 @@ export function getPublicPackageName(publicVariable: PublicPackageVariable, data
     }
 }
 
-export function isValidDevPackageName(devName: string): devName is DevPackageName {
+export function isValidDevPackageName(devName: string, publicOnly?: boolean): devName is DevPackageName {
+    if (publicOnly && privatePackages.includes(kebabize(devName) as DevPackageName)) {
+        return false;
+    }
     return Object.keys(packageMapping).some((buildType) => {
         if (isValidBuildType(buildType)) {
             return packageMapping[buildType][kebabize(devName) as DevPackageName] !== undefined;

--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -15,8 +15,8 @@ export const externalsFunction = (excludePackages: string[] = [], type: BuildTyp
         const importParts = request.split("/");
         const devPackageName = importParts[0].replace(/^babylonjs/, "") || "core";
         // check if this request needs to be ignored or transformed
-        if (excludePackages.indexOf(devPackageName) === -1 && isValidDevPackageName(devPackageName)) {
-            const packages = getPackageMappingByDevName(devPackageName);
+        if (excludePackages.indexOf(devPackageName) === -1 && isValidDevPackageName(devPackageName, true)) {
+            const packages = getPackageMappingByDevName(devPackageName, true);
             const buildTypePackage = getPublicPackageName(packages[type], request);
             const namespaceName = getPublicPackageName(packages.namespace, request);
             if (type === "umd" || type === "es6") {


### PR DESCRIPTION
Shared UI components were considered as external package instead of embedded. due to a recent change I have made.

This fixes the issue.