### PR TITLE
WebGPU: Fix geometry buffer renderer in WebGPU

### DIFF
--- a/packages/dev/core/src/Shaders/geometry.fragment.fx
+++ b/packages/dev/core/src/Shaders/geometry.fragment.fx
@@ -34,14 +34,26 @@ uniform vec2 vTangentSpaceParams;
 #endif
 
 #if defined(REFLECTIVITY)
-varying vec2 vReflectivityUV;
-varying vec2 vAlbedoUV;
-uniform sampler2D reflectivitySampler;
-uniform sampler2D albedoSampler;
-uniform vec3 reflectivityColor;
-uniform vec3 albedoColor;
-uniform float metallic;
-uniform float glossiness;
+    #if defined(ORMTEXTURE) || defined(SPECULARGLOSSINESSTEXTURE) || defined(REFLECTIVITYTEXTURE)
+        uniform sampler2D reflectivitySampler;
+        varying vec2 vReflectivityUV;
+    #endif
+    #ifdef ALBEDOTEXTURE
+        varying vec2 vAlbedoUV;
+        uniform sampler2D albedoSampler;
+    #endif
+    #ifdef REFLECTIVITYCOLOR
+        uniform vec3 reflectivityColor;
+    #endif
+    #ifdef ALBEDOCOLOR
+        uniform vec3 albedoColor;
+    #endif
+    #ifdef METALLIC
+        uniform float metallic;
+    #endif
+    #ifdef ROUGHNESS
+        uniform float glossiness;
+    #endif
 #endif
 
 #ifdef ALPHATEST


### PR DESCRIPTION
In WebGPU (WGSL), if you declare some uniforms in the shader code (even if you don't use those uniforms in the code itself) the drawing code must set their values and can't leave them empty.

So, the declarations must be guarded by some `#ifdef` to make sure the uniforms we don't set values for are not declared in the shader code.