### PR TITLE
Camera: Added divide by zero check FreeCameraTouchInput

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -190,7 +190,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
         } else {
             const speed = camera._computeLocalCameraSpeed();
-            const direction = new Vector3(0, 0, (speed * this._offsetY) / this.touchMoveSensibility);
+            const direction = new Vector3(0, 0, (this.touchMoveSensibility !== 0 ? (speed * this._offsetY) / this.touchMoveSensibility : 0));
 
             Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, camera._cameraRotationMatrix);
             camera.cameraDirection.addInPlace(Vector3.TransformCoordinates(direction, camera._cameraRotationMatrix));

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -190,7 +190,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             camera.cameraRotation.x = -this._offsetY / this.touchAngularSensibility;
         } else {
             const speed = camera._computeLocalCameraSpeed();
-            const direction = new Vector3(0, 0, (this.touchMoveSensibility !== 0 ? (speed * this._offsetY) / this.touchMoveSensibility : 0));
+            const direction = new Vector3(0, 0, this.touchMoveSensibility !== 0 ? (speed * this._offsetY) / this.touchMoveSensibility : 0);
 
             Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, camera._cameraRotationMatrix);
             camera.cameraDirection.addInPlace(Vector3.TransformCoordinates(direction, camera._cameraRotationMatrix));


### PR DESCRIPTION
In the forums, there was an issue raised where movement wasn't working on Safari.  After some investigation, it was found that the `touchMoveSensibility` property was being used in a denominator inside of the `checkInputs` function.  Because of this, if `touchMoveSensibility` was zero, it'd create a divide by zero scenario that would effectively render the camera's `cameraDirection` vector to be a vector of NaNs.  The fix for this was to just add a check to see if `touchMoveSensibility` was zero and handle things accordingly.

Forum link: https://forum.babylonjs.com/t/keyboard-control-not-working-for-latest-universalcamera-in-desktop-safari/31314