### PR TITLE
[Build] Allow editors packages to be included in a single project

### DIFF
--- a/packages/dev/buildTools/src/packageMapping.ts
+++ b/packages/dev/buildTools/src/packageMapping.ts
@@ -47,7 +47,10 @@ export type NamespacePackageName =
     | "INSPECTOR"
     | "BabylonViewer"
     | "KTX2DECODER"
-    | "BABYLON.SharedUIComponents";
+    | "INSPECTOR.SharedUIComponents"
+    | "BABYLON.SharedUIComponents"
+    | "BABYLON.NodeEditor.SharedUIComponents"
+    | "BABYLON.GuiEditor.SharedUIComponents";
 export type ES6PackageName =
     | "@babylonjs/core"
     | "@babylonjs/gui"
@@ -142,12 +145,7 @@ const packageMapping: {
         materials: "babylonjs-materials",
         loaders: "babylonjs-loaders",
         serializers: "babylonjs-serializers",
-        inspector: (filePath?: string) => {
-            if (filePath && filePath.indexOf("sharedUiComponents") !== -1) {
-                return "babylonjs-shared-ui-components";
-            }
-            return "babylonjs-inspector";
-        },
+        inspector: "babylonjs-inspector",
         "node-editor": (_filePath?: string) => {
             // if (filePath && filePath.indexOf("sharedUiComponents") !== -1) {
             //     return "babylonjs-shared-ui-components";
@@ -241,15 +239,35 @@ const packageMapping: {
             if (filePath) {
                 if (filePath.includes("shared-ui-components/") || filePath.includes("/sharedUiComponents/")) {
                     // was .endsWith
-                    return "BABYLON.SharedUIComponents";
+                    return "INSPECTOR.SharedUIComponents";
                 } else if (filePath.includes("babylonjs-gltf2interface")) {
                     return "BABYLON.GLTF2";
                 }
             }
             return "INSPECTOR";
         },
-        "node-editor": "BABYLON.NodeEditor",
-        "gui-editor": "BABYLON.GuiEditor",
+        "node-editor": (filePath?: string) => {
+            if (filePath) {
+                if (filePath.includes("shared-ui-components/") || filePath.includes("/sharedUiComponents/")) {
+                    // was .endsWith
+                    return "BABYLON.NodeEditor.SharedUIComponents";
+                } else if (filePath.includes("babylonjs-gltf2interface")) {
+                    return "BABYLON.GLTF2";
+                }
+            }
+            return "BABYLON.NodeEditor";
+        },
+        "gui-editor": (filePath?: string) => {
+            if (filePath) {
+                if (filePath.includes("shared-ui-components/") || filePath.includes("/sharedUiComponents/")) {
+                    // was .endsWith
+                    return "BABYLON.GuiEditor.SharedUIComponents";
+                } else if (filePath.includes("babylonjs-gltf2interface")) {
+                    return "BABYLON.GLTF2";
+                }
+            }
+            return "BABYLON.GuiEditor";
+        },
         "post-processes": "BABYLON",
         "procedural-textures": "BABYLON",
         ktx2decoder: "KTX2DECODER",
@@ -267,7 +285,7 @@ export function getAllBuildTypes(): BuildType[] {
     return Object.keys(packageMapping) as BuildType[];
 }
 
-export function isValidPackageMap(packageMap: { [key: string]: string | ((data?: any) => string) }, publicOnly?: boolean): packageMap is PackageMap {
+export function isValidPackageMap(packageMap: { [key: string]: string | ((data?: any) => string) }): packageMap is PackageMap {
     const packageNames = Object.keys(packageMap);
     const buildTypes = getAllBuildTypes();
 


### PR DESCRIPTION
Due to the way the shared ui components were declared it was not possible to include both editors in a single typescript project.
This generates a different namespace to the shared ui components so they are not declared twice.