### PR TITLE
[Build] add timestamp to CDN assets

### DIFF
--- a/packages/dev/buildTools/src/prepareSnapshot.ts
+++ b/packages/dev/buildTools/src/prepareSnapshot.ts
@@ -62,6 +62,11 @@ export const prepareSnapshot = () => {
         copyFile(file, path.join(snapshotDirectory, relative), true);
     }
 
+    // generate timestamp.js, which contains the current timestamp
+    const timestamp = Date.now();
+    const timestampFile = path.join(snapshotDirectory, "timestamp.js");
+    fs.writeFileSync(timestampFile, `if(typeof globalThis !== "undefined") globalThis.__babylonSnapshotTimestamp__ = ${timestamp};`);
+
     // copy the es6 builds
     // removed for now
     // {

--- a/packages/tools/guiEditor/public/index.js
+++ b/packages/tools/guiEditor/public/index.js
@@ -7,8 +7,10 @@ const fallbackUrl = "https://babylonsnapshots.z22.web.core.windows.net/refs/head
 
 let loadScriptAsync = function (url, instantResolve) {
     return new Promise((resolve) => {
+        // eslint-disable-next-line no-undef
+        let urlToLoad = typeof globalThis !== "undefined" && globalThis.__babylonSnapshotTimestamp__ ? url + "?t=" + globalThis.__babylonSnapshotTimestamp__ : url;
         const script = document.createElement("script");
-        script.src = url;
+        script.src = urlToLoad;
         script.onload = () => {
             if (!instantResolve) {
                 resolve();
@@ -22,9 +24,9 @@ let loadScriptAsync = function (url, instantResolve) {
                 if (!instantResolve) {
                     resolve();
                 }
-            }
+            };
             document.head.appendChild(fallbackScript);
-        }
+        };
         document.head.appendChild(script);
         if (instantResolve) {
             resolve();
@@ -33,7 +35,7 @@ let loadScriptAsync = function (url, instantResolve) {
 };
 
 const Versions = {
-    dist: ["https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/gui/babylon.gui.min.js"],
+    dist: ["https://preview.babylonjs.com/timestamp.js?t=" + Date.now(), "https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/gui/babylon.gui.min.js"],
     local: ["//localhost:1337/babylon.js", "//localhost:1337/gui/babylon.gui.min.js"],
 };
 

--- a/packages/tools/nodeEditor/public/index.js
+++ b/packages/tools/nodeEditor/public/index.js
@@ -8,8 +8,10 @@ const fallbackUrl = "https://babylonsnapshots.z22.web.core.windows.net/refs/head
 
 let loadScriptAsync = function (url, instantResolve) {
     return new Promise((resolve) => {
+        // eslint-disable-next-line no-undef
+        let urlToLoad = typeof globalThis !== "undefined" && globalThis.__babylonSnapshotTimestamp__ ? url + "?t=" + globalThis.__babylonSnapshotTimestamp__ : url;
         const script = document.createElement("script");
-        script.src = url;
+        script.src = urlToLoad;
         script.onload = () => {
             if (!instantResolve) {
                 resolve();
@@ -34,7 +36,11 @@ let loadScriptAsync = function (url, instantResolve) {
 };
 
 const Versions = {
-    dist: ["https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"],
+    dist: [
+        "https://preview.babylonjs.com/timestamp.js?t=" + Date.now(),
+        "https://preview.babylonjs.com/babylon.js",
+        "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js",
+    ],
     local: ["//localhost:1337/babylon.js", "//localhost:1337/loaders/babylonjs.loaders.min.js"],
 };
 

--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -2,6 +2,7 @@
 // Version
 var Versions = {
     Latest: [
+        "https://preview.babylonjs.com/timestamp.js?t=" + Date.now(),
         "https://preview.babylonjs.com/babylon.js",
         "https://preview.babylonjs.com/gui/babylon.gui.min.js",
         "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js",
@@ -66,8 +67,10 @@ const fallbackUrl = "https://babylonsnapshots.z22.web.core.windows.net/refs/head
 
 let loadScriptAsync = function (url, instantResolve) {
     return new Promise((resolve) => {
+        // eslint-disable-next-line no-undef
+        let urlToLoad = typeof globalThis !== "undefined" && globalThis.__babylonSnapshotTimestamp__ ? url + "?t=" + globalThis.__babylonSnapshotTimestamp__ : url;
         const script = document.createElement("script");
-        script.src = url;
+        script.src = urlToLoad;
         script.onload = () => {
             if (!instantResolve) {
                 resolve();

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -264,6 +264,15 @@ class Playground {
             declarations.push("https://playground.babylonjs.com/libs/babylon.manager.d.ts");
         }
 
+        const timestamp = typeof globalThis !== "undefined" && (globalThis as any).__babylonSnapshotTimestamp__ ? (globalThis as any).__babylonSnapshotTimestamp__ : 0;
+        if (timestamp) {
+            for (let index = 0; index < declarations.length; index++) {
+                if (declarations[index].indexOf("preview.babylonjs.com") !== -1) {
+                    declarations[index] = declarations[index] + "?t=" + timestamp;
+                }
+            }
+        }
+
         let libContent = "";
         const responses = await Promise.all(declarations.map((declaration) => fetch(declaration)));
         const fallbackUrl = "https://babylonsnapshots.z22.web.core.windows.net/refs/heads/master";

--- a/packages/tools/sandbox/public/index.js
+++ b/packages/tools/sandbox/public/index.js
@@ -6,8 +6,10 @@ const fallbackUrl = "https://babylonsnapshots.z22.web.core.windows.net/refs/head
 
 let loadScriptAsync = function (url, instantResolve) {
     return new Promise((resolve) => {
+        // eslint-disable-next-line no-undef
+        let urlToLoad = typeof globalThis !== "undefined" && globalThis.__babylonSnapshotTimestamp__ ? url + "?t=" + globalThis.__babylonSnapshotTimestamp__ : url;
         const script = document.createElement("script");
-        script.src = url;
+        script.src = urlToLoad;
         script.onload = () => {
             if (!instantResolve) {
                 resolve();
@@ -21,9 +23,9 @@ let loadScriptAsync = function (url, instantResolve) {
                 if (!instantResolve) {
                     resolve();
                 }
-            }
+            };
             document.head.appendChild(fallbackScript);
-        }
+        };
         document.head.appendChild(script);
         if (instantResolve) {
             resolve();
@@ -33,6 +35,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: [
+        "https://preview.babylonjs.com/timestamp.js?t=" + Date.now(),
         "https://preview.babylonjs.com/babylon.js",
         "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js",
         "https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js",
@@ -62,7 +65,7 @@ let loadInSequence = async function (versions, index, resolve) {
 let checkBabylonVersionAsync = function () {
     let activeVersion = "dist";
 
-    if ((window.location.hostname === "localhost" && window.location.search.indexOf("dist") === -1)) {
+    if (window.location.hostname === "localhost" && window.location.search.indexOf("dist") === -1) {
         activeVersion = "local";
     }
 


### PR DESCRIPTION
Every time a snapshot is created a timestamp.js file willbe updated. this timestamp will be loaded before all babylon resources, and it is never cached.
The timestamp will be used to load from the CDN, which will cache for longer time with the query string included in the cache, meaning - the resources will be cached until a new timestamp is generated.

This way we will not have to force-refresh anymore after a nightly.