### PR TITLE
GUI Editor Tool buttons now respond on the entire document instead of…

### DIFF
--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -926,26 +926,6 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
     addControls(scene: Scene) {
         scene.onKeyboardObservable.add((k: KeyboardInfo) => {
             switch (k.event.key) {
-                case "s": //select
-                case "S":
-                    this.props.globalState.tool = GUIEditorTool.SELECT;
-                    break;
-                case "p": //pan
-                case "P":
-                    this.props.globalState.tool = GUIEditorTool.PAN;
-                    break;
-                case "z": //zoom
-                case "Z":
-                    this.props.globalState.tool = GUIEditorTool.ZOOM;
-                    break;
-                case "g": //outlines
-                case "G":
-                    this.props.globalState.outlines = !this.props.globalState.outlines;
-                    break;
-                case "f": //fit to window
-                case "F":
-                    this.props.globalState.onFitControlsToWindowObservable.notifyObservers();
-                    break;
                 case "ArrowUp": // move up
                     this.moveControls(false, k.event.shiftKey ? -ARROW_KEY_MOVEMENT_LARGE : -ARROW_KEY_MOVEMENT_SMALL);
                     break;

--- a/packages/tools/guiEditor/src/globalState.ts
+++ b/packages/tools/guiEditor/src/globalState.ts
@@ -58,6 +58,7 @@ export class GlobalState {
     onPropertyChangedObservable = new Observable<PropertyChangedEvent>();
 
     private _tool: GUIEditorTool = GUIEditorTool.SELECT;
+    private _prevTool: GUIEditorTool = this._tool;
     onToolChangeObservable = new Observable<void>();
     public get tool(): GUIEditorTool {
         if (this._tool === GUIEditorTool.ZOOM) {
@@ -70,8 +71,16 @@ export class GlobalState {
     }
     public set tool(newTool: GUIEditorTool) {
         if (this._tool === newTool) return;
+        this._prevTool = this._tool;
         this._tool = newTool;
         this.onToolChangeObservable.notifyObservers();
+    }
+
+    public restorePreviousTool() {
+        if (this._tool !== this._prevTool) {
+            this._tool = this._prevTool;
+            this.onToolChangeObservable.notifyObservers();
+        }
     }
     onFitControlsToWindowObservable = new Observable<void>();
     onReframeWindowObservable = new Observable<void>();

--- a/packages/tools/guiEditor/src/workbenchEditor.tsx
+++ b/packages/tools/guiEditor/src/workbenchEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type { GlobalState } from "./globalState";
+import { GUIEditorTool } from "./globalState";
 import { PropertyTabComponent } from "./components/propertyTab/propertyTabComponent";
 import { Portal } from "./portal";
 import { LogComponent } from "./components/log/logComponent";
@@ -44,7 +45,46 @@ export class WorkbenchEditor extends React.Component<IGraphEditorProps, IGraphEd
         if (navigator.userAgent.indexOf("Mobile") !== -1) {
             ((this.props.globalState.hostDocument || document).querySelector(".blocker") as HTMLElement).style.visibility = "visible";
         }
+        document.addEventListener("keydown", this.addToolControls);
+        document.addEventListener("keyup", this.removePressToolControls);
     }
+
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.addToolControls);
+        document.removeEventListener("keyup", this.removePressToolControls);
+    }
+
+    addToolControls = (evt: KeyboardEvent) => {
+        switch (evt.key) {
+            case "s": //select
+            case "S":
+                this.props.globalState.tool = GUIEditorTool.SELECT;
+                break;
+            case "p": //pan
+            case "P":
+            case " ":
+                this.props.globalState.tool = GUIEditorTool.PAN;
+                break;
+            case "z": //zoom
+            case "Z":
+                this.props.globalState.tool = GUIEditorTool.ZOOM;
+                break;
+            case "g": //outlines
+            case "G":
+                this.props.globalState.outlines = !this.props.globalState.outlines;
+                break;
+            case "f": //fit to window
+            case "F":
+                this.props.globalState.onFitControlsToWindowObservable.notifyObservers();
+                break;
+        }
+    };
+
+    removePressToolControls = (evt: KeyboardEvent) => {
+        if (evt.key === " ") {
+            this.props.globalState.restorePreviousTool();
+        }
+    };
 
     constructor(props: IGraphEditorProps) {
         super(props);


### PR DESCRIPTION
… only in the canvas. Also fix an issue where a control could still be moved even if the space key was pressed to pan.

Forum issue: https://forum.babylonjs.com/t/gui-editor-pan-mode-does-not-work-as-expected/32767/4