### PR TITLE
InputManager: Added mouse buttons 4 and 5 to InputManager mouse handling

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -877,7 +877,13 @@ export class InputManager {
         this._deviceSourceManager.onDeviceConnectedObservable.add((deviceSource) => {
             if (deviceSource.deviceType === DeviceType.Mouse) {
                 deviceSource.onInputChangedObservable.add((eventData) => {
-                    if (eventData.inputIndex === PointerInput.LeftClick || eventData.inputIndex === PointerInput.MiddleClick || eventData.inputIndex === PointerInput.RightClick) {
+                    if (
+                        eventData.inputIndex === PointerInput.LeftClick ||
+                        eventData.inputIndex === PointerInput.MiddleClick ||
+                        eventData.inputIndex === PointerInput.RightClick ||
+                        eventData.inputIndex === PointerInput.BrowserBack ||
+                        eventData.inputIndex === PointerInput.BrowserForward
+                    ) {
                         if (attachDown && deviceSource.getInput(eventData.inputIndex) === 1) {
                             this._onPointerDown(eventData);
                         } else if (attachUp && deviceSource.getInput(eventData.inputIndex) === 0) {


### PR DESCRIPTION
A user in the forums brought an issue to our attention where the mouse 4 and 5 buttons (Browser Back and Browser Forward) weren't triggering `scene.onPointerObservable`.  This had worked previously in 4.2.  Upon further investigation, it was found that the code used in the InputManager to route the input calls had omitted these buttons.  This PR will add them back into the InputManager.

Forum Post: https://forum.babylonjs.com/t/scene-onpointerobservable-doesnt-catch-mouse4-and-mouse5-events-in-babylonjs-5/32225