### PR TITLE
Enable use of Tools.LoadScript in a WebWorker

### DIFF
--- a/packages/dev/core/src/LibDeclarations/browser.d.ts
+++ b/packages/dev/core/src/LibDeclarations/browser.d.ts
@@ -22,6 +22,12 @@ interface Window {
     setImmediate(handler: (...args: any[]) => void): number;
 }
 
+interface WorkerGlobalScope {
+    importScripts: (...args: string[]) => void;
+}
+
+type WorkerSelf = WindowOrWorkerGlobalScope & WorkerGlobalScope;
+
 interface HTMLCanvasElement {
     requestPointerLock(): void;
     msRequestPointerLock?(): void;

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -416,7 +416,16 @@ export class Tools {
      * @param scriptId defines the id of the script element
      */
     public static LoadScript(scriptUrl: string, onSuccess: () => void, onError?: (message?: string, exception?: any) => void, scriptId?: string) {
-        if (!IsWindowObjectExist()) {
+        if (typeof (self as unknown as WorkerSelf).importScripts === "function") {
+            try {
+                (self as unknown as WorkerSelf).importScripts(scriptUrl);
+                onSuccess();
+            } catch (e) {
+                onError?.(`Unable to load script '${scriptUrl}' in worker`, e)
+            }
+            return;
+        } else if (!IsWindowObjectExist()) {
+            onError?.(`Cannot load script '${scriptUrl}' outside of a window or a worker`)
             return;
         }
         const head = document.getElementsByTagName("head")[0];

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -421,11 +421,11 @@ export class Tools {
                 (self as unknown as WorkerSelf).importScripts(scriptUrl);
                 onSuccess();
             } catch (e) {
-                onError?.(`Unable to load script '${scriptUrl}' in worker`, e)
+                onError?.(`Unable to load script '${scriptUrl}' in worker`, e);
             }
             return;
         } else if (!IsWindowObjectExist()) {
-            onError?.(`Cannot load script '${scriptUrl}' outside of a window or a worker`)
+            onError?.(`Cannot load script '${scriptUrl}' outside of a window or a worker`);
             return;
         }
         const head = document.getElementsByTagName("head")[0];


### PR DESCRIPTION
Fixes #12882 

* Checks if `LoadScript` is called from a `WebWorker` context and, if so, uses `importScripts` instead of `HTMLScriptElement` to load the script.
* Ensures `LoadScript` always resolves with either `onSuccess` or `onError`

Use case: using `ImportMeshAsync` in a `WebWorker` for meshes requiring `MeshoptCompression`

RE the typings: there's apparently no clean solution as [TypeScript is extremely not a fan of code designed to run in both DOM and WebWorker](https://github.com/Microsoft/TypeScript/issues/20595), these hideous double type assertions seemed less bad than falsely declaring importScripts as available on the Window interface
