### PR TITLE
PrePass renderer: Fix engine current render pass id set too early

### DIFF
--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -153,6 +153,7 @@ export class PrePassRenderer {
             this._currentTarget = prePassRenderTarget;
         } else {
             this._currentTarget = this.defaultRT;
+            this._engine.currentRenderPassId = this._currentTarget.renderPassId;
         }
     }
 

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -230,7 +230,7 @@ export class PrePassRenderer {
 
         PrePassRenderer._SceneComponentInitialization(this._scene);
         this.defaultRT = this._createRenderTarget("sceneprePassRT", null);
-        this._setRenderTarget(null);
+        this._currentTarget = this.defaultRT;
     }
 
     /**

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -154,7 +154,6 @@ export class PrePassRenderer {
         } else {
             this._currentTarget = this.defaultRT;
         }
-        this._engine.currentRenderPassId = this._currentTarget.renderPassId;
     }
 
     /**
@@ -230,7 +229,7 @@ export class PrePassRenderer {
 
         PrePassRenderer._SceneComponentInitialization(this._scene);
         this.defaultRT = this._createRenderTarget("sceneprePassRT", null);
-        this._currentTarget = this.defaultRT;
+        this._setRenderTarget(null);
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/issue-when-prepassrenderer-and-rendertargettexture-are-used-at-the-same-time/29317/7

Basically it's a revert of my changes from:

https://github.com/BabylonJS/Babylon.js/commit/269132ca6281f1cb5c9b59474af1d2e827196d62#diff-5fec6a90573f71adda2b2d7c9364ac6da73fe8cfc6a641b129a051bf38d67cd2

I don't remember why I did this change at that time, I think it's wrong to set `Engine.currentRenderPassId` in `PrePassRenderer._setRenderTarget` as `RenderTargetTexture._renderToTarget` will set the right pass id before drawing the meshes anyway.

[EDIT] Ok, I updated the fix which is not simply a revert now: the `engine.currentRenderPassId` needs to be updated but only when setting the default RT.