### PR TITLE
Added function call to focus on canvas when setting PointerLock

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -2061,7 +2061,7 @@ export class Engine extends ThinEngine {
             element.requestPointerLock || (<any>element).msRequestPointerLock || (<any>element).mozRequestPointerLock || (<any>element).webkitRequestPointerLock;
         if (element.requestPointerLock) {
             element.requestPointerLock();
-            element.focus()
+            element.focus();
         }
     }
 

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -2061,6 +2061,7 @@ export class Engine extends ThinEngine {
             element.requestPointerLock || (<any>element).msRequestPointerLock || (<any>element).mozRequestPointerLock || (<any>element).webkitRequestPointerLock;
         if (element.requestPointerLock) {
             element.requestPointerLock();
+            element.focus()
         }
     }
 


### PR DESCRIPTION
In this PR, I've added a line to `_RequestPointerlock` called by `enterPointerlock` in the Engine that will set focus on the canvas when a pointerlock is set with `enterPointerlock`.  This reason for this fix was because a user had identified an issue where the pointerlock was successfully being set but keyboard input wasn't working.  This was due to the fact that requestPointerlock does not set focus when setting the pointerlock element so no keyboard input was being routed to the canvas.  This fix simply sets focus once the pointerlock element has been set.

This fix is in reference to this Forum post: https://forum.babylonjs.com/t/input-not-recognised-until-window-resize-triggered-or-change-focus/15653