### PR TITLE
Inspector: render N/A for internal texture unique ID when internal texture is undefined

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
@@ -346,7 +346,7 @@ export class TexturePropertyGridComponent extends React.Component<ITextureProper
                     <TextLineComponent label="Use sRGB buffers" value={texture._texture?._useSRGBBuffer ? "Yes" : "No"} />
                     {extension && <TextLineComponent label="File format" value={extension} />}
                     <TextLineComponent label="Unique ID" value={texture.uniqueId.toString()} />
-                    <TextLineComponent label="Internal Unique ID" value={texture._texture?.uniqueId.toString()} />
+                    <TextLineComponent label="Internal Unique ID" value={(texture._texture?.uniqueId ?? "N/A").toString()} />
                     <TextLineComponent label="Class" value={textureClass} />
                     {count >= 0 && <TextLineComponent label="Number of textures" value={count.toString()} />}
                     <TextLineComponent label="Has alpha" value={texture.hasAlpha ? "Yes" : "No"} />


### PR DESCRIPTION
Fixes an issue where the internal texture being undefined could lead to an inspector crash due to rendering call throwing. Will now render "N/A" if there is no internal texture.

See PG: https://playground.babylonjs.com/#436DIW#2