### PR TITLE
Normalized return values and made vector classes use extendable types

### DIFF
--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -2915,13 +2915,13 @@ export class Vector4 {
      */
     constructor(
         /** x value of the vector */
-        public x: number,
+        public x: number = 0,
         /** y value of the vector */
-        public y: number,
+        public y: number = 0,
         /** z value of the vector */
-        public z: number,
+        public z: number = 0,
         /** w value of the vector */
-        public w: number
+        public w: number = 0
     ) {}
 
     /**

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -12,10 +12,10 @@ import { EngineStore } from "../Engines/engineStore";
 
 type TransformNode = import("../Meshes/transformNode").TransformNode;
 
-export type Vector2Constructor<T extends Vector2> = new (x?: number, y?: number) => T;
-export type Vector3Constructor<T extends Vector3> = new (x?: number, y?: number, z?: number) => T;
-export type Vector4Constructor<T extends Vector4> = new (x?: number, y?: number, z?: number, w?: number) => T;
-export type QuaternionConstructor<T extends Quaternion> = new (x?: number, y?: number, z?: number, w?: number) => T;
+export type Vector2Constructor<T extends Vector2> = new (...args: ConstructorParameters<typeof Vector2>) => T;
+export type Vector3Constructor<T extends Vector3> = new (...args: ConstructorParameters<typeof Vector3>) => T;
+export type Vector4Constructor<T extends Vector4> = new (...args: ConstructorParameters<typeof Vector4>) => T;
+export type QuaternionConstructor<T extends Quaternion> = new (...args: ConstructorParameters<typeof Quaternion>) => T;
 export type MatrixConstructor<T extends Matrix> = new () => T;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -150,7 +150,7 @@ export class Vector2 {
      * @returns a new Vector2 set with the addition of the current Vector2 and the given one coordinates
      */
     public add(otherVector: DeepImmutable<Vector2>): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -185,7 +185,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public addVector3(otherVector: Vector3): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -195,7 +195,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public subtract(otherVector: Vector2): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x - otherVector.x, this.y - otherVector.y);
     }
 
     /**
@@ -241,7 +241,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiply(otherVector: DeepImmutable<Vector2>): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x * otherVector.x, this.y * otherVector.y);
     }
 
     /**
@@ -265,7 +265,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiplyByFloats(x: number, y: number): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x * x, this.y * y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x * x, this.y * y);
     }
 
     /**
@@ -275,7 +275,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public divide(otherVector: Vector2): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x / otherVector.x, this.y / otherVector.y);
     }
 
     /**
@@ -307,7 +307,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public negate(): this {
-        return new (<Vector2Constructor<this>>this.constructor)(-this.x, -this.y);
+        return new (this.constructor as Vector2Constructor<this>)(-this.x, -this.y);
     }
 
     /**
@@ -350,7 +350,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public scale(scale: number): this {
-        const result = new (<Vector2Constructor<this>>this.constructor)(0, 0);
+        const result = new (this.constructor as Vector2Constructor<this>)(0, 0);
         this.scaleToRef(scale, result);
         return result;
     }
@@ -409,7 +409,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public floor(): this {
-        return new (<Vector2Constructor<this>>this.constructor)(Math.floor(this.x), Math.floor(this.y));
+        return new (this.constructor as Vector2Constructor<this>)(Math.floor(this.x), Math.floor(this.y));
     }
 
     /**
@@ -419,7 +419,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public fract(): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
+        return new (this.constructor as Vector2Constructor<this>)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
     }
 
     /**
@@ -474,7 +474,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public clone(): this {
-        return new (<Vector2Constructor<this>>this.constructor)(this.x, this.y);
+        return new (this.constructor as Vector2Constructor<this>)(this.x, this.y);
     }
 
     // Statics
@@ -561,7 +561,7 @@ export class Vector2 {
                 (2.0 * value1.y - 5.0 * value2.y + 4.0 * value3.y - value4.y) * squared +
                 (-value1.y + 3.0 * value2.y - 3.0 * value3.y + value4.y) * cubed);
 
-        return new (<Vector2Constructor<T>>value1.constructor)(x, y);
+        return new (value1.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -583,7 +583,7 @@ export class Vector2 {
         y = y > max.y ? max.y : y;
         y = y < min.y ? min.y : y;
 
-        return new (<Vector2Constructor<T>>value.constructor)(x, y);
+        return new (value.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -613,7 +613,7 @@ export class Vector2 {
         const x = value1.x * part1 + value2.x * part2 + tangent1.x * part3 + tangent2.x * part4;
         const y = value1.y * part1 + value2.y * part2 + tangent1.y * part3 + tangent2.y * part4;
 
-        return new (<Vector2Constructor<T>>value1.constructor)(x, y);
+        return new (value1.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -633,7 +633,7 @@ export class Vector2 {
         tangent2: DeepImmutable<Vector2>,
         time: number
     ): T {
-        const result = new (<Vector2Constructor<T>>value1.constructor)();
+        const result = new (value1.constructor as Vector2Constructor<T>)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -678,7 +678,7 @@ export class Vector2 {
     public static Lerp<T extends Vector2>(start: DeepImmutable<T>, end: DeepImmutable<Vector2>, amount: number): Vector2 {
         const x = start.x + (end.x - start.x) * amount;
         const y = start.y + (end.y - start.y) * amount;
-        return new (<Vector2Constructor<T>>start.constructor)(x, y);
+        return new (start.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -699,7 +699,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
-        const newVector = new (<Vector2Constructor<T>>vector.constructor)();
+        const newVector = new (vector.constructor as Vector2Constructor<T>)();
         this.NormalizeToRef(vector, newVector);
         return newVector;
     }
@@ -733,7 +733,7 @@ export class Vector2 {
     public static Minimize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x < right.x ? left.x : right.x;
         const y = left.y < right.y ? left.y : right.y;
-        return new (<Vector2Constructor<T>>left.constructor)(x, y);
+        return new (left.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -746,7 +746,7 @@ export class Vector2 {
     public static Maximize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x > right.x ? left.x : right.x;
         const y = left.y > right.y ? left.y : right.y;
-        return new (<Vector2Constructor<T>>left.constructor)(x, y);
+        return new (left.constructor as Vector2Constructor<T>)(x, y);
     }
 
     /**
@@ -757,7 +757,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Transform<T extends Vector2>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = new (<Vector2Constructor<T>>vector.constructor)();
+        const result = new (vector.constructor as Vector2Constructor<T>)();
         Vector2.TransformToRef(vector, transformation, result);
         return result;
     }
@@ -830,7 +830,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Center<T extends Vector2>(value1: DeepImmutable<T>, value2: DeepImmutable<Vector2>): T {
-        const result = new (<Vector2Constructor<T>>value1.constructor)();
+        const result = new (value1.constructor as Vector2Constructor<T>)();
         return Vector2.CenterToRef(value1, value2, result);
     }
 
@@ -1048,7 +1048,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public add(otherVector: DeepImmutable<Vector3>): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
     /**
@@ -1082,7 +1082,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtract(otherVector: DeepImmutable<Vector3>): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
     }
 
     /**
@@ -1105,7 +1105,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtractFromFloats(x: number, y: number, z: number): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x - x, this._y - y, this._z - z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x - x, this._y - y, this._z - z);
     }
 
     /**
@@ -1127,7 +1127,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public negate(): this {
-        return new (<Vector3Constructor<this>>this.constructor)(-this._x, -this._y, -this._z);
+        return new (this.constructor as Vector3Constructor<this>)(-this._x, -this._y, -this._z);
     }
 
     /**
@@ -1172,7 +1172,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public scale(scale: number): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x * scale, this._y * scale, this._z * scale);
+        return new (this.constructor as Vector3Constructor<this>)(this._x * scale, this._y * scale, this._z * scale);
     }
 
     /**
@@ -1251,7 +1251,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public applyRotationQuaternion(q: Quaternion): this {
-        return this.applyRotationQuaternionToRef(q, new (<Vector3Constructor<this>>this.constructor)());
+        return this.applyRotationQuaternionToRef(q, new (this.constructor as Vector3Constructor<this>)());
     }
 
     /**
@@ -1273,7 +1273,7 @@ export class Vector3 {
      * @returns the projected vector3
      */
     public projectOnPlane<T extends Vector3>(plane: Plane, origin: Vector3): T {
-        const result = new (<Vector3Constructor<T>>this.constructor)();
+        const result = new (this.constructor as Vector3Constructor<T>)();
         this.projectOnPlaneToRef(plane, origin, result);
 
         return result;
@@ -1395,7 +1395,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public multiplyByFloats(x: number, y: number, z: number): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x * x, this._y * y, this._z * z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x * x, this._y * y, this._z * z);
     }
 
     /**
@@ -1405,7 +1405,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public divide(otherVector: DeepImmutable<Vector3>): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
     /**
@@ -1540,7 +1540,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public floor(): this {
-        return new (<Vector3Constructor<this>>this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
+        return new (this.constructor as Vector3Constructor<this>)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
     }
 
     /**
@@ -1549,7 +1549,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public fract(): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
+        return new (this.constructor as Vector3Constructor<this>)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
     }
 
     // Properties
@@ -1643,7 +1643,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public cross(other: Vector3): this {
-        const result = new (<Vector3Constructor<this>>this.constructor)();
+        const result = new (this.constructor as Vector3Constructor<this>)();
         return Vector3.CrossToRef(this, other, result);
     }
 
@@ -1668,7 +1668,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public normalizeToNew(): this {
-        const normalized = new (<Vector3Constructor<this>>this.constructor)(0, 0, 0);
+        const normalized = new (this.constructor as Vector3Constructor<this>)(0, 0, 0);
         this.normalizeToRef(normalized);
         return normalized;
     }
@@ -1694,7 +1694,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public clone(): this {
-        return new (<Vector3Constructor<this>>this.constructor)(this._x, this._y, this._z);
+        return new (this.constructor as Vector3Constructor<this>)(this._x, this._y, this._z);
     }
 
     /**
@@ -2226,7 +2226,7 @@ export class Vector3 {
                 (2.0 * value1._z - 5.0 * value2._z + 4.0 * value3._z - value4._z) * squared +
                 (-value1._z + 3.0 * value2._z - 3.0 * value3._z + value4._z) * cubed);
 
-        return new (<Vector3Constructor<T>>value1.constructor)(x, y, z);
+        return new (value1.constructor as Vector3Constructor<T>)(x, y, z);
     }
 
     /**
@@ -2240,7 +2240,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Clamp<T extends Vector3>(value: DeepImmutable<T>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): T {
-        const result = new (<Vector3Constructor<T>>value.constructor)();
+        const result = new (value.constructor as Vector3Constructor<T>)();
         Vector3.ClampToRef(value, min, max, result);
         return result;
     }
@@ -2311,7 +2311,7 @@ export class Vector3 {
         const x = value1._x * part1 + value2._x * part2 + tangent1._x * part3 + tangent2._x * part4;
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
-        return new (<Vector3Constructor<T>>value1.constructor)(x, y, z);
+        return new (value1.constructor as Vector3Constructor<T>)(x, y, z);
     }
 
     /**
@@ -2331,7 +2331,7 @@ export class Vector3 {
         tangent2: DeepImmutable<Vector3>,
         time: number
     ): T {
-        const result = new (<Vector3Constructor<T>>value1.constructor)();
+        const result = new (value1.constructor as Vector3Constructor<T>)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -2374,7 +2374,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Lerp<T extends Vector3>(start: DeepImmutable<T>, end: DeepImmutable<Vector3>, amount: number): T {
-        const result = new (<Vector3Constructor<T>>start.constructor)(0, 0, 0);
+        const result = new (start.constructor as Vector3Constructor<T>)(0, 0, 0);
         Vector3.LerpToRef(start, end, amount, result);
         return result;
     }
@@ -2415,7 +2415,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public static Cross<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const result = new (<Vector3Constructor<T>>left.constructor)();
+        const result = new (left.constructor as Vector3Constructor<T>)();
         Vector3.CrossToRef(left, right, result);
         return result;
     }
@@ -2471,7 +2471,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Project<T extends Vector3>(vector: DeepImmutable<T>, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>, viewport: DeepImmutable<Viewport>): T {
-        const result = new (<Vector3Constructor<T>>vector.constructor)();
+        const result = new (vector.constructor as Vector3Constructor<T>)();
         Vector3.ProjectToRef(vector, world, transform, viewport, result);
         return result;
     }
@@ -2562,7 +2562,7 @@ export class Vector3 {
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>
     ): T {
-        const result = new (<Vector3Constructor<T>>source.constructor)();
+        const result = new (source.constructor as Vector3Constructor<T>)();
 
         Vector3.UnprojectToRef(source, viewportWidth, viewportHeight, world, view, projection, result);
 
@@ -2645,7 +2645,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Minimize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const min = new (<Vector3Constructor<T>>left.constructor)();
+        const min = new (left.constructor as Vector3Constructor<T>)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -2659,7 +2659,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Maximize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const max = new (<Vector3Constructor<T>>left.constructor)();
+        const max = new (left.constructor as Vector3Constructor<T>)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -2884,7 +2884,7 @@ export class Vector3 {
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/target_align
      */
     public static RotationFromAxis<T extends Vector3>(axis1: DeepImmutable<T>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): T {
-        const rotation = new (<Vector3Constructor<T>>axis1.constructor)();
+        const rotation = new (axis1.constructor as Vector3Constructor<T>)();
         Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
         return rotation;
     }
@@ -3023,7 +3023,7 @@ export class Vector4 {
      * @returns the resulting vector
      */
     public add(otherVector: DeepImmutable<Vector4>): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
     }
 
     /**
@@ -3059,7 +3059,7 @@ export class Vector4 {
      * @returns the new vector with the result
      */
     public subtract(otherVector: DeepImmutable<Vector4>): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
     }
 
     /**
@@ -3088,7 +3088,7 @@ export class Vector4 {
      * @returns new vector containing the result
      */
     public subtractFromFloats(x: number, y: number, z: number, w: number): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     /**
@@ -3113,7 +3113,7 @@ export class Vector4 {
      * @returns a new vector with the negated values
      */
     public negate(): this {
-        return new (<Vector4Constructor<this>>this.constructor)(-this.x, -this.y, -this.z, -this.w);
+        return new (this.constructor as Vector4Constructor<this>)(-this.x, -this.y, -this.z, -this.w);
     }
 
     /**
@@ -3156,7 +3156,7 @@ export class Vector4 {
      * @returns a new vector with the result
      */
     public scale(scale: number): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
+        return new (this.constructor as Vector4Constructor<this>)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
     }
 
     /**
@@ -3243,7 +3243,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiply(otherVector: DeepImmutable<Vector4>): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
     }
     /**
      * Updates the given vector "result" with the multiplication result of the current Vector4 and the given one.
@@ -3267,7 +3267,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiplyByFloats(x: number, y: number, z: number, w: number): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x * x, this.y * y, this.z * z, this.w * w);
     }
     /**
      * Returns a new Vector4 set with the division result of the current Vector4 by the given one.
@@ -3275,7 +3275,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public divide(otherVector: DeepImmutable<Vector4>): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
     }
     /**
      * Updates the given vector "result" with the division result of the current Vector4 by the given one.
@@ -3346,7 +3346,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public floor(): this {
-        return new (<Vector4Constructor<this>>this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
+        return new (this.constructor as Vector4Constructor<this>)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
     }
 
     /**
@@ -3354,7 +3354,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public fract(): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
+        return new (this.constructor as Vector4Constructor<this>)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
     }
 
     // Properties
@@ -3400,7 +3400,7 @@ export class Vector4 {
      * @returns the new cloned vector
      */
     public clone(): this {
-        return new (<Vector4Constructor<this>>this.constructor)(this.x, this.y, this.z, this.w);
+        return new (this.constructor as Vector4Constructor<this>)(this.x, this.y, this.z, this.w);
     }
     /**
      * Updates the current Vector4 with the given one coordinates.
@@ -3554,7 +3554,7 @@ export class Vector4 {
      * @returns a new vector with the minimum of the left and right vector values
      */
     public static Minimize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const min = new (<Vector4Constructor<T>>left.constructor)();
