### PR TITLE
Use LoadFile when loading images so that WebRequest custom headers ar…

### DIFF
--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -248,7 +248,8 @@ export const LoadImage = (
         LoadFile(
             url,
             (data) => {
-                const url = `data:${mimeType};base64,` + EncodeArrayBufferToBase64(data as ArrayBuffer);
+                const blob = new Blob([data]);
+                const url = URL.createObjectURL(blob);
                 img.src = url;
             },
             undefined,

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -245,7 +245,19 @@ export const LoadImage = (
     img.addEventListener("error", errorHandler);
 
     const noOfflineSupport = () => {
-        img.src = url;
+        LoadFile(
+            url,
+            (data) => {
+                const url = `data:${mimeType};base64,` + EncodeArrayBufferToBase64(data as ArrayBuffer);
+                img.src = url;
+            },
+            undefined,
+            offlineProvider || undefined,
+            true,
+            (request, exception) => {
+                onErrorHandler(exception);
+            }
+        );
     };
 
     const loadFromOfflineSupport = () => {


### PR DESCRIPTION
…e properly passed.

Related forum issue: https://forum.babylonjs.com/t/why-does-textureassettask-ignore-webrequest/33197
Related Playground: https://playground.babylonjs.com/#ZJYNY#1297

![vvvvvvvv](https://user-images.githubusercontent.com/6002144/186015150-d25a4d1e-8da6-466a-b3ef-2840407fb761.png)
