### PR TITLE
Fix bug that prevents subsequent elapsed time queries from completing

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.query.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.query.ts
@@ -259,6 +259,7 @@ Engine.prototype.endTimeQuery = function (token: _TimeToken): int {
             timerQuery.endQueryEXT(timerQuery.TIME_ELAPSED_EXT);
         } else {
             this._gl.endQuery(timerQuery.TIME_ELAPSED_EXT);
+            this._currentNonTimestampToken = null;
         }
         token._timeElapsedQueryEnded = true;
     }
@@ -294,7 +295,6 @@ Engine.prototype.endTimeQuery = function (token: _TimeToken): int {
             this._deleteTimeQuery(token._timeElapsedQuery);
             token._timeElapsedQuery = null;
             token._timeElapsedQueryEnded = false;
-            this._currentNonTimestampToken = null;
         }
         return result;
     }


### PR DESCRIPTION
Due to the fact an elapsed time query does not typically have results upon the first call to engine.endTimeQuery(), the previous logic that seems intended to prevent overlapping elapsed time queries was causing any subsequent query to always return -1 for the time. Basically, you could only have one query in flight at a given time.

Moving around the bookkeeping logic fixes my repro playground: https://playground.babylonjs.com/#KBS9I5#23200