### PR TITLE
Exposes framebufferScaleFactor to EngineOptions

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -166,6 +166,11 @@ export interface EngineOptions extends WebGLContextAttributes {
      * This will not influence NativeEngine and WebGPUEngine which set the behavior to true during construction.
      */
     forceSRGBBufferSupportState?: boolean;
+
+    /**
+     * buffer scale from 0 .. 1 -- lower than 1 scales down
+     */
+     framebufferScaleFactor?: number;
 }
 
 /**

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -170,7 +170,7 @@ export interface EngineOptions extends WebGLContextAttributes {
     /**
      * buffer scale from 0 .. 1 -- lower than 1 scales down
      */
-     framebufferScaleFactor?: number;
+    framebufferScaleFactor?: number;
 }
 
 /**

--- a/packages/dev/core/src/XR/webXRManagedOutputCanvas.ts
+++ b/packages/dev/core/src/XR/webXRManagedOutputCanvas.ts
@@ -31,6 +31,7 @@ export class WebXRManagedOutputCanvasOptions {
      * @returns default values of this configuration object
      */
     public static GetDefaults(engine?: ThinEngine): WebXRManagedOutputCanvasOptions {
+        const engineOptions = engine ? engine.getCreationOptions() : {};
         const defaults = new WebXRManagedOutputCanvasOptions();
         defaults.canvasOptions = {
             antialias: true,
@@ -38,7 +39,7 @@ export class WebXRManagedOutputCanvasOptions {
             stencil: engine ? engine.isStencilEnable : true,
             alpha: true,
             multiview: false,
-            framebufferScaleFactor: 1,
+            framebufferScaleFactor: engineOptions.framebufferScaleFactor || 1,
         };
 
         defaults.newCanvasCssStyle = "position:absolute; bottom:0px;right:0px;z-index:10;width:90%;height:100%;background-color: #000000;";


### PR DESCRIPTION
This change allows the engine user to adjust framebufferScaleFactor on engine creation. This option will allow to reduce resolution in XR mode. For devices like the Oculus Quest, that is imho a very important option.