### PR TITLE
DeviceInputSystem: Made mousewheel passive option set to false when supported

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
@@ -8,7 +8,7 @@ import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
-import { Tools } from "core/Misc/tools";
+import { Tools } from "../../Misc/tools";
 
 /**
  * Base class for mouse wheel input..

--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
@@ -8,6 +8,7 @@ import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Base class for mouse wheel input..
@@ -52,11 +53,12 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls
-     *   should call preventdefault().  This param is no longer used because wheel events should be treated as passive.
+     *   should call preventdefault().
      *   (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
+        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
+
         this._wheel = (pointer) => {
             // sanity check - this should be a PointerWheel event.
             if (pointer.type !== PointerEventTypes.POINTERWHEEL) {
@@ -86,6 +88,12 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
                 // IE >= v9   (Has WebGL >= v11)
                 // Maybe others?
                 this._wheelDeltaY -= (this.wheelPrecisionY * (<any>event).wheelDelta) / this._normalize;
+            }
+
+            if (event.preventDefault) {
+                if (!noPreventDefault) {
+                    event.preventDefault();
+                }
             }
         };
 

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -12,6 +12,7 @@ import { Epsilon } from "../../Maths/math.constants";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
 import { Scalar } from "../../Maths/math.scalar";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Firefox uses a different scheme to report scroll distances to other
@@ -75,10 +76,9 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
-     * This param is no longer used because wheel events should be treated as passive.
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
+        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this._wheel = (p) => {
             //sanity check - this should be a PointerWheel event.
             if (p.type !== PointerEventTypes.POINTERWHEEL) {
@@ -127,6 +127,12 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
                     this._zoomToMouse(delta);
                 } else {
                     this.camera.inertialRadiusOffset += delta;
+                }
+            }
+
+            if (event.preventDefault) {
+                if (!noPreventDefault) {
+                    event.preventDefault();
                 }
             }
         };

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -12,7 +12,7 @@ import { Epsilon } from "../../Maths/math.constants";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
 import { Scalar } from "../../Maths/math.scalar";
-import { Tools } from "core/Misc/tools";
+import { Tools } from "../../Misc/tools";
 
 /**
  * Firefox uses a different scheme to report scroll distances to other

--- a/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -7,7 +7,7 @@ import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
-import { Tools } from "core/Misc/tools";
+import { Tools } from "../../Misc/tools";
 
 /**
  * Manage the mouse wheel inputs to control a follow camera.

--- a/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -7,6 +7,7 @@ import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IWheelEvent } from "../../Events/deviceInputEvents";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Manage the mouse wheel inputs to control a follow camera.
@@ -56,10 +57,9 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
-     * This param is no longer used because wheel events should be treated as passive.
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public attachControl(noPreventDefault?: boolean): void {
+        noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this._wheel = (p) => {
             // sanity check - this should be a PointerWheel event.
             if (p.type !== PointerEventTypes.POINTERWHEEL) {
@@ -104,6 +104,12 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
                     this.camera.heightOffset -= delta;
                 } else if (this.axisControlRotation) {
                     this.camera.rotationOffset -= delta;
+                }
+            }
+
+            if (event.preventDefault) {
+                if (!noPreventDefault) {
+                    event.preventDefault();
                 }
             }
         };

--- a/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/webDeviceInputSystem.ts
@@ -714,7 +714,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._elementToAttachTo.addEventListener(this._eventPrefix + "up", this._pointerUpEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
         this._elementToAttachTo.addEventListener("blur", this._pointerBlurEvent);
-        this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: true } : false);
+        this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: false } : false);
 
         // Since there's no up or down event for mouse wheel or delta x/y, clear mouse values at end of frame
         this._pointerInputClearObserver = this._engine.onEndFrameObservable.add(() => {


### PR DESCRIPTION
Originally, in two PRs (https://github.com/BabylonJS/Babylon.js/pull/12696 and https://github.com/BabylonJS/Babylon.js/pull/12703) there was a violation warning that came up because the mouse wheel was not being treated as a passive event.  My original fixes addressed the original logic, which was incorrectly assigning the passive property, and makes the default value true.  This also includes removal of the preventDefault code from some of our cameras.

This current PR will accomplish two things.  One, it will revert the changes from 12703.  Second, it will set the default state of the passive property to false.  This should address an issue found in the forums where the original behavior would successfully allow for preventDefault but the newest one wouldn't.

Forum link: https://forum.babylonjs.com/t/camera-zoom-scrolling-the-page-introduced-in-5-13-1/32223/6