### PR TITLE
Implement Lazy Picking for POINTERMOVE and modify cameras to work with DeviceSourceManager

### DIFF
--- a/packages/dev/core/src/Actions/actionManager.ts
+++ b/packages/dev/core/src/Actions/actionManager.ts
@@ -274,7 +274,7 @@ export class ActionManager extends AbstractActionManager {
         }
 
         this.actions.push(action);
-        this.getScene()._registeredActionManagers++;
+        this.getScene()._registeredActions++;
 
         if (ActionManager.Triggers[action.trigger]) {
             ActionManager.Triggers[action.trigger]++;
@@ -302,7 +302,7 @@ export class ActionManager extends AbstractActionManager {
                 delete ActionManager.Triggers[action.trigger];
             }
             action._actionManager = null;
-            this.getScene()._registeredActionManagers--;
+            this.getScene()._registeredActions--;
             return true;
         }
         return false;

--- a/packages/dev/core/src/Actions/actionManager.ts
+++ b/packages/dev/core/src/Actions/actionManager.ts
@@ -274,6 +274,7 @@ export class ActionManager extends AbstractActionManager {
         }
 
         this.actions.push(action);
+        this.getScene()._registeredActionManagers++;
 
         if (ActionManager.Triggers[action.trigger]) {
             ActionManager.Triggers[action.trigger]++;
@@ -301,6 +302,7 @@ export class ActionManager extends AbstractActionManager {
                 delete ActionManager.Triggers[action.trigger];
             }
             action._actionManager = null;
+            this.getScene()._registeredActionManagers--;
             return true;
         }
         return false;

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -1,18 +1,18 @@
 import type { Nullable } from "../../types";
 import { serialize } from "../../Misc/decorators";
-import type { EventState, Observer } from "../../Misc/observable";
+import type { Observer } from "../../Misc/observable";
 import type { ArcRotateCamera } from "../../Cameras/arcRotateCamera";
 import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
-import type { PointerInfo } from "../../Events/pointerEvents";
-import { PointerEventTypes } from "../../Events/pointerEvents";
 import { Plane } from "../../Maths/math.plane";
 import { Vector3, Matrix, TmpVectors } from "../../Maths/math.vector";
 import { Epsilon } from "../../Maths/math.constants";
-import type { IWheelEvent } from "../../Events/deviceInputEvents";
+import type { IPointerEvent, IWheelEvent } from "../../Events/deviceInputEvents";
 import { EventConstants } from "../../Events/deviceInputEvents";
 import { Scalar } from "../../Maths/math.scalar";
 import { Tools } from "../../Misc/tools";
+import type { DeviceSourceType } from "../../DeviceInput/internalDeviceSourceManager";
+import { DeviceType } from "../../DeviceInput/InputDevices/deviceEnums";
 
 /**
  * Firefox uses a different scheme to report scroll distances to other
@@ -58,8 +58,10 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
      */
     public customComputeDeltaFromMouseWheel: Nullable<(wheelDelta: number, input: ArcRotateCameraMouseWheelInput, event: IWheelEvent) => number> = null;
 
