### PR TITLE
fix: getPositionData missing slice of vertex positions

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1463,7 +1463,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
      * @returns the position data
      */
     public getPositionData(applySkeleton: boolean = false, applyMorph: boolean = false, data?: Nullable<FloatArray>): Nullable<FloatArray> {
-        data = data ?? this.getVerticesData(VertexBuffer.PositionKind);
+        data = data ?? Tools.Slice(this.getVerticesData(VertexBuffer.PositionKind));
 
         if (data && applyMorph && this.morphTargetManager) {
             let faceIndexCount = 0;

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1563,9 +1563,10 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
                     this._internalAbstractMeshDataInfo._positions[i] = pos[i]?.clone() || new Vector3();
                 }
             }
+            return this.getPositionData(applySkeleton, applyMorph, data);
         }
 
-        return this.getPositionData(applySkeleton, applyMorph, data);
+        return data;
     }
 
     /** @hidden */


### PR DESCRIPTION
Change getPositionData  to slice the vertex position array after getting it from the geometry to fix the issue that when getPositionData is called repeatedly it only worked correctly the first time.

PG: https://playground.babylonjs.com/#SYQW69#1034
Forum: https://forum.babylonjs.com/t/bug-mesh-getpositiondata-blows-up-everytime-you-run-it/29246
