### PR TITLE
GeometryBufferRenderer: Allow setting the depth texture format

### DIFF
--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -86,6 +86,7 @@ export class GeometryBufferRenderer {
     private _enablePosition: boolean = false;
     private _enableVelocity: boolean = false;
     private _enableReflectivity: boolean = false;
+    private _depthFormat: number;
 
     private _positionIndex: number = -1;
     private _velocityIndex: number = -1;
@@ -318,12 +319,14 @@ export class GeometryBufferRenderer {
     /**
      * Creates a new G Buffer for the scene
      * @param scene The scene the buffer belongs to
-     * @param ratio How big is the buffer related to the main canvas.
+     * @param ratio How big is the buffer related to the main canvas (default: 1)
+     * @param depthFormat Format of the depth texture (default: Constants.TEXTUREFORMAT_DEPTH16)
      */
-    constructor(scene: Scene, ratio: number = 1) {
+    constructor(scene: Scene, ratio: number = 1, depthFormat = Constants.TEXTUREFORMAT_DEPTH16) {
         this._scene = scene;
         this._ratio = ratio;
         this._useUbo = scene.getEngine().supportsUniformBuffers;
+        this._depthFormat = depthFormat;
 
         GeometryBufferRenderer._SceneComponentInitialization(this._scene);
 
@@ -698,7 +701,7 @@ export class GeometryBufferRenderer {
             { width: engine.getRenderWidth() * this._ratio, height: engine.getRenderHeight() * this._ratio },
             count,
             this._scene,
-            { generateMipMaps: false, generateDepthTexture: true, defaultType: type },
+            { generateMipMaps: false, generateDepthTexture: true, defaultType: type, depthTextureFormat: this._depthFormat },
             textureNames.concat("gBuffer_DepthBuffer")
         );
         if (!this.isSupported) {

--- a/packages/dev/core/src/Rendering/geometryBufferRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRendererSceneComponent.ts
@@ -5,6 +5,7 @@ import { SceneComponentConstants } from "../sceneComponent";
 import type { SmartArrayNoDuplicate } from "../Misc/smartArray";
 import type { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { GeometryBufferRenderer } from "./geometryBufferRenderer";
+import { Constants } from "../Engines/constants";
 
 declare module "../scene" {
     export interface Scene {
@@ -19,9 +20,10 @@ declare module "../scene" {
         /**
          * Enables a GeometryBufferRender and associates it with the scene
          * @param ratio defines the scaling ratio to apply to the renderer (1 by default which means same resolution)
+         * @param depthFormat Format of the depth texture (default: Constants.TEXTUREFORMAT_DEPTH16)
          * @returns the GeometryBufferRenderer
          */
-        enableGeometryBufferRenderer(ratio?: number): Nullable<GeometryBufferRenderer>;
+        enableGeometryBufferRenderer(ratio?: number, depthFormat?: number): Nullable<GeometryBufferRenderer>;
 
         /**
          * Disables the GeometryBufferRender associated with the scene
@@ -43,12 +45,12 @@ Object.defineProperty(Scene.prototype, "geometryBufferRenderer", {
     configurable: true,
 });
 
-Scene.prototype.enableGeometryBufferRenderer = function (ratio: number = 1): Nullable<GeometryBufferRenderer> {
+Scene.prototype.enableGeometryBufferRenderer = function (ratio: number = 1, depthFormat = Constants.TEXTUREFORMAT_DEPTH16): Nullable<GeometryBufferRenderer> {
     if (this._geometryBufferRenderer) {
         return this._geometryBufferRenderer;
     }
 
-    this._geometryBufferRenderer = new GeometryBufferRenderer(this, ratio);
+    this._geometryBufferRenderer = new GeometryBufferRenderer(this, ratio, depthFormat);
     if (!this._geometryBufferRenderer.isSupported) {
         this._geometryBufferRenderer = null;
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/postprocess-with-prepassrenderer-caused-msaa-not-work/33907/2