### PR TITLE
Nine patch overlap fix

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -876,20 +876,28 @@ export class Image extends Control {
         //Top Left
         this._drawImage(context, 0, 0, leftWidth, topHeight, this._currentMeasure.left, this._currentMeasure.top, leftWidth, topHeight);
         //Top
+        context.clearRect(centerLeftOffset, this._currentMeasure.top, targetCenterWidth, topHeight);
         this._drawImage(context, this._sliceLeft, 0, centerWidth, topHeight, centerLeftOffset, this._currentMeasure.top, targetCenterWidth, topHeight);
         //Top Right
-        this._drawImage(context, this.sliceRight, 0, rightWidth, topHeight, rightOffset, this._currentMeasure.top, rightWidth, topHeight);
+        context.clearRect(rightOffset, this._currentMeasure.top, rightWidth, topHeight);
+        this._drawImage(context, this._sliceRight, 0, rightWidth, topHeight, rightOffset, this._currentMeasure.top, rightWidth, topHeight);
         //Left
+        context.clearRect(this._currentMeasure.left, centerTopOffset, leftWidth, targetCenterHeight);
         this._drawImage(context, 0, this._sliceTop, leftWidth, centerHeight, this._currentMeasure.left, centerTopOffset, leftWidth, targetCenterHeight);
         // Center
+        context.clearRect(centerLeftOffset, centerTopOffset, targetCenterWidth, targetCenterHeight);
         this._drawImage(context, this._sliceLeft, this._sliceTop, centerWidth, centerHeight, centerLeftOffset, centerTopOffset, targetCenterWidth, targetCenterHeight);
         //Right
+        context.clearRect(rightOffset, centerTopOffset, rightWidth, targetCenterHeight);
         this._drawImage(context, this._sliceRight, this._sliceTop, rightWidth, centerHeight, rightOffset, centerTopOffset, rightWidth, targetCenterHeight);
         //Bottom Left
+        context.clearRect(this._currentMeasure.left, bottomOffset, leftWidth, bottomHeight);
         this._drawImage(context, 0, this._sliceBottom, leftWidth, bottomHeight, this._currentMeasure.left, bottomOffset, leftWidth, bottomHeight);
         //Bottom
+        context.clearRect(centerLeftOffset, bottomOffset, targetCenterWidth, bottomHeight);
         this._drawImage(context, this.sliceLeft, this._sliceBottom, centerWidth, bottomHeight, centerLeftOffset, bottomOffset, targetCenterWidth, bottomHeight);
         //Bottom Right
+        context.clearRect(rightOffset, bottomOffset, rightWidth, bottomHeight);
         this._drawImage(context, this._sliceRight, this._sliceBottom, rightWidth, bottomHeight, rightOffset, bottomOffset, rightWidth, bottomHeight);
     }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/nine-patch-showing-gaps-with-alpha-png/29365/7

![image](https://user-images.githubusercontent.com/1538857/166270139-4cf3bba8-3795-4828-8f41-982779757ec9.png)
The edges look weird because I edited it in photoshop before converting it to a blob for testing inline.  I have tested on firefox and brave that the interior artifacts are gone.