### PR TITLE
Force render with just that camera on CreateScreenshot

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -772,6 +772,35 @@ export class Tools {
         );
     }
 
+    static DownloadBlob(blob: Blob, fileName?: string) {
+        //Creating a link if the browser have the download attribute on the a tag, to automatically start download generated image.
+        if ("download" in document.createElement("a")) {
+            if (!fileName) {
+                const date = new Date();
+                const stringDate =
+                    (date.getFullYear() + "-" + (date.getMonth() + 1)).slice(2) + "-" + date.getDate() + "_" + date.getHours() + "-" + ("0" + date.getMinutes()).slice(-2);
+                fileName = "screenshot_" + stringDate + ".png";
+            }
+            Tools.Download(blob, fileName);
+        } else {
+            if (blob) {
+                const url = URL.createObjectURL(blob);
+
+                const newWindow = window.open("");
+                if (!newWindow) {
+                    return;
+                }
+                const img = newWindow.document.createElement("img");
+                img.onload = function () {
+                    // no longer need to read the blob so it's revoked
+                    URL.revokeObjectURL(url);
+                };
+                img.src = url;
+                newWindow.document.body.appendChild(img);
+            }
+        }
+    }
+
     /**
      * Encodes the canvas data to base 64 or automatically download the result if filename is defined
      * @param successCallback defines the callback triggered once the data are available
@@ -794,37 +823,8 @@ export class Tools {
             this.ToBlob(
                 canvas ?? Tools._ScreenshotCanvas,
                 function (blob) {
-                    //Creating a link if the browser have the download attribute on the a tag, to automatically start download generated image.
-                    if ("download" in document.createElement("a")) {
-                        if (!fileName) {
-                            const date = new Date();
-                            const stringDate =
-                                (date.getFullYear() + "-" + (date.getMonth() + 1)).slice(2) +
-                                "-" +
-                                date.getDate() +
-                                "_" +
-                                date.getHours() +
-                                "-" +
-                                ("0" + date.getMinutes()).slice(-2);
-                            fileName = "screenshot_" + stringDate + ".png";
-                        }
-                        Tools.Download(blob!, fileName);
-                    } else {
-                        if (blob) {
-                            const url = URL.createObjectURL(blob);
-
-                            const newWindow = window.open("");
-                            if (!newWindow) {
-                                return;
-                            }
-                            const img = newWindow.document.createElement("img");
-                            img.onload = function () {
-                                // no longer need to read the blob so it's revoked
-                                URL.revokeObjectURL(url);
-                            };
-                            img.src = url;
-                            newWindow.document.body.appendChild(img);
-                        }
+                    if (blob) {
+                        Tools.DownloadBlob(blob, fileName);
                     }
                 },
                 mimeType,

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -772,6 +772,12 @@ export class Tools {
         );
     }
 
+    /**
+     * Download a Blob object 
+     * @param blob the Blob object
+     * @param fileName the file name to download
+     * @returns 
+     */
     static DownloadBlob(blob: Blob, fileName?: string) {
         //Creating a link if the browser have the download attribute on the a tag, to automatically start download generated image.
         if ("download" in document.createElement("a")) {

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -773,10 +773,10 @@ export class Tools {
     }
 
     /**
-     * Download a Blob object 
+     * Download a Blob object
      * @param blob the Blob object
      * @param fileName the file name to download
-     * @returns 
+     * @returns
      */
     static DownloadBlob(blob: Blob, fileName?: string) {
         //Creating a link if the browser have the download attribute on the a tag, to automatically start download generated image.


### PR DESCRIPTION
If a camera is specified as an argument, fall back on the CreateScreenshotUsingRenderTarget function.
Related forum issue: https://forum.babylonjs.com/t/screenshot-tool-does-not-seem-to-respect-camera-argument/31167
Related Playground: https://playground.babylonjs.com/#M6HFGB