### PR TITLE
Allow HDR texture types in DepthOfFieldBlurPostProcess

### DIFF
--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -33,7 +33,7 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
     }
 
     /**
-     * Creates a new instance CircleOfConfusionPostProcess
+     * Creates a new instance DepthOfFieldBlurPostProcess
      * @param name The name of the effect.
      * @param scene The scene the effect belongs to.
      * @param direction The direction the blur should be applied.
@@ -73,8 +73,7 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
             (samplingMode = Constants.TEXTURE_BILINEAR_SAMPLINGMODE),
             engine,
             reusable,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            (textureType = Constants.TEXTURETYPE_UNSIGNED_INT),
+            textureType,
             `#define DOF 1\r\n`,
             blockCompilation
         );


### PR DESCRIPTION
This increases the quality of the depth of field effect (note the banding in the before image below), but it comes with a slight perf cost since the intermediate blur textures are now an HDR texture format instead of RGBA8.

![image](https://user-images.githubusercontent.com/20366429/169629876-195e808a-3359-40dd-96c3-27ab76bb965c.png)
