### PR TITLE
Test babylon vertex buffer instance divisor

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -385,19 +385,19 @@ export class VertexBuffer {
         this._kind = kind;
 
         if (type == undefined) {
-            const data = this.getData();
+            const vertexData = this.getData();
             this.type = VertexBuffer.FLOAT;
-            if (data instanceof Int8Array) {
+            if (vertexData instanceof Int8Array) {
                 this.type = VertexBuffer.BYTE;
-            } else if (data instanceof Uint8Array) {
+            } else if (vertexData instanceof Uint8Array) {
                 this.type = VertexBuffer.UNSIGNED_BYTE;
-            } else if (data instanceof Int16Array) {
+            } else if (vertexData instanceof Int16Array) {
                 this.type = VertexBuffer.SHORT;
-            } else if (data instanceof Uint16Array) {
+            } else if (vertexData instanceof Uint16Array) {
                 this.type = VertexBuffer.UNSIGNED_SHORT;
-            } else if (data instanceof Int32Array) {
+            } else if (vertexData instanceof Int32Array) {
                 this.type = VertexBuffer.INT;
-            } else if (data instanceof Uint32Array) {
+            } else if (vertexData instanceof Uint32Array) {
                 this.type = VertexBuffer.UNSIGNED_INT;
             }
         } else {

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -300,9 +300,13 @@ export class VertexBuffer {
     }
 
     public set instanceDivisor(value: number) {
+        const isInstanced = value != 0;
         this._instanceDivisor = value;
-        this._instanced = value != 0;
-        this._computeHashCode();
+
+        if (isInstanced !== this._instanced) {
+            this._instanced = isInstanced;
+            this._computeHashCode();
+        }
     }
 
     /**

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -301,11 +301,7 @@ export class VertexBuffer {
 
     public set instanceDivisor(value: number) {
         this._instanceDivisor = value;
-        if (value == 0) {
-            this._instanced = false;
-        } else {
-            this._instanced = true;
-        }
+        this._instanced = value != 0;
         this._computeHashCode();
     }
 

--- a/packages/dev/core/test/unit/Buffers/babylon.buffer.test.ts
+++ b/packages/dev/core/test/unit/Buffers/babylon.buffer.test.ts
@@ -1,0 +1,80 @@
+import { VertexBuffer } from "core/Buffers";
+import { Engine, NullEngine } from "core/Engines";
+import { CreateBoxVertexData, VertexData } from "core/Meshes";
+
+describe("VertexBuffer", () => {
+    describe("instanceDivisor", () => {
+        let subject: Engine;
+        let boxVertexData: VertexData;
+
+        beforeEach(function () {
+            subject = new NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+
+            boxVertexData = CreateBoxVertexData({ size: 1.0 });
+        });
+
+        it("should instanceDivisor equal to zero by default", () => {
+            const vertexBuffer = new VertexBuffer(subject, boxVertexData.positions!, VertexBuffer.PositionKind, false);
+            expect(vertexBuffer.instanceDivisor).toEqual(0);
+        });
+
+        it("should change instanceDivisor after setter", () => {
+            const vertexBuffer = new VertexBuffer(subject, boxVertexData.positions!, VertexBuffer.PositionKind, false);
+
+            vertexBuffer.instanceDivisor = 42;
+            expect(vertexBuffer.instanceDivisor).toEqual(42);
+
+            vertexBuffer.instanceDivisor = 146;
+            expect(vertexBuffer.instanceDivisor).toEqual(146);
+        });
+
+        it("should compute the hash code after change the instanceDivisor value", () => {
+            const vertexBuffer = new VertexBuffer(subject, boxVertexData.positions!, VertexBuffer.PositionKind, false);
+
+            const initialHashCode = vertexBuffer.hashCode;
+
+            vertexBuffer.instanceDivisor = 42;
+
+            const newHashCode = vertexBuffer.hashCode;
+
+            expect(initialHashCode).not.toEqual(newHashCode);
+        });
+
+        it("should not compute new hash if the instanceDivisor value did not changed but assigned", () => {
+            const vertexBuffer = new VertexBuffer(subject, boxVertexData.positions!, VertexBuffer.PositionKind, false);
+
+            vertexBuffer.instanceDivisor = 42;
+            const newHashCode = vertexBuffer.hashCode;
+
+            vertexBuffer.instanceDivisor = 100500;
+            const secondNewHashCode = vertexBuffer.hashCode;
+
+            expect(newHashCode).toEqual(secondNewHashCode);
+
+            vertexBuffer.instanceDivisor = 0;
+            const finalHashCode = vertexBuffer.hashCode;
+
+            expect(finalHashCode).not.toEqual(secondNewHashCode);
+        });
+
+        it("should set is instanced after set the instanceDivisor value", () => {
+            const vertexBuffer = new VertexBuffer(subject, boxVertexData.positions!, VertexBuffer.PositionKind, false);
+
+            expect(vertexBuffer.getIsInstanced()).toBeFalsy();
+
+            vertexBuffer.instanceDivisor = 42;
+
+            expect(vertexBuffer.getIsInstanced()).toBeTruthy();
+
+            vertexBuffer.instanceDivisor = 0;
+
+            expect(vertexBuffer.getIsInstanced()).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
Hi! There are some tests again :)

Some points here:
1. Simplify the code.
2. Setter was recompute the hash after every set call, but it shuld be only after change the `this._instanced` as it we can see in the `_computeHashCode` method.
3. I found shadowed variable (`data`) in the constructor and fix it (to `vertexData` in the local scope).

And just in case I explain my pipeline:
1. First I wrote test cases.
2. Only after it I started to modify the code.