### PR TITLE
Revert "Add warning to Bounding Box Gizmo (#12551)"

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -534,11 +534,6 @@ export class BoundingBoxGizmo extends Gizmo {
                 this._updateDummy();
             });
         }
-        // If the attachedMesh property is not set, then the attachedNode constructor was used, which
-        // the BoundingBoxGizmo doesn't support
-        if (!this.attachedMesh) {
-            Logger.Warn("Using the attachedNode attribute in BoundingBoxGizmo is not supported. Please use attachedMesh instead.");
-        }
     }
 
     private _selectNode(selectedMesh: Nullable<Mesh>) {


### PR DESCRIPTION
This reverts commit 15d670c61c29ee3922945bc937fdc9562fc94c66.

Related forum issue: https://forum.babylonjs.com/t/warning-logged-when-gizmomanagers-boundingboxgizmo-is-enabled/31644/4