### PR TITLE
Fix when BoundingBoxGizmo issues warning

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -174,6 +174,20 @@ export class BoundingBoxGizmo extends Gizmo {
             }
         });
     }
+
+    /**
+     * Using the attachedNode property in BoundingBoxGizmo is not supported. Please use attachedMesh instead.
+     */
+     public get attachedNode() {
+        return super.attachedNode;
+    }
+
+    public set attachedNode(value) {
+        super.attachedNode = value;
+
+        Logger.Warn("Using the attachedNode property in BoundingBoxGizmo is not supported. Please use attachedMesh instead.");        
+    }
+
     /**
      * Creates an BoundingBoxGizmo
      * @param color The color of the gizmo
@@ -533,11 +547,6 @@ export class BoundingBoxGizmo extends Gizmo {
             this.gizmoLayer.utilityLayerScene.onAfterRenderObservable.addOnce(() => {
                 this._updateDummy();
             });
-        }
-        // If the attachedMesh property is not set, then the attachedNode constructor was used, which
-        // the BoundingBoxGizmo doesn't support
-        if (!this.attachedMesh) {
-            Logger.Warn("Using the attachedNode attribute in BoundingBoxGizmo is not supported. Please use attachedMesh instead.");
         }
     }
 

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -309,10 +309,10 @@ export class GizmoManager implements IDisposable {
     public set boundingBoxGizmoEnabled(value: boolean) {
         if (value) {
             this.gizmos.boundingBoxGizmo = this.gizmos.boundingBoxGizmo || new BoundingBoxGizmo(this._boundingBoxColor, this._defaultKeepDepthUtilityLayer);
-            if (this._attachedMesh) {
-                this.gizmos.boundingBoxGizmo.attachedMesh = this._attachedMesh;
-            } else {
+            if (this._attachedNode) {
                 this.gizmos.boundingBoxGizmo.attachedNode = this._attachedNode;
+            } else {
+                this.gizmos.boundingBoxGizmo.attachedMesh = this._attachedMesh;
             }
 
             if (this._attachedMesh) {


### PR DESCRIPTION
PR to move the warning about setting the attachedNode property of the BoundingBoxGizmo into the setter for attachedNode to make sure that the warning is only logged when the attachedNode property is actually set. Currently there are a few commonly occurring cases when the warning will be issued even when the property isn't being used.

Forum discussion with more info and repros: 