### PR TITLE
Skip modifications of babylon CDN web requests

### DIFF
--- a/packages/dev/core/src/Misc/webRequest.ts
+++ b/packages/dev/core/src/Misc/webRequest.ts
@@ -35,8 +35,10 @@ export class WebRequest implements IWebRequest {
 
     public static SkipRequestModificationForBabylonCDN = true;
 
+    private _requestURL: string = "";
+
     private _injectCustomRequestHeaders(): void {
-        if (this._shouldSkipRequestModifications(this.responseURL)) {
+        if (this._shouldSkipRequestModifications(this._requestURL)) {
             return;
         }
         for (const key in WebRequest.CustomRequestHeaders) {
@@ -181,6 +183,8 @@ export class WebRequest implements IWebRequest {
         // Clean url
         url = url.replace("file:http:", "http:");
         url = url.replace("file:https:", "https:");
+
+        this._requestURL = url;
 
         return this._xhr.open(method, url, true);
     }

--- a/packages/dev/core/src/Misc/webRequest.ts
+++ b/packages/dev/core/src/Misc/webRequest.ts
@@ -33,13 +33,22 @@ export class WebRequest implements IWebRequest {
      */
     public static CustomRequestModifiers = new Array<(request: XMLHttpRequest, url: string) => void>();
 
+    public static SkipRequestModificationForBabylonCDN = true;
+
     private _injectCustomRequestHeaders(): void {
+        if (this._shouldSkipRequestModifications(this.responseURL)) {
+            return;
+        }
         for (const key in WebRequest.CustomRequestHeaders) {
             const val = WebRequest.CustomRequestHeaders[key];
             if (val) {
                 this._xhr.setRequestHeader(key, val);
             }
         }
+    }
+
+    private _shouldSkipRequestModifications(url: string): boolean {
+        return WebRequest.SkipRequestModificationForBabylonCDN && (url.includes("preview.babylonjs.com") || url.includes("cdn.babylonjs.com"));
     }
 
     /**
@@ -163,6 +172,9 @@ export class WebRequest implements IWebRequest {
      */
     public open(method: string, url: string): void {
         for (const update of WebRequest.CustomRequestModifiers) {
+            if (this._shouldSkipRequestModifications(url)) {
+                return;
+            }
             update(this._xhr, url);
         }
 


### PR DESCRIPTION
When setting headers and loading files from our CDN, the CDN throws a 405 error and refuses to send the file.
Apart from making sure our CDN is configured correctly, we should also ignore modifications of web requests sent to either one of our CDNs. No headers should be sent to the CDNs, only simple GET (and OPTIONS) requests