### PR TITLE
Support for extracting bloom highlights with luminance >1

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -3,6 +3,8 @@ const float HALF_MIN = 5.96046448e-08; // Smallest positive half.
 
 const float LinearEncodePowerApprox = 2.2;
 const float GammaEncodePowerApprox = 1.0 / LinearEncodePowerApprox;
+
+// The luminance weights used below are for a linear encoded color, not a gamma-corrected color.
 const vec3 LuminanceEncodeApprox = vec3(0.2126, 0.7152, 0.0722);
 
 const float Epsilon = 0.0000001;
@@ -88,6 +90,7 @@ float pow5(float value) {
     return sq * sq * value;
 }
 
+// Returns the saturated luminance. Assumes input color is linear encoded, not gamma-corrected.
 float getLuminance(vec3 color)
 {
     return clamp(dot(color, LuminanceEncodeApprox), 0., 1.);

--- a/packages/dev/core/src/Shaders/extractHighlights.fragment.fx
+++ b/packages/dev/core/src/Shaders/extractHighlights.fragment.fx
@@ -12,6 +12,6 @@ uniform float exposure;
 void main(void) 
 {
 	gl_FragColor = texture2D(textureSampler, vUV);
-	float luma = getLuminance(gl_FragColor.rgb * exposure);
+	float luma = dot(LuminanceEncodeApprox, gl_FragColor.rgb * exposure);
 	gl_FragColor.rgb = step(threshold, luma) * gl_FragColor.rgb;
 }


### PR DESCRIPTION
This is useful for HDR bloom, where the desired, exposed luminance threshold could be greater than 1.