### PR TITLE
Introduce autoFixFaceOrientation feature to solidParticleSystem

### DIFF
--- a/packages/dev/core/src/Particles/solidParticleSystem.ts
+++ b/packages/dev/core/src/Particles/solidParticleSystem.ts
@@ -167,6 +167,7 @@ export class SolidParticleSystem implements IDisposable {
      * * boundingSphereOnly (optional boolean, default false) : if the particle intersection must be computed only with the bounding sphere (no bounding box computation, so faster).
      * * bSphereRadiusFactor (optional float, default 1.0) : a number to multiply the bounding sphere radius by in order to reduce it for instance.
      * * computeBoundingBox (optional boolean, default false): if the bounding box of the entire SPS will be computed (for occlusion detection, for example). If it is false, the bounding box will be the bounding box of the first particle.
+     * * autoFixFaceOrientation (optional boolean, default false): if the particle face orientations will be flipped for transformations that change orientation (scale (-1, 1, 1), for example)
      * @param options.updatable
      * @param options.isPickable
      * @param options.enableDepthSort
@@ -177,6 +178,7 @@ export class SolidParticleSystem implements IDisposable {
      * @param options.useModelMaterial
      * @param options.enableMultiMaterial
      * @param options.computeBoundingBox
+     * @param options.autoFixFaceOrientation
      * @example bSphereRadiusFactor = 1.0 / Math.sqrt(3.0) => the bounding sphere exactly matches a spherical mesh.
      */
     constructor(
@@ -1482,26 +1484,26 @@ export class SolidParticleSystem implements IDisposable {
                 }
             }
             if (this._autoFixFaceOrientation) {
-              let particleInd = 0;
-      
-              for (let particleIdx = 0; particleIdx < this.particles.length; particleIdx++) {
-                const particle = depthSortParticles ? this.particles[this.depthSortedParticles[particleIdx].idx] : this.particles[particleIdx];
-                const flipFaces = particle.scale.x * particle.scale.y * particle.scale.z < 0;
-      
-                if (flipFaces) {
-                  for (let faceInd = 0; faceInd < particle._model._indicesLength; faceInd += 3) {
-                    const tmp = indices[particle._ind + faceInd];
-                    indices32[particleInd + faceInd] = indices[particle._ind + faceInd + 1];
-                    indices32[particleInd + faceInd + 1] = tmp;
-                  }
+                let particleInd = 0;
+
+                for (let particleIdx = 0; particleIdx < this.particles.length; particleIdx++) {
+                    const particle = depthSortParticles ? this.particles[this.depthSortedParticles[particleIdx].idx] : this.particles[particleIdx];
+                    const flipFaces = particle.scale.x * particle.scale.y * particle.scale.z < 0;
+
+                    if (flipFaces) {
+                        for (let faceInd = 0; faceInd < particle._model._indicesLength; faceInd += 3) {
+                            const tmp = indices[particle._ind + faceInd];
+                            indices32[particleInd + faceInd] = indices[particle._ind + faceInd + 1];
+                            indices32[particleInd + faceInd + 1] = tmp;
+                        }
+                    }
+
+                    particleInd += particle._model._indicesLength;
                 }
-      
-                particleInd += particle._model._indicesLength;
-              }
             }
-      
+
             if (depthSortParticles || this._autoFixFaceOrientation) {
-              mesh.updateIndices(indices32);
+                mesh.updateIndices(indices32);
             }
         }
         if (this._computeBoundingBox) {

--- a/packages/dev/core/src/Particles/solidParticleSystem.ts
+++ b/packages/dev/core/src/Particles/solidParticleSystem.ts
@@ -306,7 +306,7 @@ export class SolidParticleSystem implements IDisposable {
 
         if (!this._expandable) {
             // free memory
-            if (!this._depthSort && !this._multimaterialEnabled) {
+            if (!this._depthSort && !this._multimaterialEnabled && !this._autoFixFaceOrientation) {
                 (<any>this._indices) = null;
             }
             (<any>this._positions) = null;


### PR DESCRIPTION
**What:**
Introduce an option to "autofix face orientation" in solid particle system

**How**
When there is a transformation which changes the orientation (for example scaling `(-1, 1, 1)`), the solid particle system will automatically flip all the faces of the particle affected by this transformation.

**Why**
I needed this functionality in my application, so I decided to make a PR and hope that it will get into the babylon itself :D

**Example**
https://playground.babylonjs.com/#GLZ1PX#714
in this example, the cone on the right has flipped faces. Using the new flag will fix this issue. 