### PR TITLE
[Build] ts config for tests (older syntax) for older node.js

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,7 @@ const createProject = (type: string) => {
     const setupFileLocation = path.resolve(".", `jest.${type}.setup.ts`);
     const setupFilesAfterEnvLocation = path.resolve(".", `jest.${type}.setup.afterEnv.ts`);
     const tsConfigPath = path.resolve(".", "tsconfig.json");
+    const tsTestConfigPath = path.resolve(".", "tsconfig.test.json");
     const globalSetup = fs.existsSync(setupFileLocation) ? setupFileLocation : undefined;
     const setupFilesAfterEnv = fs.existsSync(setupFilesAfterEnvLocation) ? [setupFilesAfterEnvLocation] : undefined;
     const returnValue: Partial<Config.ProjectConfig> = {
@@ -25,7 +26,7 @@ const createProject = (type: string) => {
             "ts-jest": {
                 isolatedModules: true,
                 useESM: true,
-                tsconfig: fs.existsSync(tsConfigPath) ? tsConfigPath : path.resolve(__dirname, "tsconfig.json"),
+                tsconfig: fs.existsSync(tsTestConfigPath) ? tsTestConfigPath : fs.existsSync(tsConfigPath) ? tsConfigPath : path.resolve(__dirname, "tsconfig.json"),
             },
         },
         setupFilesAfterEnv: ["@alex_neo/jest-expect-message"],

--- a/packages/dev/core/tsconfig.test.json
+++ b/packages/dev/core/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../../tsconfig.test.json",
+
+    "compilerOptions": {
+    },
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.build.json",
+
+    "compilerOptions": {
+        "target": "es5"
+    }
+}


### PR DESCRIPTION
Node 14 and under don't support the 2021 syntax we used when running tests.
From now, when testing we compile to es5