### PR TITLE
[GUI] deal with dead codes correctly

### DIFF
--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -718,7 +718,6 @@ export class InputText extends Control implements IFocusableControl {
             this._currentKey = key;
             this.onBeforeKeyAddObservable.notifyObservers(this);
             key = this._currentKey;
-            console.log(key);
             if (this._addKey && !this._deadKey) {
                 if (this._isTextHighlightOn) {
                     this._textWrapper.removePart(this._startHighlightIndex, this._endHighlightIndex, key);
@@ -728,7 +727,6 @@ export class InputText extends Control implements IFocusableControl {
                     this._blinkIsEven = false;
                     this._markAsDirty();
                 } else if (this._cursorOffset === 0) {
-                    console.log("add to end");
                     this.text += this._deadKey && evt?.key ? evt.key : key;
                 } else {
                     const insertPosition = this._textWrapper.length - this._cursorOffset;

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -272,7 +272,7 @@ export class InputText extends Control implements IFocusableControl {
         this._markAsDirty();
     }
 
-    /** Gets or sets the dead key flag */
+    /** Gets or sets the dead key. 0 to disable. */
     @serialize()
     public get deadKey(): boolean {
         return this._deadKey;
@@ -696,28 +696,11 @@ export class InputText extends Control implements IFocusableControl {
                 this._cursorIndex = -1;
                 this._markAsDirty();
                 return;
-            case 222: // Dead
-                if (evt) {
-                    //add support for single and double quotes
-                    if (evt.code == "Quote") {
-                        if (evt.shiftKey) {
-                            keyCode = 34;
-                            key = '"';
-                        } else {
-                            keyCode = 39;
-                            key = "'";
-                        }
-                    } else {
-                        evt.preventDefault();
-                        this._cursorIndex = -1;
-                        this.deadKey = true;
-                    }
-                } else {
-                    this._cursorIndex = -1;
-                    this.deadKey = true;
-                }
-                break;
         }
+        if (keyCode === 32) {
+            key = evt?.key ?? " ";
+        }
+        this._deadKey = key === "Dead";
         // Printable characters
         if (
             key &&
@@ -735,7 +718,8 @@ export class InputText extends Control implements IFocusableControl {
             this._currentKey = key;
             this.onBeforeKeyAddObservable.notifyObservers(this);
             key = this._currentKey;
-            if (this._addKey) {
+            console.log(key);
+            if (this._addKey && !this._deadKey) {
                 if (this._isTextHighlightOn) {
                     this._textWrapper.removePart(this._startHighlightIndex, this._endHighlightIndex, key);
                     this._textHasChanged();
@@ -744,7 +728,8 @@ export class InputText extends Control implements IFocusableControl {
                     this._blinkIsEven = false;
                     this._markAsDirty();
                 } else if (this._cursorOffset === 0) {
-                    this.text += key;
+                    console.log("add to end");
+                    this.text += this._deadKey && evt?.key ? evt.key : key;
                 } else {
                     const insertPosition = this._textWrapper.length - this._cursorOffset;
                     this._textWrapper.removePart(insertPosition, insertPosition, key);


### PR DESCRIPTION
Playground: #I1Y5YT#47

This treats dead code as expected minus a few modifiers that are not available in a keyboard event. For example - on a supporting keyboard - when entering a quote (") and A afterwards we should output ä, but the expected result if entering " and f (for example) afterwards is: `"f`. This is not provided in the event. Threfore we are using the default behavior, which is output the dead key if space was entered right after.