+        const min = new (left.constructor as Vector4Constructor<T>)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -3567,7 +3567,7 @@ export class Vector4 {
      * @returns a new vector with the maximum of the left and right vector values
      */
     public static Maximize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const max = new (<Vector4Constructor<T>>left.constructor)();
+        const max = new (left.constructor as Vector4Constructor<T>)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -3677,7 +3677,7 @@ export class Vector4 {
      * @returns the new vector
      */
     public static TransformNormal<T extends Vector4>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = new (<Vector4Constructor<T>>vector.constructor)();
+        const result = new (vector.constructor as Vector4Constructor<T>)();
         Vector4.TransformNormalToRef(vector, transformation, result);
         return result;
     }
@@ -3892,7 +3892,7 @@ export class Quaternion {
      * @returns a new quaternion copied from the current one
      */
     public clone(): this {
-        return new (<QuaternionConstructor<this>>this.constructor)(this._x, this._y, this._z, this._w);
+        return new (this.constructor as QuaternionConstructor<this>)(this._x, this._y, this._z, this._w);
     }
 
     /**
@@ -3942,7 +3942,7 @@ export class Quaternion {
      * @returns a new quaternion as the addition result of the given one and the current quaternion
      */
     public add(other: DeepImmutable<Quaternion>): this {
-        return new (<QuaternionConstructor<this>>this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
+        return new (this.constructor as QuaternionConstructor<this>)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
     }
 
     /**
@@ -3964,7 +3964,7 @@ export class Quaternion {
      * @returns a new quaternion as the subtraction result of the given one from the current one
      */
     public subtract(other: Quaternion): this {
-        return new (<QuaternionConstructor<this>>this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
+        return new (this.constructor as QuaternionConstructor<this>)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
     }
 
     /**
@@ -3986,7 +3986,7 @@ export class Quaternion {
      * @returns a new quaternion set by multiplying the current quaternion coordinates by the float "scale"
      */
     public scale(value: number): this {
-        return new (<QuaternionConstructor<this>>this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
+        return new (this.constructor as QuaternionConstructor<this>)(this._x * value, this._y * value, this._z * value, this._w * value);
     }
 
     /**
@@ -4037,7 +4037,7 @@ export class Quaternion {
      * @returns a new quaternion set as the multiplication result of the current one with the given one "q1"
      */
     public multiply(q1: DeepImmutable<Quaternion>): this {
-        const result = new (<QuaternionConstructor<this>>this.constructor)(0, 0, 0, 1.0);
+        const result = new (this.constructor as QuaternionConstructor<this>)(0, 0, 0, 1.0);
         this.multiplyToRef(q1, result);
         return result;
     }
@@ -4093,7 +4093,7 @@ export class Quaternion {
      * @returns a new quaternion
      */
     public conjugate(): this {
-        return new (<QuaternionConstructor<this>>this.constructor)(-this._x, -this._y, -this._z, this._w);
+        return new (this.constructor as QuaternionConstructor<this>)(-this._x, -this._y, -this._z, this._w);
     }
 
     /**
@@ -4384,7 +4384,7 @@ export class Quaternion {
      * @returns a new quaternion as the inverted current quaternion
      */
     public static Inverse<T extends Quaternion>(q: DeepImmutable<T>): T {
-        return new (<QuaternionConstructor<T>>q.constructor)(-q._x, -q._y, -q._z, q._w);
+        return new (q.constructor as QuaternionConstructor<T>)(-q._x, -q._y, -q._z, q._w);
     }
 
     /**
@@ -4778,7 +4778,7 @@ export class Quaternion {
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
         const w = value1._w * part1 + value2._w * part2 + tangent1._w * part3 + tangent2._w * part4;
-        return new (<QuaternionConstructor<T>>value1.constructor)(x, y, z, w);
+        return new (value1.constructor as QuaternionConstructor<T>)(x, y, z, w);
     }
 
     /**
@@ -4797,7 +4797,7 @@ export class Quaternion {
         tangent2: DeepImmutable<Quaternion>,
         time: number
     ): T {
-        const result = new (<QuaternionConstructor<T>>value1.constructor)();
+        const result = new (value1.constructor as QuaternionConstructor<T>)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -5052,7 +5052,7 @@ export class Matrix {
      * @returns a new matrix as the addition of the current matrix and the given one
      */
     public add(other: DeepImmutable<Matrix>): this {
-        const result = new (<MatrixConstructor<this>>this.constructor)();
+        const result = new (this.constructor as MatrixConstructor<this>)();
         this.addToRef(other, result);
         return result;
     }
@@ -5291,7 +5291,7 @@ export class Matrix {
      * @returns a new matrix set with the multiplication result of the current Matrix and the given one
      */
     public multiply(other: DeepImmutable<Matrix>): this {
-        const result = new (<MatrixConstructor<this>>this.constructor)();
+        const result = new (this.constructor as MatrixConstructor<this>)();
         this.multiplyToRef(other, result);
         return result;
     }
@@ -5468,7 +5468,7 @@ export class Matrix {
      * @returns a new matrix from the current matrix
      */
     public clone(): this {
-        const matrix = new (<MatrixConstructor<this>>this.constructor)();
+        const matrix = new (this.constructor as MatrixConstructor<this>)();
         matrix.copyFrom(this);
         return matrix;
     }
@@ -5632,7 +5632,7 @@ export class Matrix {
      * @returns the new transposed matrix
      */
     public transpose(): this {
-        const result = new (<MatrixConstructor<this>>this.constructor)();
+        const result = new (this.constructor as MatrixConstructor<this>)();
         Matrix.TransposeToRef(this, result);
         return result;
     }
@@ -5676,7 +5676,7 @@ export class Matrix {
      * @returns a new matrix
      */
     public scale(scale: number): this {
-        const result = new (<MatrixConstructor<this>>this.constructor)();
+        const result = new (this.constructor as MatrixConstructor<this>)();
         this.scaleToRef(scale, result);
         return result;
     }
@@ -5727,7 +5727,7 @@ export class Matrix {
      * @returns a new matrix sets to the extracted rotation matrix from the current one
      */
     public getRotationMatrix(): this {
-        const result = new (<MatrixConstructor<this>>this.constructor)();
+        const result = new (this.constructor as MatrixConstructor<this>)();
         this.getRotationMatrixToRef(result);
         return result;
     }
@@ -6067,7 +6067,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Invert<T extends Matrix>(source: DeepImmutable<T>): T {
-        const result = new (<MatrixConstructor<T>>source.constructor)();
+        const result = new (source.constructor as MatrixConstructor<T>)();
         source.invertToRef(result);
         return result;
     }
@@ -6330,7 +6330,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Lerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<MatrixConstructor<T>>startValue.constructor)();
+        const result = new (startValue.constructor as MatrixConstructor<T>)();
         Matrix.LerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6365,7 +6365,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static DecomposeLerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<MatrixConstructor<T>>startValue.constructor)();
+        const result = new (startValue.constructor as MatrixConstructor<T>)();
         Matrix.DecomposeLerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -7050,7 +7050,7 @@ export class Matrix {
 
         const viewportMatrix = Matrix.FromValues(cw / 2.0, 0.0, 0.0, 0.0, 0.0, -ch / 2.0, 0.0, 0.0, 0.0, 0.0, zmax - zmin, 0.0, cx + cw / 2.0, ch / 2.0 + cy, zmin, 1.0);
 
-        const matrix = new (<MatrixConstructor<T>>world.constructor)();
+        const matrix = new (world.constructor as MatrixConstructor<T>)();
         world.multiplyToRef(view, matrix);
         matrix.multiplyToRef(projection, matrix);
         return matrix.multiplyToRef(viewportMatrix, matrix);
@@ -7083,7 +7083,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Transpose<T extends Matrix>(matrix: DeepImmutable<T>): T {
-        const result = new (<MatrixConstructor<T>>matrix.constructor)();
+        const result = new (matrix.constructor as MatrixConstructor<T>)();
         Matrix.TransposeToRef(matrix, result);
         return result;
     }

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -751,9 +751,9 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Transform<T extends Vector2>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const r = (<any>vector.constructor)();
-        Vector2.TransformToRef(vector, transformation, r);
-        return r;
+        const result = new (<any>vector.constructor)();
+        Vector2.TransformToRef(vector, transformation, result);
+        return result;
     }
 
     /**
@@ -824,7 +824,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Center<T extends Vector2>(value1: DeepImmutable<T>, value2: DeepImmutable<Vector2>): T {
-        const result = (<any>value1.constructor)();
+        const result = new (<any>value1.constructor)();
         return Vector2.CenterToRef(value1, value2, result);
     }
 
@@ -1266,9 +1266,8 @@ export class Vector3 {
      * @param origin defines the origin of the projection ray
      * @returns the projected vector3
      */
-    public projectOnPlane(plane: Plane, origin: Vector3): this {
-        const result = (<any>this.constructor)();
-
+    public projectOnPlane<T extends Vector3>(plane: Plane, origin: Vector3): T {
+        const result = new (<any>this.constructor)();
         this.projectOnPlaneToRef(plane, origin, result);
 
         return result;
@@ -1638,7 +1637,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public cross(other: Vector3): this {
-        const result = (<any>this.constructor)();
+        const result = new (<any>this.constructor)();
         return Vector3.CrossToRef(this, other, result);
     }
 
@@ -2235,9 +2234,9 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Clamp<T extends Vector3>(value: DeepImmutable<T>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): T {
-        const v = new (<any>value.constructor)();
-        Vector3.ClampToRef(value, min, max, v);
-        return v;
+        const result = new (<any>value.constructor)();
+        Vector3.ClampToRef(value, min, max, result);
+        return result;
     }
     /**
      * Sets the given vector "result" with the coordinates of "value", if the vector "value" is in the cube defined by the vectors "min" and "max"
@@ -2326,7 +2325,7 @@ export class Vector3 {
         tangent2: DeepImmutable<Vector3>,
         time: number
     ): T {
-        const result = (<any>value1.constructor)();
+        const result = new (<any>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -2410,7 +2409,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public static Cross<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const result = (<any>left.constructor)();
+        const result = new (<any>left.constructor)();
         Vector3.CrossToRef(left, right, result);
         return result;
     }
@@ -2557,7 +2556,7 @@ export class Vector3 {
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>
     ): T {
-        const result = (<any>source.constructor)();
+        const result = new (<any>source.constructor)();
 
         Vector3.UnprojectToRef(source, viewportWidth, viewportHeight, world, view, projection, result);
 
@@ -2640,7 +2639,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Minimize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const min = (<any>left.constructor)();
+        const min = new (<any>left.constructor)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -2654,7 +2653,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Maximize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const max = (<any>left.constructor)();
+        const max = new (<any>left.constructor)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -2879,7 +2878,7 @@ export class Vector3 {
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/target_align
      */
     public static RotationFromAxis<T extends Vector3>(axis1: DeepImmutable<T>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): T {
-        const rotation = (<any>axis1.constructor)();
+        const rotation = new (<any>axis1.constructor)();
         Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
         return rotation;
     }
@@ -3672,7 +3671,7 @@ export class Vector4 {
      * @returns the new vector
      */
     public static TransformNormal<T extends Vector4>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = (<any>vector.constructor)();
+        const result = new (<any>vector.constructor)();
         Vector4.TransformNormalToRef(vector, transformation, result);
         return result;
     }
@@ -4792,7 +4791,7 @@ export class Quaternion {
         tangent2: DeepImmutable<Quaternion>,
         time: number
     ): T {
-        const result = (<any>value1.constructor)();
+        const result = new (<any>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -144,7 +144,7 @@ export class Vector2 {
      * @returns a new Vector2 set with the addition of the current Vector2 and the given one coordinates
      */
     public add(otherVector: DeepImmutable<Vector2>): this {
-        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -179,7 +179,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public addVector3(otherVector: Vector3): this {
-        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -189,7 +189,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public subtract(otherVector: Vector2): this {
-        return new (<any> this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
+        return new (<any>this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
     }
 
     /**
@@ -235,7 +235,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiply(otherVector: DeepImmutable<Vector2>): this {
-        return new (<any> this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
+        return new (<any>this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
     }
 
     /**
@@ -259,7 +259,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiplyByFloats(x: number, y: number): this {
-        return new (<any> this.constructor)(this.x * x, this.y * y);
+        return new (<any>this.constructor)(this.x * x, this.y * y);
     }
 
     /**
@@ -269,7 +269,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public divide(otherVector: Vector2): this {
-        return new (<any> this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
+        return new (<any>this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
     }
 
     /**
@@ -301,7 +301,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public negate(): this {
-        return new (<any> this.constructor)(-this.x, -this.y);
+        return new (<any>this.constructor)(-this.x, -this.y);
     }
 
     /**
@@ -344,7 +344,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public scale(scale: number): this {
-        const result = new (<any> this.constructor)(0, 0) as this;
+        const result = new (<any>this.constructor)(0, 0) as this;
         this.scaleToRef(scale, result);
         return result;
     }
@@ -403,7 +403,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public floor(): this {
-        return new (<any> this.constructor)(Math.floor(this.x), Math.floor(this.y));
+        return new (<any>this.constructor)(Math.floor(this.x), Math.floor(this.y));
     }
 
     /**
@@ -413,7 +413,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public fract(): this {
-        return new (<any> this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
+        return new (<any>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
     }
 
     /**
@@ -468,7 +468,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public clone(): this {
-        return new (<any> this.constructor)(this.x, this.y);
+        return new (<any>this.constructor)(this.x, this.y);
     }
 
     // Statics
@@ -693,7 +693,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
-        const newVector = (vector.constructor)();
+        const newVector = new (<any>vector.constructor)();
         this.NormalizeToRef(vector, newVector);
         return newVector;
     }
@@ -727,7 +727,7 @@ export class Vector2 {
     public static Minimize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x < right.x ? left.x : right.x;
         const y = left.y < right.y ? left.y : right.y;
-        return new (<any> left.constructor)(x, y);
+        return new (<any>left.constructor)(x, y);
     }
 
     /**
@@ -740,7 +740,7 @@ export class Vector2 {
     public static Maximize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x > right.x ? left.x : right.x;
         const y = left.y > right.y ? left.y : right.y;
-        return new (<any> left.constructor)(x, y);
+        return new (<any>left.constructor)(x, y);
     }
 
     /**
@@ -1042,7 +1042,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public add(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any> this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
+        return new (<any>this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
     /**
@@ -1076,7 +1076,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtract(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any> this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
+        return new (<any>this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
     }
 
     /**
@@ -1099,7 +1099,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtractFromFloats(x: number, y: number, z: number): this {
-        return new (<any> this.constructor)(this._x - x, this._y - y, this._z - z);
+        return new (<any>this.constructor)(this._x - x, this._y - y, this._z - z);
     }
 
     /**
@@ -1121,7 +1121,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public negate(): this {
-        return new (<any> this.constructor)(-this._x, -this._y, -this._z);
+        return new (<any>this.constructor)(-this._x, -this._y, -this._z);
     }
 
     /**
@@ -1166,7 +1166,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public scale(scale: number): this {
-        return new (<any> this.constructor)(this._x * scale, this._y * scale, this._z * scale);
+        return new (<any>this.constructor)(this._x * scale, this._y * scale, this._z * scale);
     }
 
     /**
@@ -1245,7 +1245,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public applyRotationQuaternion(q: Quaternion): this {
-        return this.applyRotationQuaternionToRef(q, new (<any> this.constructor)());
+        return this.applyRotationQuaternionToRef(q, new (<any>this.constructor)());
     }
 
     /**
@@ -1267,7 +1267,7 @@ export class Vector3 {
      * @returns the projected vector3
      */
     public projectOnPlane(plane: Plane, origin: Vector3): this {
-        const result = (<any> this.constructor)();
+        const result = (<any>this.constructor)();
 
         this.projectOnPlaneToRef(plane, origin, result);
 
@@ -1306,7 +1306,7 @@ export class Vector3 {
             origin.addToRef(scaledV, result);
         }
 
-        return result
+        return result;
     }
 
     /**
@@ -1390,7 +1390,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public multiplyByFloats(x: number, y: number, z: number): this {
-        return new (<any> this.constructor)(this._x * x, this._y * y, this._z * z);
+        return new (<any>this.constructor)(this._x * x, this._y * y, this._z * z);
     }
 
     /**
@@ -1400,7 +1400,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public divide(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any> this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
+        return new (<any>this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
     /**
@@ -1535,7 +1535,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public floor(): this {
-        return new (<any> this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
+        return new (<any>this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
     }
 
     /**
@@ -1544,7 +1544,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public fract(): this {
-        return new (<any> this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
+        return new (<any>this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
     }
 
     // Properties
@@ -1638,7 +1638,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public cross(other: Vector3): this {
-        const result = (<any> this.constructor)()
+        const result = (<any>this.constructor)();
         return Vector3.CrossToRef(this, other, result);
     }
 
@@ -1663,7 +1663,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public normalizeToNew(): this {
-        const normalized = new (<any> this.constructor)(0, 0, 0);
+        const normalized = new (<any>this.constructor)(0, 0, 0);
         this.normalizeToRef(normalized);
         return normalized;
     }
@@ -1689,7 +1689,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public clone(): this {
-        return new (<any> this.constructor)(this._x, this._y, this._z);
+        return new (<any>this.constructor)(this._x, this._y, this._z);
     }
 
     /**
@@ -1888,7 +1888,7 @@ export class Vector3 {
         vector1Dir.scaleInPlace(scale1);
         result.copyFrom(vector0Dir).addInPlace(vector1Dir);
         result.scaleInPlace(Scalar.Lerp(vector0Length, vector1Length, slerp));
-        return result
+        return result;
     }
 
     /**
@@ -1902,7 +1902,7 @@ export class Vector3 {
      */
     public static SmoothToRef<T extends Vector3 = Vector3>(source: Vector3, goal: Vector3, deltaTime: number, lerpTime: number, result: T): T {
         Vector3.SlerpToRef(source, goal, lerpTime === 0 ? 1 : deltaTime / lerpTime, result);
-        return result
+        return result;
     }
 
     /**
@@ -1939,7 +1939,7 @@ export class Vector3 {
         result.x = array[offset];
         result.y = array[offset + 1];
         result.z = array[offset + 2];
-        return result
+        return result;
     }
 
     /**
@@ -1963,7 +1963,7 @@ export class Vector3 {
      */
     public static FromFloatsToRef<T extends Vector3 = Vector3>(x: number, y: number, z: number, result: T): T {
         result.copyFromFloats(x, y, z);
-        return result
+        return result;
     }
 
     /**
@@ -2158,7 +2158,7 @@ export class Vector3 {
      */
     public static TransformNormalToRef<T extends Vector3>(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: T): T {
         this.TransformNormalFromFloatsToRef(vector._x, vector._y, vector._z, transformation, result);
-        return result
+        return result;
     }
 
     /**
@@ -2177,7 +2177,7 @@ export class Vector3 {
         result.x = x * m[0] + y * m[4] + z * m[8];
         result.y = x * m[1] + y * m[5] + z * m[9];
         result.z = x * m[2] + y * m[6] + z * m[10];
-        return result
+        return result;
     }
 
     /**
@@ -2221,7 +2221,7 @@ export class Vector3 {
                 (2.0 * value1._z - 5.0 * value2._z + 4.0 * value3._z - value4._z) * squared +
                 (-value1._z + 3.0 * value2._z - 3.0 * value3._z + value4._z) * cubed);
 
-        return new (<any> value1.constructor)(x, y, z);
+        return new (<any>value1.constructor)(x, y, z);
     }
 
     /**
@@ -2235,7 +2235,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Clamp<T extends Vector3>(value: DeepImmutable<T>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): T {
-        const v = new (<any> value.constructor)();
+        const v = new (<any>value.constructor)();
         Vector3.ClampToRef(value, min, max, v);
         return v;
     }
@@ -2306,7 +2306,7 @@ export class Vector3 {
         const x = value1._x * part1 + value2._x * part2 + tangent1._x * part3 + tangent2._x * part4;
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
-        return new (<any> value1.constructor)(x, y, z);
+        return new (<any>value1.constructor)(x, y, z);
     }
 
     /**
@@ -2326,7 +2326,7 @@ export class Vector3 {
         tangent2: DeepImmutable<Vector3>,
         time: number
     ): T {
-        const result = (<any> value1.constructor)();
+        const result = (<any>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -2369,7 +2369,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Lerp<T extends Vector3>(start: DeepImmutable<T>, end: DeepImmutable<Vector3>, amount: number): T {
-        const result = new (<any> start.constructor)(0, 0, 0);
+        const result = new (<any>start.constructor)(0, 0, 0);
         Vector3.LerpToRef(start, end, amount, result);
         return result;
     }
@@ -2387,7 +2387,7 @@ export class Vector3 {
         result.x = start._x + (end._x - start._x) * amount;
         result.y = start._y + (end._y - start._y) * amount;
         result.z = start._z + (end._z - start._z) * amount;
-        return result
+        return result;
     }
 
     /**
@@ -2410,7 +2410,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public static Cross<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const result = (<any> left.constructor)();
+        const result = (<any>left.constructor)();
         Vector3.CrossToRef(left, right, result);
         return result;
     }
@@ -2429,7 +2429,7 @@ export class Vector3 {
         const y = left._z * right._x - left._x * right._z;
         const z = left._x * right._y - left._y * right._x;
         result.copyFromFloats(x, y, z);
-        return result
+        return result;
     }
 
     /**
@@ -2466,7 +2466,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Project<T extends Vector3>(vector: DeepImmutable<T>, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>, viewport: DeepImmutable<Viewport>): T {
-        const result = new (<any> vector.constructor)();
+        const result = new (<any>vector.constructor)();
         Vector3.ProjectToRef(vector, world, transform, viewport, result);
         return result;
     }
@@ -2515,7 +2515,7 @@ export class Vector3 {
         if (Scalar.WithinEpsilon(num, 1.0)) {
             result.scaleInPlace(1.0 / num);
         }
-        return result
+        return result;
     }
 
     /**
@@ -2528,7 +2528,13 @@ export class Vector3 {
      * @param transform defines the transform (view x projection) matrix to use
      * @returns the new Vector3
      */
-    public static UnprojectFromTransform<T extends Vector3>(source: DeepImmutable<T>, viewportWidth: number, viewportHeight: number, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>): T {
+    public static UnprojectFromTransform<T extends Vector3>(
+        source: DeepImmutable<T>,
+        viewportWidth: number,
+        viewportHeight: number,
+        world: DeepImmutable<Matrix>,
+        transform: DeepImmutable<Matrix>
+    ): T {
         return this.Unproject(source, viewportWidth, viewportHeight, world, transform, Matrix.IdentityReadOnly);
     }
 
@@ -2551,7 +2557,7 @@ export class Vector3 {
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>
     ): T {
-        const result = (<any> source.constructor)();
+        const result = (<any>source.constructor)();
 
         Vector3.UnprojectToRef(source, viewportWidth, viewportHeight, world, view, projection, result);
 
@@ -2580,7 +2586,7 @@ export class Vector3 {
         result: T
     ): T {
         Vector3.UnprojectFloatsToRef(source._x, source._y, source._z, viewportWidth, viewportHeight, world, view, projection, result);
-        return result
+        return result;
     }
 
     /**
@@ -2634,7 +2640,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Minimize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const min = (<any> left.constructor)();
+        const min = (<any>left.constructor)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -2648,7 +2654,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Maximize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const max = (<any> left.constructor)();
+        const max = (<any>left.constructor)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -2873,7 +2879,7 @@ export class Vector3 {
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/target_align
      */
     public static RotationFromAxis<T extends Vector3>(axis1: DeepImmutable<T>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): T {
-        const rotation = (<any> axis1.constructor)();
+        const rotation = (<any>axis1.constructor)();
         Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
         return rotation;
     }
@@ -2891,7 +2897,7 @@ export class Vector3 {
         const quat = MathTmp.Quaternion[0];
         Quaternion.RotationQuaternionFromAxisToRef(axis1, axis2, axis3, quat);
         quat.toEulerAnglesToRef(ref);
-        return ref
+        return ref;
     }
 }
 
@@ -3012,7 +3018,7 @@ export class Vector4 {
      * @returns the resulting vector
      */
     public add(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
+        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
     }
 
     /**
@@ -3048,7 +3054,7 @@ export class Vector4 {
      * @returns the new vector with the result
      */
     public subtract(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any> this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
+        return new (<any>this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
     }
 
     /**
@@ -3077,7 +3083,7 @@ export class Vector4 {
      * @returns new vector containing the result
      */
     public subtractFromFloats(x: number, y: number, z: number, w: number): this {
-        return new (<any> this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
+        return new (<any>this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     /**
@@ -3102,7 +3108,7 @@ export class Vector4 {
      * @returns a new vector with the negated values
      */
     public negate(): this {
-        return new (<any> this.constructor)(-this.x, -this.y, -this.z, -this.w);
+        return new (<any>this.constructor)(-this.x, -this.y, -this.z, -this.w);
     }
 
     /**
@@ -3145,7 +3151,7 @@ export class Vector4 {
      * @returns a new vector with the result
      */
     public scale(scale: number): this {
-        return new (<any> this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
+        return new (<any>this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
     }
 
     /**
@@ -3232,7 +3238,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiply(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any> this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
+        return new (<any>this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
     }
     /**
      * Updates the given vector "result" with the multiplication result of the current Vector4 and the given one.
@@ -3256,7 +3262,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiplyByFloats(x: number, y: number, z: number, w: number): this {
-        return new (<any> this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
+        return new (<any>this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
     }
     /**
      * Returns a new Vector4 set with the division result of the current Vector4 by the given one.
@@ -3264,7 +3270,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public divide(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any> this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
+        return new (<any>this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
     }
     /**
      * Updates the given vector "result" with the division result of the current Vector4 by the given one.
@@ -3335,7 +3341,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public floor(): this {
-        return new (<any> this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
+        return new (<any>this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
     }
 
     /**
@@ -3343,7 +3349,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public fract(): this {
-        return new (<any> this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
+        return new (<any>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
     }
 
     // Properties
@@ -3389,7 +3395,7 @@ export class Vector4 {
      * @returns the new cloned vector
      */
     public clone(): this {
-        return new (<any> this.constructor)(this.x, this.y, this.z, this.w);
+        return new (<any>this.constructor)(this.x, this.y, this.z, this.w);
     }
     /**
      * Updates the current Vector4 with the given one coordinates.
@@ -3543,7 +3549,7 @@ export class Vector4 {
      * @returns a new vector with the minimum of the left and right vector values
      */
     public static Minimize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const min = new (<any> left.constructor)();
+        const min = new (<any>left.constructor)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -3556,7 +3562,7 @@ export class Vector4 {
      * @returns a new vector with the maximum of the left and right vector values
      */
     public static Maximize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const max = new (<any> left.constructor)();
+        const max = new (<any>left.constructor)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -3666,7 +3672,7 @@ export class Vector4 {
      * @returns the new vector
      */
     public static TransformNormal<T extends Vector4>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = (<any> vector.constructor)();
+        const result = (<any>vector.constructor)();
         Vector4.TransformNormalToRef(vector, transformation, result);
         return result;
     }
@@ -3881,7 +3887,7 @@ export class Quaternion {
      * @returns a new quaternion copied from the current one
      */
     public clone(): this {
-        return new (<any> this.constructor)(this._x, this._y, this._z, this._w);
+        return new (<any>this.constructor)(this._x, this._y, this._z, this._w);
     }
 
     /**
@@ -3931,7 +3937,7 @@ export class Quaternion {
      * @returns a new quaternion as the addition result of the given one and the current quaternion
      */
     public add(other: DeepImmutable<Quaternion>): this {
-        return new (<any> this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
+        return new (<any>this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
     }
 
     /**
@@ -3953,7 +3959,7 @@ export class Quaternion {
      * @returns a new quaternion as the subtraction result of the given one from the current one
      */
     public subtract(other: Quaternion): this {
-        return new (<any> this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
+        return new (<any>this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
     }
 
     /**
@@ -3975,7 +3981,7 @@ export class Quaternion {
      * @returns a new quaternion set by multiplying the current quaternion coordinates by the float "scale"
      */
     public scale(value: number): this {
-        return new (<any> this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
+        return new (<any>this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
     }
 
     /**
@@ -4026,7 +4032,7 @@ export class Quaternion {
      * @returns a new quaternion set as the multiplication result of the current one with the given one "q1"
      */
     public multiply(q1: DeepImmutable<Quaternion>): this {
-        const result = new (<any> this.constructor)(0, 0, 0, 1.0);
+        const result = new (<any>this.constructor)(0, 0, 0, 1.0);
         this.multiplyToRef(q1, result);
         return result;
     }
@@ -4082,7 +4088,7 @@ export class Quaternion {
      * @returns a new quaternion
      */
     public conjugate(): this {
-        return new (<any> this.constructor)(-this._x, -this._y, -this._z, this._w);
+        return new (<any>this.constructor)(-this._x, -this._y, -this._z, this._w);
     }
 
     /**
@@ -4373,7 +4379,7 @@ export class Quaternion {
      * @returns a new quaternion as the inverted current quaternion
      */
     public static Inverse<T extends Quaternion>(q: DeepImmutable<T>): T {
-        return new (<any> q.constructor)(-q._x, -q._y, -q._z, q._w);
+        return new (<any>q.constructor)(-q._x, -q._y, -q._z, q._w);
     }
 
     /**
@@ -4767,7 +4773,7 @@ export class Quaternion {
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
         const w = value1._w * part1 + value2._w * part2 + tangent1._w * part3 + tangent2._w * part4;
-        return new (<any> value1.constructor)(x, y, z, w);
+        return new (<any>value1.constructor)(x, y, z, w);
     }
 
     /**
@@ -4786,7 +4792,7 @@ export class Quaternion {
         tangent2: DeepImmutable<Quaternion>,
         time: number
     ): T {
-        const result = (<any> value1.constructor)();
+        const result = (<any>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -5280,7 +5286,7 @@ export class Matrix {
      * @returns a new matrix set with the multiplication result of the current Matrix and the given one
      */
     public multiply(other: DeepImmutable<Matrix>): this {
-        const result = new (<any> this.constructor)();
+        const result = new (<any>this.constructor)();
         this.multiplyToRef(other, result);
         return result;
     }
@@ -5457,7 +5463,7 @@ export class Matrix {
      * @returns a new matrix from the current matrix
      */
     public clone(): this {
-        const matrix = new (<any> this.constructor)();
+        const matrix = new (<any>this.constructor)();
         matrix.copyFrom(this);
         return matrix;
     }
@@ -5621,7 +5627,7 @@ export class Matrix {
      * @returns the new transposed matrix
      */
     public transpose(): this {
-        const result = new (<any> this.constructor)();
+        const result = new (<any>this.constructor)();
         Matrix.TransposeToRef(this, result);
         return result;
     }
@@ -5665,7 +5671,7 @@ export class Matrix {
      * @returns a new matrix
      */
     public scale(scale: number): this {
-        const result = new (<any> this.constructor)();
+        const result = new (<any>this.constructor)();
         this.scaleToRef(scale, result);
         return result;
     }
@@ -5716,7 +5722,7 @@ export class Matrix {
      * @returns a new matrix sets to the extracted rotation matrix from the current one
      */
     public getRotationMatrix(): this {
-        const result = new (<any> this.constructor)();
+        const result = new (<any>this.constructor)();
         this.getRotationMatrixToRef(result);
         return result;
     }
@@ -6056,7 +6062,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Invert<T extends Matrix>(source: DeepImmutable<T>): T {
-        const result = new (<any> source.constructor)();
+        const result = new (<any>source.constructor)();
         source.invertToRef(result);
         return result;
     }
@@ -6319,7 +6325,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Lerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<any> startValue.constructor)();
+        const result = new (<any>startValue.constructor)();
         Matrix.LerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6354,7 +6360,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static DecomposeLerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<any> startValue.constructor)();
+        const result = new (<any>startValue.constructor)();
         Matrix.DecomposeLerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6638,7 +6644,16 @@ export class Matrix {
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @returns result input
      */
-    public static OrthoOffCenterLHToRef<T extends Matrix>(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: T, halfZRange?: boolean): T {
+    public static OrthoOffCenterLHToRef<T extends Matrix>(
+        left: number,
+        right: number,
+        bottom: number,
+        top: number,
+        znear: number,
+        zfar: number,
+        result: T,
+        halfZRange?: boolean
+    ): T {
         const n = znear;
         const f = zfar;
 
@@ -6688,7 +6703,16 @@ export class Matrix {
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @returns result input
      */
-    public static OrthoOffCenterRHToRef<T extends Matrix>(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: T, halfZRange?: boolean): T {
+    public static OrthoOffCenterRHToRef<T extends Matrix>(
+        left: number,
+        right: number,
+        bottom: number,
+        top: number,
+        znear: number,
+        zfar: number,
+        result: T,
+        halfZRange?: boolean
+    ): T {
         Matrix.OrthoOffCenterLHToRef(left, right, bottom, top, znear, zfar, result, halfZRange);
         result._m[10] *= -1; // No need to call markAsUpdated as previous function already called it and let _isIdentityDirty to true
         return result;
@@ -7021,7 +7045,7 @@ export class Matrix {
 
         const viewportMatrix = Matrix.FromValues(cw / 2.0, 0.0, 0.0, 0.0, 0.0, -ch / 2.0, 0.0, 0.0, 0.0, 0.0, zmax - zmin, 0.0, cx + cw / 2.0, ch / 2.0 + cy, zmin, 1.0);
 
-        const matrix = new (<any> world.constructor)();
+        const matrix = new (<any>world.constructor)();
         world.multiplyToRef(view, matrix);
         matrix.multiplyToRef(projection, matrix);
         return matrix.multiplyToRef(viewportMatrix, matrix);
@@ -7054,7 +7078,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Transpose<T extends Matrix>(matrix: DeepImmutable<T>): T {
-        const result = new (<any> matrix.constructor)();
+        const result = new (<any>matrix.constructor)();
         Matrix.TransposeToRef(matrix, result);
         return result;
     }

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -73,7 +73,7 @@ export class Vector2 {
      * @param index defines the offset in source array
      * @returns the current Vector2
      */
-    public toArray(array: FloatArray, index: number = 0): Vector2 {
+    public toArray(array: FloatArray, index: number = 0): this {
         array[index] = this.x;
         array[index + 1] = this.y;
         return this;
@@ -84,9 +84,9 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#39
      * @param array defines the destination array
      * @param index defines the offset in the destination array
-     * @returns the current Vector3
+     * @returns the current Vector2
      */
-    public fromArray(array: FloatArray, index: number = 0): Vector2 {
+    public fromArray(array: FloatArray, index: number = 0): this {
         Vector2.FromArrayToRef(array, index, this);
         return this;
     }
@@ -108,7 +108,7 @@ export class Vector2 {
      * @param source defines the source Vector2
      * @returns the current updated Vector2
      */
-    public copyFrom(source: DeepImmutable<Vector2>): Vector2 {
+    public copyFrom(source: DeepImmutable<Vector2>): this {
         this.x = source.x;
         this.y = source.y;
         return this;
@@ -121,7 +121,7 @@ export class Vector2 {
      * @param y defines the second coordinate
      * @returns the current updated Vector2
      */
-    public copyFromFloats(x: number, y: number): Vector2 {
+    public copyFromFloats(x: number, y: number): this {
         this.x = x;
         this.y = y;
         return this;
@@ -134,7 +134,7 @@ export class Vector2 {
      * @param y defines the second coordinate
      * @returns the current updated Vector2
      */
-    public set(x: number, y: number): Vector2 {
+    public set(x: number, y: number): this {
         return this.copyFromFloats(x, y);
     }
     /**
@@ -143,8 +143,8 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns a new Vector2 set with the addition of the current Vector2 and the given one coordinates
      */
-    public add(otherVector: DeepImmutable<Vector2>): Vector2 {
-        return new Vector2(this.x + otherVector.x, this.y + otherVector.y);
+    public add(otherVector: DeepImmutable<Vector2>): this {
+        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -152,12 +152,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#12
      * @param otherVector defines the other vector
      * @param result defines the target vector
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public addToRef(otherVector: DeepImmutable<Vector2>, result: Vector2): Vector2 {
+    public addToRef<T extends Vector2>(otherVector: DeepImmutable<Vector2>, result: T): T {
         result.x = this.x + otherVector.x;
         result.y = this.y + otherVector.y;
-        return this;
+        return result;
     }
 
     /**
@@ -166,7 +166,7 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns the current updated Vector2
      */
-    public addInPlace(otherVector: DeepImmutable<Vector2>): Vector2 {
+    public addInPlace(otherVector: DeepImmutable<Vector2>): this {
         this.x += otherVector.x;
         this.y += otherVector.y;
         return this;
@@ -178,8 +178,8 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns a new Vector2
      */
-    public addVector3(otherVector: Vector3): Vector2 {
-        return new Vector2(this.x + otherVector.x, this.y + otherVector.y);
+    public addVector3(otherVector: Vector3): this {
+        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -188,8 +188,8 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns a new Vector2
      */
-    public subtract(otherVector: Vector2): Vector2 {
-        return new Vector2(this.x - otherVector.x, this.y - otherVector.y);
+    public subtract(otherVector: Vector2): this {
+        return new (<any> this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
     }
 
     /**
@@ -197,12 +197,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#63
      * @param otherVector defines the other vector
      * @param result defines the target vector
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public subtractToRef(otherVector: DeepImmutable<Vector2>, result: Vector2): Vector2 {
+    public subtractToRef<T extends Vector2>(otherVector: DeepImmutable<Vector2>, result: T): T {
         result.x = this.x - otherVector.x;
         result.y = this.y - otherVector.y;
-        return this;
+        return result;
     }
     /**
      * Sets the current Vector2 coordinates by subtracting from it the given one coordinates
@@ -210,7 +210,7 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns the current updated Vector2
      */
-    public subtractInPlace(otherVector: DeepImmutable<Vector2>): Vector2 {
+    public subtractInPlace(otherVector: DeepImmutable<Vector2>): this {
         this.x -= otherVector.x;
         this.y -= otherVector.y;
         return this;
@@ -222,7 +222,7 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns the current updated Vector2
      */
-    public multiplyInPlace(otherVector: DeepImmutable<Vector2>): Vector2 {
+    public multiplyInPlace(otherVector: DeepImmutable<Vector2>): this {
         this.x *= otherVector.x;
         this.y *= otherVector.y;
         return this;
@@ -234,8 +234,8 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns a new Vector2
      */
-    public multiply(otherVector: DeepImmutable<Vector2>): Vector2 {
-        return new Vector2(this.x * otherVector.x, this.y * otherVector.y);
+    public multiply(otherVector: DeepImmutable<Vector2>): this {
+        return new (<any> this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
     }
 
     /**
@@ -243,12 +243,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#44
      * @param otherVector defines the other vector
      * @param result defines the target vector
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public multiplyToRef(otherVector: DeepImmutable<Vector2>, result: Vector2): Vector2 {
+    public multiplyToRef<T extends Vector2>(otherVector: DeepImmutable<Vector2>, result: T): T {
         result.x = this.x * otherVector.x;
         result.y = this.y * otherVector.y;
-        return this;
+        return result;
     }
 
     /**
@@ -258,8 +258,8 @@ export class Vector2 {
      * @param y defines the second coordinate
      * @returns a new Vector2
      */
-    public multiplyByFloats(x: number, y: number): Vector2 {
-        return new Vector2(this.x * x, this.y * y);
+    public multiplyByFloats(x: number, y: number): this {
+        return new (<any> this.constructor)(this.x * x, this.y * y);
     }
 
     /**
@@ -268,8 +268,8 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns a new Vector2
      */
-    public divide(otherVector: Vector2): Vector2 {
-        return new Vector2(this.x / otherVector.x, this.y / otherVector.y);
+    public divide(otherVector: Vector2): this {
+        return new (<any> this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
     }
 
     /**
@@ -277,12 +277,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#30
      * @param otherVector defines the other vector
      * @param result defines the target vector
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public divideToRef(otherVector: DeepImmutable<Vector2>, result: Vector2): Vector2 {
+    public divideToRef<T extends Vector2>(otherVector: DeepImmutable<Vector2>, result: T): T {
         result.x = this.x / otherVector.x;
         result.y = this.y / otherVector.y;
-        return this;
+        return result;
     }
 
     /**
@@ -291,7 +291,7 @@ export class Vector2 {
      * @param otherVector defines the other vector
      * @returns the current updated Vector2
      */
-    public divideInPlace(otherVector: DeepImmutable<Vector2>): Vector2 {
+    public divideInPlace(otherVector: DeepImmutable<Vector2>): this {
         return this.divideToRef(otherVector, this);
     }
 
@@ -300,8 +300,8 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#22
      * @returns a new Vector2
      */
-    public negate(): Vector2 {
-        return new Vector2(-this.x, -this.y);
+    public negate(): this {
+        return new (<any> this.constructor)(-this.x, -this.y);
     }
 
     /**
@@ -309,7 +309,7 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#23
      * @returns this
      */
-    public negateInPlace(): Vector2 {
+    public negateInPlace(): this {
         this.x *= -1;
         this.y *= -1;
         return this;
@@ -321,7 +321,7 @@ export class Vector2 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public negateToRef(result: Vector2): Vector2 {
+    public negateToRef<T extends Vector2>(result: T): T {
         return result.copyFromFloats(this.x * -1, this.y * -1);
     }
 
@@ -331,7 +331,7 @@ export class Vector2 {
      * @param scale defines the scaling factor
      * @returns the current updated Vector2
      */
-    public scaleInPlace(scale: number): Vector2 {
+    public scaleInPlace(scale: number): this {
         this.x *= scale;
         this.y *= scale;
         return this;
@@ -343,8 +343,8 @@ export class Vector2 {
      * @param scale defines the scaling factor
      * @returns a new Vector2
      */
-    public scale(scale: number): Vector2 {
-        const result = new Vector2(0, 0);
+    public scale(scale: number): this {
+        const result = new (<any> this.constructor)(0, 0) as this;
         this.scaleToRef(scale, result);
         return result;
     }
@@ -354,12 +354,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#57
      * @param scale defines the scale factor
      * @param result defines the Vector2 object where to store the result
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public scaleToRef(scale: number, result: Vector2): Vector2 {
+    public scaleToRef<T extends Vector2>(scale: number, result: T): T {
         result.x = this.x * scale;
         result.y = this.y * scale;
-        return this;
+        return result;
     }
 
     /**
@@ -367,12 +367,12 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#58
      * @param scale defines the scale factor
      * @param result defines the Vector2 object where to store the result
-     * @returns the unmodified current Vector2
+     * @returns result input
      */
-    public scaleAndAddToRef(scale: number, result: Vector2): Vector2 {
+    public scaleAndAddToRef<T extends Vector2>(scale: number, result: T): T {
         result.x += this.x * scale;
         result.y += this.y * scale;
-        return this;
+        return result;
     }
 
     /**
@@ -402,8 +402,8 @@ export class Vector2 {
      * eg (1.2, 2.31) returns (1, 2)
      * @returns a new Vector2
      */
-    public floor(): Vector2 {
-        return new Vector2(Math.floor(this.x), Math.floor(this.y));
+    public floor(): this {
+        return new (<any> this.constructor)(Math.floor(this.x), Math.floor(this.y));
     }
 
     /**
@@ -412,8 +412,8 @@ export class Vector2 {
      * eg (1.2, 2.31) returns (0.2, 0.31)
      * @returns a new Vector2
      */
-    public fract(): Vector2 {
-        return new Vector2(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
+    public fract(): this {
+        return new (<any> this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
     }
 
     /**
@@ -421,15 +421,15 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#49
      * @param angle defines the rotation angle
      * @param result defines the result vector where to store the rotated vector
-     * @returns the current vector
+     * @returns result input
      */
-    public rotateToRef(angle: number, result: Vector2) {
+    public rotateToRef<T extends Vector2>(angle: number, result: T): T {
         const cos = Math.cos(angle);
         const sin = Math.sin(angle);
         result.x = cos * this.x - sin * this.y;
         result.y = sin * this.x + cos * this.y;
 
-        return this;
+        return result;
     }
 
     // Properties
@@ -457,7 +457,7 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#48
      * @returns the current updated Vector2
      */
-    public normalize(): Vector2 {
+    public normalize(): this {
         Vector2.NormalizeToRef(this, this);
         return this;
     }
@@ -467,8 +467,8 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#20
      * @returns a new Vector2
      */
-    public clone(): Vector2 {
-        return new Vector2(this.x, this.y);
+    public clone(): this {
+        return new (<any> this.constructor)(this.x, this.y);
     }
 
     // Statics
@@ -513,10 +513,12 @@ export class Vector2 {
      * @param array defines the data source
      * @param offset defines the offset in the data source
      * @param result defines the target vector
+     * @returns result input
      */
-    public static FromArrayToRef(array: DeepImmutable<ArrayLike<number>>, offset: number, result: Vector2): void {
+    public static FromArrayToRef<T extends Vector2>(array: DeepImmutable<ArrayLike<number>>, offset: number, result: T): T {
         result.x = array[offset];
         result.y = array[offset + 1];
+        return result;
     }
 
     /**
@@ -566,7 +568,7 @@ export class Vector2 {
      * @param max defines the upper limit
      * @returns a new Vector2
      */
-    public static Clamp(value: DeepImmutable<Vector2>, min: DeepImmutable<Vector2>, max: DeepImmutable<Vector2>): Vector2 {
+    public static Clamp<T extends Vector2>(value: DeepImmutable<T>, min: DeepImmutable<Vector2>, max: DeepImmutable<Vector2>): T {
         let x = value.x;
         x = x > max.x ? max.x : x;
         x = x < min.x ? min.x : x;
@@ -575,7 +577,7 @@ export class Vector2 {
         y = y > max.y ? max.y : y;
         y = y < min.y ? min.y : y;
 
-        return new Vector2(x, y);
+        return new (<any>value.constructor)(x, y);
     }
 
     /**
@@ -588,13 +590,13 @@ export class Vector2 {
      * @param amount defines the interpolation factor
      * @returns a new Vector2
      */
-    public static Hermite(
-        value1: DeepImmutable<Vector2>,
+    public static Hermite<T extends Vector2>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Vector2>,
         value2: DeepImmutable<Vector2>,
         tangent2: DeepImmutable<Vector2>,
         amount: number
-    ): Vector2 {
+    ): T {
         const squared = amount * amount;
         const cubed = amount * squared;
         const part1 = 2.0 * cubed - 3.0 * squared + 1.0;
@@ -605,7 +607,7 @@ export class Vector2 {
         const x = value1.x * part1 + value2.x * part2 + tangent1.x * part3 + tangent2.x * part4;
         const y = value1.y * part1 + value2.y * part2 + tangent1.y * part3 + tangent2.y * part4;
 
-        return new Vector2(x, y);
+        return new (<any>value1.constructor)(x, y);
     }
 
     /**
@@ -618,14 +620,14 @@ export class Vector2 {
      * @param time define where the derivative must be done
      * @returns 1st derivative
      */
-    public static Hermite1stDerivative(
-        value1: DeepImmutable<Vector2>,
+    public static Hermite1stDerivative<T extends Vector2>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Vector2>,
         value2: DeepImmutable<Vector2>,
         tangent2: DeepImmutable<Vector2>,
         time: number
-    ): Vector2 {
-        const result = Vector2.Zero();
+    ): T {
+        const result = new (<any>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -641,19 +643,22 @@ export class Vector2 {
      * @param tangent2 defines the second tangent
      * @param time define where the derivative must be done
      * @param result define where the derivative will be stored
+     * @returns result input
      */
-    public static Hermite1stDerivativeToRef(
+    public static Hermite1stDerivativeToRef<T extends Vector2>(
         value1: DeepImmutable<Vector2>,
         tangent1: DeepImmutable<Vector2>,
         value2: DeepImmutable<Vector2>,
         tangent2: DeepImmutable<Vector2>,
         time: number,
-        result: Vector2
-    ) {
+        result: T
+    ): T {
         const t2 = time * time;
 
         result.x = (t2 - time) * 6 * value1.x + (3 * t2 - 4 * time + 1) * tangent1.x + (-t2 + time) * 6 * value2.x + (3 * t2 - 2 * time) * tangent2.x;
         result.y = (t2 - time) * 6 * value1.y + (3 * t2 - 4 * time + 1) * tangent1.y + (-t2 + time) * 6 * value2.y + (3 * t2 - 2 * time) * tangent2.y;
+
+        return result;
     }
 
     /**
@@ -664,10 +669,10 @@ export class Vector2 {
      * @param amount defines the interpolation factor
      * @returns a new Vector2
      */
-    public static Lerp(start: DeepImmutable<Vector2>, end: DeepImmutable<Vector2>, amount: number): Vector2 {
+    public static Lerp<T extends Vector2>(start: DeepImmutable<T>, end: DeepImmutable<Vector2>, amount: number): Vector2 {
         const x = start.x + (end.x - start.x) * amount;
         const y = start.y + (end.y - start.y) * amount;
-        return new Vector2(x, y);
+        return new (<any>start.constructor)(x, y);
     }
 
     /**
@@ -687,8 +692,8 @@ export class Vector2 {
      * @param vector defines the vector to normalize
      * @returns a new Vector2
      */
-    public static Normalize(vector: DeepImmutable<Vector2>): Vector2 {
-        const newVector = Vector2.Zero();
+    public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
+        const newVector = (vector.constructor)();
         this.NormalizeToRef(vector, newVector);
         return newVector;
     }
@@ -698,16 +703,18 @@ export class Vector2 {
      * Example Playground https://playground.babylonjs.com/#QYBWV4#50
      * @param vector defines the vector to normalize
      * @param result defines the vector where to store the result
+     * @returns result input
      */
-    public static NormalizeToRef(vector: DeepImmutable<Vector2>, result: Vector2) {
+    public static NormalizeToRef<T extends Vector2>(vector: DeepImmutable<Vector2>, result: T): T {
         const len = vector.length();
 
         if (len === 0) {
-            return;
+            return result;
         }
 
         result.x = vector.x / len;
         result.y = vector.y / len;
+        return result;
     }
 
     /**
@@ -717,10 +724,10 @@ export class Vector2 {
      * @param right defines 2nd vector
      * @returns a new Vector2
      */
-    public static Minimize(left: DeepImmutable<Vector2>, right: DeepImmutable<Vector2>): Vector2 {
+    public static Minimize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x < right.x ? left.x : right.x;
         const y = left.y < right.y ? left.y : right.y;
-        return new Vector2(x, y);
+        return new (<any> left.constructor)(x, y);
     }
 
     /**
@@ -730,10 +737,10 @@ export class Vector2 {
      * @param right defines 2nd vector
      * @returns a new Vector2
      */
-    public static Maximize(left: DeepImmutable<Vector2>, right: DeepImmutable<Vector2>): Vector2 {
+    public static Maximize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x > right.x ? left.x : right.x;
         const y = left.y > right.y ? left.y : right.y;
-        return new Vector2(x, y);
+        return new (<any> left.constructor)(x, y);
     }
 
     /**
@@ -743,8 +750,8 @@ export class Vector2 {
      * @param transformation defines the matrix to apply
      * @returns a new Vector2
      */
-    public static Transform(vector: DeepImmutable<Vector2>, transformation: DeepImmutable<Matrix>): Vector2 {
-        const r = Vector2.Zero();
+    public static Transform<T extends Vector2>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
+        const r = (<any>vector.constructor)();
         Vector2.TransformToRef(vector, transformation, r);
         return r;
     }
@@ -755,13 +762,15 @@ export class Vector2 {
      * @param vector defines the vector to transform
      * @param transformation defines the matrix to apply
      * @param result defines the target vector
+     * @returns result input
      */
-    public static TransformToRef(vector: DeepImmutable<Vector2>, transformation: DeepImmutable<Matrix>, result: Vector2) {
+    public static TransformToRef<T extends Vector2>(vector: DeepImmutable<Vector2>, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         const x = vector.x * m[0] + vector.y * m[4] + m[12];
         const y = vector.x * m[1] + vector.y * m[5] + m[13];
         result.x = x;
         result.y = y;
+        return result;
     }
 
     /**
@@ -773,7 +782,7 @@ export class Vector2 {
      * @param p2 defines 3rd triangle point
      * @returns true if the point "p" is in the triangle defined by the vectors "p0", "p1", "p2"
      */
-    public static PointInTriangle(p: DeepImmutable<Vector2>, p0: DeepImmutable<Vector2>, p1: DeepImmutable<Vector2>, p2: DeepImmutable<Vector2>) {
+    public static PointInTriangle(p: DeepImmutable<Vector2>, p0: DeepImmutable<Vector2>, p1: DeepImmutable<Vector2>, p2: DeepImmutable<Vector2>): boolean {
         const a = (1 / 2) * (-p1.y * p2.x + p0.y * (-p1.x + p2.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y);
         const sign = a < 0 ? -1 : 1;
         const s = (p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y) * sign;
@@ -814,8 +823,9 @@ export class Vector2 {
      * @param value2 defines second vector
      * @returns a new Vector2
      */
-    public static Center(value1: DeepImmutable<Vector2>, value2: DeepImmutable<Vector2>): Vector2 {
-        return Vector2.CenterToRef(value1, value2, Vector2.Zero());
+    public static Center<T extends Vector2>(value1: DeepImmutable<T>, value2: DeepImmutable<Vector2>): T {
+        const result = (<any>value1.constructor)();
+        return Vector2.CenterToRef(value1, value2, result);
     }
 
     /**
@@ -826,7 +836,7 @@ export class Vector2 {
      * @param ref defines third vector
      * @returns ref
      */
-    public static CenterToRef(value1: DeepImmutable<Vector2>, value2: DeepImmutable<Vector2>, ref: DeepImmutable<Vector2>): Vector2 {
+    public static CenterToRef<T extends Vector2>(value1: DeepImmutable<Vector2>, value2: DeepImmutable<Vector2>, ref: T): T {
         return ref.copyFromFloats((value1.x + value2.x) / 2, (value1.y + value2.y) / 2);
     }
 
@@ -972,7 +982,7 @@ export class Vector3 {
      * @param index defines the offset in the destination array
      * @returns the current Vector3
      */
-    public toArray(array: FloatArray, index: number = 0): Vector3 {
+    public toArray(array: FloatArray, index: number = 0): this {
         array[index] = this._x;
         array[index + 1] = this._y;
         array[index + 2] = this._z;
@@ -986,7 +996,7 @@ export class Vector3 {
      * @param index defines the offset in the destination array
      * @returns the current Vector3
      */
-    public fromArray(array: FloatArray, index: number = 0): Vector3 {
+    public fromArray(array: FloatArray, index: number = 0): this {
         Vector3.FromArrayToRef(array, index, this);
         return this;
     }
@@ -1006,7 +1016,7 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public addInPlace(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public addInPlace(otherVector: DeepImmutable<Vector3>): this {
         return this.addInPlaceFromFloats(otherVector._x, otherVector._y, otherVector._z);
     }
 
@@ -1018,7 +1028,7 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the current updated Vector3
      */
-    public addInPlaceFromFloats(x: number, y: number, z: number): Vector3 {
+    public addInPlaceFromFloats(x: number, y: number, z: number): this {
         this.x += x;
         this.y += y;
         this.z += z;
@@ -1031,8 +1041,8 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the resulting Vector3
      */
-    public add(otherVector: DeepImmutable<Vector3>): Vector3 {
-        return new Vector3(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
+    public add(otherVector: DeepImmutable<Vector3>): this {
+        return new (<any> this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
     /**
@@ -1042,7 +1052,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public addToRef(otherVector: DeepImmutable<Vector3>, result: Vector3): Vector3 {
+    public addToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
         return result.copyFromFloats(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
@@ -1052,7 +1062,7 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public subtractInPlace(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public subtractInPlace(otherVector: DeepImmutable<Vector3>): this {
         this.x -= otherVector._x;
         this.y -= otherVector._y;
         this.z -= otherVector._z;
@@ -1065,8 +1075,8 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the resulting Vector3
      */
-    public subtract(otherVector: DeepImmutable<Vector3>): Vector3 {
-        return new Vector3(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
+    public subtract(otherVector: DeepImmutable<Vector3>): this {
+        return new (<any> this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
     }
 
     /**
@@ -1076,7 +1086,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public subtractToRef(otherVector: DeepImmutable<Vector3>, result: Vector3): Vector3 {
+    public subtractToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
         return this.subtractFromFloatsToRef(otherVector._x, otherVector._y, otherVector._z, result);
     }
 
@@ -1088,8 +1098,8 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the resulting Vector3
      */
-    public subtractFromFloats(x: number, y: number, z: number): Vector3 {
-        return new Vector3(this._x - x, this._y - y, this._z - z);
+    public subtractFromFloats(x: number, y: number, z: number): this {
+        return new (<any> this.constructor)(this._x - x, this._y - y, this._z - z);
     }
 
     /**
@@ -1101,7 +1111,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public subtractFromFloatsToRef(x: number, y: number, z: number, result: Vector3): Vector3 {
+    public subtractFromFloatsToRef<T extends Vector3>(x: number, y: number, z: number, result: T): T {
         return result.copyFromFloats(this._x - x, this._y - y, this._z - z);
     }
 
@@ -1110,8 +1120,8 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#35
      * @returns a new Vector3
      */
-    public negate(): Vector3 {
-        return new Vector3(-this._x, -this._y, -this._z);
+    public negate(): this {
+        return new (<any> this.constructor)(-this._x, -this._y, -this._z);
     }
 
     /**
@@ -1119,7 +1129,7 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#36
      * @returns this
      */
-    public negateInPlace(): Vector3 {
+    public negateInPlace(): this {
         this.x *= -1;
         this.y *= -1;
         this.z *= -1;
@@ -1132,7 +1142,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public negateToRef(result: Vector3): Vector3 {
+    public negateToRef<T extends Vector3 = Vector3>(result: T): T {
         return result.copyFromFloats(this._x * -1, this._y * -1, this._z * -1);
     }
 
@@ -1142,7 +1152,7 @@ export class Vector3 {
      * @param scale defines the multiplier factor
      * @returns the current updated Vector3
      */
-    public scaleInPlace(scale: number): Vector3 {
+    public scaleInPlace(scale: number): this {
         this.x *= scale;
         this.y *= scale;
         this.z *= scale;
@@ -1155,8 +1165,8 @@ export class Vector3 {
      * @param scale defines the multiplier factor
      * @returns a new Vector3
      */
-    public scale(scale: number): Vector3 {
-        return new Vector3(this._x * scale, this._y * scale, this._z * scale);
+    public scale(scale: number): this {
+        return new (<any> this.constructor)(this._x * scale, this._y * scale, this._z * scale);
     }
 
     /**
@@ -1166,7 +1176,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public scaleToRef(scale: number, result: Vector3): Vector3 {
+    public scaleToRef<T extends Vector3>(scale: number, result: T): T {
         return result.copyFromFloats(this._x * scale, this._y * scale, this._z * scale);
     }
 
@@ -1205,7 +1215,7 @@ export class Vector3 {
      * @param result the output vector
      * @returns the result
      */
-    public applyRotationQuaternionToRef(q: Quaternion, result: Vector3): Vector3 {
+    public applyRotationQuaternionToRef<T extends Vector3>(q: Quaternion, result: T): T {
         const ix = q.w * this.x + q.y * this.z - q.z * this.y;
         const iy = q.w * this.y + q.z * this.x - q.x * this.z;
         const iz = q.w * this.z + q.x * this.y - q.y * this.x;
@@ -1224,7 +1234,7 @@ export class Vector3 {
      * @param q the unit quaternion representing the rotation
      * @returns the current updated Vector3
      */
-    public applyRotationQuaternionInPlace(q: Quaternion): Vector3 {
+    public applyRotationQuaternionInPlace(q: Quaternion): this {
         return this.applyRotationQuaternionToRef(q, this);
     }
 
@@ -1234,8 +1244,8 @@ export class Vector3 {
      * @param q the unit quaternion representing the rotation
      * @returns a new Vector3
      */
-    public applyRotationQuaternion(q: Quaternion): Vector3 {
-        return this.applyRotationQuaternionToRef(q, Vector3.Zero());
+    public applyRotationQuaternion(q: Quaternion): this {
+        return this.applyRotationQuaternionToRef(q, new (<any> this.constructor)());
     }
 
     /**
@@ -1243,9 +1253,9 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#55
      * @param scale defines the scale factor
      * @param result defines the Vector3 object where to store the result
-     * @returns the unmodified current Vector3
+     * @returns result input
      */
-    public scaleAndAddToRef(scale: number, result: Vector3): Vector3 {
+    public scaleAndAddToRef<T extends Vector3>(scale: number, result: T): T {
         return result.addInPlaceFromFloats(this._x * scale, this._y * scale, this._z * scale);
     }
 
@@ -1256,8 +1266,8 @@ export class Vector3 {
      * @param origin defines the origin of the projection ray
      * @returns the projected vector3
      */
-    public projectOnPlane(plane: Plane, origin: Vector3): Vector3 {
-        const result = Vector3.Zero();
+    public projectOnPlane(plane: Plane, origin: Vector3): this {
+        const result = (<any> this.constructor)();
 
         this.projectOnPlaneToRef(plane, origin, result);
 
@@ -1270,8 +1280,9 @@ export class Vector3 {
      * @param plane defines the plane to project to
      * @param origin defines the origin of the projection ray
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public projectOnPlaneToRef(plane: Plane, origin: Vector3, result: Vector3): void {
+    public projectOnPlaneToRef<T extends Vector3>(plane: Plane, origin: Vector3, result: T): T {
         const n = plane.normal;
         const d = plane.d;
 
@@ -1294,6 +1305,8 @@ export class Vector3 {
             const scaledV = V.scaleInPlace(t);
             origin.addToRef(scaledV, result);
         }
+
+        return result
     }
 
     /**
@@ -1340,7 +1353,7 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public multiplyInPlace(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public multiplyInPlace(otherVector: DeepImmutable<Vector3>): this {
         this.x *= otherVector._x;
         this.y *= otherVector._y;
         this.z *= otherVector._z;
@@ -1353,7 +1366,7 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the new Vector3
      */
-    public multiply(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public multiply(otherVector: DeepImmutable<Vector3>): this {
         return this.multiplyByFloats(otherVector._x, otherVector._y, otherVector._z);
     }
 
@@ -1364,7 +1377,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public multiplyToRef(otherVector: DeepImmutable<Vector3>, result: Vector3): Vector3 {
+    public multiplyToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
         return result.copyFromFloats(this._x * otherVector._x, this._y * otherVector._y, this._z * otherVector._z);
     }
 
@@ -1376,8 +1389,8 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the new Vector3
      */
-    public multiplyByFloats(x: number, y: number, z: number): Vector3 {
-        return new Vector3(this._x * x, this._y * y, this._z * z);
+    public multiplyByFloats(x: number, y: number, z: number): this {
+        return new (<any> this.constructor)(this._x * x, this._y * y, this._z * z);
     }
 
     /**
@@ -1386,8 +1399,8 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the new Vector3
      */
-    public divide(otherVector: DeepImmutable<Vector3>): Vector3 {
-        return new Vector3(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
+    public divide(otherVector: DeepImmutable<Vector3>): this {
+        return new (<any> this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
     /**
@@ -1397,7 +1410,7 @@ export class Vector3 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public divideToRef(otherVector: DeepImmutable<Vector3>, result: Vector3): Vector3 {
+    public divideToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
         return result.copyFromFloats(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
@@ -1407,7 +1420,7 @@ export class Vector3 {
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public divideInPlace(otherVector: Vector3): Vector3 {
+    public divideInPlace(otherVector: Vector3): this {
         return this.divideToRef(otherVector, this);
     }
 
@@ -1417,7 +1430,7 @@ export class Vector3 {
      * @param other defines the second operand
      * @returns the current updated Vector3
      */
-    public minimizeInPlace(other: DeepImmutable<Vector3>): Vector3 {
+    public minimizeInPlace(other: DeepImmutable<Vector3>): this {
         return this.minimizeInPlaceFromFloats(other._x, other._y, other._z);
     }
 
@@ -1427,7 +1440,7 @@ export class Vector3 {
      * @param other defines the second operand
      * @returns the current updated Vector3
      */
-    public maximizeInPlace(other: DeepImmutable<Vector3>): Vector3 {
+    public maximizeInPlace(other: DeepImmutable<Vector3>): this {
         return this.maximizeInPlaceFromFloats(other._x, other._y, other._z);
     }
 
@@ -1439,7 +1452,7 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the current updated Vector3
      */
-    public minimizeInPlaceFromFloats(x: number, y: number, z: number): Vector3 {
+    public minimizeInPlaceFromFloats(x: number, y: number, z: number): this {
         if (x < this._x) {
             this.x = x;
         }
@@ -1460,7 +1473,7 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the current updated Vector3
      */
-    public maximizeInPlaceFromFloats(x: number, y: number, z: number): Vector3 {
+    public maximizeInPlaceFromFloats(x: number, y: number, z: number): this {
         if (x > this._x) {
             this.x = x;
         }
@@ -1521,8 +1534,8 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#22
      * @returns a new Vector3
      */
-    public floor(): Vector3 {
-        return new Vector3(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
+    public floor(): this {
+        return new (<any> this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
     }
 
     /**
@@ -1530,8 +1543,8 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#23
      * @returns a new Vector3
      */
-    public fract(): Vector3 {
-        return new Vector3(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
+    public fract(): this {
+        return new (<any> this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
     }
 
     // Properties
@@ -1567,7 +1580,7 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#122
      * @returns the current updated Vector3
      */
-    public normalize(): Vector3 {
+    public normalize(): this {
         return this.normalizeFromLength(this.length());
     }
 
@@ -1596,7 +1609,7 @@ export class Vector3 {
      * @param result vector to store the result
      * @returns the resulting vector
      */
-    public rotateByQuaternionToRef(quaternion: Quaternion, result: Vector3) {
+    public rotateByQuaternionToRef<T extends Vector3>(quaternion: Quaternion, result: T): T {
         quaternion.toRotationMatrix(MathTmp.Matrix[0]);
         Vector3.TransformCoordinatesToRef(this, MathTmp.Matrix[0], result);
         return result;
@@ -1610,7 +1623,7 @@ export class Vector3 {
      * @param result vector to store the result
      * @returns the resulting vector
      */
-    public rotateByQuaternionAroundPointToRef(quaternion: Quaternion, point: Vector3, result: Vector3) {
+    public rotateByQuaternionAroundPointToRef<T extends Vector3>(quaternion: Quaternion, point: Vector3, result: T): T {
         this.subtractToRef(point, MathTmp.Vector3[0]);
         MathTmp.Vector3[0].rotateByQuaternionToRef(quaternion, MathTmp.Vector3[0]);
         point.addToRef(MathTmp.Vector3[0], result);
@@ -1624,8 +1637,9 @@ export class Vector3 {
      * @param other defines the right operand
      * @returns the cross product
      */
-    public cross(other: Vector3) {
-        return Vector3.Cross(this, other);
+    public cross(other: Vector3): this {
+        const result = (<any> this.constructor)()
+        return Vector3.CrossToRef(this, other, result);
     }
 
     /**
@@ -1635,7 +1649,7 @@ export class Vector3 {
      * @param len the length of the vector
      * @returns the current updated Vector3
      */
-    public normalizeFromLength(len: number): Vector3 {
+    public normalizeFromLength(len: number): this {
         if (len === 0 || len === 1.0) {
             return this;
         }
@@ -1648,8 +1662,8 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#124
      * @returns the new Vector3
      */
-    public normalizeToNew(): Vector3 {
-        const normalized = new Vector3(0, 0, 0);
+    public normalizeToNew(): this {
+        const normalized = new (<any> this.constructor)(0, 0, 0);
         this.normalizeToRef(normalized);
         return normalized;
     }
@@ -1660,7 +1674,7 @@ export class Vector3 {
      * @param reference define the Vector3 to update
      * @returns the updated Vector3
      */
-    public normalizeToRef(reference: Vector3): Vector3 {
+    public normalizeToRef<T extends Vector3>(reference: T): T {
         const len = this.length();
         if (len === 0 || len === 1.0) {
             return reference.copyFromFloats(this._x, this._y, this._z);
@@ -1674,8 +1688,8 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#11
      * @returns the new Vector3
      */
-    public clone(): Vector3 {
-        return new Vector3(this._x, this._y, this._z);
+    public clone(): this {
+        return new (<any> this.constructor)(this._x, this._y, this._z);
     }
 
     /**
@@ -1684,7 +1698,7 @@ export class Vector3 {
      * @param source defines the source Vector3
      * @returns the current updated Vector3
      */
-    public copyFrom(source: DeepImmutable<Vector3>): Vector3 {
+    public copyFrom(source: DeepImmutable<Vector3>): this {
         return this.copyFromFloats(source._x, source._y, source._z);
     }
 
@@ -1696,7 +1710,7 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the current updated Vector3
      */
-    public copyFromFloats(x: number, y: number, z: number): Vector3 {
+    public copyFromFloats(x: number, y: number, z: number): this {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -1711,7 +1725,7 @@ export class Vector3 {
      * @param z defines the z coordinate of the operand
      * @returns the current updated Vector3
      */
-    public set(x: number, y: number, z: number): Vector3 {
+    public set(x: number, y: number, z: number): this {
         return this.copyFromFloats(x, y, z);
     }
 
@@ -1721,7 +1735,7 @@ export class Vector3 {
      * @param v defines the x, y and z coordinates of the operand
      * @returns the current updated Vector3
      */
-    public setAll(v: number): Vector3 {
+    public setAll(v: number): this {
         this.x = this.y = this.z = v;
         return this;
     }
@@ -1737,7 +1751,7 @@ export class Vector3 {
      * @param size defines the size along the axis
      * @returns the clip factor
      */
-    public static GetClipFactor(vector0: DeepImmutable<Vector3>, vector1: DeepImmutable<Vector3>, axis: DeepImmutable<Vector3>, size: number) {
+    public static GetClipFactor(vector0: DeepImmutable<Vector3>, vector1: DeepImmutable<Vector3>, axis: DeepImmutable<Vector3>, size: number): number {
         const d0 = Vector3.Dot(vector0, axis) - size;
         const d1 = Vector3.Dot(vector1, axis) - size;
 
@@ -1809,7 +1823,7 @@ export class Vector3 {
      * @param ref the vector3 to store the result
      * @returns ref in the form (pitch, yaw, 0)
      */
-    public static PitchYawRollToMoveBetweenPointsToRef(start: Vector3, target: Vector3, ref: Vector3): Vector3 {
+    public static PitchYawRollToMoveBetweenPointsToRef<T extends Vector3>(start: Vector3, target: Vector3, ref: T): T {
         const diff = TmpVectors.Vector3[0];
         target.subtractToRef(start, diff);
         ref.y = Math.atan2(diff.x, diff.z) || 0;
@@ -1841,7 +1855,7 @@ export class Vector3 {
      * @param slerp amount (will be clamped between 0 and 1)
      * @param result The slerped vector
      */
-    public static SlerpToRef(vector0: Vector3, vector1: Vector3, slerp: number, result: Vector3) {
+    public static SlerpToRef<T extends Vector3 = Vector3>(vector0: Vector3, vector1: Vector3, slerp: number, result: T): T {
         slerp = Scalar.Clamp(slerp, 0, 1);
         const vector0Dir = MathTmp.Vector3[0];
         const vector1Dir = MathTmp.Vector3[1];
@@ -1874,6 +1888,7 @@ export class Vector3 {
         vector1Dir.scaleInPlace(scale1);
         result.copyFrom(vector0Dir).addInPlace(vector1Dir);
         result.scaleInPlace(Scalar.Lerp(vector0Length, vector1Length, slerp));
+        return result
     }
 
     /**
@@ -1885,8 +1900,9 @@ export class Vector3 {
      * @param lerpTime total interpolation time
      * @param result the smoothed vector
      */
-    public static SmoothToRef(source: Vector3, goal: Vector3, deltaTime: number, lerpTime: number, result: Vector3) {
+    public static SmoothToRef<T extends Vector3 = Vector3>(source: Vector3, goal: Vector3, deltaTime: number, lerpTime: number, result: T): T {
         Vector3.SlerpToRef(source, goal, lerpTime === 0 ? 1 : deltaTime / lerpTime, result);
+        return result
     }
 
     /**
@@ -1917,11 +1933,13 @@ export class Vector3 {
      * @param array defines the source array
      * @param offset defines the offset in the source array
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static FromArrayToRef(array: DeepImmutable<ArrayLike<number>>, offset: number, result: Vector3): void {
+    public static FromArrayToRef<T extends Vector3>(array: DeepImmutable<ArrayLike<number>>, offset: number, result: T): T {
         result.x = array[offset];
         result.y = array[offset + 1];
         result.z = array[offset + 2];
+        return result
     }
 
     /**
@@ -1931,8 +1949,8 @@ export class Vector3 {
      * @param result defines the Vector3 where to store the result
      * @deprecated Please use FromArrayToRef instead.
      */
-    public static FromFloatArrayToRef(array: DeepImmutable<Float32Array>, offset: number, result: Vector3): void {
-        return Vector3.FromArrayToRef(array, offset, result);
+    public static FromFloatArrayToRef<T extends Vector3>(array: DeepImmutable<Float32Array>, offset: number, result: T): T {
+        return Vector3.FromArrayToRef<T>(array, offset, result);
     }
 
     /**
@@ -1943,8 +1961,9 @@ export class Vector3 {
      * @param z defines the z coordinate of the source
      * @param result defines the Vector3 where to store the result
      */
-    public static FromFloatsToRef(x: number, y: number, z: number, result: Vector3): void {
+    public static FromFloatsToRef<T extends Vector3 = Vector3>(x: number, y: number, z: number, result: T): T {
         result.copyFromFloats(x, y, z);
+        return result
     }
 
     /**
@@ -2070,7 +2089,7 @@ export class Vector3 {
      * @param transformation defines the transformation matrix
      * @returns the transformed Vector3
      */
-    public static TransformCoordinates(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>): Vector3 {
+    public static TransformCoordinates<T extends Vector3>(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>): Vector3 {
         const result = Vector3.Zero();
         Vector3.TransformCoordinatesToRef(vector, transformation, result);
         return result;
@@ -2083,9 +2102,11 @@ export class Vector3 {
      * @param vector defines the Vector3 to transform
      * @param transformation defines the transformation matrix
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static TransformCoordinatesToRef(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: Vector3): void {
+    public static TransformCoordinatesToRef<T extends Vector3>(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: T): T {
         Vector3.TransformCoordinatesFromFloatsToRef(vector._x, vector._y, vector._z, transformation, result);
+        return result;
     }
 
     /**
@@ -2097,8 +2118,9 @@ export class Vector3 {
      * @param z define the z coordinate of the source vector
      * @param transformation defines the transformation matrix
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static TransformCoordinatesFromFloatsToRef(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: Vector3): void {
+    public static TransformCoordinatesFromFloatsToRef<T extends Vector3>(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         const rx = x * m[0] + y * m[4] + z * m[8] + m[12];
         const ry = x * m[1] + y * m[5] + z * m[9] + m[13];
@@ -2108,6 +2130,7 @@ export class Vector3 {
         result.x = rx * rw;
         result.y = ry * rw;
         result.z = rz * rw;
+        return result;
     }
 
     /**
@@ -2131,9 +2154,11 @@ export class Vector3 {
      * @param vector defines the Vector3 to transform
      * @param transformation defines the transformation matrix
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static TransformNormalToRef(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: Vector3): void {
+    public static TransformNormalToRef<T extends Vector3>(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: T): T {
         this.TransformNormalFromFloatsToRef(vector._x, vector._y, vector._z, transformation, result);
+        return result
     }
 
     /**
@@ -2145,12 +2170,14 @@ export class Vector3 {
      * @param z define the z coordinate of the source vector
      * @param transformation defines the transformation matrix
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static TransformNormalFromFloatsToRef(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: Vector3): void {
+    public static TransformNormalFromFloatsToRef<T extends Vector3>(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         result.x = x * m[0] + y * m[4] + z * m[8];
         result.y = x * m[1] + y * m[5] + z * m[9];
         result.z = x * m[2] + y * m[6] + z * m[10];
+        return result
     }
 
     /**
@@ -2163,13 +2190,13 @@ export class Vector3 {
      * @param amount defines the amount on the spline to use
      * @returns the new Vector3
      */
-    public static CatmullRom(
-        value1: DeepImmutable<Vector3>,
+    public static CatmullRom<T extends Vector3>(
+        value1: DeepImmutable<T>,
         value2: DeepImmutable<Vector3>,
         value3: DeepImmutable<Vector3>,
         value4: DeepImmutable<Vector3>,
         amount: number
-    ): Vector3 {
+    ): T {
         const squared = amount * amount;
         const cubed = amount * squared;
 
@@ -2194,7 +2221,7 @@ export class Vector3 {
                 (2.0 * value1._z - 5.0 * value2._z + 4.0 * value3._z - value4._z) * squared +
                 (-value1._z + 3.0 * value2._z - 3.0 * value3._z + value4._z) * cubed);
 
-        return new Vector3(x, y, z);
+        return new (<any> value1.constructor)(x, y, z);
     }
 
     /**
@@ -2207,8 +2234,8 @@ export class Vector3 {
      * @param max defines the upper range value
      * @returns the new Vector3
      */
-    public static Clamp(value: DeepImmutable<Vector3>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): Vector3 {
-        const v = new Vector3();
+    public static Clamp<T extends Vector3>(value: DeepImmutable<T>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): T {
+        const v = new (<any> value.constructor)();
         Vector3.ClampToRef(value, min, max, v);
         return v;
     }
@@ -2221,8 +2248,9 @@ export class Vector3 {
      * @param min defines the lower range value
      * @param max defines the upper range value
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static ClampToRef(value: DeepImmutable<Vector3>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>, result: Vector3): void {
+    public static ClampToRef<T extends Vector3>(value: DeepImmutable<Vector3>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>, result: T): T {
         let x = value._x;
         x = x > max._x ? max._x : x;
         x = x < min._x ? min._x : x;
@@ -2236,6 +2264,7 @@ export class Vector3 {
         z = z < min._z ? min._z : z;
 
         result.copyFromFloats(x, y, z);
+        return result;
     }
 
     /**
@@ -2260,13 +2289,13 @@ export class Vector3 {
      * @param amount defines the amount on the interpolation spline (between 0 and 1)
      * @returns the new Vector3
      */
-    public static Hermite(
-        value1: DeepImmutable<Vector3>,
+    public static Hermite<T extends Vector3>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Vector3>,
         value2: DeepImmutable<Vector3>,
         tangent2: DeepImmutable<Vector3>,
         amount: number
-    ): Vector3 {
+    ): T {
         const squared = amount * amount;
         const cubed = amount * squared;
         const part1 = 2.0 * cubed - 3.0 * squared + 1.0;
@@ -2277,7 +2306,7 @@ export class Vector3 {
         const x = value1._x * part1 + value2._x * part2 + tangent1._x * part3 + tangent2._x * part4;
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
-        return new Vector3(x, y, z);
+        return new (<any> value1.constructor)(x, y, z);
     }
 
     /**
@@ -2290,14 +2319,14 @@ export class Vector3 {
      * @param time define where the derivative must be done
      * @returns 1st derivative
      */
-    public static Hermite1stDerivative(
-        value1: DeepImmutable<Vector3>,
+    public static Hermite1stDerivative<T extends Vector3>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Vector3>,
         value2: DeepImmutable<Vector3>,
         tangent2: DeepImmutable<Vector3>,
         time: number
-    ): Vector3 {
-        const result = Vector3.Zero();
+    ): T {
+        const result = (<any> value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -2313,20 +2342,22 @@ export class Vector3 {
      * @param tangent2 defines the second tangent
      * @param time define where the derivative must be done
      * @param result define where to store the derivative
+     * @returns result input
      */
-    public static Hermite1stDerivativeToRef(
+    public static Hermite1stDerivativeToRef<T extends Vector3>(
         value1: DeepImmutable<Vector3>,
         tangent1: DeepImmutable<Vector3>,
         value2: DeepImmutable<Vector3>,
         tangent2: DeepImmutable<Vector3>,
         time: number,
-        result: Vector3
-    ) {
+        result: T
+    ): T {
         const t2 = time * time;
 
         result.x = (t2 - time) * 6 * value1.x + (3 * t2 - 4 * time + 1) * tangent1.x + (-t2 + time) * 6 * value2.x + (3 * t2 - 2 * time) * tangent2.x;
         result.y = (t2 - time) * 6 * value1.y + (3 * t2 - 4 * time + 1) * tangent1.y + (-t2 + time) * 6 * value2.y + (3 * t2 - 2 * time) * tangent2.y;
         result.z = (t2 - time) * 6 * value1.z + (3 * t2 - 4 * time + 1) * tangent1.z + (-t2 + time) * 6 * value2.z + (3 * t2 - 2 * time) * tangent2.z;
+        return result;
     }
 
     /**
@@ -2337,8 +2368,8 @@ export class Vector3 {
      * @param amount max defines amount between both (between 0 and 1)
      * @returns the new Vector3
      */
-    public static Lerp(start: DeepImmutable<Vector3>, end: DeepImmutable<Vector3>, amount: number): Vector3 {
-        const result = new Vector3(0, 0, 0);
+    public static Lerp<T extends Vector3>(start: DeepImmutable<T>, end: DeepImmutable<Vector3>, amount: number): T {
+        const result = new (<any> start.constructor)(0, 0, 0);
         Vector3.LerpToRef(start, end, amount, result);
         return result;
     }
@@ -2350,11 +2381,13 @@ export class Vector3 {
      * @param end defines the end value
      * @param amount max defines amount between both (between 0 and 1)
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static LerpToRef(start: DeepImmutable<Vector3>, end: DeepImmutable<Vector3>, amount: number, result: Vector3): void {
+    public static LerpToRef<T extends Vector3>(start: DeepImmutable<Vector3>, end: DeepImmutable<Vector3>, amount: number, result: T): T {
         result.x = start._x + (end._x - start._x) * amount;
         result.y = start._y + (end._y - start._y) * amount;
         result.z = start._z + (end._z - start._z) * amount;
+        return result
     }
 
     /**
@@ -2376,8 +2409,8 @@ export class Vector3 {
      * @param right defines the right operand
      * @returns the cross product
      */
-    public static Cross(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>): Vector3 {
-        const result = Vector3.Zero();
+    public static Cross<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
+        const result = (<any> left.constructor)();
         Vector3.CrossToRef(left, right, result);
         return result;
     }
@@ -2389,12 +2422,14 @@ export class Vector3 {
      * @param left defines the left operand
      * @param right defines the right operand
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static CrossToRef(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>, result: Vector3): void {
+    public static CrossToRef<T extends Vector3>(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>, result: T): T {
         const x = left._y * right._z - left._z * right._y;
         const y = left._z * right._x - left._x * right._z;
         const z = left._x * right._y - left._y * right._x;
         result.copyFromFloats(x, y, z);
+        return result
     }
 
     /**
@@ -2414,9 +2449,11 @@ export class Vector3 {
      * Example Playground https://playground.babylonjs.com/#R1F8YU#98
      * @param vector defines the Vector3 to normalize
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static NormalizeToRef(vector: DeepImmutable<Vector3>, result: Vector3): void {
+    public static NormalizeToRef<T extends Vector3>(vector: DeepImmutable<Vector3>, result: T): T {
         vector.normalizeToRef(result);
+        return result;
     }
 
     /**
@@ -2428,8 +2465,8 @@ export class Vector3 {
      * @param viewport defines the screen viewport to use
      * @returns the new Vector3
      */
-    public static Project(vector: DeepImmutable<Vector3>, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>, viewport: DeepImmutable<Viewport>): Vector3 {
-        const result = new Vector3();
+    public static Project<T extends Vector3>(vector: DeepImmutable<T>, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>, viewport: DeepImmutable<Viewport>): T {
+        const result = new (<any> vector.constructor)();
         Vector3.ProjectToRef(vector, world, transform, viewport, result);
         return result;
     }
@@ -2442,15 +2479,15 @@ export class Vector3 {
      * @param transform defines the transform (view x projection) matrix to use
      * @param viewport defines the screen viewport to use
      * @param result the vector in which the screen space will be stored
-     * @returns the new Vector3
+     * @returns result input
      */
-    public static ProjectToRef(
+    public static ProjectToRef<T extends Vector3>(
         vector: DeepImmutable<Vector3>,
         world: DeepImmutable<Matrix>,
         transform: DeepImmutable<Matrix>,
         viewport: DeepImmutable<Viewport>,
-        result: DeepImmutable<Vector3>
-    ): Vector3 {
+        result: T
+    ): T {
         const cw = viewport.width;
         const ch = viewport.height;
         const cx = viewport.x;
@@ -2471,13 +2508,14 @@ export class Vector3 {
     /**
      * @internal
      */
-    public static _UnprojectFromInvertedMatrixToRef(source: DeepImmutable<Vector3>, matrix: DeepImmutable<Matrix>, result: Vector3) {
+    public static _UnprojectFromInvertedMatrixToRef<T extends Vector3>(source: DeepImmutable<Vector3>, matrix: DeepImmutable<Matrix>, result: T): T {
         Vector3.TransformCoordinatesToRef(source, matrix, result);
         const m = matrix.m;
         const num = source._x * m[3] + source._y * m[7] + source._z * m[11] + m[15];
         if (Scalar.WithinEpsilon(num, 1.0)) {
             result.scaleInPlace(1.0 / num);
         }
+        return result
     }
 
     /**
@@ -2490,7 +2528,7 @@ export class Vector3 {
      * @param transform defines the transform (view x projection) matrix to use
      * @returns the new Vector3
      */
-    public static UnprojectFromTransform(source: Vector3, viewportWidth: number, viewportHeight: number, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>): Vector3 {
+    public static UnprojectFromTransform<T extends Vector3>(source: DeepImmutable<T>, viewportWidth: number, viewportHeight: number, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>): T {
         return this.Unproject(source, viewportWidth, viewportHeight, world, transform, Matrix.IdentityReadOnly);
     }
 
@@ -2505,15 +2543,15 @@ export class Vector3 {
      * @param projection defines the projection matrix to use
      * @returns the new Vector3
      */
-    public static Unproject(
-        source: DeepImmutable<Vector3>,
+    public static Unproject<T extends Vector3>(
+        source: DeepImmutable<T>,
         viewportWidth: number,
         viewportHeight: number,
         world: DeepImmutable<Matrix>,
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>
-    ): Vector3 {
-        const result = Vector3.Zero();
+    ): T {
+        const result = (<any> source.constructor)();
 
         Vector3.UnprojectToRef(source, viewportWidth, viewportHeight, world, view, projection, result);
 
@@ -2530,17 +2568,19 @@ export class Vector3 {
      * @param view defines the view matrix to use
      * @param projection defines the projection matrix to use
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static UnprojectToRef(
+    public static UnprojectToRef<T extends Vector3>(
         source: DeepImmutable<Vector3>,
         viewportWidth: number,
         viewportHeight: number,
         world: DeepImmutable<Matrix>,
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>,
-        result: Vector3
-    ): void {
+        result: T
+    ): T {
         Vector3.UnprojectFloatsToRef(source._x, source._y, source._z, viewportWidth, viewportHeight, world, view, projection, result);
+        return result
     }
 
     /**
@@ -2555,8 +2595,9 @@ export class Vector3 {
      * @param view defines the view matrix to use
      * @param projection defines the projection matrix to use
      * @param result defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static UnprojectFloatsToRef(
+    public static UnprojectFloatsToRef<T extends Vector3>(
         sourceX: float,
         sourceY: float,
         sourceZ: float,
@@ -2565,8 +2606,8 @@ export class Vector3 {
         world: DeepImmutable<Matrix>,
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>,
-        result: Vector3
-    ): void {
+        result: T
+    ): T {
         const matrix = MathTmp.Matrix[0];
         world.multiplyToRef(view, matrix);
         matrix.multiplyToRef(projection, matrix);
@@ -2582,6 +2623,7 @@ export class Vector3 {
         }
 
         Vector3._UnprojectFromInvertedMatrixToRef(screenSource, matrix, result);
+        return result;
     }
 
     /**
@@ -2591,8 +2633,9 @@ export class Vector3 {
      * @param right defines the second operand
      * @returns the new Vector3
      */
-    public static Minimize(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>): Vector3 {
-        const min = left.clone();
+    public static Minimize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
+        const min = (<any> left.constructor)();
+        min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
     }
@@ -2604,8 +2647,9 @@ export class Vector3 {
      * @param right defines the second operand
      * @returns the new Vector3
      */
-    public static Maximize(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>): Vector3 {
-        const max = left.clone();
+    public static Maximize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
+        const max = (<any> left.constructor)();
+        max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
     }
@@ -2812,7 +2856,7 @@ export class Vector3 {
      * @param ref defines third vector
      * @returns ref
      */
-    public static CenterToRef(value1: DeepImmutable<Vector3>, value2: DeepImmutable<Vector3>, ref: DeepImmutable<Vector3>): Vector3 {
+    public static CenterToRef<T extends Vector3>(value1: DeepImmutable<Vector3>, value2: DeepImmutable<Vector3>, ref: T): T {
         return ref.copyFromFloats((value1._x + value2._x) / 2, (value1._y + value2._y) / 2, (value1._z + value2._z) / 2);
     }
 
@@ -2828,8 +2872,8 @@ export class Vector3 {
      * @returns a new Vector3
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/target_align
      */
-    public static RotationFromAxis(axis1: DeepImmutable<Vector3>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): Vector3 {
-        const rotation = Vector3.Zero();
+    public static RotationFromAxis<T extends Vector3>(axis1: DeepImmutable<T>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): T {
+        const rotation = (<any> axis1.constructor)();
         Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
         return rotation;
     }
@@ -2841,11 +2885,13 @@ export class Vector3 {
      * @param axis2 defines the second axis
      * @param axis3 defines the third axis
      * @param ref defines the Vector3 where to store the result
+     * @returns result input
      */
-    public static RotationFromAxisToRef(axis1: DeepImmutable<Vector3>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>, ref: Vector3): void {
+    public static RotationFromAxisToRef<T extends Vector3>(axis1: DeepImmutable<Vector3>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>, ref: T): T {
         const quat = MathTmp.Quaternion[0];
         Quaternion.RotationQuaternionFromAxisToRef(axis1, axis2, axis3, quat);
         quat.toEulerAnglesToRef(ref);
+        return ref
     }
 }
 
@@ -2925,7 +2971,7 @@ export class Vector4 {
      * @param index index of the array to start at (default: 0)
      * @returns the Vector4.
      */
-    public toArray(array: FloatArray, index?: number): Vector4 {
+    public toArray(array: FloatArray, index?: number): this {
         if (index === undefined) {
             index = 0;
         }
@@ -2942,7 +2988,7 @@ export class Vector4 {
      * @param index defines the offset in the destination array
      * @returns the current Vector3
      */
-    public fromArray(array: FloatArray, index: number = 0): Vector4 {
+    public fromArray(array: FloatArray, index: number = 0): this {
         Vector4.FromArrayToRef(array, index, this);
         return this;
     }
@@ -2952,7 +2998,7 @@ export class Vector4 {
      * @param otherVector the vector to add
      * @returns the updated Vector4.
      */
-    public addInPlace(otherVector: DeepImmutable<Vector4>): Vector4 {
+    public addInPlace(otherVector: DeepImmutable<Vector4>): this {
         this.x += otherVector.x;
         this.y += otherVector.y;
         this.z += otherVector.z;
@@ -2965,22 +3011,22 @@ export class Vector4 {
      * @param otherVector the vector to add
      * @returns the resulting vector
      */
-    public add(otherVector: DeepImmutable<Vector4>): Vector4 {
-        return new Vector4(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
+    public add(otherVector: DeepImmutable<Vector4>): this {
+        return new (<any> this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
     }
 
     /**
      * Updates the given vector "result" with the result of the addition of the current Vector4 and the given one.
      * @param otherVector the vector to add
      * @param result the vector to store the result
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public addToRef(otherVector: DeepImmutable<Vector4>, result: Vector4): Vector4 {
+    public addToRef<T extends Vector4>(otherVector: DeepImmutable<Vector4>, result: T): T {
         result.x = this.x + otherVector.x;
         result.y = this.y + otherVector.y;
         result.z = this.z + otherVector.z;
         result.w = this.w + otherVector.w;
-        return this;
+        return result;
     }
 
     /**
@@ -2988,7 +3034,7 @@ export class Vector4 {
      * @param otherVector the vector to subtract
      * @returns the updated Vector4.
      */
-    public subtractInPlace(otherVector: DeepImmutable<Vector4>): Vector4 {
+    public subtractInPlace(otherVector: DeepImmutable<Vector4>): this {
         this.x -= otherVector.x;
         this.y -= otherVector.y;
         this.z -= otherVector.z;
@@ -3001,22 +3047,22 @@ export class Vector4 {
      * @param otherVector the vector to add
      * @returns the new vector with the result
      */
-    public subtract(otherVector: DeepImmutable<Vector4>): Vector4 {
-        return new Vector4(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
+    public subtract(otherVector: DeepImmutable<Vector4>): this {
+        return new (<any> this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
     }
 
     /**
      * Sets the given vector "result" with the result of the subtraction of the given vector from the current Vector4.
      * @param otherVector the vector to subtract
      * @param result the vector to store the result
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public subtractToRef(otherVector: DeepImmutable<Vector4>, result: Vector4): Vector4 {
+    public subtractToRef<T extends Vector4>(otherVector: DeepImmutable<Vector4>, result: T): T {
         result.x = this.x - otherVector.x;
         result.y = this.y - otherVector.y;
         result.z = this.z - otherVector.z;
         result.w = this.w - otherVector.w;
-        return this;
+        return result;
     }
 
     /**
@@ -3030,8 +3076,8 @@ export class Vector4 {
      * @param w value to subtract
      * @returns new vector containing the result
      */
-    public subtractFromFloats(x: number, y: number, z: number, w: number): Vector4 {
-        return new Vector4(this.x - x, this.y - y, this.z - z, this.w - w);
+    public subtractFromFloats(x: number, y: number, z: number, w: number): this {
+        return new (<any> this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     /**
@@ -3041,29 +3087,29 @@ export class Vector4 {
      * @param z value to subtract
      * @param w value to subtract
      * @param result the vector to store the result in
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public subtractFromFloatsToRef(x: number, y: number, z: number, w: number, result: Vector4): Vector4 {
+    public subtractFromFloatsToRef<T extends Vector4>(x: number, y: number, z: number, w: number, result: T): T {
         result.x = this.x - x;
         result.y = this.y - y;
         result.z = this.z - z;
         result.w = this.w - w;
-        return this;
+        return result;
     }
 
     /**
      * Returns a new Vector4 set with the current Vector4 negated coordinates.
      * @returns a new vector with the negated values
      */
-    public negate(): Vector4 {
-        return new Vector4(-this.x, -this.y, -this.z, -this.w);
+    public negate(): this {
+        return new (<any> this.constructor)(-this.x, -this.y, -this.z, -this.w);
     }
 
     /**
      * Negate this vector in place
      * @returns this
      */
-    public negateInPlace(): Vector4 {
+    public negateInPlace(): this {
         this.x *= -1;
         this.y *= -1;
         this.z *= -1;
@@ -3076,7 +3122,7 @@ export class Vector4 {
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public negateToRef(result: Vector4): Vector4 {
+    public negateToRef<T extends Vector4>(result: T): T {
         return result.copyFromFloats(this.x * -1, this.y * -1, this.z * -1, this.w * -1);
     }
 
@@ -3085,7 +3131,7 @@ export class Vector4 {
      * @param scale the number to scale with
      * @returns the updated Vector4.
      */
-    public scaleInPlace(scale: number): Vector4 {
+    public scaleInPlace(scale: number): this {
         this.x *= scale;
         this.y *= scale;
         this.z *= scale;
@@ -3098,36 +3144,36 @@ export class Vector4 {
      * @param scale the number to scale with
      * @returns a new vector with the result
      */
-    public scale(scale: number): Vector4 {
-        return new Vector4(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
+    public scale(scale: number): this {
+        return new (<any> this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
     }
 
     /**
      * Sets the given vector "result" with the current Vector4 coordinates multiplied by scale (float).
      * @param scale the number to scale with
      * @param result a vector to store the result in
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public scaleToRef(scale: number, result: Vector4): Vector4 {
+    public scaleToRef<T extends Vector4>(scale: number, result: T): T {
         result.x = this.x * scale;
         result.y = this.y * scale;
         result.z = this.z * scale;
         result.w = this.w * scale;
-        return this;
+        return result;
     }
 
     /**
      * Scale the current Vector4 values by a factor and add the result to a given Vector4
      * @param scale defines the scale factor
      * @param result defines the Vector4 object where to store the result
-     * @returns the unmodified current Vector4
+     * @returns result input
      */
-    public scaleAndAddToRef(scale: number, result: Vector4): Vector4 {
+    public scaleAndAddToRef<T extends Vector4>(scale: number, result: T): T {
         result.x += this.x * scale;
         result.y += this.y * scale;
         result.z += this.z * scale;
         result.w += this.w * scale;
-        return this;
+        return result;
     }
 
     /**
@@ -3172,7 +3218,7 @@ export class Vector4 {
      * @param otherVector vector to multiple with
      * @returns the updated Vector4.
      */
-    public multiplyInPlace(otherVector: Vector4): Vector4 {
+    public multiplyInPlace(otherVector: Vector4): this {
         this.x *= otherVector.x;
         this.y *= otherVector.y;
         this.z *= otherVector.z;
@@ -3185,21 +3231,21 @@ export class Vector4 {
      * @param otherVector vector to multiple with
      * @returns resulting new vector
      */
-    public multiply(otherVector: DeepImmutable<Vector4>): Vector4 {
-        return new Vector4(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
+    public multiply(otherVector: DeepImmutable<Vector4>): this {
+        return new (<any> this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
     }
     /**
      * Updates the given vector "result" with the multiplication result of the current Vector4 and the given one.
      * @param otherVector vector to multiple with
      * @param result vector to store the result
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public multiplyToRef(otherVector: DeepImmutable<Vector4>, result: Vector4): Vector4 {
+    public multiplyToRef<T extends Vector4>(otherVector: DeepImmutable<Vector4>, result: T): T {
         result.x = this.x * otherVector.x;
         result.y = this.y * otherVector.y;
         result.z = this.z * otherVector.z;
         result.w = this.w * otherVector.w;
-        return this;
+        return result;
     }
     /**
      * Returns a new Vector4 set with the multiplication result of the given floats and the current Vector4 coordinates.
@@ -3209,29 +3255,29 @@ export class Vector4 {
      * @param w w value multiply with
      * @returns resulting new vector
      */
-    public multiplyByFloats(x: number, y: number, z: number, w: number): Vector4 {
-        return new Vector4(this.x * x, this.y * y, this.z * z, this.w * w);
+    public multiplyByFloats(x: number, y: number, z: number, w: number): this {
+        return new (<any> this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
     }
     /**
      * Returns a new Vector4 set with the division result of the current Vector4 by the given one.
      * @param otherVector vector to devide with
      * @returns resulting new vector
      */
-    public divide(otherVector: DeepImmutable<Vector4>): Vector4 {
-        return new Vector4(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
+    public divide(otherVector: DeepImmutable<Vector4>): this {
+        return new (<any> this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
     }
     /**
      * Updates the given vector "result" with the division result of the current Vector4 by the given one.
      * @param otherVector vector to devide with
      * @param result vector to store the result
-     * @returns the current Vector4.
+     * @returns result input
      */
-    public divideToRef(otherVector: DeepImmutable<Vector4>, result: Vector4): Vector4 {
+    public divideToRef<T extends Vector4>(otherVector: DeepImmutable<Vector4>, result: T): T {
         result.x = this.x / otherVector.x;
         result.y = this.y / otherVector.y;
         result.z = this.z / otherVector.z;
         result.w = this.w / otherVector.w;
-        return this;
+        return result;
     }
 
     /**
@@ -3239,7 +3285,7 @@ export class Vector4 {
      * @param otherVector vector to devide with
      * @returns the updated Vector3.
      */
-    public divideInPlace(otherVector: DeepImmutable<Vector4>): Vector4 {
+    public divideInPlace(otherVector: DeepImmutable<Vector4>): this {
         return this.divideToRef(otherVector, this);
     }
 
@@ -3248,7 +3294,7 @@ export class Vector4 {
      * @param other defines the second operand
      * @returns the current updated Vector4
      */
-    public minimizeInPlace(other: DeepImmutable<Vector4>): Vector4 {
+    public minimizeInPlace(other: DeepImmutable<Vector4>): this {
         if (other.x < this.x) {
             this.x = other.x;
         }
@@ -3268,7 +3314,7 @@ export class Vector4 {
      * @param other defines the second operand
      * @returns the current updated Vector4
      */
-    public maximizeInPlace(other: DeepImmutable<Vector4>): Vector4 {
+    public maximizeInPlace(other: DeepImmutable<Vector4>): this {
         if (other.x > this.x) {
             this.x = other.x;
         }
@@ -3288,16 +3334,16 @@ export class Vector4 {
      * Gets a new Vector4 from current Vector4 floored values
      * @returns a new Vector4
      */
-    public floor(): Vector4 {
-        return new Vector4(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
+    public floor(): this {
+        return new (<any> this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
     }
 
     /**
      * Gets a new Vector4 from current Vector4 fractional values
      * @returns a new Vector4
      */
-    public fract(): Vector4 {
-        return new Vector4(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
+    public fract(): this {
+        return new (<any> this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
     }
 
     // Properties
@@ -3321,7 +3367,7 @@ export class Vector4 {
      * Normalizes in place the Vector4.
      * @returns the updated Vector4.
      */
-    public normalize(): Vector4 {
+    public normalize(): this {
         const len = this.length();
 
         if (len === 0) {
@@ -3342,15 +3388,15 @@ export class Vector4 {
      * Returns a new Vector4 copied from the current one.
      * @returns the new cloned vector
      */
-    public clone(): Vector4 {
-        return new Vector4(this.x, this.y, this.z, this.w);
+    public clone(): this {
+        return new (<any> this.constructor)(this.x, this.y, this.z, this.w);
     }
     /**
      * Updates the current Vector4 with the given one coordinates.
      * @param source the source vector to copy from
      * @returns the updated Vector4.
      */
-    public copyFrom(source: DeepImmutable<Vector4>): Vector4 {
+    public copyFrom(source: DeepImmutable<Vector4>): this {
         this.x = source.x;
         this.y = source.y;
         this.z = source.z;
@@ -3365,7 +3411,7 @@ export class Vector4 {
      * @param w float to copy from
      * @returns the updated Vector4.
      */
-    public copyFromFloats(x: number, y: number, z: number, w: number): Vector4 {
+    public copyFromFloats(x: number, y: number, z: number, w: number): this {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -3380,7 +3426,7 @@ export class Vector4 {
      * @param w float to set from
      * @returns the updated Vector4.
      */
-    public set(x: number, y: number, z: number, w: number): Vector4 {
+    public set(x: number, y: number, z: number, w: number): this {
         return this.copyFromFloats(x, y, z, w);
     }
 
@@ -3389,7 +3435,7 @@ export class Vector4 {
      * @param v defines the x, y, z and w coordinates of the operand
      * @returns the current updated Vector3
      */
-    public setAll(v: number): Vector4 {
+    public setAll(v: number): this {
         this.x = this.y = this.z = this.w = v;
         return this;
     }
@@ -3412,21 +3458,25 @@ export class Vector4 {
      * @param array the array to pull values from
      * @param offset the offset into the array to start at
      * @param result the vector to store the result in
+     * @returns result input
      */
-    public static FromArrayToRef(array: DeepImmutable<ArrayLike<number>>, offset: number, result: Vector4): void {
+    public static FromArrayToRef<T extends Vector4>(array: DeepImmutable<ArrayLike<number>>, offset: number, result: T): T {
         result.x = array[offset];
         result.y = array[offset + 1];
         result.z = array[offset + 2];
         result.w = array[offset + 3];
+        return result;
     }
     /**
      * Updates the given vector "result" from the starting index of the given Float32Array.
      * @param array the array to pull values from
      * @param offset the offset into the array to start at
      * @param result the vector to store the result in
+     * @returns result input
      */
-    public static FromFloatArrayToRef(array: DeepImmutable<Float32Array>, offset: number, result: Vector4): void {
+    public static FromFloatArrayToRef<T extends Vector4>(array: DeepImmutable<Float32Array>, offset: number, result: T): T {
         Vector4.FromArrayToRef(array, offset, result);
+        return result;
     }
     /**
      * Updates the given vector "result" coordinates from the given floats.
@@ -3435,12 +3485,14 @@ export class Vector4 {
      * @param z float to set from
      * @param w float to set from
      * @param result the vector to the floats in
+     * @returns result input
      */
-    public static FromFloatsToRef(x: number, y: number, z: number, w: number, result: Vector4): void {
+    public static FromFloatsToRef<T extends Vector4>(x: number, y: number, z: number, w: number, result: T): T {
         result.x = x;
         result.y = y;
         result.z = z;
         result.w = w;
+        return result;
     }
     /**
      * Returns a new Vector4 set to (0.0, 0.0, 0.0, 0.0)
@@ -3476,10 +3528,12 @@ export class Vector4 {
      * Updates the given vector "result" from the normalization of the given one.
      * @param vector the vector to normalize
      * @param result the vector to store the result in
+     * @returns result input
      */
-    public static NormalizeToRef(vector: DeepImmutable<Vector4>, result: Vector4): void {
+    public static NormalizeToRef<T extends Vector4>(vector: DeepImmutable<Vector4>, result: T): T {
         result.copyFrom(vector);
         result.normalize();
+        return result;
     }
 
     /**
@@ -3488,8 +3542,9 @@ export class Vector4 {
      * @param right right vector to minimize
      * @returns a new vector with the minimum of the left and right vector values
      */
-    public static Minimize(left: DeepImmutable<Vector4>, right: DeepImmutable<Vector4>): Vector4 {
-        const min = left.clone();
+    public static Minimize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
+        const min = new (<any> left.constructor)();
+        min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
     }
@@ -3500,8 +3555,9 @@ export class Vector4 {
      * @param right right vector to maximize
      * @returns a new vector with the maximum of the left and right vector values
      */
-    public static Maximize(left: DeepImmutable<Vector4>, right: DeepImmutable<Vector4>): Vector4 {
-        const max = left.clone();
+    public static Maximize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
+        const max = new (<any> left.constructor)();
+        max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
     }
@@ -3545,7 +3601,7 @@ export class Vector4 {
      * @param ref defines third vector
      * @returns ref
      */
-    public static CenterToRef(value1: DeepImmutable<Vector4>, value2: DeepImmutable<Vector4>, ref: DeepImmutable<Vector4>): Vector4 {
+    public static CenterToRef<T extends Vector4>(value1: DeepImmutable<Vector4>, value2: DeepImmutable<Vector4>, ref: T): T {
         return ref.copyFromFloats((value1.x + value2.x) / 2, (value1.y + value2.y) / 2, (value1.z + value2.z) / 2, (value1.w + value2.w) / 2);
     }
 
@@ -3570,9 +3626,11 @@ export class Vector4 {
      * @param vector defines the Vector3 to transform
      * @param transformation defines the transformation matrix
      * @param result defines the Vector4 where to store the result
+     * @returns result input
      */
-    public static TransformCoordinatesToRef(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: Vector4): void {
+    public static TransformCoordinatesToRef<T extends Vector4>(vector: DeepImmutable<Vector3>, transformation: DeepImmutable<Matrix>, result: T): T {
         Vector4.TransformCoordinatesFromFloatsToRef(vector._x, vector._y, vector._z, transformation, result);
+        return result;
     }
 
     /**
@@ -3584,8 +3642,9 @@ export class Vector4 {
      * @param z define the z coordinate of the source vector
      * @param transformation defines the transformation matrix
      * @param result defines the Vector4 where to store the result
+     * @returns result input
      */
-    public static TransformCoordinatesFromFloatsToRef(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: Vector4): void {
+    public static TransformCoordinatesFromFloatsToRef<T extends Vector4>(x: number, y: number, z: number, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         const rx = x * m[0] + y * m[4] + z * m[8] + m[12];
         const ry = x * m[1] + y * m[5] + z * m[9] + m[13];
@@ -3596,6 +3655,7 @@ export class Vector4 {
         result.y = ry;
         result.z = rz;
         result.w = rw;
+        return result;
     }
 
     /**
@@ -3605,8 +3665,8 @@ export class Vector4 {
      * @param transformation the transformation matrix to apply
      * @returns the new vector
      */
-    public static TransformNormal(vector: DeepImmutable<Vector4>, transformation: DeepImmutable<Matrix>): Vector4 {
-        const result = Vector4.Zero();
+    public static TransformNormal<T extends Vector4>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
+        const result = (<any> vector.constructor)();
         Vector4.TransformNormalToRef(vector, transformation, result);
         return result;
     }
@@ -3617,8 +3677,9 @@ export class Vector4 {
      * @param vector the vector to transform
      * @param transformation the transformation matrix to apply
      * @param result the vector to store the result in
+     * @returns result input
      */
-    public static TransformNormalToRef(vector: DeepImmutable<Vector4>, transformation: DeepImmutable<Matrix>, result: Vector4): void {
+    public static TransformNormalToRef<T extends Vector4>(vector: DeepImmutable<Vector4>, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         const x = vector.x * m[0] + vector.y * m[4] + vector.z * m[8];
         const y = vector.x * m[1] + vector.y * m[5] + vector.z * m[9];
@@ -3627,6 +3688,7 @@ export class Vector4 {
         result.y = y;
         result.z = z;
         result.w = vector.w;
+        return result;
     }
 
     /**
@@ -3638,13 +3700,15 @@ export class Vector4 {
      * @param w value to transform
      * @param transformation the transformation matrix to apply
      * @param result the vector to store the results in
+     * @returns result input
      */
-    public static TransformNormalFromFloatsToRef(x: number, y: number, z: number, w: number, transformation: DeepImmutable<Matrix>, result: Vector4): void {
+    public static TransformNormalFromFloatsToRef<T extends Vector4>(x: number, y: number, z: number, w: number, transformation: DeepImmutable<Matrix>, result: T): T {
         const m = transformation.m;
         result.x = x * m[0] + y * m[4] + z * m[8];
         result.y = x * m[1] + y * m[5] + z * m[9];
         result.z = x * m[2] + y * m[6] + z * m[10];
         result.w = w;
+        return result;
     }
 
     /**
@@ -3816,8 +3880,8 @@ export class Quaternion {
      * Clone the current quaternion
      * @returns a new quaternion copied from the current one
      */
-    public clone(): Quaternion {
-        return new Quaternion(this._x, this._y, this._z, this._w);
+    public clone(): this {
+        return new (<any> this.constructor)(this._x, this._y, this._z, this._w);
     }
 
     /**
@@ -3825,7 +3889,7 @@ export class Quaternion {
      * @param other defines the other quaternion
      * @returns the updated current quaternion
      */
-    public copyFrom(other: DeepImmutable<Quaternion>): Quaternion {
+    public copyFrom(other: DeepImmutable<Quaternion>): this {
         this.x = other._x;
         this.y = other._y;
         this.z = other._z;
@@ -3841,7 +3905,7 @@ export class Quaternion {
      * @param w defines the w coordinate
      * @returns the updated current quaternion
      */
-    public copyFromFloats(x: number, y: number, z: number, w: number): Quaternion {
+    public copyFromFloats(x: number, y: number, z: number, w: number): this {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -3857,7 +3921,7 @@ export class Quaternion {
      * @param w defines the w coordinate
      * @returns the updated current quaternion
      */
-    public set(x: number, y: number, z: number, w: number): Quaternion {
+    public set(x: number, y: number, z: number, w: number): this {
         return this.copyFromFloats(x, y, z, w);
     }
 
@@ -3866,8 +3930,8 @@ export class Quaternion {
      * @param other defines the second operand
      * @returns a new quaternion as the addition result of the given one and the current quaternion
      */
-    public add(other: DeepImmutable<Quaternion>): Quaternion {
-        return new Quaternion(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
+    public add(other: DeepImmutable<Quaternion>): this {
+        return new (<any> this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
     }
 
     /**
@@ -3875,7 +3939,7 @@ export class Quaternion {
      * @param other defines the quaternion to add
      * @returns the current quaternion
      */
-    public addInPlace(other: DeepImmutable<Quaternion>): Quaternion {
+    public addInPlace(other: DeepImmutable<Quaternion>): this {
         this._x += other._x;
         this._y += other._y;
         this._z += other._z;
@@ -3888,8 +3952,8 @@ export class Quaternion {
      * @param other defines the second operand
      * @returns a new quaternion as the subtraction result of the given one from the current one
      */
-    public subtract(other: Quaternion): Quaternion {
-        return new Quaternion(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
+    public subtract(other: Quaternion): this {
+        return new (<any> this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
     }
 
     /**
@@ -3897,7 +3961,7 @@ export class Quaternion {
      * @param other defines the quaternion to subtract
      * @returns the current quaternion
      */
-    public subtractInPlace(other: DeepImmutable<Quaternion>): Quaternion {
+    public subtractInPlace(other: DeepImmutable<Quaternion>): this {
         this._x -= other._x;
         this._y -= other._y;
         this._z -= other._z;
@@ -3910,22 +3974,22 @@ export class Quaternion {
      * @param value defines the scale factor
      * @returns a new quaternion set by multiplying the current quaternion coordinates by the float "scale"
      */
-    public scale(value: number): Quaternion {
-        return new Quaternion(this._x * value, this._y * value, this._z * value, this._w * value);
+    public scale(value: number): this {
+        return new (<any> this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
     }
 
     /**
      * Scale the current quaternion values by a factor and stores the result to a given quaternion
      * @param scale defines the scale factor
      * @param result defines the Quaternion object where to store the result
-     * @returns the unmodified current quaternion
+     * @returns result input
      */
-    public scaleToRef(scale: number, result: Quaternion): Quaternion {
+    public scaleToRef<T extends Quaternion>(scale: number, result: T): T {
         result.x = this._x * scale;
         result.y = this._y * scale;
         result.z = this._z * scale;
         result.w = this._w * scale;
-        return this;
+        return result;
     }
 
     /**
@@ -3933,7 +3997,7 @@ export class Quaternion {
      * @param value defines the scale factor
      * @returns the current modified quaternion
      */
-    public scaleInPlace(value: number): Quaternion {
+    public scaleInPlace(value: number): this {
         this.x *= value;
         this.y *= value;
         this.z *= value;
@@ -3946,14 +4010,14 @@ export class Quaternion {
      * Scale the current quaternion values by a factor and add the result to a given quaternion
      * @param scale defines the scale factor
      * @param result defines the Quaternion object where to store the result
-     * @returns the unmodified current quaternion
+     * @returns result input
      */
-    public scaleAndAddToRef(scale: number, result: Quaternion): Quaternion {
+    public scaleAndAddToRef<T extends Quaternion>(scale: number, result: T): T {
         result.x += this._x * scale;
         result.y += this._y * scale;
         result.z += this._z * scale;
         result.w += this._w * scale;
-        return this;
+        return result;
     }
 
     /**
@@ -3961,8 +4025,8 @@ export class Quaternion {
      * @param q1 defines the second operand
      * @returns a new quaternion set as the multiplication result of the current one with the given one "q1"
      */
-    public multiply(q1: DeepImmutable<Quaternion>): Quaternion {
-        const result = new Quaternion(0, 0, 0, 1.0);
+    public multiply(q1: DeepImmutable<Quaternion>): this {
+        const result = new (<any> this.constructor)(0, 0, 0, 1.0);
         this.multiplyToRef(q1, result);
         return result;
     }
@@ -3973,13 +4037,13 @@ export class Quaternion {
      * @param result defines the target quaternion
      * @returns the current quaternion
      */
-    public multiplyToRef(q1: DeepImmutable<Quaternion>, result: Quaternion): Quaternion {
+    public multiplyToRef<T extends Quaternion>(q1: DeepImmutable<Quaternion>, result: T): T {
         const x = this._x * q1._w + this._y * q1._z - this._z * q1._y + this._w * q1._x;
         const y = -this._x * q1._z + this._y * q1._w + this._z * q1._x + this._w * q1._y;
         const z = this._x * q1._y - this._y * q1._x + this._z * q1._w + this._w * q1._z;
         const w = -this._x * q1._x - this._y * q1._y - this._z * q1._z + this._w * q1._w;
         result.copyFromFloats(x, y, z, w);
-        return this;
+        return result;
     }
 
     /**
@@ -3987,7 +4051,7 @@ export class Quaternion {
      * @param q1 defines the second operand
      * @returns the currentupdated quaternion
      */
-    public multiplyInPlace(q1: DeepImmutable<Quaternion>): Quaternion {
+    public multiplyInPlace(q1: DeepImmutable<Quaternion>): this {
         this.multiplyToRef(q1, this);
         return this;
     }
@@ -3995,18 +4059,18 @@ export class Quaternion {
     /**
      * Conjugates (1-q) the current quaternion and stores the result in the given quaternion
      * @param ref defines the target quaternion
-     * @returns the current quaternion
+     * @returns result input
      */
-    public conjugateToRef(ref: Quaternion): Quaternion {
+    public conjugateToRef<T extends Quaternion>(ref: T): T {
         ref.copyFromFloats(-this._x, -this._y, -this._z, this._w);
-        return this;
+        return ref;
     }
 
     /**
      * Conjugates in place (1-q) the current quaternion
      * @returns the current updated quaternion
      */
-    public conjugateInPlace(): Quaternion {
+    public conjugateInPlace(): this {
         this.x *= -1;
         this.y *= -1;
         this.z *= -1;
@@ -4017,15 +4081,15 @@ export class Quaternion {
      * Conjugates in place (1-q) the current quaternion
      * @returns a new quaternion
      */
-    public conjugate(): Quaternion {
-        return new Quaternion(-this._x, -this._y, -this._z, this._w);
+    public conjugate(): this {
+        return new (<any> this.constructor)(-this._x, -this._y, -this._z, this._w);
     }
 
     /**
      * Returns the inverse of the current quaternion
      * @returns a new quaternion
      */
-    public invert(): Quaternion {
+    public invert(): this {
         const conjugate = this.conjugate();
         const lengthSquared = this.lengthSquared();
         if (lengthSquared == 0 || lengthSquared == 1) {
@@ -4039,7 +4103,7 @@ export class Quaternion {
      * Invert in place the current quaternion
      * @returns this quaternion
      */
-    public invertInPlace(): Quaternion {
+    public invertInPlace(): this {
         this.conjugateInPlace();
         const lengthSquared = this.lengthSquared();
         if (lengthSquared == 0 || lengthSquared == 1) {
@@ -4069,7 +4133,7 @@ export class Quaternion {
      * Normalize in place the current quaternion
      * @returns the current updated quaternion
      */
-    public normalize(): Quaternion {
+    public normalize(): this {
         const len = this.length();
         if (len === 0) {
             return this;
@@ -4084,7 +4148,7 @@ export class Quaternion {
      * Normalize a copy of the current quaternion
      * @returns the normalized quaternion
      */
-    public normalizeToNew(): Quaternion {
+    public normalizeToNew(): this {
         const len = this.length();
         if (len === 0) {
             return this.clone();
@@ -4108,10 +4172,10 @@ export class Quaternion {
     /**
      * Sets the given vector3 "result" with the Euler angles translated from the current quaternion
      * @param result defines the vector which will be filled with the Euler angles
-     * @returns the current unchanged quaternion
+     * @returns result input
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/rotation_conventions
      */
-    public toEulerAnglesToRef(result: Vector3): Quaternion {
+    public toEulerAnglesToRef<T extends Vector3>(result: T): T {
         const qz = this._z;
         const qx = this._x;
         const qy = this._y;
@@ -4138,7 +4202,7 @@ export class Quaternion {
             result.y = Math.atan2(2.0 * (qz * qx + qy * qw), sqz - sqx - sqy + sqw);
         }
 
-        return this;
+        return result;
     }
 
     /**
@@ -4146,9 +4210,9 @@ export class Quaternion {
      * @param result defines the target matrix
      * @returns the current unchanged quaternion
      */
-    public toRotationMatrix(result: Matrix): Quaternion {
+    public toRotationMatrix<T extends Matrix>(result: T): T {
         Matrix.FromQuaternionToRef(this, result);
-        return this;
+        return result;
     }
 
     /**
@@ -4156,7 +4220,7 @@ export class Quaternion {
      * @param matrix defines the source matrix
      * @returns the current updated quaternion
      */
-    public fromRotationMatrix(matrix: DeepImmutable<Matrix>): Quaternion {
+    public fromRotationMatrix(matrix: DeepImmutable<Matrix>): this {
         Quaternion.FromRotationMatrixToRef(matrix, this);
         return this;
     }
@@ -4178,8 +4242,9 @@ export class Quaternion {
      * Updates the given quaternion with the given rotation matrix values
      * @param matrix defines the source matrix
      * @param result defines the target quaternion
+     * @returns result input
      */
-    public static FromRotationMatrixToRef(matrix: DeepImmutable<Matrix>, result: Quaternion): void {
+    public static FromRotationMatrixToRef<T extends Quaternion>(matrix: DeepImmutable<Matrix>, result: T): T {
         const data = matrix.m;
         const m11 = data[0],
             m12 = data[4],
@@ -4222,6 +4287,7 @@ export class Quaternion {
             result.y = (m23 + m32) / s;
             result.z = 0.25 * s;
         }
+        return result;
     }
 
     /**
@@ -4285,11 +4351,12 @@ export class Quaternion {
      * @param lerpTime total interpolation time
      * @param result the smoothed quaternion
      */
-    public static SmoothToRef(source: Quaternion, goal: Quaternion, deltaTime: number, lerpTime: number, result: Quaternion) {
+    public static SmoothToRef<T extends Quaternion>(source: Quaternion, goal: Quaternion, deltaTime: number, lerpTime: number, result: T): T {
         let slerp = lerpTime === 0 ? 1 : deltaTime / lerpTime;
         slerp = Scalar.Clamp(slerp, 0, 1);
 
         Quaternion.SlerpToRef(source, goal, slerp, result);
+        return result;
     }
 
     /**
@@ -4305,8 +4372,8 @@ export class Quaternion {
      * @param q defines the source quaternion
      * @returns a new quaternion as the inverted current quaternion
      */
-    public static Inverse(q: DeepImmutable<Quaternion>): Quaternion {
-        return new Quaternion(-q._x, -q._y, -q._z, q._w);
+    public static Inverse<T extends Quaternion>(q: DeepImmutable<T>): T {
+        return new (<any> q.constructor)(-q._x, -q._y, -q._z, q._w);
     }
 
     /**
@@ -4315,7 +4382,7 @@ export class Quaternion {
      * @param result the quaternion the result will be stored in
      * @returns the result quaternion
      */
-    public static InverseToRef(q: Quaternion, result: Quaternion): Quaternion {
+    public static InverseToRef<T extends Quaternion>(q: Quaternion, result: T): T {
         result.set(-q._x, -q._y, -q._z, q._w);
         return result;
     }
@@ -4354,7 +4421,7 @@ export class Quaternion {
      * @param result defines the target quaternion
      * @returns the target quaternion
      */
-    public static RotationAxisToRef(axis: DeepImmutable<Vector3>, angle: number, result: Quaternion): Quaternion {
+    public static RotationAxisToRef<T extends Quaternion>(axis: DeepImmutable<Vector3>, angle: number, result: T): T {
         const sin = Math.sin(angle / 2);
         axis.normalize();
         result.w = Math.cos(angle / 2);
@@ -4382,12 +4449,14 @@ export class Quaternion {
      * @param array the array to pull values from
      * @param offset the offset into the array to start at
      * @param result the quaternion to store the result in
+     * @returns result input
      */
-    public static FromArrayToRef(array: DeepImmutable<ArrayLike<number>>, offset: number, result: Quaternion): void {
+    public static FromArrayToRef<T extends Quaternion>(array: DeepImmutable<ArrayLike<number>>, offset: number, result: T): T {
         result.x = array[offset];
         result.y = array[offset + 1];
         result.z = array[offset + 2];
         result.w = array[offset + 3];
+        return result;
     }
 
     /**
@@ -4411,7 +4480,7 @@ export class Quaternion {
      * @param result the quaternion to store the result
      * @returns the updated quaternion
      */
-    public static FromEulerAnglesToRef(x: number, y: number, z: number, result: Quaternion): Quaternion {
+    public static FromEulerAnglesToRef<T extends Quaternion>(x: number, y: number, z: number, result: T): T {
         Quaternion.RotationYawPitchRollToRef(y, x, z, result);
         return result;
     }
@@ -4433,7 +4502,7 @@ export class Quaternion {
      * @param result the quaternion to store the result
      * @returns the updated quaternion
      */
-    public static FromEulerVectorToRef(vec: DeepImmutable<Vector3>, result: Quaternion): Quaternion {
+    public static FromEulerVectorToRef<T extends Quaternion>(vec: DeepImmutable<Vector3>, result: T): T {
         Quaternion.RotationYawPitchRollToRef(vec._y, vec._x, vec._z, result);
         return result;
     }
@@ -4445,7 +4514,7 @@ export class Quaternion {
      * @param result the quaternion to store the result
      * @returns the updated quaternion
      */
-    public static FromUnitVectorsToRef(vecFrom: DeepImmutable<Vector3>, vecTo: DeepImmutable<Vector3>, result: Quaternion): Quaternion {
+    public static FromUnitVectorsToRef<T extends Quaternion>(vecFrom: DeepImmutable<Vector3>, vecTo: DeepImmutable<Vector3>, result: T): T {
         const r = Vector3.Dot(vecFrom, vecTo) + 1;
 
         if (r < Epsilon) {
@@ -4481,8 +4550,9 @@ export class Quaternion {
      * @param pitch defines the rotation around X axis
      * @param roll defines the rotation around Z axis
      * @param result defines the target quaternion
+     * @returns result input
      */
-    public static RotationYawPitchRollToRef(yaw: number, pitch: number, roll: number, result: Quaternion): void {
+    public static RotationYawPitchRollToRef<T extends Quaternion>(yaw: number, pitch: number, roll: number, result: T): T {
         // Produces a quaternion from Euler angles in the z-y-x orientation (Tait-Bryan angles)
         const halfRoll = roll * 0.5;
         const halfPitch = pitch * 0.5;
@@ -4499,6 +4569,7 @@ export class Quaternion {
         result.y = sinYaw * cosPitch * cosRoll - cosYaw * sinPitch * sinRoll;
         result.z = cosYaw * cosPitch * sinRoll - sinYaw * sinPitch * cosRoll;
         result.w = cosYaw * cosPitch * cosRoll + sinYaw * sinPitch * sinRoll;
+        return result;
     }
 
     /**
@@ -4520,8 +4591,9 @@ export class Quaternion {
      * @param beta defines the rotation around second axis
      * @param gamma defines the rotation around third axis
      * @param result defines the target quaternion
+     * @returns result input
      */
-    public static RotationAlphaBetaGammaToRef(alpha: number, beta: number, gamma: number, result: Quaternion): void {
+    public static RotationAlphaBetaGammaToRef<T extends Quaternion>(alpha: number, beta: number, gamma: number, result: T): T {
         // Produces a quaternion from Euler angles in the z-x-z orientation
         const halfGammaPlusAlpha = (gamma + alpha) * 0.5;
         const halfGammaMinusAlpha = (gamma - alpha) * 0.5;
@@ -4531,6 +4603,7 @@ export class Quaternion {
         result.y = Math.sin(halfGammaMinusAlpha) * Math.sin(halfBeta);
         result.z = Math.sin(halfGammaPlusAlpha) * Math.cos(halfBeta);
         result.w = Math.cos(halfGammaPlusAlpha) * Math.cos(halfBeta);
+        return result;
     }
 
     /**
@@ -4552,11 +4625,13 @@ export class Quaternion {
      * @param axis2 defines the second axis
      * @param axis3 defines the third axis
      * @param ref defines the target quaternion
+     * @returns result input
      */
-    public static RotationQuaternionFromAxisToRef(axis1: DeepImmutable<Vector3>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>, ref: Quaternion): void {
+    public static RotationQuaternionFromAxisToRef<T extends Quaternion>(axis1: DeepImmutable<Vector3>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>, ref: T): T {
         const rotMat = MathTmp.Matrix[0];
         Matrix.FromXYZAxesToRef(axis1.normalize(), axis2.normalize(), axis3.normalize(), rotMat);
         Quaternion.FromRotationMatrixToRef(rotMat, ref);
+        return ref;
     }
 
     /**
@@ -4578,11 +4653,13 @@ export class Quaternion {
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param ref defines the target quaternion.
+     * @returns result input
      */
-    public static FromLookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
+    public static FromLookDirectionLHToRef<T extends Quaternion>(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: T): T {
         const rotMat = MathTmp.Matrix[0];
         Matrix.LookDirectionLHToRef(forward, up, rotMat);
         Quaternion.FromRotationMatrixToRef(rotMat, ref);
+        return ref;
     }
 
     /**
@@ -4604,8 +4681,9 @@ export class Quaternion {
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param ref defines the target quaternion.
+     * @returns result input
      */
-    public static FromLookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: Quaternion): void {
+    public static FromLookDirectionRHToRef<T extends Quaternion>(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, ref: T): T {
         const rotMat = MathTmp.Matrix[0];
         Matrix.LookDirectionRHToRef(forward, up, rotMat);
         return Quaternion.FromRotationMatrixToRef(rotMat, ref);
@@ -4632,8 +4710,9 @@ export class Quaternion {
      * @param right defines second quaternion
      * @param amount defines the gradient to use
      * @param result defines the target quaternion
+     * @returns result input
      */
-    public static SlerpToRef(left: DeepImmutable<Quaternion>, right: DeepImmutable<Quaternion>, amount: number, result: Quaternion): void {
+    public static SlerpToRef<T extends Quaternion>(left: DeepImmutable<Quaternion>, right: DeepImmutable<Quaternion>, amount: number, result: T): T {
         let num2;
         let num3;
         let num4 = left._x * right._x + left._y * right._y + left._z * right._z + left._w * right._w;
@@ -4658,6 +4737,7 @@ export class Quaternion {
         result.y = num3 * left._y + num2 * right._y;
         result.z = num3 * left._z + num2 * right._z;
         result.w = num3 * left._w + num2 * right._w;
+        return result;
     }
 
     /**
@@ -4669,13 +4749,13 @@ export class Quaternion {
      * @param amount defines the target quaternion
      * @returns the new interpolated quaternion
      */
-    public static Hermite(
-        value1: DeepImmutable<Quaternion>,
+    public static Hermite<T extends Quaternion>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Quaternion>,
         value2: DeepImmutable<Quaternion>,
         tangent2: DeepImmutable<Quaternion>,
         amount: number
-    ): Quaternion {
+    ): T {
         const squared = amount * amount;
         const cubed = amount * squared;
         const part1 = 2.0 * cubed - 3.0 * squared + 1.0;
@@ -4687,7 +4767,7 @@ export class Quaternion {
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
         const w = value1._w * part1 + value2._w * part2 + tangent1._w * part3 + tangent2._w * part4;
-        return new Quaternion(x, y, z, w);
+        return new (<any> value1.constructor)(x, y, z, w);
     }
 
     /**
@@ -4699,14 +4779,14 @@ export class Quaternion {
      * @param time define where the derivative must be done
      * @returns 1st derivative
      */
-    public static Hermite1stDerivative(
-        value1: DeepImmutable<Quaternion>,
+    public static Hermite1stDerivative<T extends Quaternion>(
+        value1: DeepImmutable<T>,
         tangent1: DeepImmutable<Quaternion>,
         value2: DeepImmutable<Quaternion>,
         tangent2: DeepImmutable<Quaternion>,
         time: number
-    ): Quaternion {
-        const result = Quaternion.Zero();
+    ): T {
+        const result = (<any> value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -4721,21 +4801,23 @@ export class Quaternion {
      * @param tangent2 defines the second tangent
      * @param time define where the derivative must be done
      * @param result define where to store the derivative
+     * @returns result input
      */
-    public static Hermite1stDerivativeToRef(
+    public static Hermite1stDerivativeToRef<T extends Quaternion>(
         value1: DeepImmutable<Quaternion>,
         tangent1: DeepImmutable<Quaternion>,
         value2: DeepImmutable<Quaternion>,
         tangent2: DeepImmutable<Quaternion>,
         time: number,
-        result: Quaternion
-    ) {
+        result: T
+    ): T {
         const t2 = time * time;
 
         result.x = (t2 - time) * 6 * value1.x + (3 * t2 - 4 * time + 1) * tangent1.x + (-t2 + time) * 6 * value2.x + (3 * t2 - 2 * time) * tangent2.x;
         result.y = (t2 - time) * 6 * value1.y + (3 * t2 - 4 * time + 1) * tangent1.y + (-t2 + time) * 6 * value2.y + (3 * t2 - 2 * time) * tangent2.y;
         result.z = (t2 - time) * 6 * value1.z + (3 * t2 - 4 * time + 1) * tangent1.z + (-t2 + time) * 6 * value2.z + (3 * t2 - 2 * time) * tangent2.z;
         result.w = (t2 - time) * 6 * value1.w + (3 * t2 - 4 * time + 1) * tangent1.w + (-t2 + time) * 6 * value2.w + (3 * t2 - 2 * time) * tangent2.w;
+        return result;
     }
 }
 
@@ -4939,7 +5021,7 @@ export class Matrix {
      * Inverts the current matrix in place
      * @returns the current inverted matrix
      */
-    public invert(): Matrix {
+    public invert(): this {
         this.invertToRef(this);
         return this;
     }
@@ -4947,7 +5029,7 @@ export class Matrix {
      * Sets all the matrix elements to zero
      * @returns the current matrix
      */
-    public reset(): Matrix {
+    public reset(): this {
         Matrix.FromValuesToRef(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, this);
         this._updateIdentityStatus(false);
         return this;
@@ -4958,8 +5040,8 @@ export class Matrix {
      * @param other defines the matrix to add
      * @returns a new matrix as the addition of the current matrix and the given one
      */
-    public add(other: DeepImmutable<Matrix>): Matrix {
-        const result = new Matrix();
+    public add(other: DeepImmutable<Matrix>): this {
+        const result = new (<any>this.constructor)();
         this.addToRef(other, result);
         return result;
     }
@@ -4968,9 +5050,9 @@ export class Matrix {
      * Sets the given matrix "result" to the addition of the current matrix and the given one
      * @param other defines the matrix to add
      * @param result defines the target matrix
-     * @returns the current matrix
+     * @returns result input
      */
-    public addToRef(other: DeepImmutable<Matrix>, result: Matrix): Matrix {
+    public addToRef<T extends Matrix>(other: DeepImmutable<Matrix>, result: T): T {
         const m = this._m;
         const resultM = result._m;
         const otherM = other.m;
@@ -4978,7 +5060,7 @@ export class Matrix {
             resultM[index] = m[index] + otherM[index];
         }
         result.markAsUpdated();
-        return this;
+        return result;
     }
 
     /**
@@ -4986,7 +5068,7 @@ export class Matrix {
      * @param other defines the second operand
      * @returns the current updated matrix
      */
-    public addToSelf(other: DeepImmutable<Matrix>): Matrix {
+    public addToSelf(other: DeepImmutable<Matrix>): this {
         const m = this._m;
         const otherM = other.m;
         for (let index = 0; index < 16; index++) {
@@ -4999,12 +5081,12 @@ export class Matrix {
     /**
      * Sets the given matrix to the current inverted Matrix
      * @param other defines the target matrix
-     * @returns the unmodified current matrix
+     * @returns result input
      */
-    public invertToRef(other: Matrix): Matrix {
+    public invertToRef<T extends Matrix>(other: T): T {
         if (this._isIdentity === true) {
             Matrix.IdentityToRef(other);
-            return this;
+            return other;
         }
 
         // the inverse of a Matrix is the transpose of cofactor matrix divided by the determinant
@@ -5043,7 +5125,7 @@ export class Matrix {
         if (det === 0) {
             // not invertible
             other.copyFrom(this);
-            return this;
+            return other;
         }
 
         const detInv = 1 / det;
@@ -5095,7 +5177,7 @@ export class Matrix {
             other
         );
 
-        return this;
+        return other;
     }
 
     /**
@@ -5104,7 +5186,7 @@ export class Matrix {
      * @param value the value to be added
      * @returns the current updated matrix
      */
-    public addAtIndex(index: number, value: number): Matrix {
+    public addAtIndex(index: number, value: number): this {
         this._m[index] += value;
         this.markAsUpdated();
         return this;
@@ -5116,7 +5198,7 @@ export class Matrix {
      * @param value the value to be added
      * @returns the current updated matrix
      */
-    public multiplyAtIndex(index: number, value: number): Matrix {
+    public multiplyAtIndex(index: number, value: number): this {
         this._m[index] *= value;
         this.markAsUpdated();
         return this;
@@ -5129,7 +5211,7 @@ export class Matrix {
      * @param z defines the 3rd component of the translation
      * @returns the current updated matrix
      */
-    public setTranslationFromFloats(x: number, y: number, z: number): Matrix {
+    public setTranslationFromFloats(x: number, y: number, z: number): this {
         this._m[12] = x;
         this._m[13] = y;
         this._m[14] = z;
@@ -5144,7 +5226,7 @@ export class Matrix {
      * @param z defines the 3rd component of the translation
      * @returns the current updated matrix
      */
-    public addTranslationFromFloats(x: number, y: number, z: number): Matrix {
+    public addTranslationFromFloats(x: number, y: number, z: number): this {
         this._m[12] += x;
         this._m[13] += y;
         this._m[14] += z;
@@ -5157,7 +5239,7 @@ export class Matrix {
      * @param vector3 defines the translation to insert
      * @returns the current updated matrix
      */
-    public setTranslation(vector3: DeepImmutable<Vector3>): Matrix {
+    public setTranslation(vector3: DeepImmutable<Vector3>): this {
         return this.setTranslationFromFloats(vector3._x, vector3._y, vector3._z);
     }
 
@@ -5174,18 +5256,18 @@ export class Matrix {
      * @param result defines the Vector3 where to store the translation
      * @returns the current matrix
      */
-    public getTranslationToRef(result: Vector3): Matrix {
+    public getTranslationToRef<T extends Vector3>(result: T): T {
         result.x = this._m[12];
         result.y = this._m[13];
         result.z = this._m[14];
-        return this;
+        return result;
     }
 
     /**
      * Remove rotation and scaling part from the matrix
      * @returns the updated matrix
      */
-    public removeRotationAndScaling(): Matrix {
+    public removeRotationAndScaling(): this {
         const m = this.m;
         Matrix.FromValuesToRef(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, m[12], m[13], m[14], m[15], this);
         this._updateIdentityStatus(m[12] === 0 && m[13] === 0 && m[14] === 0 && m[15] === 1);
@@ -5197,8 +5279,8 @@ export class Matrix {
      * @param other defines the second operand
      * @returns a new matrix set with the multiplication result of the current Matrix and the given one
      */
-    public multiply(other: DeepImmutable<Matrix>): Matrix {
-        const result = new Matrix();
+    public multiply(other: DeepImmutable<Matrix>): this {
+        const result = new (<any> this.constructor)();
         this.multiplyToRef(other, result);
         return result;
     }
@@ -5208,7 +5290,7 @@ export class Matrix {
      * @param other defines the source matrix
      * @returns the current updated matrix
      */
-    public copyFrom(other: DeepImmutable<Matrix>): Matrix {
+    public copyFrom(other: DeepImmutable<Matrix>): this {
         other.copyToArray(this._m);
         const o = other as Matrix;
         this.updateFlag = o.updateFlag;
@@ -5222,7 +5304,7 @@ export class Matrix {
      * @param offset defines the offset in the target array where to start storing values
      * @returns the current matrix
      */
-    public copyToArray(array: Float32Array | Array<number>, offset: number = 0): Matrix {
+    public copyToArray(array: Float32Array | Array<number>, offset: number = 0): this {
         const source = this._m;
         array[offset] = source[0];
         array[offset + 1] = source[1];
@@ -5248,21 +5330,21 @@ export class Matrix {
      * Sets the given matrix "result" with the multiplication result of the current Matrix and the given one
      * @param other defines the second operand
      * @param result defines the matrix where to store the multiplication
-     * @returns the current matrix
+     * @returns result input
      */
-    public multiplyToRef(other: DeepImmutable<Matrix>, result: Matrix): Matrix {
+    public multiplyToRef<T extends Matrix>(other: DeepImmutable<Matrix>, result: T): T {
         if (this._isIdentity) {
             result.copyFrom(other);
-            return this;
+            return result;
         }
         if ((other as Matrix)._isIdentity) {
             result.copyFrom(this);
-            return this;
+            return result;
         }
 
         this.multiplyToArray(other, result._m, 0);
         result.markAsUpdated();
-        return this;
+        return result;
     }
 
     /**
@@ -5272,7 +5354,7 @@ export class Matrix {
      * @param offset defines the offset in the target array where to start storing values
      * @returns the current matrix
      */
-    public multiplyToArray(other: DeepImmutable<Matrix>, result: Float32Array | Array<number>, offset: number): Matrix {
+    public multiplyToArray(other: DeepImmutable<Matrix>, result: Float32Array | Array<number>, offset: number): this {
         const m = this._m;
         const otherM = other.m;
         const tm0 = m[0],
@@ -5374,8 +5456,8 @@ export class Matrix {
      * Clone the current matrix
      * @returns a new matrix from the current matrix
      */
-    public clone(): Matrix {
-        const matrix = new Matrix();
+    public clone(): this {
+        const matrix = new (<any> this.constructor)();
         matrix.copyFrom(this);
         return matrix;
     }
@@ -5511,9 +5593,9 @@ export class Matrix {
      * Gets specific row of the matrix to ref
      * @param index defines the number of the row to get
      * @param rowVector vector to store the index-th row of the current matrix
-     * @returns the current matrix
+     * @returns result input
      */
-    public getRowToRef(index: number, rowVector: Vector4): Matrix {
+    public getRowToRef<T extends Vector4>(index: number, rowVector: T): T {
         if (index >= 0 && index < 3) {
             const i = index * 4;
             rowVector.x = this._m[i + 0];
@@ -5521,7 +5603,7 @@ export class Matrix {
             rowVector.z = this._m[i + 2];
             rowVector.w = this._m[i + 3];
         }
-        return this;
+        return rowVector;
     }
 
     /**
@@ -5530,7 +5612,7 @@ export class Matrix {
      * @param row defines the target vector4
      * @returns the updated current matrix
      */
-    public setRow(index: number, row: Vector4): Matrix {
+    public setRow(index: number, row: Vector4): this {
         return this.setRowFromFloats(index, row.x, row.y, row.z, row.w);
     }
 
@@ -5538,18 +5620,20 @@ export class Matrix {
      * Compute the transpose of the matrix
      * @returns the new transposed matrix
      */
-    public transpose(): Matrix {
-        return Matrix.Transpose(this);
+    public transpose(): this {
+        const result = new (<any> this.constructor)();
+        Matrix.TransposeToRef(this, result);
+        return result;
     }
 
     /**
      * Compute the transpose of the matrix and store it in a given matrix
      * @param result defines the target matrix
-     * @returns the current matrix
+     * @returns result input
      */
-    public transposeToRef(result: Matrix): Matrix {
+    public transposeToRef<T extends Matrix>(result: T): T {
         Matrix.TransposeToRef(this, result);
-        return this;
+        return result;
     }
 
     /**
@@ -5561,7 +5645,7 @@ export class Matrix {
      * @param w defines the w component to set
      * @returns the updated current matrix
      */
-    public setRowFromFloats(index: number, x: number, y: number, z: number, w: number): Matrix {
+    public setRowFromFloats(index: number, x: number, y: number, z: number, w: number): this {
         if (index < 0 || index > 3) {
             return this;
         }
@@ -5580,8 +5664,8 @@ export class Matrix {
      * @param scale defines the scale factor
      * @returns a new matrix
      */
-    public scale(scale: number): Matrix {
-        const result = new Matrix();
+    public scale(scale: number): this {
+        const result = new (<any> this.constructor)();
         this.scaleToRef(scale, result);
         return result;
     }
@@ -5590,48 +5674,49 @@ export class Matrix {
      * Scale the current matrix values by a factor to a given result matrix
      * @param scale defines the scale factor
      * @param result defines the matrix to store the result
-     * @returns the current matrix
+     * @returns result input
      */
-    public scaleToRef(scale: number, result: Matrix): Matrix {
+    public scaleToRef<T extends Matrix>(scale: number, result: T): T {
         for (let index = 0; index < 16; index++) {
             result._m[index] = this._m[index] * scale;
         }
         result.markAsUpdated();
-        return this;
+        return result;
     }
 
     /**
      * Scale the current matrix values by a factor and add the result to a given matrix
      * @param scale defines the scale factor
      * @param result defines the Matrix to store the result
-     * @returns the current matrix
+     * @returns result input
      */
-    public scaleAndAddToRef(scale: number, result: Matrix): Matrix {
+    public scaleAndAddToRef<T extends Matrix>(scale: number, result: T): T {
         for (let index = 0; index < 16; index++) {
             result._m[index] += this._m[index] * scale;
         }
         result.markAsUpdated();
-        return this;
+        return result;
     }
 
     /**
      * Writes to the given matrix a normal matrix, computed from this one (using values from identity matrix for fourth row and column).
      * @param ref matrix to store the result
      */
-    public toNormalMatrix(ref: Matrix): void {
+    public toNormalMatrix<T extends Matrix>(ref: T): T {
         const tmp = MathTmp.Matrix[0];
         this.invertToRef(tmp);
         tmp.transposeToRef(ref);
         const m = ref._m;
         Matrix.FromValuesToRef(m[0], m[1], m[2], 0.0, m[4], m[5], m[6], 0.0, m[8], m[9], m[10], 0.0, 0.0, 0.0, 0.0, 1.0, ref);
+        return ref;
     }
 
     /**
      * Gets only rotation part of the current matrix
      * @returns a new matrix sets to the extracted rotation matrix from the current one
      */
-    public getRotationMatrix(): Matrix {
-        const result = new Matrix();
+    public getRotationMatrix(): this {
+        const result = new (<any> this.constructor)();
         this.getRotationMatrixToRef(result);
         return result;
     }
@@ -5639,13 +5724,13 @@ export class Matrix {
     /**
      * Extracts the rotation matrix from the current one and sets it as the given "result"
      * @param result defines the target matrix to store data to
-     * @returns the current matrix
+     * @returns result input
      */
-    public getRotationMatrixToRef(result: Matrix): Matrix {
+    public getRotationMatrixToRef<T extends Matrix>(result: T): T {
         const scale = MathTmp.Vector3[0];
         if (!this.decompose(scale)) {
             Matrix.IdentityToRef(result);
-            return this;
+            return result;
         }
 
         const m = this._m;
@@ -5653,13 +5738,13 @@ export class Matrix {
             sy = 1 / scale._y,
             sz = 1 / scale._z;
         Matrix.FromValuesToRef(m[0] * sx, m[1] * sx, m[2] * sx, 0.0, m[4] * sy, m[5] * sy, m[6] * sy, 0.0, m[8] * sz, m[9] * sz, m[10] * sz, 0.0, 0.0, 0.0, 0.0, 1.0, result);
-        return this;
+        return result;
     }
 
     /**
      * Toggles model matrix from being right handed to left handed in place and vice versa
      */
-    public toggleModelMatrixHandInPlace() {
+    public toggleModelMatrixHandInPlace(): this {
         const m = this._m;
         m[2] *= -1;
         m[6] *= -1;
@@ -5667,18 +5752,20 @@ export class Matrix {
         m[9] *= -1;
         m[14] *= -1;
         this.markAsUpdated();
+        return this;
     }
 
     /**
      * Toggles projection matrix from being right handed to left handed in place and vice versa
      */
-    public toggleProjectionMatrixHandInPlace() {
+    public toggleProjectionMatrixHandInPlace(): this {
         const m = this._m;
         m[8] *= -1;
         m[9] *= -1;
         m[10] *= -1;
         m[11] *= -1;
         this.markAsUpdated();
+        return this;
     }
 
     // Statics
@@ -5699,12 +5786,14 @@ export class Matrix {
      * @param array defines the source array
      * @param offset defines an offset in the source array
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static FromArrayToRef(array: DeepImmutable<ArrayLike<number>>, offset: number, result: Matrix) {
+    public static FromArrayToRef<T extends Matrix>(array: DeepImmutable<ArrayLike<number>>, offset: number, result: T): T {
         for (let index = 0; index < 16; index++) {
             result._m[index] = array[index + offset];
         }
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -5713,12 +5802,14 @@ export class Matrix {
      * @param offset defines the offset in the source array
      * @param scale defines the scaling factor
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static FromFloat32ArrayToRefScaled(array: DeepImmutable<Float32Array | Array<number>>, offset: number, scale: number, result: Matrix) {
+    public static FromFloat32ArrayToRefScaled<T extends Matrix>(array: DeepImmutable<Float32Array | Array<number>>, offset: number, scale: number, result: T): T {
         for (let index = 0; index < 16; index++) {
             result._m[index] = array[index + offset] * scale;
         }
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -5747,6 +5838,7 @@ export class Matrix {
      * @param initialM43 defines 3rd value of 4th row
      * @param initialM44 defines 4th value of 4th row
      * @param result defines the target matrix
+     * @returns result input
      */
     public static FromValuesToRef(
         initialM11: number,
@@ -5867,8 +5959,9 @@ export class Matrix {
      * @param rotation defines the rotation quaternion
      * @param translation defines the translation vector3
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static ComposeToRef(scale: DeepImmutable<Vector3>, rotation: DeepImmutable<Quaternion>, translation: DeepImmutable<Vector3>, result: Matrix): void {
+    public static ComposeToRef<T extends Matrix>(scale: DeepImmutable<Vector3>, rotation: DeepImmutable<Quaternion>, translation: DeepImmutable<Vector3>, result: T): T {
         const m = result._m;
         const x = rotation._x,
             y = rotation._y,
@@ -5912,6 +6005,7 @@ export class Matrix {
         m[15] = 1;
 
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -5927,10 +6021,12 @@ export class Matrix {
     /**
      * Creates a new identity matrix and stores the result in a given matrix
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static IdentityToRef(result: Matrix): void {
+    public static IdentityToRef<T extends Matrix>(result: T): T {
         Matrix.FromValuesToRef(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, result);
         result._updateIdentityStatus(true);
+        return result;
     }
 
     /**
@@ -5959,8 +6055,8 @@ export class Matrix {
      * @param source defines the source matrix
      * @returns the new matrix
      */
-    public static Invert(source: DeepImmutable<Matrix>): Matrix {
-        const result = new Matrix();
+    public static Invert<T extends Matrix>(source: DeepImmutable<T>): T {
+        const result = new (<any> source.constructor)();
         source.invertToRef(result);
         return result;
     }
@@ -5969,13 +6065,15 @@ export class Matrix {
      * Creates a new rotation matrix for "angle" radians around the X axis and stores it in a given matrix
      * @param angle defines the angle (in radians) to use
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationXToRef(angle: number, result: Matrix): void {
+    public static RotationXToRef<T extends Matrix>(angle: number, result: T): T {
         const s = Math.sin(angle);
         const c = Math.cos(angle);
         Matrix.FromValuesToRef(1.0, 0.0, 0.0, 0.0, 0.0, c, s, 0.0, 0.0, -s, c, 0.0, 0.0, 0.0, 0.0, 1.0, result);
 
         result._updateIdentityStatus(c === 1 && s === 0);
+        return result;
     }
 
     /**
@@ -5993,13 +6091,15 @@ export class Matrix {
      * Creates a new rotation matrix for "angle" radians around the Y axis and stores it in a given matrix
      * @param angle defines the angle (in radians) to use
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationYToRef(angle: number, result: Matrix): void {
+    public static RotationYToRef<T extends Matrix>(angle: number, result: T): T {
         const s = Math.sin(angle);
         const c = Math.cos(angle);
         Matrix.FromValuesToRef(c, 0.0, -s, 0.0, 0.0, 1.0, 0.0, 0.0, s, 0.0, c, 0.0, 0.0, 0.0, 0.0, 1.0, result);
 
         result._updateIdentityStatus(c === 1 && s === 0);
+        return result;
     }
 
     /**
@@ -6017,13 +6117,15 @@ export class Matrix {
      * Creates a new rotation matrix for "angle" radians around the Z axis and stores it in a given matrix
      * @param angle defines the angle (in radians) to use
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationZToRef(angle: number, result: Matrix): void {
+    public static RotationZToRef<T extends Matrix>(angle: number, result: T): T {
         const s = Math.sin(angle);
         const c = Math.cos(angle);
         Matrix.FromValuesToRef(c, s, 0.0, 0.0, -s, c, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, result);
 
         result._updateIdentityStatus(c === 1 && s === 0);
+        return result;
     }
 
     /**
@@ -6043,8 +6145,9 @@ export class Matrix {
      * @param axis defines the axis to use
      * @param angle defines the angle (in radians) to use
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationAxisToRef(axis: DeepImmutable<Vector3>, angle: number, result: Matrix): void {
+    public static RotationAxisToRef<T extends Matrix>(axis: DeepImmutable<Vector3>, angle: number, result: T): T {
         const s = Math.sin(-angle);
         const c = Math.cos(-angle);
         const c1 = 1 - c;
@@ -6072,6 +6175,7 @@ export class Matrix {
         m[15] = 1.0;
 
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -6080,8 +6184,9 @@ export class Matrix {
      * @param from defines the vector to align
      * @param to defines the vector to align to
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationAlignToRef(from: DeepImmutable<Vector3>, to: DeepImmutable<Vector3>, result: Matrix): void {
+    public static RotationAlignToRef<T extends Matrix>(from: DeepImmutable<Vector3>, to: DeepImmutable<Vector3>, result: T): T {
         const c = Vector3.Dot(to, from);
         const m = result._m;
         if (c < -1 + Epsilon) {
@@ -6121,6 +6226,7 @@ export class Matrix {
         m[14] = 0;
         m[15] = 1;
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -6142,10 +6248,12 @@ export class Matrix {
      * @param pitch defines the pitch angle in radians (X axis)
      * @param roll defines the roll angle in radians (Z axis)
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static RotationYawPitchRollToRef(yaw: number, pitch: number, roll: number, result: Matrix): void {
+    public static RotationYawPitchRollToRef<T extends Matrix>(yaw: number, pitch: number, roll: number, result: T): T {
         Quaternion.RotationYawPitchRollToRef(yaw, pitch, roll, MathTmp.Quaternion[0]);
         MathTmp.Quaternion[0].toRotationMatrix(result);
+        return result;
     }
 
     /**
@@ -6167,11 +6275,13 @@ export class Matrix {
      * @param y defines the scale factor on Y axis
      * @param z defines the scale factor on Z axis
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static ScalingToRef(x: number, y: number, z: number, result: Matrix): void {
+    public static ScalingToRef<T extends Matrix>(x: number, y: number, z: number, result: T): T {
         Matrix.FromValuesToRef(x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, 1.0, result);
 
         result._updateIdentityStatus(x === 1 && y === 1 && z === 1);
+        return result;
     }
 
     /**
@@ -6193,10 +6303,12 @@ export class Matrix {
      * @param y defines the translation on Y axis
      * @param z defines the translationon Z axis
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static TranslationToRef(x: number, y: number, z: number, result: Matrix): void {
+    public static TranslationToRef<T extends Matrix>(x: number, y: number, z: number, result: T): T {
         Matrix.FromValuesToRef(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, z, 1.0, result);
         result._updateIdentityStatus(x === 0 && y === 0 && z === 0);
+        return result;
     }
 
     /**
@@ -6206,8 +6318,8 @@ export class Matrix {
      * @param gradient defines the gradient factor
      * @returns the new matrix
      */
-    public static Lerp(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number): Matrix {
-        const result = new Matrix();
+    public static Lerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
+        const result = new (<any> startValue.constructor)();
         Matrix.LerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6218,8 +6330,9 @@ export class Matrix {
      * @param endValue defines the end value
      * @param gradient defines the gradient factor
      * @param result defines the Matrix object where to store data
+     * @returns result input
      */
-    public static LerpToRef(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number, result: Matrix): void {
+    public static LerpToRef<T extends Matrix>(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number, result: T): T {
         const resultM = result._m;
         const startM = startValue.m;
         const endM = endValue.m;
@@ -6227,6 +6340,7 @@ export class Matrix {
             resultM[index] = startM[index] * (1.0 - gradient) + endM[index] * gradient;
         }
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -6239,8 +6353,8 @@ export class Matrix {
      * @param gradient defines the gradient between the two matrices
      * @returns the new matrix
      */
-    public static DecomposeLerp(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number): Matrix {
-        const result = new Matrix();
+    public static DecomposeLerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
+        const result = new (<any> startValue.constructor)();
         Matrix.DecomposeLerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6254,8 +6368,9 @@ export class Matrix {
      * @param endValue defines the second matrix
      * @param gradient defines the gradient between the two matrices
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static DecomposeLerpToRef(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number, result: Matrix) {
+    public static DecomposeLerpToRef<T extends Matrix>(startValue: DeepImmutable<Matrix>, endValue: DeepImmutable<Matrix>, gradient: number, result: T): T {
         const startScale = MathTmp.Vector3[0];
         const startRotation = MathTmp.Quaternion[0];
         const startTranslation = MathTmp.Vector3[1];
@@ -6275,6 +6390,7 @@ export class Matrix {
         Vector3.LerpToRef(startTranslation, endTranslation, gradient, resultTranslation);
 
         Matrix.ComposeToRef(resultScale, resultRotation, resultTranslation, result);
+        return result;
     }
 
     /**
@@ -6298,6 +6414,7 @@ export class Matrix {
      * @param target defines where the entity should look at
      * @param up defines the up vector for the entity
      * @param result defines the target matrix
+     * @returns result input
      */
     public static LookAtLHToRef(eye: DeepImmutable<Vector3>, target: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
         const xAxis = MathTmp.Vector3[0];
@@ -6351,8 +6468,9 @@ export class Matrix {
      * @param target defines where the entity should look at
      * @param up defines the up vector for the entity
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static LookAtRHToRef(eye: DeepImmutable<Vector3>, target: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
+    public static LookAtRHToRef<T extends Matrix>(eye: DeepImmutable<Vector3>, target: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: T): T {
         const xAxis = MathTmp.Vector3[0];
         const yAxis = MathTmp.Vector3[1];
         const zAxis = MathTmp.Vector3[2];
@@ -6381,6 +6499,7 @@ export class Matrix {
         const ez = -Vector3.Dot(zAxis, eye);
 
         Matrix.FromValuesToRef(xAxis._x, yAxis._x, zAxis._x, 0.0, xAxis._y, yAxis._y, zAxis._y, 0.0, xAxis._z, yAxis._z, zAxis._z, 0.0, ex, ey, ez, 1.0, result);
+        return result;
     }
 
     /**
@@ -6402,8 +6521,9 @@ export class Matrix {
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static LookDirectionLHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
+    public static LookDirectionLHToRef<T extends Matrix>(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: T): T {
         const back = MathTmp.Vector3[0];
         back.copyFrom(forward);
         back.scaleInPlace(-1);
@@ -6412,6 +6532,7 @@ export class Matrix {
 
         // Generate the rotation matrix.
         Matrix.FromValuesToRef(left._x, left._y, left._z, 0.0, up._x, up._y, up._z, 0.0, back._x, back._y, back._z, 0.0, 0, 0, 0, 1.0, result);
+        return result;
     }
 
     /**
@@ -6433,13 +6554,15 @@ export class Matrix {
      * @param forward defines the forward direction - Must be normalized and orthogonal to up.
      * @param up defines the up vector for the entity - Must be normalized and orthogonal to forward.
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static LookDirectionRHToRef(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: Matrix): void {
+    public static LookDirectionRHToRef<T extends Matrix>(forward: DeepImmutable<Vector3>, up: DeepImmutable<Vector3>, result: T): T {
         const right = MathTmp.Vector3[2];
         Vector3.CrossToRef(up, forward, right);
 
         // Generate the rotation matrix.
         Matrix.FromValuesToRef(right._x, right._y, right._z, 0.0, up._x, up._y, up._z, 0.0, forward._x, forward._y, forward._z, 0.0, 0, 0, 0, 1.0, result);
+        return result;
     }
 
     /**
@@ -6465,8 +6588,9 @@ export class Matrix {
      * @param zfar defines the far clip plane
      * @param result defines the target matrix
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
+     * @returns result input
      */
-    public static OrthoLHToRef(width: number, height: number, znear: number, zfar: number, result: Matrix, halfZRange?: boolean): void {
+    public static OrthoLHToRef<T extends Matrix>(width: number, height: number, znear: number, zfar: number, result: T, halfZRange?: boolean): T {
         const n = znear;
         const f = zfar;
 
@@ -6482,6 +6606,7 @@ export class Matrix {
         }
 
         result._updateIdentityStatus(a === 1 && b === 1 && c === 1 && d === 0);
+        return result;
     }
 
     /**
@@ -6511,8 +6636,9 @@ export class Matrix {
      * @param zfar defines the far clip plane
      * @param result defines the target matrix
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
+     * @returns result input
      */
-    public static OrthoOffCenterLHToRef(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: Matrix, halfZRange?: boolean): void {
+    public static OrthoOffCenterLHToRef<T extends Matrix>(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: T, halfZRange?: boolean): T {
         const n = znear;
         const f = zfar;
 
@@ -6530,6 +6656,7 @@ export class Matrix {
         }
 
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -6559,10 +6686,12 @@ export class Matrix {
      * @param zfar defines the far clip plane
      * @param result defines the target matrix
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
+     * @returns result input
      */
-    public static OrthoOffCenterRHToRef(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: Matrix, halfZRange?: boolean): void {
+    public static OrthoOffCenterRHToRef<T extends Matrix>(left: number, right: number, bottom: number, top: number, znear: number, zfar: number, result: T, halfZRange?: boolean): T {
         Matrix.OrthoOffCenterLHToRef(left, right, bottom, top, znear, zfar, result, halfZRange);
         result._m[10] *= -1; // No need to call markAsUpdated as previous function already called it and let _isIdentityDirty to true
+        return result;
     }
 
     /**
@@ -6633,18 +6762,19 @@ export class Matrix {
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @param projectionPlaneTilt optional tilt angle of the projection plane around the X axis (horizontal)
      * @param reverseDepthBufferMode true to indicate that we are in a reverse depth buffer mode (meaning znear and zfar have been inverted when calling the function)
+     * @returns result input
      */
-    public static PerspectiveFovLHToRef(
+    public static PerspectiveFovLHToRef<T extends Matrix>(
         fov: number,
         aspect: number,
         znear: number,
         zfar: number,
-        result: Matrix,
+        result: T,
         isVerticalFovFixed = true,
         halfZRange?: boolean,
         projectionPlaneTilt: number = 0,
         reverseDepthBufferMode: boolean = false
-    ): void {
+    ): T {
         const n = znear;
         const f = zfar;
 
@@ -6662,6 +6792,7 @@ export class Matrix {
         }
 
         result._updateIdentityStatus(false);
+        return result;
     }
 
     /**
@@ -6674,17 +6805,18 @@ export class Matrix {
      * @param isVerticalFovFixed defines it the fov is vertically fixed (default) or horizontally
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @param projectionPlaneTilt optional tilt angle of the projection plane around the X axis (horizontal)
+     * @returns result input
      */
-    public static PerspectiveFovReverseLHToRef(
+    public static PerspectiveFovReverseLHToRef<T extends Matrix>(
         fov: number,
         aspect: number,
         znear: number,
         zfar: number,
-        result: Matrix,
+        result: T,
         isVerticalFovFixed = true,
         halfZRange?: boolean,
         projectionPlaneTilt: number = 0
-    ): void {
+    ): T {
         const t = 1.0 / Math.tan(fov * 0.5);
         const a = isVerticalFovFixed ? t / aspect : t;
         const b = isVerticalFovFixed ? t : t * aspect;
@@ -6695,6 +6827,7 @@ export class Matrix {
             result.multiplyToRef(mtxConvertNDCToHalfZRange, result);
         }
         result._updateIdentityStatus(false);
+        return result;
     }
 
     /**
@@ -6733,18 +6866,19 @@ export class Matrix {
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @param projectionPlaneTilt optional tilt angle of the projection plane around the X axis (horizontal)
      * @param reverseDepthBufferMode true to indicate that we are in a reverse depth buffer mode (meaning znear and zfar have been inverted when calling the function)
+     * @returns result input
      */
-    public static PerspectiveFovRHToRef(
+    public static PerspectiveFovRHToRef<T extends Matrix>(
         fov: number,
         aspect: number,
         znear: number,
         zfar: number,
-        result: Matrix,
+        result: T,
         isVerticalFovFixed = true,
         halfZRange?: boolean,
         projectionPlaneTilt: number = 0,
         reverseDepthBufferMode: boolean = false
-    ): void {
+    ): T {
         //alternatively this could be expressed as:
         //    m = PerspectiveFovLHToRef
         //    m[10] *= -1.0;
@@ -6767,6 +6901,7 @@ export class Matrix {
         }
 
         result._updateIdentityStatus(false);
+        return result;
     }
 
     /**
@@ -6779,17 +6914,18 @@ export class Matrix {
      * @param isVerticalFovFixed defines it the fov is vertically fixed (default) or horizontally
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @param projectionPlaneTilt optional tilt angle of the projection plane around the X axis (horizontal)
+     * @returns result input
      */
-    public static PerspectiveFovReverseRHToRef(
+    public static PerspectiveFovReverseRHToRef<T extends Matrix>(
         fov: number,
         aspect: number,
         znear: number,
         zfar: number,
-        result: Matrix,
+        result: T,
         isVerticalFovFixed = true,
         halfZRange?: boolean,
         projectionPlaneTilt: number = 0
-    ): void {
+    ): T {
         const t = 1.0 / Math.tan(fov * 0.5);
         const a = isVerticalFovFixed ? t / aspect : t;
         const b = isVerticalFovFixed ? t : t * aspect;
@@ -6802,6 +6938,7 @@ export class Matrix {
         }
 
         result._updateIdentityStatus(false);
+        return result;
     }
 
     /**
@@ -6817,16 +6954,17 @@ export class Matrix {
      * @param rightHanded defines if the matrix must be in right-handed mode (false by default)
      * @param halfZRange true to generate NDC coordinates between 0 and 1 instead of -1 and 1 (default: false)
      * @param projectionPlaneTilt optional tilt angle of the projection plane around the X axis (horizontal)
+     * @returns result input
      */
-    public static PerspectiveFovWebVRToRef(
+    public static PerspectiveFovWebVRToRef<T extends Matrix>(
         fov: { upDegrees: number; downDegrees: number; leftDegrees: number; rightDegrees: number },
         znear: number,
         zfar: number,
-        result: Matrix,
+        result: T,
         rightHanded = false,
         halfZRange?: boolean,
         projectionPlaneTilt: number = 0
-    ): void {
+    ): T {
         const rightHandedFactor = rightHanded ? -1 : 1;
 
         const upTan = Math.tan((fov.upDegrees * Math.PI) / 180.0);
@@ -6855,6 +6993,7 @@ export class Matrix {
         }
 
         result.markAsUpdated();
+        return result;
     }
 
     /**
@@ -6867,14 +7006,14 @@ export class Matrix {
      * @param zmax defines the far clip plane
      * @returns the transformation matrix
      */
-    public static GetFinalMatrix(
+    public static GetFinalMatrix<T extends Matrix>(
         viewport: DeepImmutable<Viewport>,
-        world: DeepImmutable<Matrix>,
+        world: DeepImmutable<T>,
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>,
         zmin: number,
         zmax: number
-    ): Matrix {
+    ): T {
         const cw = viewport.width;
         const ch = viewport.height;
         const cx = viewport.x;
@@ -6882,10 +7021,10 @@ export class Matrix {
 
         const viewportMatrix = Matrix.FromValues(cw / 2.0, 0.0, 0.0, 0.0, 0.0, -ch / 2.0, 0.0, 0.0, 0.0, 0.0, zmax - zmin, 0.0, cx + cw / 2.0, ch / 2.0 + cy, zmin, 1.0);
 
-        const matrix = MathTmp.Matrix[0];
+        const matrix = new (<any> world.constructor)();
         world.multiplyToRef(view, matrix);
         matrix.multiplyToRef(projection, matrix);
-        return matrix.multiply(viewportMatrix);
+        return matrix.multiplyToRef(viewportMatrix, matrix);
     }
 
     /**
@@ -6914,8 +7053,8 @@ export class Matrix {
      * @param matrix defines the matrix to transpose
      * @returns the new matrix
      */
-    public static Transpose(matrix: DeepImmutable<Matrix>): Matrix {
-        const result = new Matrix();
+    public static Transpose<T extends Matrix>(matrix: DeepImmutable<T>): T {
+        const result = new (<any> matrix.constructor)();
         Matrix.TransposeToRef(matrix, result);
         return result;
     }
@@ -6924,8 +7063,9 @@ export class Matrix {
      * Compute the transpose of a matrix and store it in a target matrix
      * @param matrix defines the matrix to transpose
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static TransposeToRef(matrix: DeepImmutable<Matrix>, result: Matrix): void {
+    public static TransposeToRef<T extends Matrix>(matrix: DeepImmutable<Matrix>, result: T): T {
         const rm = result._m;
         const mm = matrix.m;
         rm[0] = mm[0];
@@ -6952,6 +7092,7 @@ export class Matrix {
 
         // identity-ness does not change when transposing
         result._updateIdentityStatus((matrix as Matrix)._isIdentity, (matrix as Matrix)._isIdentityDirty);
+        return result;
     }
 
     /**
@@ -6969,8 +7110,9 @@ export class Matrix {
      * Computes a reflection matrix from a plane
      * @param plane defines the reflection plane
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static ReflectionToRef(plane: DeepImmutable<IPlaneLike>, result: Matrix): void {
+    public static ReflectionToRef<T extends Matrix>(plane: DeepImmutable<IPlaneLike>, result: T): T {
         plane.normalize();
         const x = plane.normal.x;
         const y = plane.normal.y;
@@ -6997,6 +7139,7 @@ export class Matrix {
             1.0,
             result
         );
+        return result;
     }
 
     /**
@@ -7005,17 +7148,20 @@ export class Matrix {
      * @param yaxis defines the value of the 2nd axis
      * @param zaxis defines the value of the 3rd axis
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static FromXYZAxesToRef(xaxis: DeepImmutable<Vector3>, yaxis: DeepImmutable<Vector3>, zaxis: DeepImmutable<Vector3>, result: Matrix) {
+    public static FromXYZAxesToRef<T extends Matrix>(xaxis: DeepImmutable<Vector3>, yaxis: DeepImmutable<Vector3>, zaxis: DeepImmutable<Vector3>, result: T): T {
         Matrix.FromValuesToRef(xaxis._x, xaxis._y, xaxis._z, 0.0, yaxis._x, yaxis._y, yaxis._z, 0.0, zaxis._x, zaxis._y, zaxis._z, 0.0, 0.0, 0.0, 0.0, 1.0, result);
+        return result;
     }
 
     /**
      * Creates a rotation matrix from a quaternion and stores it in a target matrix
      * @param quat defines the quaternion to use
      * @param result defines the target matrix
+     * @returns result input
      */
-    public static FromQuaternionToRef(quat: DeepImmutable<Quaternion>, result: Matrix) {
+    public static FromQuaternionToRef<T extends Matrix>(quat: DeepImmutable<Quaternion>, result: T): T {
         const xx = quat._x * quat._x;
         const yy = quat._y * quat._y;
         const zz = quat._z * quat._z;
@@ -7047,6 +7193,7 @@ export class Matrix {
         result._m[15] = 1.0;
 
         result.markAsUpdated();
+        return result;
     }
 }
 

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -12,10 +12,10 @@ import { EngineStore } from "../Engines/engineStore";
 
 type TransformNode = import("../Meshes/transformNode").TransformNode;
 
-export type Vector2Constructor<T extends Vector2> = (new (x?: number, y?: number) => T);
-export type Vector3Constructor<T extends Vector3> = (new (x?: number, y?: number, z?: number) => T);
-export type Vector4Constructor<T extends Vector4> = (new (x?: number, y?: number, z?: number, w?: number) => T);
-export type QuaternionConstructor<T extends Quaternion> = (new (x?: number, y?: number, z?: number, w?: number) => T);
+export type Vector2Constructor<T extends Vector2> = new (x?: number, y?: number) => T;
+export type Vector3Constructor<T extends Vector3> = new (x?: number, y?: number, z?: number) => T;
+export type Vector4Constructor<T extends Vector4> = new (x?: number, y?: number, z?: number, w?: number) => T;
+export type QuaternionConstructor<T extends Quaternion> = new (x?: number, y?: number, z?: number, w?: number) => T;
 export type MatrixConstructor<T extends Matrix> = new () => T;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -3354,7 +3354,12 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public fract(): this {
-        return new (this.constructor as Vector4Constructor<this>)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
+        return new (this.constructor as Vector4Constructor<this>)(
+            this.x - Math.floor(this.x),
+            this.y - Math.floor(this.y),
+            this.z - Math.floor(this.z),
+            this.w - Math.floor(this.w)
+        );
     }
 
     // Properties

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -12,6 +12,12 @@ import { EngineStore } from "../Engines/engineStore";
 
 type TransformNode = import("../Meshes/transformNode").TransformNode;
 
+export type Vector2Constructor<T extends Vector2> = (new (x?: number, y?: number) => T);
+export type Vector3Constructor<T extends Vector3> = (new (x?: number, y?: number, z?: number) => T);
+export type Vector4Constructor<T extends Vector4> = (new (x?: number, y?: number, z?: number, w?: number) => T);
+export type QuaternionConstructor<T extends Quaternion> = (new (x?: number, y?: number, z?: number, w?: number) => T);
+export type MatrixConstructor<T extends Matrix> = new () => T;
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _ExtractAsInt = (value: number) => {
     return parseInt(value.toString().replace(/\W/g, ""));
@@ -144,7 +150,7 @@ export class Vector2 {
      * @returns a new Vector2 set with the addition of the current Vector2 and the given one coordinates
      */
     public add(otherVector: DeepImmutable<Vector2>): this {
-        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -179,7 +185,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public addVector3(otherVector: Vector3): this {
-        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y);
     }
 
     /**
@@ -189,7 +195,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public subtract(otherVector: Vector2): this {
-        return new (<any>this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x - otherVector.x, this.y - otherVector.y);
     }
 
     /**
@@ -235,7 +241,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiply(otherVector: DeepImmutable<Vector2>): this {
-        return new (<any>this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x * otherVector.x, this.y * otherVector.y);
     }
 
     /**
@@ -259,7 +265,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public multiplyByFloats(x: number, y: number): this {
-        return new (<any>this.constructor)(this.x * x, this.y * y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x * x, this.y * y);
     }
 
     /**
@@ -269,7 +275,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public divide(otherVector: Vector2): this {
-        return new (<any>this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x / otherVector.x, this.y / otherVector.y);
     }
 
     /**
@@ -301,7 +307,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public negate(): this {
-        return new (<any>this.constructor)(-this.x, -this.y);
+        return new (<Vector2Constructor<this>>this.constructor)(-this.x, -this.y);
     }
 
     /**
@@ -344,7 +350,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public scale(scale: number): this {
-        const result = new (<any>this.constructor)(0, 0) as this;
+        const result = new (<Vector2Constructor<this>>this.constructor)(0, 0);
         this.scaleToRef(scale, result);
         return result;
     }
@@ -403,7 +409,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public floor(): this {
-        return new (<any>this.constructor)(Math.floor(this.x), Math.floor(this.y));
+        return new (<Vector2Constructor<this>>this.constructor)(Math.floor(this.x), Math.floor(this.y));
     }
 
     /**
@@ -413,7 +419,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public fract(): this {
-        return new (<any>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
+        return new (<Vector2Constructor<this>>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y));
     }
 
     /**
@@ -468,7 +474,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public clone(): this {
-        return new (<any>this.constructor)(this.x, this.y);
+        return new (<Vector2Constructor<this>>this.constructor)(this.x, this.y);
     }
 
     // Statics
@@ -531,13 +537,13 @@ export class Vector2 {
      * @param amount defines the interpolation factor
      * @returns a new Vector2
      */
-    public static CatmullRom(
-        value1: DeepImmutable<Vector2>,
+    public static CatmullRom<T extends Vector2>(
+        value1: DeepImmutable<T>,
         value2: DeepImmutable<Vector2>,
         value3: DeepImmutable<Vector2>,
         value4: DeepImmutable<Vector2>,
         amount: number
-    ): Vector2 {
+    ): T {
         const squared = amount * amount;
         const cubed = amount * squared;
 
@@ -555,7 +561,7 @@ export class Vector2 {
                 (2.0 * value1.y - 5.0 * value2.y + 4.0 * value3.y - value4.y) * squared +
                 (-value1.y + 3.0 * value2.y - 3.0 * value3.y + value4.y) * cubed);
 
-        return new Vector2(x, y);
+        return new (<Vector2Constructor<T>>value1.constructor)(x, y);
     }
 
     /**
@@ -577,7 +583,7 @@ export class Vector2 {
         y = y > max.y ? max.y : y;
         y = y < min.y ? min.y : y;
 
-        return new (<any>value.constructor)(x, y);
+        return new (<Vector2Constructor<T>>value.constructor)(x, y);
     }
 
     /**
@@ -607,7 +613,7 @@ export class Vector2 {
         const x = value1.x * part1 + value2.x * part2 + tangent1.x * part3 + tangent2.x * part4;
         const y = value1.y * part1 + value2.y * part2 + tangent1.y * part3 + tangent2.y * part4;
 
-        return new (<any>value1.constructor)(x, y);
+        return new (<Vector2Constructor<T>>value1.constructor)(x, y);
     }
 
     /**
@@ -627,7 +633,7 @@ export class Vector2 {
         tangent2: DeepImmutable<Vector2>,
         time: number
     ): T {
-        const result = new (<any>value1.constructor)();
+        const result = new (<Vector2Constructor<T>>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -672,7 +678,7 @@ export class Vector2 {
     public static Lerp<T extends Vector2>(start: DeepImmutable<T>, end: DeepImmutable<Vector2>, amount: number): Vector2 {
         const x = start.x + (end.x - start.x) * amount;
         const y = start.y + (end.y - start.y) * amount;
-        return new (<any>start.constructor)(x, y);
+        return new (<Vector2Constructor<T>>start.constructor)(x, y);
     }
 
     /**
@@ -693,7 +699,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
-        const newVector = new (<any>vector.constructor)();
+        const newVector = new (<Vector2Constructor<T>>vector.constructor)();
         this.NormalizeToRef(vector, newVector);
         return newVector;
     }
@@ -727,7 +733,7 @@ export class Vector2 {
     public static Minimize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x < right.x ? left.x : right.x;
         const y = left.y < right.y ? left.y : right.y;
-        return new (<any>left.constructor)(x, y);
+        return new (<Vector2Constructor<T>>left.constructor)(x, y);
     }
 
     /**
@@ -740,7 +746,7 @@ export class Vector2 {
     public static Maximize<T extends Vector2>(left: DeepImmutable<T>, right: DeepImmutable<Vector2>): T {
         const x = left.x > right.x ? left.x : right.x;
         const y = left.y > right.y ? left.y : right.y;
-        return new (<any>left.constructor)(x, y);
+        return new (<Vector2Constructor<T>>left.constructor)(x, y);
     }
 
     /**
@@ -751,7 +757,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Transform<T extends Vector2>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = new (<any>vector.constructor)();
+        const result = new (<Vector2Constructor<T>>vector.constructor)();
         Vector2.TransformToRef(vector, transformation, result);
         return result;
     }
@@ -824,7 +830,7 @@ export class Vector2 {
      * @returns a new Vector2
      */
     public static Center<T extends Vector2>(value1: DeepImmutable<T>, value2: DeepImmutable<Vector2>): T {
-        const result = new (<any>value1.constructor)();
+        const result = new (<Vector2Constructor<T>>value1.constructor)();
         return Vector2.CenterToRef(value1, value2, result);
     }
 
@@ -1042,7 +1048,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public add(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any>this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
     /**
@@ -1076,7 +1082,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtract(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any>this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
     }
 
     /**
@@ -1099,7 +1105,7 @@ export class Vector3 {
      * @returns the resulting Vector3
      */
     public subtractFromFloats(x: number, y: number, z: number): this {
-        return new (<any>this.constructor)(this._x - x, this._y - y, this._z - z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x - x, this._y - y, this._z - z);
     }
 
     /**
@@ -1121,7 +1127,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public negate(): this {
-        return new (<any>this.constructor)(-this._x, -this._y, -this._z);
+        return new (<Vector3Constructor<this>>this.constructor)(-this._x, -this._y, -this._z);
     }
 
     /**
@@ -1166,7 +1172,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public scale(scale: number): this {
-        return new (<any>this.constructor)(this._x * scale, this._y * scale, this._z * scale);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x * scale, this._y * scale, this._z * scale);
     }
 
     /**
@@ -1245,7 +1251,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public applyRotationQuaternion(q: Quaternion): this {
-        return this.applyRotationQuaternionToRef(q, new (<any>this.constructor)());
+        return this.applyRotationQuaternionToRef(q, new (<Vector3Constructor<this>>this.constructor)());
     }
 
     /**
@@ -1267,7 +1273,7 @@ export class Vector3 {
      * @returns the projected vector3
      */
     public projectOnPlane<T extends Vector3>(plane: Plane, origin: Vector3): T {
-        const result = new (<any>this.constructor)();
+        const result = new (<Vector3Constructor<T>>this.constructor)();
         this.projectOnPlaneToRef(plane, origin, result);
 
         return result;
@@ -1389,7 +1395,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public multiplyByFloats(x: number, y: number, z: number): this {
-        return new (<any>this.constructor)(this._x * x, this._y * y, this._z * z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x * x, this._y * y, this._z * z);
     }
 
     /**
@@ -1399,7 +1405,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public divide(otherVector: DeepImmutable<Vector3>): this {
-        return new (<any>this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
     /**
@@ -1534,7 +1540,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public floor(): this {
-        return new (<any>this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
+        return new (<Vector3Constructor<this>>this.constructor)(Math.floor(this._x), Math.floor(this._y), Math.floor(this._z));
     }
 
     /**
@@ -1543,7 +1549,7 @@ export class Vector3 {
      * @returns a new Vector3
      */
     public fract(): this {
-        return new (<any>this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
+        return new (<Vector3Constructor<this>>this.constructor)(this._x - Math.floor(this._x), this._y - Math.floor(this._y), this._z - Math.floor(this._z));
     }
 
     // Properties
@@ -1637,7 +1643,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public cross(other: Vector3): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<Vector3Constructor<this>>this.constructor)();
         return Vector3.CrossToRef(this, other, result);
     }
 
@@ -1662,7 +1668,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public normalizeToNew(): this {
-        const normalized = new (<any>this.constructor)(0, 0, 0);
+        const normalized = new (<Vector3Constructor<this>>this.constructor)(0, 0, 0);
         this.normalizeToRef(normalized);
         return normalized;
     }
@@ -1688,7 +1694,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public clone(): this {
-        return new (<any>this.constructor)(this._x, this._y, this._z);
+        return new (<Vector3Constructor<this>>this.constructor)(this._x, this._y, this._z);
     }
 
     /**
@@ -2220,7 +2226,7 @@ export class Vector3 {
                 (2.0 * value1._z - 5.0 * value2._z + 4.0 * value3._z - value4._z) * squared +
                 (-value1._z + 3.0 * value2._z - 3.0 * value3._z + value4._z) * cubed);
 
-        return new (<any>value1.constructor)(x, y, z);
+        return new (<Vector3Constructor<T>>value1.constructor)(x, y, z);
     }
 
     /**
@@ -2234,7 +2240,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Clamp<T extends Vector3>(value: DeepImmutable<T>, min: DeepImmutable<Vector3>, max: DeepImmutable<Vector3>): T {
-        const result = new (<any>value.constructor)();
+        const result = new (<Vector3Constructor<T>>value.constructor)();
         Vector3.ClampToRef(value, min, max, result);
         return result;
     }
@@ -2305,7 +2311,7 @@ export class Vector3 {
         const x = value1._x * part1 + value2._x * part2 + tangent1._x * part3 + tangent2._x * part4;
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
-        return new (<any>value1.constructor)(x, y, z);
+        return new (<Vector3Constructor<T>>value1.constructor)(x, y, z);
     }
 
     /**
@@ -2325,7 +2331,7 @@ export class Vector3 {
         tangent2: DeepImmutable<Vector3>,
         time: number
     ): T {
-        const result = new (<any>value1.constructor)();
+        const result = new (<Vector3Constructor<T>>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -2368,7 +2374,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Lerp<T extends Vector3>(start: DeepImmutable<T>, end: DeepImmutable<Vector3>, amount: number): T {
-        const result = new (<any>start.constructor)(0, 0, 0);
+        const result = new (<Vector3Constructor<T>>start.constructor)(0, 0, 0);
         Vector3.LerpToRef(start, end, amount, result);
         return result;
     }
@@ -2409,7 +2415,7 @@ export class Vector3 {
      * @returns the cross product
      */
     public static Cross<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const result = new (<any>left.constructor)();
+        const result = new (<Vector3Constructor<T>>left.constructor)();
         Vector3.CrossToRef(left, right, result);
         return result;
     }
@@ -2465,7 +2471,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Project<T extends Vector3>(vector: DeepImmutable<T>, world: DeepImmutable<Matrix>, transform: DeepImmutable<Matrix>, viewport: DeepImmutable<Viewport>): T {
-        const result = new (<any>vector.constructor)();
+        const result = new (<Vector3Constructor<T>>vector.constructor)();
         Vector3.ProjectToRef(vector, world, transform, viewport, result);
         return result;
     }
@@ -2556,7 +2562,7 @@ export class Vector3 {
         view: DeepImmutable<Matrix>,
         projection: DeepImmutable<Matrix>
     ): T {
-        const result = new (<any>source.constructor)();
+        const result = new (<Vector3Constructor<T>>source.constructor)();
 
         Vector3.UnprojectToRef(source, viewportWidth, viewportHeight, world, view, projection, result);
 
@@ -2639,7 +2645,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Minimize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const min = new (<any>left.constructor)();
+        const min = new (<Vector3Constructor<T>>left.constructor)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -2653,7 +2659,7 @@ export class Vector3 {
      * @returns the new Vector3
      */
     public static Maximize<T extends Vector3>(left: DeepImmutable<T>, right: DeepImmutable<Vector3>): T {
-        const max = new (<any>left.constructor)();
+        const max = new (<Vector3Constructor<T>>left.constructor)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -2878,7 +2884,7 @@ export class Vector3 {
      * @see https://doc.babylonjs.com/divingDeeper/mesh/transforms/center_origin/target_align
      */
     public static RotationFromAxis<T extends Vector3>(axis1: DeepImmutable<T>, axis2: DeepImmutable<Vector3>, axis3: DeepImmutable<Vector3>): T {
-        const rotation = new (<any>axis1.constructor)();
+        const rotation = new (<Vector3Constructor<T>>axis1.constructor)();
         Vector3.RotationFromAxisToRef(axis1, axis2, axis3, rotation);
         return rotation;
     }
@@ -3017,7 +3023,7 @@ export class Vector4 {
      * @returns the resulting vector
      */
     public add(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any>this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z, this.w + otherVector.w);
     }
 
     /**
@@ -3053,7 +3059,7 @@ export class Vector4 {
      * @returns the new vector with the result
      */
     public subtract(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any>this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z, this.w - otherVector.w);
     }
 
     /**
@@ -3082,7 +3088,7 @@ export class Vector4 {
      * @returns new vector containing the result
      */
     public subtractFromFloats(x: number, y: number, z: number, w: number): this {
-        return new (<any>this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x - x, this.y - y, this.z - z, this.w - w);
     }
 
     /**
@@ -3107,7 +3113,7 @@ export class Vector4 {
      * @returns a new vector with the negated values
      */
     public negate(): this {
-        return new (<any>this.constructor)(-this.x, -this.y, -this.z, -this.w);
+        return new (<Vector4Constructor<this>>this.constructor)(-this.x, -this.y, -this.z, -this.w);
     }
 
     /**
@@ -3150,7 +3156,7 @@ export class Vector4 {
      * @returns a new vector with the result
      */
     public scale(scale: number): this {
-        return new (<any>this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x * scale, this.y * scale, this.z * scale, this.w * scale);
     }
 
     /**
@@ -3237,7 +3243,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiply(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any>this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x * otherVector.x, this.y * otherVector.y, this.z * otherVector.z, this.w * otherVector.w);
     }
     /**
      * Updates the given vector "result" with the multiplication result of the current Vector4 and the given one.
@@ -3261,7 +3267,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public multiplyByFloats(x: number, y: number, z: number, w: number): this {
-        return new (<any>this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x * x, this.y * y, this.z * z, this.w * w);
     }
     /**
      * Returns a new Vector4 set with the division result of the current Vector4 by the given one.
@@ -3269,7 +3275,7 @@ export class Vector4 {
      * @returns resulting new vector
      */
     public divide(otherVector: DeepImmutable<Vector4>): this {
-        return new (<any>this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x / otherVector.x, this.y / otherVector.y, this.z / otherVector.z, this.w / otherVector.w);
     }
     /**
      * Updates the given vector "result" with the division result of the current Vector4 by the given one.
@@ -3340,7 +3346,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public floor(): this {
-        return new (<any>this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
+        return new (<Vector4Constructor<this>>this.constructor)(Math.floor(this.x), Math.floor(this.y), Math.floor(this.z), Math.floor(this.w));
     }
 
     /**
@@ -3348,7 +3354,7 @@ export class Vector4 {
      * @returns a new Vector4
      */
     public fract(): this {
-        return new (<any>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
+        return new (<Vector4Constructor<this>>this.constructor)(this.x - Math.floor(this.x), this.y - Math.floor(this.y), this.z - Math.floor(this.z), this.w - Math.floor(this.w));
     }
 
     // Properties
@@ -3394,7 +3400,7 @@ export class Vector4 {
      * @returns the new cloned vector
      */
     public clone(): this {
-        return new (<any>this.constructor)(this.x, this.y, this.z, this.w);
+        return new (<Vector4Constructor<this>>this.constructor)(this.x, this.y, this.z, this.w);
     }
     /**
      * Updates the current Vector4 with the given one coordinates.
@@ -3548,7 +3554,7 @@ export class Vector4 {
      * @returns a new vector with the minimum of the left and right vector values
      */
     public static Minimize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const min = new (<any>left.constructor)();
+        const min = new (<Vector4Constructor<T>>left.constructor)();
         min.copyFrom(left);
         min.minimizeInPlace(right);
         return min;
@@ -3561,7 +3567,7 @@ export class Vector4 {
      * @returns a new vector with the maximum of the left and right vector values
      */
     public static Maximize<T extends Vector4>(left: DeepImmutable<T>, right: DeepImmutable<Vector4>): T {
-        const max = new (<any>left.constructor)();
+        const max = new (<Vector4Constructor<T>>left.constructor)();
         max.copyFrom(left);
         max.maximizeInPlace(right);
         return max;
@@ -3671,7 +3677,7 @@ export class Vector4 {
      * @returns the new vector
      */
     public static TransformNormal<T extends Vector4>(vector: DeepImmutable<T>, transformation: DeepImmutable<Matrix>): T {
-        const result = new (<any>vector.constructor)();
+        const result = new (<Vector4Constructor<T>>vector.constructor)();
         Vector4.TransformNormalToRef(vector, transformation, result);
         return result;
     }
@@ -3886,7 +3892,7 @@ export class Quaternion {
      * @returns a new quaternion copied from the current one
      */
     public clone(): this {
-        return new (<any>this.constructor)(this._x, this._y, this._z, this._w);
+        return new (<QuaternionConstructor<this>>this.constructor)(this._x, this._y, this._z, this._w);
     }
 
     /**
@@ -3936,7 +3942,7 @@ export class Quaternion {
      * @returns a new quaternion as the addition result of the given one and the current quaternion
      */
     public add(other: DeepImmutable<Quaternion>): this {
-        return new (<any>this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
+        return new (<QuaternionConstructor<this>>this.constructor)(this._x + other._x, this._y + other._y, this._z + other._z, this._w + other._w);
     }
 
     /**
@@ -3958,7 +3964,7 @@ export class Quaternion {
      * @returns a new quaternion as the subtraction result of the given one from the current one
      */
     public subtract(other: Quaternion): this {
-        return new (<any>this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
+        return new (<QuaternionConstructor<this>>this.constructor)(this._x - other._x, this._y - other._y, this._z - other._z, this._w - other._w);
     }
 
     /**
@@ -3980,7 +3986,7 @@ export class Quaternion {
      * @returns a new quaternion set by multiplying the current quaternion coordinates by the float "scale"
      */
     public scale(value: number): this {
-        return new (<any>this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
+        return new (<QuaternionConstructor<this>>this.constructor)(this._x * value, this._y * value, this._z * value, this._w * value);
     }
 
     /**
@@ -4031,7 +4037,7 @@ export class Quaternion {
      * @returns a new quaternion set as the multiplication result of the current one with the given one "q1"
      */
     public multiply(q1: DeepImmutable<Quaternion>): this {
-        const result = new (<any>this.constructor)(0, 0, 0, 1.0);
+        const result = new (<QuaternionConstructor<this>>this.constructor)(0, 0, 0, 1.0);
         this.multiplyToRef(q1, result);
         return result;
     }
@@ -4087,7 +4093,7 @@ export class Quaternion {
      * @returns a new quaternion
      */
     public conjugate(): this {
-        return new (<any>this.constructor)(-this._x, -this._y, -this._z, this._w);
+        return new (<QuaternionConstructor<this>>this.constructor)(-this._x, -this._y, -this._z, this._w);
     }
 
     /**
@@ -4378,7 +4384,7 @@ export class Quaternion {
      * @returns a new quaternion as the inverted current quaternion
      */
     public static Inverse<T extends Quaternion>(q: DeepImmutable<T>): T {
-        return new (<any>q.constructor)(-q._x, -q._y, -q._z, q._w);
+        return new (<QuaternionConstructor<T>>q.constructor)(-q._x, -q._y, -q._z, q._w);
     }
 
     /**
@@ -4772,7 +4778,7 @@ export class Quaternion {
         const y = value1._y * part1 + value2._y * part2 + tangent1._y * part3 + tangent2._y * part4;
         const z = value1._z * part1 + value2._z * part2 + tangent1._z * part3 + tangent2._z * part4;
         const w = value1._w * part1 + value2._w * part2 + tangent1._w * part3 + tangent2._w * part4;
-        return new (<any>value1.constructor)(x, y, z, w);
+        return new (<QuaternionConstructor<T>>value1.constructor)(x, y, z, w);
     }
 
     /**
@@ -4791,7 +4797,7 @@ export class Quaternion {
         tangent2: DeepImmutable<Quaternion>,
         time: number
     ): T {
-        const result = new (<any>value1.constructor)();
+        const result = new (<QuaternionConstructor<T>>value1.constructor)();
 
         this.Hermite1stDerivativeToRef(value1, tangent1, value2, tangent2, time, result);
 
@@ -5046,7 +5052,7 @@ export class Matrix {
      * @returns a new matrix as the addition of the current matrix and the given one
      */
     public add(other: DeepImmutable<Matrix>): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<MatrixConstructor<this>>this.constructor)();
         this.addToRef(other, result);
         return result;
     }
@@ -5285,7 +5291,7 @@ export class Matrix {
      * @returns a new matrix set with the multiplication result of the current Matrix and the given one
      */
     public multiply(other: DeepImmutable<Matrix>): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<MatrixConstructor<this>>this.constructor)();
         this.multiplyToRef(other, result);
         return result;
     }
@@ -5462,7 +5468,7 @@ export class Matrix {
      * @returns a new matrix from the current matrix
      */
     public clone(): this {
-        const matrix = new (<any>this.constructor)();
+        const matrix = new (<MatrixConstructor<this>>this.constructor)();
         matrix.copyFrom(this);
         return matrix;
     }
@@ -5626,7 +5632,7 @@ export class Matrix {
      * @returns the new transposed matrix
      */
     public transpose(): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<MatrixConstructor<this>>this.constructor)();
         Matrix.TransposeToRef(this, result);
         return result;
     }
@@ -5670,7 +5676,7 @@ export class Matrix {
      * @returns a new matrix
      */
     public scale(scale: number): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<MatrixConstructor<this>>this.constructor)();
         this.scaleToRef(scale, result);
         return result;
     }
@@ -5721,7 +5727,7 @@ export class Matrix {
      * @returns a new matrix sets to the extracted rotation matrix from the current one
      */
     public getRotationMatrix(): this {
-        const result = new (<any>this.constructor)();
+        const result = new (<MatrixConstructor<this>>this.constructor)();
         this.getRotationMatrixToRef(result);
         return result;
     }
@@ -6061,7 +6067,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Invert<T extends Matrix>(source: DeepImmutable<T>): T {
-        const result = new (<any>source.constructor)();
+        const result = new (<MatrixConstructor<T>>source.constructor)();
         source.invertToRef(result);
         return result;
     }
@@ -6324,7 +6330,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Lerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<any>startValue.constructor)();
+        const result = new (<MatrixConstructor<T>>startValue.constructor)();
         Matrix.LerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -6359,7 +6365,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static DecomposeLerp<T extends Matrix>(startValue: DeepImmutable<T>, endValue: DeepImmutable<Matrix>, gradient: number): T {
-        const result = new (<any>startValue.constructor)();
+        const result = new (<MatrixConstructor<T>>startValue.constructor)();
         Matrix.DecomposeLerpToRef(startValue, endValue, gradient, result);
         return result;
     }
@@ -7044,7 +7050,7 @@ export class Matrix {
 
         const viewportMatrix = Matrix.FromValues(cw / 2.0, 0.0, 0.0, 0.0, 0.0, -ch / 2.0, 0.0, 0.0, 0.0, 0.0, zmax - zmin, 0.0, cx + cw / 2.0, ch / 2.0 + cy, zmin, 1.0);
 
-        const matrix = new (<any>world.constructor)();
+        const matrix = new (<MatrixConstructor<T>>world.constructor)();
         world.multiplyToRef(view, matrix);
         matrix.multiplyToRef(projection, matrix);
         return matrix.multiplyToRef(viewportMatrix, matrix);
@@ -7077,7 +7083,7 @@ export class Matrix {
      * @returns the new matrix
      */
     public static Transpose<T extends Matrix>(matrix: DeepImmutable<T>): T {
-        const result = new (<any>matrix.constructor)();
+        const result = new (<MatrixConstructor<T>>matrix.constructor)();
         Matrix.TransposeToRef(matrix, result);
         return result;
     }

--- a/what's new.md
+++ b/what's new.md
@@ -284,6 +284,7 @@
 
 - Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
 - Added `decomposeToTransformNode` ([RaananW](https://github.com/RaananW))
+- Normalized types and return values in math.vector.ts ([LostInClams](https://github.com/LostInClams))
 
 ### Serializers
 

--- a/what's new.md
+++ b/what's new.md
@@ -284,7 +284,6 @@
 
 - Faster scalar's WithinEpsilon with Math.abs ([nekochanoide](https://github.com/nekochanoide))
 - Added `decomposeToTransformNode` ([RaananW](https://github.com/RaananW))
-- Normalized types and return values in math.vector.ts ([LostInClams](https://github.com/LostInClams))
 
 ### Serializers
 


### PR DESCRIPTION
This commit tries to normalize the return type of all math functions so that all ToRef versions return the ref. It also changes so that functions that create new Objects try to do that with an extended type when possible.

More information can be found [here](https://forum.babylonjs.com/t/types-in-math-vector-ts/34514/13)