### PR TITLE
PBR thin instance color attribute needs to be pushed

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1326,6 +1326,10 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             attribs.push(VertexBuffer.ColorKind);
         }
 
+        if (defines.INSTANCESCOLOR) {
+            attribs.push(VertexBuffer.ColorInstanceKind);
+        }
+
         MaterialHelper.PrepareAttributesForBones(attribs, mesh, defines, fallbacks);
         MaterialHelper.PrepareAttributesForInstances(attribs, defines);
         MaterialHelper.PrepareAttributesForMorphTargets(attribs, mesh, defines);


### PR DESCRIPTION
PBRBaseMaterial is missing the code to push the attribute for thin instance color. This PR just copies the same lines from StandardMaterial.

Here's a [PG](https://playground.babylonjs.com/#JGBXWZ#3) that shows the issue that's fixed by the PR, where the thin instances are black when they should be red.