### PR TITLE
Change private members in gizmo to protected

### DIFF
--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -23,7 +23,7 @@ export class AxisDragGizmo extends Gizmo {
      * Drag behavior responsible for the gizmos dragging interactions
      */
     public dragBehavior: PointerDragBehavior;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     /**
      * Drag distance in babylon units that the gizmo will snap to when dragged (Default: 0)
      */
@@ -34,14 +34,14 @@ export class AxisDragGizmo extends Gizmo {
      */
     public onSnapObservable = new Observable<{ snapDistance: number }>();
 
-    private _isEnabled: boolean = true;
-    private _parent: Nullable<PositionGizmo> = null;
+    protected _isEnabled: boolean = true;
+    protected _parent: Nullable<PositionGizmo> = null;
 
-    private _gizmoMesh: Mesh;
-    private _coloredMaterial: StandardMaterial;
-    private _hoverMaterial: StandardMaterial;
-    private _disableMaterial: StandardMaterial;
-    private _dragging: boolean = false;
+    protected _gizmoMesh: Mesh;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverMaterial: StandardMaterial;
+    protected _disableMaterial: StandardMaterial;
+    protected _dragging: boolean = false;
 
     /**
      * @param scene

--- a/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisScaleGizmo.ts
@@ -26,7 +26,7 @@ export class AxisScaleGizmo extends Gizmo {
      * Drag behavior responsible for the gizmos dragging interactions
      */
     public dragBehavior: PointerDragBehavior;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     /**
      * Scale distance in babylon units that the gizmo will snap to when dragged (Default: 0)
      */
@@ -49,17 +49,17 @@ export class AxisScaleGizmo extends Gizmo {
      */
     public dragScale = 1;
 
-    private _isEnabled: boolean = true;
-    private _parent: Nullable<ScaleGizmo> = null;
+    protected _isEnabled: boolean = true;
+    protected _parent: Nullable<ScaleGizmo> = null;
 
-    private _gizmoMesh: Mesh;
-    private _coloredMaterial: StandardMaterial;
-    private _hoverMaterial: StandardMaterial;
-    private _disableMaterial: StandardMaterial;
-    private _dragging: boolean = false;
-    private _tmpVector = new Vector3();
-    private _tmpMatrix = new Matrix();
-    private _tmpMatrix2 = new Matrix();
+    protected _gizmoMesh: Mesh;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverMaterial: StandardMaterial;
+    protected _disableMaterial: StandardMaterial;
+    protected _dragging: boolean = false;
+    protected _tmpVector = new Vector3();
+    protected _tmpMatrix = new Matrix();
+    protected _tmpMatrix2 = new Matrix();
 
     /**
      * Creates an AxisScaleGizmo
@@ -226,7 +226,7 @@ export class AxisScaleGizmo extends Gizmo {
      * @param thickness
      * @param isCollider
      */
-    private _createGizmoMesh(parentMesh: AbstractMesh, thickness: number, isCollider = false) {
+    protected _createGizmoMesh(parentMesh: AbstractMesh, thickness: number, isCollider = false) {
         const arrowMesh = CreateBox("yPosMesh", { size: 0.4 * (1 + (thickness - 1) / 4) }, this.gizmoLayer.utilityLayerScene);
         const arrowTail = CreateCylinder(
             "cylinder",

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -25,13 +25,13 @@ import type { IPointerEvent } from "../Events/deviceInputEvents";
  * Bounding box gizmo
  */
 export class BoundingBoxGizmo extends Gizmo {
-    private _lineBoundingBox: AbstractMesh;
-    private _rotateSpheresParent: AbstractMesh;
-    private _scaleBoxesParent: AbstractMesh;
-    private _boundingDimensions = new Vector3(1, 1, 1);
-    private _renderObserver: Nullable<Observer<Scene>> = null;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
-    private _scaleDragSpeed = 0.2;
+    protected _lineBoundingBox: AbstractMesh;
+    protected _rotateSpheresParent: AbstractMesh;
+    protected _scaleBoxesParent: AbstractMesh;
+    protected _boundingDimensions = new Vector3(1, 1, 1);
+    protected _renderObserver: Nullable<Observer<Scene>> = null;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _scaleDragSpeed = 0.2;
 
     private _tmpQuaternion = new Quaternion();
     private _tmpVector = new Vector3(0, 0, 0);
@@ -94,7 +94,7 @@ export class BoundingBoxGizmo extends Gizmo {
     /**
      * Scale factor used for masking some axis
      */
-    private _axisFactor = new Vector3(1, 1, 1);
+    protected _axisFactor = new Vector3(1, 1, 1);
 
     /**
      * Sets the axis factor
@@ -150,16 +150,16 @@ export class BoundingBoxGizmo extends Gizmo {
     /**
      * Mesh used as a pivot to rotate the attached node
      */
-    private _anchorMesh: AbstractMesh;
+    protected _anchorMesh: AbstractMesh;
 
-    private _existingMeshScale = new Vector3();
+    protected _existingMeshScale = new Vector3();
 
     // Dragging
-    private _dragMesh: Nullable<Mesh> = null;
-    private _pointerDragBehavior = new PointerDragBehavior();
+    protected _dragMesh: Nullable<Mesh> = null;
+    protected _pointerDragBehavior = new PointerDragBehavior();
 
-    private _coloredMaterial: StandardMaterial;
-    private _hoverColoredMaterial: StandardMaterial;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverColoredMaterial: StandardMaterial;
 
     /**
      * Sets the color of the bounding box gizmo
@@ -536,7 +536,7 @@ export class BoundingBoxGizmo extends Gizmo {
         }
     }
 
-    private _selectNode(selectedMesh: Nullable<Mesh>) {
+    protected _selectNode(selectedMesh: Nullable<Mesh>) {
         this._rotateSpheresParent
             .getChildMeshes()
             .concat(this._scaleBoxesParent.getChildMeshes())
@@ -614,7 +614,7 @@ export class BoundingBoxGizmo extends Gizmo {
         }
     }
 
-    private _updateRotationSpheres() {
+    protected _updateRotationSpheres() {
         const rotateSpheres = this._rotateSpheresParent.getChildMeshes();
         for (let i = 0; i < 3; i++) {
             for (let j = 0; j < 2; j++) {
@@ -659,7 +659,7 @@ export class BoundingBoxGizmo extends Gizmo {
         }
     }
 
-    private _updateScaleBoxes() {
+    protected _updateScaleBoxes() {
         const scaleBoxes = this._scaleBoxesParent.getChildMeshes();
         let index = 0;
         for (let i = 0; i < 3; i++) {
@@ -724,7 +724,7 @@ export class BoundingBoxGizmo extends Gizmo {
         });
     }
 
-    private _updateDummy() {
+    protected _updateDummy() {
         if (this._dragMesh) {
             this._dragMesh.position.copyFrom(this._lineBoundingBox.getAbsolutePosition());
             this._dragMesh.scaling.copyFrom(this._lineBoundingBox.scaling);

--- a/packages/dev/core/src/Gizmos/cameraGizmo.ts
+++ b/packages/dev/core/src/Gizmos/cameraGizmo.ts
@@ -20,10 +20,10 @@ import { Observable } from "../Misc/observable";
  * Gizmo that enables viewing a camera
  */
 export class CameraGizmo extends Gizmo {
-    private _cameraMesh: Mesh;
-    private _cameraLinesMesh: Mesh;
-    private _material: StandardMaterial;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _cameraMesh: Mesh;
+    protected _cameraLinesMesh: Mesh;
+    protected _material: StandardMaterial;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
 
     /**
      * Event that fires each time the gizmo is clicked
@@ -52,7 +52,7 @@ export class CameraGizmo extends Gizmo {
             }
         }, PointerEventTypes.POINTERDOWN);
     }
-    private _camera: Nullable<Camera> = null;
+    protected _camera: Nullable<Camera> = null;
 
     /** Gets or sets a boolean indicating if frustum lines must be rendered (true by default)) */
     public get displayFrustum() {

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -46,9 +46,9 @@ export class Gizmo implements IDisposable {
      * The root mesh of the gizmo
      */
     public _rootMesh: Mesh;
-    private _attachedMesh: Nullable<AbstractMesh> = null;
-    private _attachedNode: Nullable<Node> = null;
-    private _customRotationQuaternion: Nullable<Quaternion> = null;
+    protected _attachedMesh: Nullable<AbstractMesh> = null;
+    protected _attachedNode: Nullable<Node> = null;
+    protected _customRotationQuaternion: Nullable<Quaternion> = null;
     /**
      * Ratio for the scale of the gizmo (Default: 1)
      */
@@ -154,7 +154,7 @@ export class Gizmo implements IDisposable {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected _attachedNodeChanged(value: Nullable<Node>) {}
 
-    private _beforeRenderObserver: Nullable<Observer<Scene>>;
+    protected _beforeRenderObserver: Nullable<Observer<Scene>>;
     private _tempQuaternion = new Quaternion(0, 0, 0, 1);
     private _tempVector = new Vector3();
     private _tempVector2 = new Vector3();

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -38,10 +38,53 @@ export interface GizmoAxisCache {
     /** DragBehavior */
     dragBehavior: PointerDragBehavior;
 }
+
+/**
+ * Interface for basic gizmo
+ */
+export interface IGizmo extends IDisposable {
+    /** True when the mouse pointer is hovered a gizmo mesh */
+    readonly isHovered: boolean;
+    /** The root mesh of the gizmo */
+    _rootMesh: Mesh;
+    /** Ratio for the scale of the gizmo */
+    scaleRatio: number;
+    /**
+     * Mesh that the gizmo will be attached to. (eg. on a drag gizmo the mesh that will be dragged)
+     * * When set, interactions will be enabled
+     */
+    attachedMesh: Nullable<AbstractMesh>;
+    /**
+     * Node that the gizmo will be attached to. (eg. on a drag gizmo the mesh, bone or NodeTransform that will be dragged)
+     * * When set, interactions will be enabled
+     */
+    attachedNode: Nullable<Node>;
+    /**
+     * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
+     */
+    updateGizmoRotationToMatchAttachedMesh: boolean;
+    /** The utility layer the gizmo will be added to */
+    gizmoLayer: UtilityLayerRenderer;
+    /**
+     * If set the gizmo's position will be updated to match the attached mesh each frame (Default: true)
+     */
+    updateGizmoPositionToMatchAttachedMesh: boolean;
+    /**
+     * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
+     */
+    updateScale: boolean;
+    /**
+     * posture that the gizmo will be display
+     * When set null, default value will be used (Quaternion(0, 0, 0, 1))
+     */
+    customRotationQuaternion: Nullable<Quaternion>;
+    /** Disposes and replaces the current meshes in the gizmo with the specified mesh */
+    setCustomMesh(mesh: Mesh): void;
+}
 /**
  * Renders gizmos on top of an existing scene which provide controls for position, rotation, etc.
  */
-export class Gizmo implements IDisposable {
+export class Gizmo implements IGizmo {
     /**
      * The root mesh of the gizmo
      */

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -43,15 +43,15 @@ export class GizmoManager implements IDisposable {
     /** Fires an event when the manager is attached to a node */
     public onAttachedToNodeObservable = new Observable<Nullable<Node>>();
 
-    private _gizmosEnabled = { positionGizmo: false, rotationGizmo: false, scaleGizmo: false, boundingBoxGizmo: false };
-    private _pointerObservers: Observer<PointerInfo>[] = [];
-    private _attachedMesh: Nullable<AbstractMesh> = null;
-    private _attachedNode: Nullable<Node> = null;
-    private _boundingBoxColor = Color3.FromHexString("#0984e3");
-    private _defaultUtilityLayer: UtilityLayerRenderer;
-    private _defaultKeepDepthUtilityLayer: UtilityLayerRenderer;
-    private _thickness: number = 1;
-    private _scaleRatio: number = 1;
+    protected _gizmosEnabled = { positionGizmo: false, rotationGizmo: false, scaleGizmo: false, boundingBoxGizmo: false };
+    protected _pointerObservers: Observer<PointerInfo>[] = [];
+    protected _attachedMesh: Nullable<AbstractMesh> = null;
+    protected _attachedNode: Nullable<Node> = null;
+    protected _boundingBoxColor = Color3.FromHexString("#0984e3");
+    protected _defaultUtilityLayer: UtilityLayerRenderer;
+    protected _defaultKeepDepthUtilityLayer: UtilityLayerRenderer;
+    protected _thickness: number = 1;
+    protected _scaleRatio: number = 1;
 
     /** Node Caching for quick lookup */
     private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();

--- a/packages/dev/core/src/Gizmos/lightGizmo.ts
+++ b/packages/dev/core/src/Gizmos/lightGizmo.ts
@@ -25,12 +25,12 @@ import { CreateCylinder } from "../Meshes/Builders/cylinderBuilder";
  * Gizmo that enables viewing a light
  */
 export class LightGizmo extends Gizmo {
-    private _lightMesh: Mesh;
-    private _material: StandardMaterial;
-    private _cachedPosition = new Vector3();
-    private _cachedForward = new Vector3(0, 0, 1);
-    private _attachedMeshParent: TransformNode;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _lightMesh: Mesh;
+    protected _material: StandardMaterial;
+    protected _cachedPosition = new Vector3();
+    protected _cachedForward = new Vector3(0, 0, 1);
+    protected _attachedMeshParent: TransformNode;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
 
     /**
      * Event that fires each time the gizmo is clicked
@@ -62,7 +62,7 @@ export class LightGizmo extends Gizmo {
             }
         }, PointerEventTypes.POINTERDOWN);
     }
-    private _light: Nullable<Light> = null;
+    protected _light: Nullable<Light> = null;
 
     /**
      * Override attachedNode because lightgizmo only support attached mesh

--- a/packages/dev/core/src/Gizmos/planeDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeDragGizmo.ts
@@ -23,7 +23,7 @@ export class PlaneDragGizmo extends Gizmo {
      * Drag behavior responsible for the gizmos dragging interactions
      */
     public dragBehavior: PointerDragBehavior;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     /**
      * Drag distance in babylon units that the gizmo will snap to when dragged (Default: 0)
      */
@@ -34,14 +34,14 @@ export class PlaneDragGizmo extends Gizmo {
      */
     public onSnapObservable = new Observable<{ snapDistance: number }>();
 
-    private _gizmoMesh: TransformNode;
-    private _coloredMaterial: StandardMaterial;
-    private _hoverMaterial: StandardMaterial;
-    private _disableMaterial: StandardMaterial;
+    protected _gizmoMesh: TransformNode;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverMaterial: StandardMaterial;
+    protected _disableMaterial: StandardMaterial;
 
-    private _isEnabled: boolean = false;
-    private _parent: Nullable<PositionGizmo> = null;
-    private _dragging: boolean = false;
+    protected _isEnabled: boolean = false;
+    protected _parent: Nullable<PositionGizmo> = null;
+    protected _dragging: boolean = false;
 
     /**
      * @param scene

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -27,7 +27,7 @@ export class PlaneRotationGizmo extends Gizmo {
      * Drag behavior responsible for the gizmos dragging interactions
      */
     public dragBehavior: PointerDragBehavior;
-    private _pointerObserver: Nullable<Observer<PointerInfo>> = null;
+    protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
 
     /**
      * Rotation distance in radians that the gizmo will snap to (Default: 0)
@@ -50,17 +50,17 @@ export class PlaneRotationGizmo extends Gizmo {
      */
     public angle: number = 0;
 
-    private _isEnabled: boolean = true;
-    private _parent: Nullable<RotationGizmo> = null;
-    private _coloredMaterial: StandardMaterial;
-    private _hoverMaterial: StandardMaterial;
-    private _disableMaterial: StandardMaterial;
-    private _gizmoMesh: Mesh;
-    private _rotationDisplayPlane: Mesh;
-    private _dragging: boolean = false;
-    private _angles = new Vector3();
+    protected _isEnabled: boolean = true;
+    protected _parent: Nullable<RotationGizmo> = null;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverMaterial: StandardMaterial;
+    protected _disableMaterial: StandardMaterial;
+    protected _gizmoMesh: Mesh;
+    protected _rotationDisplayPlane: Mesh;
+    protected _dragging: boolean = false;
+    protected _angles = new Vector3();
 
-    private static _RotationGizmoVertexShader = `
+    protected static _RotationGizmoVertexShader = `
         precision highp float;
         attribute vec3 position;
         attribute vec2 uv;
@@ -72,7 +72,7 @@ export class PlaneRotationGizmo extends Gizmo {
             vUV = uv;
         }`;
 
-    private static _RotationGizmoFragmentShader = `
+    protected static _RotationGizmoFragmentShader = `
         precision highp float;
         varying vec2 vUV;
         varying vec3 vPosition;
@@ -101,7 +101,7 @@ export class PlaneRotationGizmo extends Gizmo {
             gl_FragColor = vec4(1.,1.,0., min(intensity * 0.25, 0.8)) * opacity;
         }`;
 
-    private _rotationShaderMaterial: ShaderMaterial;
+    protected _rotationShaderMaterial: ShaderMaterial;
 
     /**
      * Creates a PlaneRotationGizmo
@@ -339,7 +339,7 @@ export class PlaneRotationGizmo extends Gizmo {
      * @param thickness
      * @param tessellation
      */
-    private _createGizmoMesh(parentMesh: AbstractMesh, thickness: number, tessellation: number) {
+    protected _createGizmoMesh(parentMesh: AbstractMesh, thickness: number, tessellation: number) {
         const collider = CreateTorus(
             "ignore",
             {

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -44,15 +44,15 @@ export class PositionGizmo extends Gizmo {
     public zPlaneGizmo: PlaneDragGizmo;
 
     /**
-     * private variables
+     * protected variables
      */
-    private _meshAttached: Nullable<AbstractMesh> = null;
-    private _nodeAttached: Nullable<Node> = null;
-    private _snapDistance: number;
-    private _observables: Observer<PointerInfo>[] = [];
+    protected _meshAttached: Nullable<AbstractMesh> = null;
+    protected _nodeAttached: Nullable<Node> = null;
+    protected _snapDistance: number;
+    protected _observables: Observer<PointerInfo>[] = [];
 
     /** Node Caching for quick lookup */
-    private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
+    protected _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
 
     /** Fires an event when any of it's sub gizmos are dragged */
     public onDragStartObservable = new Observable();
@@ -62,7 +62,7 @@ export class PositionGizmo extends Gizmo {
     /**
      * If set to true, planar drag is enabled
      */
-    private _planarGizmoEnabled = false;
+    protected _planarGizmoEnabled = false;
 
     public get attachedMesh() {
         return this._meshAttached;

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -73,12 +73,12 @@ export class RotationGizmo extends Gizmo {
     /** Fires an event when any of it's sub gizmos are released from dragging */
     public onDragEndObservable = new Observable();
 
-    private _meshAttached: Nullable<AbstractMesh>;
-    private _nodeAttached: Nullable<Node>;
-    private _observables: Observer<PointerInfo>[] = [];
+    protected _meshAttached: Nullable<AbstractMesh>;
+    protected _nodeAttached: Nullable<Node>;
+    protected _observables: Observer<PointerInfo>[] = [];
 
     /** Node Caching for quick lookup */
-    private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
+    protected _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
 
     public get attachedMesh() {
         return this._meshAttached;

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -37,19 +37,19 @@ export class ScaleGizmo extends Gizmo {
      */
     public uniformScaleGizmo: AxisScaleGizmo;
 
-    private _meshAttached: Nullable<AbstractMesh> = null;
-    private _nodeAttached: Nullable<Node> = null;
-    private _snapDistance: number;
-    private _uniformScalingMesh: Mesh;
-    private _octahedron: Mesh;
-    private _sensitivity: number = 1;
-    private _coloredMaterial: StandardMaterial;
-    private _hoverMaterial: StandardMaterial;
-    private _disableMaterial: StandardMaterial;
-    private _observables: Observer<PointerInfo>[] = [];
+    protected _meshAttached: Nullable<AbstractMesh> = null;
+    protected _nodeAttached: Nullable<Node> = null;
+    protected _snapDistance: number;
+    protected _uniformScalingMesh: Mesh;
+    protected _octahedron: Mesh;
+    protected _sensitivity: number = 1;
+    protected _coloredMaterial: StandardMaterial;
+    protected _hoverMaterial: StandardMaterial;
+    protected _disableMaterial: StandardMaterial;
+    protected _observables: Observer<PointerInfo>[] = [];
 
     /** Node Caching for quick lookup */
-    private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
+    protected _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
 
     /** Fires an event when any of it's sub gizmos are dragged */
     public onDragStartObservable = new Observable();
@@ -132,7 +132,7 @@ export class ScaleGizmo extends Gizmo {
     }
 
     /** Create Geometry for Gizmo */
-    private _createUniformScaleMesh(): AxisScaleGizmo {
+    protected _createUniformScaleMesh(): AxisScaleGizmo {
         this._coloredMaterial = new StandardMaterial("", this.gizmoLayer.utilityLayerScene);
         this._coloredMaterial.diffuseColor = Color3.Gray();
 


### PR DESCRIPTION
close https://github.com/BabylonJS/Babylon.js/issues/12795

I changed most of member from private to protected, even for those with public setters and getters, as setters and getters can be overwritten.

Except for

1. caching variables like `_tmpQuaternion`
1. static method of mesh creation

One thing I'm not sure about is the shader code in`planeRotationGizmo.ts`. If I change from `private` to `protected`, eslint complains about naming convention, but I wonder whether it is worth to rename.

```ts
private static _RotationGizmoFragmentShader
```

I'll leave this as a draft for discussion for now, and meanwhile continue to test the extendability on this PR.
 