### PR TITLE
Inspectable options fix

### DIFF
--- a/packages/dev/core/src/Misc/iInspectable.ts
+++ b/packages/dev/core/src/Misc/iInspectable.ts
@@ -96,5 +96,5 @@ export interface IInspectable {
     /**
      * Gets the list of options when using "Option" mode
      */
-    options?: [];
+    options?: IInspectableOptions[];
 }

--- a/what's new.md
+++ b/what's new.md
@@ -159,7 +159,6 @@
 - Added live connection to GUI editor ([darraghjburke](https://github.com/darraghjburke))
 - Add `getAlphaFromRGB` checkbox on Texture view ([carolhmj](https://github.com/carolhmj))
 - Make sure popups are closed when page refreshes ([RaananW](https://github.com/RaananW))
-- IInspectable `options` property is now of appropriate type `IInspectableOptions | undefined` ([GordonTombola](https://github.com/GordonTombola))
 
 ### Playground
 

--- a/what's new.md
+++ b/what's new.md
@@ -159,6 +159,7 @@
 - Added live connection to GUI editor ([darraghjburke](https://github.com/darraghjburke))
 - Add `getAlphaFromRGB` checkbox on Texture view ([carolhmj](https://github.com/carolhmj))
 - Make sure popups are closed when page refreshes ([RaananW](https://github.com/RaananW))
+- IInspectable `options` property is now of appropriate type `IInspectableOptions | undefined` ([GordonTombola](https://github.com/GordonTombola))
 
 ### Playground
 


### PR DESCRIPTION
Custom inspectables could not be provided with an appropriate options array as the type was either undefined or empty array, this way it can be undefined or an array of IInspectableOptions

Here is an example of being forced to use "as any" with current babylonjs in typescript when using the custom inspectable type options, when removing the "as any" this will break:
https://playground.babylonjs.com/#LTH16U

Here is an example with the snapshot where we aren't forced to use "as any":
https://playground.babylonjs.com/?snapshot=refs/pull/12669/merge#TCE5N9
