### PR TITLE
Fix empty screenshot when enabling antialiasing

### DIFF
--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -215,14 +215,14 @@ export function CreateScreenshotUsingRenderTarget(
     texture.samples = samples;
     texture.renderSprites = renderSprites;
 
-    engine.onEndFrameObservable.addOnce(() => {
-        texture.readPixels(undefined, undefined, undefined, false)!.then((data) => {
-            Tools.DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true);
-            texture.dispose();
-        });
-    });
-
     const renderToTexture = () => {
+        engine.onEndFrameObservable.addOnce(() => {
+            texture.readPixels(undefined, undefined, undefined, false)!.then((data) => {
+                Tools.DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true);
+                texture.dispose();
+            });
+        });
+
         // render the RTT
         scene.incrementRenderId();
         scene.resetCachedMaterial();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/chrome-issue-with-create-screenshot-using-render-target/29367/2