### PR TITLE
DeviceInputSystem: Add check for matchMedia in WebDeviceInputSystem

### DIFF
--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -231,7 +231,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         }
 
         // If the device in use has mouse capabilities, pre-register mouse
-        if (globalThis.matchMedia && matchMedia("(pointer:fine)").matches) {
+        if (typeof matchMedia === "function" && matchMedia("(pointer:fine)").matches) {
             // This will provide a dummy value for the cursor position and is expected to be overridden when the first mouse event happens.
             // There isn't any good way to get the current position outside of a pointer event so that's why this was done.
             this._addPointerDevice(DeviceType.Mouse, 0, 0, 0);

--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -231,7 +231,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         }
 
         // If the device in use has mouse capabilities, pre-register mouse
-        if (matchMedia("(pointer:fine)").matches) {
+        if (globalThis.matchMedia && matchMedia("(pointer:fine)").matches) {
             // This will provide a dummy value for the cursor position and is expected to be overridden when the first mouse event happens.
             // There isn't any good way to get the current position outside of a pointer event so that's why this was done.
             this._addPointerDevice(DeviceType.Mouse, 0, 0, 0);


### PR DESCRIPTION
A user in the forum recently found an issue where the error `matchMedia is not defined` was occurring in an offscreen canvas.  Because the offscreen canvas was in a worker thread, it had no context of the `Window` interface and the `matchMedia` function.  This PR will add a check in the `WebDeviceInputSystem` to verify the existence of this function before attempting to execute it.

Forum Link: https://forum.babylonjs.com/t/offscreen-canvas-matchmedia/30682/10