### PR TITLE
add overrideCloneAlphaBetaRadius to ArcRotateCamera

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -50,6 +50,13 @@ export class ArcRotateCamera extends TargetCamera {
     @serialize()
     public radius: number;
 
+     /**
+     * Defines an override value to use as the parameter to setTarget.
+     * This allows the parameter to be specified when animating the target (e.g. using FramingBehavior).
+     */
+    @serialize()
+    public overrideCloneAlphaBetaRadius: Nullable<boolean>;
+
     @serializeAsVector3("target")
     protected _target: Vector3;
     @serializeAsMeshReference("targetHost")
@@ -1075,6 +1082,8 @@ export class ArcRotateCamera extends TargetCamera {
      * @param cloneAlphaBetaRadius If true, replicate the current setup (alpha, beta, radius) on the new target
      */
     public setTarget(target: AbstractMesh | Vector3, toBoundingCenter = false, allowSamePosition = false, cloneAlphaBetaRadius = false): void {
+        cloneAlphaBetaRadius = this.overrideCloneAlphaBetaRadius ?? cloneAlphaBetaRadius;        
+
         if ((<any>target).getBoundingInfo) {
             if (toBoundingCenter) {
                 this._targetBoundingCenter = (<any>target).getBoundingInfo().boundingBox.centerWorld.clone();

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -50,7 +50,7 @@ export class ArcRotateCamera extends TargetCamera {
     @serialize()
     public radius: number;
 
-     /**
+    /**
      * Defines an override value to use as the parameter to setTarget.
      * This allows the parameter to be specified when animating the target (e.g. using FramingBehavior).
      */

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1082,7 +1082,7 @@ export class ArcRotateCamera extends TargetCamera {
      * @param cloneAlphaBetaRadius If true, replicate the current setup (alpha, beta, radius) on the new target
      */
     public setTarget(target: AbstractMesh | Vector3, toBoundingCenter = false, allowSamePosition = false, cloneAlphaBetaRadius = false): void {
-        cloneAlphaBetaRadius = this.overrideCloneAlphaBetaRadius ?? cloneAlphaBetaRadius;        
+        cloneAlphaBetaRadius = this.overrideCloneAlphaBetaRadius ?? cloneAlphaBetaRadius;
 
         if ((<any>target).getBoundingInfo) {
             if (toBoundingCenter) {


### PR DESCRIPTION
Adds new property overrideCloneAlphaBetaRadius to the class ArcRotateCamera. This allows the parameter to setTarget to be specified when animating the camera's target property.

For example, when using FramingBehavior the override can be set to true, which then allows the framingTime (i.e. speed) of the framing animation to be changed independently, without altering anything else about the animation.

Forum discussion: https://forum.babylonjs.com/t/zoomonmesheshierarchy-inconsistent-camera-rotation/29100/8