### PR TITLE
[Build] Load shared-ui-components from src and not dist

### DIFF
--- a/packages/tools/guiEditor/tsconfig.build.json
+++ b/packages/tools/guiEditor/tsconfig.build.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "./src",
+        "rootDir": "../../",
         "composite": true
     },
 

--- a/packages/tools/guiEditor/tsconfig.build.json
+++ b/packages/tools/guiEditor/tsconfig.build.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "../../",
+        "rootDir": "./src",
         "composite": true
     },
 
@@ -13,6 +13,9 @@
         },
         {
             "path": "../../dev/gui/tsconfig.build.json"
+        },
+        {
+            "path": "../../dev/sharedUiComponents/tsconfig.build.json"
         }
     ],
 

--- a/packages/tools/guiEditor/webpack.config.js
+++ b/packages/tools/guiEditor/webpack.config.js
@@ -38,14 +38,11 @@ module.exports = (env) => {
                 includeCSS: true,
                 includeAssets: true,
                 sideEffects: true,
-                // extraRules: [
-                //     {
-                //         test: /\.svg$/,
-                //         use: {
-                //             loader: path.resolve('./svg.loader.js')
-                //         }
-                //     }
-                // ]
+                tsOptions: {
+                    compilerOptions: {
+                        "rootDir": "../../",
+                    }
+                }
             }),
         },
         devServer: {

--- a/packages/tools/guiEditor/webpack.config.js
+++ b/packages/tools/guiEditor/webpack.config.js
@@ -13,9 +13,9 @@ module.exports = (env) => {
             devtoolModuleFilenameTemplate: production ? "webpack://[namespace]/[resource-path]?[loaders]" : "file:///[absolute-resource-path]",
         },
         resolve: {
-            extensions: [".js", ".ts", ".tsx", ".svg"],
+            extensions: [".js", ".ts", ".tsx", ".svg", "*.scss"],
             alias: {
-                "shared-ui-components": path.resolve("../../dev/sharedUiComponents/dist"),
+                "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
             },
         },
         externals: [

--- a/packages/tools/nodeEditor/tsconfig.build.json
+++ b/packages/tools/nodeEditor/tsconfig.build.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "./src",
+        "rootDir": "../../",
         "composite": true
     },
 

--- a/packages/tools/nodeEditor/tsconfig.build.json
+++ b/packages/tools/nodeEditor/tsconfig.build.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "../../",
+        "rootDir": "./src",
         "composite": true
     },
 

--- a/packages/tools/nodeEditor/webpack.config.js
+++ b/packages/tools/nodeEditor/webpack.config.js
@@ -32,7 +32,16 @@ module.exports = (env) => {
             // React, react dom etc'
         ],
         module: {
-            rules: webpackTools.getRules(),
+            rules: webpackTools.getRules({
+                includeCSS: true,
+                includeAssets: true,
+                sideEffects: true,
+                tsOptions: {
+                    compilerOptions: {
+                        "rootDir": "../../",
+                    }
+                }
+            }),
         },
         devServer: {
             static: {

--- a/packages/tools/nodeEditor/webpack.config.js
+++ b/packages/tools/nodeEditor/webpack.config.js
@@ -13,9 +13,9 @@ module.exports = (env) => {
             devtoolModuleFilenameTemplate: production ? "webpack://[namespace]/[resource-path]?[loaders]" : "file:///[absolute-resource-path]",
         },
         resolve: {
-            extensions: [".js", ".ts", ".tsx"],
+            extensions: [".js", ".ts", ".tsx", ".scss", "*.svg"],
             alias: {
-                "shared-ui-components": path.resolve("../../dev/sharedUiComponents/dist"),
+                "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
             },
         },
         externals: [


### PR DESCRIPTION
In both gui editor and node material editor, the shared ui components are now loaded from source, as they are not served by the babylon server. any tool using it will require this change to make sure hot reload works as expected.