### PR TITLE
[GC] Switch `= []` to `.length = 0` where possible

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -858,7 +858,7 @@ Scene.prototype.stopAllAnimations = function (): void {
         for (let i = 0; i < this._activeAnimatables.length; i++) {
             this._activeAnimatables[i].stop();
         }
-        this._activeAnimatables = [];
+        this._activeAnimatables.length = 0;
     }
 
     for (const group of this.animationGroups) {

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -309,7 +309,7 @@ export class AnimationGroup implements IDisposable {
     }
 
     private _animationLoopCount: number;
-    private _animationLoopFlags: boolean[];
+    private _animationLoopFlags: boolean[] = [];
 
     private _processLoop(animatable: Animatable, targetedAnimation: TargetedAnimation, index: number) {
         animatable.onAnimationLoop = () => {
@@ -325,7 +325,7 @@ export class AnimationGroup implements IDisposable {
             if (this._animationLoopCount === this._targetedAnimations.length) {
                 this.onAnimationGroupLoopObservable.notifyObservers(this);
                 this._animationLoopCount = 0;
-                this._animationLoopFlags = [];
+                this._animationLoopFlags.length = 0;
             }
         };
     }
@@ -347,7 +347,7 @@ export class AnimationGroup implements IDisposable {
         this._loopAnimation = loop;
 
         this._animationLoopCount = 0;
-        this._animationLoopFlags = [];
+        this._animationLoopFlags.length = 0;
 
         for (let index = 0; index < this._targetedAnimations.length; index++) {
             const targetedAnimation = this._targetedAnimations[index];
@@ -535,8 +535,8 @@ export class AnimationGroup implements IDisposable {
      * Dispose all associated resources
      */
     public dispose(): void {
-        this._targetedAnimations = [];
-        this._animatables = [];
+        this._targetedAnimations.length = 0;
+        this._animatables.length = 0;
 
         // Remove from scene
         const index = this._scene.animationGroups.indexOf(this);

--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -687,7 +687,7 @@ export class Skeleton implements IAnimatable {
      * Releases all resources associated with the current skeleton
      */
     public dispose() {
-        this._meshesWithPoseMatrix = [];
+        this._meshesWithPoseMatrix.length = 0;
 
         // Animations
         this.getScene().stopAnimation(this);

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
@@ -103,7 +103,7 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
         this._engine = this._scene.getEngine();
 
         this._onCanvasBlurObserver = this._engine.onCanvasBlurObservable.add(() => {
-            this._keys = [];
+            this._keys.length = 0;
         });
 
         this._onKeyboardObserver = this._scene.onKeyboardObservable.add((info) => {
@@ -172,7 +172,7 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
             this._onCanvasBlurObserver = null;
         }
 
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
@@ -78,7 +78,7 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
         this._engine = this._scene.getEngine();
 
         this._onCanvasBlurObserver = this._engine.onCanvasBlurObservable.add(() => {
-            this._keys = [];
+            this._keys.length = 0;
         });
 
         this._onKeyboardObserver = this._scene.onKeyboardObservable.add((info) => {
@@ -139,7 +139,7 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
             this._onKeyboardObserver = null;
             this._onCanvasBlurObserver = null;
         }
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**
@@ -154,7 +154,7 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
      * @hidden
      */
     public _onLostFocus(): void {
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/followCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraKeyboardMoveInput.ts
@@ -152,7 +152,7 @@ export class FollowCameraKeyboardMoveInput implements ICameraInput<FollowCamera>
         this._engine = this._scene.getEngine();
 
         this._onCanvasBlurObserver = this._engine.onCanvasBlurObservable.add(() => {
-            this._keys = [];
+            this._keys.length = 0;
         });
 
         this._onKeyboardObserver = this._scene.onKeyboardObservable.add((info) => {
@@ -224,7 +224,7 @@ export class FollowCameraKeyboardMoveInput implements ICameraInput<FollowCamera>
             this._onCanvasBlurObserver = null;
         }
 
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
@@ -95,7 +95,7 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
         this._engine = this._scene.getEngine();
 
         this._onCanvasBlurObserver = this._engine.onCanvasBlurObservable.add(() => {
-            this._keys = [];
+            this._keys.length = 0;
         });
 
         this._onKeyboardObserver = this._scene.onKeyboardObservable.add((info) => {
@@ -161,7 +161,7 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
             this._onKeyboardObserver = null;
             this._onCanvasBlurObserver = null;
         }
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**
@@ -217,7 +217,7 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
 
     /** @hidden */
     public _onLostFocus(): void {
-        this._keys = [];
+        this._keys.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -166,7 +166,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
                 element && element.removeEventListener("blur", this._onLostFocus);
                 this._onLostFocus = null;
             }
-            this._pointerPressed = [];
+            this._pointerPressed.length = 0;
             this._offsetX = null;
             this._offsetY = null;
         }

--- a/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
+++ b/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
@@ -2390,7 +2390,7 @@ export class VRExperienceHelper {
             this.xr.dispose();
         }
 
-        this._floorMeshesCollection = [];
+        this._floorMeshesCollection.length = 0;
 
         document.removeEventListener("keydown", this._onKeyDown);
         window.removeEventListener("vrdisplaypresentchange", this._onVrDisplayPresentChangeBind);

--- a/packages/dev/core/src/Cameras/VR/webVRCamera.ts
+++ b/packages/dev/core/src/Cameras/VR/webVRCamera.ts
@@ -747,7 +747,7 @@ export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
      * Initializes the controllers and their meshes
      */
     public initControllers() {
-        this.controllers = [];
+        this.controllers.length = 0;
 
         const manager = this.getScene().gamepadManager;
         this._onGamepadDisconnectedObserver = manager.onGamepadDisconnectedObservable.add((gamepad) => {

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -1083,10 +1083,10 @@ export class Camera extends Node {
         if (this._rigPostProcess) {
             this._rigPostProcess.dispose(this);
             this._rigPostProcess = null;
-            this._postProcesses = [];
+            this._postProcesses.length = 0;
         } else if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
             this._rigPostProcess = null;
-            this._postProcesses = [];
+            this._postProcesses.length = 0;
         } else {
             let i = this._postProcesses.length;
             while (--i >= 0) {
@@ -1102,7 +1102,7 @@ export class Camera extends Node {
         while (--i >= 0) {
             this.customRenderTargets[i].dispose();
         }
-        this.customRenderTargets = [];
+        this.customRenderTargets.length = 0;
 
         // Active Meshes
         this._activeMeshes.dispose();

--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -1,6 +1,6 @@
 /** @hidden */
 export class ShaderCodeCursor {
-    private _lines: string[];
+    private _lines: string[] = [];
     lineIndex: number;
 
     get currentLine(): string {
@@ -12,7 +12,7 @@ export class ShaderCodeCursor {
     }
 
     set lines(value: string[]) {
-        this._lines = [];
+        this._lines.length = 0;
 
         for (const line of value) {
             // Prevent removing line break in macros.

--- a/packages/dev/core/src/Engines/WebGPU/webgpuOcclusionQuery.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuOcclusionQuery.ts
@@ -112,6 +112,6 @@ export class WebGPUOcclusionQuery {
 
     public dispose(): void {
         this._querySet?.dispose();
-        this._availableIndices = [];
+        this._availableIndices.length = 0;
     }
 }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3575,7 +3575,7 @@ export class ThinEngine {
      * This can help preventing texture load conflict due to name collision.
      */
     public clearInternalTexturesCache() {
-        this._internalTexturesCache = [];
+        this._internalTexturesCache.length = 0;
     }
 
     /**
@@ -5288,7 +5288,7 @@ export class ThinEngine {
 
         // Unbind
         this.unbindAllAttributes();
-        this._boundUniforms = [];
+        this._boundUniforms = {};
 
         // Events
         if (IsWindowObjectExist()) {
@@ -5304,7 +5304,7 @@ export class ThinEngine {
 
         this._workingCanvas = null;
         this._workingContext = null;
-        this._currentBufferPointers = [];
+        this._currentBufferPointers.length = 0;
         this._renderingCanvas = null;
         this._currentProgram = null;
         this._boundRenderFunction = null;

--- a/packages/dev/core/src/Materials/Node/Blocks/gradientBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/gradientBlock.ts
@@ -171,7 +171,7 @@ export class GradientBlock extends NodeMaterialBlock {
     public _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
         super._deserialize(serializationObject, scene, rootUrl);
 
-        this.colorSteps = [];
+        this.colorSteps.length = 0;
 
         for (const step of serializationObject.colorSteps) {
             this.colorSteps.push(new GradientBlockColorStep(step.step, new Color3(step.color.r, step.color.g, step.color.b)));

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1481,7 +1481,7 @@ export class NodeMaterial extends PushMaterial {
             block.dispose();
         }
 
-        this.attachedBlocks = [];
+        this.attachedBlocks.length = 0;
         (this._sharedData as any) = null;
         (this._vertexCompilationState as any) = null;
         (this._fragmentCompilationState as any) = null;
@@ -1532,9 +1532,9 @@ export class NodeMaterial extends PushMaterial {
      * Clear the current material
      */
     public clear() {
-        this._vertexOutputNodes = [];
-        this._fragmentOutputNodes = [];
-        this.attachedBlocks = [];
+        this._vertexOutputNodes.length = 0;
+        this._fragmentOutputNodes.length = 0;
+        this.attachedBlocks.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/prePassRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/prePassRenderTarget.ts
@@ -107,7 +107,7 @@ export class PrePassRenderTarget extends MultiRenderTarget {
      * @hidden
      */
     public _resetPostProcessChain() {
-        this._beforeCompositionPostProcesses = [];
+        this._beforeCompositionPostProcesses.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Materials/materialDefines.ts
+++ b/packages/dev/core/src/Materials/materialDefines.ts
@@ -3,7 +3,7 @@
  */
 export class MaterialDefines {
     /** @hidden */
-    protected _keys: string[];
+    protected _keys: string[] = [];
     private _isDirty = true;
     /** @hidden */
     public _renderId: number;
@@ -160,7 +160,7 @@ export class MaterialDefines {
      * Rebuilds the material defines
      */
     public rebuild() {
-        this._keys = [];
+        this._keys.length = 0;
 
         for (const key of Object.keys(this)) {
             if (key[0] === "_") {

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -2037,7 +2037,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             other._intersectionsInProgress.splice(pos, 1);
         }
 
-        this._intersectionsInProgress = [];
+        this._intersectionsInProgress.length = 0;
 
         // Lights
         const lights = this.getScene().lights;

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -155,7 +155,6 @@ export class Geometry implements IGetSetVerticesData {
             this.setAllVerticesData(vertexData, updatable);
         } else {
             this._totalVertices = 0;
-            this._indices = [];
         }
 
         if (this._engine.getCaps().vertexArrayObject) {
@@ -923,7 +922,7 @@ export class Geometry implements IGetSetVerticesData {
         for (index = 0; index < numOfMeshes; index++) {
             this.releaseForMesh(meshes[index]);
         }
-        this._meshes = [];
+        this._meshes.length = 0;
 
         this._disposeVertexArrayObjects();
 

--- a/packages/dev/core/src/Misc/smartArray.ts
+++ b/packages/dev/core/src/Misc/smartArray.ts
@@ -83,7 +83,6 @@ export class SmartArray<T> implements ISmartArrayLike<T> {
 
         if (this.data) {
             this.data.length = 0;
-            this.data = [];
         }
     }
 

--- a/packages/dev/core/src/Particles/computeShaderParticleSystem.ts
+++ b/packages/dev/core/src/Particles/computeShaderParticleSystem.ts
@@ -166,7 +166,7 @@ export class ComputeShaderParticleSystem implements IGPUParticleSystemPlatform {
             this._bufferComputeShader[i].dispose();
         }
 
-        this._bufferComputeShader = [];
+        this._bufferComputeShader.length = 0;
 
         this._simParamsComputeShader?.dispose();
         (<any>this._simParamsComputeShader) = null;
@@ -175,7 +175,7 @@ export class ComputeShaderParticleSystem implements IGPUParticleSystemPlatform {
     }
 
     public releaseVertexBuffers(): void {
-        this._renderVertexBuffers = [];
+        this._renderVertexBuffers.length = 0;
     }
 }
 

--- a/packages/dev/core/src/Particles/particleSystem.ts
+++ b/packages/dev/core/src/Particles/particleSystem.ts
@@ -1306,8 +1306,8 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
      * Remove all active particles
      */
     public reset(): void {
-        this._stockParticles = [];
-        this._particles = [];
+        this._stockParticles.length = 0;
+        this._particles.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Particles/particleSystemSet.ts
+++ b/packages/dev/core/src/Particles/particleSystemSet.ts
@@ -116,7 +116,7 @@ export class ParticleSystemSet implements IDisposable {
             system.dispose();
         }
 
-        this.systems = [];
+        this.systems.length = 0;
 
         if (this._emitterNode) {
             if ((this._emitterNode as AbstractMesh).dispose) {

--- a/packages/dev/core/src/Particles/webgl2ParticleSystem.ts
+++ b/packages/dev/core/src/Particles/webgl2ParticleSystem.ts
@@ -218,12 +218,12 @@ export class WebGL2ParticleSystem implements IGPUParticleSystemPlatform {
         for (let index = 0; index < this._updateVAO.length; index++) {
             this._engine.releaseVertexArrayObject(this._updateVAO[index]);
         }
-        this._updateVAO = [];
+        this._updateVAO.length = 0;
 
         for (let index = 0; index < this._renderVAO.length; index++) {
             this._engine.releaseVertexArrayObject(this._renderVAO[index]);
         }
-        this._renderVAO = [];
+        this._renderVAO.length = 0;
     }
 
     private _createUpdateVAO(source: Buffer): WebGLVertexArrayObject {

--- a/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
+++ b/packages/dev/core/src/Physics/Plugins/cannonJSPlugin.ts
@@ -82,7 +82,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
                     this.world.remove(physicsBody);
                 }
             });
-            this._physicsBodysToRemoveAfterStep = [];
+            this._physicsBodysToRemoveAfterStep.length = 0;
         }
     }
 

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
@@ -1621,9 +1621,9 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
         this.fxaaPostProcess = null;
         this.screenSpaceReflectionPostProcess = null;
 
-        this.luminanceDownSamplePostProcesses = [];
-        this.blurHPostProcesses = [];
-        this.blurVPostProcesses = [];
+        this.luminanceDownSamplePostProcesses.length = 0;
+        this.blurHPostProcesses.length = 0;
+        this.blurVPostProcesses.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/XR/features/WebXRLayers.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.ts
@@ -223,7 +223,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
         const engine = this._xrSessionManager.scene.getEngine();
         this._glContext = engine._gl;
         this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
-        this._existingLayers = [];
+        this._existingLayers.length = 0;
 
         const projectionLayerInit = { ...defaultXRProjectionLayerInit };
         const projectionLayerMultiview = this._options.preferMultiviewOnInit && engine.getCaps().multiview;

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -511,62 +511,62 @@ export class AssetContainer extends AbstractScene {
         this.cameras.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.cameras = [];
+        this.cameras.length = 0;
 
         this.lights.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.lights = [];
+        this.lights.length = 0;
 
         this.meshes.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.meshes = [];
+        this.meshes.length = 0;
 
         this.skeletons.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.skeletons = [];
+        this.skeletons.length = 0;
 
         this.animationGroups.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.animationGroups = [];
+        this.animationGroups.length = 0;
 
         this.multiMaterials.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.multiMaterials = [];
+        this.multiMaterials.length = 0;
 
         this.materials.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.materials = [];
+        this.materials.length = 0;
 
         this.geometries.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.geometries = [];
+        this.geometries.length = 0;
 
         this.transformNodes.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.transformNodes = [];
+        this.transformNodes.length = 0;
 
         this.actionManagers.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.actionManagers = [];
+        this.actionManagers.length = 0;
 
         this.textures.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.textures = [];
+        this.textures.length = 0;
 
         this.reflectionProbes.slice(0).forEach((o) => {
             o.dispose();
         });
-        this.reflectionProbes = [];
+        this.reflectionProbes.length = 0;
 
         if (this.environmentTexture) {
             this.environmentTexture.dispose();

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -905,7 +905,7 @@ export class Node implements IBehaviorAware<Node> {
             behavior.detach();
         }
 
-        this._behaviors = [];
+        this._behaviors.length = 0;
 
         this.metadata = null;
     }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1321,7 +1321,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             for (const component of this._transientComponents) {
                 component.register();
             }
-            this._transientComponents = [];
+            this._transientComponents.length = 0;
         }
     }
 
@@ -4502,7 +4502,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 }
             }
 
-            this._toBeDisposed = [];
+            this._toBeDisposed.length = 0;
         }
 
         if (this.dumpNextRenderTargets) {
@@ -4548,9 +4548,9 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.afterRender = null;
         this.metadata = null;
 
-        this.skeletons = [];
-        this.morphTargetManagers = [];
-        this._transientComponents = [];
+        this.skeletons.length = 0;
+        this.morphTargetManagers.length = 0;
+        this._transientComponents.length = 0;
         this._isReadyForMeshStage.clear();
         this._beforeEvaluateActiveMeshStage.clear();
         this._evaluateSubMeshStage.clear();
@@ -4596,14 +4596,14 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this._materialsRenderTargets.dispose();
         this._registeredForLateAnimationBindings.dispose();
         this._meshesForIntersections.dispose();
-        this._toBeDisposed = [];
+        this._toBeDisposed.length = 0;
 
         // Abort active requests
         const activeRequests = this._activeRequests.slice();
         for (const request of activeRequests) {
             request.abort();
         }
-        this._activeRequests = [];
+        this._activeRequests.length = 0;
 
         // Events
         this.onDisposeObservable.notifyObservers(this);

--- a/packages/dev/gui/src/2D/controls/grid.ts
+++ b/packages/dev/gui/src/2D/controls/grid.ts
@@ -504,12 +504,12 @@ export class Grid extends Container {
         for (let index = 0; index < this._columnDefinitions.length; index++) {
             this._columnDefinitions[index].onChangedObservable.remove(this._columnDefinitionObservers[index]);
         }
-        this._rowDefinitionObservers = [];
-        this._rowDefinitions = [];
-        this._columnDefinitionObservers = [];
-        this._columnDefinitions = [];
+        this._rowDefinitionObservers.length = 0;
+        this._rowDefinitions.length = 0;
+        this._columnDefinitionObservers.length = 0;
+        this._columnDefinitions.length = 0;
         this._cells = {};
-        this._childControls = [];
+        this._childControls.length = 0;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
+++ b/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
@@ -279,7 +279,7 @@ export class VirtualKeyboard extends StackPanel {
             this._connectedInputTexts.forEach((connectedInputText: ConnectedInputText) => {
                 this._removeConnectedInputObservables(connectedInputText);
             });
-            this._connectedInputTexts = [];
+            this._connectedInputTexts.length = 0;
         }
 
         if (this._connectedInputTexts.length === 0) {

--- a/packages/dev/gui/src/3D/controls/container3D.ts
+++ b/packages/dev/gui/src/3D/controls/container3D.ts
@@ -138,7 +138,7 @@ export class Container3D extends Control3D {
             control.dispose();
         }
 
-        this._children = [];
+        this._children.length = 0;
 
         super.dispose();
     }

--- a/packages/dev/loaders/src/OBJ/solidParser.ts
+++ b/packages/dev/loaders/src/OBJ/solidParser.ts
@@ -215,11 +215,11 @@ export class SolidParser {
             }
         }
         // Reset arrays for the next new meshes
-        this._wrappedPositionForBabylon = [];
-        this._wrappedNormalsForBabylon = [];
-        this._wrappedUvsForBabylon = [];
-        this._wrappedColorsForBabylon = [];
-        this._tuplePosNorm = [];
+        this._wrappedPositionForBabylon.length = 0;
+        this._wrappedNormalsForBabylon.length = 0;
+        this._wrappedUvsForBabylon.length = 0;
+        this._wrappedColorsForBabylon.length = 0;
+        this._tuplePosNorm.length = 0;
         this._curPositionInIndices = 0;
     }
 
@@ -277,7 +277,7 @@ export class SolidParser {
             );
         }
         //Reset variable for the next line
-        this._triangles = [];
+        this._triangles.length = 0;
     }
 
     /**
@@ -310,7 +310,7 @@ export class SolidParser {
         }
 
         //Reset variable for the next line
-        this._triangles = [];
+        this._triangles.length = 0;
     }
 
     /**
@@ -344,7 +344,7 @@ export class SolidParser {
             );
         }
         //Reset variable for the next line
-        this._triangles = [];
+        this._triangles.length = 0;
     }
 
     /**
@@ -375,7 +375,7 @@ export class SolidParser {
             );
         }
         //Reset variable for the next line
-        this._triangles = [];
+        this._triangles.length = 0;
     }
 
     /*
@@ -410,7 +410,7 @@ export class SolidParser {
             );
         }
         //Reset variable for the next line
-        this._triangles = [];
+        this._triangles.length = 0;
     }
 
     private _addPreviousObjMesh() {
@@ -437,11 +437,11 @@ export class SolidParser {
             }
 
             //Reset the array for the next mesh
-            this._indicesForBabylon = [];
-            this._unwrappedPositionsForBabylon = [];
-            this._unwrappedColorsForBabylon = [];
-            this._unwrappedNormalsForBabylon = [];
-            this._unwrappedUVForBabylon = [];
+            this._indicesForBabylon.length = 0;
+            this._unwrappedPositionsForBabylon.length = 0;
+            this._unwrappedColorsForBabylon.length = 0;
+            this._unwrappedNormalsForBabylon.length = 0;
+            this._unwrappedUVForBabylon.length = 0;
         }
     }
 


### PR DESCRIPTION
Quickly scraped all references to ` this.[anything] = [];` and checked if they are already created previously. In this case, setting to `length = 0` will be enough and will prevent the array from being garbage-collected.