### PR TITLE
Fix scene not clearing in some Default Rendering Pipeline with multicamera cases

### DIFF
--- a/packages/dev/core/src/Misc/arrayTools.ts
+++ b/packages/dev/core/src/Misc/arrayTools.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+
+import type { Observable } from "./observable";
+import type { Nullable } from "../types";
+
 /** @hidden */
 interface TupleTypes<T> {
     2: [T, T];
@@ -15,6 +19,12 @@ interface TupleTypes<T> {
     13: [T, T, T, T, T, T, T, T, T, T, T, T, T];
     14: [T, T, T, T, T, T, T, T, T, T, T, T, T, T];
     15: [T, T, T, T, T, T, T, T, T, T, T, T, T, T, T];
+}
+
+export interface INotifyArrayChangeType<T> {
+    target: Nullable<Array<T>>;
+    values: Nullable<Array<T>>;
+    operation: string;
 }
 
 /**
@@ -43,5 +53,46 @@ export class ArrayTools {
      */
     public static BuildTuple<T, N extends keyof TupleTypes<unknown>>(size: N, itemBuilder: () => T): TupleTypes<T>[N] {
         return ArrayTools.BuildArray(size, itemBuilder) as any;
+    }
+
+    private static _ProxySet<T>(observable: Observable<INotifyArrayChangeType<T>>, target: Array<T>, property: string | symbol, value: T): boolean {
+        observable.notifyObservers({ target, values: [value], operation: "set" });
+        return Reflect.set(target, property, value);
+    }
+
+    private static _ProxyPushOrUnshift<T>(operation: "push" | "unshift", observable: Observable<INotifyArrayChangeType<T>>, target: Array<T>, ...values: Array<T>): number {
+        observable.notifyObservers({ target, values, operation });
+        return operation === "push" ? Array.prototype.push.apply(target, values) : Array.prototype.unshift.apply(target, values);
+    }
+
+    private static _ProxyDelete<T>(observable: Observable<INotifyArrayChangeType<T>>, target: Array<T>, property: string | symbol) {
+        observable.notifyObservers({ target, values: [Reflect.get(target, property)], operation: "delete" });
+        return Reflect.deleteProperty(target, property);
+    }
+
+    private static _ProxyPopOrShift<T>(operation: "pop" | "shift", observable: Observable<INotifyArrayChangeType<T>>, target: Array<T>) {
+        const value = operation === "pop" ? Array.prototype.pop.apply(target) : Array.prototype.shift.apply(target);
+        observable.notifyObservers({ target, operation, values: [value] });
+        return value;
+    }
+
+    private static _ProxySplice<T>(observable: Observable<INotifyArrayChangeType<T>>, target: Array<T>, start: number, deleteNumber: number, ...added: Array<T>) {
+        const values = Array.prototype.splice.apply(target, [start, deleteNumber, added]);
+        observable.notifyObservers({ target, values, operation: "splice" });
+        return values;
+    }
+
+    public static MakeObservableArray<T>(observable: Observable<INotifyArrayChangeType<T>>, initialArray: Array<T>) {
+        const _proxyObject = {
+            set: (target: Array<T>, property: string | symbol, value: T) => ArrayTools._ProxySet(observable, target, property, value),
+            push: (target: Array<T>, ...values: Array<T>) => ArrayTools._ProxyPushOrUnshift("push", observable, target, ...values),
+            unshift: (target: Array<T>, ...values: Array<T>) => ArrayTools._ProxyPushOrUnshift("unshift", observable, target, ...values),
+            delete: (target: Array<T>, property: string | symbol) => ArrayTools._ProxyDelete(observable, target, property),
+            pop: (target: Array<T>) => ArrayTools._ProxyPopOrShift("pop", observable, target),
+            shift: (target: Array<T>) => ArrayTools._ProxyPopOrShift("shift", observable, target),
+            splice: (target: Array<T>, start: number, deleteNumber: number, ...added: Array<T>) => ArrayTools._ProxySplice(observable, target, start, deleteNumber, added),
+        };
+
+        return new Proxy(initialArray, _proxyObject);
     }
 }

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -27,6 +27,7 @@ import { RegisterClass } from "../../../Misc/typeStore";
 import { EngineStore } from "../../../Engines/engineStore";
 
 import "../../../PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
+import type { INotifyArrayChangeType } from "core/Misc/arrayTools";
 
 declare type Animation = import("../../../Animations/animation").Animation;
 
@@ -554,7 +555,7 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
 
     private _depthOfFieldSceneObserver: Nullable<Observer<Scene>> = null;
     private _activeCameraChangedObserver: Nullable<Observer<Scene>> = null;
