### PR TITLE
Wait to add pending data to the scene before loading screen logic

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -945,6 +945,13 @@ export class SceneLoader {
             return null;
         }
 
+        const loadingToken = {};
+        scene.addPendingData(loadingToken);
+
+        const disposeHandler = () => {
+            scene.removePendingData(loadingToken);
+        };
+
         if (SceneLoader.ShowLoadingScreen && !this._ShowingLoadingScreen) {
             this._ShowingLoadingScreen = true;
             scene.getEngine().displayLoadingUI();
@@ -953,13 +960,6 @@ export class SceneLoader {
                 this._ShowingLoadingScreen = false;
             });
         }
-
-        const loadingToken = {};
-        scene.addPendingData(loadingToken);
-
-        const disposeHandler = () => {
-            scene.removePendingData(loadingToken);
-        };
 
         const errorHandler = (message?: string, exception?: any) => {
             const errorMessage = SceneLoader._FormatErrorMessage(fileInfo, message, exception);


### PR DESCRIPTION
Fix this issue: https://forum.babylonjs.com/t/sceneloader-append-breaks-the-loading-screen-in-5-0/32372