### PR TITLE
ktxTextureLoader: Mark _useSRGBBuffers when loading an SRGB-enabled texture format

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -175,22 +175,46 @@ export class Constants {
 
     /** Compressed BC7 */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM = 36492;
+    /** Compressed BC7 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM = 36493;
     /** Compressed BC6 unsigned float */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT = 36495;
     /** Compressed BC6 signed float */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGB_BPTC_SIGNED_FLOAT = 36494;
     /** Compressed BC3 */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5 = 33779;
+    /** Compressed BC3 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT = 35919;
     /** Compressed BC2 */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3 = 33778;
+    /** Compressed BC2 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT = 35918;
     /** Compressed BC1 (RGBA) */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT1 = 33777;
     /** Compressed BC1 (RGB) */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1 = 33776;
+    /** Compressed BC1 (SRGB+A) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT = 35917;
+    /** Compressed BC1 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB_S3TC_DXT1_EXT = 35916;
     /** Compressed ASTC 4x4 */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4 = 37808;
-    /**  Compressed ETC1 (RGB) */
+    /** Compressed ASTC 4x4 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR = 37840;
+    /** Compressed ETC1 (RGB) */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGB_ETC1_WEBGL = 36196;
+    /** Compressed ETC2 (RGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_RGB8_ETC2 = 37492;
+    /** Compressed ETC2 (SRGB) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB8_ETC2 = 37493;
+    /** Compressed ETC2 (RGB+A1) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 37494;
+    /** Compressed ETC2 (SRGB+A1)*/
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 37495;
+    /** Compressed ETC2 (RGB+A) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC = 37496;
+    /** Compressed ETC2 (SRGB+1) */
+    public static readonly TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 37497;
 
     /** UNSIGNED_BYTE */
     public static readonly TEXTURETYPE_UNSIGNED_BYTE = 0;

--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -6,6 +6,7 @@ import type { InternalTexture } from "../../../Materials/Textures/internalTextur
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
 import { EndsWith } from "../../../Misc/stringTools";
 import { Logger } from "../../../Misc/logger";
+import { Constants } from "../../../Engines/constants";
 
 /**
  * Implementation of the KTX Texture Loader.
@@ -82,6 +83,56 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
             // Need to invert vScale as invertY via UNPACK_FLIP_Y_WEBGL is not supported by compressed texture
             texture._invertVScale = !texture.invertY;
             const ktx = new KhronosTextureContainer(data, 1);
+
+            switch (ktx.glInternalFormat) {
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT1:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_SIGNED_FLOAT:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_ETC1_WEBGL:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB8_ETC2:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC:
+                case Constants.TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+                    texture.format = ktx.glInternalFormat;
+                    // Leave texture._useSRGBBuffer alone.
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_S3TC_DXT1_EXT:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ETC2:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB8_ETC2;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4;
+                    texture._useSRGBBuffer = true;
+                    break;
+                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM:
+                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM;
+                    texture._useSRGBBuffer = true;
+                    break;
+            }
+
             callback(
                 ktx.pixelWidth,
                 ktx.pixelHeight,

--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -8,6 +8,29 @@ import { EndsWith } from "../../../Misc/stringTools";
 import { Logger } from "../../../Misc/logger";
 import { Constants } from "../../../Engines/constants";
 
+function mapSRGBToLinear(format: number): Nullable<number> {
+    switch (format) {
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_S3TC_DXT1_EXT:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ETC2:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGB8_ETC2;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4;
+        case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM:
+            return Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM;
+    }
+
+    return null;
+}
+
 /**
  * Implementation of the KTX Texture Loader.
  * @hidden
@@ -84,53 +107,13 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
             texture._invertVScale = !texture.invertY;
             const ktx = new KhronosTextureContainer(data, 1);
 
-            switch (ktx.glInternalFormat) {
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT1:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_SIGNED_FLOAT:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB_ETC1_WEBGL:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB8_ETC2:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC:
-                case Constants.TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
-                    texture.format = ktx.glInternalFormat;
-                    // Leave texture._useSRGBBuffer alone.
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_S3TC_DXT1_EXT:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB_S3TC_DXT1;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT3;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_S3TC_DXT5;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ETC2:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB8_ETC2;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA8_ETC2_EAC;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4;
-                    texture._useSRGBBuffer = true;
-                    break;
-                case Constants.TEXTUREFORMAT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM:
-                    texture.format = Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM;
-                    texture._useSRGBBuffer = true;
-                    break;
+            const mappedFormat = mapSRGBToLinear(ktx.glInternalFormat);
+            if (mappedFormat) {
+                texture.format = mappedFormat;
+                texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, texture.generateMipMaps);
+                texture._gammaSpace = true;
+            } else {
+                texture.format = ktx.glInternalFormat;
             }
 
             callback(

--- a/packages/dev/core/src/Misc/khronosTextureContainer.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer.ts
@@ -170,7 +170,7 @@ export class KhronosTextureContainer {
                 const byteArray = new Uint8Array(this.data.buffer, this.data.byteOffset + dataOffset, imageSize);
 
                 const engine = texture.getEngine();
-                engine._uploadCompressedDataToTextureDirectly(texture, this.glInternalFormat, width, height, byteArray, face, level);
+                engine._uploadCompressedDataToTextureDirectly(texture, texture.format, width, height, byteArray, face, level);
 
                 dataOffset += imageSize; // add size of the image for the next face/mipmap
                 dataOffset += 3 - ((imageSize + 3) % 4); // add padding for odd sized image


### PR DESCRIPTION
Also set texture.format to the correct value,
since it seems the code elsewhere, like in the WebGPU engine, would
like a "base" texture format.

Completely untested patch to try and fix https://forum.babylonjs.com/t/compressed-ktx-texture-appears-too-dark/29060/4