### PR TITLE
Export Material Plugin Events

### DIFF
--- a/packages/dev/core/src/Materials/index.ts
+++ b/packages/dev/core/src/Materials/index.ts
@@ -26,5 +26,6 @@ export * from "./shadowDepthWrapper";
 export * from "./drawWrapper";
 export * from "./materialPluginBase";
 export * from "./materialPluginManager";
+export * from "./materialPluginEvent";
 export * from "./material.detailMapConfiguration";
 export * from "./materialPluginFactoryExport";


### PR DESCRIPTION
https://forum.babylonjs.com/t/materialpluginevent-is-not-exported-in-materials-index-ts/32760