### PR TITLE
Save resources by not binding a color texture to a render target

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
@@ -65,12 +65,14 @@ ThinEngine.prototype.createRenderTargetTexture = function (this: ThinEngine, siz
     if (options !== undefined && typeof options === "object") {
         fullOptions.generateDepthBuffer = !!options.generateDepthBuffer;
         fullOptions.generateStencilBuffer = !!options.generateStencilBuffer;
+        fullOptions.noColorTarget = !!options.noColorTarget;
     } else {
         fullOptions.generateDepthBuffer = true;
         fullOptions.generateStencilBuffer = false;
+        fullOptions.noColorTarget = false;
     }
 
-    const texture = this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget);
+    const texture = fullOptions.noColorTarget ? null : this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget);
     const width = (<{ width: number; height: number; layers?: number }>size).width || <number>size;
     const height = (<{ width: number; height: number; layers?: number }>size).height || <number>size;
 
@@ -83,7 +85,7 @@ ThinEngine.prototype.createRenderTargetTexture = function (this: ThinEngine, siz
     rtWrapper._depthStencilBuffer = this._setupFramebufferDepthAttachments(fullOptions.generateStencilBuffer ? true : false, fullOptions.generateDepthBuffer, width, height);
 
     // No need to rebind on every frame
-    if (!texture.is2DArray) {
+    if (texture && !texture.is2DArray) {
         gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture._hardwareTexture!.underlyingResource, 0);
     }
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
@@ -23,15 +23,17 @@ WebGPUEngine.prototype.createRenderTargetTexture = function (size: TextureSize, 
         fullOptions.generateStencilBuffer = fullOptions.generateDepthBuffer && options.generateStencilBuffer;
         fullOptions.samplingMode = options.samplingMode === undefined ? Constants.TEXTURE_TRILINEAR_SAMPLINGMODE : options.samplingMode;
         fullOptions.creationFlags = options.creationFlags ?? 0;
+        fullOptions.noColorTarget = !!options.noColorTarget;
     } else {
         fullOptions.generateMipMaps = <boolean>options;
         fullOptions.generateDepthBuffer = true;
         fullOptions.generateStencilBuffer = false;
         fullOptions.samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
         fullOptions.creationFlags = 0;
+        fullOptions.noColorTarget = false;
     }
 
-    const texture = this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget);
+    const texture = fullOptions.noColorTarget ? null : this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget);
 
     rtWrapper._generateDepthBuffer = fullOptions.generateDepthBuffer;
     rtWrapper._generateStencilBuffer = fullOptions.generateStencilBuffer ? true : false;
@@ -55,14 +57,16 @@ WebGPUEngine.prototype.createRenderTargetTexture = function (size: TextureSize, 
         );
     }
 
