### PR TITLE
Fix uninitialized last ray for PointerDragBehavior

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -533,6 +533,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      *  Detaches the behavior from the mesh
      */
     public detach(): void {
+        this._lastPointerRay = {};
         if (this.attachedNode) {
             this.attachedNode.isNearGrabbable = false;
         }


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/pointerdragbehavior-ghost-movement-on-click-bug/29512
`this._lastPointerRay` was not reinitialized when detaching a mesh.
So, when a new mesh is attached, the previous ray is still active a newly picked mesh translates to the previous position.