### PR TITLE
Fix shortcuts firing while user inputs text

### DIFF
--- a/packages/tools/guiEditor/src/globalState.ts
+++ b/packages/tools/guiEditor/src/globalState.ts
@@ -63,7 +63,7 @@ export class GlobalState {
     public get tool(): GUIEditorTool {
         if (this._tool === GUIEditorTool.ZOOM) {
             return GUIEditorTool.ZOOM;
-        } else if (this._tool === GUIEditorTool.PAN || this.keys.isKeyDown("space")) {
+        } else if (this._tool === GUIEditorTool.PAN) {
             return GUIEditorTool.PAN;
         } else {
             return GUIEditorTool.SELECT;

--- a/packages/tools/guiEditor/src/workbenchEditor.tsx
+++ b/packages/tools/guiEditor/src/workbenchEditor.tsx
@@ -55,6 +55,11 @@ export class WorkbenchEditor extends React.Component<IGraphEditorProps, IGraphEd
     }
 
     addToolControls = (evt: KeyboardEvent) => {
+        // If the event target is a text input, we're currently focused on it, and the user
+        // just wants to type normal text
+        if (evt.target && evt.target instanceof HTMLInputElement && evt.target.type === "text") {
+            return;
+        }
         switch (evt.key) {
             case "s": //select
             case "S":


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/gui-editor-shortcuts-bug-on-inputtext/32884