### PR TITLE
Fixed Logic for FreeCameraTouchInput to properly detect when input is mouse input

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -76,9 +76,9 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             this._pointerInput = (p) => {
                 const evt = <IPointerEvent>p.event;
 
-                const isMouseEvent = !this.camera.getEngine().hostInformation.isMobile && evt instanceof MouseEvent;
+                const isMouseEvent = evt.pointerType === "mouse";
 
-                if (!this.allowMouse && (evt.pointerType === "mouse" || isMouseEvent)) {
+                if (!this.allowMouse && isMouseEvent) {
                     return;
                 }
 


### PR DESCRIPTION
A user in the forums found that there was no touch input working with the universal camera, which uses FreeCameraTouchInput as part of its attached inputs.  Upon closer inspection, it was determined that the logic that was used to detect if the input was from a mouse or not was incorrect.  It originally said that if the browser was a not from mobile browser and if the event was an instance of MouseEvent, that it was from the mouse.  The new logic just checks the pointer type and uses that, which is a much more reliable method and also works with touch devices using non-mobile browsers.