### PR TITLE
Fix GlowLayer resize bug

### DIFF
--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -121,6 +121,7 @@ export class GlowLayer extends EffectLayer {
      * Sets the kernel size of the blur.
      */
     public set blurKernelSize(value: number) {
+        this._options.blurKernelSize = value * 2;
         this._horizontalBlurPostprocess1.kernel = value;
         this._verticalBlurPostprocess1.kernel = value;
         this._horizontalBlurPostprocess2.kernel = value;

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -121,7 +121,7 @@ export class GlowLayer extends EffectLayer {
      * Sets the kernel size of the blur.
      */
     public set blurKernelSize(value: number) {
-        // On resize, _createTextureAndPostProcesses will divide this value by 2 so we multiply it by 2 here.
+        // On resize _createTextureAndPostProcesses will divide this value by 2 so we multiply it by 2 here.
         this._options.blurKernelSize = value * 2;
 
         this._horizontalBlurPostprocess1.kernel = value;

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -121,7 +121,9 @@ export class GlowLayer extends EffectLayer {
      * Sets the kernel size of the blur.
      */
     public set blurKernelSize(value: number) {
+        // On resize, _createTextureAndPostProcesses will divide this value by 2 so we multiply it by 2 here.
         this._options.blurKernelSize = value * 2;
+
         this._horizontalBlurPostprocess1.kernel = value;
         this._verticalBlurPostprocess1.kernel = value;
         this._horizontalBlurPostprocess2.kernel = value;


### PR DESCRIPTION
Fix GlowLayer issue where blurKernelSize is reset when canvas is resized. Note: the value passed to the setter is multiplied by 2 because later _createTextureAndPostProcesses() will divide it by 2.

Test Playground: https://playground.babylonjs.com/#RPA5G8
Forum: https://forum.babylonjs.com/t/glowlayers-kernelblursize-is-reset-on-canvas-resize/34495