### PR TITLE
Fxi heightmap impostor with Cannon

### DIFF
--- a/packages/dev/core/src/Physics/physicsImpostor.ts
+++ b/packages/dev/core/src/Physics/physicsImpostor.ts
@@ -894,6 +894,7 @@ export class PhysicsImpostor {
         // take the position set and make it the absolute position of this object.
         this.object.setAbsolutePosition(this.object.position);
         this._deltaRotation && this.object.rotationQuaternion && this.object.rotationQuaternion.multiplyToRef(this._deltaRotation, this.object.rotationQuaternion);
+        this.object.computeWorldMatrix(true);
         this.object.translate(this._deltaPosition, 1);
     };
 


### PR DESCRIPTION
fixes #12578 
World transform was not updated properly and adding/removing delta was happening with different world matrix values leading to a translation each frame.