### PR TITLE
[Bug] Fix OimoJS plugin syncMeshWithImpostor method.

### DIFF
--- a/packages/dev/core/src/Physics/Plugins/oimoJSPlugin.ts
+++ b/packages/dev/core/src/Physics/Plugins/oimoJSPlugin.ts
@@ -477,7 +477,7 @@ export class OimoJSPlugin implements IPhysicsEnginePlugin {
             mesh.rotationQuaternion.x = body.orientation.x;
             mesh.rotationQuaternion.y = body.orientation.y;
             mesh.rotationQuaternion.z = body.orientation.z;
-            mesh.rotationQuaternion.w = body.orientation.s;
+            mesh.rotationQuaternion.w = body.orientation.w;
         }
     }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/physicsviewer-working-only-with-meshimposter/29654 and Playground: https://playground.babylonjs.com/#WIR77Z#1317