### PR TITLE
Enforce parent blocks being empty in octree

### DIFF
--- a/packages/dev/core/src/Culling/Octrees/octreeBlock.ts
+++ b/packages/dev/core/src/Culling/Octrees/octreeBlock.ts
@@ -225,6 +225,7 @@ export class OctreeBlock<T> {
      */
     public createInnerBlocks(): void {
         OctreeBlock._CreateBlocks(this._minPoint, this._maxPoint, this.entries, this._capacity, this._depth, this._maxDepth, this, this._creationFunc);
+        this.entries.splice(0);
     }
 
     /**


### PR DESCRIPTION
When creating inner blocks the code enforces that the parent blocks `entries` are ignored (in `octree.select` for example) however the actual `entries` array of the parent block is still populated. Probably not an issue when using just a few objects but it is when using thousands.

The code comment says the parent block will be emptied but it isn't.

