### PR TITLE
call the onNew observables when the elements are constructed

### DIFF
--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -145,13 +145,13 @@ export class Skeleton implements IAnimatable {
         this._scene = scene || EngineStore.LastCreatedScene;
         this._uniqueId = this._scene.getUniqueId();
 
-        this._scene.addSkeleton(this);
-
+        
         //make sure it will recalculate the matrix next time prepare is called.
         this._isDirty = true;
-
+        
         const engineCaps = this._scene.getEngine().getCaps();
         this._canUseTextureForBones = engineCaps.textureFloat && engineCaps.maxVertexTextureImageUnits > 0;
+        this._scene.addSkeleton(this);
     }
 
     /**

--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -145,10 +145,9 @@ export class Skeleton implements IAnimatable {
         this._scene = scene || EngineStore.LastCreatedScene;
         this._uniqueId = this._scene.getUniqueId();
 
-        
         //make sure it will recalculate the matrix next time prepare is called.
         this._isDirty = true;
-        
+
         const engineCaps = this._scene.getEngine().getCaps();
         this._canUseTextureForBones = engineCaps.textureFloat && engineCaps.maxVertexTextureImageUnits > 0;
         this._scene.addSkeleton(this);

--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -49,11 +49,11 @@ export class MultiMaterial extends Material {
     constructor(name: string, scene?: Scene) {
         super(name, scene, true);
 
-        this.getScene().multiMaterials.push(this);
-
+        
         this.subMaterials = new Array<Material>();
-
+        
         this._storeEffectOnSubMeshes = true; // multimaterial is considered like a push material
+        this.getScene().multiMaterials.push(this);
     }
 
     private _hookArray(array: Nullable<Material>[]): void {

--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -49,9 +49,8 @@ export class MultiMaterial extends Material {
     constructor(name: string, scene?: Scene) {
         super(name, scene, true);
 
-        
         this.subMaterials = new Array<Material>();
-        
+
         this._storeEffectOnSubMeshes = true; // multimaterial is considered like a push material
         this.getScene().multiMaterials.push(this);
     }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2704,7 +2704,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         this.cameras.push(newCamera);
-        
+
         if (!newCamera.parent) {
             newCamera._addToSceneRootNodes();
         }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2359,13 +2359,12 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             newMesh._addToSceneRootNodes();
         }
 
-        this.onNewMeshAddedObservable.notifyObservers(newMesh);
-
         if (recursive) {
             newMesh.getChildMeshes().forEach((m) => {
                 this.addMesh(m);
             });
         }
+        setTimeout(() => this.onNewMeshAddedObservable.notifyObservers(newMesh));
     }
 
     /**
@@ -2418,7 +2417,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             newTransformNode._addToSceneRootNodes();
         }
 
-        this.onNewTransformNodeAddedObservable.notifyObservers(newTransformNode);
+        setTimeout(() => this.onNewTransformNodeAddedObservable.notifyObservers(newTransformNode));
     }
 
     /**
@@ -2683,7 +2682,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             }
         }
 
-        this.onNewLightAddedObservable.notifyObservers(newLight);
+        setTimeout(() => this.onNewLightAddedObservable.notifyObservers(newLight));
     }
 
     /**
@@ -2705,11 +2704,12 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         this.cameras.push(newCamera);
-        this.onNewCameraAddedObservable.notifyObservers(newCamera);
-
+        
         if (!newCamera.parent) {
             newCamera._addToSceneRootNodes();
         }
+
+        setTimeout(() => this.onNewCameraAddedObservable.notifyObservers(newCamera));
     }
 
     /**
@@ -2785,7 +2785,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         newMaterial._indexInSceneMaterialArray = this.materials.length;
         this.materials.push(newMaterial);
-        this.onNewMaterialAddedObservable.notifyObservers(newMaterial);
+        setTimeout(() => this.onNewMaterialAddedObservable.notifyObservers(newMaterial));
     }
 
     /**
@@ -2833,7 +2833,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             return;
         }
         this.textures.push(newTexture);
-        this.onNewTextureAddedObservable.notifyObservers(newTexture);
+        setTimeout(() => this.onNewTextureAddedObservable.notifyObservers(newTexture));
     }
 
     /**


### PR DESCRIPTION
OnNew observables were called earlier than they should have. When, for example, a PBR material is constructed, the onNewMaterialAdded observable notifies when the Material constructor is done but before the PBR material constructor is done.
This wraps the needed observables in a setTimeout that guarantees that the observable notifies in the next tick and after the (sync) constructor is done.