### PR TITLE
Fixed transform gizmos screen size

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -204,7 +204,7 @@ export class Gizmo implements IGizmo {
     private _tempMatrix1 = new Matrix();
     private _tempMatrix2 = new Matrix();
     private _rightHandtoLeftHandMatrix = Matrix.RotationY(Math.PI);
-    private _back = Vector3.Backward();
+    private _forward = Vector3.Forward();
 
     /**
      * Creates a gizmo
@@ -283,7 +283,7 @@ export class Gizmo implements IGizmo {
                         scale *= orthoHeight;
                     }
                 } else {
-                    const direction = activeCamera.getDirection(this._back);
+                    const direction = activeCamera.getDirection(this._forward);
                     scale *= Vector3.Dot(this._tempVector, direction);
                 }
                 this._rootMesh.scaling.set(scale, scale, scale);

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -204,8 +204,6 @@ export class Gizmo implements IGizmo {
     private _tempMatrix1 = new Matrix();
     private _tempMatrix2 = new Matrix();
     private _rightHandtoLeftHandMatrix = Matrix.RotationY(Math.PI);
-    private _forward = Vector3.Forward();
-    private _back = Vector3.Backward();
 
     /**
      * Creates a gizmo
@@ -284,11 +282,11 @@ export class Gizmo implements IGizmo {
                         scale *= orthoHeight;
                     }
                 } else {
-                    const camForward = activeCamera.getScene().useRightHandedSystem ? this._back : this._forward;
+                    const camForward = activeCamera.getScene().useRightHandedSystem ? Vector3.RightHandedForwardReadOnly : Vector3.LeftHandedForwardReadOnly;
                     const direction = activeCamera.getDirection(camForward);
                     scale *= Vector3.Dot(this._tempVector, direction);
                 }
-                this._rootMesh.scaling.set(scale, scale, scale);
+                this._rootMesh.scaling.setAll(scale);
 
                 // Account for handedness, similar to Matrix.decompose
                 if (effectiveNode._getWorldMatrixDeterminant() < 0 && !Gizmo.PreserveScaling) {

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -205,6 +205,7 @@ export class Gizmo implements IGizmo {
     private _tempMatrix2 = new Matrix();
     private _rightHandtoLeftHandMatrix = Matrix.RotationY(Math.PI);
     private _forward = Vector3.Forward();
+    private _back = Vector3.Backward();
 
     /**
      * Creates a gizmo
@@ -283,7 +284,8 @@ export class Gizmo implements IGizmo {
                         scale *= orthoHeight;
                     }
                 } else {
-                    const direction = activeCamera.getDirection(this._forward);
+                    const camForward = activeCamera.getScene().useRightHandedSystem ? this._back : this._forward;
+                    const direction = activeCamera.getDirection(camForward);
                     scale *= Vector3.Dot(this._tempVector, direction);
                 }
                 this._rootMesh.scaling.set(scale, scale, scale);

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -5,7 +5,7 @@ import type { Scene, IDisposable } from "../scene";
 import { Quaternion, Vector3, Matrix } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Mesh } from "../Meshes/mesh";
-import type { Camera } from "../Cameras/camera";
+import { Camera } from "../Cameras/camera";
 import type { TargetCamera } from "../Cameras/targetCamera";
 import type { Node } from "../node";
 import type { Bone } from "../Bones/bone";
@@ -204,6 +204,7 @@ export class Gizmo implements IGizmo {
     private _tempMatrix1 = new Matrix();
     private _tempMatrix2 = new Matrix();
     private _rightHandtoLeftHandMatrix = Matrix.RotationY(Math.PI);
+    private _back = Vector3.Backward();
 
     /**
      * Creates a gizmo
@@ -275,8 +276,17 @@ export class Gizmo implements IGizmo {
                     cameraPosition = (<WebVRFreeCamera>activeCamera).devicePosition;
                 }
                 this._rootMesh.position.subtractToRef(cameraPosition, this._tempVector);
-                const dist = this._tempVector.length() * this.scaleRatio;
-                this._rootMesh.scaling.set(dist, dist, dist);
+                let scale = this.scaleRatio;
+                if (activeCamera.mode == Camera.ORTHOGRAPHIC_CAMERA) {
+                    if (activeCamera.orthoTop && activeCamera.orthoBottom) {
+                        const orthoHeight = activeCamera.orthoTop - activeCamera.orthoBottom;
+                        scale *= orthoHeight;
+                    }
+                } else {
+                    const direction = activeCamera.getDirection(this._back);
+                    scale *= Vector3.Dot(this._tempVector, direction);
+                }
+                this._rootMesh.scaling.set(scale, scale, scale);
 
                 // Account for handedness, similar to Matrix.decompose
                 if (effectiveNode._getWorldMatrixDeterminant() < 0 && !Gizmo.PreserveScaling) {


### PR DESCRIPTION
Hi,
I noticed that [gizmos](https://doc.babylonjs.com/features/featuresDeepDive/mesh/gizmo) do not correctly preserve the size on the screen.

You can notice that if the aspect ratio of the screen is big enough and you move a gizmo to the edge of the screen. It gets bigger. And this doesn't work at all with ORTHO-cameras.

I've fixed the math a little bit and added branching depending on whether the camera is PERSP or ORTHO
Before:
https://user-images.githubusercontent.com/2855321/194728765-276ae78a-4906-4c95-9ef9-6a4bae9d5501.mp4
After:
https://user-images.githubusercontent.com/2855321/194755033-bfe76baf-25d3-40a0-9795-f891941d6d51.mp4



