### PR TITLE
Update ComputePressureObserver

### DIFF
--- a/packages/dev/core/src/Misc/computePressure.ts
+++ b/packages/dev/core/src/Misc/computePressure.ts
@@ -25,6 +25,7 @@ export class ComputePressureObserverWrapper {
 
     /**
      * Method that must be called to begin observing changes, and triggering callbacks.
+     * @param source defines the source to observe
      */
     observe(source: IComputePressureSource): void {
         this._observer?.observe &&
@@ -35,6 +36,7 @@ export class ComputePressureObserverWrapper {
 
     /**
      * Method that must be called to stop observing changes and triggering callbacks (cleanup function).
+     * @param source defines the source to unobserve
      */
     unobserve(source: IComputePressureSource): void {
         try {

--- a/packages/dev/core/src/Misc/computePressure.ts
+++ b/packages/dev/core/src/Misc/computePressure.ts
@@ -20,15 +20,15 @@ export class ComputePressureObserverWrapper {
      * Returns true if ComputePressureObserver is available for use, false otherwise.
      */
     public static get IsAvailable() {
-        return IsWindowObjectExist() && "ComputePressureObserver" in window;
+        return IsWindowObjectExist() && "ComputePressureObserver" in window && (<any>window).ComputePressureObserver?.supportedSources?.includes("cpu");
     }
 
     /**
      * Method that must be called to begin observing changes, and triggering callbacks.
      */
-    observe(): void {
+    observe(source: IComputePressureSource): void {
         this._observer?.observe &&
-            this._observer?.observe().catch(() => {
+            this._observer?.observe(source).catch(() => {
                 // Ignore error
             });
     }
@@ -36,9 +36,9 @@ export class ComputePressureObserverWrapper {
     /**
      * Method that must be called to stop observing changes and triggering callbacks (cleanup function).
      */
-    unobserve(): void {
+    unobserve(source: IComputePressureSource): void {
         try {
-            this._observer?.unobserve && this._observer?.unobserve();
+            this._observer?.unobserve && this._observer?.unobserve(source);
         } catch {
             // Ignore error
         }
@@ -73,3 +73,8 @@ export interface IComputePressureData {
      */
     cpuSpeed: number;
 }
+
+/**
+ * The possible sources for the compute pressure observer.
+ */
+export type IComputePressureSource = "cpu";

--- a/packages/dev/core/src/Misc/computePressure.ts
+++ b/packages/dev/core/src/Misc/computePressure.ts
@@ -37,7 +37,11 @@ export class ComputePressureObserverWrapper {
      * Method that must be called to stop observing changes and triggering callbacks (cleanup function).
      */
     unobserve(): void {
-        this._observer?.unobserve && this._observer?.unobserve();
+        try {
+            this._observer?.unobserve && this._observer?.unobserve();
+        } catch {
+            // Ignore error
+        }
     }
 }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1541,7 +1541,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                     cpuSpeedThresholds: [0.5],
                 }
             );
-            this._computePressureObserver.observe();
+            this._computePressureObserver.observe("cpu");
         }
     }
 
@@ -4658,7 +4658,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.onActiveCameraChanged.clear();
         this.onComputePressureChanged.clear();
 
-        this._computePressureObserver?.unobserve();
+        this._computePressureObserver?.unobserve("cpu");
         this._computePressureObserver = undefined;
 
         this.detachControl();


### PR DESCRIPTION
Hello.

I have been working on updating our electron app to the latest electron version (20.0.1, previously we used 17.3.1) and we had a breakage in our use of babylon.js when the scene is disposed:

> TypeError: Failed to execute 'unobserve' on 'ComputePressureObserver': 1 argument required, but only 0 present.

Note that not all electron applications will experience this problem. ComputePressureObserver is only exposed if you use `experimentalFeatures: true`.

It appears that electron 19 and up is using a Chromium version with an updated ComputePressureObserver API. Here is the relevant change in [the working draft](https://wicg.github.io/compute-pressure/):
- https://github.com/WICG/compute-pressure/issues/21
- https://github.com/WICG/compute-pressure/pull/25

The error is ignored in `observe` but not in `unobserve`. My first commit here catches the error in `unobserve`. I first tried to use `catch()` like in `observe` but it didn't work so I had to use `try { ... } catch {}`. Even though it isn't documented in the spec, `observe` is returning a promise but `unobserve` is not.

The second commit updates the use of the observer to work with electron >= 19. This disables the observer for electron < 19 (`ComputePressureObserver.supportedSources` is not defined), but I don't think many will notice since the only thing this is used for is the CPU utilization metric in the Realtime Performance Viewer.

![Screen Shot 2022-08-09 at 14 41 31](https://user-images.githubusercontent.com/1991151/183777526-040bc374-458b-446a-9fd6-5f26676ef13b.png)

The spec appears to have more updates than what electron supports. Doesn't look like the `samplerate` property works.

I made this simple Electron Fiddle that can be used to test with: https://gist.github.com/stefansundin/4cee8e88133efb196f54f2d2a9f05155. You need to run `npm run start` to run the babylon.js server as well.

Please let me know if you want me to change anything! Thanks!