### PR TITLE
Fix quaternion blending math

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -952,10 +952,13 @@ Scene.prototype._processLateAnimationBindingsForMatrices = function (holder: {
             const currentQuaternion = TmpVectors.Quaternion[1];
 
             runtimeAnimation.currentValue.decompose(currentScaling, currentQuaternion, currentPosition);
+
             currentScaling.scaleAndAddToRef(scale, finalScaling);
-            currentQuaternion.scaleAndAddToRef(scale, finalQuaternion);
+            currentQuaternion.scaleAndAddToRef(Quaternion.Dot(finalQuaternion, currentQuaternion) > 0 ? scale : -scale, finalQuaternion);
             currentPosition.scaleAndAddToRef(scale, finalPosition);
         }
+
+        finalQuaternion.normalize();
     }
 
     // Add up the additive animations


### PR DESCRIPTION
See https://forum.babylonjs.com/t/not-able-to-blend-animation-with-beginweightedanimation/32204

Solution based on quaternion average approximation: https://math.stackexchange.com/questions/61146/averaging-quaternions