### PR TITLE
WebGPU: Fix RenderAttachment flag for 3D textures

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -1221,7 +1221,7 @@ export class WebGPUTextureHelper {
         const usages = usage >= 0 ? usage : WebGPUConstants.TextureUsage.CopySrc | WebGPUConstants.TextureUsage.CopyDst | WebGPUConstants.TextureUsage.TextureBinding;
         additionalUsages |= hasMipmaps && !isCompressedFormat ? WebGPUConstants.TextureUsage.CopySrc | WebGPUConstants.TextureUsage.RenderAttachment : 0;
 
-        if (!isCompressedFormat) {
+        if (!isCompressedFormat && !is3D) {
             // we don't know in advance if the texture will be updated with copyExternalImageToTexture (which requires to have those flags), so we need to force the flags all the times
             additionalUsages |= WebGPUConstants.TextureUsage.RenderAttachment | WebGPUConstants.TextureUsage.CopyDst;
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-to-get-error-callback-when-computeshader-dispatch-work-wrong/29571/6