### PR TITLE
Do not use determinant when preserving scaling

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -231,7 +231,7 @@ export class Gizmo implements IDisposable {
                 this._rootMesh.scaling.set(dist, dist, dist);
 
                 // Account for handedness, similar to Matrix.decompose
-                if (effectiveNode._getWorldMatrixDeterminant() < 0) {
+                if (effectiveNode._getWorldMatrixDeterminant() < 0 && !Gizmo.PreserveScaling) {
                     this._rootMesh.scaling.y *= -1;
                 }
             } else {


### PR DESCRIPTION
Yet another fix for scaling perservation with Gizmos. https://forum.babylonjs.com/t/gizmo-use-tmpparent-but-do-not-preserve-scaling-sign/29270/35
Mesh Matrix determinant is used to check if Y axis should be inverted. This should not happen with PreverseScaling.