### PR TITLE
Remove loading of GLTF files as the current architecture doesn't support them

### DIFF
--- a/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
@@ -125,7 +125,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
         }
 
         const options = this.props.globalState.mode === NodeMaterialModes.Particle ? particleTypeOptions : meshTypeOptions;
-        const accept = this.props.globalState.mode === NodeMaterialModes.Particle ? ".json" : ".gltf, .glb, .babylon, .obj";
+        const accept = this.props.globalState.mode === NodeMaterialModes.Particle ? ".json" : ".glb, .babylon, .obj";
 
         return (
             <div id="preview-mesh-bar">


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/nme-cant-upload-custom-gltf-for-preview/32172/2