### PR TITLE
OIT aliasing fixes

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -386,7 +386,7 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
 
     // Dispose previous render buffers
     const useDepthStencil = !!rtWrapper._depthStencilBuffer;
-    if (rtWrapper._depthStencilBuffer) {
+    if (useDepthStencil) {
         gl.deleteRenderbuffer(rtWrapper._depthStencilBuffer);
         rtWrapper._depthStencilBuffer = null;
     }

--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -385,6 +385,7 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
     samples = Math.min(samples, this.getCaps().maxMSAASamples);
 
     // Dispose previous render buffers
+    const useDepthStencil = !!rtWrapper._depthStencilBuffer;
     if (rtWrapper._depthStencilBuffer) {
         gl.deleteRenderbuffer(rtWrapper._depthStencilBuffer);
         rtWrapper._depthStencilBuffer = null;
@@ -393,14 +394,6 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
     if (rtWrapper._MSAAFramebuffer) {
         gl.deleteFramebuffer(rtWrapper._MSAAFramebuffer);
         rtWrapper._MSAAFramebuffer = null;
-    }
-
-    for (let i = 0; i < count; i++) {
-        const hardwareTexture = rtWrapper.textures![i]._hardwareTexture as Nullable<WebGLHardwareTexture>;
-        if (hardwareTexture?._MSAARenderBuffer) {
-            gl.deleteRenderbuffer(hardwareTexture._MSAARenderBuffer);
-            hardwareTexture._MSAARenderBuffer = null;
-        }
     }
 
     if (samples > 1 && gl.renderbufferStorageMultisample) {
@@ -420,14 +413,17 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
             const hardwareTexture = texture._hardwareTexture as WebGLHardwareTexture;
             const attachment = (<any>gl)[this.webGLVersion > 1 ? "COLOR_ATTACHMENT" + i : "COLOR_ATTACHMENT" + i + "_WEBGL"];
 
-            const colorRenderbuffer = this._createRenderBuffer(
-                texture.width,
-                texture.height,
-                samples,
-                -1 /* not used */,
-                this._getRGBAMultiSampleBufferFormat(texture.type),
-                attachment
-            );
+            const colorRenderbuffer = hardwareTexture._MSAARenderBuffer
+                ? this._updateRenderBuffer(
+                      hardwareTexture._MSAARenderBuffer,
+                      texture.width,
+                      texture.height,
+                      samples,
+                      -1 /* not used */,
+                      this._getRGBAMultiSampleBufferFormat(texture.type),
+                      attachment
+                  )
+                : this._createRenderBuffer(texture.width, texture.height, samples, -1 /* not used */, this._getRGBAMultiSampleBufferFormat(texture.type), attachment);
 
             if (!colorRenderbuffer) {
                 throw new Error("Unable to create multi sampled framebuffer");
@@ -445,13 +441,15 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
         this._bindUnboundFramebuffer(rtWrapper._framebuffer);
     }
 
-    rtWrapper._depthStencilBuffer = this._setupFramebufferDepthAttachments(
-        rtWrapper._generateStencilBuffer,
-        rtWrapper._generateDepthBuffer,
-        rtWrapper.texture.width,
-        rtWrapper.texture.height,
-        samples
-    );
+    if (useDepthStencil) {
+        rtWrapper._depthStencilBuffer = this._setupFramebufferDepthAttachments(
+            rtWrapper._generateStencilBuffer,
+            rtWrapper._generateDepthBuffer,
+            rtWrapper.texture.width,
+            rtWrapper.texture.height,
+            samples
+        );
+    }
 
     this._bindUnboundFramebuffer(null);
 

--- a/packages/dev/core/src/Engines/WebGL/webGLRenderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/WebGL/webGLRenderTargetWrapper.ts
@@ -59,7 +59,7 @@ export class WebGLRenderTargetWrapper extends RenderTargetWrapper {
 
         const gl = this._context;
         const depthbuffer = this._depthStencilBuffer;
-        const framebuffer = renderTarget._framebuffer;
+        const framebuffer = renderTarget._MSAAFramebuffer || renderTarget._framebuffer;
 
         if (renderTarget._depthStencilBuffer) {
             gl.deleteRenderbuffer(renderTarget._depthStencilBuffer);

--- a/packages/dev/core/src/Engines/renderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/renderTargetWrapper.ts
@@ -24,6 +24,7 @@ export class RenderTargetWrapper {
     private _isCube: boolean;
     private _isMulti: boolean;
     private _textures: Nullable<InternalTexture[]> = null;
+    private _samples = 1;
 
     /** @hidden */
     public _attachments: Nullable<number[]> = null;
@@ -118,7 +119,7 @@ export class RenderTargetWrapper {
      * Gets the sample count of the render target
      */
     public get samples(): number {
-        return this.texture?.samples ?? 1;
+        return this._samples;
     }
 
     /**
@@ -133,9 +134,11 @@ export class RenderTargetWrapper {
             return value;
         }
 
-        return this._isMulti
+        const result = this._isMulti
             ? this._engine.updateMultipleRenderTargetTextureSampleCount(this, value, initializeBuffers)
             : this._engine.updateRenderTargetTextureSampleCount(this, value);
+        this._samples = value;
+        return result;
     }
 
     /**

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4847,6 +4847,20 @@ export class ThinEngine {
     ): Nullable<WebGLRenderbuffer> {
         const gl = this._gl;
         const renderBuffer = gl.createRenderbuffer();
+        return this._updateRenderBuffer(renderBuffer, width, height, samples, internalFormat, msInternalFormat, attachment, unbindBuffer);
+    }
+
+    public _updateRenderBuffer(
+        renderBuffer: Nullable<WebGLRenderbuffer>,
+        width: number,
+        height: number,
+        samples: number,
+        internalFormat: number,
+        msInternalFormat: number,
+        attachment: number,
+        unbindBuffer = true
+    ): Nullable<WebGLRenderbuffer> {
+        const gl = this._gl;
 
         gl.bindRenderbuffer(gl.RENDERBUFFER, renderBuffer);
 

--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -15,6 +15,7 @@ import { EffectRenderer, EffectWrapper } from "../Materials/effectRenderer";
 import type { PrePassEffectConfiguration } from "./prePassEffectConfiguration";
 import type { PrePassRenderer } from "./prePassRenderer";
 import type { InternalTexture } from "../Materials/Textures/internalTexture";
+import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { Logger } from "../Misc/logger";
 import type { IMaterialContext } from "../Engines/IMaterialContext";
 import type { DrawWrapper } from "../Materials/drawWrapper";
@@ -23,7 +24,6 @@ import { Material } from "../Materials/material";
 import "../Shaders/postprocess.vertex";
 import "../Shaders/oitFinal.fragment";
 import "../Shaders/oitBackBlend.fragment";
-import { RenderTargetTexture } from "..";
 
 class DepthPeelingEffectConfiguration implements PrePassEffectConfiguration {
     /**
@@ -364,7 +364,7 @@ export class DepthPeelingRenderer {
     }
 
     private _finalCompose(writeId: number) {
-        const output = this._scene.prePassRenderer?.setDepthPeelingOutput(this._outputRT);
+        const output = this._scene.prePassRenderer?.setCustomOutput(this._outputRT);
         if (output) {
             this._engine.bindFramebuffer(this._outputRT.renderTarget!);
         } else {

--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -205,13 +205,15 @@ export class DepthPeelingRenderer {
         }
     }
 
-    public set samples(value: number) {
-        for (let i = 0; i < 2; i++) {
-            this._depthMrts[i].samples = value;
-            this._colorMrts[i].samples = value;
-        }
-        this._scene.prePassRenderer!.samples = value;
-    }
+    // TODO : explore again MSAA with depth peeling when
+    // we are able to fetch individual samples in a multisampled renderbuffer
+    // public set samples(value: number) {
+    //     for (let i = 0; i < 2; i++) {
+    //         this._depthMrts[i].samples = value;
+    //         this._colorMrts[i].samples = value;
+    //     }
+    //     this._scene.prePassRenderer!.samples = value;
+    // }
 
     private _disposeTextures() {
         for (let i = 0; i < this._thinTextures.length; i++) {

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -418,7 +418,14 @@ export class PrePassRenderer {
         }
     }
 
-    public setDepthPeelingOutput(rt: RenderTargetTexture) {
+    /**
+     * Sets an intermediary texture between prepass and postprocesses. This texture
+     * will be used as input for post processes
+     * @param rt
+     * @returns true if there are postprocesses that will use this texture,
+     * false if there is no postprocesses - and the function has no effect
+     */
+    public setCustomOutput(rt: RenderTargetTexture) {
         const firstPP = this._postProcessesSourceForThisPass[0];
         if (!firstPP) {
             return false;

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -418,6 +418,17 @@ export class PrePassRenderer {
         }
     }
 
+    public setDepthPeelingOutput(rt: RenderTargetTexture) {
+        const firstPP = this._postProcessesSourceForThisPass[0];
+        if (!firstPP) {
+            return false;
+        }
+
+        firstPP.inputTexture = rt.renderTarget!;
+
+        return true;
+    }
+
     private _renderPostProcesses(prePassRenderTarget: PrePassRenderTarget, faceIndex?: number) {
         const firstPP = this._postProcessesSourceForThisPass[0];
         const outputTexture = firstPP ? firstPP.inputTexture : prePassRenderTarget.renderTargetTexture ? prePassRenderTarget.renderTargetTexture.renderTarget : null;

--- a/packages/dev/core/src/Shaders/ShadersInclude/oitFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/oitFragment.fx
@@ -35,7 +35,7 @@
     // alpha is cleared to 0, and we want to initialize alpha to 1. 
     // The operation will be canceled in the fragment shader by writing 1 - a for the next passes
     float alphaMultiplier = 1.0 - lastFrontColor.a;
-
+    
 #ifdef USE_REVERSE_DEPTHBUFFER
     if (fragDepth > nearestDepth || fragDepth < furthestDepth) {
 #else


### PR DESCRIPTION
* Implemented multisampling for DepthPeeling (works but has artifacts along triangle edges because we need to access multisampled depth in the shader, which cannot be done for now)
* Made depth peeling compatible with post processes to be able to use FXAA post process