### PR TITLE
Fix getHeightAtCoordinates with Impostors and out of bound

### DIFF
--- a/packages/dev/core/src/Meshes/groundMesh.ts
+++ b/packages/dev/core/src/Meshes/groundMesh.ts
@@ -99,7 +99,7 @@ export class GroundMesh extends Mesh {
         Vector3.TransformCoordinatesFromFloatsToRef(x, 0.0, z, invMat, tmpVect); // transform x,z in the mesh local space
         x = tmpVect.x;
         z = tmpVect.z;
-        if (x < this._minX || x > this._maxX || z < this._minZ || z > this._maxZ) {
+        if (x < this._minX || x >= this._maxX || z <= this._minZ || z > this._maxZ) {
             return this.position.y;
         }
         if (!this._heightQuads || this._heightQuads.length == 0) {

--- a/packages/dev/core/src/Physics/physicsImpostor.ts
+++ b/packages/dev/core/src/Physics/physicsImpostor.ts
@@ -893,9 +893,14 @@ export class PhysicsImpostor {
         }
         // take the position set and make it the absolute position of this object.
         this.object.setAbsolutePosition(this.object.position);
-        this._deltaRotation && this.object.rotationQuaternion && this.object.rotationQuaternion.multiplyToRef(this._deltaRotation, this.object.rotationQuaternion);
+        if (this._deltaRotation) {
+            this.object.rotationQuaternion && this.object.rotationQuaternion.multiplyToRef(this._deltaRotation, this.object.rotationQuaternion);
+            this._deltaPosition.applyRotationQuaternionToRef(this._deltaRotation, PhysicsImpostor._TmpVecs[0]);
+            this.object.translate(PhysicsImpostor._TmpVecs[0], 1);
+        } else {
+            this.object.translate(this._deltaPosition, 1);
+        }
         this.object.computeWorldMatrix(true);
-        this.object.translate(this._deltaPosition, 1);
     };
 
     /**


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/groundmesh-getheightatcoordinates-is-corrupted-by-physicsimpostor-heightmapimpostor/32774

2 bugs at once:
- The bounds check was not correct
- This fix was incomplete : https://github.com/BabylonJS/Babylon.js/pull/12818