### PR TITLE
disable antialias in safari 15.4

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -137,6 +137,11 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         }
 
         try {
+            // TODO - remove this once not needed anymore. Spoofing Safari 15.4.X
+            const fixYourBugsAlreadyRegexp = /.*AppleWebKit.*(15.4).*Safari/g;
+            const allowOtherBrowsersAlready = /.*(15.4).*AppleWebKit.*Safari/g;
+            const fixYourBugsAlreadyMatch = navigator.userAgent.match(fixYourBugsAlreadyRegexp) || navigator.userAgent.match(allowOtherBrowsersAlready);
+            const antialias = fixYourBugsAlreadyMatch ? false : undefined;
             // Set up the global object ("window" and "this" for user code).
             // Delete (or rewrite) previous-run globals to avoid confusion.
             const globalObject = window as any;
@@ -168,10 +173,11 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 };
             } else {
                 globalObject.createDefaultEngine = function () {
-                    return new Engine(canvas, true, {
+                    return new Engine(canvas, antialias, {
                         disableWebGL2Support: forceWebGL1,
                         preserveDrawingBuffer: true,
                         stencil: true,
+                        antialias
                     });
                 };
             }

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -58,10 +58,11 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
 
     async initEngine() {
         const useWebGPU = location.href.indexOf("webgpu") !== -1 && !!(navigator as any).gpu;
-        // TODO - remove this once not needed anymore. Spoofig Safari 15.4
-        const fixYourBugsAlreadyRegexp = /AppleWebKit\/[\d\.]+\s+\(.+\)\s+Version\/(1[0-9]|[2-9][0-9]|\d{3,})\.(\d+)/g;
-        const fixYourBugsAlreadyMatch = fixYourBugsAlreadyRegexp.exec(navigator.userAgent);
-        const disableAntialiasOnThisVersion = fixYourBugsAlreadyMatch && +fixYourBugsAlreadyMatch[1] === 15 && +fixYourBugsAlreadyMatch[2] === 4 ? false : undefined;
+        // TODO - remove this once not needed anymore. Spoofing Safari 15.4.X
+        const fixYourBugsAlreadyRegexp = /.*AppleWebKit.*(15.4).*Safari/g;
+        const allowOtherBrowsersAlready = /.*(15.4).*AppleWebKit.*Safari/g;
+        const fixYourBugsAlreadyMatch = navigator.userAgent.match(fixYourBugsAlreadyRegexp) || navigator.userAgent.match(allowOtherBrowsersAlready);
+        const disableAntialiasOnThisVersion = fixYourBugsAlreadyMatch ? false : undefined;
         const antialias = this.props.globalState.commerceMode ? false : disableAntialiasOnThisVersion;
 
         this._canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;


### PR DESCRIPTION
Fixing #12507

This will match all ua strings that have both AppleWebKit and Safari, and has a reference to the version 15.4

Among others, the following were (positivly) tested:

```
// iOS 15.4.1 Chrome 101
Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/101.0.4951.44 Mobile/15E148 Safari/604.1
// iOS 15.4.1 Safari 15.4.1
Mozilla/5.0 (iPhone; CPU iPhone OS 15_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1

// iPadOS 15.4.1 Chrome 101
Mozilla/5.0 (iPad; CPU OS 15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/101.0.4951.44 Mobile/15E148 Safari/604.1
// iPadOS 15.4.1 Safari 15.4.1
Mozilla/5.0 (iPad; CPU OS 15_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15H321 Safari/604.1

Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15
```