### PR TITLE
no plane update for axis gizmos

### DIFF
--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -137,6 +137,7 @@ export class AxisDragGizmo extends Gizmo {
         // Add drag behavior to handle events when the gizmo is dragged
         this.dragBehavior = new PointerDragBehavior({ dragAxis: dragAxis });
         this.dragBehavior.moveAttached = false;
+        this.dragBehavior.updateDragPlane = false;
         this._rootMesh.addBehavior(this.dragBehavior);
 
         this.dragBehavior.onDragObservable.add((event) => {

--- a/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
@@ -124,6 +124,7 @@ export class AxisScaleGizmo extends Gizmo {
         // Add drag behavior to handle events when the gizmo is dragged
         this.dragBehavior = new PointerDragBehavior({ dragAxis: dragAxis });
         this.dragBehavior.moveAttached = false;
+        this.dragBehavior.updateDragPlane = false;
         this._rootMesh.addBehavior(this.dragBehavior);
 
         let currentSnapDragDistance = 0;


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/breaking-change-in-axisscalegizmo/4167/3

Axis scale and axis drag gizmo used to update plane for pointerDragBehavior. This leads to instability when gizmo gets out of screen.