### PR TITLE
Added code to track buttons pressed while meta key is active on MacOS

### DIFF
--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -21,7 +21,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     private _keyboardActive: boolean = false;
     private _pointerActive: boolean = false;
     private _elementToAttachTo: HTMLElement;
-    private _metaKeys: Set<number>;
+    private _metaKeys: Array<number>;
     private readonly _engine: Engine;
     private readonly _usingSafari: boolean = Tools.IsSafari();
     // Found solution for determining if MacOS is being used here:
@@ -86,7 +86,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._enableEvents();
 
         if (this._usingMacOS) {
-            this._metaKeys = new Set();
+            this._metaKeys = [];
         }
 
         // Set callback to enable event handler switching when inputElement changes
@@ -335,7 +335,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.inputIndex = evt.keyCode;
 
                 if (this._usingMacOS && evt.metaKey && evt.key !== "Meta") {
-                    this._metaKeys.add(evt.keyCode);
+                    if (!this._metaKeys.includes(evt.keyCode)) {
+                        this._metaKeys.push(evt.keyCode);
+                    }
                 }
 
                 this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
@@ -355,14 +357,13 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 const deviceEvent = evt as IUIEvent;
                 deviceEvent.inputIndex = evt.keyCode;
 
-                if (this._usingMacOS && evt.key === "Meta" && this._metaKeys.size > 0) {
-                    for (const k in this._metaKeys.values) {
-                        const keyCode: number = +k;
+                if (this._usingMacOS && evt.key === "Meta" && this._metaKeys.length > 0) {
+                    for (const keyCode of this._metaKeys) {
                         const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, keyCode, 0, this, this._elementToAttachTo);
                         kbKey[keyCode] = 0;
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
-                    this._metaKeys.clear();
+                    this._metaKeys.splice(0, this._metaKeys.length);
                 }
 
                 this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
@@ -382,7 +383,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
                 }
-                this._metaKeys.clear();
+                this._metaKeys.splice(0, this._metaKeys.length);
             }
         };
 

--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -383,7 +383,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
                 }
-                this._metaKeys.splice(0, this._metaKeys.length);
+                if (this._usingMacOS) {
+                    this._metaKeys.splice(0, this._metaKeys.length);
+                }
             }
         };
 

--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -112,7 +112,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             throw `Unable to find device ${DeviceType[deviceType]}`;
         }
 
-        if (deviceType >= DeviceType.DualShock && deviceType <= DeviceType.DualSense && navigator.getGamepads) {
+        if (deviceType >= DeviceType.DualShock && deviceType <= DeviceType.DualSense) {
             this._updateDevice(deviceType, deviceSlot, inputIndex);
         }
 
@@ -356,9 +356,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.inputIndex = evt.keyCode;
 
                 if (this._usingMacOS && evt.key === "Meta" && this._metaKeys.size > 0) {
-                    for(const k of this._metaKeys) {
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, k, 0, this, this._elementToAttachTo);
-                        kbKey[k] = 0;
+                    for (const k in this._metaKeys.values) {
+                        const keyCode: number = +k;
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, keyCode, 0, this, this._elementToAttachTo);
+                        kbKey[keyCode] = 0;
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
                     this._metaKeys.clear();
@@ -478,7 +479,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         }
                     }
 
-                    if (!document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
+                    if (!document.pointerLockElement) {
                         try {
                             this._elementToAttachTo.setPointerCapture(this._mouseId);
                         } catch (e) {
@@ -487,7 +488,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 } else {
                     // Touch; Since touches are dynamically assigned, only set capture if we have an id
-                    if (evt.pointerId && !document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
+                    if (evt.pointerId && !document.pointerLockElement) {
                         try {
                             this._elementToAttachTo.setPointerCapture(evt.pointerId);
                         } catch (e) {


### PR DESCRIPTION
There was an issue found on the forum where `keyup` events for keys weren't firing while the Meta key (Command) was pressed for all browsers on MacOS.  This has led to a scenario where said buttons weren't being properly treated as released.  Upon investigation, it has been determined that this issue occurs at an OS level and therefore, there isn't much we can do about it (https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser).  This PR contains a workaround so that if BJS is being run in a browser on MacOS, any buttons pressed while the Meta key is active will be tracked and have `keyup` events fired for them when the Meta key is released.  All other platforms will work as before without this tracking code.

Forum Link: https://forum.babylonjs.com/t/modifier-keyboard-shortcuts-with-devicesourcemanager-copy-to-clipboard/31743/7