### PR TITLE
ArcRotateCamera: Modify rotation logic to use invertRotation flag

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -921,9 +921,9 @@ export class ArcRotateCamera extends TargetCamera {
             if (this.parent && this.parent._getWorldMatrixDeterminant() < 0) {
                 inertialAlphaOffset *= -1;
             }
-            this.alpha += inertialAlphaOffset;
+            this.alpha += inertialAlphaOffset * (this.invertRotation ? -this.inverseRotationSpeed : 1);
 
-            this.beta += this.inertialBetaOffset;
+            this.beta += this.inertialBetaOffset * (this.invertRotation ? -this.inverseRotationSpeed : 1);
 
             this.radius -= this.inertialRadiusOffset;
             this.inertialAlphaOffset *= this.inertia;

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -911,6 +911,7 @@ export class ArcRotateCamera extends TargetCamera {
         this.inputs.checkInputs();
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
+            const directionModifier = (this.invertRotation ? -1 : 1);
             let inertialAlphaOffset = this.inertialAlphaOffset;
             if (this.beta <= 0) {
                 inertialAlphaOffset *= -1;
@@ -921,9 +922,9 @@ export class ArcRotateCamera extends TargetCamera {
             if (this.parent && this.parent._getWorldMatrixDeterminant() < 0) {
                 inertialAlphaOffset *= -1;
             }
-            this.alpha += inertialAlphaOffset * (this.invertRotation ? -this.inverseRotationSpeed : 1);
+            this.alpha += inertialAlphaOffset * directionModifier;
 
-            this.beta += this.inertialBetaOffset * (this.invertRotation ? -this.inverseRotationSpeed : 1);
+            this.beta += this.inertialBetaOffset * directionModifier;
 
             this.radius -= this.inertialRadiusOffset;
             this.inertialAlphaOffset *= this.inertia;

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -911,7 +911,7 @@ export class ArcRotateCamera extends TargetCamera {
         this.inputs.checkInputs();
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
-            const directionModifier = (this.invertRotation ? -1 : 1);
+            const directionModifier = this.invertRotation ? -1 : 1;
             let inertialAlphaOffset = this.inertialAlphaOffset;
             if (this.beta <= 0) {
                 inertialAlphaOffset *= -1;


### PR DESCRIPTION
The `invertRotation` flag is primarily used with the FreeCamera and any Cameras that inherit from it.  Since the ArcRotateCamera uses different rotation logic, it never actually makes use of the `invertRotation` flag or its numerical counterpart, the `invertRotationSpeed` property.  This PR allow the user to use this flag with the ArcRotateCamera and specify the inverted rotational speed.  The discrepancy was initially brought up in the forum thread: https://forum.babylonjs.com/t/inverting-arcrotatecamera-controls-for-photodome/32147/6.

