### PR TITLE
[Build] Allow package name in local files.

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -59,10 +59,10 @@ export const getRules = (
         resourceType?: "asset/inline" | "asset/resource";
         extraRules?: RuleSetRule[];
     } = {
-            includeAssets: true,
-            includeCSS: true,
-            sideEffects: true,
-        }
+        includeAssets: true,
+        includeCSS: true,
+        sideEffects: true,
+    }
 ) => {
     const rules: RuleSetRule[] = [
         {
@@ -166,9 +166,11 @@ export const commonUMDWebpackConfiguration = (options: {
     const packageMapping = getPackageMappingByDevName(options.devPackageName);
     const packageName = getPublicPackageName(options.es6Mode ? packageMapping.es6 : packageMapping.umd);
     const umdPackageName = getPublicPackageName(packageMapping.umd);
-    const filename = `${options.overrideFilename && typeof options.overrideFilename === "string" ? options.overrideFilename : umdPackageMapping[umdPackageName as UMDPackageName].baseFilename
-        }${umdPackageMapping[umdPackageName as UMDPackageName].isBundle ? ".bundle" : ""}${options.maxMode ? (options.mode && options.mode === "development" ? ".max" : "") : options.mode && options.mode === "production" ? ".min" : ""
-        }.js`;
+    const filename = `${
+        options.overrideFilename && typeof options.overrideFilename === "string" ? options.overrideFilename : umdPackageMapping[umdPackageName as UMDPackageName].baseFilename
+    }${umdPackageMapping[umdPackageName as UMDPackageName].isBundle ? ".bundle" : ""}${
+        options.maxMode ? (options.mode && options.mode === "development" ? ".max" : "") : options.mode && options.mode === "production" ? ".min" : ""
+    }.js`;
     return {
         entry: options.entryPoints ?? "./src/index.ts",
         devtool: "source-map",

--- a/packages/dev/core/tsconfig.build.json
+++ b/packages/dev/core/tsconfig.build.json
@@ -6,6 +6,9 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "skipLibCheck": true,
+        "paths": {
+            "core/*": ["dev/core/src/*"],
+        }
     },
 
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],

--- a/packages/dev/gui/tsconfig.build.json
+++ b/packages/dev/gui/tsconfig.build.json
@@ -4,7 +4,11 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/src/*"],
+        }
     },
 
     "references": [

--- a/packages/dev/inspector/tsconfig.build.json
+++ b/packages/dev/inspector/tsconfig.build.json
@@ -4,7 +4,23 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/dist/*"],
+            "materials/*": ["dev/materials/dist/*"],
+            "post-processes/*": ["dev/postProcesses/dist/*"],
+            "procedural-textures/*": ["dev/proceduralTextures/dist/*"],
+            "loaders/*": ["dev/loaders/dist/*"],
+            "serializers/*": ["dev/serializers/dist/*"],
+            "inspector/*": ["dev/inspector/src/*"],
+            "shared-ui-components/*": ["dev/sharedUiComponents/dist/*"],
+            "node-editor/*": ["tools/nodeEditor/dist/*"],
+            "gui-editor/*": ["tools/guiEditor/dist/*"],
+            "viewer/*": ["tools/viewer/dist/*"],
+            "ktx2decoder/*": ["tools/ktx2Decoder/dist/*"],
+            "vsm": ["tools/vsm/dist/*"]
+        }
     },
 
     "references": [

--- a/packages/dev/loaders/tsconfig.build.json
+++ b/packages/dev/loaders/tsconfig.build.json
@@ -4,7 +4,11 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "loaders/*": ["dev/loaders/src/*"]
+        }
     },
 
     "references": [
@@ -14,8 +18,5 @@
     ],
 
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-    ]
+    "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/dev/materials/tsconfig.build.json
+++ b/packages/dev/materials/tsconfig.build.json
@@ -4,7 +4,11 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "materials/*": ["dev/materials/src/*"]
+        }
     },
 
     "references": [

--- a/packages/dev/postProcesses/tsconfig.build.json
+++ b/packages/dev/postProcesses/tsconfig.build.json
@@ -4,7 +4,11 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "post-processes/*": ["dev/postProcesses/src/*"]
+        }
     },
 
     "references": [

--- a/packages/dev/proceduralTextures/tsconfig.build.json
+++ b/packages/dev/proceduralTextures/tsconfig.build.json
@@ -4,7 +4,11 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "procedural-textures/*": ["dev/proceduralTextures/src/*"]
+        }
     },
 
     "references": [
@@ -14,8 +18,5 @@
     ],
 
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-    ]
+    "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/dev/serializers/tsconfig.build.json
+++ b/packages/dev/serializers/tsconfig.build.json
@@ -4,12 +4,19 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "serializers/*": ["dev/serializers/src/*"]
+        }
     },
 
+    "references": [
+        {
+            "path": "../core/tsconfig.build.json"
+        }
+    ],
+
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-    ]
+    "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/dev/sharedUiComponents/tsconfig.build.json
+++ b/packages/dev/sharedUiComponents/tsconfig.build.json
@@ -4,12 +4,20 @@
     "compilerOptions": {
         "composite": true,
         "outDir": "./dist",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/dist/*"],
+            "shared-ui-components/*": ["dev/sharedUiComponents/src/*"]
+        }
     },
 
+    "references": [
+        {
+            "path": "../core/tsconfig.build.json"
+        }
+    ],
+
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-    ]
+    "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/tools/guiEditor/tsconfig.build.json
+++ b/packages/tools/guiEditor/tsconfig.build.json
@@ -4,7 +4,13 @@
     "compilerOptions": {
         "outDir": "./dist",
         "rootDir": "./src",
-        "composite": true
+        "composite": true,
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/dist/*"],
+            "shared-ui-components/*": ["dev/sharedUiComponents/dist/*"],
+            "gui-editor/*": ["tools/guiEditor/src/*"]
+        }
     },
 
     "references": [
@@ -20,8 +26,5 @@
     ],
 
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-    ]
+    "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/tools/nodeEditor/tsconfig.build.json
+++ b/packages/tools/nodeEditor/tsconfig.build.json
@@ -4,7 +4,13 @@
     "compilerOptions": {
         "outDir": "./dist",
         "rootDir": "./src",
-        "composite": true
+        "composite": true,
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/dist/*"],
+            "shared-ui-components/*": ["dev/sharedUiComponents/dist/*"],
+            "node-editor/*": ["tools/nodeEditor/src/*"]
+        }
     },
 
     "references": [

--- a/packages/tools/playground/tsconfig.build.json
+++ b/packages/tools/playground/tsconfig.build.json
@@ -4,6 +4,12 @@
     "compilerOptions": {
         "outDir": "./dist",
         "rootDir": "./src",
+        "paths": {
+            "core/*": ["dev/core/dist/*"],
+            "gui/*": ["dev/gui/dist/*"],
+            "shared-ui-components/*": ["dev/sharedUiComponents/dist/*"],
+            "playground/*": ["tools/playground/src/*"]
+        }
     },
 
     "include": ["./src/**/*"]

--- a/tsconfig.devpackages.json
+++ b/tsconfig.devpackages.json
@@ -11,34 +11,34 @@
             "path": "packages/dev/core/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/gui/tsconfig.nocomposite.json"
+            "path": "packages/dev/gui/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/sharedUiComponents/tsconfig.nocomposite.json"
+            "path": "packages/dev/sharedUiComponents/tsconfig.build.json"
         },
         {
-            "path": "packages/tools/guiEditor/tsconfig.nocomposite.json"
+            "path": "packages/tools/guiEditor/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/materials/tsconfig.nocomposite.json"
+            "path": "packages/dev/materials/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/loaders/tsconfig.nocomposite.json"
+            "path": "packages/dev/loaders/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/serializers/tsconfig.nocomposite.json"
+            "path": "packages/dev/serializers/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/postProcesses/tsconfig.nocomposite.json"
+            "path": "packages/dev/postProcesses/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/proceduralTextures/tsconfig.nocomposite.json"
+            "path": "packages/dev/proceduralTextures/tsconfig.build.json"
         },
         {
-            "path": "packages/tools/nodeEditor/tsconfig.nocomposite.json"
+            "path": "packages/tools/nodeEditor/tsconfig.build.json"
         },
         {
-            "path": "packages/dev/inspector/tsconfig.nocomposite.json"
+            "path": "packages/dev/inspector/tsconfig.build.json"
         },
         {
             "path": "packages/tools/ktx2Decoder/tsconfig.build.json"


### PR DESCRIPTION
This PR provides the ability to import from the local package's package - for example use `import ... from core/...` in the core directory. So far we had to have relative files.

There might be other consequences to the change, so I will be monitoring that.