### PR TITLE
Physics,scene Bug fixes

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -745,7 +745,12 @@ export class InputManager {
 
             // Meshes
             this._pickedDownMesh = null;
-            const pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
+            let pickResult;
+            if (scene.skipPointerDownPicking) {
+                pickResult = new PickingInfo();
+            } else {
+                pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
+            }
 
             this._processPointerDown(pickResult, evt);
         };

--- a/packages/dev/core/src/Physics/physicsImpostor.ts
+++ b/packages/dev/core/src/Physics/physicsImpostor.ts
@@ -542,7 +542,7 @@ export class PhysicsImpostor {
      * @returns boolean specifying if body initialization is required
      */
     public isBodyInitRequired(): boolean {
-        return this._bodyUpdateRequired || (!this._physicsBody && !this._parent);
+        return this._bodyUpdateRequired || (!this._physicsBody && (!this._parent || !!this._options.ignoreParent));
     }
 
     /**

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -707,6 +707,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      */
     public skipPointerMovePicking = false;
 
+    /**
+     * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer down event occurs.
+     */
+     public skipPointerDownPicking = false;
+
     /** Callback called when a pointer move is detected */
     public onPointerMove: (evt: IPointerEvent, pickInfo: PickingInfo, type: PointerEventTypes) => void;
     /** Callback called when a pointer down is detected  */

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -84,7 +84,7 @@ export class MeshPropertyGridComponent extends React.Component<
             return;
         }
 
-        const wireframeOver = mesh.clone(mesh.name + "_wireframeover", null, true)!;
+        const wireframeOver = mesh.clone(mesh.name + "_wireframeover", null, true, false)!;
         wireframeOver.reservedDataStore = { hidden: true };
 
         // Sets up the mesh to be attached to the parent.


### PR DESCRIPTION
- Bug fix https://forum.babylonjs.com/t/inspector-bug-with-wireframe-not-being-aligned-on-mesh/29021/10
Clone for wireframe mesh was also cloning physics impostor. And the impostor having a delta rotation, it was applied twice (parent's delta + delta) causing invalid rendering
- Bug fix https://forum.babylonjs.com/t/physicsimpostor-ignoreparent-causes-crash/29194/4
- scene `skipPointerDownPicking` : do not pick ray in scene when not appropriate. This is causing massive performance drop on native.