### PR TITLE
Add missing observer trigger - onLoadedObservable notify method for hdrCubeTexture

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
@@ -603,6 +603,9 @@ ThinEngine.prototype.createRawCubeTextureFromUrl = function (
         // this.resetTextureCache();
         scene?._removePendingData(texture);
 
+        texture.onLoadedObservable.notifyObservers(texture);
+        texture.onLoadedObservable.clear();
+
         if (onLoad) {
             onLoad();
         }


### PR DESCRIPTION
I found a minor issue during loading textures through `add task` of `asset manager`
when I try to load the same texture files several times for different purposes, `cubeTextureTask` can be finished normally but `hdrCubeTextureTask` can't be finished even though it has been already finished

* this playground can show task count on `console`
https://playground.babylonjs.com/#M5L9FH

So, I have debugged and I found the creating function of hdrTexture has lost the `load observable notify` method that is included in the `creating function of cubeTexture`

- `engine.cubeTexture.ts` 
<img width="385" alt="스크린샷 2022-05-30 오후 3 57 43" src="https://user-images.githubusercontent.com/70849655/170935258-89b47f42-e6a3-4366-bde0-003f602b558e.png">
<img width="473" alt="스크린샷 2022-05-30 오후 3 57 36" src="https://user-images.githubusercontent.com/70849655/170935273-108c1e51-48bf-4190-bcec-a38084b0ddb2.png">

- `engine.rawTexture.ts`
<img width="820" alt="스크린샷 2022-05-30 오후 3 57 57" src="https://user-images.githubusercontent.com/70849655/170935403-edc25ad8-6a49-417f-bf9b-f6a6d9a0fbfd.png">
<img width="452" alt="스크린샷 2022-05-30 오후 3 59 26" src="https://user-images.githubusercontent.com/70849655/170935417-11a8b868-e752-4451-982f-4e99ad92b7c1.png">

I add above code in `raw texture` and then it worked well
![스크린샷 2022-05-30 오후 4 06 10](https://user-images.githubusercontent.com/70849655/170936119-0438806d-e447-4027-ab92-7540e4c3c65e.png)
