### PR TITLE
[XR] make sure pointer up only triggers once

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -744,6 +744,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             this._xrSessionManager.runInXRFrame(() => {
                 this._augmentPointerInit(pointerEventInit, controllerData.id, controllerData.screenCoordinates);
                 this._scene.simulatePointerUp(new PickingInfo(), pointerEventInit);
+                controllerData.finalPointerUpTriggered = true;
             });
         }
         this._xrSessionManager.scene.onBeforeRenderObservable.addOnce(() => {


### PR DESCRIPTION
Adressing this:

https://forum.babylonjs.com/t/webxr-pointer-up-event-trigger-twice-on-one-single-touch/29370?u=raananw