### PR TITLE
Clamp negative rgb values to zero to avoid parse errors in native

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssaoRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssaoRenderingPipeline.ts
@@ -356,9 +356,9 @@ export class SSAORenderingPipeline extends PostProcessRenderPipeline {
 
         for (let x = 0; x < size; x++) {
             for (let y = 0; y < size; y++) {
-                randVector.x = Math.floor(rand(-1.0, 1.0) * 255);
-                randVector.y = Math.floor(rand(-1.0, 1.0) * 255);
-                randVector.z = Math.floor(rand(-1.0, 1.0) * 255);
+                randVector.x = Math.floor(Math.max(0.0, rand(-1.0, 1.0)) * 255);
+                randVector.y = Math.floor(Math.max(0.0, rand(-1.0, 1.0)) * 255);
+                randVector.z = Math.floor(Math.max(0.0, rand(-1.0, 1.0)) * 255);
 
                 context.fillStyle = "rgb(" + randVector.x + ", " + randVector.y + ", " + randVector.z + ")";
                 context.fillRect(x, y, 1, 1);


### PR DESCRIPTION
When setting a canvas's fill style to `"rgb(x, y, z)"`, browsers clamp negative x/y/z values to zero but native throws parse errors like "Exception in HostFunction: Unable to parse color: rgb(-51, 13, -128)".

This change fixes the issue by clamping negative rgb values to zero before using them in the style's rgb function.