### PR TITLE
Add dithering effect to image processing.

### DIFF
--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -133,6 +133,7 @@ class BackgroundMaterialDefines extends MaterialDefines implements IImageProcess
     public COLORGRADING3D = false;
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
+    public DITHER = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public EXPOSURE = false;

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
@@ -75,6 +75,7 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
         state._excludeVariableName("vCameraColorCurvePositive");
         state._excludeVariableName("txColorTransform");
         state._excludeVariableName("colorTransformSettings");
+        state._excludeVariableName("ditherIntensity");
     }
 
     public isReady(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
@@ -127,6 +128,7 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
         state.uniforms.push("vCameraColorCurvePositive");
         state.uniforms.push("txColorTransform");
         state.uniforms.push("colorTransformSettings");
+        state.uniforms.push("ditherIntensity");
 
         // Emit code
         const color = this.color;

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1041,6 +1041,7 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         state.uniforms.push("vCameraColorCurvePositive");
         state.uniforms.push("txColorTransform");
         state.uniforms.push("colorTransformSettings");
+        state.uniforms.push("ditherIntensity");
 
         //
         // Includes

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -111,6 +111,7 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public COLORGRADING3D = false;
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
+    public DITHER = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -216,6 +216,7 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public COLORGRADING3D = false;
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
+    public DITHER = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public EXPOSURE = false;

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -175,6 +175,7 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public COLORGRADING3D = false;
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
+    public DITHER = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public MULTIVIEW = false;

--- a/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
@@ -325,7 +325,7 @@ export class ImageProcessingPostProcess extends PostProcess {
     /**
      * Gets intensity of the dithering effect.
      */
-     public get ditheringIntensity(): number {
+    public get ditheringIntensity(): number {
         return this.imageProcessingConfiguration.ditheringIntensity;
     }
     /**

--- a/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
@@ -322,6 +322,32 @@ export class ImageProcessingPostProcess extends PostProcess {
         this.imageProcessingConfiguration.vignetteEnabled = value;
     }
 
+    /**
+     * Gets intensity of the dithering effect.
+     */
+     public get ditheringIntensity(): number {
+        return this.imageProcessingConfiguration.ditheringIntensity;
+    }
+    /**
+     * Sets intensity of the dithering effect.
+     */
+    public set ditheringIntensity(value: number) {
+        this.imageProcessingConfiguration.ditheringIntensity = value;
+    }
+
+    /**
+     * Gets whether the dithering effect is enabled.
+     */
+    public get ditheringEnabled(): boolean {
+        return this.imageProcessingConfiguration.ditheringEnabled;
+    }
+    /**
+     * Sets whether the dithering effect is enabled.
+     */
+    public set ditheringEnabled(value: boolean) {
+        this.imageProcessingConfiguration.ditheringEnabled = value;
+    }
+
     @serialize()
     private _fromLinearSpace = true;
     /**
@@ -359,6 +385,7 @@ export class ImageProcessingPostProcess extends PostProcess {
         FROMLINEARSPACE: false,
         SAMPLER3DGREENDEPTH: false,
         SAMPLER3DBGRMAP: false,
+        DITHER: false,
         IMAGEPROCESSINGPOSTPROCESS: false,
         EXPOSURE: false,
         SKIPFINALCOLORCLAMP: false,

--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -166,8 +166,8 @@ float getRand(vec2 seed) {
 
 float dither(vec2 seed, float varianceAmount) {
     float rand = getRand(seed);
-    float dither = mix(-varianceAmount/255.0, varianceAmount/255.0, rand);
-    
+    float normVariance = varianceAmount / 255.0;
+    float dither = mix(-normVariance, normVariance, rand);
     return dither;
 }
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/imageProcessingDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/imageProcessingDeclaration.fx
@@ -6,8 +6,11 @@
 	uniform float contrast;
 #endif
 
-#ifdef VIGNETTE
+#if defined(VIGNETTE) || defined(DITHER)
 	uniform vec2 vInverseScreenSize;
+#endif
+
+#ifdef VIGNETTE
 	uniform vec4 vignetteSettings1;
 	uniform vec4 vignetteSettings2;
 #endif
@@ -25,4 +28,8 @@
 		uniform sampler2D txColorTransform;
 	#endif
 	uniform vec4 colorTransformSettings;
+#endif
+
+#ifdef DITHER
+	uniform float ditherIntensity;
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/imageProcessingFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/imageProcessingFunctions.fx
@@ -168,5 +168,11 @@ vec4 applyImageProcessing(vec4 result) {
 	result.rgb = mix(vec3(luma), result.rgb, colorCurve.a);
 #endif
 
+#ifdef DITHER
+	float rand = getRand(gl_FragCoord.xy * vInverseScreenSize);
+	float dither = mix(-ditherIntensity, ditherIntensity, rand);
+	result.rgb = saturate(result.rgb + vec3(dither));
+#endif
+
 	return result;
 }

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/defaultRenderingPipelinePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/defaultRenderingPipelinePropertyGridComponent.tsx
@@ -398,7 +398,8 @@ export class DefaultRenderingPipelinePropertyGridComponent extends React.Compone
                                 propertyName="vignetteBlendMode"
                                 onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                                 onSelect={(value) => this.setState({ mode: value })}
-                            /><CheckBoxLineComponent
+                            />
+                            <CheckBoxLineComponent
                                 label="Dithering"
                                 target={renderPipeline.imageProcessing}
                                 propertyName="ditheringEnabled"

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/defaultRenderingPipelinePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/defaultRenderingPipelinePropertyGridComponent.tsx
@@ -398,6 +398,21 @@ export class DefaultRenderingPipelinePropertyGridComponent extends React.Compone
                                 propertyName="vignetteBlendMode"
                                 onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                                 onSelect={(value) => this.setState({ mode: value })}
+                            /><CheckBoxLineComponent
+                                label="Dithering"
+                                target={renderPipeline.imageProcessing}
+                                propertyName="ditheringEnabled"
+                                onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                            />
+                            <SliderLineComponent
+                                lockObject={this.props.lockObject}
+                                minimum={0}
+                                maximum={1}
+                                step={0.5 / 255.0}
+                                label="Dithering intensity"
+                                target={renderPipeline.imageProcessing}
+                                propertyName="ditheringIntensity"
+                                onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                             />
                         </div>
                     )}

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/scenePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/scenePropertyGridComponent.tsx
@@ -322,6 +322,22 @@ export class ScenePropertyGridComponent extends React.Component<IScenePropertyGr
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                         onSelect={(value) => this.setState({ mode: value })}
                     />
+                    <CheckBoxLineComponent
+                        label="Dithering"
+                        target={imageProcessing}
+                        propertyName="ditheringEnabled"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        minimum={0}
+                        maximum={1}
+                        step={0.5 / 255.0}
+                        label="Dithering intensity"
+                        target={imageProcessing}
+                        propertyName="ditheringIntensity"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                 </LineContainerComponent>
                 {dummy !== null && (
                     <LineContainerComponent title="PHYSICS" closed={true} selection={this.props.globalState}>

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -72,6 +72,7 @@ class WaterMaterialDefines extends MaterialDefines implements IImageProcessingCo
     public COLORGRADING3D = false;
     public SAMPLER3DGREENDEPTH = false;
     public SAMPLER3DBGRMAP = false;
+    public DITHER = false;
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
 


### PR DESCRIPTION
This can be used to reduce banding in final output. It's good to have it as part of the image processing functions, as the more artistic alternative to this would be the grain post process which requires a separate pass and thus has more overhead. If all you're looking for is to reduce banding, this will be a simple/efficient option.

I've been testing this change via the inspector -> add a default rendering pipeline -> enable dithering.