-    if (options !== undefined && typeof options === "object" && options.createMipMaps && !fullOptions.generateMipMaps) {
-        texture.generateMipMaps = true;
-    }
+    if (texture) {
+        if (options !== undefined && typeof options === "object" && options.createMipMaps && !fullOptions.generateMipMaps) {
+            texture.generateMipMaps = true;
+        }
 
-    this._textureHelper.createGPUTextureForInternalTexture(texture, undefined, undefined, undefined, fullOptions.creationFlags);
+        this._textureHelper.createGPUTextureForInternalTexture(texture, undefined, undefined, undefined, fullOptions.creationFlags);
 
-    if (options !== undefined && typeof options === "object" && options.createMipMaps && !fullOptions.generateMipMaps) {
-        texture.generateMipMaps = false;
+        if (options !== undefined && typeof options === "object" && options.createMipMaps && !fullOptions.generateMipMaps) {
+            texture.generateMipMaps = false;
+        }
     }
 
     return rtWrapper;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuBundleList.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuBundleList.ts
@@ -158,7 +158,7 @@ export class WebGPUBundleList {
         this._currentItemIsBundle = false;
     }
 
-    public getBundleEncoder(colorFormats: GPUTextureFormat[], depthStencilFormat: GPUTextureFormat | undefined, sampleCount: number): GPURenderBundleEncoder {
+    public getBundleEncoder(colorFormats: (GPUTextureFormat | null)[], depthStencilFormat: GPUTextureFormat | undefined, sampleCount: number): GPURenderBundleEncoder {
         if (!this._currentItemIsBundle) {
             this.addBundle();
             this._bundleEncoder = this._device.createRenderBundleEncoder({

--- a/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.ts
@@ -31,7 +31,7 @@ export class WebGPUClearQuad {
         this._cacheRenderPipeline.setDepthStencilFormat(format);
     }
 
-    public setColorFormat(format: GPUTextureFormat): void {
+    public setColorFormat(format: GPUTextureFormat | null): void {
         this._cacheRenderPipeline.setColorFormat(format);
     }
 
@@ -70,7 +70,7 @@ export class WebGPUClearQuad {
             let idx = 0;
             this._keyTemp.length = 0;
             for (let i = 0; i < this._cacheRenderPipeline.colorFormats.length; ++i) {
-                this._keyTemp[idx++] = renderableTextureFormatToIndex[this._cacheRenderPipeline.colorFormats[i]];
+                this._keyTemp[idx++] = renderableTextureFormatToIndex[this._cacheRenderPipeline.colorFormats[i] ?? ""];
             }
 
             const depthStencilFormatIndex = renderableTextureFormatToIndex[this._depthTextureFormat ?? 0];

--- a/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassWrapper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassWrapper.ts
@@ -7,7 +7,7 @@ export class WebGPURenderPassWrapper {
     public renderPass: Nullable<GPURenderPassEncoder>;
     public colorAttachmentViewDescriptor: Nullable<GPUTextureViewDescriptor>;
     public depthAttachmentViewDescriptor: Nullable<GPUTextureViewDescriptor>;
-    public colorAttachmentGPUTextures: WebGPUHardwareTexture[] = [];
+    public colorAttachmentGPUTextures: (WebGPUHardwareTexture | null)[] = [];
     public depthTextureFormat: GPUTextureFormat | undefined;
 
     constructor() {

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -331,8 +331,6 @@ export class WebGPUEngine extends Engine {
     /** @hidden */
     public dbgShowShaderCode = false;
     /** @hidden */
-    public dbgSanityChecks = true;
-    /** @hidden */
     public dbgVerboseLogsForFirstFrames = false;
     /** @hidden */
     public dbgVerboseLogsNumFrames = 10;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -281,7 +281,7 @@ export class WebGPUEngine extends Engine {
     private _depthTexture: GPUTexture;
     private _mainTextureExtends: GPUExtent3D;
     private _depthTextureFormat: GPUTextureFormat | undefined;
-    private _colorFormat: GPUTextureFormat;
+    private _colorFormat: GPUTextureFormat | null;
     /** @hidden */
     public _ubInvertY: WebGPUDataBuffer;
     /** @hidden */
@@ -846,7 +846,7 @@ export class WebGPUEngine extends Engine {
         this._configureContext(this._canvas.width, this._canvas.height);
         this._colorFormat = this._options.swapChainFormat!;
         this._mainRenderPassWrapper.colorAttachmentGPUTextures = [new WebGPUHardwareTexture()];
-        this._mainRenderPassWrapper.colorAttachmentGPUTextures[0].format = this._colorFormat;
+        this._mainRenderPassWrapper.colorAttachmentGPUTextures[0]!.format = this._colorFormat;
     }
 
     // Set default values as WebGL with depth and stencil attachment for the broadest Compat.
@@ -2548,8 +2548,13 @@ export class WebGPUEngine extends Engine {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public readPixels(x: number, y: number, width: number, height: number, hasAlpha = true, flushRenderer = true): Promise<ArrayBufferView> {
         const renderPassWrapper = this._rttRenderPassWrapper.renderPass ? this._rttRenderPassWrapper : this._mainRenderPassWrapper;
-        const gpuTexture = renderPassWrapper.colorAttachmentGPUTextures![0].underlyingResource;
-        const gpuTextureFormat = renderPassWrapper.colorAttachmentGPUTextures![0].format;
+        const hardwareTexture = renderPassWrapper.colorAttachmentGPUTextures[0];
+        if (!hardwareTexture) {
+            // we are calling readPixels for a render pass with no color texture bound
+            return Promise.resolve(new Uint8Array(0));
+        }
+        const gpuTexture = hardwareTexture.underlyingResource;
+        const gpuTextureFormat = hardwareTexture.format;
         if (!gpuTexture) {
             // we are calling readPixels before startMainRenderPass has been called and no RTT is bound, so swapChainTexture is not setup yet!
             return Promise.resolve(new Uint8Array(0));
@@ -2718,7 +2723,7 @@ export class WebGPUEngine extends Engine {
         const depthMSAATextureView = gpuDepthStencilMSAATexture?.createView(this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
         const depthTextureHasStencil = gpuDepthStencilWrapper ? WebGPUTextureHelper.HasStencilAspect(gpuDepthStencilWrapper.format) : false;
 
-        const colorAttachments: GPURenderPassColorAttachment[] = [];
+        const colorAttachments: (GPURenderPassColorAttachment | null)[] = [];
 
         if (this.useReverseDepthBuffer) {
             this.setDepthFunctionToGreaterOrEqual();
@@ -2760,21 +2765,25 @@ export class WebGPUEngine extends Engine {
             this._cacheRenderPipeline.setMRTAttachments(this._mrtAttachments);
         } else {
             // single render target
-            const internalTexture = rtWrapper.texture!;
-            const gpuWrapper = internalTexture._hardwareTexture as WebGPUHardwareTexture;
-            const gpuTexture = gpuWrapper.underlyingResource!;
+            const internalTexture = rtWrapper.texture;
+            if (internalTexture) {
+                const gpuWrapper = internalTexture._hardwareTexture as WebGPUHardwareTexture;
+                const gpuTexture = gpuWrapper.underlyingResource!;
 
-            const gpuMSAATexture = gpuWrapper.msaaTexture;
-            const colorTextureView = gpuTexture.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
-            const colorMSAATextureView = gpuMSAATexture?.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
+                const gpuMSAATexture = gpuWrapper.msaaTexture;
+                const colorTextureView = gpuTexture.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
+                const colorMSAATextureView = gpuMSAATexture?.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
 
-            colorAttachments.push({
-                view: colorMSAATextureView ? colorMSAATextureView : colorTextureView,
-                resolveTarget: gpuMSAATexture ? colorTextureView : undefined,
-                clearValue: mustClearColor ? clearColor : undefined,
-                loadOp: mustClearColor ? WebGPUConstants.LoadOp.Clear : WebGPUConstants.LoadOp.Load,
-                storeOp: WebGPUConstants.StoreOp.Store,
-            });
+                colorAttachments.push({
+                    view: colorMSAATextureView ? colorMSAATextureView : colorTextureView,
+                    resolveTarget: gpuMSAATexture ? colorTextureView : undefined,
+                    clearValue: mustClearColor ? clearColor : undefined,
+                    loadOp: mustClearColor ? WebGPUConstants.LoadOp.Clear : WebGPUConstants.LoadOp.Load,
+                    storeOp: WebGPUConstants.StoreOp.Store,
+                });
+            } else {
+                colorAttachments.push(null);
+            }
         }
 
         this._debugPushGroup?.("render target pass", 1);
@@ -2836,8 +2845,8 @@ export class WebGPUEngine extends Engine {
     /** @hidden */
     public _endRenderTargetRenderPass() {
         if (this._currentRenderPass) {
-            const gpuWrapper = this._currentRenderTarget!.texture!._hardwareTexture as WebGPUHardwareTexture;
-            if (!this._snapshotRendering.endRenderTargetPass(this._currentRenderPass, gpuWrapper) && !this.compatibilityMode) {
+            const gpuWrapper = this._currentRenderTarget!.texture?._hardwareTexture as Nullable<WebGPUHardwareTexture>;
+            if (gpuWrapper && !this._snapshotRendering.endRenderTargetPass(this._currentRenderPass, gpuWrapper) && !this.compatibilityMode) {
                 this._bundleListRenderTarget.run(this._currentRenderPass);
                 this._bundleListRenderTarget.reset();
             }
@@ -2906,7 +2915,7 @@ export class WebGPUEngine extends Engine {
         this._mainRenderPassWrapper.renderPassDescriptor!.occlusionQuerySet = this._occlusionQuery?.hasQueries ? this._occlusionQuery.querySet : undefined;
 
         this._swapChainTexture = this._context.getCurrentTexture();
-        this._mainRenderPassWrapper.colorAttachmentGPUTextures![0].set(this._swapChainTexture);
+        this._mainRenderPassWrapper.colorAttachmentGPUTextures[0]!.set(this._swapChainTexture);
 
         // Resolve in case of MSAA
         if (this._options.antialiasing) {
@@ -2995,18 +3004,13 @@ export class WebGPUEngine extends Engine {
     ): void {
         const hardwareTexture = texture.texture?._hardwareTexture as Nullable<WebGPUHardwareTexture>;
 
-        if (!hardwareTexture) {
-            if (this.dbgSanityChecks) {
-                console.error("bindFramebuffer: Trying to bind a texture that does not have a hardware texture!", texture, hardwareTexture);
-            }
-            return;
-        }
-
         if (this._currentRenderTarget) {
             this.unBindFramebuffer(this._currentRenderTarget);
         }
         this._currentRenderTarget = texture;
-        hardwareTexture._currentLayer = texture.isCube ? layer * 6 + faceIndex : layer;
+        if (hardwareTexture) {
+            hardwareTexture._currentLayer = texture.isCube ? layer * 6 + faceIndex : layer;
+        }
 
         this._rttRenderPassWrapper.colorAttachmentGPUTextures[0] = hardwareTexture;
         this._rttRenderPassWrapper.depthTextureFormat = this._currentRenderTarget._depthStencilTexture
@@ -3017,7 +3021,7 @@ export class WebGPUEngine extends Engine {
         this._setColorFormat(this._rttRenderPassWrapper);
 
         this._rttRenderPassWrapper.colorAttachmentViewDescriptor = {
-            format: this._colorFormat,
+            format: this._colorFormat as GPUTextureFormat,
             dimension: WebGPUConstants.TextureViewDimension.E2d,
             mipLevelCount: 1,
             baseArrayLayer: texture.isCube ? layer * 6 + faceIndex : layer,
@@ -3160,7 +3164,7 @@ export class WebGPUEngine extends Engine {
      * @hidden
      */
     public _setColorFormat(wrapper: WebGPURenderPassWrapper): void {
-        const format = wrapper.colorAttachmentGPUTextures[0].format;
+        const format = wrapper.colorAttachmentGPUTextures[0]?.format ?? null;
         this._cacheRenderPipeline.setColorFormat(format);
         if (this._colorFormat === format) {
             return;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -331,6 +331,8 @@ export class WebGPUEngine extends Engine {
     /** @hidden */
     public dbgShowShaderCode = false;
     /** @hidden */
+    public dbgSanityChecks = true;
+    /** @hidden */
     public dbgVerboseLogsForFirstFrames = false;
     /** @hidden */
     public dbgVerboseLogsNumFrames = 10;

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -377,6 +377,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * @param delayAllocation if the texture allocation should be delayed (default: false)
      * @param samples sample count to use when creating the RTT
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
+     * @param noColorTarget True to indicate that no color target should be created. Useful if you only want to write to the depth buffer, for eg
      */
     constructor(
         name: string,
@@ -393,7 +394,8 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         format = Constants.TEXTUREFORMAT_RGBA,
         delayAllocation = false,
         samples?: number,
-        creationFlags?: number
+        creationFlags?: number,
+        noColorTarget = false
     ) {
         super(null, scene, !generateMipMaps, undefined, samplingMode, undefined, undefined, undefined, undefined, format);
         scene = this.getScene();
@@ -437,6 +439,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             generateStencilBuffer: generateStencilBuffer,
             samples,
             creationFlags,
+            noColorTarget,
         };
 
         if (this.samplingMode === Texture.NEAREST_SAMPLINGMODE) {
@@ -1056,10 +1059,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         const engine = scene.getEngine();
 
-        if (!this._texture) {
-            return;
-        }
-
         engine._debugPushGroup?.(`render to face #${faceIndex} layer #${layer}`, 1);
 
         // Bind
@@ -1129,11 +1128,13 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                 step.action(this, faceIndex, layer);
             }
 
-            const saveGenerateMipMaps = this._texture.generateMipMaps;
+            const saveGenerateMipMaps = this._texture?.generateMipMaps ?? false;
 
-            this._texture.generateMipMaps = false; // if left true, the mipmaps will be generated (if this._texture.generateMipMaps = true) when the first post process binds its own RTT: by doing so it will unbind the current RTT,
-            // which will trigger a mipmap generation. We don't want this because it's a wasted work, we will do an unbind of the current RTT at the end of the process (see unbindFrameBuffer) which will
-            // trigger the generation of the final mipmaps
+            if (this._texture) {
+                this._texture.generateMipMaps = false; // if left true, the mipmaps will be generated (if this._texture.generateMipMaps = true) when the first post process binds its own RTT: by doing so it will unbind the current RTT,
+                // which will trigger a mipmap generation. We don't want this because it's a wasted work, we will do an unbind of the current RTT at the end of the process (see unbindFrameBuffer) which will
+                // trigger the generation of the final mipmaps
+            }
 
             if (this._postProcessManager) {
                 this._postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, faceIndex, this._postProcesses, this.ignoreCameraViewport);
@@ -1141,7 +1142,9 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                 scene.postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, faceIndex);
             }
 
-            this._texture.generateMipMaps = saveGenerateMipMaps;
+            if (this._texture) {
+                this._texture.generateMipMaps = saveGenerateMipMaps;
+            }
 
             if (!this._doNotChangeAspectRatio) {
                 scene.updateTransformMatrix(true);
@@ -1165,7 +1168,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         // Unbind
         this._unbindFrameBuffer(engine, faceIndex);
 
-        if (this.isCube && faceIndex === 5) {
+        if (this._texture && this.isCube && faceIndex === 5) {
             engine.generateMipMapsForCubemap(this._texture);
         }
 

--- a/packages/dev/core/src/Materials/Textures/textureCreationOptions.ts
+++ b/packages/dev/core/src/Materials/Textures/textureCreationOptions.ts
@@ -30,6 +30,8 @@ export interface RenderTargetCreationOptions extends InternalTextureCreationOpti
     generateDepthBuffer?: boolean;
     /** Specifies whether or not a stencil should be allocated in the texture (false by default)*/
     generateStencilBuffer?: boolean;
+    /** Specifies that no color target should be bound to the render target (useful if you only want to write to the depth buffer, for eg) */
+    noColorTarget?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR allows the user to indicate that the color texture should not be created/bound when creating a render target.

It's a waste of resources (a texture the size of the render target) if all you want is generating the depth buffer/texture and don't have anything to write in a color texture.

Here's a PG to test it: https://playground.babylonjs.com/#0PYWXZ#1

With Spector, you will see that only the depth buffer is bound:
![image](https://user-images.githubusercontent.com/4152247/165773484-5532cab3-989b-470e-8474-6dbdafe03b8e.png)

Without the PR, a color texture is also bound:
![image](https://user-images.githubusercontent.com/4152247/165773612-9ef55b45-f03a-45be-af14-3d92cf15e5d5.png)
