### PR TITLE
Fix blur kernel size in glow layer second try

### DIFF
--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -139,7 +139,7 @@ export class GlowLayer extends EffectLayer {
      */
     @serialize()
     public get blurKernelSize(): number {
-        return this._horizontalBlurPostprocess1.kernel;
+        return this._options.blurKernelSize;
     }
 
     /**


### PR DESCRIPTION
https://forum.babylonjs.com/t/glowlayers-kernelblursize-is-reset-on-canvas-resize/34495/4