### PR TITLE
Fix distorted normals in large-radius flat IcoSpheres.

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
@@ -275,8 +275,8 @@ export function CreateIcoSphereVertexData(options: {
                 icoVertices[3 * vertices_unalias_id[v_id] + 1],
                 icoVertices[3 * vertices_unalias_id[v_id] + 2]
             );
-            // Normalize to get normal, then scale to radius
-            face_vertex_pos[v012].normalize().scaleInPlace(radius);
+            // Normalize to get normal
+            face_vertex_pos[v012].normalize();
 
             // uv Coordinates from vertex ID
             face_vertex_uv[v012].copyFromFloats(


### PR DESCRIPTION
Prior to this commit, a subdivided IcoSphere with a large radius would have distorted normals
for the vertices that were in the original set prior to subdivision.

Here is an example of a flat IcoSphere with `radius: 100`:

![image](https://user-images.githubusercontent.com/4623870/180621057-ea6deece-ea68-475e-874b-460e0bc8e4f2.png)

After some troubleshooting, I discovered that this problem was due to scaling at an inappropriate
point in the process of generating the mesh. After removing this inappropriate scaling,
the normals of the vertices now look as expected without distortion.

![image](https://user-images.githubusercontent.com/4623870/180621074-52e1063a-6a1c-4de6-b077-4c74064f68a8.png)

Non-flat icospheres are unaffected - they still look appropriately round, as they did before.

![image](https://user-images.githubusercontent.com/4623870/180621092-0061c0ca-4e6c-4856-aa3d-95ab2a2e01bf.png)
