### PR TITLE
warning and checks for noimpostor children

### DIFF
--- a/packages/dev/core/src/Debug/physicsViewer.ts
+++ b/packages/dev/core/src/Debug/physicsViewer.ts
@@ -248,7 +248,8 @@ export class PhysicsViewer {
         let mesh: Nullable<AbstractMesh> = null;
         const utilityLayerScene = this._utilityLayer.utilityLayerScene;
         if (!impostor.physicsBody) {
-            Logger.Warn("Unable to get physicsBody of impostor. It might be initialized later with by its parent's impostor.");
+            Logger.Warn("Unable to get physicsBody of impostor. It might be initialized later by its parent's impostor.");
+
             return null;
         }
         switch (impostor.type) {

--- a/packages/dev/core/src/Debug/physicsViewer.ts
+++ b/packages/dev/core/src/Debug/physicsViewer.ts
@@ -247,7 +247,10 @@ export class PhysicsViewer {
 
         let mesh: Nullable<AbstractMesh> = null;
         const utilityLayerScene = this._utilityLayer.utilityLayerScene;
-
+        if (!impostor.physicsBody) {
+            Logger.Warn("Unable to get physicsBody of impostor. It might be initialized later with by its parent's impostor.");
+            return null;
+        }
         switch (impostor.type) {
             case PhysicsImpostor.BoxImpostor:
                 mesh = this._getDebugBoxMesh(utilityLayerScene);

--- a/packages/dev/core/src/Debug/physicsViewer.ts
+++ b/packages/dev/core/src/Debug/physicsViewer.ts
@@ -249,7 +249,6 @@ export class PhysicsViewer {
         const utilityLayerScene = this._utilityLayer.utilityLayerScene;
         if (!impostor.physicsBody) {
             Logger.Warn("Unable to get physicsBody of impostor. It might be initialized later by its parent's impostor.");
-
             return null;
         }
         switch (impostor.type) {

--- a/packages/dev/core/src/Debug/physicsViewer.ts
+++ b/packages/dev/core/src/Debug/physicsViewer.ts
@@ -15,6 +15,7 @@ import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
 import { CreateCylinder } from "../Meshes/Builders/cylinderBuilder";
 import type { ICreateCapsuleOptions } from "../Meshes/Builders/capsuleBuilder";
 import { CreateCapsule } from "../Meshes/Builders/capsuleBuilder";
+import { Logger } from "../Misc/logger";
 
 /**
  * Used to show the physics impostor around the specific mesh
@@ -309,6 +310,8 @@ export class PhysicsViewer {
                             }
                         }
                     });
+                } else {
+                    Logger.Warn("No target mesh parameter provided for NoImpostor. Skipping.");
                 }
                 mesh = null;
                 break;

--- a/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
@@ -679,15 +679,26 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
     }
 
     public getRadius(impostor: PhysicsImpostor): number {
-        const shape = impostor.physicsBody.shapes[0];
-        return shape.boundingSphereRadius;
+        if (impostor.physicsBody && impostor.physicsBody.shapes && impostor.physicsBody.shapes.length) {
+            const shape = impostor.physicsBody.shapes[0];
+            return shape.boundingSphereRadius;
+        }
+        Logger.Warn("Unable to get radius of impostor. It might be initialized later with by its parent's impostor.");
+        return 0;
     }
 
     public getBoxSizeToRef(impostor: PhysicsImpostor, result: Vector3): void {
-        const shape = impostor.physicsBody.shapes[0];
-        result.x = shape.halfExtents.x * 2;
-        result.y = shape.halfExtents.y * 2;
-        result.z = shape.halfExtents.z * 2;
+        if (impostor.physicsBody && impostor.physicsBody.shapes && impostor.physicsBody.shapes.length) {
+            const shape = impostor.physicsBody.shapes[0];
+            result.x = shape.halfExtents.x * 2;
+            result.y = shape.halfExtents.y * 2;
+            result.z = shape.halfExtents.z * 2;
+        } else {
+            Logger.Warn("Unable to get box size of impostor. It might be initialized later with by its parent's impostor.");
+            result.x = 0;
+            result.y = 0;
+            result.z = 0;
+        }
     }
 
     public dispose() {}

--- a/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
@@ -679,26 +679,15 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
     }
 
     public getRadius(impostor: PhysicsImpostor): number {
-        if (impostor.physicsBody && impostor.physicsBody.shapes && impostor.physicsBody.shapes.length) {
-            const shape = impostor.physicsBody.shapes[0];
-            return shape.boundingSphereRadius;
-        }
-        Logger.Warn("Unable to get radius of impostor. It might be initialized later with by its parent's impostor.");
-        return 0;
+        const shape = impostor.physicsBody.shapes[0];
+        return shape.boundingSphereRadius;
     }
 
     public getBoxSizeToRef(impostor: PhysicsImpostor, result: Vector3): void {
-        if (impostor.physicsBody && impostor.physicsBody.shapes && impostor.physicsBody.shapes.length) {
-            const shape = impostor.physicsBody.shapes[0];
-            result.x = shape.halfExtents.x * 2;
-            result.y = shape.halfExtents.y * 2;
-            result.z = shape.halfExtents.z * 2;
-        } else {
-            Logger.Warn("Unable to get box size of impostor. It might be initialized later with by its parent's impostor.");
-            result.x = 0;
-            result.y = 0;
-            result.z = 0;
-        }
+        const shape = impostor.physicsBody.shapes[0];
+        result.x = shape.halfExtents.x * 2;
+        result.y = shape.halfExtents.y * 2;
+        result.z = shape.halfExtents.z * 2;
     }
 
     public dispose() {}


### PR DESCRIPTION
fixes #12446 

2 issues :
- when creating impostor for children mesh, their impostor will effectively be created with the NoImpostor. So shapes are not available and you get the crash. I've added a check and log a warning
- The correct way to debugdisplay impostor in this case is to do the call on the NoImpostor parent. But you have to provide a 2nd parameter or nothing appears. I've also added a warning in that particular case.