### PR TITLE
Gizmo/camera fixes

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -546,7 +546,7 @@ export class BoundingBoxGizmo extends Gizmo {
     }
     /**
      * returns an array containing all boxes used for scaling (in increasing x, y and z orders)
-    */
+     */
     public getScaleBoxes() {
         return this._scaleBoxesParent.getChildMeshes();
     }

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -544,6 +544,12 @@ export class BoundingBoxGizmo extends Gizmo {
                 m.isVisible = !selectedMesh || m == selectedMesh;
             });
     }
+    /**
+     * returns an array containing all boxes used for scaling (in increasing x, y and z orders)
+    */
+    public getScaleBoxes() {
+        return this._scaleBoxesParent.getChildMeshes();
+    }
 
     /**
      * Updates the bounding box information for the Gizmo

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4459,6 +4459,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         // Multi-cameras?
+        // save current active camera, following calls will change it, discarding user settings
+        const activeCamera = this._activeCamera;
         if (this.activeCameras && this.activeCameras.length > 0) {
             for (let cameraIndex = 0; cameraIndex < this.activeCameras.length; cameraIndex++) {
                 this._processSubCameras(this.activeCameras[cameraIndex], cameraIndex > 0);
@@ -4470,6 +4472,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
             this._processSubCameras(this.activeCamera, !!this.activeCamera.outputRenderTarget);
         }
+        this._activeCamera = activeCamera;
 
         // Intersection checks
         this._checkIntersections();

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -233,6 +233,7 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
 
         if (!scene.reservedDataStore.gizmoManager) {
             scene.reservedDataStore.gizmoManager = new GizmoManager(scene);
+            scene.reservedDataStore.gizmoManager.utilityLayer.setRenderCamera(scene.activeCamera);
         }
 
         const manager: GizmoManager = scene.reservedDataStore.gizmoManager;


### PR DESCRIPTION
https://forum.babylonjs.com/t/the-gizmo-uses-the-latest-cameras-in-inspector/31221

- scene.activeCamera value is discarded during rendering when having multiple camera. The value set by the user was replaced. 
- set the rendering layer camera as the active camera for rendering

fixes #12650 
https://forum.babylonjs.com/t/can-non-uniform-scaling-be-disabled-on-the-bounding-box-gizmo/28735/7

- simple accessor to get the scaling boxes so user can tweak them
