### PR TITLE
Clear some values used during loading at the end of the load

### DIFF
--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -544,6 +544,10 @@ const loadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError
             }
         }
 
+        scene.geometries.forEach((g) => {
+            g._loadedUniqueId = "";
+        });
+
         AbstractScene.Parse(parsedData, scene, container, rootUrl);
 
         // Actions (scene) Done last as it can access other objects.


### PR DESCRIPTION
Related issue: https://forum.babylonjs.com/t/imported-meshes-appear-broken-if-they-have-the-same-geometry-uniqueid/33567/3