### PR TITLE
DeviceInputSystem: Fixed Passive Support Check to prevent Violation Warning

### DIFF
--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -104,7 +104,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             throw `Unable to find device ${DeviceType[deviceType]}`;
         }
 
-        if (deviceType >= DeviceType.DualShock && deviceType <= DeviceType.DualSense && navigator.getGamepads) {
+        if (deviceType >= DeviceType.DualShock && deviceType <= DeviceType.DualSense) {
             this._updateDevice(deviceType, deviceSlot, inputIndex);
         }
 
@@ -456,7 +456,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                         }
                     }
 
-                    if (!document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
+                    if (!document.pointerLockElement) {
                         try {
                             this._elementToAttachTo.setPointerCapture(this._mouseId);
                         } catch (e) {
@@ -465,7 +465,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     }
                 } else {
                     // Touch; Since touches are dynamically assigned, only set capture if we have an id
-                    if (evt.pointerId && !document.pointerLockElement && this._elementToAttachTo.hasPointerCapture) {
+                    if (evt.pointerId && !document.pointerLockElement) {
                         try {
                             this._elementToAttachTo.setPointerCapture(evt.pointerId);
                         } catch (e) {
@@ -592,13 +592,11 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         const noop = function () {};
 
         try {
-            const options: object = {
-                passive: {
-                    get: function () {
-                        passiveSupported = true;
-                    },
+            const options = Object.defineProperty({}, "passive", {
+                get: function () {
+                    passiveSupported = true;
                 },
-            };
+            });
 
             this._elementToAttachTo.addEventListener("test", noop, options);
             this._elementToAttachTo.removeEventListener("test", noop, options);

--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -690,7 +690,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._elementToAttachTo.addEventListener(this._eventPrefix + "up", this._pointerUpEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
         this._elementToAttachTo.addEventListener("blur", this._pointerBlurEvent);
-        this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: false } : false);
+        this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: true } : false);
 
         // Since there's no up or down event for mouse wheel or delta x/y, clear mouse values at end of frame
         this._pointerInputClearObserver = this._engine.onEndFrameObservable.add(() => {


### PR DESCRIPTION
There was a warning found by a user on the forums that, in Verbose mode, a Violation warning was occurring:
![image](https://user-images.githubusercontent.com/50599569/176553040-80f67f6f-a818-4494-9f8a-f36f5e4c4739.png)
This warning was happening because the `wheel` event listener didn't have the "passive" option set to true when able.  After closer investigation, it was found that the code used to determine if passive was supported was always returning false, causing this warning to occur.  This PR modifies the logic to fix this.

Forum link: https://forum.babylonjs.com/t/bjs-console-warnings-when-using-cleargizmoonemptypointerevent/31447/8