### PR TITLE
Camera: Remove code execute preventDefault for wheel events

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
@@ -6,7 +6,6 @@ import type { Camera } from "../../Cameras/camera";
 import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
-import { Tools } from "../../Misc/tools";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
 
@@ -53,13 +52,11 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls
-     *   should call preventdefault().
+     *   should call preventdefault().  This param is no longer used because wheel events should be treated as passive.
      *   (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
-        // eslint-disable-next-line prefer-rest-params
-        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
-
         this._wheel = (pointer) => {
             // sanity check - this should be a PointerWheel event.
             if (pointer.type !== PointerEventTypes.POINTERWHEEL) {
@@ -89,12 +86,6 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
                 // IE >= v9   (Has WebGL >= v11)
                 // Maybe others?
                 this._wheelDeltaY -= (this.wheelPrecisionY * (<any>event).wheelDelta) / this._normalize;
-            }
-
-            if (event.preventDefault) {
-                if (!noPreventDefault) {
-                    event.preventDefault();
-                }
             }
         };
 

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -6,7 +6,6 @@ import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
-import { Tools } from "../../Misc/tools";
 import { Plane } from "../../Maths/math.plane";
 import { Vector3, Matrix, TmpVectors } from "../../Maths/math.vector";
 import { Epsilon } from "../../Maths/math.constants";
@@ -76,11 +75,10 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
+     * This param is no longer used because wheel events should be treated as passive.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
-        // was there a second variable defined?
-        // eslint-disable-next-line prefer-rest-params
-        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this._wheel = (p) => {
             //sanity check - this should be a PointerWheel event.
             if (p.type !== PointerEventTypes.POINTERWHEEL) {
@@ -129,12 +127,6 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
                     this._zoomToMouse(delta);
                 } else {
                     this.camera.inertialRadiusOffset += delta;
-                }
-            }
-
-            if (event.preventDefault) {
-                if (!noPreventDefault) {
-                    event.preventDefault();
                 }
             }
         };

--- a/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -6,7 +6,6 @@ import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
-import { Tools } from "../../Misc/tools";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 
 /**
@@ -57,10 +56,10 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
+     * This param is no longer used because wheel events should be treated as passive.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
-        // eslint-disable-next-line prefer-rest-params
-        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this._wheel = (p) => {
             // sanity check - this should be a PointerWheel event.
             if (p.type !== PointerEventTypes.POINTERWHEEL) {
@@ -105,12 +104,6 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
                     this.camera.heightOffset -= delta;
                 } else if (this.axisControlRotation) {
                     this.camera.rotationOffset -= delta;
-                }
-            }
-
-            if (event.preventDefault) {
-                if (!noPreventDefault) {
-                    event.preventDefault();
                 }
             }
         };


### PR DESCRIPTION
Recently, there was a fix done for mouse wheel events to allow them to properly be identified as supporting the passive flag.  Because of this, there was a side effect introduced where if preventDefault is enabled for camera wheel input objects, it will throw an error because passive events ignore preventDefault calls.  This was brought to our attention in this forum post: https://forum.babylonjs.com/t/updated-babylon-now-getting-unable-to-preventdefault-inside-passive-event-listener-invocation-error/31842

This PR removes the, now obsolete, preventDefault calls from our wheel inputs to prevent this error from popping up.