### PR TITLE
More fix for glTF loader skinning code

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -71,7 +71,6 @@ import type { IDataBuffer } from "core/Misc/dataReader";
 import { DecodeBase64UrlToBinary, IsBase64DataUrl, LoadFileError } from "core/Misc/fileTools";
 import { Logger } from "core/Misc/logger";
 import type { Light } from "core/Lights/light";
-
 import { BoundingInfo } from "core/Culling/boundingInfo";
 import { StringTools } from "core/Misc/stringTools";
 import type { AssetContainer } from "core/assetContainer";
@@ -800,16 +799,12 @@ export class GLTFLoader implements IGLTFLoader {
                     this._loadMeshAsync(`/meshes/${mesh.index}`, node, mesh, (babylonTransformNode) => {
                         const babylonTransformNodeForSkin = node._babylonTransformNodeForSkin!;
 
-                        // Duplicate the metadata from the skin node to the skinned mesh in case any loader extension added metadata.
-                        babylonTransformNode.metadata = babylonTransformNodeForSkin.metadata;
-
                         // Add a reference to the skinned mesh from the transform node.
-                        babylonTransformNodeForSkin.metadata.gltf.skinnedMesh = babylonTransformNode;
+                        const gltf = babylonTransformNodeForSkin.metadata.gltf;
+                        gltf.skinnedMesh = babylonTransformNode;
                         babylonTransformNode.onDisposeObservable.addOnce(() => {
-                            if (babylonTransformNodeForSkin.metadata && babylonTransformNodeForSkin.metadata.gltf) {
-                                // Delete the reference when the skinned mesh is disposed.
-                                delete babylonTransformNodeForSkin.metadata.gltf.skinnedMesh;
-                            }
+                            // Delete the reference when the skinned mesh is disposed.
+                            delete gltf.skinnedMesh;
                         });
 
                         const skin = ArrayItem.Get(`${context}/skin`, this._gltf.skins, node.skin);


### PR DESCRIPTION
Previous code still had some weird issues as pointed out by the forum: https://forum.babylonjs.com/t/assetcontainer-dispose-throws-typeerror-r-metadata-is-null/30360/9