### PR TITLE
Fix BoundingBoxGizmo rotate incorrectly when using RightHand system.

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -358,6 +358,11 @@ export class BoundingBoxGizmo extends Gizmo {
 
                         // Rotate around center of bounding box
                         this._anchorMesh.addChild(this.attachedMesh, Gizmo.PreserveScaling);
+                        if (this._anchorMesh.getScene().useRightHandedSystem) {
+                            this._tmpQuaternion.x *= -1;
+                            this._tmpQuaternion.y *= -1;
+                            this._tmpQuaternion.z *= -1;
+                        }
                         this._anchorMesh.rotationQuaternion!.multiplyToRef(this._tmpQuaternion, this._anchorMesh.rotationQuaternion!);
                         this._anchorMesh.removeChild(this.attachedMesh, Gizmo.PreserveScaling);
                         this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);


### PR DESCRIPTION
This PR fix a bug of BoundingBoxGizmo. when scene.useRightHandedSystem = true, BoundingBoxGizmo rotate to opposite direction.
Related issue: [https://forum.babylonjs.com/t/bounding-box-gizmo-rotate-incorrectly-when-scene-is-using-right-hand-system/30206](url)
Playground: [https://playground.babylonjs.com/#SG9ZZB#15](url)