### PR TITLE
Fix wrong plugin name check for babylon serialization

### DIFF
--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -962,11 +962,11 @@ SceneLoader.RegisterPlugin({
             //Physics
             if (parsedData.physicsEnabled) {
                 let physicsPlugin;
-                if (parsedData.physicsEngine === "cannon") {
+                if (parsedData.physicsEngine === "cannon" || parsedData.physicsEngine === CannonJSPlugin.name) {
                     physicsPlugin = new CannonJSPlugin(undefined, undefined, BabylonFileLoaderConfiguration.LoaderInjectedPhysicsEngine);
-                } else if (parsedData.physicsEngine === "oimo") {
+                } else if (parsedData.physicsEngine === "oimo" || parsedData.physicsEngine === OimoJSPlugin.name) {
                     physicsPlugin = new OimoJSPlugin(undefined, BabylonFileLoaderConfiguration.LoaderInjectedPhysicsEngine);
-                } else if (parsedData.physicsEngine === "ammo") {
+                } else if (parsedData.physicsEngine === "ammo" || parsedData.physicsEngine === AmmoJSPlugin.name) {
                     physicsPlugin = new AmmoJSPlugin(undefined, BabylonFileLoaderConfiguration.LoaderInjectedPhysicsEngine, undefined);
                 }
                 log = "\tPhysics engine " + (parsedData.physicsEngine ? parsedData.physicsEngine : "oimo") + " enabled\n";


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/physics-plugin-names-are-different-from-the-name-used-in-babylonfileloader-ts/34345
Fix bad plugin name check. Keep previous ones, just in case for back compat.