### PR TITLE
Add support of clipplanes in GlowLayer

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -648,6 +648,27 @@ export abstract class EffectLayer {
             }
         }
 
+        // ClipPlanes
+        const scene = this._scene;
+        if (scene.clipPlane) {
+            defines.push("#define CLIPPLANE");
+        }
+        if (scene.clipPlane2) {
+            defines.push("#define CLIPPLANE2");
+        }
+        if (scene.clipPlane3) {
+            defines.push("#define CLIPPLANE3");
+        }
+        if (scene.clipPlane4) {
+            defines.push("#define CLIPPLANE4");
+        }
+        if (scene.clipPlane5) {
+            defines.push("#define CLIPPLANE5");
+        }
+        if (scene.clipPlane6) {
+            defines.push("#define CLIPPLANE6");
+        }
+
         this._addCustomEffectDefines(defines);
 
         // Get correct effect
@@ -672,6 +693,12 @@ export abstract class EffectLayer {
                         "opacityIntensity",
                         "morphTargetTextureInfo",
                         "morphTargetTextureIndices",
+                        "vClipPlane",
+                        "vClipPlane2",
+                        "vClipPlane3",
+                        "vClipPlane4",
+                        "vClipPlane5",
+                        "vClipPlane6",
                     ],
                     ["diffuseSampler", "emissiveSampler", "opacitySampler", "boneSampler", "morphTargets"],
                     join,
@@ -956,6 +983,9 @@ export abstract class EffectLayer {
                 if (enableAlphaMode) {
                     engine.setAlphaMode(material.alphaMode);
                 }
+
+                // Clip planes
+                MaterialHelper.BindClipPlane(effect, scene);
             }
 
             // Draw

--- a/packages/dev/core/src/Shaders/glowMapGeneration.fragment.fx
+++ b/packages/dev/core/src/Shaders/glowMapGeneration.fragment.fx
@@ -24,11 +24,14 @@ uniform sampler2D emissiveSampler;
 
 uniform vec4 glowColor;
 
+#include<clipPlaneFragmentDeclaration>
 
 #define CUSTOM_FRAGMENT_DEFINITIONS
 
 void main(void)
 {
+
+#include<clipPlaneFragment>
 
 vec4 finalColor = glowColor;
 

--- a/packages/dev/core/src/Shaders/glowMapGeneration.vertex.fx
+++ b/packages/dev/core/src/Shaders/glowMapGeneration.vertex.fx
@@ -7,6 +7,8 @@ attribute vec3 position;
 #include<morphTargetsVertexGlobalDeclaration>
 #include<morphTargetsVertexDeclaration>[0..maxSimultaneousMorphTargets]
 
+#include<clipPlaneVertexDeclaration>
+
 // Uniforms
 #include<instancesDeclaration>
 
@@ -59,11 +61,13 @@ void main(void)
 #include<bonesVertex>
 #include<bakedVertexAnimation>
 
+vec4 worldPos = finalWorld * vec4(positionUpdated, 1.0);
+
 #ifdef CUBEMAP
-	vPosition = finalWorld * vec4(positionUpdated, 1.0);
+	vPosition = worldPos;
 	gl_Position = viewProjection * finalWorld * vec4(position, 1.0);
 #else
-	vPosition = viewProjection * finalWorld * vec4(positionUpdated, 1.0);
+	vPosition = viewProjection * worldPos;
 	gl_Position = vPosition;
 #endif
 
@@ -97,4 +101,7 @@ void main(void)
 #ifdef VERTEXALPHA
     vColor = color;
 #endif
+
+#include<clipPlaneVertex>
+
 }


### PR DESCRIPTION
https://forum.babylonjs.com/t/clipping-plane-has-no-effect-on-a-meshs-glow-in-a-glow-layer-unsure-if-this-by-design-or-this-is-a-bug/33565