### PR TITLE
Fix creation of cube textures from URL

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.cubeTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.cubeTexture.ts
@@ -357,8 +357,9 @@ ThinEngine.prototype.createCubeTextureBase = function (
         rootUrl = this._transformTextureUrl(rootUrl);
     }
 
-    const lastDot = rootUrl.lastIndexOf(".");
-    const extension = forcedExtension ? forcedExtension : lastDot > -1 ? rootUrl.substring(lastDot).toLowerCase() : "";
+    const rootUrlWithoutUriParams = rootUrl.split("?")[0];
+    const lastDot = rootUrlWithoutUriParams.lastIndexOf(".");
+    const extension = forcedExtension ? forcedExtension : lastDot > -1 ? rootUrlWithoutUriParams.substring(lastDot).toLowerCase() : "";
 
     let loader: Nullable<IInternalTextureLoader> = null;
     for (const availableLoader of ThinEngine._TextureLoaders) {


### PR DESCRIPTION
This PR should fix the issue mentioned in this [forum post](https://forum.babylonjs.com/t/cubetexture-createfromprefiltereddata-does-not-work-with-url-that-contains-uri-params/34097) by cropping the URL params before parsing the file extension.