### PR TITLE
WebGPU: more changes and fixes for stencil support

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
@@ -76,11 +76,11 @@ WebGPUEngine.prototype._createDepthStencilTexture = function (size: TextureSize,
         comparisonFunction: 0,
         generateStencil: false,
         samples: 1,
-        depthTextureFormat: Constants.TEXTUREFORMAT_DEPTH32_FLOAT,
+        depthTextureFormat: options.generateStencil ? Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 : Constants.TEXTUREFORMAT_DEPTH32_FLOAT,
         ...options,
     };
 
-    internalTexture.format = internalOptions.generateStencil ? Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 : internalOptions.depthTextureFormat;
+    internalTexture.format = internalOptions.depthTextureFormat;
 
     this._setupDepthStencilTexture(
         internalTexture,

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -699,6 +699,10 @@ export class WebGPUTextureHelper {
                 return WebGPUConstants.TextureFormat.Depth24PlusStencil8;
             case Constants.TEXTUREFORMAT_DEPTH32_FLOAT:
                 return WebGPUConstants.TextureFormat.Depth32Float;
+            case Constants.TEXTUREFORMAT_DEPTH24UNORM_STENCIL8:
+                return WebGPUConstants.TextureFormat.Depth24UnormStencil8;
+            case Constants.TEXTUREFORMAT_DEPTH32FLOAT_STENCIL8:
+                return WebGPUConstants.TextureFormat.Depth32FloatStencil8;
 
             case Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM:
                 return useSRGBBuffer ? WebGPUConstants.TextureFormat.BC7RGBAUnormSRGB : WebGPUConstants.TextureFormat.BC7RGBAUnorm;
@@ -982,6 +986,17 @@ export class WebGPUTextureHelper {
     public static HasStencilAspect(format: GPUTextureFormat): boolean {
         switch (format) {
             case WebGPUConstants.TextureFormat.Stencil8:
+            case WebGPUConstants.TextureFormat.Depth24UnormStencil8:
+            case WebGPUConstants.TextureFormat.Depth32FloatStencil8:
+            case WebGPUConstants.TextureFormat.Depth24PlusStencil8:
+                return true;
+        }
+
+        return false;
+    }
+
+    public static HasDepthAndStencilAspects(format: GPUTextureFormat): boolean {
+        switch (format) {
             case WebGPUConstants.TextureFormat.Depth24UnormStencil8:
             case WebGPUConstants.TextureFormat.Depth32FloatStencil8:
             case WebGPUConstants.TextureFormat.Depth24PlusStencil8:
@@ -1478,7 +1493,7 @@ export class WebGPUTextureHelper {
                     baseArrayLayer: 0,
                     baseMipLevel: 0,
                     arrayLayerCount: 6,
-                    aspect: WebGPUConstants.TextureAspect.All,
+                    aspect: WebGPUTextureHelper.HasDepthAndStencilAspects(gpuTextureWrapper.format) ? WebGPUConstants.TextureAspect.DepthOnly : WebGPUConstants.TextureAspect.All,
                 },
                 isStorageTexture
             );
@@ -1510,7 +1525,7 @@ export class WebGPUTextureHelper {
                     baseArrayLayer: 0,
                     baseMipLevel: 0,
                     arrayLayerCount: texture.is3D ? 1 : layerCount,
-                    aspect: WebGPUConstants.TextureAspect.All,
+                    aspect: WebGPUTextureHelper.HasDepthAndStencilAspects(gpuTextureWrapper.format) ? WebGPUConstants.TextureAspect.DepthOnly : WebGPUConstants.TextureAspect.All,
                 },
                 isStorageTexture
             );

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -172,6 +172,10 @@ export class Constants {
     public static readonly TEXTUREFORMAT_DEPTH16 = 15;
     /** Depth 24 bits */
     public static readonly TEXTUREFORMAT_DEPTH24 = 16;
+    /** Depth 24 bits unorm + Stencil 8 bits */
+    public static readonly TEXTUREFORMAT_DEPTH24UNORM_STENCIL8 = 17;
+    /** Depth 32 bits float + Stencil 8 bits */
+    public static readonly TEXTUREFORMAT_DEPTH32FLOAT_STENCIL8 = 18;
 
     /** Compressed BC7 */
     public static readonly TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM = 36492;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -2716,6 +2716,7 @@ export class WebGPUEngine extends Engine {
 
         const depthTextureView = gpuDepthStencilTexture?.createView(this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
         const depthMSAATextureView = gpuDepthStencilMSAATexture?.createView(this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
+        const depthTextureHasStencil = gpuDepthStencilWrapper ? WebGPUTextureHelper.HasStencilAspect(gpuDepthStencilWrapper.format) : false;
 
         const colorAttachments: GPURenderPassColorAttachment[] = [];
 
@@ -2788,12 +2789,12 @@ export class WebGPUEngine extends Engine {
                           depthLoadOp: mustClearDepth ? WebGPUConstants.LoadOp.Clear : WebGPUConstants.LoadOp.Load,
                           depthStoreOp: WebGPUConstants.StoreOp.Store,
                           stencilClearValue: rtWrapper._depthStencilTextureWithStencil && mustClearStencil ? this._clearStencilValue : undefined,
-                          stencilLoadOp: !this.isStencilEnable
+                          stencilLoadOp: !depthTextureHasStencil
                               ? undefined
                               : rtWrapper._depthStencilTextureWithStencil && mustClearStencil
                               ? WebGPUConstants.LoadOp.Clear
                               : WebGPUConstants.LoadOp.Load,
-                          stencilStoreOp: !this.isStencilEnable ? undefined : WebGPUConstants.StoreOp.Store,
+                          stencilStoreOp: !depthTextureHasStencil ? undefined : WebGPUConstants.StoreOp.Store,
                       }
                     : undefined,
             occlusionQuerySet: this._occlusionQuery?.hasQueries ? this._occlusionQuery.querySet : undefined,

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/texturePropertyGridComponent.tsx
@@ -63,6 +63,8 @@ const textureFormat = [
     { label: "Depth32 float", normalizable: 0, hideType: true, value: Constants.TEXTUREFORMAT_DEPTH32_FLOAT },
     { label: "Depth16", normalizable: 0, value: Constants.TEXTUREFORMAT_DEPTH16 },
     { label: "Depth24", normalizable: 0, value: Constants.TEXTUREFORMAT_DEPTH24 },
+    { label: "Depth24Unorm/Stencil8", normalizable: 0, hideType: true, value: Constants.TEXTUREFORMAT_DEPTH24UNORM_STENCIL8 },
+    { label: "Depth32Float/Stencil8", normalizable: 0, hideType: true, value: Constants.TEXTUREFORMAT_DEPTH32FLOAT_STENCIL8 },
     { label: "RGBA BPTC UNorm", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGBA_BPTC_UNORM },
     { label: "RGB BPTC UFloat", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT },
     { label: "RGB BPTC SFloat", normalizable: 0, compressed: true, value: Constants.TEXTUREFORMAT_COMPRESSED_RGB_BPTC_SIGNED_FLOAT },


### PR DESCRIPTION
When a texture has both a depth and stencil aspects, only one of these can be used in a texture lookup. So, when creating a texture view, we must choose between depth and stencil.

We currently choose "depth" as it is what the user would most likely want, but we will need to come up with a way to be able to specify "stencil" instead. However, I don't know how we can do that, that would require some annotations in the shader so that we know a texture should be bound with the stencil aspect...