### PR TITLE
Fix ThinEngine.updateDynamicIndexBuffer

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
@@ -32,11 +32,11 @@ ThinEngine.prototype.updateDynamicIndexBuffer = function (this: ThinEngine, inde
 
     if (indexBuffer.is32Bits) {
         // anything else than Uint32Array needs to be converted to Uint32Array
-        arrayBuffer = indices instanceof Uint32Array ? indices : Uint32Array.from(indices)
+        arrayBuffer = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
     }
     else {
         // anything else than Uint16Array needs to be converted to Uint16Array
-        arrayBuffer = indices instanceof Uint16Array ? indices : Uint16Array.from(indices)
+        arrayBuffer = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
     }
 
     this._gl.bufferData(this._gl.ELEMENT_ARRAY_BUFFER, arrayBuffer, this._gl.DYNAMIC_DRAW);

--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
@@ -28,18 +28,18 @@ ThinEngine.prototype.updateDynamicIndexBuffer = function (this: ThinEngine, inde
     // Force cache update
     this._currentBoundBuffer[this._gl.ELEMENT_ARRAY_BUFFER] = null;
     this.bindIndexBuffer(indexBuffer);
-    let arrayBuffer;
 
+    let view: ArrayBufferView;
     if (indexBuffer.is32Bits) {
         // anything else than Uint32Array needs to be converted to Uint32Array
-        arrayBuffer = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
+        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
     }
     else {
         // anything else than Uint16Array needs to be converted to Uint16Array
-        arrayBuffer = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
+        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
     }
 
-    this._gl.bufferData(this._gl.ELEMENT_ARRAY_BUFFER, arrayBuffer, this._gl.DYNAMIC_DRAW);
+    this._gl.bufferData(this._gl.ELEMENT_ARRAY_BUFFER, view, this._gl.DYNAMIC_DRAW);
 
     this._resetIndexBufferBinding();
 };

--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
@@ -31,11 +31,11 @@ ThinEngine.prototype.updateDynamicIndexBuffer = function (this: ThinEngine, inde
     let arrayBuffer;
 
     if (indexBuffer.is32Bits) {
-        // any else than Uint32Array needs to be converted to Uint32Array
+        // anything else than Uint32Array needs to be converted to Uint32Array
         arrayBuffer = indices instanceof Uint32Array ? indices : Uint32Array.from(indices)
     }
     else {
-        // any else than Uint16Array needs to be converted to Uint16Array
+        // anything else than Uint16Array needs to be converted to Uint16Array
         arrayBuffer = indices instanceof Uint16Array ? indices : Uint16Array.from(indices)
     }
 

--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
@@ -30,10 +30,13 @@ ThinEngine.prototype.updateDynamicIndexBuffer = function (this: ThinEngine, inde
     this.bindIndexBuffer(indexBuffer);
     let arrayBuffer;
 
-    if (indices instanceof Uint16Array || indices instanceof Uint32Array) {
-        arrayBuffer = indices;
-    } else {
-        arrayBuffer = indexBuffer.is32Bits ? new Uint32Array(indices) : new Uint16Array(indices);
+    if (indexBuffer.is32Bits) {
+        // any else than Uint32Array needs to be converted to Uint32Array
+        arrayBuffer = indices instanceof Uint32Array ? indices : Uint32Array.from(indices)
+    }
+    else {
+        // any else than Uint16Array needs to be converted to Uint16Array
+        arrayBuffer = indices instanceof Uint16Array ? indices : Uint16Array.from(indices)
     }
 
     this._gl.bufferData(this._gl.ELEMENT_ARRAY_BUFFER, arrayBuffer, this._gl.DYNAMIC_DRAW);

--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicBuffer.ts
@@ -32,11 +32,10 @@ ThinEngine.prototype.updateDynamicIndexBuffer = function (this: ThinEngine, inde
     let view: ArrayBufferView;
     if (indexBuffer.is32Bits) {
         // anything else than Uint32Array needs to be converted to Uint32Array
-        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
-    }
-    else {
+        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices);
+    } else {
         // anything else than Uint16Array needs to be converted to Uint16Array
-        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
+        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices);
     }
 
     this._gl.bufferData(this._gl.ELEMENT_ARRAY_BUFFER, view, this._gl.DYNAMIC_DRAW);

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.dynamicBuffer.ts
@@ -8,10 +8,9 @@ WebGPUEngine.prototype.updateDynamicIndexBuffer = function (indexBuffer: DataBuf
 
     let view: ArrayBufferView;
     if (indexBuffer.is32Bits) {
-        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
-    }
-    else {
-        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
+        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices);
+    } else {
+        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices);
     }
 
     this._bufferManager.setSubData(gpuBuffer, offset, view);

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.dynamicBuffer.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.dynamicBuffer.ts
@@ -7,24 +7,11 @@ WebGPUEngine.prototype.updateDynamicIndexBuffer = function (indexBuffer: DataBuf
     const gpuBuffer = indexBuffer as WebGPUDataBuffer;
 
     let view: ArrayBufferView;
-    if (indices instanceof Uint16Array) {
-        if (indexBuffer.is32Bits) {
-            view = Uint32Array.from(indices);
-        } else {
-            view = indices;
-        }
-    } else if (indices instanceof Uint32Array) {
-        if (indexBuffer.is32Bits) {
-            view = indices;
-        } else {
-            view = Uint16Array.from(indices);
-        }
-    } else {
-        if (indexBuffer.is32Bits) {
-            view = new Uint32Array(indices);
-        } else {
-            view = new Uint16Array(indices);
-        }
+    if (indexBuffer.is32Bits) {
+        view = indices instanceof Uint32Array ? indices : new Uint32Array(indices)
+    }
+    else {
+        view = indices instanceof Uint16Array ? indices : new Uint16Array(indices)
     }
 
     this._bufferManager.setSubData(gpuBuffer, offset, view);


### PR DESCRIPTION
This is to fix a bug we ran into.

To repro :
- at creation time, provide a mesh with indices of type `Array<number>`  => if all the indies are below 65535, the `Array<number>` is normallized into an `UInt16Array` in `ThinEngine._normalizeIndexData`

- call `Mesh.updateIndices` with a `UInt32Array` => instead of converting to `UInt16Array` as if a `Array<number>` had been passed, the `UInt32Array` is forwarded to WebGL, leading to wrong indexing.

