### PR TITLE
GLB header length check from exception to warning

### DIFF
--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -964,10 +964,12 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
                 this._log(`Binary version: ${version}`);
             }
 
-            const length = dataReader.readUint32();
-            if (dataReader.buffer.byteLength !== 0 && length !== dataReader.buffer.byteLength) {
-                throw new Error(`Length in header does not match actual data length: ${length} != ${dataReader.buffer.byteLength}`);
+            const headerLength = dataReader.readUint32();
+            if (dataReader.buffer.byteLength !== 0 && headerLength !== dataReader.buffer.byteLength) {
+                Logger.Warn(`Header length does not match actual data length: ${headerLength} != ${dataReader.buffer.byteLength}`);
             }
+
+            const length = Math.min(headerLength, dataReader.buffer.byteLength);
 
             let unpacked: Promise<IGLTFLoaderData>;
             switch (version) {

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -964,12 +964,10 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
                 this._log(`Binary version: ${version}`);
             }
 
-            const headerLength = dataReader.readUint32();
-            if (dataReader.buffer.byteLength !== 0 && headerLength !== dataReader.buffer.byteLength) {
-                Logger.Warn(`Header length does not match actual data length: ${headerLength} != ${dataReader.buffer.byteLength}`);
+            const length = dataReader.readUint32();
+            if (!this.useRangeRequests && length !== dataReader.buffer.byteLength) {
+                Logger.Warn(`Length in header does not match actual data length: ${length} != ${dataReader.buffer.byteLength}`);
             }
-
-            const length = Math.min(headerLength, dataReader.buffer.byteLength);
 
             let unpacked: Promise<IGLTFLoaderData>;
             switch (version) {


### PR DESCRIPTION
glTF-Validator accepts some GLBs that we don't. Loosening the check to allow them to go through with a warning in the log.