### PR TITLE
Remove BABYLON namespace references in the Inspector

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
@@ -63,9 +63,6 @@ export interface IToolParameters {
     setMetadata: (data: any) => void;
     /** Returns the texture coordinates under the cursor */
     getMouseCoordinates: (pointerInfo: PointerInfo) => Vector2;
-    /** Provides access to the BABYLON namespace */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    BABYLON: any;
     /** Provides a canvas that you can use the canvas API to paint on. */
     startPainting: () => Promise<CanvasRenderingContext2D>;
     /** After you have painted on your canvas, call this method to push the updates back to the texture. */
@@ -244,8 +241,6 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
             setMetadata: (data: any) => this.setMetadata(data),
             getMouseCoordinates: (pointerInfo: PointerInfo) => this._textureCanvasManager.getMouseCoordinates(pointerInfo),
             interactionEnabled: () => this._textureCanvasManager.toolInteractionEnabled(),
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            BABYLON: BABYLON,
         };
     }
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import type { Observable } from "core/Misc/observable";
-import { Tools } from "core/Misc/tools";
 import { Vector3, TmpVectors } from "core/Maths/math.vector";
 import { Color3 } from "core/Maths/math.color";
 import type { Mesh } from "core/Meshes/mesh";
@@ -36,6 +35,7 @@ import { HexLineComponent } from "shared-ui-components/lines/hexLineComponent";
 import { SkeletonViewer } from "core/Debug/skeletonViewer";
 import type { ShaderMaterial } from "core/Materials/shaderMaterial";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
