### PR TITLE
Remove unneeded prefixes and unused code

### DIFF
--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -111,8 +111,7 @@ export class AudioEngine implements IAudioEngine {
         if (!IsWindowObjectExist()) {
             return;
         }
-        if (typeof window.AudioContext !== "undefined" || typeof window.webkitAudioContext !== "undefined") {
-            window.AudioContext = window.AudioContext || window.webkitAudioContext;
+        if (typeof window.AudioContext !== "undefined") {
             this.canUseWebAudio = true;
         }
 

--- a/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
+++ b/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
@@ -956,10 +956,6 @@ export class VRExperienceHelper {
 
         hostWindow.addEventListener("resize", this._onResize);
         document.addEventListener("fullscreenchange", this._onFullscreenChange, false);
-        document.addEventListener("mozfullscreenchange", this._onFullscreenChange, false);
-        document.addEventListener("webkitfullscreenchange", this._onFullscreenChange, false);
-        document.addEventListener("msfullscreenchange", this._onFullscreenChange, false);
-        (<any>document).onmsfullscreenchange = this._onFullscreenChange;
 
         // Display vr button when headset is connected
         if (webVROptions.createFallbackVRDeviceOrientationFreeCamera) {
@@ -2381,10 +2377,6 @@ export class VRExperienceHelper {
 
         window.removeEventListener("resize", this._onResize);
         document.removeEventListener("fullscreenchange", this._onFullscreenChange);
-        document.removeEventListener("mozfullscreenchange", this._onFullscreenChange);
-        document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
-        document.removeEventListener("msfullscreenchange", this._onFullscreenChange);
-        (<any>document).onmsfullscreenchange = null;
 
         this._scene.getEngine().onVRDisplayChangedObservable.removeCallback(this._onVRDisplayChangedBind);
         this._scene.getEngine().onVRRequestPresentStart.removeCallback(this._onVRRequestPresentStart);

--- a/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
+++ b/packages/dev/core/src/Cameras/VR/vrExperienceHelper.ts
@@ -1072,18 +1072,7 @@ export class VRExperienceHelper {
     };
 
     private _onFullscreenChange = () => {
-        const anyDoc = document as any;
-        if (anyDoc.fullscreen !== undefined) {
-            this._fullscreenVRpresenting = (<any>document).fullscreen;
-        } else if (anyDoc.mozFullScreen !== undefined) {
-            this._fullscreenVRpresenting = anyDoc.mozFullScreen;
-        } else if (anyDoc.webkitIsFullScreen !== undefined) {
-            this._fullscreenVRpresenting = anyDoc.webkitIsFullScreen;
-        } else if (anyDoc.msIsFullScreen !== undefined) {
-            this._fullscreenVRpresenting = anyDoc.msIsFullScreen;
-        } else if ((<any>document).msFullscreenElement !== undefined) {
-            this._fullscreenVRpresenting = (<any>document).msFullscreenElement;
-        }
+        this._fullscreenVRpresenting = !!document.fullscreenElement;
         if (!this._fullscreenVRpresenting && this._inputElement) {
             this.exitVR();
             if (!this._useCustomVRButton && this._btnVR) {

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -423,13 +423,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 const deviceEvent = evt as IPointerEvent;
                 deviceEvent.inputIndex = PointerInput.Move;
 
-                if (evt.movementX === undefined) {
-                    evt.movementX = evt.mozMovementX || evt.webkitMovementX || evt.msMovementX || evt.clientX - pointer[PointerInput.Horizontal];
-                }
-                if (evt.movementY === undefined) {
-                    evt.movementY = evt.mozMovementY || evt.webkitMovementY || evt.msMovementY || evt.clientY - pointer[PointerInput.Vertical];
-                }
-
                 pointer[PointerInput.Horizontal] = evt.clientX;
                 pointer[PointerInput.Vertical] = evt.clientY;
 
@@ -520,12 +513,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
                     deviceEvent.inputIndex = PointerInput.Move;
-                    if (evt.movementX === undefined) {
-                        evt.movementX = evt.mozMovementX || evt.webkitMovementX || evt.msMovementX || evt.clientX - pointer[PointerInput.Horizontal];
-                    }
-                    if (evt.movementY === undefined) {
-                        evt.movementY = evt.mozMovementY || evt.webkitMovementY || evt.msMovementY || evt.clientY - pointer[PointerInput.Vertical];
-                    }
                     this._onInputChanged(deviceType, deviceSlot, deviceEvent);
                 }
             }
@@ -556,12 +543,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
                     deviceEvent.inputIndex = PointerInput.Move;
-                    if (evt.movementX === undefined) {
-                        evt.movementX = evt.mozMovementX || evt.webkitMovementX || evt.msMovementX || evt.clientX - pointer[PointerInput.Horizontal];
-                    }
-                    if (evt.movementY === undefined) {
-                        evt.movementY = evt.mozMovementY || evt.webkitMovementY || evt.msMovementY || evt.clientY - pointer[PointerInput.Vertical];
-                    }
                     this._onInputChanged(deviceType, deviceSlot, deviceEvent);
                 }
 

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -2028,7 +2028,6 @@ export class Engine extends ThinEngine {
      * Asks the browser to exit pointerlock mode
      */
     static _ExitPointerlock(): void {
-        const anyDoc = document as any;
         if (document.exitPointerLock) {
             document.exitPointerLock();
         }

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -599,19 +599,9 @@ export class Engine extends ThinEngine {
             this._sharedInit(canvas, !!options.doNotHandleTouchAction, options.audioEngine!);
 
             if (IsWindowObjectExist()) {
-                const anyDoc = document as any;
-
                 // Fullscreen
                 this._onFullscreenChange = () => {
-                    if (anyDoc.fullscreen !== undefined) {
-                        this.isFullscreen = anyDoc.fullscreen;
-                    } else if (anyDoc.mozFullScreen !== undefined) {
-                        this.isFullscreen = anyDoc.mozFullScreen;
-                    } else if (anyDoc.webkitIsFullScreen !== undefined) {
-                        this.isFullscreen = anyDoc.webkitIsFullScreen;
-                    } else if (anyDoc.msIsFullScreen !== undefined) {
-                        this.isFullscreen = anyDoc.msIsFullScreen;
-                    }
+                    this.isFullscreen = !!document.fullscreenElement;
 
                     // Pointer lock
                     if (this.isFullscreen && this._pointerLockRequested && canvas) {
@@ -620,22 +610,14 @@ export class Engine extends ThinEngine {
                 };
 
                 document.addEventListener("fullscreenchange", this._onFullscreenChange, false);
-                document.addEventListener("mozfullscreenchange", this._onFullscreenChange, false);
                 document.addEventListener("webkitfullscreenchange", this._onFullscreenChange, false);
-                document.addEventListener("msfullscreenchange", this._onFullscreenChange, false);
 
                 // Pointer lock
                 this._onPointerLockChange = () => {
-                    this.isPointerLock =
-                        anyDoc.mozPointerLockElement === canvas ||
-                        anyDoc.webkitPointerLockElement === canvas ||
-                        anyDoc.msPointerLockElement === canvas ||
-                        anyDoc.pointerLockElement === canvas;
+                    this.isPointerLock = document.pointerLockElement === canvas;
                 };
 
                 document.addEventListener("pointerlockchange", this._onPointerLockChange, false);
-                document.addEventListener("mspointerlockchange", this._onPointerLockChange, false);
-                document.addEventListener("mozpointerlockchange", this._onPointerLockChange, false);
                 document.addEventListener("webkitpointerlockchange", this._onPointerLockChange, false);
 
                 // Create Audio Engine if needed.
@@ -1951,7 +1933,6 @@ export class Engine extends ThinEngine {
 
         this._renderingCanvas.setAttribute("touch-action", "none");
         this._renderingCanvas.style.touchAction = "none";
-        (this._renderingCanvas.style as any).msTouchAction = "none";
         (this._renderingCanvas.style as any).webkitTapHighlightColor = "transparent";
     }
 
@@ -2037,8 +2018,6 @@ export class Engine extends ThinEngine {
      * @param element defines the DOM element to promote
      */
     static _RequestPointerlock(element: HTMLElement): void {
-        element.requestPointerLock =
-            element.requestPointerLock || (<any>element).msRequestPointerLock || (<any>element).mozRequestPointerLock || (<any>element).webkitRequestPointerLock;
         if (element.requestPointerLock) {
             element.requestPointerLock();
             element.focus();
@@ -2050,8 +2029,6 @@ export class Engine extends ThinEngine {
      */
     static _ExitPointerlock(): void {
         const anyDoc = document as any;
-        document.exitPointerLock = document.exitPointerLock || anyDoc.msExitPointerLock || anyDoc.mozExitPointerLock || anyDoc.webkitExitPointerLock;
-
         if (document.exitPointerLock) {
             document.exitPointerLock();
         }
@@ -2062,7 +2039,7 @@ export class Engine extends ThinEngine {
      * @param element defines the DOM element to promote
      */
     static _RequestFullscreen(element: HTMLElement): void {
-        const requestFunction = element.requestFullscreen || (<any>element).msRequestFullscreen || (<any>element).webkitRequestFullscreen || (<any>element).mozRequestFullScreen;
+        const requestFunction = element.requestFullscreen || (<any>element).webkitRequestFullscreen;
         if (!requestFunction) {
             return;
         }
@@ -2077,12 +2054,8 @@ export class Engine extends ThinEngine {
 
         if (document.exitFullscreen) {
             document.exitFullscreen();
-        } else if (anyDoc.mozCancelFullScreen) {
-            anyDoc.mozCancelFullScreen();
         } else if (anyDoc.webkitCancelFullScreen) {
             anyDoc.webkitCancelFullScreen();
-        } else if (anyDoc.msCancelFullScreen) {
-            anyDoc.msCancelFullScreen();
         }
     }
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5862,14 +5862,6 @@ export class ThinEngine {
             return requester.requestPostAnimationFrame(func);
         } else if (requester.requestAnimationFrame) {
             return requester.requestAnimationFrame(func);
-        } else if (requester.msRequestAnimationFrame) {
-            return requester.msRequestAnimationFrame(func);
-        } else if (requester.webkitRequestAnimationFrame) {
-            return requester.webkitRequestAnimationFrame(func);
-        } else if (requester.mozRequestAnimationFrame) {
-            return requester.mozRequestAnimationFrame(func);
-        } else if (requester.oRequestAnimationFrame) {
-            return requester.oRequestAnimationFrame(func);
         } else {
             return window.setTimeout(func, 16);
         }

--- a/packages/dev/core/src/Gamepads/gamepadManager.ts
+++ b/packages/dev/core/src/Gamepads/gamepadManager.ts
@@ -42,7 +42,7 @@ export class GamepadManager {
             this._gamepadEventSupported = false;
         } else {
             this._gamepadEventSupported = "GamepadEvent" in window;
-            this._gamepadSupport = navigator && (navigator.getGamepads || navigator.webkitGetGamepads || navigator.msGetGamepads || navigator.webkitGamepads);
+            this._gamepadSupport = navigator && navigator.getGamepads;
         }
 
         this.onGamepadConnectedObservable = new Observable<Gamepad>((observer) => {

--- a/packages/dev/core/src/Gamepads/gamepadManager.ts
+++ b/packages/dev/core/src/Gamepads/gamepadManager.ts
@@ -238,7 +238,7 @@ export class GamepadManager {
     // This function is called only on Chrome, which does not properly support
     // connection/disconnection events and forces you to recopy again the gamepad object
     private _updateGamepadObjects() {
-        const gamepads = navigator.getGamepads ? navigator.getGamepads() : navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : [];
+        const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
         for (let i = 0; i < gamepads.length; i++) {
             const gamepad = gamepads[i];
             if (gamepad) {

--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -431,7 +431,6 @@ export class VideoTexture extends Texture {
             if (typeof video.srcObject == "object") {
                 video.srcObject = stream;
             } else {
-                window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
                 // older API. See https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams
                 video.src = window.URL && window.URL.createObjectURL(stream as any);
             }
@@ -495,7 +494,8 @@ export class VideoTexture extends Texture {
                     return this.CreateFromStreamAsync(scene, stream, constraints, invertY);
                 });
         } else {
-            const getUserMedia = (navigator as any).getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
+            // This is technically not needed because all moden browsers support mediaDevices.getUserMedia
+            const getUserMedia = (navigator as any).getUserMedia || navigator.mozGetUserMedia;
 
             if (getUserMedia) {
                 getUserMedia(

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -547,7 +547,7 @@ export class Tools {
      */
     public static FileAsURL(content: string): string {
         const fileBlob = new Blob([content]);
-        const url = window.URL || window.webkitURL;
+        const url = window.URL;
         const link: string = url.createObjectURL(fileBlob);
         return link;
     }

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -882,11 +882,6 @@ export class Tools {
      * @param fileName defines the name of the downloaded file
      */
     public static Download(blob: Blob, fileName: string): void {
-        if (navigator && (navigator as any).msSaveBlob) {
-            (navigator as any).msSaveBlob(blob, fileName);
-            return;
-        }
-
         if (typeof URL === "undefined") {
             return;
         }

--- a/packages/dev/core/src/Misc/virtualJoystick.ts
+++ b/packages/dev/core/src/Misc/virtualJoystick.ts
@@ -197,7 +197,6 @@ export class VirtualJoystick {
             VirtualJoystick.Canvas.style.top = "0px";
             VirtualJoystick.Canvas.style.left = "0px";
             VirtualJoystick.Canvas.style.zIndex = "5";
-            (VirtualJoystick.Canvas.style as any).msTouchAction = "none";
             VirtualJoystick.Canvas.style.touchAction = "none"; // fix https://forum.babylonjs.com/t/virtualjoystick-needs-to-set-style-touch-action-none-explicitly/9562
             // Support for jQuery PEP polyfill
             VirtualJoystick.Canvas.setAttribute("touch-action", "none");


### PR DESCRIPTION
Those were found while working on thinEngine/Engine optimizations as part of the ESM work.

Each function was inspected for backwards compatibility. If a prefix is needed (as the case in some webkit-functionalities) it stayed, otherwise it was removed. 