### PR TITLE
Fix crash when using a custom material for LineMesh with an effect layer

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -400,11 +400,7 @@ export abstract class EffectLayer {
         }
 
         this._mainTexture.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (!mesh.isReady(false)) {
-                return false;
-            }
-            if (refreshRate === 0 && mesh.subMeshes) {
-                // full check: check that the effects are ready
+            if (mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -399,8 +399,8 @@ export abstract class EffectLayer {
             this._mainTexture.setMaterialForRendering(mesh, material);
         }
 
-        this._mainTexture.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (mesh.subMeshes) {
+        this._mainTexture.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => {
+            if ((preWarm || refreshRate === 0) && mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -110,7 +110,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     /**
      * Override the mesh isReady function with your own one.
      */
-    public customIsReadyFunction: (mesh: AbstractMesh, refreshRate: number) => boolean;
+    public customIsReadyFunction: (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => boolean;
     /**
      * Override the render function of the texture with your own one.
      */
@@ -877,7 +877,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                     }
 
                     if (this.customIsReadyFunction) {
-                        if (!this.customIsReadyFunction(mesh, this.refreshRate)) {
+                        if (!this.customIsReadyFunction(mesh, this.refreshRate, checkReadiness)) {
                             returnValue = false;
                             break;
                         }
@@ -933,7 +933,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
             if (mesh && !mesh.isBlocked) {
                 if (this.customIsReadyFunction) {
-                    if (!this.customIsReadyFunction(mesh, this.refreshRate)) {
+                    if (!this.customIsReadyFunction(mesh, this.refreshRate, false)) {
                         this.resetRefreshCounter();
                         continue;
                     }

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -436,8 +436,8 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             scene.clearColor = savedSceneClearColor;
         });
 
-        this._volumetricLightScatteringRTT.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (mesh.subMeshes) {
+        this._volumetricLightScatteringRTT.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => {
+            if ((preWarm || refreshRate === 0) && mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -437,11 +437,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
         });
 
         this._volumetricLightScatteringRTT.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (!mesh.isReady(false)) {
-                return false;
-            }
-            if (refreshRate === 0 && mesh.subMeshes) {
-                // full check: check that the effects are ready
+            if (mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -142,11 +142,7 @@ export class DepthRenderer {
         });
 
         this._depthMap.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (!mesh.isReady(false)) {
-                return false;
-            }
-            if (refreshRate === 0 && mesh.subMeshes) {
-                // full check: check that the effects are ready
+            if (mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const renderingMesh = subMesh.getRenderingMesh();

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -141,8 +141,8 @@ export class DepthRenderer {
             engine._debugPopGroup?.(1);
         });
 
-        this._depthMap.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (mesh.subMeshes) {
+        this._depthMap.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => {
+            if ((preWarm || refreshRate === 0) && mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const renderingMesh = subMesh.getRenderingMesh();

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -945,11 +945,7 @@ export class GeometryBufferRenderer {
         };
 
         this._multiRenderTarget.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (!mesh.isReady(false)) {
-                return false;
-            }
-            if (refreshRate === 0 && mesh.subMeshes) {
-                // full check: check that the effects are ready
+            if (mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -944,8 +944,8 @@ export class GeometryBufferRenderer {
             }
         };
 
-        this._multiRenderTarget.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number) => {
-            if (mesh.subMeshes) {
+        this._multiRenderTarget.customIsReadyFunction = (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => {
+            if ((preWarm || refreshRate === 0) && mesh.subMeshes) {
                 for (let i = 0; i < mesh.subMeshes.length; ++i) {
                     const subMesh = mesh.subMeshes[i];
                     const material = subMesh.getMaterial();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/exception-if-material-parameter-set-on-linesmesh/34769/8

It's actually a problem of the `isReady` function being called for the wrong material when testing for material readyness in a RTT.

It was normally already handled by #11696, but the `mesh.isReady(false)` call I added at the start of the `customIsReadyFunction` implementation can end up calling a `isReady` function for the wrong material if the `Mesh.isReady` function is overriden, which is what `LineMesh` is doing: 

```typescript
public isReady() {
    if (!this._lineMaterial.isReady(this, !!this._userInstancedBuffersStorage)) {
        return false;
    }

    return super.isReady();
}
```
