### PR TITLE
setSnapshotRenderingMode should have no effect on WebGL engine

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -700,7 +700,7 @@ export class ThinEngine {
     }
 
     public set snapshotRenderingMode(mode: number) {
-        this._snapshotRenderingMode = mode;
+        // Noop on webgl, as snapshot rendering is only for WebGPU
     }
 
     protected _useExactSrgbConversions = false;


### PR DESCRIPTION
Playground example: https://playground.babylonjs.com/?#SYQW69#951