### PR TITLE
Fix some NME bugs.

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -211,7 +211,10 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
 
         state._emitUniformFromString(this._tangentSpaceParameterName, "vec2");
 
-        const normalSamplerName = (this.normalMapColor.connectedPoint!._ownerBlock as TextureBlock).samplerName;
+        let normalSamplerName = null;
+        if (this.normalMapColor.connectedPoint) {
+            normalSamplerName = (this.normalMapColor.connectedPoint!._ownerBlock as TextureBlock).samplerName;
+        }
         const useParallax = this.viewDirection.isConnected && ((this.useParallaxOcclusion && normalSamplerName) || (!this.useParallaxOcclusion && this.parallaxHeight.isConnected));
 
         const replaceForParallaxInfos = !this.parallaxScale.isConnectedToInputBlock

--- a/packages/dev/sharedUiComponents/src/components/MessageDialog.tsx
+++ b/packages/dev/sharedUiComponents/src/components/MessageDialog.tsx
@@ -6,6 +6,7 @@ import styles from "./MessageDialog.modules.scss";
 export interface MessageDialogProps {
     message: string;
     isError: boolean;
+    onClose?: () => void;
 }
 
 export const MessageDialog: React.FC<MessageDialogProps> = (props) => {
@@ -17,16 +18,23 @@ export const MessageDialog: React.FC<MessageDialogProps> = (props) => {
         setIsError(props.isError);
     }, [props]);
 
+    const onClick = () => {
+        setMessage("");
+        if (props.onClose) {
+            props.onClose();
+        }
+    };
+
     if (!message) {
         return null;
     }
 
     return (
-        <div className={ClassNames({ "dialog-container": true }, styles)}>
-            <div className={ClassNames({ dialog: true }, styles)}>
-                <div className={ClassNames({ "dialog-message": true }, styles)}>{message}</div>
-                <div className={ClassNames({ "dialog-buttons": true }, styles)}>
-                    <div className={ClassNames({ "dialog-button-ok": true, error: isError }, styles)} onClick={() => setMessage("")}>
+        <div className={styles["dialog-container"]}>
+            <div className={styles["dialog"]}>
+                <div className={styles["dialog-message"]}>{message}</div>
+                <div className={styles["dialog-buttons"]}>
+                    <div className={ClassNames({ "dialog-button-ok": true, error: isError }, styles)} onClick={onClick}>
                         OK
                     </div>
                 </div>

--- a/packages/tools/nodeEditor/src/graphEditor.tsx
+++ b/packages/tools/nodeEditor/src/graphEditor.tsx
@@ -682,7 +682,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
 
                     <LogComponent globalState={this.props.globalState} />
                 </div>
-                <MessageDialog message={this.state.message} isError={this.state.isError} />
+                <MessageDialog message={this.state.message} isError={this.state.isError} onClose={() => this.setState({ message: "" })} />
                 <div className="blocker">Node Material Editor runs only on desktop</div>
                 <div className="wait-screen hidden">Processing...please wait</div>
             </Portal>


### PR DESCRIPTION
1 - When dragging a unique block to the graph twice and closing the error message, for each subsequent block added (even the non-unique ones), the error message was still appearing.
2 - When using the PerturbNormal block without the connected normalColor input, the following error message appeared:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/6002144/188502443-f3ca0a1b-ec89-4185-8deb-3e4524e051e7.png)
