### PR TITLE
[NME] Fix light selection in Light Information Block

### DIFF
--- a/packages/tools/nodeEditor/src/diagram/properties/lightInformationPropertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/diagram/properties/lightInformationPropertyTabComponent.tsx
@@ -25,6 +25,7 @@ export class LightInformationPropertyTabComponent extends React.Component<IPrope
                         options={lightOptions}
                         target={lightInformationBlock}
                         propertyName="name"
+                        getSelection={(target) => target.light.name}
                         onSelect={(name: any) => {
                             lightInformationBlock.light = scene.getLightByName(name);
                             this.forceUpdate();


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/nme-lightinformationblock-properties-cant-select-light-1-or-light-2/29888

The light property was correctly selected, but the options element wasn't updated.
Simple NME example: https://nme.babylonjs.com/#KDHJPM