### PR TITLE
Skeleton._sortBones() crash for bones with parents from other skeletons

### DIFF
--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -878,6 +878,8 @@ export class Skeleton implements IAnimatable {
         visited[index] = true;
 
         const bone = this.bones[index];
+        if (!bone) return;
+
         if (bone._index === undefined) {
             bone._index = index;
         }


### PR DESCRIPTION
It is possible for a bone to have a parent bone from a skeleton different from the original one.
Currently, the method crashes when this is the case.
This simple check fixes it. Notice that "index" might be -1 when the parent is from another skeleton in the previous iteration.