### PR TITLE
[XR] changes to minZ and maxZ while a session is running should update the XR session

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -173,6 +173,19 @@ export class WebXRCamera extends FreeCamera {
         const trackingState = pose.emulatedPosition ? WebXRTrackingState.TRACKING_LOST : WebXRTrackingState.TRACKING;
         this._setTrackingState(trackingState);
 
+        // check min/max Z and update if not the same as in cache
+        if (this.minZ !== this._cache.minZ || this.maxZ !== this._cache.maxZ) {
+            const xrRenderState: XRRenderStateInit = {
+                // if maxZ is 0 it should be "Infinity", but it doesn't work with the WebXR API. Setting to a large number.
+                depthFar: this.maxZ || 10000,
+                depthNear: this.minZ,
+            };
+
+            this._xrSessionManager.updateRenderState(xrRenderState);
+            this._cache.minZ = this.minZ;
+            this._cache.maxZ = this.maxZ;
+        }
+
         if (pose.transform) {
             const orientation = pose.transform.orientation;
             if (pose.transform.orientation.x === undefined) {

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -131,7 +131,8 @@ export class WebXRExperienceHelper implements IDisposable {
             const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
 
             const xrRenderState: XRRenderStateInit = {
-                depthFar: this.camera.maxZ,
+                // if maxZ is 0 it should be "Infinity", but it doesn't work with the WebXR API. Setting to a large number.
+                depthFar: this.camera.maxZ || 10000,
                 depthNear: this.camera.minZ,
             };
 


### PR DESCRIPTION
Fixes #12448

maxZ should be infinity, but when setting is to a very large number, both the XR emulator and native XR fail. This is why 10000 was chosed to be max (which is 10000 meters in VR).

Test playground (when merged) https://playground.babylonjs.com/#F41V6N#913