### PR TITLE
Fix command-drag multiselect for NME on Mac

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
@@ -656,7 +656,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
         this._rootContainer.setPointerCapture(evt.pointerId);
 
         // Selection?
-        if (evt.currentTarget === this._hostCanvas && evt.ctrlKey) {
+        if (evt.currentTarget === this._hostCanvas && this._multiKeyIsPressed) {
             this._selectionBox = this.props.stateManager.hostDocument.createElement("div");
             this._selectionBox.classList.add("selection-box");
             this._selectionContainer.appendChild(this._selectionBox);


### PR DESCRIPTION
When doing click-and-drag multiselect of NME nodes, check _multiKeyIsPressed which will be true if either ctrl or command key is pressed down, instead of just checking for ctrl key. This adds Mac support.
Forum: https://forum.babylonjs.com/t/is-it-possible-to-change-shoutcut-for-node-material-editor/31808/14