-    private _wheel: Nullable<(p: PointerInfo, s: EventState) => void>;
-    private _observer: Nullable<Observer<PointerInfo>>;
+    private _wheel: (event: IWheelEvent) => void;
+    private _observer: Nullable<Observer<IPointerEvent | IWheelEvent>>;
+    private _connectedObserver: Nullable<Observer<DeviceSourceType>>;
+    private _disconnectedObserver: Nullable<Observer<DeviceSourceType>>;
     private _hitPlane: Nullable<Plane>;
 
     protected _computeDeltaFromMouseWheelLegacyEvent(mouseWheelDelta: number, radius: number) {
@@ -79,12 +81,25 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
      */
     public attachControl(noPreventDefault?: boolean): void {
         noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
-        this._wheel = (p) => {
-            //sanity check - this should be a PointerWheel event.
-            if (p.type !== PointerEventTypes.POINTERWHEEL) {
-                return;
+
+        this._connectedObserver = this.camera._deviceSourceManager!.onDeviceConnectedObservable.add((deviceSource) => {
+            if (deviceSource.deviceType === DeviceType.Mouse) {
+                this._observer = deviceSource.onInputChangedObservable.add((eventData) => {
+                    if ("deltaY" in eventData) {
+                        this._wheel(eventData);
+                    }
+                });
             }
-            const event = <IWheelEvent>p.event;
+        });
+
+        this._disconnectedObserver = this.camera._deviceSourceManager!.onDeviceDisconnectedObservable.add((deviceSource) => {
+            if (deviceSource.deviceType === DeviceType.Mouse) {
+                deviceSource.onInputChangedObservable.remove(this._observer);
+                this._observer = null;
+            }
+        });
+
+        this._wheel = (event) => {
             let delta = 0;
 
             const mouseWheelLegacyEvent = event as any;
@@ -137,8 +152,6 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
             }
         };
 
-        this._observer = this.camera.getScene().onPointerObservable.add(this._wheel, PointerEventTypes.POINTERWHEEL);
-
         if (this.zoomToMouseLocation) {
             this._inertialPanning.setAll(0);
         }
@@ -149,9 +162,11 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene().onPointerObservable.remove(this._observer);
+            this.camera._deviceSourceManager?.onDeviceConnectedObservable.remove(this._connectedObserver);
+            this.camera._deviceSourceManager?.onDeviceDisconnectedObservable.remove(this._disconnectedObserver);
+            const mouse = this.camera._deviceSourceManager?.getDeviceSource(DeviceType.Mouse);
+            mouse?.onInputChangedObservable.remove(this._observer);
             this._observer = null;
-            this._wheel = null;
         }
     }
 

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -17,6 +17,7 @@ import type { ArcRotateCameraMouseWheelInput } from "../Cameras/Inputs/arcRotate
 import { ArcRotateCameraInputsManager } from "../Cameras/arcRotateCameraInputsManager";
 import { Epsilon } from "../Maths/math.constants";
 import { Tools } from "../Misc/tools";
+import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 
 declare type Collider = import("../Collisions/collider").Collider;
 
@@ -863,6 +864,7 @@ export class ArcRotateCamera extends TargetCamera {
      * @param panningMouseButton Defines whether panning is allowed through mouse click button
      */
     public attachControl(ignored: any, noPreventDefault?: boolean, useCtrlForPanning: boolean | number = true, panningMouseButton: number = 2): void {
+        this._deviceSourceManager = new DeviceSourceManager(this.getEngine());
         // eslint-disable-next-line prefer-rest-params
         const args = arguments;
 
@@ -895,6 +897,8 @@ export class ArcRotateCamera extends TargetCamera {
      */
     public detachControl(): void {
         this.inputs.detachElement();
+        this._deviceSourceManager?.dispose();
+        this._deviceSourceManager = null;
 
         if (this._reset) {
             this._reset();

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -17,6 +17,7 @@ import { Viewport } from "../Maths/math.viewport";
 import { Frustum } from "../Maths/math.frustum";
 import type { Plane } from "../Maths/math.plane";
 import { Constants } from "../Engines/constants";
+import type { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 
 declare type PostProcess = import("../PostProcesses/postProcess").PostProcess;
 declare type RenderTargetTexture = import("../Materials/Textures/renderTargetTexture").RenderTargetTexture;
@@ -164,6 +165,9 @@ export class Camera extends Node {
 
         return x * y;
     }
+
+    /** @hidden */
+    public _deviceSourceManager: Nullable<DeviceSourceManager>;
 
     /**
      * Define the current limit on the left side for an orthographic camera

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -10,6 +10,7 @@ import { FlyCameraInputsManager } from "./flyCameraInputsManager";
 import type { FlyCameraMouseInput } from "../Cameras/Inputs/flyCameraMouseInput";
 import type { FlyCameraKeyboardInput } from "../Cameras/Inputs/flyCameraKeyboardInput";
 import { Tools } from "../Misc/tools";
+import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 
 declare type Collider = import("../Collisions/collider").Collider;
 
@@ -284,6 +285,7 @@ export class FlyCamera extends TargetCamera {
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
      */
     public attachControl(ignored: any, noPreventDefault?: boolean): void {
+        this._deviceSourceManager = new DeviceSourceManager(this.getEngine());
         // eslint-disable-next-line prefer-rest-params
         noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this.inputs.attachElement(noPreventDefault);
@@ -295,6 +297,8 @@ export class FlyCamera extends TargetCamera {
      */
     public detachControl(): void {
         this.inputs.detachElement();
+        this._deviceSourceManager?.dispose();
+        this._deviceSourceManager = null;
 
         this.cameraDirection = new Vector3(0, 0, 0);
     }

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -7,6 +7,7 @@ import { TmpVectors, Vector3 } from "../Maths/math.vector";
 import { Node } from "../node";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { FollowCameraInputsManager } from "./followCameraInputsManager";
+import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 Node.AddNodeConstructor("FollowCamera", (name, scene) => {
     return () => new FollowCamera(name, Vector3.Zero(), scene);
 });
@@ -173,6 +174,7 @@ export class FollowCamera extends TargetCamera {
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
      */
     public attachControl(ignored: any, noPreventDefault?: boolean): void {
+        this._deviceSourceManager = new DeviceSourceManager(this.getEngine());
         // eslint-disable-next-line prefer-rest-params
         noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this.inputs.attachElement(noPreventDefault);
@@ -185,6 +187,8 @@ export class FollowCamera extends TargetCamera {
      */
     public detachControl(): void {
         this.inputs.detachElement();
+        this._deviceSourceManager?.dispose();
+        this._deviceSourceManager = null;
 
         if (this._reset) {
             this._reset();

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -9,6 +9,7 @@ import { FreeCameraInputsManager } from "./freeCameraInputsManager";
 import type { FreeCameraMouseInput } from "../Cameras/Inputs/freeCameraMouseInput";
 import type { FreeCameraKeyboardMoveInput } from "../Cameras/Inputs/freeCameraKeyboardMoveInput";
 import { Tools } from "../Misc/tools";
+import { DeviceSourceManager } from "../DeviceInput/InputDevices/deviceSourceManager";
 
 declare type Collider = import("../Collisions/collider").Collider;
 
@@ -277,6 +278,7 @@ export class FreeCamera extends TargetCamera {
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
      */
     public attachControl(ignored?: any, noPreventDefault?: boolean): void {
+        this._deviceSourceManager = new DeviceSourceManager(this.getEngine());
         // eslint-disable-next-line prefer-rest-params
         noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this.inputs.attachElement(noPreventDefault);
@@ -287,6 +289,8 @@ export class FreeCamera extends TargetCamera {
      */
     public detachControl(): void {
         this.inputs.detachElement();
+        this._deviceSourceManager?.dispose();
+        this._deviceSourceManager = null;
 
         this.cameraDirection = new Vector3(0, 0, 0);
         this.cameraRotation = new Vector2(0, 0);

--- a/packages/dev/core/src/Collisions/pickingInfo.ts
+++ b/packages/dev/core/src/Collisions/pickingInfo.ts
@@ -12,9 +12,6 @@ declare type Ray = import("../Culling/ray").Ray;
  * @see https://doc.babylonjs.com/divingDeeper/mesh/interactions/picking_collisions
  */
 export class PickingInfo {
-    /** @hidden */
-    public _pickingUnavailable = false;
-
     /**
      * If the pick collided with an object
      */

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -925,6 +925,14 @@ Scene.prototype.pickWithBoundingInfo = function (
     return result;
 };
 
+Object.defineProperty(Scene.prototype, "_pickingAvailable", {
+    get: function () {
+        return true;
+    },
+    enumerable: false,
+    configurable: false,
+});
+
 Scene.prototype.pick = function (
     x: number,
     y: number,

--- a/packages/dev/core/src/Events/pointerEvents.ts
+++ b/packages/dev/core/src/Events/pointerEvents.ts
@@ -1,7 +1,8 @@
 import type { Nullable } from "../types";
 import { Vector2 } from "../Maths/math.vector";
 import type { PickingInfo } from "../Collisions/pickingInfo";
-import type { IMouseEvent } from "./deviceInputEvents";
+import type { IMouseEvent, IPointerEvent } from "./deviceInputEvents";
+import type { InputManager } from "../Inputs/scene.inputManager";
 
 declare type Ray = import("../Culling/ray").Ray;
 
@@ -104,35 +105,31 @@ export class PointerInfoPre extends PointerInfoBase {
  * The event member is an instance of PointerEvent for all types except PointerWheel and is of type MouseWheelEvent when type equals PointerWheel. The different event types can be found in the PointerEventTypes class.
  */
 export class PointerInfo extends PointerInfoBase {
-    private _getPickInfo: () => Nullable<PickingInfo>;
+    private _pickInfo: Nullable<PickingInfo>;
+    private _inputManager: Nullable<InputManager>;
 
     /**
      * Defines the picking info associated to the info (if any)
      */
     public get pickInfo(): Nullable<PickingInfo> {
-        return this._getPickInfo();
+        if (this._inputManager) {
+            this._pickInfo = this._inputManager._pickMove((this.event as IPointerEvent).pointerId);
+            this._inputManager = null;
+        }
+
+        return this._pickInfo;
     }
     /**
      * Instantiates a PointerInfo to store pointer related info to the onPointerObservable event.
      * @param type Defines the type of event (PointerEventTypes)
      * @param event Defines the related dom event
-     * @param pickInfo Defines the picking info associated to the info (if any)\
+     * @param pickInfo Defines the picking info associated to the info (if any)
+     * @param inputManager Defines the InputManager to use if there is no pickInfo
      */
-    constructor(type: number, event: IMouseEvent, pickInfo: Nullable<PickingInfo> | (() => Nullable<PickingInfo>)) {
+    constructor(type: number, event: IMouseEvent, pickInfo: Nullable<PickingInfo>, inputManager: Nullable<InputManager> = null) {
         super(type, event);
-
-        if (typeof pickInfo === "function") {
-            let info: Nullable<PickingInfo> = null;
-            this._getPickInfo = () => {
-                if (!info) {
-                    info = pickInfo();
-                }
-
-                return info;
-            };
-        } else {
-            this._getPickInfo = () => pickInfo;
-        }
+        this._pickInfo = pickInfo;
+        this._inputManager = inputManager;
     }
 }
 

--- a/packages/dev/core/src/Events/pointerEvents.ts
+++ b/packages/dev/core/src/Events/pointerEvents.ts
@@ -104,21 +104,35 @@ export class PointerInfoPre extends PointerInfoBase {
  * The event member is an instance of PointerEvent for all types except PointerWheel and is of type MouseWheelEvent when type equals PointerWheel. The different event types can be found in the PointerEventTypes class.
  */
 export class PointerInfo extends PointerInfoBase {
+    private _getPickInfo: () => Nullable<PickingInfo>;
+
+    /**
+     * Defines the picking info associated to the info (if any)
+     */
+    public get pickInfo(): Nullable<PickingInfo> {
+        return this._getPickInfo();
+    }
     /**
      * Instantiates a PointerInfo to store pointer related info to the onPointerObservable event.
      * @param type Defines the type of event (PointerEventTypes)
      * @param event Defines the related dom event
      * @param pickInfo Defines the picking info associated to the info (if any)\
      */
-    constructor(
-        type: number,
-        event: IMouseEvent,
-        /**
-         * Defines the picking info associated to the info (if any)\
-         */
-        public pickInfo: Nullable<PickingInfo>
-    ) {
+    constructor(type: number, event: IMouseEvent, pickInfo: Nullable<PickingInfo> | (() => Nullable<PickingInfo>)) {
         super(type, event);
+
+        if (typeof pickInfo === "function") {
+            let info: Nullable<PickingInfo> = null;
+            this._getPickInfo = () => {
+                if (!info) {
+                    info = pickInfo();
+                }
+
+                return info;
+            };
+        } else {
+            this._getPickInfo = () => pickInfo;
+        }
     }
 }
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -516,7 +516,7 @@ export class InputManager {
         // Because this is only called from _initClickEvent, which is called in _onPointerUp, we'll use the pointerUpPredicate for the pick call
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
             if (!this._meshPickProceed) {
-                const pickResult = scene.skipPointerUpPicking
+                const pickResult = scene.skipPointerUpPicking || (scene._registeredActionManagers === 0 && !scene.onPointerObservable.hasObservers())
                     ? null
                     : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
@@ -775,7 +775,7 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking) {
+            if (scene.skipPointerDownPicking || (scene._registeredActionManagers === 0 && !scene.onPointerObservable.hasObservers())) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -201,7 +201,7 @@ export class InputManager {
             }
         }
 
-        if (scene._registeredActionManagers > 0){
+        if (scene._registeredActionManagers > 0) {
             pickResult = typeof pickResult === "function" ? pickResult() : pickResult;
         }
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -246,7 +246,7 @@ export class InputManager {
     // Pointers handling
     private _setRayOnPointerInfo(pointerInfo: PointerInfo, pickInfoType: string) {
         const scene = this._scene;
-        if (pickInfoType !== "function" && pointerInfo.pickInfo && scene._pickingAvailable) {
+        if (pickInfoType === "object" && pointerInfo.pickInfo && scene._pickingAvailable) {
             if (!pointerInfo.pickInfo.ray) {
                 pointerInfo.pickInfo.ray = scene.createPickingRay(pointerInfo.event.offsetX, pointerInfo.event.offsetY, Matrix.Identity(), scene.activeCamera);
             }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4886,7 +4886,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
     /** @hidden */
     public _registeredActionManagers: number = 0;
-    
+
     /** Launch a ray to try to pick a mesh in the scene
      * @param x position on screen
      * @param y position on screen

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4884,9 +4884,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         return false;
     }
 
-    /** @hidden */
-    public _registeredActionManagers: number = 0;
-
     /** Launch a ray to try to pick a mesh in the scene
      * @param x position on screen
      * @param y position on screen

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4880,6 +4880,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         throw _WarnImport("Ray");
     }
 
+    public get _pickingAvailable(): boolean {
+        return false;
+    }
+
+    /** @hidden */
+    public _registeredActionManagers: number = 0;
+    
     /** Launch a ray to try to pick a mesh in the scene
      * @param x position on screen
      * @param y position on screen
@@ -4899,7 +4906,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     ): Nullable<PickingInfo> {
         // Dummy info if picking as not been imported
         const pi = new PickingInfo();
-        pi._pickingUnavailable = true;
         return pi;
     }
 
@@ -4914,7 +4920,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public pickWithBoundingInfo(x: number, y: number, predicate?: (mesh: AbstractMesh) => boolean, fastCheck?: boolean, camera?: Nullable<Camera>): Nullable<PickingInfo> {
         // Dummy info if picking as not been imported
         const pi = new PickingInfo();
-        pi._pickingUnavailable = true;
         return pi;
     }
 


### PR DESCRIPTION
This PR contains the following changes:
- All Camera pointer (mouse/touch/wheel) inputs will work with the DeviceSourceManager instead of working off of the scene's `onPointerObservable`.
- All picking done during pointer movement will now be "lazy".  What this means is that the picking information will be stored in a callback that will return `PickingInfo` if accessed.
- Additional checks have been added to prevent `pointerdown/up` picking when there are no Action Managers, Gizmos, Behaviors, or Observers.