### PR TITLE
Fix doc for property "bloomThreshold"

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -190,7 +190,7 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
     }
 
     /**
-     * The strength of the bloom.
+     * The luminance threshold to find bright areas of the image to bloom.
      */
     public set bloomThreshold(value: number) {
         if (this._bloomThreshold === value) {


### PR DESCRIPTION
Fix the documentation for the property [bloomThreshold](https://doc.babylonjs.com/typedoc/classes/babylon.defaultrenderingpipeline#bloomthreshold) to be the same as the documentation for the [BloomEffect property](https://doc.babylonjs.com/typedoc/classes/babylon.bloomeffect#threshold) that it wraps. Currently the documentation is mistakenly copied from the documentation for the [weight](https://doc.babylonjs.com/typedoc/classes/babylon.bloomeffect#weight) property.

https://forum.babylonjs.com/t/white-texture-seems-overexposure-if-open-bloom-post-process/30384/8