### PR TITLE
make param defaults explicit for function getPositionData

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1462,7 +1462,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
      * @param data defines the position data to apply the skeleton and morph to
      * @returns the position data
      */
-    public getPositionData(applySkeleton: boolean, applyMorph: boolean, data?: Nullable<FloatArray>): Nullable<FloatArray> {
+    public getPositionData(applySkeleton: boolean = false, applyMorph: boolean = false, data?: Nullable<FloatArray>): Nullable<FloatArray> {
         data = data ?? this.getVerticesData(VertexBuffer.PositionKind);
 
         if (data && applyMorph && this.morphTargetManager) {


### PR DESCRIPTION
For the function getPositionData that I PR'ed a few months ago, the params applySkeleton and applyMorph default to false implicitly (an oversight). This PR just makes those param defaults explicit for clarity and proper typing (e.g. for TS).