### PR TITLE
Update VSCode settings to include Prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,10 @@
     },
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
+	},
+	"prettier.printWidth": 180,
+	"prettier.tabWidth": 4,
+	"prettier.useTabs": false,
+	"prettier.semi": true,
+	"prettier.singleQuote": false,
 }


### PR DESCRIPTION
Updates VSCode workspace settings so that the prettier extension will format correctly.