### PR TITLE
prepass reflectivity channel support unlit materials

### DIFF
--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -670,7 +670,11 @@ void main(void) {
     #endif
 
     #ifdef PREPASS_REFLECTIVITY
-        gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(toGammaSpace(specularEnvironmentR0), microSurface) * writeGeometryInfo;
+        #ifndef UNLIT
+            gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(toGammaSpace(specularEnvironmentR0), microSurface) * writeGeometryInfo;
+        #else
+            gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4( 0.0, 0.0, 0.0, 1.0 ) * writeGeometryInfo;
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
Add support for prepass reflectivity channel with unlit materials.
Before: https://playground.babylonjs.com/#RPBXIC
After: https://playground.babylonjs.com/#RPBXIC#1