### PR TITLE
Add VirtualKeyboard support to InputTextArea

### DIFF
--- a/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
+++ b/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
@@ -9,6 +9,7 @@ import type { TextBlock } from "./textBlock";
 import type { InputText } from "./inputText";
 import { RegisterClass } from "core/Misc/typeStore";
 import type { AdvancedDynamicTexture } from "../advancedDynamicTexture";
+import { InputTextArea } from "./inputTextArea";
 
 /**
  * Class used to store key control properties
@@ -169,12 +170,12 @@ export class VirtualKeyboard extends StackPanel {
         }
     }
 
-    private _currentlyConnectedInputText: Nullable<InputText> = null;
+    private _currentlyConnectedInputText: Nullable<InputText | InputTextArea> = null;
     private _connectedInputTexts: ConnectedInputText[] = [];
     private _onKeyPressObserver: Nullable<Observer<string>> = null;
 
     /** Gets the input text control currently attached to the keyboard */
-    public get connectedInputText(): Nullable<InputText> {
+    public get connectedInputText(): Nullable<InputText | InputTextArea> {
         return this._currentlyConnectedInputText;
     }
 
@@ -206,13 +207,25 @@ export class VirtualKeyboard extends StackPanel {
                         this.applyShiftState(this.shiftState);
                         return;
                     case "\u2190":
-                        this._currentlyConnectedInputText.processKey(8);
+                        if (this._currentlyConnectedInputText instanceof InputTextArea) {
+                            this._currentlyConnectedInputText.alternativeProcessKey("Backspace");
+                        } else {
+                            this._currentlyConnectedInputText.processKey(8);
+                        }
                         return;
                     case "\u21B5":
-                        this._currentlyConnectedInputText.processKey(13);
+                        if (this._currentlyConnectedInputText instanceof InputTextArea) {
+                            this._currentlyConnectedInputText.alternativeProcessKey("Enter");
+                        } else {
+                            this._currentlyConnectedInputText.processKey(13);
+                        }
                         return;
                 }
-                this._currentlyConnectedInputText.processKey(-1, this.shiftState ? key.toUpperCase() : key);
+                if (this._currentlyConnectedInputText instanceof InputTextArea) {
+                    this._currentlyConnectedInputText.alternativeProcessKey("", this.shiftState ? key.toUpperCase() : key);
+                } else {
+                    this._currentlyConnectedInputText.processKey(-1, this.shiftState ? key.toUpperCase() : key);
+                }
 
                 if (this.shiftState === 1) {
                     this.shiftState = 0;


### PR DESCRIPTION
This PR adds VirtualKeyboard support to InputTextArea.

I check  if `this._currentlyConnectedInputText instanceof InputTextArea` to call matching method `this._currentlyConnectedInputText.alternativeProcessKey`, or call `processKey` for InputText.

Besides, pass different parameters for the input of `Enter` and `Backspace`.
```
inputText.processKey(8);
inputTextArea.alternativeProcessKey('Backspace');
```


So that an InputTextArea could be connected by a VirtualKeyboard and respond to virtual keyboard input.
```
const textarea = new InputTextArea('Textarea');
const keyboard = new VirtualKeyboard('Keyboard');
keyboard.connect(textarea);

```
 
Discussed in https://forum.babylonjs.com/t/improve-gui-virtualkeyboard-to-support-inputtextarea/32108.