### PR TITLE
Draw rectangles with properly rounded corners

### DIFF
--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -142,13 +142,13 @@ export class Rectangle extends Container {
         context.beginPath();
         context.moveTo(x + radius, y);
         context.lineTo(x + width - radius, y);
-        // context.arc(x + width - radius, y + radius, radius, 0, Math.PI / 2, true);
+        context.arc(x + width - radius, y + radius, radius, (3 * Math.PI) / 2, Math.PI * 2);
         context.lineTo(x + width, y + height - radius);
-        // context.arc(x + width - radius, y + height - radius, radius, Math.PI / 2, Math.PI, true);
+        context.arc(x + width - radius, y + height - radius, radius, 0, Math.PI / 2);
         context.lineTo(x + radius, y + height);
-        // context.arc(x + radius, y + height - radius, radius, Math.PI, (3 * Math.PI) / 2, true);
+        context.arc(x + radius, y + height - radius, radius, Math.PI / 2, Math.PI);
         context.lineTo(x, y + radius);
-        // context.arc(x + radius, y + radius, radius, (3 * Math.PI) / 2, 2 * Math.PI, true);
+        context.arc(x + radius, y + radius, radius, Math.PI, (3 * Math.PI) / 2);
         context.closePath();
     }
 

--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -142,13 +142,13 @@ export class Rectangle extends Container {
         context.beginPath();
         context.moveTo(x + radius, y);
         context.lineTo(x + width - radius, y);
-        context.quadraticCurveTo(x + width, y, x + width, y + radius);
+        // context.arc(x + width - radius, y + radius, radius, 0, Math.PI / 2, true);
         context.lineTo(x + width, y + height - radius);
-        context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+        // context.arc(x + width - radius, y + height - radius, radius, Math.PI / 2, Math.PI, true);
         context.lineTo(x + radius, y + height);
-        context.quadraticCurveTo(x, y + height, x, y + height - radius);
+        // context.arc(x + radius, y + height - radius, radius, Math.PI, (3 * Math.PI) / 2, true);
         context.lineTo(x, y + radius);
-        context.quadraticCurveTo(x, y, x + radius, y);
+        // context.arc(x + radius, y + radius, radius, (3 * Math.PI) / 2, 2 * Math.PI, true);
         context.closePath();
     }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-rectangle-cannot-achieve-semicircular-fillet/32934

Before, for a rectangle with same width and height, and a high corner radius, we didn't get a circle:
![image](https://user-images.githubusercontent.com/6002144/184880333-2636f5e9-3485-46c7-90ee-ba62e4031d44.png)
Now, using arcs to draw the rect:
![image](https://user-images.githubusercontent.com/6002144/184880425-1ae03483-65e7-4cc7-bd88-f3e5e8be2ce7.png)

Same for width != height, before:
![image](https://user-images.githubusercontent.com/6002144/184880503-9782c85f-f344-4b07-83f1-ef3e564d24dd.png)
Now:
![image](https://user-images.githubusercontent.com/6002144/184880537-3c50cb3c-a6d8-4390-acbc-792b2321ce31.png)
