### PR TITLE
Fix declaration generation when "as" is used

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -190,6 +190,7 @@ function getClassesMap(source: string, originalDevPackageName: string, originalS
         devPackageName?: DevPackageName;
         externalName?: string;
         fullPath: string;
+        exported?: boolean;
     }[] = [];
     while (matches !== null) {
         const classes = matches[1].split(","); //.map((className) => className.trim());
@@ -238,6 +239,50 @@ function getClassesMap(source: string, originalDevPackageName: string, originalS
         });
         matches = regex.exec(source);
     }
+    // check if the index exports it as something else
+
+    // fist check if an index exists on the same directory
+    let indexFilePath = path.resolve(path.dirname(originalSourcefilePath), "index.js");
+    if (!fs.existsSync(indexFilePath)) {
+        indexFilePath = path.resolve(path.dirname(originalSourcefilePath), "..", "index.js");
+    }
+    if (fs.existsSync(indexFilePath)) {
+        const indexSource = fs.readFileSync(indexFilePath, "utf-8");
+        // get relative path
+        const relativePath = path
+            .relative(path.dirname(indexFilePath), originalSourcefilePath)
+            .replace(/\\/g, "/")
+            .replace(/\.d\.ts$/, "");
+        const indexRegex = new RegExp(`export {(.*)} from ['"]./${relativePath}['"];`, "g");
+        let indexMatches = indexRegex.exec(indexSource);
+        while (indexMatches !== null) {
+            const classes = indexMatches[1].split(","); //.map((className) => className.trim());
+            classes.forEach((className) => {
+                // just a typescript thing...
+                if (!indexMatches) {
+                    return;
+                }
+                const parts = className.split(" as ");
+                if (parts.length === 2) {
+                    console.log(`aliasing ${parts[0]} as ${parts[1]}`);
+                    const realClassName = parts[1].trim();
+                    const alias = parts[0] ? parts[0].trim() : realClassName;
+                    const devPackageName = originalDevPackageName;
+                    if (isValidDevPackageName(devPackageName)) {
+                        mappingArray.push({
+                            alias,
+                            realClassName,
+                            devPackageName,
+                            fullPath: path.resolve(path.dirname(originalSourcefilePath)).replace(/\\/g, "/"),
+                            exported: true,
+                        });
+                    }
+                }
+            });
+            indexMatches = indexRegex.exec(indexSource);
+        }
+    }
+
     return mappingArray;
 }
 
@@ -250,6 +295,7 @@ function getPackageDeclaration(
         devPackageName?: DevPackageName;
         externalName?: string;
         fullPath: string;
+        exported?: boolean;
     }[],
     devPackageName: DevPackageName
 ) {
@@ -319,32 +365,38 @@ function getPackageDeclaration(
     let processedSource = lines.join("\n").replace(/^(?:[\t ]*(?:\r?\n|\r))+/gm, "") + "\n\n";
 
     // replaces classes definitions with namespace definitions
-    classesMappingArray.forEach((classMapping: { alias: string; realClassName: string; devPackageName?: DevPackageName; externalName?: string; fullPath: string }) => {
-        const { alias, realClassName, devPackageName: localDevPackageMap, fullPath, externalName } = classMapping;
-        // TODO - make a list of dependencies that are accepted by each package
-        if (!localDevPackageMap) {
-            if (externalName) {
-                if (externalName === "@fortawesome" || externalName === "react-contextmenu") {
-                    // replace with any
-                    const matchRegex = new RegExp(`([ <])(${alias}[^;\n ]*)([^\\w])`, "g");
-                    processedSource = processedSource.replace(matchRegex, `$1any$3`);
-                    return;
-                } else if (externalName === "react") {
-                    const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
-                    processedSource = processedSource.replace(matchRegex, `$1React.${realClassName}$3`);
+    classesMappingArray.forEach(
+        (classMapping: { alias: string; realClassName: string; devPackageName?: DevPackageName; externalName?: string; fullPath: string; exported?: boolean }) => {
+            const { alias, realClassName, devPackageName: localDevPackageMap, fullPath, externalName, exported } = classMapping;
+            // TODO - make a list of dependencies that are accepted by each package
+            if (!localDevPackageMap) {
+                if (externalName) {
+                    if (externalName === "@fortawesome" || externalName === "react-contextmenu") {
+                        // replace with any
+                        const matchRegex = new RegExp(`([ <])(${alias}[^;\n ]*)([^\\w])`, "g");
+                        processedSource = processedSource.replace(matchRegex, `$1any$3`);
+                        return;
+                    } else if (externalName === "react") {
+                        const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
+                        processedSource = processedSource.replace(matchRegex, `$1React.${realClassName}$3`);
+                    }
+                }
+
+                return;
+            }
+            const devPackageToUse = isValidDevPackageName(localDevPackageMap, true) ? localDevPackageMap : devPackageName;
+            const originalNamespace = getPublicPackageName(getPackageMappingByDevName(devPackageToUse).namespace);
+            const namespace = getPublicPackageName(getPackageMappingByDevName(devPackageToUse).namespace, fullPath /*, fullPath*/);
+            if (namespace !== defaultModuleName || originalNamespace !== namespace || alias !== realClassName) {
+                const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
+                if (exported) {
+                    processedSource = processedSource.replace(matchRegex, `$1${realClassName}$3`);
+                } else {
+                    processedSource = processedSource.replace(matchRegex, `$1${namespace}.${realClassName}$3`);
                 }
             }
-
-            return;
         }
-        const devPackageToUse = isValidDevPackageName(localDevPackageMap, true) ? localDevPackageMap : devPackageName;
-        const originalNamespace = getPublicPackageName(getPackageMappingByDevName(devPackageToUse).namespace);
-        const namespace = getPublicPackageName(getPackageMappingByDevName(devPackageToUse).namespace, fullPath /*, fullPath*/);
-        if (namespace !== defaultModuleName || originalNamespace !== namespace || alias !== realClassName) {
-            const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
-            processedSource = processedSource.replace(matchRegex, `$1${namespace}.${realClassName}$3`);
-        }
-    });
+    );
 
     processedSource = processedSource.replace(
         / global {([^}]*)}/gm,

--- a/packages/dev/gui/src/3D/controls/index.ts
+++ b/packages/dev/gui/src/3D/controls/index.ts
@@ -21,5 +21,4 @@ export * from "./touchHolographicMenu";
 export * from "./volumeBasedPanel";
 
 // MRTK3 Controls
-import { TouchHolographicButton } from "./MRTK3/touchHolographicButton";
-export { TouchHolographicButton as TouchHolographicButtonV3 };
+export { TouchHolographicButton as TouchHolographicButtonV3 } from "./MRTK3/touchHolographicButton";


### PR DESCRIPTION
After this change, every `export { C as B } from "path"` will be supported when exporting the declaration. This will fix the issue with the TouchHolographicButtonV3