### PR TITLE
Engine: Add event listener to disable right-click menu when there's a canvas element

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -396,6 +396,11 @@ export class Engine extends ThinEngine {
     public disableManifestCheck = false;
 
     /**
+     * Gets or sets a boolean to enable/disable the context (right-click) menu from appearing on the main canvas
+     */
+    public disableContextMenu: boolean = true;
+
+    /**
      * Gets the list of created scenes
      */
     public scenes = new Array<Scene>();
@@ -532,6 +537,7 @@ export class Engine extends ThinEngine {
     private _onCanvasPointerOut: (event: PointerEvent) => void;
     private _onCanvasBlur: () => void;
     private _onCanvasFocus: () => void;
+    private _onCanvasContextMenu: (evt: Event) => void;
 
     private _onFullscreenChange: () => void;
     private _onPointerLockChange: () => void;
@@ -671,8 +677,15 @@ export class Engine extends ThinEngine {
             this.onCanvasBlurObservable.notifyObservers(this);
         };
 
+        this._onCanvasContextMenu = (evt: Event) => {
+            if (this.disableContextMenu) {
+                evt.preventDefault();
+            }
+        };
+
         canvas.addEventListener("focus", this._onCanvasFocus);
         canvas.addEventListener("blur", this._onCanvasBlur);
+        canvas.addEventListener("contextmenu", this._onCanvasContextMenu);
 
         this._onBlur = () => {
             if (this.disablePerformanceMonitorInBackground) {
@@ -1933,6 +1946,7 @@ export class Engine extends ThinEngine {
                 this._renderingCanvas.removeEventListener("focus", this._onCanvasFocus);
                 this._renderingCanvas.removeEventListener("blur", this._onCanvasBlur);
                 this._renderingCanvas.removeEventListener("pointerout", this._onCanvasPointerOut);
+                this._renderingCanvas.removeEventListener("contextmenu", this._onCanvasContextMenu);
             }
 
             if (IsDocumentAvailable()) {

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -396,7 +396,7 @@ export class Engine extends ThinEngine {
     public disableManifestCheck = false;
 
     /**
-     * Gets or sets a boolean to enable/disable the context (right-click) menu from appearing on the main canvas
+     * Gets or sets a boolean to enable/disable the context menu (right-click) from appearing on the main canvas
      */
     public disableContextMenu: boolean = true;
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -366,7 +366,22 @@ export class ThinEngine {
     public _gl: WebGLRenderingContext;
     /** @hidden */
     public _webGLVersion = 1.0;
-    protected _renderingCanvas: Nullable<HTMLCanvasElement>;
+    private _renCanvas: Nullable<HTMLCanvasElement>;
+    private _preventContextMenu: (evt: any) => void = (evt: any) => {
+        evt.preventDefault();
+    };
+    protected set _renderingCanvas (renderingCanvas: Nullable<HTMLCanvasElement>) {
+        if (this._renCanvas) {
+            this._renCanvas.removeEventListener("contextmenu", this._preventContextMenu);
+        }
+        this._renCanvas = renderingCanvas;
+        if (this._renCanvas) {
+            this._renCanvas.addEventListener("contextmenu", this._preventContextMenu);
+        }
+    }
+    protected get _renderingCanvas () {
+        return this._renCanvas;
+    }
     protected _windowIsBackground = false;
     protected _creationOptions: EngineOptions;
     protected _audioContext: Nullable<AudioContext>;
@@ -5250,6 +5265,10 @@ export class ThinEngine {
 
                 window.removeEventListener("resize", this._checkForMobile);
             }
+        }
+
+        if (this._renCanvas) {
+            this._renCanvas.removeEventListener("contextmenu", this._preventContextMenu);
         }
 
         this._workingCanvas = null;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -366,22 +366,7 @@ export class ThinEngine {
     public _gl: WebGLRenderingContext;
     /** @hidden */
     public _webGLVersion = 1.0;
-    private _renCanvas: Nullable<HTMLCanvasElement>;
-    private _preventContextMenu: (evt: any) => void = (evt: any) => {
-        evt.preventDefault();
-    };
-    protected set _renderingCanvas (renderingCanvas: Nullable<HTMLCanvasElement>) {
-        if (this._renCanvas) {
-            this._renCanvas.removeEventListener("contextmenu", this._preventContextMenu);
-        }
-        this._renCanvas = renderingCanvas;
-        if (this._renCanvas) {
-            this._renCanvas.addEventListener("contextmenu", this._preventContextMenu);
-        }
-    }
-    protected get _renderingCanvas () {
-        return this._renCanvas;
-    }
+    protected _renderingCanvas: Nullable<HTMLCanvasElement>;
     protected _windowIsBackground = false;
     protected _creationOptions: EngineOptions;
     protected _audioContext: Nullable<AudioContext>;
@@ -5265,10 +5250,6 @@ export class ThinEngine {
 
                 window.removeEventListener("resize", this._checkForMobile);
             }
-        }
-
-        if (this._renCanvas) {
-            this._renCanvas.removeEventListener("contextmenu", this._preventContextMenu);
         }
 
         this._workingCanvas = null;


### PR DESCRIPTION
There was an issue found on the forums where the right-click context menu was appearing when a user used custom mouse controls.  Upon closer investigation, it was determined that the reason the context menu didn't appear in other scenarios was that there was specific code to suppress it in all of our cameras' mouse input code.  This proposed fix will add code to suppress the context menu when the rendering canvas is set to a non-null HTMLElement.

Forum Post: https://forum.babylonjs.com/t/even-by-using-evt-preventdefault-the-browser-menu-pops-up-after-i-changed-from-bjs-5-0-to-5-10/31383/8