### PR TITLE
Add support for GLTF 2.0 Serializer KHR_materials_specular

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -4,7 +4,6 @@ import { _Exporter } from "../glTFExporter";
 import type { Material } from "core/Materials/material";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";
-import { Color3 } from "core/Maths/math.color";
 
 const NAME = "KHR_materials_specular";
 
@@ -56,8 +55,8 @@ export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
     }
 
     private _isExtensionEnabled(mat: PBRMaterial):boolean{
-       return  (mat.metallicF0Factor && mat.metallicF0Factor != 1.0) || 
-               (mat.metallicReflectanceColor  && !mat.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0)) ||
+       return  (mat.metallicF0Factor != undefined && mat.metallicF0Factor != 1.0) || 
+               (mat.metallicReflectanceColor  != undefined && !mat.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0)) ||
                this._hasTexturesExtension(mat) ;
     }
 
@@ -77,14 +76,16 @@ export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
 
                 node.extensions = node.extensions || {};
                 
-                const metallicReflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.metallicReflectanceTexture);
-                const reflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.reflectanceTexture);
+                const metallicReflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.metallicReflectanceTexture) ?? undefined;
+                const reflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.reflectanceTexture) ?? undefined;
+                const metallicF0Factor = babylonMaterial.metallicF0Factor == 1.0 ? undefined : babylonMaterial.metallicF0Factor
+                const metallicReflectanceColor = babylonMaterial.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0) ? undefined : babylonMaterial.metallicReflectanceColor.asArray();
  
                 const specularInfo : IKHRMaterialsSpecular = {
-                    specularFactor : babylonMaterial.metallicF0Factor ?? 1.0, 
-                    specularTexture : metallicReflectanceTexture ?? undefined,
-                    specularColorFactor : (babylonMaterial.metallicReflectanceColor ?? Color3.White).asArray(),
-                    specularColorTexture : reflectanceTexture ?? undefined,
+                    specularFactor : metallicF0Factor, 
+                    specularTexture : metallicReflectanceTexture ,
+                    specularColorFactor : metallicReflectanceColor,
+                    specularColorTexture : reflectanceTexture,
                     hasTextures: () => {
                         return this._hasTexturesExtension(babylonMaterial);
                     },

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -8,7 +8,7 @@ import type { BaseTexture } from "core/Materials/Textures/baseTexture";
 const NAME = "KHR_materials_specular";
 
 /**
- * @hidden
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_specular/README.md)
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class KHR_materials_specular implements IGLTFExporterExtensionV2 {

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -1,0 +1,99 @@
+import type { IMaterial, IKHRMaterialsSpecular } from "babylonjs-gltf2interface";
+import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
+import { _Exporter } from "../glTFExporter";
+import type { Material } from "core/Materials/material";
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import type { BaseTexture } from "core/Materials/Textures/baseTexture";
+import { Color3 } from "core/Maths/math.color";
+
+const NAME = "KHR_materials_specular";
+
+/**
+ * @hidden
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
+    /** Name of this extension */
+    public readonly name = NAME;
+
+    /** Defines whether this extension is enabled */
+    public enabled = true;
+
+    /** Defines whether this extension is required */
+    public required = false;
+
+    private _exporter: _Exporter;
+
+    private _wasUsed = false;
+
+    constructor(exporter: _Exporter) {
+        this._exporter = exporter;
+    }
+
+    public dispose() {}
+
+    /** @hidden */
+    public get wasUsed() {
+        return this._wasUsed;
+    }
+
+    public postExportMaterialAdditionalTextures?(context: string, node: IMaterial, babylonMaterial: Material): BaseTexture[] {
+        const additionalTextures: BaseTexture[] = [];
+
+        if (babylonMaterial instanceof PBRMaterial) {
+            if (this._isExtensionEnabled(babylonMaterial)) {
+                if (babylonMaterial.metallicReflectanceTexture) {
+                    additionalTextures.push(babylonMaterial.metallicReflectanceTexture);
+                }
+                if (babylonMaterial.reflectanceTexture) {
+                    additionalTextures.push(babylonMaterial.reflectanceTexture);
+                }
+                return additionalTextures;
+            }
+        }
+
+        return additionalTextures;
+    }
+
+    private _isExtensionEnabled(mat: PBRMaterial):boolean{
+       return  (mat.metallicF0Factor && mat.metallicF0Factor != 1.0) || 
+               (mat.metallicReflectanceColor  && !mat.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0)) ||
+               this._hasTexturesExtension(mat) ;
+    }
+
+    private _hasTexturesExtension(mat: PBRMaterial):boolean{
+        return  mat.metallicReflectanceTexture != null  || mat.reflectanceTexture != null ;
+     }
+
+    public postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
+        return new Promise((resolve) => {
+            if (babylonMaterial instanceof PBRMaterial) {
+                if (!this._isExtensionEnabled(babylonMaterial)) {
+                    resolve(node);
+                    return;
+                }
+
+                this._wasUsed = true;
+
+                node.extensions = node.extensions || {};
+                
+                const metallicReflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.metallicReflectanceTexture);
+                const reflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.reflectanceTexture);
+ 
+                const specularInfo : IKHRMaterialsSpecular = {
+                    specularFactor : babylonMaterial.metallicF0Factor ?? 1.0, 
+                    specularTexture : metallicReflectanceTexture ?? undefined,
+                    specularColorFactor : (babylonMaterial.metallicReflectanceColor ?? Color3.White).asArray(),
+                    specularColorTexture : reflectanceTexture ?? undefined,
+                    hasTextures: () => {
+                        return this._hasTexturesExtension(babylonMaterial);
+                    },
+                }
+                node.extensions[NAME] = specularInfo;
+            }
+            resolve(node);
+        });
+    }
+}
+
+_Exporter.RegisterExtension(NAME, (exporter) => new KHR_materials_specular(exporter));

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -54,15 +54,17 @@ export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
         return additionalTextures;
     }
 
