### PR TITLE
Make scene param optional for NodeMaterial.ParseFromSnippetAsync

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2055,7 +2055,13 @@ export class NodeMaterial extends PushMaterial {
      * @param skipBuild defines whether to build the node material
      * @returns a promise that will resolve to the new node material
      */
-    public static ParseFromSnippetAsync(snippetId: string, scene: Scene, rootUrl: string = "", nodeMaterial?: NodeMaterial, skipBuild: boolean = false): Promise<NodeMaterial> {
+    public static ParseFromSnippetAsync(
+        snippetId: string,
+        scene: Scene = EngineStore.LastCreatedScene!,
+        rootUrl: string = "",
+        nodeMaterial?: NodeMaterial,
+        skipBuild: boolean = false
+    ): Promise<NodeMaterial> {
         if (snippetId === "_BLANK") {
             return Promise.resolve(this.CreateDefault("blank", scene));
         }


### PR DESCRIPTION
Make scene param optional for NodeMaterial.ParseFromSnippetAsync

Forum: https://forum.babylonjs.com/t/make-scene-param-optional-for-nodematerial-parsefromsnippetasync/30747/7