### PR TITLE
Optional camera for all post processes

### DIFF
--- a/packages/dev/core/src/PostProcesses/blackAndWhitePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blackAndWhitePostProcess.ts
@@ -39,7 +39,7 @@ export class BlackAndWhitePostProcess extends PostProcess {
      * @param engine The engine which the post process will be applied. (default: current engine)
      * @param reusable If the post process can be reused on the same frame. (default: false)
      */
-    constructor(name: string, options: number | PostProcessOptions, camera: Camera, samplingMode?: number, engine?: Engine, reusable?: boolean) {
+    constructor(name: string, options: number | PostProcessOptions, camera: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean) {
         super(name, "blackAndWhite", ["degree"], null, options, camera, samplingMode, engine, reusable);
 
         this.onApplyObservable.add((effect: Effect) => {

--- a/packages/dev/core/src/PostProcesses/colorCorrectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/colorCorrectionPostProcess.ts
@@ -44,10 +44,11 @@ export class ColorCorrectionPostProcess extends PostProcess {
         return "ColorCorrectionPostProcess";
     }
 
-    constructor(name: string, colorTableUrl: string, options: number | PostProcessOptions, camera: Camera, samplingMode?: number, engine?: Engine, reusable?: boolean) {
+    constructor(name: string, colorTableUrl: string, options: number | PostProcessOptions, camera: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean) {
         super(name, "colorCorrection", null, ["colorTable"], options, camera, samplingMode, engine, reusable);
 
-        this._colorTableTexture = new Texture(colorTableUrl, camera.getScene(), true, false, Texture.TRILINEAR_SAMPLINGMODE);
+        const scene = camera?.getScene() || null;
+        this._colorTableTexture = new Texture(colorTableUrl, scene, true, false, Texture.TRILINEAR_SAMPLINGMODE);
         this._colorTableTexture.anisotropicFilteringLevel = 1;
         this._colorTableTexture.wrapU = Texture.CLAMP_ADDRESSMODE;
         this._colorTableTexture.wrapV = Texture.CLAMP_ADDRESSMODE;

--- a/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
@@ -9,7 +9,7 @@ import type { Engine } from "../Engines/engine";
 import "../Shaders/refraction.fragment";
 import { RegisterClass } from "../Misc/typeStore";
 import { SerializationHelper, serialize } from "../Misc/decorators";
-import { Nullable } from "../types";
+import type { Nullable } from "../types";
 
 declare type Scene = import("../scene").Scene;
 

--- a/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
@@ -9,6 +9,7 @@ import type { Engine } from "../Engines/engine";
 import "../Shaders/refraction.fragment";
 import { RegisterClass } from "../Misc/typeStore";
 import { SerializationHelper, serialize } from "../Misc/decorators";
+import { Nullable } from "../types";
 
 declare type Scene = import("../scene").Scene;
 
@@ -82,7 +83,7 @@ export class RefractionPostProcess extends PostProcess {
         depth: number,
         colorLevel: number,
         options: number | PostProcessOptions,
-        camera: Camera,
+        camera: Nullable<Camera>,
         samplingMode?: number,
         engine?: Engine,
         reusable?: boolean

--- a/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
@@ -4,6 +4,7 @@ import { PostProcess } from "./postProcess";
 import { Constants } from "../Engines/constants";
 
 import "../Shaders/tonemap.fragment";
+import { Nullable } from "../types";
 
 declare type Engine = import("../Engines/engine").Engine;
 
@@ -47,7 +48,7 @@ export class TonemapPostProcess extends PostProcess {
         private _operator: TonemappingOperator,
         /** Defines the required exposure adjustment */
         public exposureAdjustment: number,
-        camera: Camera,
+        camera: Nullable<Camera>,
         samplingMode: number = Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
         engine?: Engine,
         textureFormat = Constants.TEXTURETYPE_UNSIGNED_INT,

--- a/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
@@ -4,7 +4,7 @@ import { PostProcess } from "./postProcess";
 import { Constants } from "../Engines/constants";
 
 import "../Shaders/tonemap.fragment";
-import { Nullable } from "../types";
+import type { Nullable } from "../types";
 
 declare type Engine = import("../Engines/engine").Engine;
 

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -26,7 +26,7 @@ import "../Shaders/volumetricLightScatteringPass.fragment";
 import { Color4, Color3 } from "../Maths/math.color";
 import { Viewport } from "../Maths/math.viewport";
 import { RegisterClass } from "../Misc/typeStore";
-import { Nullable } from "../types";
+import type { Nullable } from "../types";
 
 declare type Engine = import("../Engines/engine").Engine;
 

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -26,6 +26,7 @@ import "../Shaders/volumetricLightScatteringPass.fragment";
 import { Color4, Color3 } from "../Maths/math.color";
 import { Viewport } from "../Maths/math.viewport";
 import { RegisterClass } from "../Misc/typeStore";
+import { Nullable } from "../types";
 
 declare type Engine = import("../Engines/engine").Engine;
 
@@ -125,7 +126,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
     constructor(
         name: string,
         ratio: any,
-        camera: Camera,
+        camera: Nullable<Camera>,
         mesh?: Mesh,
         samples: number = 100,
         samplingMode: number = Texture.BILINEAR_SAMPLINGMODE,
@@ -145,7 +146,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             reusable,
             "#define NUM_SAMPLES " + samples
         );
-        scene = camera?.getScene() ?? scene; // parameter "scene" can be null.
+        scene = camera?.getScene() ?? scene ?? this._scene; // parameter "scene" can be null.
 
         engine = scene.getEngine();
         this._viewPort = new Viewport(0, 0, 1, 1).toGlobal(engine.getRenderWidth(), engine.getRenderHeight());

--- a/packages/dev/core/src/PostProcesses/vrDistortionCorrectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/vrDistortionCorrectionPostProcess.ts
@@ -6,6 +6,7 @@ import { Texture } from "../Materials/Textures/texture";
 import { PostProcess } from "./postProcess";
 
 import "../Shaders/vrDistortionCorrection.fragment";
+import { Nullable } from "../types";
 
 /**
  * VRDistortionCorrectionPostProcess used for mobile VR
@@ -34,7 +35,7 @@ export class VRDistortionCorrectionPostProcess extends PostProcess {
      * @param isRightEye If this is for the right eye distortion
      * @param vrMetrics All the required metrics for the VR camera
      */
-    constructor(name: string, camera: Camera, isRightEye: boolean, vrMetrics: VRCameraMetrics) {
+    constructor(name: string, camera: Nullable<Camera>, isRightEye: boolean, vrMetrics: VRCameraMetrics) {
         super(name, "vrDistortionCorrection", ["LensCenter", "Scale", "ScaleIn", "HmdWarpParam"], null, vrMetrics.postProcessScaleFactor, camera, Texture.BILINEAR_SAMPLINGMODE);
 
         this._isRightEye = isRightEye;

--- a/packages/dev/core/src/PostProcesses/vrDistortionCorrectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/vrDistortionCorrectionPostProcess.ts
@@ -6,7 +6,7 @@ import { Texture } from "../Materials/Textures/texture";
 import { PostProcess } from "./postProcess";
 
 import "../Shaders/vrDistortionCorrection.fragment";
-import { Nullable } from "../types";
+import type { Nullable } from "../types";
 
 /**
  * VRDistortionCorrectionPostProcess used for mobile VR

--- a/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
@@ -29,7 +29,7 @@ export class VRMultiviewToSingleviewPostProcess extends PostProcess {
     constructor(name: string, camera: Nullable<Camera>, scaleFactor: number) {
         super(name, "vrMultiviewToSingleview", ["imageIndex"], ["multiviewSampler"], scaleFactor, camera, Texture.BILINEAR_SAMPLINGMODE);
 
-        const cam = camera ??  this.getCamera();
+        const cam = camera ?? this.getCamera();
         this.onSizeChangedObservable.add(() => {});
         this.onApplyObservable.add((effect: Effect) => {
             if (cam._scene.activeCamera && cam._scene.activeCamera.isLeftCamera) {

--- a/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
@@ -5,7 +5,7 @@ import { PostProcess } from "./postProcess";
 
 import "../Shaders/vrMultiviewToSingleview.fragment";
 import "../Engines/Extensions/engine.multiview";
-import { Nullable } from "../types";
+import type { Nullable } from "../types";
 
 /**
  * VRMultiviewToSingleview used to convert multiview texture arrays to standard textures for scenarios such as webVR

--- a/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/vrMultiviewToSingleviewPostProcess.ts
@@ -5,6 +5,7 @@ import { PostProcess } from "./postProcess";
 
 import "../Shaders/vrMultiviewToSingleview.fragment";
 import "../Engines/Extensions/engine.multiview";
+import { Nullable } from "../types";
 
 /**
  * VRMultiviewToSingleview used to convert multiview texture arrays to standard textures for scenarios such as webVR
@@ -25,17 +26,18 @@ export class VRMultiviewToSingleviewPostProcess extends PostProcess {
      * @param camera camera to be applied to
      * @param scaleFactor scaling factor to the size of the output texture
      */
-    constructor(name: string, camera: Camera, scaleFactor: number) {
+    constructor(name: string, camera: Nullable<Camera>, scaleFactor: number) {
         super(name, "vrMultiviewToSingleview", ["imageIndex"], ["multiviewSampler"], scaleFactor, camera, Texture.BILINEAR_SAMPLINGMODE);
 
+        const cam = camera ??  this.getCamera();
         this.onSizeChangedObservable.add(() => {});
         this.onApplyObservable.add((effect: Effect) => {
-            if (camera._scene.activeCamera && camera._scene.activeCamera.isLeftCamera) {
+            if (cam._scene.activeCamera && cam._scene.activeCamera.isLeftCamera) {
                 effect.setInt("imageIndex", 0);
             } else {
                 effect.setInt("imageIndex", 1);
             }
-            effect.setTexture("multiviewSampler", camera._multiviewTexture);
+            effect.setTexture("multiviewSampler", cam._multiviewTexture);
         });
     }
 }

--- a/packages/dev/postProcesses/src/asciiArt/asciiArtPostProcess.ts
+++ b/packages/dev/postProcesses/src/asciiArt/asciiArtPostProcess.ts
@@ -222,17 +222,7 @@ export class AsciiArtPostProcess extends PostProcess {
      * @param options can either be the font name or an option object following the IAsciiArtPostProcessOptions format
      */
     constructor(name: string, camera: Nullable<Camera>, options?: string | IAsciiArtPostProcessOptions) {
-        super(
-            name,
-            "asciiart",
-            ["asciiArtFontInfos", "asciiArtOptions"],
-            ["asciiArtFont"],
-            1,
-            camera,
-            Texture.TRILINEAR_SAMPLINGMODE,
-            undefined,
-            true
-        );
+        super(name, "asciiart", ["asciiArtFontInfos", "asciiArtOptions"], ["asciiArtFont"], 1, camera, Texture.TRILINEAR_SAMPLINGMODE, undefined, true);
 
         // Default values.
         let font = "40px Monospace";
@@ -250,7 +240,6 @@ export class AsciiArtPostProcess extends PostProcess {
             }
         }
 
-        
         const scene = camera?.getScene() || this._scene;
         this._asciiArtFontTexture = new AsciiArtFontTexture(name, font, characterSet, scene);
         const textureSize = this._asciiArtFontTexture.getSize();

--- a/packages/dev/postProcesses/src/asciiArt/asciiArtPostProcess.ts
+++ b/packages/dev/postProcesses/src/asciiArt/asciiArtPostProcess.ts
@@ -221,19 +221,16 @@ export class AsciiArtPostProcess extends PostProcess {
      * @param camera
      * @param options can either be the font name or an option object following the IAsciiArtPostProcessOptions format
      */
-    constructor(name: string, camera: Camera, options?: string | IAsciiArtPostProcessOptions) {
+    constructor(name: string, camera: Nullable<Camera>, options?: string | IAsciiArtPostProcessOptions) {
         super(
             name,
             "asciiart",
             ["asciiArtFontInfos", "asciiArtOptions"],
             ["asciiArtFont"],
-            {
-                width: camera.getEngine().getRenderWidth(),
-                height: camera.getEngine().getRenderHeight(),
-            },
+            1,
             camera,
             Texture.TRILINEAR_SAMPLINGMODE,
-            camera.getEngine(),
+            undefined,
             true
         );
 
@@ -253,7 +250,9 @@ export class AsciiArtPostProcess extends PostProcess {
             }
         }
 
-        this._asciiArtFontTexture = new AsciiArtFontTexture(name, font, characterSet, camera.getScene());
+        
+        const scene = camera?.getScene() || this._scene;
+        this._asciiArtFontTexture = new AsciiArtFontTexture(name, font, characterSet, scene);
         const textureSize = this._asciiArtFontTexture.getSize();
 
         this.onApply = (effect: Effect) => {

--- a/packages/dev/postProcesses/src/digitalRain/digitalRainPostProcess.ts
+++ b/packages/dev/postProcesses/src/digitalRain/digitalRainPostProcess.ts
@@ -249,7 +249,8 @@ export class DigitalRainPostProcess extends PostProcess {
             }
         }
 
-        this._digitalRainFontTexture = new DigitalRainFontTexture(name, font, characterSet, camera.getScene());
+        const scene = camera?.getScene() || null;
+        this._digitalRainFontTexture = new DigitalRainFontTexture(name, font, characterSet, scene);
         const textureSize = this._digitalRainFontTexture.getSize();
 
         let alpha = 0.0;

--- a/packages/dev/postProcesses/src/digitalRain/digitalRainPostProcess.ts
+++ b/packages/dev/postProcesses/src/digitalRain/digitalRainPostProcess.ts
@@ -220,19 +220,16 @@ export class DigitalRainPostProcess extends PostProcess {
      * @param camera
      * @param options can either be the font name or an option object following the IDigitalRainPostProcessOptions format
      */
-    constructor(name: string, camera: Camera, options?: string | IDigitalRainPostProcessOptions) {
+    constructor(name: string, camera: Nullable<Camera>, options?: string | IDigitalRainPostProcessOptions) {
         super(
             name,
             "digitalrain",
             ["digitalRainFontInfos", "digitalRainOptions", "cosTimeZeroOne", "matrixSpeed"],
             ["digitalRainFont"],
-            {
-                width: camera.getEngine().getRenderWidth(),
-                height: camera.getEngine().getRenderHeight(),
-            },
+            1.0,
             camera,
             Texture.TRILINEAR_SAMPLINGMODE,
-            camera.getEngine(),
+            undefined,
             true
         );
 


### PR DESCRIPTION
Camera is now optional for all posteffects except for anaglyph and multiview

[Thread](https://forum.babylonjs.com/t/issues-in-the-documentation-for-posteffects/34370) in the forums