### PR TITLE
Fix minor shader compiler issues

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -21,6 +21,12 @@ export class ShaderCodeCursor {
                 continue;
             }
 
+            // Do not split single line comments
+            if (line.trim().startsWith("//")) {
+                this._lines.push(line);
+                continue;
+            }
+
             const split = line.split(";");
 
             for (let index = 0; index < split.length; index++) {


### PR DESCRIPTION
Changes:
 - Allow semicolons in shader single line comments
 - ~~Allow indented multiline macros~~
 
Related post in forum showing reproduction for the single line comment issue:
- https://forum.babylonjs.com/t/possible-shader-compiler-bug-with-single-line-comments/29182

~~There are no reports for the indented multiline macro issue, but I verified locally that indenting a multiline macro would break compiler, and with this fix, it works.~~
