### PR TITLE
Fix: NME TBNBlock world input doesn't work if connected to a vertex node

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/index.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/index.ts
@@ -6,4 +6,3 @@ export * from "./currentScreenBlock";
 export * from "./sceneDepthBlock";
 export * from "./imageSourceBlock";
 export * from "./clipPlanesBlock";
-export * from "./TBNBlock";

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
@@ -19,11 +19,11 @@ export class TBNBlock extends NodeMaterialBlock {
      * @param name defines the block name
      */
     public constructor(name: string) {
-        super(name, NodeMaterialBlockTargets.VertexAndFragment, true);
+        super(name, NodeMaterialBlockTargets.Fragment, true);
 
-        this.registerInput("normal", NodeMaterialBlockConnectionPointTypes.Vector4, false, NodeMaterialBlockTargets.Fragment);
+        this.registerInput("normal", NodeMaterialBlockConnectionPointTypes.Vector4, false);
         this.normal.acceptedConnectionPointTypes.push(NodeMaterialBlockConnectionPointTypes.Vector3);
-        this.registerInput("tangent", NodeMaterialBlockConnectionPointTypes.Vector4, false, NodeMaterialBlockTargets.Fragment);
+        this.registerInput("tangent", NodeMaterialBlockConnectionPointTypes.Vector4, false);
         this.registerInput("world", NodeMaterialBlockConnectionPointTypes.Matrix, false);
 
         this.registerOutput(
@@ -83,7 +83,7 @@ export class TBNBlock extends NodeMaterialBlock {
     }
 
     public get target() {
-        return NodeMaterialBlockTargets.VertexAndFragment;
+        return NodeMaterialBlockTargets.Fragment;
     }
 
     public set target(value: NodeMaterialBlockTargets) {}

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/index.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/index.ts
@@ -8,3 +8,4 @@ export * from "./fragCoordBlock";
 export * from "./screenSizeBlock";
 export * from "./screenSpaceBlock";
 export * from "./twirlBlock";
+export * from "./TBNBlock";

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -12,7 +12,7 @@ import type { Scene } from "../../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../nodeMaterialDecorator";
 import type { TextureBlock } from "../Dual/textureBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import { TBNBlock } from "../Dual/TBNBlock";
+import { TBNBlock } from "./TBNBlock";
 
 import "../../../../Shaders/ShadersInclude/bumpFragmentMainFunctions";
 import "../../../../Shaders/ShadersInclude/bumpFragmentFunctions";

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -8,7 +8,7 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import { TBNBlock } from "../Dual/TBNBlock";
+import { TBNBlock } from "../Fragment/TBNBlock";
 
 /**
  * Block used to implement the anisotropy module of the PBR material

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
@@ -18,7 +18,7 @@ import type { PBRMetallicRoughnessBlock } from "./pbrMetallicRoughnessBlock";
 import type { PerturbNormalBlock } from "../Fragment/perturbNormalBlock";
 import { PBRClearCoatConfiguration } from "../../../PBR/pbrClearCoatConfiguration";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../nodeMaterialDecorator";
-import { TBNBlock } from "../Dual/TBNBlock";
+import { TBNBlock } from "../Fragment/TBNBlock";
 
 /**
  * Block used to implement the clear coat module of the PBR material

--- a/packages/tools/nodeEditor/src/blockTools.ts
+++ b/packages/tools/nodeEditor/src/blockTools.ts
@@ -42,7 +42,7 @@ import { LightInformationBlock } from "core/Materials/Node/Blocks/Vertex/lightIn
 import { MaxBlock } from "core/Materials/Node/Blocks/maxBlock";
 import { MinBlock } from "core/Materials/Node/Blocks/minBlock";
 import { PerturbNormalBlock } from "core/Materials/Node/Blocks/Fragment/perturbNormalBlock";
-import { TBNBlock } from "core/Materials/Node/Blocks/Dual/TBNBlock";
+import { TBNBlock } from "core/Materials/Node/Blocks/Fragment/TBNBlock";
 import { LengthBlock } from "core/Materials/Node/Blocks/lengthBlock";
 import { DistanceBlock } from "core/Materials/Node/Blocks/distanceBlock";
 import { FrontFacingBlock } from "core/Materials/Node/Blocks/Fragment/frontFacingBlock";


### PR DESCRIPTION
This fixes: https://forum.babylonjs.com/t/nme-tbnblock-world-input-doesnt-work-if-connected-to-another-vertex-node-block/30322

Whole TNBBlock is switched to `Fragment` target type as it already kind of was. And moved to Fragment nodes folder where it now belongs.

With this fix in place Playground example [#VL1FPT#8](https://playground.babylonjs.com/#VL1FPT#8) should now work without a shader error.