### PR TITLE
Scaling preservation fix for boundingBoxGizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
@@ -163,7 +163,7 @@ export class AxisScaleGizmo extends Gizmo {
                 Matrix.ScalingToRef(1 + tmpVector.x, 1 + tmpVector.y, 1 + tmpVector.z, this._tmpMatrix2);
 
                 this._tmpMatrix2.multiplyToRef(this.attachedNode.getWorldMatrix(), this._tmpMatrix);
-                const transformNode = (<Mesh>this.attachedNode)._isMesh ? this.attachedNode as TransformNode : undefined;
+                const transformNode = (<Mesh>this.attachedNode)._isMesh ? (this.attachedNode as TransformNode) : undefined;
                 this._tmpMatrix.decompose(this._tmpVector, undefined, undefined, Gizmo.PreserveScaling ? transformNode : undefined);
 
                 const maxScale = 100000;

--- a/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
@@ -96,7 +96,7 @@ export class AxisScaleGizmo extends Gizmo {
         const collider = this._createGizmoMesh(this._gizmoMesh, thickness + 4, true);
 
         this._gizmoMesh.lookAt(this._rootMesh.position.add(dragAxis));
-        this._rootMesh.addChild(this._gizmoMesh);
+        this._rootMesh.addChild(this._gizmoMesh, Gizmo.PreserveScaling);
         this._gizmoMesh.scaling.scaleInPlace(1 / 3);
 
         // Closure of initial prop values for resetting

--- a/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
@@ -16,6 +16,7 @@ import { Gizmo } from "./gizmo";
 import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
 import type { ScaleGizmo } from "./scaleGizmo";
 import { Color3 } from "../Maths/math.color";
+import type { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Single axis scale gizmo
@@ -162,7 +163,8 @@ export class AxisScaleGizmo extends Gizmo {
                 Matrix.ScalingToRef(1 + tmpVector.x, 1 + tmpVector.y, 1 + tmpVector.z, this._tmpMatrix2);
 
                 this._tmpMatrix2.multiplyToRef(this.attachedNode.getWorldMatrix(), this._tmpMatrix);
-                this._tmpMatrix.decompose(this._tmpVector);
+                const transformNode = (<Mesh>this.attachedNode)._isMesh ? this.attachedNode as TransformNode : undefined;
+                this._tmpMatrix.decompose(this._tmpVector, undefined, undefined, Gizmo.PreserveScaling ? transformNode : undefined);
 
                 const maxScale = 100000;
                 if (Math.abs(this._tmpVector.x) < maxScale && Math.abs(this._tmpVector.y) < maxScale && Math.abs(this._tmpVector.z) < maxScale) {

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -360,7 +360,7 @@ export class BoundingBoxGizmo extends Gizmo {
                         this._anchorMesh.addChild(this.attachedMesh, Gizmo.PreserveScaling);
                         this._anchorMesh.rotationQuaternion!.multiplyToRef(this._tmpQuaternion, this._anchorMesh.rotationQuaternion!);
                         this._anchorMesh.removeChild(this.attachedMesh, Gizmo.PreserveScaling);
-                        this.attachedMesh.setParent(originalParent);
+                        this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);
                     }
                     this.updateBoundingBox();
 
@@ -448,7 +448,7 @@ export class BoundingBoxGizmo extends Gizmo {
                                 this._anchorMesh.scaling.subtractInPlace(deltaScale);
                             }
                             this._anchorMesh.removeChild(this.attachedMesh, Gizmo.PreserveScaling);
-                            this.attachedMesh.setParent(originalParent);
+                            this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);
                             PivotTools._RestorePivotPoint(this.attachedMesh);
                         }
                         this._updateDummy();
@@ -520,7 +520,7 @@ export class BoundingBoxGizmo extends Gizmo {
             const originalParent = value.parent;
             this._anchorMesh.addChild(value, Gizmo.PreserveScaling);
             this._anchorMesh.removeChild(value, Gizmo.PreserveScaling);
-            value.setParent(originalParent);
+            value.setParent(originalParent, Gizmo.PreserveScaling);
             PivotTools._RestorePivotPoint(value);
             this.updateBoundingBox();
             value.getChildMeshes(false).forEach((m) => {
@@ -551,7 +551,7 @@ export class BoundingBoxGizmo extends Gizmo {
 
             // Store original parent
             const originalParent = this.attachedMesh.parent;
-            this.attachedMesh.setParent(null);
+            this.attachedMesh.setParent(null, Gizmo.PreserveScaling);
 
             this._update();
 
@@ -593,7 +593,7 @@ export class BoundingBoxGizmo extends Gizmo {
             this.attachedMesh.position.copyFrom(this._tmpVector);
 
             // Restore original parent
-            this.attachedMesh.setParent(originalParent);
+            this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);
         }
 
         this._updateRotationSpheres();

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -209,7 +209,8 @@ export class Gizmo implements IDisposable {
 
             // Rotation
             if (this.updateGizmoRotationToMatchAttachedMesh) {
-                effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!);
+                const transformNode = (<Mesh>effectiveNode)._isMesh ? effectiveNode as TransformNode : undefined;
+                effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!, undefined, Gizmo.PreserveScaling ? transformNode : undefined);
             } else {
                 if (this._customRotationQuaternion) {
                     this._rootMesh.rotationQuaternion!.copyFrom(this._customRotationQuaternion);

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -209,7 +209,7 @@ export class Gizmo implements IDisposable {
 
             // Rotation
             if (this.updateGizmoRotationToMatchAttachedMesh) {
-                const transformNode = (<Mesh>effectiveNode)._isMesh ? effectiveNode as TransformNode : undefined;
+                const transformNode = (<Mesh>effectiveNode)._isMesh ? (effectiveNode as TransformNode) : undefined;
                 effectiveNode.getWorldMatrix().decompose(undefined, this._rootMesh.rotationQuaternion!, undefined, Gizmo.PreserveScaling ? transformNode : undefined);
             } else {
                 if (this._customRotationQuaternion) {

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -167,7 +167,7 @@ export class PlaneRotationGizmo extends Gizmo {
         this._rotationDisplayPlane.visibility = 0.999;
 
         this._gizmoMesh.lookAt(this._rootMesh.position.add(planeNormal));
-        this._rootMesh.addChild(this._gizmoMesh);
+        this._rootMesh.addChild(this._gizmoMesh, Gizmo.PreserveScaling);
         this._gizmoMesh.scaling.scaleInPlace(1 / 3);
         // Add drag behavior to handle events when the gizmo is dragged
         this.dragBehavior = new PointerDragBehavior({ dragPlaneNormal: planeNormal });
@@ -365,8 +365,8 @@ export class PlaneRotationGizmo extends Gizmo {
         rotationMesh.rotation.x = Math.PI / 2;
         collider.rotation.x = Math.PI / 2;
 
-        parentMesh.addChild(rotationMesh);
-        parentMesh.addChild(collider);
+        parentMesh.addChild(rotationMesh, Gizmo.PreserveScaling);
+        parentMesh.addChild(collider, Gizmo.PreserveScaling);
         return { rotationMesh, collider };
     }
 


### PR DESCRIPTION
More use cases fixed for scaling perservation. follow up https://forum.babylonjs.com/t/gizmo-use-tmpparent-but-do-not-preserve-scaling-sign/29270/29