### PR TITLE
[Build] move core dependencies to peer dependencies

### DIFF
--- a/packages/public/@babylonjs/gui-editor/package.json
+++ b/packages/public/@babylonjs/gui-editor/package.json
@@ -17,15 +17,16 @@
         "build:declaration": "build-tools -c pud --config ./config.json",
         "clean": "rimraf dist"
     },
-    "dependencies": {
-        "@babylonjs/core": "^5.11.0",
-        "@babylonjs/gui": "^5.11.0"
-    },
+    "dependencies": {},
     "peerDependencies": {
+        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/gui": "^5.0.0",
         "@types/react": ">=16.7.3",
         "@types/react-dom": ">=16.0.9"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
+        "@babylonjs/gui": "^5.11.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
@@ -49,3 +50,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/gui/package.json
+++ b/packages/public/@babylonjs/gui/package.json
@@ -19,14 +19,17 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/gui": "1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -48,3 +51,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/inspector/package.json
+++ b/packages/public/@babylonjs/inspector/package.json
@@ -17,21 +17,27 @@
         "clean": "rimraf dist"
     },
     "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.0",
+        "@fortawesome/free-regular-svg-icons": "^6.0.0",
+        "@fortawesome/free-solid-svg-icons": "^6.0.0"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/gui": "^5.0.0",
+        "@babylonjs/gui-editor": "^5.0.0",
+        "@babylonjs/loaders": "^5.0.0",
+        "@babylonjs/materials": "^5.0.0",
+        "@babylonjs/serializers": "^5.0.0",
+        "@types/react": ">=16.7.3",
+        "@types/react-dom": ">=16.0.9"
+    },
+    "devDependencies": {
         "@babylonjs/core": "^5.11.0",
         "@babylonjs/gui": "^5.11.0",
         "@babylonjs/gui-editor": "^5.11.0",
         "@babylonjs/loaders": "^5.11.0",
         "@babylonjs/materials": "^5.11.0",
         "@babylonjs/serializers": "^5.11.0",
-        "@fortawesome/fontawesome-svg-core": "^6.1.0",
-        "@fortawesome/free-regular-svg-icons": "^6.0.0",
-        "@fortawesome/free-solid-svg-icons": "^6.0.0"
-    },
-    "peerDependencies": {
-        "@types/react": ">=16.7.3",
-        "@types/react-dom": ">=16.0.9"
-    },
-    "devDependencies": {
         "@lts/gui": "1.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -57,3 +63,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/loaders/package.json
+++ b/packages/public/@babylonjs/loaders/package.json
@@ -19,15 +19,19 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
-        "babylonjs-gltf2interface": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
+        "babylonjs-gltf2interface": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/loaders": "^1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0",
+        "babylonjs-gltf2interface": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -49,3 +53,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/materials/package.json
+++ b/packages/public/@babylonjs/materials/package.json
@@ -19,14 +19,17 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/materials": "^1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -48,3 +51,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/node-editor/package.json
+++ b/packages/public/@babylonjs/node-editor/package.json
@@ -17,14 +17,14 @@
         "build:declaration": "build-tools -c pud --config ./config.json",
         "clean": "rimraf dist"
     },
-    "dependencies": {
-        "@babylonjs/core": "^5.11.0"
-    },
+    "dependencies": {},
     "peerDependencies": {
+        "@babylonjs/core": "^5.0.0",
         "@types/react": ">=16.7.3",
         "@types/react-dom": ">=16.0.9"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
@@ -48,3 +48,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/post-processes/package.json
+++ b/packages/public/@babylonjs/post-processes/package.json
@@ -19,14 +19,17 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/post-processes": "^1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -48,3 +51,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/procedural-textures/package.json
+++ b/packages/public/@babylonjs/procedural-textures/package.json
@@ -19,14 +19,17 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/procedural-textures": "^1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -48,3 +51,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+

--- a/packages/public/@babylonjs/serializers/package.json
+++ b/packages/public/@babylonjs/serializers/package.json
@@ -19,15 +19,19 @@
         "prepublishOnly": "build-tools -c prepare-es6-build"
     },
     "dependencies": {
-        "@babylonjs/core": "^5.11.0",
-        "babylonjs-gltf2interface": "^5.11.0",
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@babylonjs/core": "^5.11.0",
+        "babylonjs-gltf2interface": "^5.11.0",
         "@dev/build-tools": "^1.0.0",
         "@lts/serializers": "^1.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^5.0.0",
+        "babylonjs-gltf2interface": "^5.0.0"
     },
     "keywords": [
         "3D",
@@ -49,3 +53,4 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
+


### PR DESCRIPTION
Addressing https://forum.babylonjs.com/t/babylon-materials-and-babylon-loaders-resolve-babylon-core-5-4-0-as-a-sub-dependency/30722