### PR TITLE
Prepare plugin defines after material helper defines

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
@@ -95,7 +95,7 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
         return true;
     }
 
-    public prepareDefines(defines: MaterialAnisotropicDefines, scene: Scene, mesh: AbstractMesh): void {
+    public prepareDefinesBeforeAttributes(defines: MaterialAnisotropicDefines, scene: Scene, mesh: AbstractMesh): void {
         if (this._isEnabled) {
             defines.ANISOTROPIC = this._isEnabled;
             if (this._isEnabled && !mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1818,17 +1818,17 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             defines.UNLIT = this._unlit || ((this.pointsCloud || this.wireframe) && !mesh.isVerticesDataPresent(VertexBuffer.NormalKind));
             defines.DEBUGMODE = this._debugMode;
         }
-
-        // External config
-        this._eventInfo.defines = defines;
-        this._eventInfo.mesh = mesh;
-        this._callbackPluginEventPrepareDefines(this._eventInfo);
-
+        
         // Values that need to be evaluated on every frame
         MaterialHelper.PrepareDefinesForFrameBoundValues(scene, engine, defines, useInstances ? true : false, useClipPlane, useThinInstances);
 
         // Attribs
         MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, true, true, this._transparencyMode !== PBRBaseMaterial.PBRMATERIAL_OPAQUE);
+
+        // External config
+        this._eventInfo.defines = defines;
+        this._eventInfo.mesh = mesh;
+        this._callbackPluginEventPrepareDefines(this._eventInfo);
     }
 
     /**

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1818,7 +1818,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             defines.UNLIT = this._unlit || ((this.pointsCloud || this.wireframe) && !mesh.isVerticesDataPresent(VertexBuffer.NormalKind));
             defines.DEBUGMODE = this._debugMode;
         }
-        
+
         // Values that need to be evaluated on every frame
         MaterialHelper.PrepareDefinesForFrameBoundValues(scene, engine, defines, useInstances ? true : false, useClipPlane, useThinInstances);
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1822,12 +1822,15 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         // Values that need to be evaluated on every frame
         MaterialHelper.PrepareDefinesForFrameBoundValues(scene, engine, defines, useInstances ? true : false, useClipPlane, useThinInstances);
 
+        // External config
+        this._eventInfo.defines = defines;
+        this._eventInfo.mesh = mesh;
+        this._callbackPluginEventPrepareDefinesBeforeAttributes(this._eventInfo);
+
         // Attribs
         MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, true, true, this._transparencyMode !== PBRBaseMaterial.PBRMATERIAL_OPAQUE);
 
         // External config
-        this._eventInfo.defines = defines;
-        this._eventInfo.mesh = mesh;
         this._callbackPluginEventPrepareDefines(this._eventInfo);
     }
 

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -799,7 +799,7 @@ export class Material implements IAnimatable {
     /** @hidden */
     public _callbackPluginEventPrepareDefines: (eventData: MaterialPluginPrepareDefines) => void = () => void 0;
     /** @hidden */
-    public _callbackPluginEventPrepareDefinesBeforeAttributes: (eventData: MaterialPluginPrepareDefines) => void = () => void 0;    
+    public _callbackPluginEventPrepareDefinesBeforeAttributes: (eventData: MaterialPluginPrepareDefines) => void = () => void 0;
     /** @hidden */
     public _callbackPluginEventHardBindForSubMesh: (eventData: MaterialPluginHardBindForSubMesh) => void = () => void 0;
     /** @hidden */

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -799,6 +799,8 @@ export class Material implements IAnimatable {
     /** @hidden */
     public _callbackPluginEventPrepareDefines: (eventData: MaterialPluginPrepareDefines) => void = () => void 0;
     /** @hidden */
+    public _callbackPluginEventPrepareDefinesBeforeAttributes: (eventData: MaterialPluginPrepareDefines) => void = () => void 0;    
+    /** @hidden */
     public _callbackPluginEventHardBindForSubMesh: (eventData: MaterialPluginHardBindForSubMesh) => void = () => void 0;
     /** @hidden */
     public _callbackPluginEventBindForSubMesh: (eventData: MaterialPluginBindForSubMesh) => void = () => void 0;

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -169,6 +169,15 @@ export class MaterialPluginBase {
     }
 
     /**
+     * Sets the defines for the next rendering. Called before MaterialHelper.PrepareDefinesForAttributes is called.
+     * @param defines the list of "defines" to update.
+     * @param scene defines the scene to the material belongs to.
+     * @param mesh the mesh being rendered
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public prepareDefinesBeforeAttributes(defines: MaterialDefines, scene: Scene, mesh: AbstractMesh): void {}
+
+    /**
      * Sets the defines for the next rendering
      * @param defines the list of "defines" to update.
      * @param scene defines the scene to the material belongs to.

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -117,6 +117,7 @@ export class MaterialPluginManager {
             this._activePlugins.sort((a, b) => a.priority - b.priority);
 
             this._material._callbackPluginEventIsReadyForSubMesh = this._handlePluginEventIsReadyForSubMesh.bind(this);
+            this._material._callbackPluginEventPrepareDefinesBeforeAttributes = this._handlePluginEventPrepareDefinesBeforeAttributes.bind(this);
             this._material._callbackPluginEventPrepareDefines = this._handlePluginEventPrepareDefines.bind(this);
             this._material._callbackPluginEventBindForSubMesh = this._handlePluginEventBindForSubMesh.bind(this);
 
@@ -150,6 +151,12 @@ export class MaterialPluginManager {
             isReady = isReady && plugin.isReadyForSubMesh(eventData.defines, this._scene, this._engine, eventData.subMesh);
         }
         eventData.isReadyForSubMesh = isReady;
+    }
+
+    protected _handlePluginEventPrepareDefinesBeforeAttributes(eventData: MaterialPluginPrepareDefines): void {
+        for (const plugin of this._activePlugins) {
+            plugin.prepareDefinesBeforeAttributes(eventData.defines, this._scene, eventData.mesh);
+        }
     }
 
     protected _handlePluginEventPrepareDefines(eventData: MaterialPluginPrepareDefines): void {

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1167,15 +1167,18 @@ export class StandardMaterial extends PushMaterial {
             defines
         );
 
-        // Attribs
-        MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, true, true);
-
         // Values that need to be evaluated on every frame
         MaterialHelper.PrepareDefinesForFrameBoundValues(scene, engine, defines, useInstances, null, subMesh.getRenderingMesh().hasThinInstances);
 
         // External config
         this._eventInfo.defines = defines;
         this._eventInfo.mesh = mesh;
+        this._callbackPluginEventPrepareDefinesBeforeAttributes(this._eventInfo);
+
+        // Attribs
+        MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, true, true);
+
+        // External config        
         this._callbackPluginEventPrepareDefines(this._eventInfo);
 
         // Get correct effect

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1178,7 +1178,7 @@ export class StandardMaterial extends PushMaterial {
         // Attribs
         MaterialHelper.PrepareDefinesForAttributes(mesh, defines, true, true, true);
 
-        // External config        
+        // External config
         this._callbackPluginEventPrepareDefines(this._eventInfo);
 
         // Get correct effect


### PR DESCRIPTION
For PBRBaseMaterial, this PR moves the call to _callbackPluginEventPrepareDefines to right after the calls to PrepareDefinesForFrameBoundValues and PrepareDefinesForAttributes instead of right before them. This way values set by the plugin for these defines won't be overwritten by these MaterialHelper functions. For StandardMaterial this is already the case (_callbackPluginEventPrepareDefines is called right after them).

Since the anisotropy plugin is relying on the current order of these function calls, PrepareDefinesBeforeAttributes was added to allow defines to be set right before MaterialHelper.PrepareDefinesForAttributes is called.

Forum: https://forum.babylonjs.com/t/pbrbasematerial-overwrites-plugins-defines/31262
Test PG: https://playground.babylonjs.com/#UIXTIF#6