### PR TITLE
[GUI] On parse, reconnects the keys of the virtual keyboard

### DIFF
--- a/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
+++ b/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
@@ -8,6 +8,7 @@ import type { Container } from "./container";
 import type { TextBlock } from "./textBlock";
 import type { InputText } from "./inputText";
 import { RegisterClass } from "core/Misc/typeStore";
+import { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 
 /**
  * Class used to store key control properties
@@ -308,6 +309,27 @@ export class VirtualKeyboard extends StackPanel {
         returnValue.addKeysRow([" "], [{ width: "200px" }]);
 
         return returnValue;
+    }
+
+    /**
+     * @param serializedObject
+     * @param host
+     * @hidden
+     */
+    public _parseFromContent(serializedObject: any, host: AdvancedDynamicTexture) {
+        super._parseFromContent(serializedObject, host);
+        for (const row of this.children) {
+            if (row.getClassName() === "StackPanel") {
+                const stackPanel = row as StackPanel;
+                for (const key of stackPanel.children) {
+                    if (key.getClassName() === "Button" && key.name) {
+                        key.onPointerUpObservable.add(() => {
+                            this.onKeyPressObservable.notifyObservers(key.name as string);
+                        });
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Forum thread: https://forum.babylonjs.com/t/webxr-gui-editor-and-virtualkeyboard/27826

When parsing a virtual keyboard, we can scan the children for any key buttons and reconnect them to the keyboard. This PR uses the name of the button to do this - this will work unless they have renamed the control. We could also consider using the text of the button instead.

@RaananW curious about your thoughts on this. I know we debated whether or not this was worth supporting but I think it's a small enough change that it might be worth having.