### PR TITLE
Fix crash on smooth shading for meshes with no index buffers on Babylon Native.

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -1101,7 +1101,7 @@ export class NativeEngine extends Engine {
                 const vertexBuffer = vertexBuffers[kind];
                 if (vertexBuffer) {
                     const buffer = vertexBuffer.getBuffer() as Nullable<NativeDataBuffer>;
-                    if (buffer) {
+                    if (buffer && buffer.nativeVertexBuffer) {
                         this._engine.recordVertexBuffer(
                             vertexArray,
                             buffer.nativeVertexBuffer!,


### PR DESCRIPTION
## Overview 

When forceSharedVertices is called on a mesh that does not have an index buffer, the forceSharedVertices will create empty arrays for its positions and normals vertex attributes. This will result in a NativeEngine::RecordVertexBuffer been called with undefined arguments been passed as VertexBuffer* argument on Native engine. 

This problem does not happen on the web engine because it creates vertex attribute arrays of size zero when an empty array is provided, which results in no rendering for those meshes. 

## Issues
- Fixes Native issue [#1108 ](https://github.com/BabylonJS/BabylonNative/issues/1108)