### PR TITLE
Update default linter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,7 @@
         "**/*.vertex.ts": true,
         "**/*.compute.ts": true,
     },
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
 }


### PR DESCRIPTION
I thought the old way worked, but it doesn't. This change comes directly from using vscode's UI, so hopefully it will stick this time.