### PR TITLE
Add missing interpolation to glTF animation key targeting weights

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1679,6 +1679,7 @@ export class GLTFLoader implements IGLTFLoader {
                             inTangent: key.inTangent ? key.inTangent[targetIndex] : undefined,
                             value: key.value[targetIndex],
                             outTangent: key.outTangent ? key.outTangent[targetIndex] : undefined,
+                            interpolation: key.interpolation,
                         }))
                     );
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/gltf-loader-animation-path-weights-ignores-step-interpolation/30719