### PR TITLE
Volumetric light scattering post process: Fix support for thin instances

### DIFF
--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -399,10 +399,16 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
                     }
                 }
 
+                if (hardwareInstancedRendering && renderingMesh.hasThinInstances) {
+                    effect.setMatrix("world", effectiveMesh.getWorldMatrix());
+                }
+
                 // Draw
-                renderingMesh._processRendering(effectiveMesh, subMesh, effect, Material.TriangleFillMode, batch, hardwareInstancedRendering, (isInstance, world) =>
-                    effect.setMatrix("world", world)
-                );
+                renderingMesh._processRendering(effectiveMesh, subMesh, effect, Material.TriangleFillMode, batch, hardwareInstancedRendering, (isInstance, world) => {
+                    if (!isInstance) {
+                        effect.setMatrix("world", world);
+                    }
+                });
             }
         };
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-i-can-use-volumetric-rendering-pipeline-vrp-with-thininstances/29544