### PR TITLE
[GUI] fix container regression

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -412,7 +412,7 @@ export class Container extends Control {
 
                     if (child._layout(this._measureForChildren, context)) {
                         if (child.isVisible && !child.notRenderable) {
-                            if (this.adaptWidthToChildren && child._width.isPixel ) {
+                            if (this.adaptWidthToChildren && child._width.isPixel) {
                                 computedWidth = Math.max(computedWidth, child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels);
                             }
                             if (this.adaptHeightToChildren && child._height.isPixel) {

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -408,15 +408,16 @@ export class Container extends Control {
 
             if (!this._isClipped) {
                 for (const child of this._children) {
-                    if (!child.isVisible || child.notRenderable) continue;
                     child._tempParentMeasure.copyFrom(this._measureForChildren);
 
                     if (child._layout(this._measureForChildren, context)) {
-                        if (this.adaptWidthToChildren && child._width.isPixel) {
-                            computedWidth = Math.max(computedWidth, child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels);
-                        }
-                        if (this.adaptHeightToChildren && child._height.isPixel) {
-                            computedHeight = Math.max(computedHeight, child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels);
+                        if (child.isVisible && !child.notRenderable) {
+                            if (this.adaptWidthToChildren && child._width.isPixel ) {
+                                computedWidth = Math.max(computedWidth, child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels);
+                            }
+                            if (this.adaptHeightToChildren && child._height.isPixel) {
+                                computedHeight = Math.max(computedHeight, child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes a regression in GUI introduced by #12392. Invisible children were not being laid out correctly. See forum thread: https://forum.babylonjs.com/t/2d-gui-elements-not-hiding-in-5-2-0/29390/6

Now, we still call layout, but we just don't count them towards the computedWidth/computedHeight of the parent container.