### PR TITLE
Wrong rotation offset camera correction

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -48,7 +48,6 @@ import { _GLTFAnimation } from "./glTFAnimation";
 import { Camera } from "core/Cameras/camera";
 import { EngineStore } from "core/Engines/engineStore";
 import { MultiMaterial } from "core/Materials/multiMaterial";
-import { TargetCamera } from "core/Cameras/targetCamera";
 
 /**
  * Utility interface for storing vertex attribute data

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1340,12 +1340,12 @@ export class _Exporter {
         }
     }
 
-    private _setCameraTransformation(node: INode, babylonCamera: TargetCamera, convertToRightHandedSystem: boolean): void {
+    private _setCameraTransformation(node: INode, babylonCamera: Camera, convertToRightHandedSystem: boolean): void {
         if (!babylonCamera.position.equalsToFloats(0, 0, 0)) {
             node.translation = convertToRightHandedSystem ? _GLTFUtilities._GetRightHandedPositionVector3(babylonCamera.position).asArray() : babylonCamera.position.asArray();
         }
 
-        const rotationQuaternion = babylonCamera.rotationQuaternion; // we target the local transformation if one.
+        const rotationQuaternion = (<any>babylonCamera).rotationQuaternion; // we target the local transformation if one.
 
         if (rotationQuaternion && !Quaternion.IsIdentity(rotationQuaternion)) {
             if (convertToRightHandedSystem) {
@@ -2218,7 +2218,7 @@ export class _Exporter {
                     }
                     return node;
                 });
-            } else if (babylonNode instanceof TargetCamera) {
+            } else if (babylonNode instanceof Camera) {
                 this._setCameraTransformation(node, babylonNode, convertToRightHandedSystem);
                 return node;
             } else {

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -48,6 +48,7 @@ import { _GLTFAnimation } from "./glTFAnimation";
 import { Camera } from "core/Cameras/camera";
 import { EngineStore } from "core/Engines/engineStore";
 import { MultiMaterial } from "core/Materials/multiMaterial";
+import { TargetCamera } from "core/Cameras/targetCamera";
 
 /**
  * Utility interface for storing vertex attribute data
@@ -1339,13 +1340,14 @@ export class _Exporter {
         }
     }
 
-    private _setCameraTransformation(node: INode, babylonCamera: Camera, convertToRightHandedSystem: boolean): void {
+    private _setCameraTransformation(node: INode, babylonCamera: TargetCamera, convertToRightHandedSystem: boolean): void {
         if (!babylonCamera.position.equalsToFloats(0, 0, 0)) {
             node.translation = convertToRightHandedSystem ? _GLTFUtilities._GetRightHandedPositionVector3(babylonCamera.position).asArray() : babylonCamera.position.asArray();
         }
 
-        const rotationQuaternion = babylonCamera.absoluteRotation;
-        if (!Quaternion.IsIdentity(rotationQuaternion)) {
+        const rotationQuaternion = babylonCamera.rotationQuaternion; // we target the local transformation if one.
+
+        if (rotationQuaternion && !Quaternion.IsIdentity(rotationQuaternion)) {
             if (convertToRightHandedSystem) {
                 _GLTFUtilities._GetRightHandedQuaternionFromRef(rotationQuaternion);
             }
@@ -2216,7 +2218,7 @@ export class _Exporter {
                     }
                     return node;
                 });
-            } else if (babylonNode instanceof Camera) {
+            } else if (babylonNode instanceof TargetCamera) {
                 this._setCameraTransformation(node, babylonNode, convertToRightHandedSystem);
                 return node;
             } else {


### PR DESCRIPTION
When GLB export, camera rotation was set using WorldTransform matrix `camera.getAbsoluteRotation()` instead as local. Resulting on double every rotation from upper hierarchy.
we update it  using  `camera.rotationQuaternion` which is property of `TargetCamera`
In order to let other user custom Camera to be exported, we do not change the `Camera` parameter type but cast as `any` to allow the property test.
See this forum [question](https://forum.babylonjs.com/t/gltf-export-bug-freecamera-rotation-has-wrong-offset/31278).