### PR TITLE
[XR] fix the samples returned when using multiview in WebXR

### DIFF
--- a/packages/dev/core/src/Engines/renderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/renderTargetWrapper.ts
@@ -38,6 +38,9 @@ export class RenderTargetWrapper {
     /** @internal */
     public _depthStencilTextureWithStencil: boolean = false;
 
+    /** @internal */
+    public _getSamplesFromFirstTexture: boolean = false;
+
     /**
      * Gets the depth/stencil texture (if created by a createDepthStencilTexture() call)
      */
@@ -119,7 +122,7 @@ export class RenderTargetWrapper {
      * Gets the sample count of the render target
      */
     public get samples(): number {
-        return this._samples;
+        return this._getSamplesFromFirstTexture ? this.texture?.samples || this.samples : this._samples;
     }
 
     /**

--- a/packages/dev/core/src/Engines/renderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/renderTargetWrapper.ts
@@ -24,7 +24,8 @@ export class RenderTargetWrapper {
     private _isCube: boolean;
     private _isMulti: boolean;
     private _textures: Nullable<InternalTexture[]> = null;
-    private _samples = 1;
+    /** @internal */
+    public _samples = 1;
 
     /** @internal */
     public _attachments: Nullable<number[]> = null;
@@ -37,9 +38,6 @@ export class RenderTargetWrapper {
     public _depthStencilTexture: Nullable<InternalTexture>;
     /** @internal */
     public _depthStencilTextureWithStencil: boolean = false;
-
-    /** @internal */
-    public _getSamplesFromFirstTexture: boolean = false;
 
     /**
      * Gets the depth/stencil texture (if created by a createDepthStencilTexture() call)
@@ -122,7 +120,7 @@ export class RenderTargetWrapper {
      * Gets the sample count of the render target
      */
     public get samples(): number {
-        return this._getSamplesFromFirstTexture ? this.texture?.samples || this.samples : this._samples;
+        return this._samples;
     }
 
     /**

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -79,6 +79,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         // Create render target texture from the internal texture
         const renderTargetTexture = multiview ? new MultiviewRenderTarget(this._scene, textureSize) : new RenderTargetTexture("XR renderTargetTexture", textureSize, this._scene);
         const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
+        renderTargetWrapper._getSamplesFromFirstTexture = true;
         // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
         if (framebuffer || !colorTexture) {
             renderTargetWrapper._framebuffer = framebuffer;

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -79,7 +79,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         // Create render target texture from the internal texture
         const renderTargetTexture = multiview ? new MultiviewRenderTarget(this._scene, textureSize) : new RenderTargetTexture("XR renderTargetTexture", textureSize, this._scene);
         const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
-        renderTargetWrapper._getSamplesFromFirstTexture = true;
+        renderTargetWrapper._samples = renderTargetTexture.samples;
         // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
         if (framebuffer || !colorTexture) {
             renderTargetWrapper._framebuffer = framebuffer;


### PR DESCRIPTION
When using multiview on WebXR I don't want to update the samples using `setSamples` because of the extra work done there (that is not needed).
This is one solution. A different one would be to introduce a (hidden) setter to the _samples of the wrapper but this approach makes sure the state of the wrapper doesn't change.