### PR TITLE
Create a separate callback for the FileButton

### DIFF
--- a/packages/dev/core/src/Misc/iInspectable.ts
+++ b/packages/dev/core/src/Misc/iInspectable.ts
@@ -94,10 +94,13 @@ export interface IInspectable {
      */
     step?: number;
     /**
-     * Gets the callback function when using "Button" or "FileButton" mode.
-     * In "FileButton" mode, the file is passed as the parameter.
+     * Gets the callback function when using "Button" mode
      */
     callback?: () => void;
+    /**
+     * Gets the callback function when using "FileButton" mode
+     */
+    fileCallback?: (file: File) => void;
     /**
      * Gets the list of options when using "Option" mode
      */

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/customPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/customPropertyGridComponent.tsx
@@ -139,9 +139,9 @@ export class CustomPropertyGridComponent extends React.Component<ICustomProperty
                         key={inspectable.label}
                         label={inspectable.label}
                         onClick={
-                            inspectable.callback ||
+                            inspectable.fileCallback ||
                             function () {
-                                Logger.Warn("no callback function added");
+                                Logger.Warn("no file call back function added");
                             }
                         }
                         accept={inspectable.accept || "*"}


### PR DESCRIPTION
The previous PR I recently submitted to add a FileButton can produce an error in the Typescript compiler since the `callback` function of the inspectable does not expect a parameter (so putting in a File parameter causes a compiler error).

This can be worked around by using a callback that takes a file param and then recasting it into a callback that takes no parameter i.e.,

```
        {
            label: "File Button demo",
            propertyName: "unused",
            type: InspectableType.FileButton,
            callback: ((file: File) => {
                // ...
            }) as () => void,
            accept: ".jpg, .jpeg",
        },
```

But that's not so great.

Here's a better solution. Add an explicit fileCallback that takes the file as a parameter. This is the callback that will be used with the FileButton.