### PR TITLE
Fix pointer hover on descendant controls when action manager is recursive

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -205,13 +205,10 @@ export class InputManager {
         if (isMeshPicked) {
             scene.setPointerOverMesh(pickResult!.pickedMesh, evt.pointerId, pickResult);
 
-            if (this._pointerOverMesh && this._pointerOverMesh.actionManager && this._pointerOverMesh.actionManager.hasPointerTriggers) {
-                if (!scene.doNotHandleCursors && canvas) {
-                    if (this._pointerOverMesh.actionManager.hoverCursor) {
-                        canvas.style.cursor = this._pointerOverMesh.actionManager.hoverCursor;
-                    } else {
-                        canvas.style.cursor = scene.hoverCursor;
-                    }
+            if (!scene.doNotHandleCursors && canvas && this._pointerOverMesh) {
+                const actionManager = this._pointerOverMesh._getActionManagerForTrigger();
+                if (actionManager && actionManager.hasPointerTriggers) {
+                    canvas.style.cursor = actionManager.hoverCursor || scene.hoverCursor;
                 }
             }
         } else {


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/hovercursor-does-not-change-when-hovering-child-elements/31104
Playground: https://playground.babylonjs.com/#68S8IM