### PR TITLE
Fix internal plugins that use prepareDefines

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrClearCoatConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrClearCoatConfiguration.ts
@@ -220,7 +220,7 @@ export class PBRClearCoatConfiguration extends MaterialPluginBase {
         return true;
     }
 
-    public prepareDefines(defines: MaterialClearCoatDefines, scene: Scene): void {
+    public prepareDefinesBeforeAttributes(defines: MaterialClearCoatDefines, scene: Scene): void {
         if (this._isEnabled) {
             defines.CLEARCOAT = true;
             defines.CLEARCOAT_USE_ROUGHNESS_FROM_MAINTEXTURE = this._useRoughnessFromMainTexture;

--- a/packages/dev/core/src/Materials/PBR/pbrIridescenceConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrIridescenceConfiguration.ts
@@ -142,7 +142,7 @@ export class PBRIridescenceConfiguration extends MaterialPluginBase {
         return true;
     }
 
-    public prepareDefines(defines: MaterialIridescenceDefines, scene: Scene): void {
+    public prepareDefinesBeforeAttributes(defines: MaterialIridescenceDefines, scene: Scene): void {
         if (this._isEnabled) {
             defines.IRIDESCENCE = true;
             defines.IRIDESCENCE_USE_THICKNESS_FROM_MAINTEXTURE =

--- a/packages/dev/core/src/Materials/PBR/pbrSheenConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSheenConfiguration.ts
@@ -154,7 +154,7 @@ export class PBRSheenConfiguration extends MaterialPluginBase {
         return true;
     }
 
-    public prepareDefines(defines: MaterialSheenDefines, scene: Scene): void {
+    public prepareDefinesBeforeAttributes(defines: MaterialSheenDefines, scene: Scene): void {
         if (this._isEnabled) {
             defines.SHEEN = true;
             defines.SHEEN_LINKWITHALBEDO = this._linkSheenWithAlbedo;

--- a/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
@@ -351,7 +351,7 @@ export class PBRSubSurfaceConfiguration extends MaterialPluginBase {
         return true;
     }
 
-    public prepareDefines(defines: MaterialSubSurfaceDefines, scene: Scene): void {
+    public prepareDefinesBeforeAttributes(defines: MaterialSubSurfaceDefines, scene: Scene): void {
         if (!this._isRefractionEnabled && !this._isTranslucencyEnabled && !this._isScatteringEnabled) {
             defines.SUBSURFACE = false;
             defines.SS_TRANSLUCENCY = false;


### PR DESCRIPTION
Stemming from this [prev PR](https://github.com/BabylonJS/Babylon.js/pull/12643) prepareDefines is now called after PrepareDefinesForAttributes so that the plugin's defines aren't overwritten. However some of the built-in plugins rely on prepareDefines being called before PrepareDefinesForAttributes (in particular the ones that call PrepareDefinesForMergedUV which needs to be called before PrepareDefinesForAttributes).

So this PR just changes these plugins to use prepareDefinesBeforeAttributes, which is called before PrepareDefinesForAttributes to match the original behavior (this is the same fix that was created for the PBRAnisotropicConfiguration plugin in the original PR, which I thought was the only one affected).

Forum issue about the PBRSheenConfiguration plugin: https://forum.babylonjs.com/t/texture-not-displaying-for-sheen-extension/32110