### PR TITLE
Missing null for First go to frame in Animation

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -22,7 +22,7 @@ export class Animatable {
     private _speedRatio = 1;
     private _weight = -1.0;
     private _syncRoot: Nullable<Animatable> = null;
-    private _frameToSyncFromJump: Nullable<number> = 0;
+    private _frameToSyncFromJump: Nullable<number> = null;
 
     /**
      * Gets or sets a boolean indicating if the animatable must be disposed and removed at the end of the animation.


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/issue-animation-gotoframe/29493/3

`_frameToSyncFromJump` for was null and was not used correctly for 1st go to frame. After the 1st go to frame, it's set to null and everything is fine.