### PR TITLE
Add Safari 15.4 to Exception list

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -129,7 +129,6 @@ export interface EngineOptions extends WebGLContextAttributes {
      * Defines that engine should ignore context lost events
      * If this event happens when this parameter is true, you will have to reload the page to restore rendering
      */
-
     doNotHandleContextLost?: boolean;
     /**
      * Defines that engine should ignore modifying touch action attribute and style
@@ -183,6 +182,10 @@ export class ThinEngine {
         { key: "Mac OS.+Chrome/71", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome/72", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
+        // desktop osx safari 15.4
+        { key: ".*AppleWebKit.*(15.4).*Safari", capture: null, captureConstraint: null, targets: ["antialias", "maxMSAASamples"] },
+        // mobile browsers using safari 15.4 on ios
+        { key: ".*(15.4).*AppleWebKit.*Safari", capture: null, captureConstraint: null, targets: ["antialias", "maxMSAASamples"] },
     ];
 
     /** @hidden */
@@ -537,6 +540,7 @@ export class ThinEngine {
 
     private _nextFreeTextureSlots = new Array<number>();
     private _maxSimultaneousTextures = 0;
+    private _maxMSAASamplesOverride: Nullable<number> = null;
 
     private _activeRequests = new Array<IFileRequest>();
 
@@ -857,6 +861,12 @@ export class ThinEngine {
                                     break;
                                 case "vao":
                                     this.disableVertexArrayObjects = true;
+                                    break;
+                                case "antialias":
+                                    options.antialias = false;
+                                    break;
+                                case "maxMSAASamples":
+                                    this._maxMSAASamplesOverride = 1;
                                     break;
                             }
                         }
@@ -1227,7 +1237,7 @@ export class ThinEngine {
         // Draw buffers
         if (this._webGLVersion > 1) {
             this._caps.drawBuffersExtension = true;
-            this._caps.maxMSAASamples = this._gl.getParameter(this._gl.MAX_SAMPLES);
+            this._caps.maxMSAASamples = this._maxMSAASamplesOverride !== null ? this._maxMSAASamplesOverride : this._gl.getParameter(this._gl.MAX_SAMPLES);
         } else {
             const drawBuffersExtension = this._gl.getExtension("WEBGL_draw_buffers");
 

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -137,11 +137,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         }
 
         try {
-            // TODO - remove this once not needed anymore. Spoofing Safari 15.4.X
-            const fixYourBugsAlreadyRegexp = /.*AppleWebKit.*(15.4).*Safari/g;
-            const allowOtherBrowsersAlready = /.*(15.4).*AppleWebKit.*Safari/g;
-            const fixYourBugsAlreadyMatch = navigator.userAgent.match(fixYourBugsAlreadyRegexp) || navigator.userAgent.match(allowOtherBrowsersAlready);
-            const antialias = fixYourBugsAlreadyMatch ? false : undefined;
             // Set up the global object ("window" and "this" for user code).
             // Delete (or rewrite) previous-run globals to avoid confusion.
             const globalObject = window as any;
@@ -173,11 +168,10 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 };
             } else {
                 globalObject.createDefaultEngine = function () {
-                    return new Engine(canvas, antialias, {
+                    return new Engine(canvas, true, {
                         disableWebGL2Support: forceWebGL1,
                         preserveDrawingBuffer: true,
                         stencil: true,
-                        antialias,
                     });
                 };
             }

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -59,11 +59,7 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
     async initEngine() {
         const useWebGPU = location.href.indexOf("webgpu") !== -1 && !!(navigator as any).gpu;
         // TODO - remove this once not needed anymore. Spoofing Safari 15.4.X
-        const fixYourBugsAlreadyRegexp = /.*AppleWebKit.*(15.4).*Safari/g;
-        const allowOtherBrowsersAlready = /.*(15.4).*AppleWebKit.*Safari/g;
-        const fixYourBugsAlreadyMatch = navigator.userAgent.match(fixYourBugsAlreadyRegexp) || navigator.userAgent.match(allowOtherBrowsersAlready);
-        const disableAntialiasOnThisVersion = fixYourBugsAlreadyMatch ? false : undefined;
-        const antialias = this.props.globalState.commerceMode ? false : disableAntialiasOnThisVersion;
+        const antialias = this.props.globalState.commerceMode ? false : undefined;
 
         this._canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
         if (useWebGPU) {


### PR DESCRIPTION
This adds two regexp to the exception list, setting antialia off and maxMSAASamples to 1 on safari 15.4 browsers.
It ain't pretty. But it'll fix a lot of issues with this version of safari.