### PR TITLE
Fix #13082 Shadow generator on NullEngine

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -758,7 +758,7 @@ export class NullEngine extends Engine {
      * @param options defines the options used to create the texture
      * @returns a new render target wrapper
      */
-     public createRenderTargetCubeTexture(size: number, options?: Partial<RenderTargetCreationOptions>): RenderTargetWrapper {
+    public createRenderTargetCubeTexture(size: number, options?: Partial<RenderTargetCreationOptions>): RenderTargetWrapper {
         const rtWrapper = this._createHardwareRenderTargetWrapper(false, true, size);
 
         const fullOptions = {

--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -753,6 +753,54 @@ export class NullEngine extends Engine {
     }
 
     /**
+     * Creates a new render target wrapper
+     * @param size defines the size of the texture
+     * @param options defines the options used to create the texture
+     * @returns a new render target wrapper
+     */
+     public createRenderTargetCubeTexture(size: number, options?: Partial<RenderTargetCreationOptions>): RenderTargetWrapper {
+        const rtWrapper = this._createHardwareRenderTargetWrapper(false, true, size);
+
+        const fullOptions = {
+            generateMipMaps: true,
+            generateDepthBuffer: true,
+            generateStencilBuffer: false,
+            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
+            format: Constants.TEXTUREFORMAT_RGBA,
+            ...options,
+        };
+        fullOptions.generateStencilBuffer = fullOptions.generateDepthBuffer && fullOptions.generateStencilBuffer;
+
+        if (fullOptions.type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloatLinearFiltering) {
+            // if floating point linear (gl.FLOAT) then force to NEAREST_SAMPLINGMODE
+            fullOptions.samplingMode = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
+        } else if (fullOptions.type === Constants.TEXTURETYPE_HALF_FLOAT && !this._caps.textureHalfFloatLinearFiltering) {
+            // if floating point linear (HALF_FLOAT) then force to NEAREST_SAMPLINGMODE
+            fullOptions.samplingMode = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
+        }
+
+        rtWrapper._generateDepthBuffer = fullOptions.generateDepthBuffer;
+        rtWrapper._generateStencilBuffer = fullOptions.generateStencilBuffer ? true : false;
+
+        const texture = new InternalTexture(this, InternalTextureSource.RenderTarget);
+        texture.baseWidth = size;
+        texture.baseHeight = size;
+        texture.width = size;
+        texture.height = size;
+        texture.isReady = true;
+        texture.isCube = true;
+        texture.samples = 1;
+        texture.generateMipMaps = fullOptions.generateMipMaps ? true : false;
+        texture.samplingMode = fullOptions.samplingMode;
+        texture.type = fullOptions.type;
+
+        this._internalTexturesCache.push(texture);
+
+        return rtWrapper;
+    }
+
+    /**
      * Update the sampling mode of a given texture
      * @param samplingMode defines the required sampling mode
      * @param texture defines the texture to update

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -139,7 +139,7 @@ export class GlowLayer extends EffectLayer {
      */
     @serialize()
     public get blurKernelSize(): number {
-        return this._horizontalBlurPostprocess1.kernel;
+        return this._options.blurKernelSize;
     }
 
     /**

--- a/packages/dev/core/test/unit/Lights/Shadows/babylon.shadowGenerator.test.ts
+++ b/packages/dev/core/test/unit/Lights/Shadows/babylon.shadowGenerator.test.ts
@@ -1,0 +1,32 @@
+import { NullEngine } from "core/Engines";
+import type { Engine } from "core/Engines";
+import { PointLight } from "core/Lights/pointLight";
+import { ShadowGenerator } from "core/Lights/Shadows/shadowGenerator";
+import { Vector3 } from "core/Maths/math.vector";
+import { Scene } from "core/scene";
+
+import "core/Lights/Shadows/shadowGeneratorSceneComponent";
+
+describe("ShadowGenerator", () => {
+    describe("instantiate", () => {
+        let subject: Engine;
+
+        beforeEach(function () {
+            subject = new NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+        });
+
+        it("should be able to be instantiated with a null engine", () => {
+            const scene = new Scene(subject);
+            const light = new PointLight("Point", new Vector3(1,1,1), scene);
+            const generator = new ShadowGenerator(1024, light);
+
+            expect(generator).not.toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
https://forum.babylonjs.com/t/cannot-create-shadow-map-with-point-light-in-node-on-server/21450/5