### PR TITLE
Fix version sorting in changelog generator

### DIFF
--- a/scripts/generateChangelog.js
+++ b/scripts/generateChangelog.js
@@ -172,7 +172,15 @@ async function generateChangelog(nextVersion) {
 function generateMarkdown(finalChangelog) {
     let markdown = "# Changelog\n";
     // Sort versions
-    const versions = Object.keys(finalChangelog).sort().reverse();
+    const versions = Object.keys(finalChangelog).sort((a,b) => {
+        const sepA = a.split(".");
+        const sepB = b.split(".");
+        for(let i = 0; i < sepA.length; i++) {
+            if(sepA[i] !== sepB[i]) {
+                return sepA[i] - sepB[i];
+            }
+        }
+    }).reverse();
     // per package
     const versionChangelog = {};
     versions.forEach((version) => {


### PR DESCRIPTION
Versions in CHANGELOG.md were incorrectly sorted because 5.2.0 is sorted higher than 5.16.0

This sorts the versions according go the right order