### PR TITLE
Add custom attributes for material plugins

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1449,6 +1449,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         this._eventInfo.fallbackRank = fallbackRank;
         this._eventInfo.defines = defines;
         this._eventInfo.uniforms = uniforms;
+        this._eventInfo.attributes = attribs;
         this._eventInfo.samplers = samplers;
         this._eventInfo.uniformBuffersNames = uniformBuffers;
         this._eventInfo.customCode = undefined;

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -235,6 +235,13 @@ export class MaterialPluginBase {
     public getSamplers(samplers: string[]): void {}
 
     /**
+     * Gets the attributes used by the plugin.
+     * @param attributes list that the attribute names should be added to.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public getAttributes(attributes: string[]): void {}
+
+    /**
      * Gets the uniform buffers names added by the plugin.
      * @param ubos list that the ubo names should be added to.
      */

--- a/packages/dev/core/src/Materials/materialPluginEvent.ts
+++ b/packages/dev/core/src/Materials/materialPluginEvent.ts
@@ -42,6 +42,7 @@ export type MaterialPluginPrepareEffect = {
     fallbacks: EffectFallbacks;
     fallbackRank: number;
     customCode?: ShaderCustomProcessingFunction;
+    attributes: string[];
     uniforms: string[];
     samplers: string[];
     uniformBuffersNames: string[];

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -246,6 +246,7 @@ export class MaterialPluginManager {
                 const eventData = info as MaterialPluginPrepareEffect;
                 for (const plugin of this._activePlugins) {
                     eventData.fallbackRank = plugin.addFallbacks(eventData.defines, eventData.fallbacks, eventData.fallbackRank);
+                    plugin.getAttributes(eventData.attributes);
                 }
                 if (this._uniformList.length > 0) {
                     eventData.uniforms.push(...this._uniformList);

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1364,6 +1364,7 @@ export class StandardMaterial extends PushMaterial {
             this._eventInfo.fallbackRank = 0;
             this._eventInfo.defines = defines;
             this._eventInfo.uniforms = uniforms;
+            this._eventInfo.attributes = attribs;
             this._eventInfo.samplers = samplers;
             this._eventInfo.uniformBuffersNames = uniformBuffers;
             this._eventInfo.customCode = undefined;

--- a/packages/dev/core/src/Misc/computePressure.ts
+++ b/packages/dev/core/src/Misc/computePressure.ts
@@ -27,9 +27,10 @@ export class ComputePressureObserverWrapper {
      * Method that must be called to begin observing changes, and triggering callbacks.
      */
     observe(): void {
-        this._observer?.observe && this._observer?.observe().catch(() => {
-            // Ignore error
-        });
+        this._observer?.observe &&
+            this._observer?.observe().catch(() => {
+                // Ignore error
+            });
     }
 
     /**


### PR DESCRIPTION
Allow material plugins to implement the method getAttributes which pushes the plugin's attribute names onto the array passed to it, similar to the getSamplers function.

Forum discussion: https://forum.babylonjs.com/t/using-custom-attribute-with-material-plugin/31142/3
Test PG: https://playground.babylonjs.com/#UIXTIF