### PR TITLE
Set target to ES2018

### DIFF
--- a/packages/public/@babylonjs/core/tsconfig.build.json
+++ b/packages/public/@babylonjs/core/tsconfig.build.json
@@ -5,7 +5,7 @@
         "outDir": "./dist",
         "rootDir": "../../../lts/core/generated",
         "declaration": true,
-        "target": "ES2021",
+        "target": "ES2018",
         "importHelpers": true,
         "plugins": [
             { "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/core", "appendJS": true },

--- a/packages/public/@babylonjs/gui/tsconfig.build.json
+++ b/packages/public/@babylonjs/gui/tsconfig.build.json
@@ -5,7 +5,7 @@
         "outDir": "./dist",
         "rootDir": "../../../lts/gui/generated",
         "declaration": true,
-        "target": "ES2021",
+        "target": "ES2018",
         "importHelpers": true,
         "plugins": [
             { "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/gui", "appendJS": true },

--- a/packages/public/@babylonjs/loaders/tsconfig.build.json
+++ b/packages/public/@babylonjs/loaders/tsconfig.build.json
@@ -6,6 +6,7 @@
         "rootDir": "../../../lts/loaders/generated",
         "declaration": true,
         "importHelpers": true,
+        "target": "ES2018",
         "plugins": [
             { "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/loaders", "appendJS": true },
         ],

--- a/packages/public/@babylonjs/materials/tsconfig.build.json
+++ b/packages/public/@babylonjs/materials/tsconfig.build.json
@@ -6,6 +6,7 @@
         "rootDir": "../../../lts/materials/generated",
         "declaration": true,
         "importHelpers": true,
+        "target": "ES2018",
         "plugins": [{ "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/materials", "appendJS": true }],
         "paths": {
             "core/*": ["lts/core/dist/*"],

--- a/packages/public/@babylonjs/post-processes/tsconfig.build.json
+++ b/packages/public/@babylonjs/post-processes/tsconfig.build.json
@@ -6,6 +6,7 @@
         "rootDir": "../../../lts/postProcesses/generated",
         "declaration": true,
         "importHelpers": true,
+        "target": "ES2018",
         "plugins": [{ "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/post-processes", "appendJS": true }],
         "paths": {
             "core/*": ["lts/core/dist/*"],

--- a/packages/public/@babylonjs/procedural-textures/tsconfig.build.json
+++ b/packages/public/@babylonjs/procedural-textures/tsconfig.build.json
@@ -6,6 +6,7 @@
         "rootDir": "../../../lts/proceduralTextures/generated",
         "declaration": true,
         "importHelpers": true,
+        "target": "ES2018",
         "plugins": [
             { "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/procedural-textures", "appendJS": true },
         ]

--- a/packages/public/@babylonjs/serializers/tsconfig.build.json
+++ b/packages/public/@babylonjs/serializers/tsconfig.build.json
@@ -6,6 +6,7 @@
         "rootDir": "../../../lts/serializers/generated",
         "declaration": true,
         "importHelpers": true,
+        "target": "ES2018",
         "plugins": [
             { "transform": "../../../dev/buildTools/src/pathTransform.ts", "buildType": "es6", "basePackage": "@babylonjs/serializers", "appendJS": true },
         ]


### PR DESCRIPTION
Based on feedback and babylon native needs I am moving the target for our es packages to es2018