### PR TITLE
add support for custom attributes to convertToUnIndexedMesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3137,7 +3137,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         // Updating vertex buffers
         for (kindIndex = 0; kindIndex < kinds.length; kindIndex++) {
             kind = kinds[kindIndex];
-            this.setVerticesData(kind, newdata[kind], vbs[kind].isUpdatable());
+            this.setVerticesData(kind, newdata[kind], vbs[kind].isUpdatable(), vbs[kind].getStrideSize());
         }
 
         // Updating submeshes


### PR DESCRIPTION
Add support for custom attributes to the function convertToUnIndexedMesh. Currently calling it on a mesh with custom attribute(s) set causes an error to be thrown since the attribute's stride can't be deduced.

Forum: https://forum.babylonjs.com/t/allow-converttounindexedmesh-to-support-custom-attributes/31486