### PR TITLE
Depth of field optimizations and cleanup

### DIFF
--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -96,6 +96,7 @@ export class BlurPostProcess extends PostProcess {
      * @param textureType Type of textures used when performing the post process. (default: 0)
      * @param defines
      * @param _blockCompilation If compilation of the shader should not be done in the constructor. The updateEffect method can be used to compile the shader at a later time. (default: false)
+     * @param textureFormat Format of textures used when performing the post process. (default: TEXTUREFORMAT_RGBA)
      */
     constructor(
         name: string,

--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -113,7 +113,7 @@ export class BlurPostProcess extends PostProcess {
         super(
             name,
             "kernelBlur",
-            ["delta", "direction", "cameraMinMaxZ"],
+            ["delta", "direction"],
             ["circleOfConfusionSampler"],
             options,
             camera,

--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -106,9 +106,10 @@ export class BlurPostProcess extends PostProcess {
         samplingMode: number = Texture.BILINEAR_SAMPLINGMODE,
         engine?: Engine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
         defines = "",
-        private _blockCompilation = false
+        private _blockCompilation = false,
+        textureFormat = Constants.TEXTUREFORMAT_RGBA
     ) {
         super(
             name,
@@ -124,7 +125,8 @@ export class BlurPostProcess extends PostProcess {
             textureType,
             "kernelBlur",
             { varyingCount: 0, depCount: 0 },
-            true
+            true,
+            textureFormat
         );
         this._staticDefines = defines;
         this.direction = direction;

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -67,7 +67,8 @@ export class CircleOfConfusionPostProcess extends PostProcess {
         engine?: Engine,
         reusable?: boolean,
         textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
-        blockCompilation = false
+        blockCompilation = false,
+        textureFormat = Constants.TEXTUREFORMAT_RGBA
     ) {
         super(
             name,
@@ -83,7 +84,8 @@ export class CircleOfConfusionPostProcess extends PostProcess {
             textureType,
             undefined,
             null,
-            blockCompilation
+            blockCompilation,
+            textureFormat
         );
         this._depthTexture = depthTexture;
         this.onApplyObservable.add((effect: Effect) => {

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -66,9 +66,8 @@ export class CircleOfConfusionPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: Engine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
-        blockCompilation = false,
-        textureFormat = Constants.TEXTUREFORMAT_RGBA
+        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        blockCompilation = false
     ) {
         super(
             name,
@@ -84,8 +83,7 @@ export class CircleOfConfusionPostProcess extends PostProcess {
             textureType,
             undefined,
             null,
-            blockCompilation,
-            textureFormat
+            blockCompilation
         );
         this._depthTexture = depthTexture;
         this.onApplyObservable.add((effect: Effect) => {
@@ -102,7 +100,7 @@ export class CircleOfConfusionPostProcess extends PostProcess {
             effect.setFloat("focusDistance", this.focusDistance);
             effect.setFloat("cocPrecalculation", cocPrecalculation);
             const activeCamera = this._depthTexture.activeCamera!;
-            effect.setFloat2("cameraMinMaxZ", activeCamera.minZ, activeCamera.maxZ - activeCamera.minZ);
+            effect.setFloat2("cameraMinMaxZ", activeCamera.minZ, activeCamera.maxZ);
         });
     }
 

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -99,7 +99,8 @@ export class CircleOfConfusionPostProcess extends PostProcess {
 
             effect.setFloat("focusDistance", this.focusDistance);
             effect.setFloat("cocPrecalculation", cocPrecalculation);
-            effect.setFloat2("cameraMinMaxZ", this._depthTexture.activeCamera!.minZ, this._depthTexture.activeCamera!.maxZ);
+            const activeCamera = this._depthTexture.activeCamera!;
+            effect.setFloat2("cameraMinMaxZ", activeCamera.minZ, activeCamera.maxZ - activeCamera.minZ);
         });
     }
 

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -100,7 +100,7 @@ export class CircleOfConfusionPostProcess extends PostProcess {
             effect.setFloat("focusDistance", this.focusDistance);
             effect.setFloat("cocPrecalculation", cocPrecalculation);
             const activeCamera = this._depthTexture.activeCamera!;
-            effect.setFloat2("cameraMinMaxZ", activeCamera.minZ, activeCamera.maxZ);
+            effect.setFloat2("cameraMinMaxZ", activeCamera.minZ, activeCamera.maxZ - activeCamera.minZ);
         });
     }
 

--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -47,6 +47,7 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
      * @param reusable If the post process can be reused on the same frame. (default: false)
      * @param textureType Type of textures used when performing the post process. (default: 0)
      * @param blockCompilation If compilation of the shader should not be done in the constructor. The updateEffect method can be used to compile the shader at a later time. (default: false)
+     * @param textureFormat Format of textures used when performing the post process. (default: TEXTUREFORMAT_RGBA)
      */
     constructor(
         name: string,

--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -86,9 +86,6 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
                 effect.setTextureFromPostProcess("textureSampler", imageToBlur);
             }
             effect.setTextureFromPostProcessOutput("circleOfConfusionSampler", circleOfConfusion);
-            if (scene.activeCamera) {
-                effect.setFloat2("cameraMinMaxZ", scene.activeCamera.minZ, scene.activeCamera.maxZ);
-            }
         });
     }
 }

--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -57,11 +57,12 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
         camera: Nullable<Camera>,
         circleOfConfusion: PostProcess,
         imageToBlur: Nullable<PostProcess> = null,
-        samplingMode: number = Texture.BILINEAR_SAMPLINGMODE,
+        samplingMode = Texture.BILINEAR_SAMPLINGMODE,
         engine?: Engine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
-        blockCompilation = false
+        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        blockCompilation = false,
+        textureFormat = Constants.TEXTUREFORMAT_RGBA
     ) {
         super(
             name,
@@ -75,7 +76,8 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
             reusable,
             textureType,
             `#define DOF 1\r\n`,
-            blockCompilation
+            blockCompilation,
+            textureFormat
         );
 
         this.direction = direction;

--- a/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
@@ -108,7 +108,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
 
         // Use R-only formats if supported.
         const engine = scene.getEngine();
-        const circleOfConfusionTextureFormat = engine.isWebGPU || engine.webGLVersion > 1 ? Constants.TEXTUREFORMAT_R : Constants.TEXTUREFORMAT_RGBA;
+        const circleOfConfusionTextureFormat = engine.isWebGPU || engine.webGLVersion > 1 ? Constants.TEXTUREFORMAT_RED : Constants.TEXTUREFORMAT_RGBA;
 
         // Circle of confusion value for each pixel is used to determine how much to blur that pixel
         this._circleOfConfusion = new CircleOfConfusionPostProcess(
@@ -120,8 +120,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             engine,
             false,
             pipelineTextureType,
-            blockCompilation,
-            circleOfConfusionTextureFormat
+            blockCompilation
         );
 
         // Create a pyramid of blurred images (eg. fullSize 1/4 blur, half size 1/2 blur, quarter size 3/4 blur, eith size 4/4 blur)
@@ -164,7 +163,8 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
                 engine,
                 false,
                 pipelineTextureType,
-                blockCompilation
+                blockCompilation,
+                i == 0 ? circleOfConfusionTextureFormat : Constants.TEXTUREFORMAT_RGBA
             );
             blurY.autoClear = false;
             ratio = 0.75 / Math.pow(2, i);

--- a/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
@@ -106,7 +106,8 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             true
         );
 
-        // Use R-only formats if supported.
+        // Use R-only formats if supported to store the circle of confusion values,
+        // This should be more space and bandwidth efficient than using RGBA.
         const engine = scene.getEngine();
         const circleOfConfusionTextureFormat = engine.isWebGPU || engine.webGLVersion > 1 ? Constants.TEXTUREFORMAT_RED : Constants.TEXTUREFORMAT_RGBA;
 

--- a/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
@@ -9,6 +9,7 @@ import { CircleOfConfusionPostProcess } from "./circleOfConfusionPostProcess";
 import { DepthOfFieldBlurPostProcess } from "./depthOfFieldBlurPostProcess";
 import { DepthOfFieldMergePostProcess } from "./depthOfFieldMergePostProcess";
 import type { Scene } from "../scene";
+import { Constants } from "../Engines/constants";
 
 /**
  * Specifies the level of max blur that should be applied when using the depth of field effect
@@ -104,6 +105,11 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             },
             true
         );
+
+        // Use R-only formats if supported.
+        const engine = scene.getEngine();
+        const circleOfConfusionTextureFormat = engine.isWebGPU || engine.webGLVersion > 1 ? Constants.TEXTUREFORMAT_R : Constants.TEXTUREFORMAT_RGBA;
+
         // Circle of confusion value for each pixel is used to determine how much to blur that pixel
         this._circleOfConfusion = new CircleOfConfusionPostProcess(
             "circleOfConfusion",
@@ -111,10 +117,11 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             1,
             null,
             Texture.BILINEAR_SAMPLINGMODE,
-            scene.getEngine(),
+            engine,
             false,
             pipelineTextureType,
-            blockCompilation
+            blockCompilation,
+            circleOfConfusionTextureFormat
         );
 
         // Create a pyramid of blurred images (eg. fullSize 1/4 blur, half size 1/2 blur, quarter size 3/4 blur, eith size 4/4 blur)
@@ -154,7 +161,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
                 this._circleOfConfusion,
                 i == 0 ? this._circleOfConfusion : null,
                 Texture.BILINEAR_SAMPLINGMODE,
-                scene.getEngine(),
+                engine,
                 false,
                 pipelineTextureType,
                 blockCompilation
@@ -171,7 +178,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
                 this._circleOfConfusion,
                 null,
                 Texture.BILINEAR_SAMPLINGMODE,
-                scene.getEngine(),
+                engine,
                 false,
                 pipelineTextureType,
                 blockCompilation
@@ -197,7 +204,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             ratio,
             null,
             Texture.BILINEAR_SAMPLINGMODE,
-            scene.getEngine(),
+            engine,
             false,
             pipelineTextureType,
             blockCompilation

--- a/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
@@ -106,7 +106,7 @@ export class DepthOfFieldEffect extends PostProcessRenderEffect {
             true
         );
 
-        // Use R-only formats if supported to store the circle of confusion values,
+        // Use R-only formats if supported to store the circle of confusion values.
         // This should be more space and bandwidth efficient than using RGBA.
         const engine = scene.getEngine();
         const circleOfConfusionTextureFormat = engine.isWebGPU || engine.webGLVersion > 1 ? Constants.TEXTUREFORMAT_RED : Constants.TEXTUREFORMAT_RGBA;

--- a/packages/dev/core/src/PostProcesses/depthOfFieldMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldMergePostProcess.ts
@@ -68,7 +68,7 @@ export class DepthOfFieldMergePostProcess extends PostProcess {
         samplingMode?: number,
         engine?: Engine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
         blockCompilation = false
     ) {
         super(

--- a/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
+++ b/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
@@ -5,6 +5,7 @@ uniform sampler2D depthSampler;
 varying vec2 vUV;
 
 // precomputed uniforms (not effect parameters)
+// cameraMinMaxZ.y => "maxZ - minZ" i.e., the near-to-far distance.
 uniform vec2 cameraMinMaxZ;
 
 // uniforms

--- a/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
+++ b/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
@@ -4,7 +4,8 @@ uniform sampler2D depthSampler;
 // varyings
 varying vec2 vUV;
 
-// preconputed uniforms (not effect parameters)
+// precomputed uniforms (not effect parameters)
+// cameraMinMaxZ.y => (maxZ - minZ)
 uniform vec2 cameraMinMaxZ;
 
 // uniforms
@@ -17,8 +18,8 @@ uniform float cocPrecalculation;
 void main(void)
 {
     float depth = texture2D(depthSampler, vUV).r;
-    float pixelDistance = (cameraMinMaxZ.x + (cameraMinMaxZ.y - cameraMinMaxZ.x)*depth)*1000.0;	// actual distance from the lens in scene units/1000 (eg. millimeter)
-    float coc = abs(cocPrecalculation* ((focusDistance - pixelDistance)/pixelDistance));
+    float pixelDistance = (cameraMinMaxZ.x + cameraMinMaxZ.y * depth) * 1000.0; // actual distance from the lens in scene units/1000 (eg. millimeter)
+    float coc = abs(cocPrecalculation * ((focusDistance - pixelDistance) / pixelDistance));
     coc = clamp(coc, 0.0, 1.0);
-    gl_FragColor = vec4(coc, depth, coc, 1.0);
+    gl_FragColor = vec4(coc, coc, coc, 1.0);
 }

--- a/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
+++ b/packages/dev/core/src/Shaders/circleOfConfusion.fragment.fx
@@ -5,7 +5,6 @@ uniform sampler2D depthSampler;
 varying vec2 vUV;
 
 // precomputed uniforms (not effect parameters)
-// cameraMinMaxZ.y => (maxZ - minZ)
 uniform vec2 cameraMinMaxZ;
 
 // uniforms

--- a/packages/dev/core/src/Shaders/depthOfFieldMerge.fragment.fx
+++ b/packages/dev/core/src/Shaders/depthOfFieldMerge.fragment.fx
@@ -28,7 +28,7 @@ void main(void)
         vec4 blurred1 = texture2D(blurStep1, vUV);
         gl_FragColor = mix(original, blurred1, coc/0.5);
     }else{
-        vec4 blurred0 = texture2D(blurStep0, vUV);   
+        vec4 blurred0 = texture2D(blurStep0, vUV);
         vec4 blurred1 = texture2D(blurStep1, vUV);
         gl_FragColor = mix(blurred1, blurred0, (coc-0.5)/0.5);
     }

--- a/packages/dev/core/src/Shaders/kernelBlur.fragment.fx
+++ b/packages/dev/core/src/Shaders/kernelBlur.fragment.fx
@@ -8,22 +8,16 @@ varying vec2 sampleCenter;
 #ifdef DOF
     uniform sampler2D circleOfConfusionSampler;
 
-    uniform vec2 cameraMinMaxZ;
-
-    float sampleDistance(in vec2 offset) {
-        float depth = texture2D(circleOfConfusionSampler, offset).g; // depth value from DepthRenderer: 0 to 1 
-        return cameraMinMaxZ.x + (cameraMinMaxZ.y - cameraMinMaxZ.x)*depth; // actual distance from the lens 
-    }
     float sampleCoC(in vec2 offset) {
-        float coc = texture2D(circleOfConfusionSampler, offset).r; 
-        return coc; // actual distance from the lens 
+        float coc = texture2D(circleOfConfusionSampler, offset).r;
+        return coc; // actual distance from the lens
     }
 #endif
 
 #include<kernelBlurVaryingDeclaration>[0..varyingCount]
 
 #ifdef PACKEDFLOAT
-	#include<packingFunctions>
+    #include<packingFunctions>
 #endif
 
 

--- a/packages/dev/core/src/Shaders/kernelBlur.fragment.fx
+++ b/packages/dev/core/src/Shaders/kernelBlur.fragment.fx
@@ -27,7 +27,7 @@ void main(void)
 {
     float computedWeight = 0.0;
 
-    #ifdef PACKEDFLOAT	
+    #ifdef PACKEDFLOAT
         float blend = 0.;
     #else
         vec4 blend = vec4(0.);


### PR DESCRIPTION
The main change here is to use R-only texture format for the circle of confusion (which only needs to store a single value per pixel) rather than using an RGBA texture. This will save space and should be more bandwidth efficient to sample from during the subsequent blur passes.

Also removes `sampleDistance` from the blur shader-- it's not used AFAICT and deleting this code removes the need for passing cameraMinMaxZ uniform.

Other changes here are just minor cleanup. 