### PR TITLE
InputManager: Fix Picking on PointerUp and add bool to skip pointerup picking

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -824,7 +824,6 @@ export class InputManager {
                     this._initActionManager(null, clickInfo);
                 }
 
-                //let pickResult;
                 if (scene.skipPointerUpPicking) {
                     pickResult = new PickingInfo();
                 } else {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -824,7 +824,7 @@ export class InputManager {
                     this._initActionManager(null, clickInfo);
                 }
 
-                if (scene.skipPointerUpPicking) {
+                if (!pickResult && scene.skipPointerUpPicking) {
                     pickResult = this._currentPickResult;
                 } else {
                     pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -826,6 +826,9 @@ export class InputManager {
                 if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers())) {
                     this._initActionManager(null, clickInfo);
                 }
+                if (!pickResult) {
+                    pickResult = this._currentPickResult;
+                }
 
                 this._processPointerUp(pickResult, evt, clickInfo);
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -824,9 +824,11 @@ export class InputManager {
                     this._initActionManager(null, clickInfo);
                 }
 
-                if (!pickResult && scene.skipPointerUpPicking) {
+                if (!pickResult) {
                     pickResult = this._currentPickResult;
-                } else {
+                }
+
+                if (!scene.skipPointerUpPicking) {
                     pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                     this._currentPickResult = pickResult;
                 }

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -508,7 +508,10 @@ export class InputManager {
         this._deviceSourceManager = new DeviceSourceManager(engine);
 
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
-            if (!this._meshPickProceed) {
+            if (scene.skipPointerDownPicking && scene.skipPointerMovePicking && scene.skipPointerUpPicking) {
+                this._currentPickResult = this._currentPickResult || new PickingInfo();
+            }
+            else if (!this._meshPickProceed) {
                 const pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
                 if (pickResult) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -825,7 +825,7 @@ export class InputManager {
                 }
 
                 if (scene.skipPointerUpPicking) {
-                    pickResult = new PickingInfo();
+                    pickResult = this._currentPickResult;
                 } else {
                     pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                     this._currentPickResult = pickResult;

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -507,12 +507,12 @@ export class InputManager {
         }
         this._deviceSourceManager = new DeviceSourceManager(engine);
 
+        // Because this is only called from _initClickEvent, which is called in _onPointerUp, we'll use the pointerUpPredicate for the pick call
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
-            if (scene.skipPointerDownPicking && scene.skipPointerMovePicking && scene.skipPointerUpPicking) {
-                this._currentPickResult = this._currentPickResult || new PickingInfo();
-            }
-            else if (!this._meshPickProceed) {
-                const pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
+            if (!this._meshPickProceed) {
+                const pickResult = scene.skipPointerUpPicking
+                    ? null
+                    : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
                 if (pickResult) {
                     act = pickResult.hit && pickResult.pickedMesh ? pickResult.pickedMesh._getActionManagerForTrigger() : null;
@@ -825,15 +825,6 @@ export class InputManager {
                 // Meshes
                 if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers())) {
                     this._initActionManager(null, clickInfo);
-                }
-
-                if (!pickResult) {
-                    pickResult = this._currentPickResult;
-                }
-
-                if (!scene.skipPointerUpPicking) {
-                    pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
-                    this._currentPickResult = pickResult;
                 }
 
                 this._processPointerUp(pickResult, evt, clickInfo);

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -405,7 +405,7 @@ export class InputManager {
 
     private _processPointerUp(pickResult: Nullable<PickingInfo>, evt: IPointerEvent, clickInfo: _ClickInfo): void {
         const scene = this._scene;
-        if (pickResult && pickResult && pickResult.pickedMesh) {
+        if (pickResult && pickResult.hit && pickResult.pickedMesh) {
             this._pickedUpMesh = pickResult.pickedMesh;
             if (this._pickedDownMesh === this._pickedUpMesh) {
                 if (scene.onPointerPick) {
@@ -463,7 +463,6 @@ export class InputManager {
 
             if (!clickInfo.ignore) {
                 type = PointerEventTypes.POINTERUP;
-
                 const pi = new PointerInfo(type, evt, pickResult);
                 this._setRayOnPointerInfo(pi);
                 scene.onPointerObservable.notifyObservers(pi, type);
@@ -824,8 +823,13 @@ export class InputManager {
                 if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers())) {
                     this._initActionManager(null, clickInfo);
                 }
-                if (!pickResult) {
-                    pickResult = this._currentPickResult;
+
+                //let pickResult;
+                if (scene.skipPointerUpPicking) {
+                    pickResult = new PickingInfo();
+                } else {
+                    pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
+                    this._currentPickResult = pickResult;
                 }
 
                 this._processPointerUp(pickResult, evt, clickInfo);

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -697,6 +697,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * Gets or sets a predicate used to select candidate meshes for a pointer up event
      */
     public pointerUpPredicate: (Mesh: AbstractMesh) => boolean;
+
     /**
      * Gets or sets a predicate used to select candidate meshes for a pointer move event
      */
@@ -711,6 +712,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer down event occurs.
      */
     public skipPointerDownPicking = false;
+
+    /**
+     * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer up event occurs.
+     */
+    public skipPointerUpPicking = false;
 
     /** Callback called when a pointer move is detected */
     public onPointerMove: (evt: IPointerEvent, pickInfo: PickingInfo, type: PointerEventTypes) => void;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -714,9 +714,9 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public skipPointerDownPicking = false;
 
     /**
-     * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer up event occurs.
+     * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer up event occurs.  Off by default.
      */
-    public skipPointerUpPicking = false;
+    public skipPointerUpPicking = true;
 
     /** Callback called when a pointer move is detected */
     public onPointerMove: (evt: IPointerEvent, pickInfo: PickingInfo, type: PointerEventTypes) => void;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -716,7 +716,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * Gets or sets a boolean indicating if the user want to entirely skip the picking phase when a pointer up event occurs.  Off by default.
      */
-    public skipPointerUpPicking = true;
+    public skipPointerUpPicking = false;
 
     /** Callback called when a pointer move is detected */
     public onPointerMove: (evt: IPointerEvent, pickInfo: PickingInfo, type: PointerEventTypes) => void;


### PR DESCRIPTION
Recently on the forums ([forum post](https://forum.babylonjs.com/t/no-api-to-disable-mesh-picking-for-some-buttons-and-keep-onpointerobservable/29887)), there was a user who found an issue with the pointerUpPredicate not being used by the InputManager properly.  When a dummy predicate was used (`() => false`), there was still a pickedmesh/point in the pickInfo object.  This PR does a couple of things:
- Fix for the picking logic to use the `pointerUpPredicate` and actually call `scene.pick`
- Add a boolean to scene that allows the user to skip picking on pointerup (same as move and down)