### PR TITLE
[XR] No need to clear (depth) in utility layer

### DIFF
--- a/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
+++ b/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
@@ -326,10 +326,6 @@ export class UtilityLayerRenderer implements IDisposable {
         this._afterRenderObserver = this.originalScene.onAfterCameraRenderObservable.add((camera) => {
             // Only render when the render camera finishes rendering
             if (this.shouldRender && camera == this.getRenderCamera()) {
-                if (camera.outputRenderTarget && camera.isRigCamera) {
-                    // clear depth for the utility layer to render correctly
-                    this.originalScene.getEngine().clear(null, false, true, false);
-                }
                 this.render();
             }
         });


### PR DESCRIPTION
This scene fails when in XR:

https://playground.babylonjs.com/#HJZBRG#253

Forum reference - https://forum.babylonjs.com/t/button3d-in-vr-is-rendered-on-top-of-everything/30772

I am not 100% sure why it was needed until now, so I am going to wait for reviews first before merging this.