### PR TITLE
Fix null error in late animation bindings

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -1085,7 +1085,9 @@ Scene.prototype._processLateAnimationBindings = function (): void {
             const holder = target._lateAnimationHolders[path];
             const originalAnimation: RuntimeAnimation = holder.animations[0];
             const originalValue = holder.originalValue;
-
+            if (originalValue === undefined || originalValue === null) {
+                continue;
+            }
             const matrixDecomposeMode = Animation.AllowMatrixDecomposeForInterpolation && originalValue.m; // ie. data is matrix
 
             let finalValue: any = target[path];


### PR DESCRIPTION
https://forum.babylonjs.com/t/error-in-processlateanimationbindings/33464

```
TypeError: Cannot read properties of null (reading 'm')
    at core_scene.a._processLateAnimationBindings (animatable.js:730:48)
    at core_scene.a._animate (animatable.js:429:1)
    at Scene.animate (scene.js:3661:1)
    at Scene.render (scene.js:3737:1)
```