### PR TITLE
[GUI] Block pointer events to scene when pointer is captured

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -863,8 +863,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             const pointerId = (pi.event as IPointerEvent).pointerId || this._defaultMousePointerId;
             this._doPicking(x, y, pi, pi.type, pointerId, pi.event.button, (<IWheelEvent>pi.event).deltaX, (<IWheelEvent>pi.event).deltaY);
             // Avoid overwriting a true skipOnPointerObservable to false
-            if (this._shouldBlockPointer) {
-                pi.skipOnPointerObservable = this._shouldBlockPointer;
+            if (this._shouldBlockPointer || this._capturingControl[pointerId]) {
+                pi.skipOnPointerObservable = true;
             }
         } else {
             this._doPicking(x, y, null, PointerEventTypes.POINTERMOVE, this._defaultMousePointerId, 0);


### PR DESCRIPTION
When a pointer is captured (for example, if the user is dragging a scrollbar), pointer events should not be passed to the scene.

This matches the behavior of setPointerCapture() on the web, which forces all pointer events to fire on a particular element.

Resolves forum issue: https://forum.babylonjs.com/t/scrollbar-and-pointerblocker/28732
See playground: #XNY77K#3