### PR TITLE
Use only the mesh's enabled state, not its parent's, when cloning.

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -625,8 +625,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 Tags.AddTagsTo(this, Tags.GetTags(source, true));
             }
 
-            // Enabled
-            this.setEnabled(source.isEnabled());
+            // Enabled. We shouldn't need to check the source's ancestors, as this mesh
+            // will have the same ones.
+            this.setEnabled(source.isEnabled(false));
 
             // Parent
             this.parent = source.parent;


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/cloned-objects-dont-seem-to-have-the-same-enabled-state-as-the-original-object/32311

Example playground: https://playground.babylonjs.com/#48QWI6