### PR TITLE
Skip some WebAPI calls when setting up VideoTexture in the context of Babylon Native

### DIFF
--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -422,7 +422,9 @@ export class VideoTexture extends Texture {
         video.setAttribute("playsinline", "");
         video.muted = true;
 
-        if (video.mozSrcObject !== undefined) {
+        if (video.isNative) {
+            // No additional configuration needed for native
+        } else if (video.mozSrcObject !== undefined) {
             // hack for Firefox < 19
             video.mozSrcObject = stream;
         } else {


### PR DESCRIPTION
This change prevents `VideoTexture` from calling `window.URL.createObjectURL` during initialization when running in the context of Babylon Native. Somehow this WebAPI is defined in regular Babylon Native (there is no native polyfill, so is JSC/V8 providing this?), though it is unnecessary (the `src` property is unused in Babylon Native's `VideoTexture` implementation), and in React Native `window.URL.createObjectURL` is polyfilled partially and dies on this call. Avoiding this call makes `VideoTexture` work in Babylon React Native. The extra direct check for `video.isNative` in the BJS code is not great, but other code in this file already does it, so following the existing pattern.