### PR TITLE
[Viewer] fix default material init

### DIFF
--- a/packages/tools/viewer/src/viewer/defaultViewer.ts
+++ b/packages/tools/viewer/src/viewer/defaultViewer.ts
@@ -51,9 +51,6 @@ export class DefaultViewer extends AbstractViewerWithTemplate {
             this.sceneManager.onLightsConfiguredObservable.add(() => {
                 this._configureLights();
             });
-        });
-
-        this.onInitDoneObservable.add(() => {
             this.sceneManager.setDefaultMaterial = function (sceneConfig: ISceneConfiguration) {
                 const conf = sceneConfig.defaultMaterial;
                 if (!conf) {


### PR DESCRIPTION
If a mesh has no material the default material would initialize too late, not being applied correctly.

This PR fixes that.