### PR TITLE
Camera: Modified isMouseEvent bool logic for Safari

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -45,6 +45,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
     private _pointerInput?: (p: PointerInfo, s: EventState) => void;
     private _observer: Nullable<Observer<PointerInfo>>;
     private _onLostFocus: Nullable<(e: FocusEvent) => any>;
+    private _isSafari: boolean;
 
     /**
      * Manage the touch inputs to control the movement of a free camera.
@@ -56,7 +57,9 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
          * Define if mouse events can be treated as touch events
          */
         public allowMouse = false
-    ) {}
+    ) {
+        this._isSafari = Tools.IsSafari();
+    }
 
     /**
      * Attach the input controls to a specific dom element to get the input from.
@@ -76,7 +79,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             this._pointerInput = (p) => {
                 const evt = <IPointerEvent>p.event;
 
-                const isMouseEvent = evt.pointerType === "mouse";
+                const isMouseEvent = evt.pointerType === "mouse" || (this._isSafari && typeof evt.pointerType === "undefined");
 
                 if (!this.allowMouse && isMouseEvent) {
                     return;


### PR DESCRIPTION
There was an issue found in the forum where movement of the UniversalCamera, using a mouse, on Safari wasn't stopping properly.  After investigating the issue, it was found that the mouse events were triggering both mouse and touch movement.  The main issue was that, in FreeCameraTouchInput, the `isMouseEvent` boolean was incorrect being evaluated as false for mouse because the assigning logic was looking for a parameter that isn't available to mouse events generated in Safari.  The fix was to modify the logic to work with Safari-specific mouse events.

Relevant Forum Link: https://forum.babylonjs.com/t/keyboard-control-not-working-for-latest-universalcamera-in-desktop-safari/31314/8