### PR TITLE
[GE] Make sure artboard is resized correctly when resizing the canvas

### DIFF
--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -226,14 +226,15 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
             framesToUpdate += 5;
         });
         globalState.onNewSceneObservable.add((scene) => {
-            scene && scene.onBeforeRenderObservable.add(() => {
-                if (framesToUpdate > 0) {
-                    framesToUpdate--;
-                    globalState.onGizmoUpdateRequireObservable.notifyObservers();
-                    this._engine.resize();
-                    globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
-                }
-            });
+            scene &&
+                scene.onBeforeRenderObservable.add(() => {
+                    if (framesToUpdate > 0) {
+                        framesToUpdate--;
+                        globalState.onGizmoUpdateRequireObservable.notifyObservers();
+                        this._engine.resize();
+                        globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
+                    }
+                });
         });
 
         globalState.onCopyObservable.add((copyFn) => this.copyToClipboard(copyFn));

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -102,7 +102,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         this._visibleRegionContainer.heightInPixels = this._guiSize.height;
         this.props.globalState.onResizeObservable.notifyObservers(this._guiSize);
         this.props.globalState.onReframeWindowObservable.notifyObservers();
-        this.props.globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
+        this.props.globalState.onWindowResizeObservable.notifyObservers();
     }
 
     public applyEditorTransformation() {
@@ -220,11 +220,20 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         // Hotkey shortcuts
         globalState.hostDocument!.addEventListener("keydown", this.keyEvent, false);
         globalState.hostDocument!.defaultView!.addEventListener("blur", this.blurEvent, false);
-
+        let framesToUpdate = 1;
         globalState.onWindowResizeObservable.add(() => {
-            globalState.onGizmoUpdateRequireObservable.notifyObservers();
-            globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
-            this._engine.resize();
+            // update the size for the next 5 frames
+            framesToUpdate += 5;
+        });
+        globalState.onNewSceneObservable.add((scene) => {
+            scene && scene.onBeforeRenderObservable.add(() => {
+                if (framesToUpdate > 0) {
+                    framesToUpdate--;
+                    globalState.onGizmoUpdateRequireObservable.notifyObservers();
+                    this._engine.resize();
+                    globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
+                }
+            });
         });
 
         globalState.onCopyObservable.add((copyFn) => this.copyToClipboard(copyFn));
@@ -854,8 +863,11 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         // Watch for browser/canvas resize events
         this.props.globalState.hostWindow.addEventListener("resize", () => {
             this.props.globalState.onWindowResizeObservable.notifyObservers();
+            this._scene.onBeforeRenderObservable.addOnce(() => {
+                this.props.globalState.onWindowResizeObservable.notifyObservers();
+            });
         });
-        this._engine.resize();
+        this.props.globalState.onWindowResizeObservable.notifyObservers();
 
         this.props.globalState.guiTexture.onBeginRenderObservable.add(() => {
             this.applyEditorTransformation();
@@ -863,7 +875,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
         this.props.globalState.onPropertyChangedObservable.add((ev) => {
             (ev.object as Control).markAsDirty(false);
-            this.props.globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
+            this.props.globalState.onWindowResizeObservable.notifyObservers();
         });
 
         // Every time the original ADT re-renders, we must also re-render, so that layout information is computed correctly
@@ -971,8 +983,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         const panningDelta = this.getScaledPointerPosition().subtract(this._initialPanningOffset).multiplyByFloats(1, -1);
         this._panningOffset = this._panningOffset.add(panningDelta);
         this._initialPanningOffset = this.getScaledPointerPosition();
-        this.props.globalState.onArtBoardUpdateRequiredObservable.notifyObservers();
-        this.props.globalState.onGizmoUpdateRequireObservable.notifyObservers();
+        this.props.globalState.onWindowResizeObservable.notifyObservers();
     }
 
     // Move the selected controls. Can be either on horizontal (leftInPixels) or


### PR DESCRIPTION
There seems to be a race condition between the HTML page and the babylon scene/engine.
I will create an issue to follow up on this and find a proper fix, but for now, it is enough to run the rezise callback 5 times every time it is needed.

For future reference, there seems to be an issue with the `top` on the Rect created in ArtBoardComponent