### PR TITLE
Added AudioBuffer as parameter for Sound

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -158,7 +158,7 @@ export class Sound {
     private _registerFunc: Nullable<(connectedMesh: TransformNode) => void>;
     private _isOutputConnected = false;
     private _htmlAudioElement: HTMLAudioElement;
-    private _urlType: "Unknown" | "String" | "Array" | "ArrayBuffer" | "MediaStream" | "AudioBuffer" |"MediaElement" = "Unknown";
+    private _urlType: "Unknown" | "String" | "Array" | "ArrayBuffer" | "MediaStream" | "AudioBuffer" | "MediaElement" = "Unknown";
     private _length?: number;
     private _offset?: number;
 
@@ -274,7 +274,7 @@ export class Sound {
                                 this._readyToPlayCallback();
                             }
                             break;
-                        case "ArrayBuffer":                            
+                        case "ArrayBuffer":
                             if ((<ArrayBuffer>urlOrArrayBuffer).byteLength > 0) {
                                 codecSupportedFound = true;
                                 this._soundLoaded(urlOrArrayBuffer);
@@ -451,7 +451,7 @@ export class Sound {
     private _audioBufferLoaded(buffer: AudioBuffer) {
         if (!Engine.audioEngine?.audioContext) {
             return;
-        }       
+        }
         this._audioBuffer = buffer;
         this._isReadyToPlay = true;
         if (this.autoplay) {

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -158,7 +158,7 @@ export class Sound {
     private _registerFunc: Nullable<(connectedMesh: TransformNode) => void>;
     private _isOutputConnected = false;
     private _htmlAudioElement: HTMLAudioElement;
-    private _urlType: "Unknown" | "String" | "Array" | "ArrayBuffer" | "MediaStream" | "MediaElement" = "Unknown";
+    private _urlType: "Unknown" | "String" | "Array" | "ArrayBuffer" | "MediaStream" | "AudioBuffer" |"MediaElement" = "Unknown";
     private _length?: number;
     private _offset?: number;
 
@@ -238,6 +238,8 @@ export class Sound {
                         this._urlType = "MediaElement";
                     } else if (urlOrArrayBuffer instanceof MediaStream) {
                         this._urlType = "MediaStream";
+                    } else if (urlOrArrayBuffer instanceof AudioBuffer) {
+                        this._urlType = "AudioBuffer";
                     } else if (Array.isArray(urlOrArrayBuffer)) {
                         this._urlType = "Array";
                     }
@@ -272,11 +274,14 @@ export class Sound {
                                 this._readyToPlayCallback();
                             }
                             break;
-                        case "ArrayBuffer":
+                        case "ArrayBuffer":                            
                             if ((<ArrayBuffer>urlOrArrayBuffer).byteLength > 0) {
                                 codecSupportedFound = true;
                                 this._soundLoaded(urlOrArrayBuffer);
                             }
+                            break;
+                        case "AudioBuffer":
+                            this._audioBufferLoaded(urlOrArrayBuffer);
                             break;
                         case "String":
                             urls.push(urlOrArrayBuffer);
@@ -443,6 +448,20 @@ export class Sound {
         return "Sound";
     }
 
+    private _audioBufferLoaded(buffer: AudioBuffer) {
+        if (!Engine.audioEngine?.audioContext) {
+            return;
+        }       
+        this._audioBuffer = buffer;
+        this._isReadyToPlay = true;
+        if (this.autoplay) {
+            this.play(0, this._offset, this._length);
+        }
+        if (this._readyToPlayCallback) {
+            this._readyToPlayCallback();
+        }
+    }
+
     private _soundLoaded(audioData: ArrayBuffer) {
         if (!Engine.audioEngine?.audioContext) {
             return;
@@ -450,14 +469,7 @@ export class Sound {
         Engine.audioEngine.audioContext.decodeAudioData(
             audioData,
             (buffer) => {
-                this._audioBuffer = buffer;
-                this._isReadyToPlay = true;
-                if (this.autoplay) {
-                    this.play(0, this._offset, this._length);
-                }
-                if (this._readyToPlayCallback) {
-                    this._readyToPlayCallback();
-                }
+                this._audioBufferLoaded(buffer);
             },
             (err: any) => {
                 Logger.Error("Error while decoding audio data for: " + this.name + " / Error: " + err);

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -173,7 +173,7 @@ export class Sound {
     /**
      * Create a sound and attach it to a scene
      * @param name Name of your sound
-     * @param urlOrArrayBuffer Url to the sound to load async or ArrayBuffer, it also works with MediaStreams
+     * @param urlOrArrayBuffer Url to the sound to load async or ArrayBuffer, it also works with MediaStreams and AudioBuffers
      * @param scene defines the scene the sound belongs to
      * @param readyToPlayCallback Provide a callback function if you'd like to load your code once the sound is ready to be played
      * @param options Objects to provide with the current available options: autoplay, loop, volume, spatialSound, maxDistance, rolloffFactor, refDistance, distanceModel, panningModel, streaming


### PR DESCRIPTION
I ran into a situation where I wanted to use the sound engine in Babylon to play my pre-generated Web Audio Buffer. I managed to get it to work by looking at the code, but I had to access some private properties. I noticed that it would be pretty small refactoring to implement it correctly since the code was already there. This PR enable the passing of an AudioBuffer to the constructor of BABYLON.Sound.

This (very simplified) example shows how it is used:


```
var createScene = function () {

    var scene = new BABYLON.Scene(engine);
    const camera = new BABYLON.ArcRotateCamera("Camera", -Math.PI / 2, Math.PI / 4, 15, BABYLON.Vector3.Zero());
    camera.attachControl(canvas, true);

    // Create buffer
    let sineBuffer = BABYLON.Engine.audioEngine.audioContext.createBuffer(1, 12e3, 48e3);
    const hitBufferData = sineBuffer.getChannelData(0);
    for (let i = 12e3; i--;) hitBufferData[i] = Math.cos(i * .04); 

    // Create and use the sound
    this.sineSound = new BABYLON.Sound("sine", sineBuffer); 
    this.sineSound.play();

    return scene;
};
```

