### PR TITLE
Force createGlobalSubmesh in Mesh.SetVerticesData if Mesh is Unindexed

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -308,7 +308,7 @@ export class Geometry implements IGetSetVerticesData {
             for (let index = 0; index < numOfMeshes; index++) {
                 const mesh = meshes[index];
                 mesh.buildBoundingInfo(this._extend.minimum, this._extend.maximum);
-                mesh._createGlobalSubMesh(false);
+                mesh._createGlobalSubMesh(mesh.isUnIndexed);
                 mesh.computeWorldMatrix(true);
                 mesh.synchronizeInstances();
             }
@@ -732,7 +732,7 @@ export class Geometry implements IGetSetVerticesData {
                 }
                 mesh.buildBoundingInfo(this._extend.minimum, this._extend.maximum);
 
-                mesh._createGlobalSubMesh(false);
+                mesh._createGlobalSubMesh(mesh.isUnIndexed);
 
                 //bounding info was just created again, world matrix should be applied again.
                 mesh._updateBoundingInfo();


### PR DESCRIPTION
This a a fix for the bug reported in the forum here : https://forum.babylonjs.com/t/bug-when-calling-setverticesdata-on-a-unindexed-mesh/31009

repro here : https://www.babylonjs-playground.com/#JX7SUF