### PR TITLE
Fix crash when cloning meshes with thin instances that are using instance color

### DIFF
--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -298,7 +298,7 @@ export class MaterialHelper {
             defines["VERTEXALPHA"] = mesh.hasVertexAlpha && hasVertexColors && useVertexAlpha;
         }
 
-        if (mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind)) {
+        if (mesh.isVerticesDataPresent(VertexBuffer.ColorInstanceKind) && (mesh.hasInstances || mesh.hasThinInstances)) {
             defines["INSTANCESCOLOR"] = true;
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/vertex-error-and-no-colors-on-thin-instances-after-upgrade/28492/23