### PR TITLE
DeviceInputSystem: Remove pollInput calls for MouseWheel from EventFactory

### DIFF
--- a/packages/dev/core/src/DeviceInput/Helpers/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/Helpers/eventFactory.ts
@@ -106,9 +106,21 @@ export class DeviceEventFactory {
 
         evt.type = "wheel";
         evt.deltaMode = EventConstants.DOM_DELTA_PIXEL;
-        evt.deltaX = inputIndex === PointerInput.MouseWheelX ? currentState : deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MouseWheelX);
-        evt.deltaY = inputIndex === PointerInput.MouseWheelY ? currentState : deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MouseWheelY);
-        evt.deltaZ = inputIndex === PointerInput.MouseWheelZ ? currentState : deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MouseWheelZ);
+        evt.deltaX = 0;
+        evt.deltaY = 0;
+        evt.deltaZ = 0;
+
+        switch(inputIndex) {
+            case PointerInput.MouseWheelX:
+                evt.deltaX = currentState;
+                break;
+            case PointerInput.MouseWheelY:
+                evt.deltaY = currentState;
+                break;
+            case PointerInput.MouseWheelZ:
+                evt.deltaZ = currentState;
+                break;
+        }
 
         return evt;
     }

--- a/packages/dev/core/src/DeviceInput/Helpers/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/Helpers/eventFactory.ts
@@ -110,7 +110,7 @@ export class DeviceEventFactory {
         evt.deltaY = 0;
         evt.deltaZ = 0;
 
-        switch(inputIndex) {
+        switch (inputIndex) {
             case PointerInput.MouseWheelX:
                 evt.deltaX = currentState;
                 break;

--- a/packages/dev/core/src/DeviceInput/InputDevices/deviceTypes.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/deviceTypes.ts
@@ -6,7 +6,7 @@ import type { DeviceType, PointerInput, DualShockInput, XboxInput, SwitchInput, 
 export type DeviceInput<T extends DeviceType> = T extends DeviceType.Keyboard | DeviceType.Generic
     ? number
     : T extends DeviceType.Mouse | DeviceType.Touch
-    ? Exclude<PointerInput, PointerInput.Move>
+    ? Exclude<PointerInput, PointerInput.Move | PointerInput.MouseWheelX | PointerInput.MouseWheelY | PointerInput.MouseWheelZ>
     : T extends DeviceType.DualShock
     ? DualShockInput
     : T extends DeviceType.Xbox

--- a/packages/dev/core/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/nativeDeviceInputSystem.ts
@@ -1,7 +1,7 @@
 import type { INative } from "../../Engines/Native/nativeInterfaces";
 import type { IUIEvent } from "../../Events/deviceInputEvents";
 import { DeviceEventFactory } from "../Helpers/eventFactory";
-import { DeviceType, NativePointerInput, PointerInput } from "./deviceEnums";
+import { DeviceType } from "./deviceEnums";
 import type { IDeviceInputSystem } from "./inputInterfaces";
 
 declare const _native: INative;
@@ -17,14 +17,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
     ) {
         this._nativeInput = _native.DeviceInputSystem
             ? new _native.DeviceInputSystem(onDeviceConnected, onDeviceDisconnected, (deviceType, deviceSlot, inputIndex, currentState) => {
-                  const idx =
-                      inputIndex === NativePointerInput.Horizontal ||
-                      inputIndex === NativePointerInput.Vertical ||
-                      inputIndex === NativePointerInput.DeltaHorizontal ||
-                      inputIndex === NativePointerInput.DeltaVertical
-                          ? PointerInput.Move
-                          : inputIndex;
-                  const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, idx, currentState, this);
+                  const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
 
                   onInputChanged(deviceType, deviceSlot, evt);
               })

--- a/what's new.md
+++ b/what's new.md
@@ -466,4 +466,3 @@ BABYLON.SceneLoader.OnPluginActivatedObservable.add(function(plugin) {
 - `currentState` and `previousState` have been removed from use in `onInputChangedObservable` in the `DeviceSourceManager` ([PolygonalSun](https://github.com/PolygonalSun))
 - `PointerInput` movement enums are no longer being used in any movement event handling in the `DeviceInputSystem` and `InputManager` ([PolygonalSun](https://github.com/PolygonalSun))
 - Shadow generators now use the `Material.alphaCutOff` value instead of a hard-coded 0.4 value. ([Popov72](https://github.com/Popov72))
-- `PointerInput` mouse enums are no longer usable with the `DeviceSource`'s `getInput` function for Mouse and Touch ([PolygonalSun](https://github.com/PolygonalSun))

--- a/what's new.md
+++ b/what's new.md
@@ -466,3 +466,4 @@ BABYLON.SceneLoader.OnPluginActivatedObservable.add(function(plugin) {
 - `currentState` and `previousState` have been removed from use in `onInputChangedObservable` in the `DeviceSourceManager` ([PolygonalSun](https://github.com/PolygonalSun))
 - `PointerInput` movement enums are no longer being used in any movement event handling in the `DeviceInputSystem` and `InputManager` ([PolygonalSun](https://github.com/PolygonalSun))
 - Shadow generators now use the `Material.alphaCutOff` value instead of a hard-coded 0.4 value. ([Popov72](https://github.com/Popov72))
+- `PointerInput` mouse enums are no longer usable with the `DeviceSource`'s `getInput` function for Mouse and Touch ([PolygonalSun](https://github.com/PolygonalSun))


### PR DESCRIPTION
This PR contains two changes.  First, all pollInput calls that reference MouseWheelX/Y/Z as it's not necessary for Native to get that value.  Additionally, the Move conditional has been removed from NativeDeviceInputSystem as it's not needed.