+import { NormalMaterial } from "materials/normal/normalMaterial";
 
 import "core/Physics/physicsEngineComponent";
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
@@ -166,11 +166,12 @@ export class MeshPropertyGridComponent extends React.Component<
             mesh.reservedDataStore.originalMaterial = null;
             this.setState({ displayNormals: false });
         } else {
-            if (!(BABYLON as any).NormalMaterial) {
-                this.setState({ displayNormals: true });
-                Tools.LoadScript("https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js", () => {
-                    this.displayNormals();
-                });
+            if (!NormalMaterial) {
+                // this.setState({ displayNormals: true });
+                // Tools.LoadScript("https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js", () => {
+                //     this.displayNormals();
+                // });
+                console.log("NormalMaterial not found");
                 return;
             }
 
@@ -182,7 +183,7 @@ export class MeshPropertyGridComponent extends React.Component<
                 mesh.reservedDataStore.originalMaterial = mesh.material;
             }
 
-            const normalMaterial = new (BABYLON as any).NormalMaterial("normalMaterial", scene);
+            const normalMaterial = new NormalMaterial("normalMaterial", scene);
             normalMaterial.disableLighting = true;
             if (mesh.material) {
                 normalMaterial.sideOrientation = mesh.material.sideOrientation;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -39,6 +39,7 @@ import { NormalMaterial } from "materials/normal/normalMaterial";
 
 import "core/Physics/physicsEngineComponent";
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
+import { Tools } from "core/Misc/tools";
 
 interface IMeshPropertyGridComponentProps {
     globalState: GlobalState;
@@ -166,12 +167,8 @@ export class MeshPropertyGridComponent extends React.Component<
             mesh.reservedDataStore.originalMaterial = null;
             this.setState({ displayNormals: false });
         } else {
-            if (!NormalMaterial) {
-                // this.setState({ displayNormals: true });
-                // Tools.LoadScript("https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js", () => {
-                //     this.displayNormals();
-                // });
-                console.log("NormalMaterial not found");
+            if (typeof NormalMaterial === "undefined") {
+                Tools.Warn("NormalMaterial not found. Make sure to load the materials library.");
                 return;
             }
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -17,7 +17,7 @@ import { SceneSerializer } from "core/Misc/sceneSerializer";
 import { Mesh } from "core/Meshes/mesh";
 import { FilesInput } from "core/Misc/filesInput";
 import type { Scene } from "core/scene";
-import { SceneLoaderAnimationGroupLoadingMode } from "core/Loading/sceneLoader";
+import { SceneLoader, SceneLoaderAnimationGroupLoadingMode } from "core/Loading/sceneLoader";
 import { Reflector } from "core/Misc/reflector";
 import { GLTFComponent } from "./tools/gltfComponent";
 // TODO - does it still work if loading the modules from the correct files?
@@ -39,6 +39,7 @@ import { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
 import GIF from "gif.js.optimized";
 import { Camera } from "core/Cameras/camera";
 import { Light } from "core/Lights/light";
+import { GLTFFileLoader } from "loaders/glTF/glTFFileLoader";
 
 const envExportImageTypes = [
     { label: "PNG", value: 0, imageType: "image/png" },
@@ -84,8 +85,9 @@ export class ToolsTabComponent extends PaneComponent {
     }
 
     componentDidMount() {
-        if (!(BABYLON as any).GLTF2Export) {
-            Tools.LoadScript("https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js", () => {});
+        if (!GLTF2Export) {
+            console.log("GLTF2Export is not available");
+            // Tools.LoadScript("https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js", () => {});
             return;
         }
     }
@@ -216,7 +218,7 @@ export class ToolsTabComponent extends PaneComponent {
                         currentGroup.play(true);
                     }
                 };
-                (BABYLON as any).SceneLoader.ImportAnimationsAsync("file:", sceneFile, scene, overwriteAnimations, animationGroupLoadingMode, null, onSuccess);
+                SceneLoader.ImportAnimationsAsync("file:", sceneFile, scene, overwriteAnimations, animationGroupLoadingMode, null, onSuccess);
             }
         };
         const filesInputAnimation = new FilesInput(
@@ -480,7 +482,7 @@ export class ToolsTabComponent extends PaneComponent {
                         </>
                     )}
                 </LineContainerComponent>
-                {(BABYLON as any).GLTFFileLoader && <GLTFComponent scene={scene} globalState={this.props.globalState!} />}
+                {GLTFFileLoader && <GLTFComponent scene={scene} globalState={this.props.globalState!} />}
                 <LineContainerComponent title="REFLECTOR" selection={this.props.globalState}>
                     <TextInputLineComponent lockObject={this._lockObject} label="Hostname" target={this} propertyName="_reflectorHostname" />
                     <FloatLineComponent lockObject={this._lockObject} label="Port" target={this} propertyName="_reflectorPort" isInteger={true} />

--- a/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -86,8 +86,7 @@ export class ToolsTabComponent extends PaneComponent {
 
     componentDidMount() {
         if (!GLTF2Export) {
-            console.log("GLTF2Export is not available");
-            // Tools.LoadScript("https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js", () => {});
+            Tools.Warn("GLTF2Export is not available. Make sure to load the serializers library");
             return;
         }
     }

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -7,12 +7,13 @@ declare let BABYLON: any;
 
 let editorUrl = `https://unpkg.com/babylonjs-gui-editor@${Engine.Version}/babylon.guiEditor.js`;
 // eslint-disable-next-line @typescript-eslint/naming-convention
-let guiEditorContainer: { GUIEditor: typeof GUIEditor } = { GUIEditor };
+let guiEditorContainer: { GUIEditor: typeof GUIEditor };
 /** Get the inspector from bundle or global */
-function _getGlobalGUIEditor(): any {
+function _getGlobalGUIEditor(): { GUIEditor: typeof GUIEditor } | undefined {
     // UMD Global name detection from Webpack Bundle UMD Name.
     if (typeof GUIEditor !== "undefined") {
-        return GUIEditor;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        return { GUIEditor };
     }
 
     // In case of module let's check the global emitted from the editor entry point.
@@ -46,10 +47,10 @@ export function SetGUIEditorURL(guiEditorURL: string) {
  * @param adt
  */
 export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture) {
+    guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
     if (!guiEditorContainer) {
         if (typeof BABYLON !== "undefined") {
             // we are in UMD environment
-            guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
             if (typeof guiEditorContainer === "undefined") {
                 // Load editor and add it to the DOM
                 try {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -1,17 +1,18 @@
 import type { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
 import { Engine } from "core/Engines/engine";
 import { Tools } from "core/Misc/tools";
+import { GUIEditor } from "gui-editor/guiEditor";
 
-declare let GUIEDITOR: any;
 declare let BABYLON: any;
 
 let editorUrl = `https://unpkg.com/babylonjs-gui-editor@${Engine.Version}/babylon.guiEditor.js`;
-let guiEditor: any = null;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let guiEditorContainer: { GUIEditor: typeof GUIEditor } = { GUIEditor };
 /** Get the inspector from bundle or global */
 function _getGlobalGUIEditor(): any {
     // UMD Global name detection from Webpack Bundle UMD Name.
-    if (typeof GUIEDITOR !== "undefined") {
-        return GUIEDITOR;
+    if (typeof GUIEditor !== "undefined") {
+        return GUIEditor;
     }
 
     // In case of module let's check the global emitted from the editor entry point.
@@ -27,7 +28,7 @@ function _getGlobalGUIEditor(): any {
  * @param guiEditorPackage
  */
 export function InjectGUIEditor(guiEditorPackage: any) {
-    guiEditor = guiEditorPackage;
+    guiEditorContainer = guiEditorPackage;
 }
 
 /**
@@ -45,15 +46,15 @@ export function SetGUIEditorURL(guiEditorURL: string) {
  * @param adt
  */
 export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture) {
-    if (!guiEditor) {
+    if (!guiEditorContainer) {
         if (typeof BABYLON !== "undefined") {
             // we are in UMD environment
-            guiEditor = guiEditor || _getGlobalGUIEditor();
-            if (typeof guiEditor === "undefined") {
+            guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
+            if (typeof guiEditorContainer === "undefined") {
                 // Load editor and add it to the DOM
                 try {
                     await Tools.LoadScriptAsync(editorUrl);
-                    guiEditor = guiEditor || _getGlobalGUIEditor();
+                    guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
                 } catch {
                     throw `Failed to load GUI editor from ${editorUrl}`;
                 }
@@ -63,5 +64,5 @@ export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture) {
             throw `Tried to call EditAdvancedDynamicTexture without first injecting the GUI editor. You need to call InjectGUIEditor() with a reference to @babylonjs/gui-editor. It can be imported at runtime using await import("@babylonjs/gui-editor").`;
         }
     }
-    guiEditor.GUIEditor.Show({ liveGuiTexture: adt });
+    guiEditorContainer.GUIEditor.Show({ liveGuiTexture: adt });
 }

--- a/packages/tools/devHost/webpack.config.js
+++ b/packages/tools/devHost/webpack.config.js
@@ -29,6 +29,8 @@ module.exports = (env) => {
                 materials: `@${source}/materials/dist`,
                 "post-processes": `@${source}/post-processes/dist`,
                 "procedural-textures": `@${source}/procedural-textures/dist`,
+                "gui-editor": `@tools/gui-editor/dist`,
+                "node-editor": `@tools/node-editor/dist`,
             },
         },
         experiments: {

--- a/packages/tools/guiEditor/src/guiEditor.ts
+++ b/packages/tools/guiEditor/src/guiEditor.ts
@@ -11,7 +11,7 @@ import type { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
  */
 export interface IGUIEditorOptions {
     liveGuiTexture?: AdvancedDynamicTexture;
-    customLoad: { label: string; action: (data: string) => Promise<string> } | undefined;
+    customLoad?: { label: string; action: (data: string) => Promise<string> } | undefined;
     hostElement?: HTMLElement;
     customSave?: { label: string; action: (data: string) => Promise<string> };
     currentSnippetToken?: string;

--- a/packages/tools/guiEditor/src/legacy/legacy.ts
+++ b/packages/tools/guiEditor/src/legacy/legacy.ts
@@ -5,6 +5,7 @@ const globalObject = typeof global !== "undefined" ? global : typeof window !== 
 if (typeof globalObject !== "undefined") {
     (<any>globalObject).BABYLON = (<any>globalObject).BABYLON || {};
     (<any>globalObject).BABYLON.GuiEditor = GUIEditor;
+    (<any>globalObject).BABYLON.GUIEditor = GUIEditor;
     // eslint-disable-next-line @typescript-eslint/naming-convention
     (<any>globalObject).GUIEDITOR = { GUIEditor };
 }


### PR DESCRIPTION
Fixes #12343

The build system now allows to set dependencies to both the es6 and the umd packages, so importing from gui-editor is enough