### PR TITLE
Add tests for the DeviceSourceManager to check for memory leaks

### DIFF
--- a/packages/tools/tests/test/integration/leaks/playgrounds.test.ts
+++ b/packages/tools/tests/test/integration/leaks/playgrounds.test.ts
@@ -31,6 +31,7 @@ const playgrounds = [
     // "#6FBD14#2004",
     "#KQV9SA",
     "#7CBW04",
+    "#IC07YA#2",
 ];
 
 // IN TESTS

--- a/packages/tools/tests/test/performance/playgrounds.test.ts
+++ b/packages/tools/tests/test/performance/playgrounds.test.ts
@@ -16,7 +16,6 @@ const playgrounds = [
     "#6FBD14#2004",
     "#KQV9SA",
     "#7CBW04",
-    "#IC07YA#2",
 ];
 
 // IN TESTS

--- a/packages/tools/tests/test/performance/playgrounds.test.ts
+++ b/packages/tools/tests/test/performance/playgrounds.test.ts
@@ -16,6 +16,7 @@ const playgrounds = [
     "#6FBD14#2004",
     "#KQV9SA",
     "#7CBW04",
+    "#IC07YA#2",
 ];
 
 // IN TESTS


### PR DESCRIPTION
This PR contains a reference to a specific PR ([#IC07YA#2](https://playground.babylonjs.com/#IC07YA#2)) that creates multiple instances of the DeviceSourceManager and runs through some inputs before tearing things down and measuring  memory usage after the test is run.  This is done via our Integration playground test file