### PR TITLE
Grid children disappear once linked mesh is outside view

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -142,6 +142,7 @@ export class Container extends Control {
 
     public _flagDescendantsAsMatrixDirty(): void {
         for (const child of this.children) {
+            child._isClipped = false;
             child._markMatrixAsDirty();
         }
     }


### PR DESCRIPTION
Fixes #12602
This forces resetting the clipping state of children when their matrix is set as dirty.