### PR TITLE
Disallow users to change the frame of the first key, ensuring that th…

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/controls/textInputComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/controls/textInputComponent.tsx
@@ -12,6 +12,7 @@ interface ITextInputComponentProps {
     isNumber?: boolean;
     complement?: string;
     onValueAsNumberChanged?: (value: number, isFocused: boolean) => void;
+    disabled?: boolean;
 }
 
 interface ITextInputComponentState {
@@ -103,6 +104,7 @@ export class TextInputComponent extends React.Component<ITextInputComponentProps
                 onKeyPress={(evt) => this._onKeyPress(evt)}
                 value={(this.state.value || "") + (!this.state.isFocused && this.props.complement ? this.props.complement : "")}
                 id={this.props.id}
+                disabled={this.props.disabled}
             ></input>
         );
     }

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/rangeFrameBarComponent.tsx
@@ -128,7 +128,7 @@ export class RangeFrameBarComponent extends React.Component<IRangeFrameBarCompon
     }
 
     private _buildActiveFrame() {
-        if (this.props.context.activeFrame !== null && this.props.context.activeFrame !== undefined) {
+        if (this.props.context.activeFrame === null || this.props.context.activeFrame === undefined) {
             return null;
         }
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/scss/curveEditor.scss
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/scss/curveEditor.scss
@@ -75,5 +75,10 @@
         &:focus {
             outline: none;
         }
+
+        &:disabled {
+            background: #444444;
+            border: #555555 solid 1px;
+        }
     }
 }

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/topBarComponent.tsx
@@ -97,9 +97,14 @@ export class TopBarComponent extends React.Component<ITopBarComponentProps, ITop
                     value={this.state.keyFrameValue}
                     tooltip="Frame"
                     id="key-frame"
-                    onValueAsNumberChanged={(newValue) => this.props.context.onFrameManuallyEntered.notifyObservers(newValue)}
+                    onValueAsNumberChanged={(newValue) => {
+                        if (newValue !== 0) {
+                            this.props.context.onFrameManuallyEntered.notifyObservers(newValue);
+                        }
+                    }}
                     globalState={this.props.globalState}
                     context={this.props.context}
+                    disabled={parseFloat(this.state.keyFrameValue) === 0}
                 />
                 <TextInputComponent
                     className={hasActiveAnimations && this.state.valueControlEnabled ? "" : "disabled"}


### PR DESCRIPTION
…ere is always a frame at 0. It was already not possible to drag the first frame outside of 0, but this covers the top bar input.