### PR TITLE
change CustomProceduralTexture constructor size type

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Procedurals/customProceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/customProceduralTexture.ts
@@ -5,6 +5,7 @@ import { Color4, Color3 } from "../../../Maths/math.color";
 import { Texture } from "../../../Materials/Textures/texture";
 import { ProceduralTexture } from "./proceduralTexture";
 import { WebRequest } from "../../../Misc/webRequest";
+import type { TextureSize } from "../../../Materials/Textures/textureCreationOptions";
 /**
  * Procedural texturing is a way to programmatically create a texture. There are 2 types of procedural textures: code-only, and code that references some classic 2D images, sometimes called 'refMaps' or 'sampler' images.
  * Custom Procedural textures are the easiest way to create your own procedural in your application.
@@ -29,7 +30,7 @@ export class CustomProceduralTexture extends ProceduralTexture {
      * @param generateMipMaps Define if the texture should creates mip maps or not
      * @param skipJson Define a boolena indicating that there is no json config file to load
      */
-    constructor(name: string, texturePath: string, size: number, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean, skipJson?: boolean) {
+    constructor(name: string, texturePath: string, size: TextureSize, scene: Scene, fallbackTexture?: Texture, generateMipMaps?: boolean, skipJson?: boolean) {
         super(name, size, null, scene, fallbackTexture, generateMipMaps);
         this._texturePath = texturePath;
 


### PR DESCRIPTION
The type of param size in CustomProceduralTexture'constructor is now number, I think it is more appropriate to use TextureSize instead.