### PR TITLE
[GLTF Serializer] Allow GLTF Exporter to export WebP images

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -1142,6 +1142,9 @@ export class _GLTFMaterialExporter {
                         case "image/png":
                             mimeType = ImageMimeType.PNG;
                             break;
+                        case "image/webp":
+                            mimeType = ImageMimeType.WEBP;
+                            break;
                     }
                 }
 
@@ -1209,7 +1212,7 @@ export class _GLTFMaterialExporter {
         }
 
         imageData[textureName] = imageValues;
-        if (mimeType === ImageMimeType.JPEG || mimeType === ImageMimeType.PNG) {
+        if (mimeType === ImageMimeType.JPEG || mimeType === ImageMimeType.PNG || mimeType === ImageMimeType.WEBP) {
             const glTFImage: IImage = {
                 name: baseTextureName,
                 uri: textureName,

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -144,6 +144,10 @@ declare module BABYLON.GLTF2 {
          * PNG Mime-type
          */
         PNG = "image/png",
+        /**
+         * WEBP Mime-type
+         */
+        WEBP = "image/webp",
     }
 
     /**


### PR DESCRIPTION
Adds JPEG and WEBP as valid optional mimetype options when serializing to a GLB. 

Usage:
Add this to the dev host scene's button:

```
button1.onPointerUpObservable.add(function () {
        GLTF2Export.GLBAsync(scene, "webp.glb", {mimeType: ImageMimeType.WEBP}).then((glb) => {
            glb.downloadFiles();
          });
    });
```  

Output as per `gltf-transform inspect`
**PNG**
```
TEXTURES
 ────────────────────────────────────────────
┌───┬─────────────────────────────────────┬─────┬──────────────────────────┬───────────┬───────────┬────────────┬───────────┬──────────┐
│ # │ name                                │ uri │ slots                    │ instances │ mimeType  │ resolution │ size      │ gpuSize¹ │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼───────────┼────────────┼───────────┼──────────┤
│ 0 │ Material (Base Color) image         │     │ baseColorTexture         │ 1         │ image/png │ 1024x1024  │ 380.17 KB │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼───────────┼────────────┼───────────┼──────────┤
│ 1 │ Material (Metallic Roughness) image │     │ metallicRoughnessTexture │ 1         │ image/png │ 1024x1024  │ 2.66 MB   │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼───────────┼────────────┼───────────┼──────────┤
│ 2 │ Material (Normal) image             │     │ normalTexture            │ 1         │ image/png │ 1024x1024  │ 2.89 MB   │ 5.59 MB  │
└───┴─────────────────────────────────────┴─────┴──────────────────────────┴───────────┴───────────┴────────────┴───────────┴──────────┘
```


**JPEG***
```
TEXTURES
 ────────────────────────────────────────────
┌───┬─────────────────────────────────────┬─────┬──────────────────────────┬───────────┬────────────┬────────────┬───────────┬──────────┐
│ # │ name                                │ uri │ slots                    │ instances │ mimeType   │ resolution │ size      │ gpuSize¹ │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 0 │ Material (Base Color) image         │     │ baseColorTexture         │ 1         │ image/jpeg │ 1024x1024  │ 42.62 KB  │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 1 │ Material (Metallic Roughness) image │     │ metallicRoughnessTexture │ 1         │ image/jpeg │ 1024x1024  │ 537.51 KB │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 2 │ Material (Normal) image             │     │ normalTexture            │ 1         │ image/jpeg │ 1024x1024  │ 584.05 KB │ 5.59 MB  │
└───┴─────────────────────────────────────┴─────┴──────────────────────────┴───────────┴────────────┴────────────┴───────────┴──────────┘
```
**WEBP**
```
TEXTURES
 ────────────────────────────────────────────
┌───┬─────────────────────────────────────┬─────┬──────────────────────────┬───────────┬────────────┬────────────┬───────────┬──────────┐
│ # │ name                                │ uri │ slots                    │ instances │ mimeType   │ resolution │ size      │ gpuSize¹ │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 0 │ Material (Base Color) image         │     │ baseColorTexture         │ 1         │ image/webp │ 1024x1024  │ 12.19 KB  │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 1 │ Material (Metallic Roughness) image │     │ metallicRoughnessTexture │ 1         │ image/webp │ 1024x1024  │ 375.18 KB │ 5.59 MB  │
├───┼─────────────────────────────────────┼─────┼──────────────────────────┼───────────┼────────────┼────────────┼───────────┼──────────┤
│ 2 │ Material (Normal) image             │     │ normalTexture            │ 1         │ image/webp │ 1024x1024  │ 418.08 KB │ 5.59 MB  │
└───┴─────────────────────────────────────┴─────┴──────────────────────────┴───────────┴────────────┴────────────┴───────────┴──────────┘
```

My first PR for this project, so let me know if I'm missing anything. 