### PR TITLE
Check autoClear for RTT to fix utility layer on native OpenXR

### DIFF
--- a/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
+++ b/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
@@ -323,7 +323,7 @@ export class UtilityLayerRenderer implements IDisposable {
         // Render directly on top of existing scene without clearing
         this.utilityLayerScene.autoClear = false;
 
-        this._afterRenderObserver = this.originalScene.onAfterCameraRenderObservable.add((camera) => {
+        this._afterRenderObserver = this.originalScene.onAfterRenderCameraObservable.add((camera) => {
             // Only render when the render camera finishes rendering
             if (this.shouldRender && camera == this.getRenderCamera()) {
                 this.render();

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -3984,7 +3984,9 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             if (rtt.onClearObservable.hasObservers()) {
                 rtt.onClearObservable.notifyObservers(this._engine);
             } else if (!rtt.skipInitialClear) {
-                this._engine.clear(rtt.clearColor || this.clearColor, !rtt._cleared, true, true);
+                if (this.autoClear) {
+                    this._engine.clear(rtt.clearColor || this.clearColor, !rtt._cleared, true, true);
+                }
                 rtt._cleared = true;
             }
         } else {


### PR DESCRIPTION
Illustration showing left and right eyes in a HoloLens 2 running BabylonNative:
<img width="600" alt="stereo-clear-artifacts" src="https://user-images.githubusercontent.com/4724014/180064594-238f7fc0-6b3f-4aeb-bd45-9c7e5244362b.png">

fixes https://github.com/BabylonJS/BabylonNative/issues/1087

There were two issues going on here. The first is that we needed to render the utility layer _after_ rendering to both eyes in the target scene. By rendering the utility layer scene in between eye renders, we were getting weird clearing behavior that is hard to describe. The second is that we were double-clearing our output render target textures in cases where `RenderTargetTexture.skipInitialClear = false`.

By changing the observable used in `utilityLayerRenderer` from `onAfterCameraRenderObservable` to `onAfterRenderCameraObservable`, we're making sure to render the layer only once after finishing both eyes (instead of after the left and before the right and then again after both eyes). This doesn't meaningfully change any behavior in rendering scenarios with cameras without sub-cameras.

By checking `Scene.autoClear` when clearing the camera's output render target, we avoid clearing our render targets when rendering multiple scenes that are supposed to layer onto those render targets. This means that clearing behavior when rendering a scene to a render target matches the clearing behavior when rendering that same scene to the default frame buffer. **This is a breaking change for experiences that expected the scene not to honor `autoClear = false` when rendering to a RTT, but this is not documented/expected behavior as far as I know.**

We weren't seeing this bug in any other scenario (i.e. Oculus on Web, native iOS, native Android, etc) because on all other platforms `RenderTargetTexture.skipInitialClear = true`, and so we never saw any weird clearing behavior because the RTT's were never getting cleared in the first place, which on those platforms is totally acceptable because they get automatically cleared by either the WebXR runtime or the BabylonNative XR implementation at the top of the frame.

