### PR TITLE
fix default material to use vertex alpha for thin instances

### DIFF
--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -310,7 +310,7 @@ vec4 reflectionColor = vec4(0., 0., 0., 1.);
 
 #endif
 
-#ifdef VERTEXALPHA
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR)
 	alpha *= vColor.a;
 #endif
 


### PR DESCRIPTION
Fix default material to use vertex alpha for thin instances

Forum issue: https://forum.babylonjs.com/t/different-transparency-while-using-thin-instances/30574