### PR TITLE
Fixed easing function links in API docs

### DIFF
--- a/packages/dev/core/src/Animations/easing.ts
+++ b/packages/dev/core/src/Animations/easing.ts
@@ -3,7 +3,7 @@ import { BezierCurve } from "../Maths/math.path";
 /**
  * This represents the main contract an easing function should follow.
  * Easing functions are used throughout the animation system.
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export interface IEasingFunction {
     /**
@@ -19,7 +19,7 @@ export interface IEasingFunction {
 
 /**
  * Base class used for every default easing function.
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class EasingFunction implements IEasingFunction {
     /**
@@ -89,7 +89,7 @@ export class EasingFunction implements IEasingFunction {
 /**
  * Easing function with a circle shape (see link below).
  * @see https://easings.net/#easeInCirc
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class CircleEase extends EasingFunction implements IEasingFunction {
     /**
@@ -105,7 +105,7 @@ export class CircleEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a ease back shape (see link below).
  * @see https://easings.net/#easeInBack
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class BackEase extends EasingFunction implements IEasingFunction {
     /**
@@ -133,7 +133,7 @@ export class BackEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a bouncing shape (see link below).
  * @see https://easings.net/#easeInBounce
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class BounceEase extends EasingFunction implements IEasingFunction {
     /**
@@ -180,7 +180,7 @@ export class BounceEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a power of 3 shape (see link below).
  * @see https://easings.net/#easeInCubic
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class CubicEase extends EasingFunction implements IEasingFunction {
     /**
@@ -195,7 +195,7 @@ export class CubicEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with an elastic shape (see link below).
  * @see https://easings.net/#easeInElastic
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class ElasticEase extends EasingFunction implements IEasingFunction {
     /**
@@ -234,7 +234,7 @@ export class ElasticEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with an exponential shape (see link below).
  * @see https://easings.net/#easeInExpo
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class ExponentialEase extends EasingFunction implements IEasingFunction {
     /**
@@ -265,7 +265,7 @@ export class ExponentialEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a power shape (see link below).
  * @see https://easings.net/#easeInQuad
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class PowerEase extends EasingFunction implements IEasingFunction {
     /**
@@ -293,7 +293,7 @@ export class PowerEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a power of 2 shape (see link below).
  * @see https://easings.net/#easeInQuad
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class QuadraticEase extends EasingFunction implements IEasingFunction {
     /**
@@ -308,7 +308,7 @@ export class QuadraticEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a power of 4 shape (see link below).
  * @see https://easings.net/#easeInQuart
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class QuarticEase extends EasingFunction implements IEasingFunction {
     /**
@@ -323,7 +323,7 @@ export class QuarticEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a power of 5 shape (see link below).
  * @see https://easings.net/#easeInQuint
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class QuinticEase extends EasingFunction implements IEasingFunction {
     /**
@@ -338,7 +338,7 @@ export class QuinticEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a sin shape (see link below).
  * @see https://easings.net/#easeInSine
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class SineEase extends EasingFunction implements IEasingFunction {
     /**
@@ -353,7 +353,7 @@ export class SineEase extends EasingFunction implements IEasingFunction {
 /**
  * Easing function with a bezier shape (see link below).
  * @see http://cubic-bezier.com/#.17,.67,.83,.67
- * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
+ * @see https://doc.babylonjs.com/divingDeeper/animation/advanced_animations#easing-functions
  */
 export class BezierCurveEase extends EasingFunction implements IEasingFunction {
     /**


### PR DESCRIPTION
Ref https://forum.babylonjs.com/t/the-easing-function-link-in-the-api-documentation-may-be-incorrect/30377