### PR TITLE
Fix thinInstanceCount setter to work with mesh clone

### DIFF
--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -188,7 +188,7 @@ Object.defineProperty(Mesh.prototype, "thinInstanceCount", {
         return this._thinInstanceDataStorage.instancesCount;
     },
     set: function (this: Mesh, value: number) {
-        const numMaxInstances = (this._thinInstanceDataStorage.matrixData?.length ?? 0) / 16;
+        const numMaxInstances = (this._thinInstanceDataStorage.matrixData?.length ?? (this.source?._thinInstanceDataStorage.matrixData?.length ?? 0)) / 16;
 
         if (value <= numMaxInstances) {
             this._thinInstanceDataStorage.instancesCount = value;

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -188,7 +188,8 @@ Object.defineProperty(Mesh.prototype, "thinInstanceCount", {
         return this._thinInstanceDataStorage.instancesCount;
     },
     set: function (this: Mesh, value: number) {
-        const numMaxInstances = (this._thinInstanceDataStorage.matrixData?.length ?? (this.source?._thinInstanceDataStorage.matrixData?.length ?? 0)) / 16;
+        const matrixData = this._thinInstanceDataStorage.matrixData ?? this.source?._thinInstanceDataStorage.matrixData;
+        const numMaxInstances = matrixData ? (matrixData.length / 16) : 0;
 
         if (value <= numMaxInstances) {
             this._thinInstanceDataStorage.instancesCount = value;

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -189,7 +189,7 @@ Object.defineProperty(Mesh.prototype, "thinInstanceCount", {
     },
     set: function (this: Mesh, value: number) {
         const matrixData = this._thinInstanceDataStorage.matrixData ?? this.source?._thinInstanceDataStorage.matrixData;
-        const numMaxInstances = matrixData ? (matrixData.length / 16) : 0;
+        const numMaxInstances = matrixData ? matrixData.length / 16 : 0;
 
         if (value <= numMaxInstances) {
             this._thinInstanceDataStorage.instancesCount = value;


### PR DESCRIPTION
After cloning a mesh that has thin instances, setting thinInstanceCount on the clone currently doesn't work (unless it is set to 0 the setter will return without updating the internal instanceCount).

With this PR, if a mesh doesn't have the thin instance matrixData, then it checks to see if the mesh's source has it before defaulting the max instance count to 0.

PG Repro: https://playground.babylonjs.com/#217750#76
Forum: https://forum.babylonjs.com/t/cant-set-thininstancecount-for-clone/29674
