### PR TITLE
Fix where canvas could have a blue highlight effect on tap.

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1973,6 +1973,7 @@ export class Engine extends ThinEngine {
         this._renderingCanvas.setAttribute("touch-action", "none");
         this._renderingCanvas.style.touchAction = "none";
         (this._renderingCanvas.style as any).msTouchAction = "none";
+        (this._renderingCanvas.style as any).webkitTapHighlightColor = 'transparent';
     }
 
     // Loading screen

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1973,7 +1973,7 @@ export class Engine extends ThinEngine {
         this._renderingCanvas.setAttribute("touch-action", "none");
         this._renderingCanvas.style.touchAction = "none";
         (this._renderingCanvas.style as any).msTouchAction = "none";
-        (this._renderingCanvas.style as any).webkitTapHighlightColor = 'transparent';
+        (this._renderingCanvas.style as any).webkitTapHighlightColor = "transparent";
     }
 
     // Loading screen


### PR DESCRIPTION
For #12634.

Added a line to also disable the webkitTapHighlight when touch actions are disabled.