### PR TITLE
GUI Editor launches from PG with correct size

### DIFF
--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/advancedDynamicTextureTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/advancedDynamicTextureTreeItemComponent.tsx
@@ -66,7 +66,7 @@ export class AdvancedDynamicTextureTreeItemComponent extends React.Component<IAd
         return (
             <div className="adtextureTools">
                 <TreeItemLabelComponent label={this.props.texture.name} onClick={() => this.props.onClick()} icon={faImage} color="mediumpurple" />
-                <div className={"icon edit"} onClick={() => EditAdvancedDynamicTexture(this.props.texture)} title="Edit">
+                <div className={"icon edit"} onClick={() => EditAdvancedDynamicTexture(this.props.texture, true)} title="Edit">
                     <FontAwesomeIcon icon={faPen} />
                 </div>
                 <div

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -45,8 +45,9 @@ export function SetGUIEditorURL(guiEditorURL: string) {
  * if you are in an ES6 environment, you must first call InjectGUIEditor to provide the gui-editor package
  * If you are in a UMD environment, it will load the package from a URL
  * @param adt
+ * @param fromPG defines whether editor is being opened from the Playground
  */
-export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture) {
+export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture, fromPG?: boolean) {
     guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
     if (!guiEditorContainer) {
         if (typeof BABYLON !== "undefined") {
@@ -65,5 +66,5 @@ export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture) {
             throw `Tried to call EditAdvancedDynamicTexture without first injecting the GUI editor. You need to call InjectGUIEditor() with a reference to @babylonjs/gui-editor. It can be imported at runtime using await import("@babylonjs/gui-editor").`;
         }
     }
-    guiEditorContainer.GUIEditor.Show({ liveGuiTexture: adt });
+    guiEditorContainer.GUIEditor.Show({ liveGuiTexture: adt }, fromPG);
 }

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -45,9 +45,9 @@ export function SetGUIEditorURL(guiEditorURL: string) {
  * if you are in an ES6 environment, you must first call InjectGUIEditor to provide the gui-editor package
  * If you are in a UMD environment, it will load the package from a URL
  * @param adt
- * @param fromPG defines whether editor is being opened from the Playground
+ * @param embed defines whether editor is being opened from the Playground
  */
-export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture, fromPG?: boolean) {
+export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture, embed?: boolean) {
     guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
     if (!guiEditorContainer) {
         if (typeof BABYLON !== "undefined") {
@@ -66,5 +66,5 @@ export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture, fr
             throw `Tried to call EditAdvancedDynamicTexture without first injecting the GUI editor. You need to call InjectGUIEditor() with a reference to @babylonjs/gui-editor. It can be imported at runtime using await import("@babylonjs/gui-editor").`;
         }
     }
-    guiEditorContainer.GUIEditor.Show({ liveGuiTexture: adt }, fromPG);
+    guiEditorContainer.GUIEditor.Show({ liveGuiTexture: adt }, embed);
 }

--- a/packages/tools/guiEditor/src/components/commandBarComponent.tsx
+++ b/packages/tools/guiEditor/src/components/commandBarComponent.tsx
@@ -88,6 +88,9 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         props.globalState.onSelectionChangedObservable.add(() => {
             this.forceUpdate();
         });
+        props.globalState.onWindowResizeObservable.add(() => {
+            this.forceUpdate();
+        });
     }
 
     public render() {
@@ -96,6 +99,11 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         const copyyIcon = this.props.globalState.selectedControls.length === 0 ? copyIconDisabled : copyIcon;
         const deleteeIcon = this.props.globalState.selectedControls.length === 0 ? deleteIconDisabled : deleteIcon;
         const pasteeIcon = isPasteDisabled ? pasteIconDisabled : pasteIcon;
+
+        const responsiveSelected = this.props.globalState.fromPG ? window.localStorage.getItem("responsive") === "true" : DataStorage.ReadBoolean("Responsive", true);
+        const responsiveUI = this.props.globalState.fromPG ? window.localStorage.getItem("responsiveUI") === "true" : DataStorage.ReadBoolean("Responsive", true);
+        const unresponsiveUI = this.props.globalState.fromPG ? window.localStorage.getItem("responsiveUI") === "false" : !DataStorage.ReadBoolean("Responsive", true);
+
         this._sizeOption = _sizeValues.findIndex((value) => value.width == size.width && value.height == size.height);
         if (this._sizeOption < 0) {
             this.props.globalState.onResponsiveChangeObservable.notifyObservers(false);
@@ -242,20 +250,24 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                         <CheckBoxLineComponent
                             label="Responsive:"
                             iconLabel="Responsive GUIs will resize the UI layout and reflow controls to accommodate different device screen sizes"
-                            isSelected={() => DataStorage.ReadBoolean("Responsive", true)}
+                            isSelected={() => responsiveSelected}
                             onSelect={(value: boolean) => {
                                 this.props.globalState.onResponsiveChangeObservable.notifyObservers(value);
                                 DataStorage.WriteBoolean("Responsive", value);
+                                window.localStorage.setItem("responsive", String(value));
+                                window.localStorage.setItem("responsiveUI", String(value));
                                 this._sizeOption = _sizeOptions.length;
                                 if (value) {
                                     this._sizeOption = 0;
                                     this.props.globalState.workbench.guiSize = _sizeValues[this._sizeOption];
+                                    window.localStorage.setItem("width", String(this.props.globalState.workbench.guiSize.width));
+                                    window.localStorage.setItem("height", String(this.props.globalState.workbench.guiSize.height));
                                 }
                                 this.forceUpdate();
                             }}
                             large
                         />
-                        {DataStorage.ReadBoolean("Responsive", true) && (
+                        {responsiveUI && (
                             <OptionsLineComponent
                                 label=""
                                 iconLabel="Size"
@@ -268,12 +280,14 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     if (this._sizeOption !== _sizeOptions.length) {
                                         const newSize = _sizeValues[this._sizeOption];
                                         this.props.globalState.workbench.guiSize = newSize;
+                                        window.localStorage.setItem("width", String(this.props.globalState.workbench.guiSize.width));
+                                        window.localStorage.setItem("height", String(this.props.globalState.workbench.guiSize.height));
                                     }
                                     this.forceUpdate();
                                 }}
                             />
                         )}
-                        {!DataStorage.ReadBoolean("Responsive", true) && (
+                        {unresponsiveUI && (
                             <>
                                 <FloatLineComponent
                                     lockObject={this._lockObject}
@@ -285,6 +299,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onChange={(newValue) => {
                                         if (!this._stopUpdating) {
                                             this.props.globalState.workbench.guiSize = { width: newValue, height: size.height };
+                                            window.localStorage.setItem("width", String(newValue));
                                         }
                                     }}
                                     onDragStart={() => {
@@ -293,6 +308,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onDragStop={(newValue) => {
                                         this._stopUpdating = false;
                                         this.props.globalState.workbench.guiSize = { width: newValue, height: size.height };
+                                        window.localStorage.setItem("width", String(newValue));
                                     }}
                                     arrows={true}
                                     isInteger={true}
@@ -307,6 +323,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onChange={(newValue) => {
                                         if (!this._stopUpdating) {
                                             this.props.globalState.workbench.guiSize = { width: size.width, height: newValue };
+                                            window.localStorage.setItem("height", String(newValue));
                                         }
                                     }}
                                     onDragStart={() => {
@@ -315,6 +332,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onDragStop={(newValue) => {
                                         this._stopUpdating = false;
                                         this.props.globalState.workbench.guiSize = { width: size.width, height: newValue };
+                                        window.localStorage.setItem("height", String(newValue));
                                     }}
                                     arrows={true}
                                     isInteger={true}

--- a/packages/tools/guiEditor/src/components/commandBarComponent.tsx
+++ b/packages/tools/guiEditor/src/components/commandBarComponent.tsx
@@ -100,8 +100,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         const deleteeIcon = this.props.globalState.selectedControls.length === 0 ? deleteIconDisabled : deleteIcon;
         const pasteeIcon = isPasteDisabled ? pasteIconDisabled : pasteIcon;
 
-        const responsiveSelected = this.props.globalState.fromPG ? window.localStorage.getItem("responsive") === "true" : DataStorage.ReadBoolean("Responsive", true);
-        const responsiveUI = this.props.globalState.fromPG ? window.localStorage.getItem("responsiveUI") === "true" : DataStorage.ReadBoolean("Responsive", true);
+        const responsiveUI = this.props.globalState.fromPG ? DataStorage.ReadBoolean("responsiveUI", true) : DataStorage.ReadBoolean("Responsive", true);
 
         this._sizeOption = _sizeValues.findIndex((value) => value.width == size.width && value.height == size.height);
         if (this._sizeOption < 0) {
@@ -249,18 +248,17 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                         <CheckBoxLineComponent
                             label="Responsive:"
                             iconLabel="Responsive GUIs will resize the UI layout and reflow controls to accommodate different device screen sizes"
-                            isSelected={() => responsiveSelected}
+                            isSelected={() => DataStorage.ReadBoolean("Responsive", true)}
                             onSelect={(value: boolean) => {
                                 this.props.globalState.onResponsiveChangeObservable.notifyObservers(value);
                                 DataStorage.WriteBoolean("Responsive", value);
-                                window.localStorage.setItem("responsive", String(value));
-                                window.localStorage.setItem("responsiveUI", String(value));
+                                DataStorage.WriteBoolean("responsiveUI", value);
                                 this._sizeOption = _sizeOptions.length;
                                 if (value) {
                                     this._sizeOption = 0;
                                     this.props.globalState.workbench.guiSize = _sizeValues[this._sizeOption];
-                                    window.localStorage.setItem("width", String(this.props.globalState.workbench.guiSize.width));
-                                    window.localStorage.setItem("height", String(this.props.globalState.workbench.guiSize.height));
+                                    DataStorage.WriteNumber("width", this.props.globalState.workbench.guiSize.width);
+                                    DataStorage.WriteNumber("height", this.props.globalState.workbench.guiSize.height);
                                 }
                                 this.forceUpdate();
                             }}
@@ -279,8 +277,8 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     if (this._sizeOption !== _sizeOptions.length) {
                                         const newSize = _sizeValues[this._sizeOption];
                                         this.props.globalState.workbench.guiSize = newSize;
-                                        window.localStorage.setItem("width", String(this.props.globalState.workbench.guiSize.width));
-                                        window.localStorage.setItem("height", String(this.props.globalState.workbench.guiSize.height));
+                                        DataStorage.WriteNumber("width", this.props.globalState.workbench.guiSize.width);
+                                        DataStorage.WriteNumber("height", this.props.globalState.workbench.guiSize.height);
                                     }
                                     this.forceUpdate();
                                 }}
@@ -298,7 +296,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onChange={(newValue) => {
                                         if (!this._stopUpdating) {
                                             this.props.globalState.workbench.guiSize = { width: newValue, height: size.height };
-                                            window.localStorage.setItem("width", String(newValue));
+                                            DataStorage.WriteNumber("width", this.props.globalState.workbench.guiSize.width);
                                         }
                                     }}
                                     onDragStart={() => {
@@ -307,7 +305,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onDragStop={(newValue) => {
                                         this._stopUpdating = false;
                                         this.props.globalState.workbench.guiSize = { width: newValue, height: size.height };
-                                        window.localStorage.setItem("width", String(newValue));
+                                        DataStorage.WriteNumber("width", this.props.globalState.workbench.guiSize.width);
                                     }}
                                     arrows={true}
                                     isInteger={true}
@@ -322,7 +320,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onChange={(newValue) => {
                                         if (!this._stopUpdating) {
                                             this.props.globalState.workbench.guiSize = { width: size.width, height: newValue };
-                                            window.localStorage.setItem("height", String(newValue));
+                                            DataStorage.WriteNumber("height", this.props.globalState.workbench.guiSize.width);
                                         }
                                     }}
                                     onDragStart={() => {
@@ -331,7 +329,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                     onDragStop={(newValue) => {
                                         this._stopUpdating = false;
                                         this.props.globalState.workbench.guiSize = { width: size.width, height: newValue };
-                                        window.localStorage.setItem("height", String(newValue));
+                                        DataStorage.WriteNumber("height", this.props.globalState.workbench.guiSize.width);
                                     }}
                                     arrows={true}
                                     isInteger={true}

--- a/packages/tools/guiEditor/src/components/commandBarComponent.tsx
+++ b/packages/tools/guiEditor/src/components/commandBarComponent.tsx
@@ -102,7 +102,6 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
 
         const responsiveSelected = this.props.globalState.fromPG ? window.localStorage.getItem("responsive") === "true" : DataStorage.ReadBoolean("Responsive", true);
         const responsiveUI = this.props.globalState.fromPG ? window.localStorage.getItem("responsiveUI") === "true" : DataStorage.ReadBoolean("Responsive", true);
-        const unresponsiveUI = this.props.globalState.fromPG ? window.localStorage.getItem("responsiveUI") === "false" : !DataStorage.ReadBoolean("Responsive", true);
 
         this._sizeOption = _sizeValues.findIndex((value) => value.width == size.width && value.height == size.height);
         if (this._sizeOption < 0) {
@@ -287,7 +286,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                 }}
                             />
                         )}
-                        {unresponsiveUI && (
+                        {!responsiveUI && (
                             <>
                                 <FloatLineComponent
                                     lockObject={this._lockObject}

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -816,7 +816,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         }
     }
 
-    public createGUICanvas(fromPG?: boolean) {
+    public createGUICanvas(embed?: boolean) {
         // Get the canvas element from the DOM.
 
         const canvas = this._rootContainer.current as HTMLCanvasElement;
@@ -830,7 +830,7 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         const light = new HemisphericLight("light1", Axis.Y, this._scene);
         light.intensity = 0.9;
 
-        if (fromPG) {
+        if (embed) {
             this.props.globalState.fromPG = true;
             this._guiSize.width = Number(window.localStorage.getItem("width"));
             this._guiSize.height = Number(window.localStorage.getItem("height"));

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -816,8 +816,9 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         }
     }
 
-    public createGUICanvas() {
+    public createGUICanvas(fromPG?: boolean) {
         // Get the canvas element from the DOM.
+
         const canvas = this._rootContainer.current as HTMLCanvasElement;
         // Associate a Babylon Engine to it.
         this._engine = new Engine(canvas);
@@ -829,7 +830,11 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
         const light = new HemisphericLight("light1", Axis.Y, this._scene);
         light.intensity = 0.9;
 
-        this._guiSize = this._defaultGUISize;
+        if (fromPG) {
+            this.props.globalState.fromPG = true;
+            this._guiSize.width = Number(window.localStorage.getItem("width"));
+            this._guiSize.height = Number(window.localStorage.getItem("height"));
+        }
 
         this._panAndZoomContainer = new Container("panAndZoom");
         this._panAndZoomContainer.clipContent = false;

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -28,6 +28,7 @@ import { Logger } from "core/Misc/logger";
 import "./workbenchCanvas.scss";
 import { ValueAndUnit } from "gui/2D/valueAndUnit";
 import type { StackPanel } from "gui/2D/controls/stackPanel";
+import { DataStorage } from "core/Misc/dataStorage";
 
 export interface IWorkbenchComponentProps {
     globalState: GlobalState;
@@ -832,8 +833,8 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
         if (embed) {
             this.props.globalState.fromPG = true;
-            this._guiSize.width = Number(window.localStorage.getItem("width"));
-            this._guiSize.height = Number(window.localStorage.getItem("height"));
+            this._guiSize.width = DataStorage.ReadNumber("width", 1024);
+            this._guiSize.height = DataStorage.ReadNumber("height", 1024);
         }
 
         this._panAndZoomContainer = new Container("panAndZoom");

--- a/packages/tools/guiEditor/src/globalState.ts
+++ b/packages/tools/guiEditor/src/globalState.ts
@@ -49,6 +49,7 @@ export class GlobalState {
     private _backgroundColor: Color3;
     private _outlines: boolean = false;
     public keys: KeyboardManager;
+    private _fromPG: boolean;
     /** DO NOT USE: in the process of removing */
     public blockKeyboardEvents = false;
     onOutlineChangedObservable = new Observable<void>();
@@ -157,6 +158,12 @@ export class GlobalState {
 
     public get backgroundColor() {
         return this._backgroundColor;
+    }
+    public get fromPG() {
+        return this._fromPG;
+    }
+    public set fromPG(value: boolean) {
+        this._fromPG = value;
     }
 
     public set backgroundColor(value: Color3) {

--- a/packages/tools/guiEditor/src/guiEditor.ts
+++ b/packages/tools/guiEditor/src/guiEditor.ts
@@ -26,8 +26,9 @@ export class GUIEditor {
     /**
      * Show the gui editor
      * @param options defines the options to use to configure the gui editor
+     * @param fromPG defines whether editor is being opened from the Playground
      */
-    public static async Show(options: IGUIEditorOptions) {
+    public static async Show(options: IGUIEditorOptions, fromPG?: boolean) {
         let hostElement = options.hostElement;
 
         // if we are in a standalone window and we have some current state, just load the GUI from the snippet server, don't do anything else
@@ -68,7 +69,7 @@ export class GUIEditor {
         ReactDOM.render(graphEditor, hostElement);
         // create the middle workbench canvas
         if (!globalState.guiTexture) {
-            globalState.workbench.createGUICanvas();
+            globalState.workbench.createGUICanvas(fromPG);
             if (options.currentSnippetToken) {
                 try {
                     await globalState.workbench.loadFromSnippet(options.currentSnippetToken);

--- a/packages/tools/guiEditor/src/guiEditor.ts
+++ b/packages/tools/guiEditor/src/guiEditor.ts
@@ -26,9 +26,9 @@ export class GUIEditor {
     /**
      * Show the gui editor
      * @param options defines the options to use to configure the gui editor
-     * @param fromPG defines whether editor is being opened from the Playground
+     * @param embed defines whether editor is being opened from the Playground
      */
-    public static async Show(options: IGUIEditorOptions, fromPG?: boolean) {
+    public static async Show(options: IGUIEditorOptions, embed?: boolean) {
         let hostElement = options.hostElement;
 
         // if we are in a standalone window and we have some current state, just load the GUI from the snippet server, don't do anything else
@@ -69,7 +69,7 @@ export class GUIEditor {
         ReactDOM.render(graphEditor, hostElement);
         // create the middle workbench canvas
         if (!globalState.guiTexture) {
-            globalState.workbench.createGUICanvas(fromPG);
+            globalState.workbench.createGUICanvas(embed);
             if (options.currentSnippetToken) {
                 try {
                     await globalState.workbench.loadFromSnippet(options.currentSnippetToken);


### PR DESCRIPTION
Launching the GUI Editor from the PG would always have the GUI texture be at the default size (1024x1024) instead of whatever size it was orignally defined as 