### PR TITLE
Fix Color3.asArray, Color4.asArray, Color4.toArray and docs for Color…

### DIFF
--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -1010,15 +1010,15 @@ export class Color4 {
 
     /**
      * Creates a new Color4 from the string containing valid hexadecimal values.
-     * 
+     *
      * A valid hex string is either in the format #RRGGBB or #RRGGBBAA.
-     * 
+     *
      * When a hex string without alpha is passed, the resulting Color4 has
      * its alpha value set to 1.0.
-     * 
-     * An invalid string results in a Color with all its channels set to 0.0, 
+     *
+     * An invalid string results in a Color with all its channels set to 0.0,
      * i.e. "transparent black".
-     * 
+     *
      * @param hex defines a string containing valid hexadecimal values
      * @returns a new Color4 object
      */

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -97,9 +97,7 @@ export class Color3 {
      * @returns the new array
      */
     public asArray(): number[] {
-        const result = new Array<number>();
-        this.toArray(result, 0);
-        return result;
+        return [this.r, this.g, this.b];
     }
 
     /**
@@ -723,9 +721,7 @@ export class Color4 {
      * @returns the new array
      */
     public asArray(): number[] {
-        const result = new Array<number>();
-        this.toArray(result, 0);
-        return result;
+        return [this.r, this.g, this.b, this.a];
     }
 
     /**
@@ -734,7 +730,7 @@ export class Color4 {
      * @param index defines an optional index in the target array to define where to start storing values
      * @returns the current Color4 object
      */
-    public toArray(array: number[], index: number = 0): Color4 {
+    public toArray(array: FloatArray, index: number = 0): Color4 {
         array[index] = this.r;
         array[index + 1] = this.g;
         array[index + 2] = this.b;
@@ -1013,7 +1009,16 @@ export class Color4 {
     // Statics
 
     /**
-     * Creates a new Color4 from the string containing valid hexadecimal values
+     * Creates a new Color4 from the string containing valid hexadecimal values.
+     * 
+     * A valid hex string is either in the format #RRGGBB or #RRGGBBAA.
+     * 
+     * When a hex string without alpha is passed, the resulting Color4 has
+     * its alpha value set to 1.0.
+     * 
+     * An invalid string results in a Color with all its channels set to 0.0, 
+     * i.e. "transparent black".
+     * 
      * @param hex defines a string containing valid hexadecimal values
      * @returns a new Color4 object
      */


### PR DESCRIPTION
…4.fromHexString.

As proposed in the forum: https://forum.babylonjs.com/t/several-small-issues-with-color3-and-color4/29092/2

Three small fixes for Color3 and Color4:
- Simpler implementation of Color3.asArray and Color4.asArray as the original implementation was slow in my experience.
- Use FloatArray as first argument of Color4.toArray so it can write to Float32Array.
- Improve documentation for Color4.fromHexString to document behaviour, including the change introduced in Babylon 5.