### PR TITLE
[XR] assign the number of textures correctly

### DIFF
--- a/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
@@ -24,6 +24,7 @@ export class MultiviewRenderTarget extends RenderTargetTexture {
         this._texture.isMultiview = true;
         this._texture.format = Constants.TEXTUREFORMAT_RGBA;
         this.samples = this._getEngine()!.getCaps().maxSamples || this.samples;
+        this._texture.samples = this._samples;
     }
 
     /**


### PR DESCRIPTION
The number of samples was not assigned correctly and was always 1 when binding to multisampled multiview (i.e. the oculus browser).

This PR fixes that.