### PR TITLE
Added referrer policy support to GUI Image to control xhr request header

### DIFF
--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -1,7 +1,7 @@
 /**
  * Class used to abstract a canvas
  */
- export interface ICanvas {
+export interface ICanvas {
     /**
      * Canvas width.
      */

--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -1,7 +1,7 @@
 /**
  * Class used to abstract a canvas
  */
-export interface ICanvas {
+ export interface ICanvas {
     /**
      * Canvas width.
      */
@@ -72,6 +72,12 @@ export interface IImage {
      * thereby enabling the configuration of the CORS requests for the element's fetched data.
      */
     crossOrigin: string | null;
+
+    /**
+     * provides support for referrer policy on xhr load request,
+     * it is used to control the request header.
+     */
+    referrerPolicy: string;
 }
 
 /**

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -310,6 +310,16 @@ export class Tools {
         SetCorsBehavior(url, element);
     }
 
+    /**
+     * Sets the referrerPolicy behavior on a dom element.
+     * @param referrerPolicy define the referrer policy to use
+     * @param element define the dom element where to configure the referrer policy
+     * @param element.referrerPolicy
+     */
+    public static SetReferrerPolicyBehavior(referrerPolicy: Nullable<ReferrerPolicy>, element: { referrerPolicy: string | null }): void {
+        element.referrerPolicy = referrerPolicy;
+    }
+
     // External files
 
     /**

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -293,7 +293,7 @@ export class Image extends Control {
     }
 
     /**
-     * Gets or sets the referrer policy to apply on the img load request, 
+     * Gets or sets the referrer policy to apply on the img load request,
      * you should set this field before set the source field if you want to ensure the header will be present on the xhr loading request
      */
     @serialize()
@@ -541,7 +541,7 @@ export class Image extends Control {
         }
         this._domImage = engine.createCanvasImage();
         this._domImage.referrerPolicy = this._referrerPolicy;
-        
+
         this._domImage.onload = () => {
             this._onImageLoaded();
         };

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -22,6 +22,7 @@ export class Image extends Control {
     private _stretch = Image.STRETCH_FILL;
     private _source: Nullable<string>;
     private _autoScale = false;
+    private _referrerPolicy: ReferrerPolicy = "strict-origin-when-cross-origin";
 
     private _sourceLeft = 0;
     private _sourceTop = 0;
@@ -291,6 +292,24 @@ export class Image extends Control {
         }
     }
 
+    /**
+     * Gets or sets the referrer policy to apply on the img load request, 
+     * you should set this field before set the source field if you want to ensure the header will be present on the xhr loading request
+     */
+    @serialize()
+    public get referrerPolicy(): ReferrerPolicy {
+        return this._referrerPolicy;
+    }
+
+    public set referrerPolicy(value: ReferrerPolicy) {
+        if (this._referrerPolicy === value) {
+            return;
+        }
+
+        this._referrerPolicy = value;
+        this._domImage.referrerPolicy = value.toString();
+    }
+
     /** Gets or sets the stretching mode used by the image */
     @serialize()
     public get stretch(): number {
@@ -521,7 +540,8 @@ export class Image extends Control {
             throw new Error("Invalid engine. Unable to create a canvas.");
         }
         this._domImage = engine.createCanvasImage();
-
+        this._domImage.referrerPolicy = this._referrerPolicy;
+        
         this._domImage.onload = () => {
             this._onImageLoaded();
         };

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -22,7 +22,6 @@ export class Image extends Control {
     private _stretch = Image.STRETCH_FILL;
     private _source: Nullable<string>;
     private _autoScale = false;
-    private _referrerPolicy: ReferrerPolicy = "strict-origin-when-cross-origin";
 
     private _sourceLeft = 0;
     private _sourceTop = 0;
@@ -58,6 +57,12 @@ export class Image extends Control {
      * Observable notified when _sourceLeft, _sourceTop, _sourceWidth and _sourceHeight are computed
      */
     public onSVGAttributesComputedObservable = new Observable<Image>();
+
+    /**
+     * Gets or sets the referrer policy to apply on the img element load request.
+     * You should set referrerPolicy before set the source of the image if you want to ensure the header will be present on the xhr loading request
+     */
+    public referrerPolicy: Nullable<ReferrerPolicy>;
 
     /**
      * Gets a boolean indicating that the content is loaded
@@ -292,24 +297,6 @@ export class Image extends Control {
         }
     }
 
-    /**
-     * Gets or sets the referrer policy to apply on the img load request,
-     * you should set this field before set the source field if you want to ensure the header will be present on the xhr loading request
-     */
-    @serialize()
-    public get referrerPolicy(): ReferrerPolicy {
-        return this._referrerPolicy;
-    }
-
-    public set referrerPolicy(value: ReferrerPolicy) {
-        if (this._referrerPolicy === value) {
-            return;
-        }
-
-        this._referrerPolicy = value;
-        this._domImage.referrerPolicy = value.toString();
-    }
-
     /** Gets or sets the stretching mode used by the image */
     @serialize()
     public get stretch(): number {
@@ -540,13 +527,13 @@ export class Image extends Control {
             throw new Error("Invalid engine. Unable to create a canvas.");
         }
         this._domImage = engine.createCanvasImage();
-        this._domImage.referrerPolicy = this._referrerPolicy;
 
         this._domImage.onload = () => {
             this._onImageLoaded();
         };
         if (value) {
             Tools.SetCorsBehavior(value, this._domImage);
+            Tools.SetReferrerPolicyBehavior(this.referrerPolicy, this._domImage);
             this._domImage.src = value;
         }
     }

--- a/what's new.md
+++ b/what's new.md
@@ -207,6 +207,7 @@
 - Added ValueAndUnit change observable and Grid to listen for changes ([brianzinn](https://github.com/brianzinn))
 - Added `closeShape` and `closePath` as extra options parameters in `ExtrudeShape` and `ExtrudeShapeCustom` ([JohnK](https://github.com/BabylonJSGuide))
 - Added `markAsDirty` and `markAllAsDirty` public functions on `Control` ([carolhmj](https://github.com/carolhmj))
+- Added support of referrer Policy to control image's request header in GUI Image element ([BrunevalPE](https://github.com/BrunevalPE))
 
 ### Behaviors
 

--- a/what's new.md
+++ b/what's new.md
@@ -207,7 +207,6 @@
 - Added ValueAndUnit change observable and Grid to listen for changes ([brianzinn](https://github.com/brianzinn))
 - Added `closeShape` and `closePath` as extra options parameters in `ExtrudeShape` and `ExtrudeShapeCustom` ([JohnK](https://github.com/BabylonJSGuide))
 - Added `markAsDirty` and `markAllAsDirty` public functions on `Control` ([carolhmj](https://github.com/carolhmj))
-- Added support of referrer Policy to control image's request header in GUI Image element ([BrunevalPE](https://github.com/BrunevalPE))
 
 ### Behaviors
 


### PR DESCRIPTION
This feature will allow user's to control the **header** in the **xhr request to load the image**, `Referrer Policy`.

More info here : 
The Referrer-Policy [HTTP header](https://developer.mozilla.org/en-US/docs/Glossary/HTTP_header) 

Default value is : `strict-origin-when-cross-origin`