### PR TITLE
Fix snippet loading on GUI Editor

### DIFF
--- a/packages/tools/guiEditor/public/index.js
+++ b/packages/tools/guiEditor/public/index.js
@@ -154,7 +154,8 @@ checkBabylonVersionAsync().then(() => {
                     action: (data) => {
                         return new Promise((resolve, reject) => {
                             let baseUrl = location.href.replace(location.hash, "").replace(location.search, "");
-                            let newUrl = baseUrl + "#" + data;
+                            let dataHash = data.startsWith('#') ? data : '#' + data;
+                            let newUrl = baseUrl + dataHash;
                             currentSnippetToken = data;
                             location.href = newUrl;
                             resolve();


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-editor-loading-from-snippet-id-only-not-entering-full-link-is-incomplete/31803