### PR TITLE
Make sure legacy support doesn't throw exceptions

### DIFF
--- a/packages/lts/core/src/Legacy/legacy.ts
+++ b/packages/lts/core/src/Legacy/legacy.ts
@@ -15,15 +15,19 @@ const globalObject = typeof global !== "undefined" ? global : typeof window !== 
 if (typeof globalObject !== "undefined") {
     (<any>globalObject).BABYLON = (<any>globalObject).BABYLON || {};
     const BABYLONGLOBAL = (<any>globalObject).BABYLON;
-    BABYLONGLOBAL.Debug = BABYLONGLOBAL.Debug || {};
+    if (!BABYLONGLOBAL.Debug) {
+        BABYLONGLOBAL.Debug = BABYLONGLOBAL.Debug || {};
 
-    const keys = [];
-    for (const key in DebugImport) {
-        BABYLONGLOBAL.Debug[key] = (<any>DebugImport)[key];
-        keys.push(key);
+        for (const key in DebugImport) {
+            if (!BABYLONGLOBAL.Debug[key]) {
+                BABYLONGLOBAL.Debug[key] = (<any>DebugImport)[key];
+            }
+        }
     }
     for (const key in BABYLON) {
-        BABYLONGLOBAL[key] = (<any>BABYLON)[key];
+        if (!BABYLONGLOBAL[key]) {
+            BABYLONGLOBAL[key] = (<any>BABYLON)[key];
+        }
     }
 }
 

--- a/packages/lts/gui/src/legacy/legacy.ts
+++ b/packages/lts/gui/src/legacy/legacy.ts
@@ -10,7 +10,9 @@ import * as GUI from "gui/index";
 const globalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
 if (typeof globalObject !== "undefined") {
     (<any>globalObject).BABYLON = (<any>globalObject).BABYLON || {};
-    (<any>globalObject).BABYLON.GUI = GUI;
+    if (!(<any>globalObject).BABYLON.GUI) {
+        (<any>globalObject).BABYLON.GUI = GUI;
+    }
 }
 
 export * from "gui/index";

--- a/packages/lts/loaders/src/legacy/legacy-objFileLoader.ts
+++ b/packages/lts/loaders/src/legacy/legacy-objFileLoader.ts
@@ -8,7 +8,9 @@ import * as Loaders from "loaders/OBJ/index";
 const globalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
 if (typeof globalObject !== "undefined") {
     for (const key in Loaders) {
-        (<any>globalObject).BABYLON[key] = (<any>Loaders)[key];
+        if (!(<any>globalObject).BABYLON[key]) {
+            (<any>globalObject).BABYLON[key] = (<any>Loaders)[key];
+        }
     }
 }
 

--- a/packages/lts/loaders/src/legacy/legacy-stlFileLoader.ts
+++ b/packages/lts/loaders/src/legacy/legacy-stlFileLoader.ts
@@ -8,7 +8,9 @@ import * as Loaders from "loaders/STL/index";
 const globalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
 if (typeof globalObject !== "undefined") {
     for (const key in Loaders) {
-        (<any>globalObject).BABYLON[key] = (<any>Loaders)[key];
+        if (!(<any>globalObject).BABYLON[key]) {
+            (<any>globalObject).BABYLON[key] = (<any>Loaders)[key];
+        }
     }
 }
 


### PR DESCRIPTION
When loading the framework twice on the same page an exception was thrown, as we were re-setting unsettable parameters.