### PR TITLE
Handle CSP violation errors when loading images.

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3924,7 +3924,7 @@ export class ThinEngine {
             this._internalTexturesCache.push(texture);
         }
 
-        const onInternalError = (message?: string, exception?: any, loadFallback: boolean = true) => {
+        const onInternalError = (message?: string, exception?: any) => {
             if (scene) {
                 scene.removePendingData(texture);
             }
@@ -3934,7 +3934,7 @@ export class ThinEngine {
                     texture.onLoadedObservable.remove(onLoadObserver);
                 }
 
-                if (EngineStore.UseFallbackTexture && loadFallback) {
+                if (EngineStore.UseFallbackTexture) {
                     this._createTextureBase(
                         EngineStore.FallbackTexture,
                         noMipmap,

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3924,7 +3924,7 @@ export class ThinEngine {
             this._internalTexturesCache.push(texture);
         }
 
-        const onInternalError = (message?: string, exception?: any) => {
+        const onInternalError = (message?: string, exception?: any, loadFallback: boolean = true) => {
             if (scene) {
                 scene.removePendingData(texture);
             }
@@ -3934,7 +3934,7 @@ export class ThinEngine {
                     texture.onLoadedObservable.remove(onLoadObserver);
                 }
 
-                if (EngineStore.UseFallbackTexture) {
+                if (EngineStore.UseFallbackTexture && loadFallback) {
                     this._createTextureBase(
                         EngineStore.FallbackTexture,
                         noMipmap,

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -220,7 +220,7 @@ export const LoadImage = (
     const img = new Image();
     SetCorsBehavior(url, img);
 
-    const handlersList: { target: any; name: string; handler: any }[] = [];
+    let handlersList: { target: any; name: string; handler: any }[] = [];
 
     const loadHandlersList = () => {
         handlersList.forEach((handler) => {
@@ -232,6 +232,7 @@ export const LoadImage = (
         handlersList.forEach((handler) => {
             handler.target.removeEventListener(handler.name, handler.handler);
         });
+        handlersList = [];
     };
 
     const loadHandler = () => {

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -152,7 +152,7 @@ export const SetCorsBehavior = (url: string | string[], element: { crossOrigin: 
 export const LoadImage = (
     input: string | ArrayBuffer | ArrayBufferView | Blob,
     onLoad: (img: HTMLImageElement | ImageBitmap) => void,
-    onError: (message?: string, exception?: any, ...extra: any[]) => void,
+    onError: (message?: string, exception?: any) => void,
     offlineProvider: Nullable<IOfflineProvider>,
     mimeType: string = "",
     imageBitmapOptions?: ImageBitmapOptions
@@ -177,14 +177,10 @@ export const LoadImage = (
 
     const engine = EngineStore.LastCreatedEngine;
 
-    const onErrorHandler = (exception: any, loadFallback: boolean = true) => {
+    const onErrorHandler = (exception: any) => {
         if (onError) {
             const inputText = url || input.toString();
-            onError(
-                `Error while trying to load image: ${inputText.indexOf("http") === 0 || inputText.length <= 128 ? inputText : inputText.slice(0, 128) + "..."}`,
-                exception,
-                loadFallback
-            );
+            onError(`Error while trying to load image: ${inputText.indexOf("http") === 0 || inputText.length <= 128 ? inputText : inputText.slice(0, 128) + "..."}`, exception);
         }
     };
 
@@ -261,7 +257,8 @@ export const LoadImage = (
         unloadHandlersList();
         const cspException = new Error(`CSP violation of policy ${err.effectiveDirective} ${err.blockedURI}. Current policy is ${err.originalPolicy}`);
 
-        onErrorHandler(cspException, false);
+        EngineStore.UseFallbackTexture = false;
+        onErrorHandler(cspException);
         if (usingObjectURL && img.src) {
             URL.revokeObjectURL(img.src);
         }


### PR DESCRIPTION
Previously, whenever a texture fetch failed, we would try to load the fallback texture with "data:". If the user's page has a CSP rule that prohibits this, this fallback load would fail and prompt another fallback load, leading to an infinite loop. Now, we stop trying to load the fallback if we hit a security violation error (which is where CSP falls).

This behavior can be reproduced on the Playground by adding the CSP tag to the document:
https://playground.babylonjs.com/#YCY2IL#1105
https://playground.babylonjs.com/#8LFTCH#1452