### PR TITLE
Some fixes to OptionLineComponent related to wrong parent info showin…

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -26,6 +26,7 @@ export interface IOptionsLineComponentProps {
     defaultIfNull?: number;
     fromFontDropdown?: boolean;
     valueProp?: number;
+    fallbackValue?: number;
 }
 
 export class OptionsLineComponent extends React.Component<IOptionsLineComponentProps, { value: number | string; addCustom: boolean }> {
@@ -46,6 +47,11 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
     }
 
     constructor(props: IOptionsLineComponentProps) {
+        // Initialize default props
+        props = {
+            ...props,
+            fallbackValue: -1,
+        };
         super(props);
 
         this.state = { value: this._remapValueIn(this._getValue(props)), addCustom: false };
@@ -173,7 +179,7 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
                     ) : (
                         <select
                             onChange={(evt) => this.updateValue(evt.target.value)}
-                            value={this.state.value === -1 || this.state.value === null || this.state.value === undefined ? 1 : this.state.value}
+                            value={this.state.value === null || this.state.value === undefined ? this.props.fallbackValue : this.state.value}
                         >
                             {this.props.options.map((option, i) => {
                                 return (

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -737,6 +737,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                                 options={fonts}
                                 addVal={this.addVal}
                                 fromFontDropdown={true}
+                                fallbackValue={1}
                                 onSelect={(newValue) => {
                                     const fontFamily = this.state.fontFamilyOptions.filter(({ value }) => value === newValue).map(({ label }) => label);
                                     proxy.fontFamily = fontFamily[0];


### PR DESCRIPTION
…g up on Inspector.

Related forum issue: https://forum.babylonjs.com/t/bug-display-of-parent-in-the-inspector-shows-parenting-that-has-not-been-set/34256