### PR TITLE
Testing: Update Safari Interactions test to point to BrowserStack

### DIFF
--- a/packages/tools/testTools/src/seleniumTestUtils.ts
+++ b/packages/tools/testTools/src/seleniumTestUtils.ts
@@ -2,6 +2,20 @@ import type { ThenableWebDriver } from "selenium-webdriver";
 import "selenium-webdriver/safari";
 import { evaluateDisposeSceneForVisualization, evaluateInitEngineForVisualization, evaluatePrepareScene, evaluateRenderSceneForVisualization } from "./visualizationUtils";
 
+export const macOSSafariCapabilities = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    "bstack:options": {
+        os: "OS X",
+        osVersion: "Monterey",
+        local: "false",
+        seleniumVersion: "4.3.0",
+        userName: process.env["BROWSERSTACK_USERNAME"],
+        accessKey: process.env["BROWSERSTACK_ACCESS_KEY"],
+    },
+    browserName: "Safari",
+    browserVersion: "latest",
+};
+
 // Take Playgorund Id and Selenium webdriver and load snippet info into test page
 export const LoadPlayground = async (
     driver: ThenableWebDriver,

--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -11,7 +11,6 @@ describe("safari", () => {
       .build();
 
     beforeAll(async () => {
-        console.log(getGlobalConfig().baseUrl);
         await driver.get(getGlobalConfig().baseUrl + `/empty.html`);
     });
 

--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -11,6 +11,7 @@ describe("safari", () => {
       .build();
 
     beforeAll(async () => {
+        console.log(getGlobalConfig().baseUrl);
         await driver.get(getGlobalConfig().baseUrl + `/empty.html`);
     });
 

--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -5,10 +5,8 @@ jest.setTimeout(60000);
 
 describe("safari", () => {
     const hubURL = "https://hub.browserstack.com/wd/hub";
-    const driver = new Builder()
-      .usingServer(hubURL)
-      .withCapabilities(macOSSafariCapabilities)
-      .build();
+    // If running on local MacOS machine, use local WebDriver
+    const driver = process.platform === "darwin" ? new Builder().forBrowser("safari").build() : new Builder().usingServer(hubURL).withCapabilities(macOSSafariCapabilities).build();
 
     beforeAll(async () => {
         await driver.get(getGlobalConfig().baseUrl + `/empty.html`);
@@ -54,26 +52,24 @@ describe("safari", () => {
 
         await driver.sleep(1000);
 
-        await driver
-            .executeScript("BABYLON.Scene.DoubleClickDelay = 500;")
-            .then(async () => {
-                await driver
-                    .actions()
-                    .move({ origin: el })
-                    .press(Button.LEFT)
-                    .release(Button.LEFT)
-                    .press(Button.LEFT)
-                    .release(Button.LEFT)
-                    .press(Button.RIGHT)
-                    .release(Button.RIGHT)
-                    .press(Button.RIGHT)
-                    .release(Button.RIGHT)
-                    .press(Button.MIDDLE)
-                    .release(Button.MIDDLE)
-                    .press(Button.MIDDLE)
-                    .release(Button.MIDDLE)
-                    .perform();
-            });
+        await driver.executeScript("BABYLON.Scene.DoubleClickDelay = 500;").then(async () => {
+            await driver
+                .actions()
+                .move({ origin: el })
+                .press(Button.LEFT)
+                .release(Button.LEFT)
+                .press(Button.LEFT)
+                .release(Button.LEFT)
+                .press(Button.RIGHT)
+                .release(Button.RIGHT)
+                .press(Button.RIGHT)
+                .release(Button.RIGHT)
+                .press(Button.MIDDLE)
+                .release(Button.MIDDLE)
+                .press(Button.MIDDLE)
+                .release(Button.MIDDLE)
+                .perform();
+        });
 
         const testStatus = await CheckTestSuccessStatus(driver);
         expect(testStatus).toBe(true);

--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -1,10 +1,14 @@
-import { CheckTestSuccessStatus, getGlobalConfig, LoadPlayground } from "@tools/test-tools";
+import { CheckTestSuccessStatus, getGlobalConfig, LoadPlayground, macOSSafariCapabilities } from "@tools/test-tools";
 import { Builder, Button, By, Key } from "selenium-webdriver";
 
 jest.setTimeout(60000);
 
 describe("safari", () => {
-    const driver = new Builder().forBrowser("safari").build();
+    const hubURL = "https://hub.browserstack.com/wd/hub";
+    const driver = new Builder()
+      .usingServer(hubURL)
+      .withCapabilities(macOSSafariCapabilities)
+      .build();
 
     beforeAll(async () => {
         await driver.get(getGlobalConfig().baseUrl + `/empty.html`);


### PR DESCRIPTION
There are slight modifications that have been made to the safari tests so that they use BrowserStack.  This change should allow these tests to be used in the CI.