### PR TITLE
[GUI] Lines array is generated later

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -547,7 +547,7 @@ export class TextBlock extends Control {
     }
 
     protected _renderLines(context: ICanvasRenderingContext): void {
-        if (!this._fontOffset) {
+        if (!this._fontOffset || !this._lines) {
             return;
         }
         const height = this._currentMeasure.height;


### PR DESCRIPTION
this._lines is generated when the  control is in view. If you create a control that is not in view it will fail.

This makes sure it doesn't fail even when out of view. 

Test playground - https://www.babylonjs-playground.com/#XCPP9Y#13890