### PR TITLE
[Playground] allow saving a playground when using snapshots

### DIFF
--- a/packages/tools/playground/src/tools/saveManager.ts
+++ b/packages/tools/playground/src/tools/saveManager.ts
@@ -41,7 +41,7 @@ export class SaveManager {
                         }
                     } else {
                         // default behavior!
-                        const baseUrl = location.href.replace(location.hash, "").replace(location.search, "");
+                        const baseUrl = location.href.replace(location.hash, "");
                         let newUrl = baseUrl + "#" + snippet.id;
                         newUrl = newUrl.replace("##", "#");
                         this.globalState.currentSnippetToken = snippet.id;


### PR DESCRIPTION
The snapshot was always removed when a snippet was saved. A clear of location.search is not needed.