### PR TITLE
[GUI] make sure component init before render

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -547,6 +547,9 @@ export class TextBlock extends Control {
     }
 
     protected _renderLines(context: ICanvasRenderingContext): void {
+        if (!this._fontOffset) {
+            return;
+        }
         const height = this._currentMeasure.height;
         let rootY = 0;
         switch (this._textVerticalAlignment) {


### PR DESCRIPTION
Reproduction:

This playground fails - https://www.babylonjs-playground.com/#XCPP9Y#13718

Because when setting the radius we are setting everything as dirty (including the fontOffset-related function, even though fontOffset is not yet set).

fontOffset is being set when the UI element is being rendered. In this playground the initial state of the component is hidden (it is outside of the frustum).