### PR TITLE
fix physics regression

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1573,7 +1573,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         if (this._boundingInfo) {
             this._boundingInfo.update(this.worldMatrixFromCache);
         } else {
-            this._boundingInfo = new BoundingInfo(this.position, this.position, this.worldMatrixFromCache);
+            this._boundingInfo = new BoundingInfo(Vector3.Zero(), Vector3.Zero(), this.worldMatrixFromCache);
         }
         this._updateSubMeshesBoundingInfo(this.worldMatrixFromCache);
         return this;


### PR DESCRIPTION
followup https://forum.babylonjs.com/t/compound-to-empty-mesh-demo-works-differently-for-cannon-omio-vs-ammo/29062

When computing bounding info from scratch, before this change, the min and max position was `mesh.position`. So, in this case:
```
var compoundBody = new BABYLON.Mesh("compoundBody", scene);
compoundBody.position.y=3;

compoundBody.computeWorldMatrix(true);
console.log(compoundBody.getBoundingInfo().boundingSphere.centerWorld.y);
console.log(compoundBody.position.y);
```
min and max are (0,3,0), bouding sphere local center is (0,3,0).
world bounding sphere center is local center transformed by world matrix and its value is (0,6, 0) which is not correct. It breaks the physics for oimo and cannon. Computation is different with ammo and was not touched by this issue.


@RaananW Git blame indicates you changed it last. Do you remember why/what it fixed?