### PR TITLE
Store which pointerIds have been captured by the ADV so those are the…

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -86,6 +86,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _defaultMousePointerId = 0;
 
     /** @hidden */
+    public _capturedPointerIds = new Set<number>();
+
+    /** @hidden */
     public _numLayoutCalls = 0;
     /** Gets the number of layout calls made the last time the ADT has been rendered */
     public get numLayoutCalls(): number {
@@ -886,7 +889,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         const tempViewport = new Viewport(0, 0, 0, 0);
 
         this._prePointerObserver = scene.onPrePointerObservable.add((pi) => {
-            if (scene.isPointerCaptured((<IPointerEvent>pi.event).pointerId) && pi.type === PointerEventTypes.POINTERUP) {
+            if (
+                scene.isPointerCaptured((<IPointerEvent>pi.event).pointerId) &&
+                pi.type === PointerEventTypes.POINTERUP &&
+                !this._capturedPointerIds.has((pi.event as IPointerEvent).pointerId)
+            ) {
                 return;
             }
             if (
@@ -907,7 +914,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                     this._defaultMousePointerId = (pi.event as IPointerEvent).pointerId; // This is required to make sure we have the correct pointer ID for wheel
                 }
             }
-
             this._translateToPicking(scene, tempViewport, pi);
         });
         this._attachPickingToSceneRender(scene, () => this._translateToPicking(scene, tempViewport, null), false);

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -21,6 +21,7 @@ import { RegisterClass } from "core/Misc/typeStore";
 import { SerializationHelper, serialize } from "core/Misc/decorators";
 import type { ICanvasRenderingContext } from "core/Engines/ICanvas";
 import { EngineStore } from "core/Engines/engineStore";
+import type { IPointerEvent } from "core/Events/deviceInputEvents";
 
 /**
  * Root class used for all 2D controls
@@ -2200,6 +2201,10 @@ export class Control {
             this.parent._onPointerDown(target, coordinates, pointerId, buttonIndex, pi);
         }
 
+        if (pi && this.uniqueId !== this._host.rootContainer.uniqueId) {
+            this._host._capturedPointerIds.add((pi.event as IPointerEvent).pointerId);
+        }
+
         return true;
     }
 
@@ -2228,6 +2233,10 @@ export class Control {
 
         if (canNotify && this.parent != null && !this.isPointerBlocker) {
             this.parent._onPointerUp(target, coordinates, pointerId, buttonIndex, canNotifyClick, pi);
+        }
+
+        if (pi && this.uniqueId !== this._host.rootContainer.uniqueId) {
+            this._host._capturedPointerIds.delete((pi.event as IPointerEvent).pointerId);
         }
     }
 


### PR DESCRIPTION
… only ones that fire pointerout events.

Related forum issue: https://forum.babylonjs.com/t/nothing-happens-when-you-click-grid/33320

This is to compliment another fix from #12887, where the condition should only apply if the control has been captured by the scene only, and not by the GUI.