### PR TITLE
GLTFSerializer : Prevent empty skin to export invalid GLTF

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -2226,7 +2226,7 @@ export class _Exporter {
         const promiseChain = Promise.resolve();
         const skinMap: { [key: number]: number } = {};
         for (const skeleton of babylonScene.skeletons) {
-            if (skeleton.bones.length == 0) {
+            if (skeleton.bones.length <= 0) {
                 continue;
             }
             // create skin

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -2226,6 +2226,9 @@ export class _Exporter {
         const promiseChain = Promise.resolve();
         const skinMap: { [key: number]: number } = {};
         for (const skeleton of babylonScene.skeletons) {
+            if (skeleton.bones.length == 0) {
+                continue;
+            }
             // create skin
             const skin: ISkin = { joints: [] };
             const inverseBindMatrices: Matrix[] = [];


### PR DESCRIPTION
If for any reason, skeletons.length is corrupted, then exported GLTF was invalid. This is a very unlikely situation, but because of the public nature of the serializer, putting a guard in place is always usefull 