### PR TITLE
Fixed removal of the last geometry in the "scene.geometries" array

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -3125,9 +3125,12 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 this.geometries[index] = lastGeometry;
                 if (this._geometriesByUniqueId) {
                     this._geometriesByUniqueId[lastGeometry.uniqueId] = index;
-                    this._geometriesByUniqueId[geometry.uniqueId] = undefined;
                 }
             }
+        }
+
+        if (this._geometriesByUniqueId) {
+            this._geometriesByUniqueId[geometry.uniqueId] = undefined;
         }
 
         this.geometries.pop();


### PR DESCRIPTION
We have:
`scene.geometries == [g1,g2,g3] `
we call:
`scene.removeGeometry(g3)`
g3 stays in the `scene._geometriesByUniqueId`  map with index == 2. This happens because it is the last one in the scene.geometries  list. This is already a bug and you can stop here but I'll describe the further horror I experienced in my project during debugging.


We call:
`scene.removeGeometry(g2)` After that scene.geometries == [g1] which is ok.
Again we call:
`scene.removeGeometry(g3)`  (This can easily happen e.g. if AssetContainer.removeAllFromScene  is called)

After that `scene.geometries == [g1, empty]` due to the conditions in the code block I'm updating in this PR. This has all sorts of nasty consequences in other parts of the engine that I'm not gonna describe in detail. Basically every iteration over geometries is in danger.