### PR TITLE
[GUI] Skip invisible or unrenderable children in layout calculations

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -408,6 +408,7 @@ export class Container extends Control {
 
             if (!this._isClipped) {
                 for (const child of this._children) {
+                    if (!child.isVisible || child.notRenderable) continue;
                     child._tempParentMeasure.copyFrom(this._measureForChildren);
 
                     if (child._layout(this._measureForChildren, context)) {


### PR DESCRIPTION
When doing layout calculations on a container, we should skip over children which are invisible or un-renderable. This will fix the case where a visible child would cause a container with `adaptWidthToChildren` to extend its width, even though it shouldn't.

As a general principle, invisible children should not take up any space in the layout. (This is what we are already doing for stack panel.)

Related forum issue: https://forum.babylonjs.com/t/gui-stackpanel-not-settings-correct-width-height-when-it-has-invisible-child-controls/29149