### PR TITLE
test(particles.cloudPoint): add tests for intersectsMesh function

### DIFF
--- a/packages/dev/core/src/Particles/cloudPoint.ts
+++ b/packages/dev/core/src/Particles/cloudPoint.ts
@@ -149,29 +149,29 @@ export class CloudPoint {
         if (!target.hasBoundingInfo) {
             return false;
         }
-        isSphere = isSphere ? isSphere : false;
+
+        if (!this._pcs.mesh) {
+            throw new Error("Point Cloud System doesnt contain the Mesh");
+        }
 
         if (isSphere) {
             return target.getBoundingInfo().boundingSphere.intersectsPoint(this.position.add(this._pcs.mesh.position));
-        } else {
-            let maxX = 0;
-            let minX = 0;
-            let maxY = 0;
-            let minY = 0;
-            let maxZ = 0;
-            let minZ = 0;
-            maxX = target.getBoundingInfo().boundingBox.maximumWorld.x;
-            minX = target.getBoundingInfo().boundingBox.minimumWorld.x;
-            maxY = target.getBoundingInfo().boundingBox.maximumWorld.y;
-            minY = target.getBoundingInfo().boundingBox.minimumWorld.y;
-            maxZ = target.getBoundingInfo().boundingBox.maximumWorld.z;
-            minZ = target.getBoundingInfo().boundingBox.minimumWorld.z;
-
-            const x = this.position.x + this._pcs.mesh.position.x;
-            const y = this.position.y + this._pcs.mesh.position.y;
-            const z = this.position.z + this._pcs.mesh.position.z;
-            return minX <= x && x <= maxX && minY <= y && y <= maxY && minZ <= z && z <= maxZ;
         }
+
+        const bbox = target.getBoundingInfo().boundingBox;
+
+        const maxX = bbox.maximumWorld.x;
+        const minX = bbox.minimumWorld.x;
+        const maxY = bbox.maximumWorld.y;
+        const minY = bbox.minimumWorld.y;
+        const maxZ = bbox.maximumWorld.z;
+        const minZ = bbox.minimumWorld.z;
+
+        const x = this.position.x + this._pcs.mesh.position.x;
+        const y = this.position.y + this._pcs.mesh.position.y;
+        const z = this.position.z + this._pcs.mesh.position.z;
+
+        return minX <= x && x <= maxX && minY <= y && y <= maxY && minZ <= z && z <= maxZ;
     }
 
     /**

--- a/packages/dev/core/test/unit/Particles/babylon.cloudPoint.test.ts
+++ b/packages/dev/core/test/unit/Particles/babylon.cloudPoint.test.ts
@@ -1,0 +1,270 @@
+import { BoundingBox, BoundingInfo, BoundingSphere } from "core/Culling";
+import { Engine, NullEngine } from "core/Engines";
+import { Vector3 } from "core/Maths";
+import { Mesh } from "core/Meshes";
+import { CloudPoint, PointsCloudSystem, PointsGroup } from "core/Particles";
+import { Scene } from "core/scene";
+import { DeepImmutable } from "core/types";
+
+describe("CloudPoint", () => {
+    describe("intersectsMesh", () => {
+        let subject: Engine;
+
+        let pointsGroup: PointsGroup;
+        let scene: Scene;
+
+        let pointsCloudSystemWithoutMesh: PointsCloudSystem;
+        let cloudPointWithoutMesh: CloudPoint;
+
+        let pointsCloudSystemWithMesh: PointsCloudSystem;
+        let cloudPointWithMesh: CloudPoint;
+
+        /**
+         * Create a new engine subject before each test.
+         */
+        beforeEach(async () => {
+            subject = new NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+
+            pointsGroup = new PointsGroup(1, () => {});
+            scene = new Scene(subject);
+
+            pointsCloudSystemWithoutMesh = new PointsCloudSystem("cloud-system", 1, scene);
+            cloudPointWithoutMesh = new CloudPoint(1, pointsGroup, 1, 0, pointsCloudSystemWithoutMesh);
+
+            pointsCloudSystemWithMesh = new PointsCloudSystem("cloud-system", 1, scene);
+            await pointsCloudSystemWithMesh.buildMeshAsync();
+            cloudPointWithMesh = new CloudPoint(1, pointsGroup, 1, 0, pointsCloudSystemWithMesh);
+        });
+
+        // Check the hasBoundingInfo
+        it("should return False when target doesnt contain Bounding Info", () => {
+            const mesh = {} as Mesh;
+            const result = cloudPointWithoutMesh.intersectsMesh(mesh, false);
+
+            expect(result).toBeFalsy();
+        });
+
+        // Check throw Error
+        it("should throw an error if Point Cloud System doesnt have a Mesh", () => {
+            const isIntersects = true;
+
+            const boundingInfo = {
+                boundingSphere: {
+                    intersectsPoint: (_point: DeepImmutable<Vector3>) => isIntersects,
+                } as BoundingSphere,
+            } as BoundingInfo;
+
+            const mesh = {
+                hasBoundingInfo: true,
+                getBoundingInfo: () => boundingInfo,
+            } as Mesh;
+
+            expect(() => cloudPointWithoutMesh.intersectsMesh(mesh, true)).toThrowError();
+        });
+
+        // Check intersect by sphere
+        it("should return True when target intersects with Point Cloud by sphere", () => {
+            const isIntersects = true;
+
+            const boundingInfo = {
+                boundingSphere: {
+                    intersectsPoint: (_point: DeepImmutable<Vector3>) => isIntersects,
+                } as BoundingSphere,
+            } as BoundingInfo;
+
+            const mesh = {
+                hasBoundingInfo: true,
+                getBoundingInfo: () => boundingInfo,
+            } as Mesh;
+
+            const result = cloudPointWithMesh.intersectsMesh(mesh, true);
+
+            expect(result).toBeTruthy();
+        });
+
+        it("should return False when target dont intersects with Point Cloud by sphere", () => {
+            const isIntersects = false;
+
+            const boundingInfo = {
+                boundingSphere: {
+                    intersectsPoint: (_point: DeepImmutable<Vector3>) => isIntersects,
+                } as BoundingSphere,
+            } as BoundingInfo;
+
+            const mesh = {
+                hasBoundingInfo: true,
+                getBoundingInfo: () => boundingInfo,
+            } as Mesh;
+
+            const result = cloudPointWithMesh.intersectsMesh(mesh, true);
+
+            expect(result).toBeFalsy();
+        });
+
+        // Check real intersects
+        describe("should check real intersects", () => {
+            const boundingBoxLimits = [
+                { min: [-1, -1, -1], max: [-1, -1, -1], result: false },
+                { min: [-1, -1, -1], max: [0, 0, -1], result: false },
+                { min: [-1, -1, -1], max: [0, 0, 0], result: true },
+                { min: [-1, -1, -1], max: [0, 0, 1], result: true },
+                { min: [-1, -1, -1], max: [0, 1, -1], result: false },
+                { min: [-1, -1, -1], max: [0, 1, 0], result: true },
+                { min: [-1, -1, -1], max: [0, 1, 1], result: true },
+                { min: [-1, -1, -1], max: [1, -1, -1], result: false },
+                { min: [-1, -1, -1], max: [1, 0, -1], result: false },
+                { min: [-1, -1, -1], max: [1, 0, 0], result: true },
+                { min: [-1, -1, -1], max: [1, 0, 1], result: true },
+                { min: [-1, -1, -1], max: [1, 1, -1], result: false },
+                { min: [-1, -1, -1], max: [1, 1, 0], result: true },
+                { min: [-1, -1, -1], max: [1, 1, 1], result: true },
+                { min: [-1, -1, 0], max: [-1, -1, -1], result: false },
+                { min: [-1, -1, 0], max: [0, 0, -1], result: false },
+                { min: [-1, -1, 0], max: [0, 0, 0], result: true },
+                { min: [-1, -1, 0], max: [0, 0, 1], result: true },
+                { min: [-1, -1, 0], max: [0, 1, -1], result: false },
+                { min: [-1, -1, 0], max: [0, 1, 0], result: true },
+                { min: [-1, -1, 0], max: [0, 1, 1], result: true },
+                { min: [-1, -1, 0], max: [1, -1, -1], result: false },
+                { min: [-1, -1, 0], max: [1, 0, -1], result: false },
+                { min: [-1, -1, 0], max: [1, 0, 0], result: true },
+                { min: [-1, -1, 0], max: [1, 0, 1], result: true },
+                { min: [-1, -1, 0], max: [1, 1, -1], result: false },
+                { min: [-1, -1, 0], max: [1, 1, 0], result: true },
+                { min: [-1, -1, 0], max: [1, 1, 1], result: true },
+                { min: [-1, -1, 1], max: [-1, -1, -1], result: false },
+                { min: [-1, 0, -1], max: [0, 0, -1], result: false },
+                { min: [-1, 0, -1], max: [0, 0, 0], result: true },
+                { min: [-1, 0, -1], max: [0, 0, 1], result: true },
+                { min: [-1, 0, -1], max: [0, 1, -1], result: false },
+                { min: [-1, 0, -1], max: [0, 1, 0], result: true },
+                { min: [-1, 0, -1], max: [0, 1, 1], result: true },
+                { min: [-1, 0, -1], max: [1, -1, -1], result: false },
+                { min: [-1, 0, -1], max: [1, 0, -1], result: false },
+                { min: [-1, 0, -1], max: [1, 0, 0], result: true },
+                { min: [-1, 0, -1], max: [1, 0, 1], result: true },
+                { min: [-1, 0, -1], max: [1, 1, -1], result: false },
+                { min: [-1, 0, -1], max: [1, 1, 0], result: true },
+                { min: [-1, 0, -1], max: [1, 1, 1], result: true },
+                { min: [-1, 0, 0], max: [-1, -1, -1], result: false },
+                { min: [-1, 0, 0], max: [0, 0, -1], result: false },
+                { min: [-1, 0, 0], max: [0, 0, 0], result: true },
+                { min: [-1, 0, 0], max: [0, 0, 1], result: true },
+                { min: [-1, 0, 0], max: [0, 1, -1], result: false },
+                { min: [-1, 0, 0], max: [0, 1, 0], result: true },
+                { min: [-1, 0, 0], max: [0, 1, 1], result: true },
+                { min: [-1, 0, 0], max: [1, -1, -1], result: false },
+                { min: [-1, 0, 0], max: [1, 0, -1], result: false },
+                { min: [-1, 0, 0], max: [1, 0, 0], result: true },
+                { min: [-1, 0, 0], max: [1, 0, 1], result: true },
+                { min: [-1, 0, 0], max: [1, 1, -1], result: false },
+                { min: [-1, 0, 0], max: [1, 1, 0], result: true },
+                { min: [-1, 0, 0], max: [1, 1, 1], result: true },
+                { min: [-1, 0, 1], max: [-1, -1, -1], result: false },
+                { min: [0, -1, -1], max: [0, 0, -1], result: false },
+                { min: [0, -1, -1], max: [0, 0, 0], result: true },
+                { min: [0, -1, -1], max: [0, 0, 1], result: true },
+                { min: [0, -1, -1], max: [0, 1, -1], result: false },
+                { min: [0, -1, -1], max: [0, 1, 0], result: true },
+                { min: [0, -1, -1], max: [0, 1, 1], result: true },
+                { min: [0, -1, -1], max: [1, -1, -1], result: false },
+                { min: [0, -1, -1], max: [1, 0, -1], result: false },
+                { min: [0, -1, -1], max: [1, 0, 0], result: true },
+                { min: [0, -1, -1], max: [1, 0, 1], result: true },
+                { min: [0, -1, -1], max: [1, 1, -1], result: false },
+                { min: [0, -1, -1], max: [1, 1, 0], result: true },
+                { min: [0, -1, -1], max: [1, 1, 1], result: true },
+                { min: [0, -1, 0], max: [-1, -1, -1], result: false },
+                { min: [0, -1, 0], max: [0, 0, -1], result: false },
+                { min: [0, -1, 0], max: [0, 0, 0], result: true },
+                { min: [0, -1, 0], max: [0, 0, 1], result: true },
+                { min: [0, -1, 0], max: [0, 1, -1], result: false },
+                { min: [0, -1, 0], max: [0, 1, 0], result: true },
+                { min: [0, -1, 0], max: [0, 1, 1], result: true },
+                { min: [0, -1, 0], max: [1, -1, -1], result: false },
+                { min: [0, -1, 0], max: [1, 0, -1], result: false },
+                { min: [0, -1, 0], max: [1, 0, 0], result: true },
+                { min: [0, -1, 0], max: [1, 0, 1], result: true },
+                { min: [0, -1, 0], max: [1, 1, -1], result: false },
+                { min: [0, -1, 0], max: [1, 1, 0], result: true },
+                { min: [0, -1, 0], max: [1, 1, 1], result: true },
+                { min: [0, -1, 1], max: [-1, -1, -1], result: false },
+                { min: [0, 0, -1], max: [0, 0, -1], result: false },
+                { min: [0, 0, -1], max: [0, 0, 0], result: true },
+                { min: [0, 0, -1], max: [0, 0, 1], result: true },
+                { min: [0, 0, -1], max: [0, 1, -1], result: false },
+                { min: [0, 0, -1], max: [0, 1, 0], result: true },
+                { min: [0, 0, -1], max: [0, 1, 1], result: true },
+                { min: [0, 0, -1], max: [1, -1, -1], result: false },
+                { min: [0, 0, -1], max: [1, 0, -1], result: false },
+                { min: [0, 0, -1], max: [1, 0, 0], result: true },
+                { min: [0, 0, -1], max: [1, 0, 1], result: true },
+                { min: [0, 0, -1], max: [1, 1, -1], result: false },
+                { min: [0, 0, -1], max: [1, 1, 0], result: true },
+                { min: [0, 0, -1], max: [1, 1, 1], result: true },
+                { min: [0, 0, 0], max: [-1, -1, -1], result: false },
+                { min: [0, 0, 0], max: [0, 0, -1], result: false },
+                { min: [0, 0, 0], max: [0, 0, 0], result: true },
+                { min: [0, 0, 0], max: [0, 0, 1], result: true },
+                { min: [0, 0, 0], max: [0, 1, -1], result: false },
+                { min: [0, 0, 0], max: [0, 1, 0], result: true },
+                { min: [0, 0, 0], max: [0, 1, 1], result: true },
+                { min: [0, 0, 0], max: [1, -1, -1], result: false },
+                { min: [0, 0, 0], max: [1, 0, -1], result: false },
+                { min: [0, 0, 0], max: [1, 0, 0], result: true },
+                { min: [0, 0, 0], max: [1, 0, 1], result: true },
+                { min: [0, 0, 0], max: [1, 1, -1], result: false },
+                { min: [0, 0, 0], max: [1, 1, 0], result: true },
+                { min: [0, 0, 0], max: [1, 1, 1], result: true },
+                { min: [0, 0, 1], max: [-1, -1, -1], result: false },
+                { min: [0, 1, -1], max: [-1, -1, -1], result: false },
+                { min: [0, 1, 0], max: [-1, -1, -1], result: false },
+                { min: [0, 1, 1], max: [-1, -1, -1], result: false },
+                { min: [1, -1, -1], max: [-1, -1, -1], result: false },
+                { min: [1, -1, 0], max: [-1, -1, -1], result: false },
+                { min: [1, -1, 1], max: [-1, -1, -1], result: false },
+                { min: [1, 0, -1], max: [-1, -1, -1], result: false },
+                { min: [1, 0, 0], max: [-1, -1, -1], result: false },
+                { min: [1, 0, 1], max: [-1, -1, -1], result: false },
+                { min: [1, 1, -1], max: [-1, -1, -1], result: false },
+                { min: [1, 1, 0], max: [-1, -1, -1], result: false },
+                { min: [1, 1, 1], max: [-1, -1, -1], result: false },
+                { min: [1, 1, 1], max: [1, 1, 1], result: false },
+            ];
+
+            boundingBoxLimits.forEach((boundingBoxLimit, index) => {
+                it("should return correct value for test case " + index, () => {
+                    const boundingInfo = {
+                        boundingBox: {
+                            maximumWorld: {
+                                x: boundingBoxLimit.max[0],
+                                y: boundingBoxLimit.max[1],
+                                z: boundingBoxLimit.max[2],
+                            },
+                            minimumWorld: {
+                                x: boundingBoxLimit.min[0],
+                                y: boundingBoxLimit.min[1],
+                                z: boundingBoxLimit.min[2],
+                            },
+                        } as BoundingBox,
+                    } as BoundingInfo;
+
+                    const mesh = {
+                        hasBoundingInfo: true,
+                        getBoundingInfo: () => boundingInfo,
+                    } as Mesh;
+
+                    const result = cloudPointWithMesh.intersectsMesh(mesh, false);
+
+                    expect(result).toEqual(boundingBoxLimit.result);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hi!
I add some tests to Particles/cloudPoint, the function is intersectsMesh.

Here I found some points.
1. The property of PointsCloudSystem `mesh` has incorrect type. In fact this property may have `undefined` as value, because it's not defined in the constructor. So I add optional mark `?` to type and required checks in the class.
2. And after this I found what the `intersectsMesh` function did not check the mesh property existing in the point cloud system. So I add a new Error here, that notice about required mesh to next calculations.
3. The line `isSphere = isSphere ? isSphere : false;` look like redundant, because TypeScript promise that it have boolean type.
4. Next I move the getBoundingInfo call into one line `const bbox = target.getBoundingInfo().boundingBox;`. It's look for me as potential performance boost, maybe.
5. And at the end I remove `else` branch because it rendundant because the code above have return statements.

And I limited test cases from 729 possible combinations to 126, they seems like corner cases for me. I dont know which cases we can reduce to save the working guarantee.