### PR TITLE
Rectangles couldn't get correctly rounded because -2 was subtracted f…

### DIFF
--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -137,7 +137,7 @@ export class Rectangle extends Container {
         const width = this._currentMeasure.width - offset * 2;
         const height = this._currentMeasure.height - offset * 2;
 
-        const radius = Math.min(height / 2 - 2, Math.min(width / 2 - 2, this._cornerRadius));
+        const radius = Math.min(height / 2, Math.min(width / 2, this._cornerRadius));
 
         context.beginPath();
         context.moveTo(x + radius, y);


### PR DESCRIPTION
…rom corner radius, so remove that subtraction.

Related forum issue: https://forum.babylonjs.com/t/gui-rectangle-cannot-achieve-semicircular-fillet/32934