### PR TITLE
Cameras: Add noPreventDefault as argument to attachControl call

### DIFF
--- a/packages/dev/core/src/Cameras/cameraInputsManager.ts
+++ b/packages/dev/core/src/Cameras/cameraInputsManager.ts
@@ -125,7 +125,7 @@ export class CameraInputsManager<TCamera extends Camera> {
         }
 
         if (this.attachedToElement) {
-            input.attachControl();
+            input.attachControl(this.noPreventDefault);
         }
     }
 


### PR DESCRIPTION
A user in the forum ([Forum Post](https://forum.babylonjs.com/t/potential-inconsistency-with-camerainputsmanagers-add-and-attachelement-functions/32639)) found that there was an inconsistency with how the `noPreventDefault` property was being handled with our camera inputs.  Specifically, if new inputs were added after controls were already attached, the value for `noPreventDefault` was not used when attaching those inputs.  This PR modifies the internal attachControl call to use the input's value for `noPreventDefault`.

Thanks to forum user **kvbh** for the fix suggestion.