### PR TITLE
isPointerBlocker fixes

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -771,6 +771,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             y = y * (textureSize.height / (engine.getRenderHeight() * viewport.height));
         }
         if (this._capturingControl[pointerId]) {
+            if (this._capturingControl[pointerId].isPointerBlocker) {
+                this._shouldBlockPointer = true;
+            }
             this._capturingControl[pointerId]._processObservables(type, x, y, pi, pointerId, buttonIndex);
             return;
         }

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -50,7 +50,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _renderObserver: Nullable<Observer<Camera>>;
     private _resizeObserver: Nullable<Observer<Engine>>;
     private _preKeyboardObserver: Nullable<Observer<KeyboardInfoPre>>;
-    private _pointerMoveObserver: Nullable<Observer<PointerInfoPre>>;
+    private _prePointerObserver: Nullable<Observer<PointerInfoPre>>;
     private _sceneRenderObserver: Nullable<Observer<Scene>>;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _canvasPointerOutObserver: Nullable<Observer<PointerEvent>>;
@@ -549,8 +549,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (this._resizeObserver) {
             scene.getEngine().onResizeObservable.remove(this._resizeObserver);
         }
-        if (this._pointerMoveObserver) {
-            scene.onPrePointerObservable.remove(this._pointerMoveObserver);
+        if (this._prePointerObserver) {
+            scene.onPrePointerObservable.remove(this._prePointerObserver);
         }
         if (this._sceneRenderObserver) {
             scene.onBeforeRenderObservable.remove(this._sceneRenderObserver);
@@ -882,10 +882,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
 
         const tempViewport = new Viewport(0, 0, 0, 0);
 
-        this._pointerMoveObserver = scene.onPrePointerObservable.add((pi) => {
-            if (scene.isPointerCaptured((<IPointerEvent>pi.event).pointerId)) {
-                return;
-            }
+        this._prePointerObserver = scene.onPrePointerObservable.add((pi) => {
             if (
                 pi.type !== PointerEventTypes.POINTERMOVE &&
                 pi.type !== PointerEventTypes.POINTERUP &&
@@ -895,8 +892,14 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 return;
             }
 
-            if (pi.type === PointerEventTypes.POINTERMOVE && (pi.event as IPointerEvent).pointerId) {
-                this._defaultMousePointerId = (pi.event as IPointerEvent).pointerId; // This is required to make sure we have the correct pointer ID for wheel
+            if (pi.type === PointerEventTypes.POINTERMOVE) {
+                // Avoid pointerMove events firing while the pointer is captured by the scene
+                if (scene.isPointerCaptured((<IPointerEvent>pi.event).pointerId)) {
+                    return;
+                }
+                if ((pi.event as IPointerEvent).pointerId) {
+                    this._defaultMousePointerId = (pi.event as IPointerEvent).pointerId; // This is required to make sure we have the correct pointer ID for wheel
+                }
             }
 
             this._translateToPicking(scene, tempViewport, pi);

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -160,7 +160,13 @@ export class Control {
     /** Gets or sets a boolean indicating if the control can be hit with pointer events */
     @serialize()
     public isHitTestVisible = true;
-    /** Gets or sets a boolean indicating if the control can block pointer events */
+    /** Gets or sets a boolean indicating if the control can block pointer events. False by default except on the following controls:
+     * * Button controls (Button, RadioButton, ToggleButton)
+     * * Checkbox
+     * * ColorPicker
+     * * InputText
+     * * Slider
+     */
     @serialize()
     public isPointerBlocker = false;
     /** Gets or sets a boolean indicating if the control can be focusable */

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2111,7 +2111,7 @@ export class Control {
     public _onPointerMove(target: Control, coordinates: Vector2, pointerId: number, pi: Nullable<PointerInfoBase>): void {
         const canNotify: boolean = this.onPointerMoveObservable.notifyObservers(coordinates, -1, target, this, pi);
 
-        if (canNotify && this.parent != null) {
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerMove(target, coordinates, pointerId, pi);
         }
     }
@@ -2137,7 +2137,7 @@ export class Control {
 
         const canNotify: boolean = this.onPointerEnterObservable.notifyObservers(this, -1, target, this, pi);
 
-        if (canNotify && this.parent != null) {
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerEnter(target, pi);
         }
 
@@ -2162,7 +2162,7 @@ export class Control {
             canNotify = this.onPointerOutObservable.notifyObservers(this, -1, target, this, pi);
         }
 
-        if (canNotify && this.parent != null) {
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerOut(target, pi, force);
         }
     }
@@ -2190,7 +2190,7 @@ export class Control {
 
         const canNotify: boolean = this.onPointerDownObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
 
-        if (canNotify && this.parent != null) {
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerDown(target, coordinates, pointerId, buttonIndex, pi);
         }
 
@@ -2220,7 +2220,7 @@ export class Control {
         }
         const canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
 
-        if (canNotify && this.parent != null) {
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerUp(target, coordinates, pointerId, buttonIndex, canNotifyClick, pi);
         }
     }

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -1098,8 +1098,8 @@ export class InputText extends Control implements IFocusableControl {
 
     public _onPointerUp(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, notifyClick: boolean): void {
         this._isPointerDown = false;
-        delete this._host._capturingControl[pointerId];
         super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
+        delete this._host._capturingControl[pointerId];
     }
 
     protected _beforeRenderText(textWrapper: TextWrapper): TextWrapper {

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -1098,8 +1098,8 @@ export class InputText extends Control implements IFocusableControl {
 
     public _onPointerUp(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, notifyClick: boolean): void {
         this._isPointerDown = false;
-        super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
         delete this._host._capturingControl[pointerId];
+        super._onPointerUp(target, coordinates, pointerId, buttonIndex, notifyClick);
     }
 
     protected _beforeRenderText(textWrapper: TextWrapper): TextWrapper {


### PR DESCRIPTION
Related issues:
https://forum.babylonjs.com/t/ispointerblocker-improvement/31152
https://forum.babylonjs.com/t/on-inputtext-click-the-pointer-should-not-go-through-it/32336

* Don't pass pointer events up the hierarchy if a control has isPointerBlocker set
* Fix inputText always passing pointer events to the scene even when isPointerBlocker is set to true
* Add some documentation to clarify which controls set isPointerBlocker to true by default