### PR TITLE
Add params scene, mesh to function getAttributes

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1451,7 +1451,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         this._eventInfo.uniforms = uniforms;
         this._eventInfo.attributes = attribs;
         this._eventInfo.samplers = samplers;
-        this._eventInfo.uniformBuffersNames = uniformBuffers;        
+        this._eventInfo.uniformBuffersNames = uniformBuffers;
         this._eventInfo.customCode = undefined;
         this._eventInfo.mesh = mesh;
         this._callbackPluginEventGeneric(MaterialPluginEvent.PrepareEffect, this._eventInfo);

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1451,8 +1451,9 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         this._eventInfo.uniforms = uniforms;
         this._eventInfo.attributes = attribs;
         this._eventInfo.samplers = samplers;
-        this._eventInfo.uniformBuffersNames = uniformBuffers;
+        this._eventInfo.uniformBuffersNames = uniformBuffers;        
         this._eventInfo.customCode = undefined;
+        this._eventInfo.mesh = mesh;
         this._callbackPluginEventGeneric(MaterialPluginEvent.PrepareEffect, this._eventInfo);
 
         PrePassConfiguration.AddUniforms(uniforms);

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -246,9 +246,11 @@ export class MaterialPluginBase {
     /**
      * Gets the attributes used by the plugin.
      * @param attributes list that the attribute names should be added to.
+     * @param scene defines the scene to the material belongs to.
+     * @param mesh the mesh being rendered.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public getAttributes(attributes: string[]): void {}
+    public getAttributes(attributes: string[], scene: Scene, mesh: AbstractMesh): void {}
 
     /**
      * Gets the uniform buffers names added by the plugin.

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -246,7 +246,7 @@ export class MaterialPluginBase {
     /**
      * Gets the attributes used by the plugin.
      * @param attributes list that the attribute names should be added to.
-     * @param scene defines the scene to the material belongs to.
+     * @param scene the scene that the material belongs to.
      * @param mesh the mesh being rendered.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/dev/core/src/Materials/materialPluginEvent.ts
+++ b/packages/dev/core/src/Materials/materialPluginEvent.ts
@@ -46,6 +46,7 @@ export type MaterialPluginPrepareEffect = {
     uniforms: string[];
     samplers: string[];
     uniformBuffersNames: string[];
+    mesh: AbstractMesh;
 };
 
 /** @hidden */

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -253,7 +253,7 @@ export class MaterialPluginManager {
                 const eventData = info as MaterialPluginPrepareEffect;
                 for (const plugin of this._activePlugins) {
                     eventData.fallbackRank = plugin.addFallbacks(eventData.defines, eventData.fallbacks, eventData.fallbackRank);
-                    plugin.getAttributes(eventData.attributes);
+                    plugin.getAttributes(eventData.attributes, this._scene, eventData.mesh);
                 }
                 if (this._uniformList.length > 0) {
                     eventData.uniforms.push(...this._uniformList);

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1371,6 +1371,7 @@ export class StandardMaterial extends PushMaterial {
             this._eventInfo.samplers = samplers;
             this._eventInfo.uniformBuffersNames = uniformBuffers;
             this._eventInfo.customCode = undefined;
+            this._eventInfo.mesh = mesh;
             this._callbackPluginEventGeneric(MaterialPluginEvent.PrepareEffect, this._eventInfo);
 
             PrePassConfiguration.AddUniforms(uniforms);


### PR DESCRIPTION
For the class MaterialPluginBase,  add params scene and mesh to the function getAttributes so that they can be used to determine which attributes to use.

Forum: https://forum.babylonjs.com/t/using-custom-attribute-with-material-plugin/31142/7