-    private _isExtensionEnabled(mat: PBRMaterial):boolean{
-       return  (mat.metallicF0Factor != undefined && mat.metallicF0Factor != 1.0) || 
-               (mat.metallicReflectanceColor  != undefined && !mat.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0)) ||
-               this._hasTexturesExtension(mat) ;
+    private _isExtensionEnabled(mat: PBRMaterial): boolean {
+        return (
+            (mat.metallicF0Factor != undefined && mat.metallicF0Factor != 1.0) ||
+            (mat.metallicReflectanceColor != undefined && !mat.metallicReflectanceColor.equalsFloats(1.0, 1.0, 1.0)) ||
+            this._hasTexturesExtension(mat)
+        );
     }
 
-    private _hasTexturesExtension(mat: PBRMaterial):boolean{
-        return  mat.metallicReflectanceTexture != null  || mat.reflectanceTexture != null ;
-     }
+    private _hasTexturesExtension(mat: PBRMaterial): boolean {
+        return mat.metallicReflectanceTexture != null || mat.reflectanceTexture != null;
+    }
 
     public postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
         return new Promise((resolve) => {
@@ -75,21 +77,23 @@ export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
                 this._wasUsed = true;
 
                 node.extensions = node.extensions || {};
-                
+
                 const metallicReflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.metallicReflectanceTexture) ?? undefined;
                 const reflectanceTexture = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.reflectanceTexture) ?? undefined;
-                const metallicF0Factor = babylonMaterial.metallicF0Factor == 1.0 ? undefined : babylonMaterial.metallicF0Factor
-                const metallicReflectanceColor = babylonMaterial.metallicReflectanceColor.equalsFloats(1.0,1.0,1.0) ? undefined : babylonMaterial.metallicReflectanceColor.asArray();
- 
-                const specularInfo : IKHRMaterialsSpecular = {
-                    specularFactor : metallicF0Factor, 
-                    specularTexture : metallicReflectanceTexture ,
-                    specularColorFactor : metallicReflectanceColor,
-                    specularColorTexture : reflectanceTexture,
+                const metallicF0Factor = babylonMaterial.metallicF0Factor == 1.0 ? undefined : babylonMaterial.metallicF0Factor;
+                const metallicReflectanceColor = babylonMaterial.metallicReflectanceColor.equalsFloats(1.0, 1.0, 1.0)
+                    ? undefined
+                    : babylonMaterial.metallicReflectanceColor.asArray();
+
+                const specularInfo: IKHRMaterialsSpecular = {
+                    specularFactor: metallicF0Factor,
+                    specularTexture: metallicReflectanceTexture,
+                    specularColorFactor: metallicReflectanceColor,
+                    specularColorTexture: reflectanceTexture,
                     hasTextures: () => {
                         return this._hasTexturesExtension(babylonMaterial);
                     },
-                }
+                };
                 node.extensions[NAME] = specularInfo;
             }
             resolve(node);

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -68,12 +68,7 @@ export class KHR_materials_specular implements IGLTFExporterExtensionV2 {
 
     public postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
         return new Promise((resolve) => {
-            if (babylonMaterial instanceof PBRMaterial) {
-                if (!this._isExtensionEnabled(babylonMaterial)) {
-                    resolve(node);
-                    return;
-                }
-
+            if (babylonMaterial instanceof PBRMaterial && this._isExtensionEnabled(babylonMaterial)) {
                 this._wasUsed = true;
 
                 node.extensions = node.extensions || {};

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
@@ -3,3 +3,4 @@ export * from "./KHR_lights_punctual";
 export * from "./KHR_materials_clearcoat";
 export * from "./KHR_materials_sheen";
 export * from "./KHR_materials_unlit";
+export * from "./KHR_materials_specular";

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -1090,10 +1090,10 @@ declare module BABYLON.GLTF2 {
 
     /** @hidden */
     interface IKHRMaterialsSpecular extends IMaterialExtension {
-        specularFactor: number;
-        specularColorFactor: number[];
-        specularTexture: ITextureInfo;
-        specularColorTexture: ITextureInfo;
+        specularFactor?: number;
+        specularColorFactor?: number[];
+        specularTexture?: ITextureInfo;
+        specularColorTexture?: ITextureInfo;
     }
 
     /**


### PR DESCRIPTION
GLTF 2.0 Serializer is missing the KHR_materials_specular extension
This PR add support for the KHR_materials_specular to the GLTF2.0 serializer.
Values are mapped as

- specularFactor : metallicF0Factor 
- specularTexture : metallicReflectanceTexture 
- specularColorFactor : metallicReflectanceColor
- specularColorTexture : reflectanceTexture

using default value or `undefined ` to decide wether or not the data should be serialized.
default values are 
- specularFactor : 1.0f 
- specularColorFactor : [1.0f,1.0f,1.0f] 

Test has been conducted using this standard sample [model](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/SpecularTest)
Materials has been loaded and serialized succesfully without any diff.
close #8968
