### PR TITLE
Native readPixels implementation

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -55,6 +55,7 @@ export interface INativeEngine {
     getTextureHeight(texture: WebGLTexture): number;
     copyTexture(desination: Nullable<WebGLTexture>, source: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
+    readTexture(texture: WebGLTexture, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBufferView>): Promise<ArrayBufferView>;
 
     createImageBitmap(data: ArrayBufferView | IImage): ImageBitmap;
     resizeImageBitmap(image: ImageBitmap, bufferWidth: number, bufferHeight: number): Uint8Array;

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -55,7 +55,7 @@ export interface INativeEngine {
     getTextureHeight(texture: WebGLTexture): number;
     copyTexture(desination: Nullable<WebGLTexture>, source: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
-    readTexture(texture: WebGLTexture, mipLevel: number, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBufferView>): Promise<ArrayBufferView>;
+    readTexture(texture: WebGLTexture, mipLevel: number, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBuffer>, bufferOffset: number, bufferLength: number): Promise<ArrayBuffer>;
 
     createImageBitmap(data: ArrayBufferView | IImage): ImageBitmap;
     resizeImageBitmap(image: ImageBitmap, bufferWidth: number, bufferHeight: number): Uint8Array;

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -55,7 +55,17 @@ export interface INativeEngine {
     getTextureHeight(texture: WebGLTexture): number;
     copyTexture(desination: Nullable<WebGLTexture>, source: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
-    readTexture(texture: WebGLTexture, mipLevel: number, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBuffer>, bufferOffset: number, bufferLength: number): Promise<ArrayBuffer>;
+    readTexture(
+        texture: WebGLTexture,
+        mipLevel: number,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        buffer: Nullable<ArrayBuffer>,
+        bufferOffset: number,
+        bufferLength: number
+    ): Promise<ArrayBuffer>;
 
     createImageBitmap(data: ArrayBufferView | IImage): ImageBitmap;
     resizeImageBitmap(image: ImageBitmap, bufferWidth: number, bufferHeight: number): Uint8Array;

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -55,7 +55,7 @@ export interface INativeEngine {
     getTextureHeight(texture: WebGLTexture): number;
     copyTexture(desination: Nullable<WebGLTexture>, source: Nullable<WebGLTexture>): void;
     deleteTexture(texture: Nullable<WebGLTexture>): void;
-    readTexture(texture: WebGLTexture, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBufferView>): Promise<ArrayBufferView>;
+    readTexture(texture: WebGLTexture, mipLevel: number, x: number, y: number, width: number, height: number, buffer: Nullable<ArrayBufferView>): Promise<ArrayBufferView>;
 
     createImageBitmap(data: ArrayBufferView | IImage): ImageBitmap;
     resizeImageBitmap(image: ImageBitmap, bufferWidth: number, bufferHeight: number): Uint8Array;

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -3231,8 +3231,6 @@ export class NativeEngine extends Engine {
         x?: number,
         y?: number
     ): Promise<ArrayBufferView> {
-        // TODO: Bump the protocol version, or check for the existence of the readTexture function.
-
         if (faceIndex !== undefined && faceIndex !== -1) {
             throw new Error(`Reading cubemap faces is not supported, but faceIndex is ${faceIndex}.`);
         }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -3237,16 +3237,13 @@ export class NativeEngine extends Engine {
             throw new Error(`Reading cubemap faces is not supported, but faceIndex is ${faceIndex}.`);
         }
 
-        if (level !== undefined && level != 0) {
-            throw new Error(`Only reading mip level 0 is supported, but level is ${level}.`);
-        }
-
         return this._engine.readTexture(
             texture._hardwareTexture?.underlyingResource,
+            level ?? 0,
             x ?? 0,
             y ?? 0,
-            Math.min(width, texture.width),
-            Math.min(height, texture.height),
+            width,
+            height,
             buffer ?? null,
         );
     }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -3235,22 +3235,24 @@ export class NativeEngine extends Engine {
             throw new Error(`Reading cubemap faces is not supported, but faceIndex is ${faceIndex}.`);
         }
 
-        return this._engine.readTexture(
-            texture._hardwareTexture?.underlyingResource,
-            level ?? 0,
-            x ?? 0,
-            y ?? 0,
-            width,
-            height,
-            buffer?.buffer ?? null,
-            buffer?.byteOffset ?? 0,
-            buffer?.byteLength ?? 0,
-        ).then((rawBuffer) => {
-            if (!buffer) {
-                buffer = new Uint8Array(rawBuffer);
-            }
-    
-            return buffer;
-        });
+        return this._engine
+            .readTexture(
+                texture._hardwareTexture?.underlyingResource,
+                level ?? 0,
+                x ?? 0,
+                y ?? 0,
+                width,
+                height,
+                buffer?.buffer ?? null,
+                buffer?.byteOffset ?? 0,
+                buffer?.byteLength ?? 0
+            )
+            .then((rawBuffer) => {
+                if (!buffer) {
+                    buffer = new Uint8Array(rawBuffer);
+                }
+
+                return buffer;
+            });
     }
 }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -3218,4 +3218,36 @@ export class NativeEngine extends Engine {
         const result = { ascent: 0, height: 0, descent: 0 };
         return result;
     }
+
+    public _readTexturePixels(
+        texture: InternalTexture,
+        width: number,
+        height: number,
+        faceIndex?: number,
+        level?: number,
+        buffer?: Nullable<ArrayBufferView>,
+        flushRenderer?: boolean,
+        noDataConversion?: boolean,
+        x?: number,
+        y?: number
+    ): Promise<ArrayBufferView> {
+        // TODO: Bump the protocol version, or check for the existence of the readTexture function.
+
+        if (faceIndex !== undefined && faceIndex !== -1) {
+            throw new Error(`Reading cubemap faces is not supported, but faceIndex is ${faceIndex}.`);
+        }
+
+        if (level !== undefined && level != 0) {
+            throw new Error(`Only reading mip level 0 is supported, but level is ${level}.`);
+        }
+
+        return this._engine.readTexture(
+            texture._hardwareTexture?.underlyingResource,
+            x ?? 0,
+            y ?? 0,
+            Math.min(width, texture.width),
+            Math.min(height, texture.height),
+            buffer ?? null,
+        );
+    }
 }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -3244,7 +3244,15 @@ export class NativeEngine extends Engine {
             y ?? 0,
             width,
             height,
-            buffer ?? null,
-        );
+            buffer?.buffer ?? null,
+            buffer?.byteOffset ?? 0,
+            buffer?.byteLength ?? 0,
+        ).then((rawBuffer) => {
+            if (!buffer) {
+                buffer = new Uint8Array(rawBuffer);
+            }
+    
+            return buffer;
+        });
     }
 }

--- a/packages/dev/core/src/Materials/Textures/baseTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/baseTexture.ts
@@ -687,7 +687,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
      * @param flushRenderer true to flush the renderer from the pending commands before reading the pixels
      * @param noDataConversion false to convert the data to Uint8Array (if texture type is UNSIGNED_BYTE) or to Float32Array (if texture type is anything but UNSIGNED_BYTE). If true, the type of the generated buffer (if buffer==null) will depend on the type of the texture
      * @param x defines the region x coordinates to start reading from (default to 0)
-     * @param y defines the region y coordinates to start reading from (default to 0)pe is UNSIGNED_BYTE) or to Float32Array (if texture type is anything but UNSIGNED_BYTE). If true, the type of the generated buffer (if buffer==null) will depend on the type of the texture
+     * @param y defines the region y coordinates to start reading from (default to 0)
      * @param width defines the region width to read from (default to the texture size at level)
      * @param height defines the region width to read from (default to the texture size at level)
      * @returns The Array buffer promise containing the pixels data.


### PR DESCRIPTION
This change provides a native implementation for reading a texture to obtain an rbga8 buffer. It does not currently support cube maps.

See the corresponding Babylon Native change here: https://github.com/BabylonJS/BabylonNative/pull/1104