### PR TITLE
TouchButton3D's getPressDepth(position) call has depth discrepancy

### DIFF
--- a/packages/dev/gui/src/3D/controls/touchButton3D.ts
+++ b/packages/dev/gui/src/3D/controls/touchButton3D.ts
@@ -199,7 +199,7 @@ export class TouchButton3D extends Button3D {
      * @hidden
      */
     public _generatePointerEventType(providedType: number, nearMeshPosition: Vector3, activeInteractionCount: number): number {
-        if (providedType === PointerEventTypes.POINTERDOWN) {
+        if (providedType === PointerEventTypes.POINTERDOWN || providedType === PointerEventTypes.POINTERMOVE) {
             if (!this._isInteractionInFrontOfButton(nearMeshPosition)) {
                 // Near interaction mesh is behind the button, don't send a pointer down
                 return PointerEventTypes.POINTERMOVE;


### PR DESCRIPTION
Fixes #12109

The issue is not exactly as described in the ticket. During apointer move, the cached integer was not updated, so onPointerMove you wouldn't be able to check the depth to the button. onPointerDown's depth is correct, as onPointerDown is triggered when the button is defined as pressed, which is not when the sphere's center is at the end of the button, but a little before. This "little" before is defined by the pickRadius in near interaction (0.02 units).

This PR updated the height variable on pointer move as well, which would allow to check the distance correctly when using pointer move.