### PR TITLE
[GUI] use ignoreAdaptiveScaling on containers width adaptWidthToChildren or adaptHeightToChildren

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -425,6 +425,7 @@ export class Container extends Control {
                     if (this.width !== computedWidth + "px") {
                         this.parent?._markAsDirty();
                         this.width = computedWidth + "px";
+                        this._width.ignoreAdaptiveScaling = true;
                         this._rebuildLayout = true;
                     }
                 }
@@ -433,6 +434,7 @@ export class Container extends Control {
                     if (this.height !== computedHeight + "px") {
                         this.parent?._markAsDirty();
                         this.height = computedHeight + "px";
+                        this._height.ignoreAdaptiveScaling = true;
                         this._rebuildLayout = true;
                     }
                 }


### PR DESCRIPTION
See forum thread: https://forum.babylonjs.com/t/gui-adaptwidthtochildren-not-working-with-adaptive-scaling/28911/7

Containers with adaptWidthToChildren or adaptHeightToChildren currently have adaptative scaling applied twice, once when their children's dimensions are computed and once when their own dimensions are computed. This PR simply turns off adaptive scaling on the relevant property when it's being adapted to the children's dimensions.