### PR TITLE
perf: Improve `MaterialHelper` tree-shaking with `LightConstants`

### DIFF
--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -8,6 +8,7 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Light } from "../Lights/light";
+import { LightConstants } from "../Lights/lightConstants";
 import { Constants } from "../Engines/constants";
 import type { PrePassConfiguration } from "../Materials/prePassConfiguration";
 
@@ -478,13 +479,13 @@ export class MaterialHelper {
         defines["LIGHT_FALLOFF_STANDARD" + lightIndex] = false;
 
         switch (light.falloffType) {
-            case Light.FALLOFF_GLTF:
+            case LightConstants.FALLOFF_GLTF:
                 defines["LIGHT_FALLOFF_GLTF" + lightIndex] = true;
                 break;
-            case Light.FALLOFF_PHYSICAL:
+            case LightConstants.FALLOFF_PHYSICAL:
                 defines["LIGHT_FALLOFF_PHYSICAL" + lightIndex] = true;
                 break;
-            case Light.FALLOFF_STANDARD:
+            case LightConstants.FALLOFF_STANDARD:
                 defines["LIGHT_FALLOFF_STANDARD" + lightIndex] = true;
                 break;
         }
@@ -524,10 +525,10 @@ export class MaterialHelper {
             }
         }
 
-        if (light.lightmapMode != Light.LIGHTMAP_DEFAULT) {
+        if (light.lightmapMode != LightConstants.LIGHTMAP_DEFAULT) {
             state.lightmapMode = true;
             defines["LIGHTMAPEXCLUDED" + lightIndex] = true;
-            defines["LIGHTMAPNOSPECULAR" + lightIndex] = light.lightmapMode == Light.LIGHTMAP_SHADOWSONLY;
+            defines["LIGHTMAPNOSPECULAR" + lightIndex] = light.lightmapMode == LightConstants.LIGHTMAP_SHADOWSONLY;
         } else {
             defines["LIGHTMAPEXCLUDED" + lightIndex] = false;
             defines["LIGHTMAPNOSPECULAR" + lightIndex] = false;

--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -7,7 +7,7 @@ import { EngineStore } from "../Engines/engineStore";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
 import { VertexBuffer } from "../Buffers/buffer";
-import { Light } from "../Lights/light";
+import type { Light } from "../Lights/light";
 import { LightConstants } from "../Lights/lightConstants";
 import { Constants } from "../Engines/constants";
 import type { PrePassConfiguration } from "../Materials/prePassConfiguration";


### PR DESCRIPTION
`MaterialHelper` don't need the whole `Light` class (only the `Light` TypeScript type).

Related to https://github.com/BabylonJS/Babylon.js/issues/10388