### PR TITLE
Add backward compatibability for param kind to be "color" for thin instance methods

### DIFF
--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -168,6 +168,10 @@ Mesh.prototype.thinInstanceSetMatrixAt = function (index: number, matrix: DeepIm
 };
 
 Mesh.prototype.thinInstanceSetAttributeAt = function (kind: string, index: number, value: Array<number>, refresh: boolean = true): boolean {
+    if (kind === VertexBuffer.ColorKind) {
+        kind = VertexBuffer.ColorInstanceKind;
+    }
+
     if (!this._userThinInstanceBuffersStorage || !this._userThinInstanceBuffersStorage.data[kind] || index >= this._thinInstanceDataStorage.instancesCount) {
         return false;
     }

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -131,6 +131,11 @@ Mesh.prototype.thinInstanceAddSelf = function (refresh: boolean = true): number 
 };
 
 Mesh.prototype.thinInstanceRegisterAttribute = function (kind: string, stride: number): void {
+    // preserve backward compatibility
+    if (kind === VertexBuffer.ColorKind) {
+        kind = VertexBuffer.ColorInstanceKind;
+    }
+
     this.removeVerticesData(kind);
 
     this._thinInstanceInitializeUserStorage();
@@ -168,6 +173,7 @@ Mesh.prototype.thinInstanceSetMatrixAt = function (index: number, matrix: DeepIm
 };
 
 Mesh.prototype.thinInstanceSetAttributeAt = function (kind: string, index: number, value: Array<number>, refresh: boolean = true): boolean {
+    // preserve backward compatibility
     if (kind === VertexBuffer.ColorKind) {
         kind = VertexBuffer.ColorInstanceKind;
     }
@@ -204,6 +210,11 @@ Object.defineProperty(Mesh.prototype, "thinInstanceCount", {
 });
 
 Mesh.prototype._thinInstanceCreateMatrixBuffer = function (kind: string, buffer: Float32Array, staticBuffer: boolean = false): Buffer {
+    // preserve backward compatibility
+    if (kind === VertexBuffer.ColorKind) {
+        kind = VertexBuffer.ColorInstanceKind;
+    }
+
     const matrixBuffer = new Buffer(this.getEngine(), buffer, !staticBuffer, 16, false, true);
 
     for (let i = 0; i < 4; i++) {
@@ -277,8 +288,15 @@ Mesh.prototype.thinInstanceBufferUpdated = function (kind: string): void {
         this._thinInstanceDataStorage.matrixBuffer?.updateDirectly(this._thinInstanceDataStorage.matrixData!, 0, this._thinInstanceDataStorage.instancesCount);
     } else if (kind === "previousMatrix") {
         this._thinInstanceDataStorage.previousMatrixBuffer?.updateDirectly(this._thinInstanceDataStorage.previousMatrixData!, 0, this._thinInstanceDataStorage.instancesCount);
-    } else if (this._userThinInstanceBuffersStorage?.vertexBuffers[kind]) {
-        this._userThinInstanceBuffersStorage.vertexBuffers[kind]!.updateDirectly(this._userThinInstanceBuffersStorage.data[kind], 0);
+    } else {
+        // preserve backward compatibility
+        if (kind === VertexBuffer.ColorKind) {
+            kind = VertexBuffer.ColorInstanceKind;
+        }
+
+        if (this._userThinInstanceBuffersStorage?.vertexBuffers[kind]) {
+            this._userThinInstanceBuffersStorage.vertexBuffers[kind]!.updateDirectly(this._userThinInstanceBuffersStorage.data[kind], 0);
+        }
     }
 };
 
@@ -287,8 +305,15 @@ Mesh.prototype.thinInstancePartialBufferUpdate = function (kind: string, data: F
         if (this._thinInstanceDataStorage.matrixBuffer) {
             this._thinInstanceDataStorage.matrixBuffer.updateDirectly(data, offset);
         }
-    } else if (this._userThinInstanceBuffersStorage?.vertexBuffers[kind]) {
-        this._userThinInstanceBuffersStorage.vertexBuffers[kind]!.updateDirectly(data, offset);
+    } else {
+        // preserve backward compatibility
+        if (kind === VertexBuffer.ColorKind) {
+            kind = VertexBuffer.ColorInstanceKind;
+        }
+
+        if (this._userThinInstanceBuffersStorage?.vertexBuffers[kind]) {
+            this._userThinInstanceBuffersStorage.vertexBuffers[kind]!.updateDirectly(data, offset);
+        }
     }
 };
 
@@ -349,6 +374,11 @@ Mesh.prototype.thinInstanceRefreshBoundingInfo = function (forceRefreshParentInf
 };
 
 Mesh.prototype._thinInstanceUpdateBufferSize = function (kind: string, numInstances: number = 1) {
+    // preserve backward compatibility
+    if (kind === VertexBuffer.ColorKind) {
+        kind = VertexBuffer.ColorInstanceKind;
+    }
+
     const kindIsMatrix = kind === "matrix";
 
     if (!kindIsMatrix && (!this._userThinInstanceBuffersStorage || !this._userThinInstanceBuffersStorage.strides[kind])) {


### PR DESCRIPTION
If kind "color" is passed to the function thinInstanceSetAttributeAt, it will be converted to "instanceColor", for back compat.
Forum: https://forum.babylonjs.com/t/vertex-error-and-no-colors-on-thin-instances-after-upgrade/28492/19

(Update: added this back compat to all thin instance methods that accept param kind)