-    private _activeCamerasChangedObserver: Nullable<Observer<Scene>> = null;
+    private _activeCamerasChangedObserver: Nullable<Observer<INotifyArrayChangeType<Camera>>> = null;
 
     private _buildPipeline() {
         if (!this._buildAllowed) {

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -553,6 +553,7 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
     }
 
     private _depthOfFieldSceneObserver: Nullable<Observer<Scene>> = null;
+    private _activeCameraChangedObserver: Nullable<Observer<Scene>> = null;
 
     private _buildPipeline() {
         if (!this._buildAllowed) {
@@ -689,8 +690,16 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
         }
 
         // In multicamera mode, the scene needs to autoclear in between cameras.
-        if (this._scene.activeCameras && this._scene.activeCameras.length > 1) {
+        if ((this._scene.activeCameras && this._scene.activeCameras.length > 1) || (this._scene.activeCamera && this.cameras.indexOf(this._scene.activeCamera) === -1)) {
             this._scene.autoClear = true;
+        }
+        // The active camera on the scene can be changed anytime
+        if (!this._activeCameraChangedObserver) {
+            this._activeCameraChangedObserver = this._scene.onActiveCameraChanged.add(() => {
+                if (this._scene.activeCamera && this.cameras.indexOf(this._scene.activeCamera) === -1) {
+                    this._scene.autoClear = true;
+                }
+            });
         }
 
         if (!this._enableMSAAOnFirstPostProcess(this.samples) && this.samples > 1) {

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -554,6 +554,7 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
 
     private _depthOfFieldSceneObserver: Nullable<Observer<Scene>> = null;
     private _activeCameraChangedObserver: Nullable<Observer<Scene>> = null;
+    private _activeCamerasChangedObserver: Nullable<Observer<Scene>> = null;
 
     private _buildPipeline() {
         if (!this._buildAllowed) {
@@ -701,6 +702,13 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
                 }
             });
         }
+        if (!this._activeCamerasChangedObserver) {
+            this._activeCamerasChangedObserver = this._scene.onActiveCamerasChanged.add(() => {
+                if (this._scene.activeCameras && this._scene.activeCameras.length > 1) {
+                    this._scene.autoClear = true;
+                }
+            });
+        }
 
         if (!this._enableMSAAOnFirstPostProcess(this.samples) && this.samples > 1) {
             Logger.Warn("MSAA failed to enable, MSAA is only supported in browsers that support webGL >= 2.0");
@@ -795,6 +803,14 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
         if (this._resizeObserver) {
             this._scene.getEngine().onResizeObservable.remove(this._resizeObserver);
             this._resizeObserver = null;
+        }
+        if (this._activeCameraChangedObserver) {
+            this._scene.onActiveCameraChanged.remove(this._activeCameraChangedObserver);
+            this._activeCameraChangedObserver = null;
+        }
+        if (this._activeCamerasChangedObserver) {
+            this._scene.onActiveCamerasChanged.remove(this._activeCamerasChangedObserver);
+            this._activeCamerasChangedObserver = null;
         }
         this._scene.imageProcessingConfiguration.onUpdateParameters.remove(this._imageProcessingConfigurationObserver);
         super.dispose();

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -805,14 +805,10 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
             this._scene.getEngine().onResizeObservable.remove(this._resizeObserver);
             this._resizeObserver = null;
         }
-        if (this._activeCameraChangedObserver) {
-            this._scene.onActiveCameraChanged.remove(this._activeCameraChangedObserver);
-            this._activeCameraChangedObserver = null;
-        }
-        if (this._activeCamerasChangedObserver) {
-            this._scene.onActiveCamerasChanged.remove(this._activeCamerasChangedObserver);
-            this._activeCamerasChangedObserver = null;
-        }
+
+        this._scene.onActiveCameraChanged.remove(this._activeCameraChangedObserver);
+        this._scene.onActiveCamerasChanged.remove(this._activeCamerasChangedObserver);
+
         this._scene.imageProcessingConfiguration.onUpdateParameters.remove(this._imageProcessingConfigurationObserver);
         super.dispose();
     }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -655,6 +655,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public onActiveCameraChanged = new Observable<Scene>();
 
     /**
+     * An event triggered when the activeCameras property is updated
+     */
+    public onActiveCamerasChanged = new Observable<Scene>();
+
+    /**
      * This Observable will be triggered before rendering each renderingGroup of each rendered camera.
      * The RenderingGroupInfo class contains all the information about the context in which the observable is called
      * If you wish to register an Observer only for a given set of renderingGroup, use the mask with a combination of the renderingGroup index elevated to the power of two (1 for renderingGroup 0, 2 for renderingrOup1, 4 for 2 and 8 for 3)
@@ -1012,8 +1017,26 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         return this._lightsEnabled;
     }
 
+    private _activeCameras: Nullable<Camera[]> = new Array<Camera>();
     /** All of the active cameras added to this scene. */
-    public activeCameras: Nullable<Camera[]> = new Array<Camera>();
+    // TODO ADD PROXY TO FIRE OBSERVABLE
+    public get activeCameras(): Nullable<Camera[]> {
+        return this._activeCameras;
+    }
+    public addActiveCamera(c: Camera) {
+        if (this._activeCameras) {
+            this._activeCameras.push(c);
+            this.onActiveCamerasChanged.notifyObservers(this);
+        }
+    }
+    public set activeCameras(cameras: Nullable<Camera[]>) {
+        if (cameras) {
+            this._activeCameras = new Array<Camera>(...cameras);
+        } else {
+            this._activeCameras = cameras;
+        }
+        this.onActiveCamerasChanged.notifyObservers(this);
+    }
 
     /** @hidden */
     public _activeCamera: Nullable<Camera>;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1026,12 +1026,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     }
 
     public set activeCameras(cameras: Nullable<Camera[]>) {
-        if (cameras) {
-            this._activeCameras = ArrayTools.MakeObservableArray(this.onActiveCamerasChanged, cameras);
-        } else {
-            this._activeCameras = cameras;
-        }
-        this.onActiveCamerasChanged.notifyObservers({ target: this.activeCameras, values: cameras, operation: "new" });
+        this._activeCameras = ArrayTools.MakeObservableArray(this.onActiveCamerasChanged, cameras);
     }
 
     /** @hidden */


### PR DESCRIPTION
Examples of where this would happen:

- Have a DRP with a camera different than the scene's active camera (rendering to a RTT for instance): https://playground.babylonjs.com/#QW6XJE#4
- Set multiple active cameras AFTER the DRP has been created: https://playground.babylonjs.com/#QW6XJE#13