### PR TITLE
Workaround Firefox Leak

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.videoTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.videoTexture.ts
@@ -1,6 +1,7 @@
 import { ThinEngine } from "../../Engines/thinEngine";
 import type { InternalTexture } from "../../Materials/Textures/internalTexture";
 import type { Nullable } from "../../types";
+import { Constants } from "../constants";
 
 declare module "../../Engines/thinEngine" {
     export interface ThinEngine {
@@ -19,6 +20,9 @@ ThinEngine.prototype.updateVideoTexture = function (texture: Nullable<InternalTe
         return;
     }
 
+    const glformat = this._getInternalFormat(texture.format);
+    const internalFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, texture.format);
+
     const wasPreviouslyBound = this._bindTextureDirectly(this._gl.TEXTURE_2D, texture, true);
     this._unpackFlipY(!invertY); // Video are upside down by default
 
@@ -28,7 +32,7 @@ ThinEngine.prototype.updateVideoTexture = function (texture: Nullable<InternalTe
             // clear old errors just in case.
             this._gl.getError();
 
-            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, this._gl.RGBA, this._gl.RGBA, this._gl.UNSIGNED_BYTE, video);
+            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, internalFormat, glformat, this._gl.UNSIGNED_BYTE, video);
 
             if (this._gl.getError() !== 0) {
                 this._videoTextureSupported = false;
@@ -55,9 +59,9 @@ ThinEngine.prototype.updateVideoTexture = function (texture: Nullable<InternalTe
             texture._workingContext!.clearRect(0, 0, texture.width, texture.height);
             texture._workingContext!.drawImage(video, 0, 0, video.videoWidth, video.videoHeight, 0, 0, texture.width, texture.height);
 
-            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, this._gl.RGBA, this._gl.RGBA, this._gl.UNSIGNED_BYTE, texture._workingCanvas as TexImageSource);
+            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, internalFormat, glformat, this._gl.UNSIGNED_BYTE, texture._workingCanvas as TexImageSource);
         } else {
-            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, this._gl.RGBA, this._gl.RGBA, this._gl.UNSIGNED_BYTE, video);
+            this._gl.texImage2D(this._gl.TEXTURE_2D, 0, internalFormat, glformat, this._gl.UNSIGNED_BYTE, video);
         }
 
         if (texture.generateMipMaps) {

--- a/packages/dev/core/src/Materials/Textures/htmlElementTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/htmlElementTexture.ts
@@ -23,6 +23,10 @@ export interface IHtmlElementTextureOptions {
      */
     samplingMode?: number;
     /**
+     * Defines the associated texture format.
+     */
+    format?: number;
+    /**
      * Defines the engine instance to use the texture with. It is not mandatory if you define a scene.
      */
     engine: Nullable<ThinEngine>;
@@ -55,10 +59,12 @@ export class HtmlElementTexture extends BaseTexture {
     private static readonly _DefaultOptions: IHtmlElementTextureOptions = {
         generateMipMaps: false,
         samplingMode: Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
+        format: Constants.TEXTUREFORMAT_RGBA,
         engine: null,
         scene: null,
     };
 
+    private readonly _format: number;
     private _textureMatrix: Matrix;
     private _isVideo: boolean;
     private _generateMipMaps: boolean;
@@ -86,6 +92,7 @@ export class HtmlElementTexture extends BaseTexture {
         this._generateMipMaps = options.generateMipMaps!;
         this._samplingMode = options.samplingMode!;
         this._textureMatrix = Matrix.Identity();
+        this._format = options.format!;
 
         this.name = name;
         this.element = element;
@@ -110,6 +117,7 @@ export class HtmlElementTexture extends BaseTexture {
         const engine = this._getEngine();
         if (engine) {
             this._texture = engine.createDynamicTexture(width, height, this._generateMipMaps, this._samplingMode);
+            this._texture.format = this._format;
         }
 
         this.update();
@@ -142,7 +150,7 @@ export class HtmlElementTexture extends BaseTexture {
             engine.updateVideoTexture(this._texture, videoElement, invertY === null ? true : invertY);
         } else {
             const canvasElement = this.element as HTMLCanvasElement;
-            engine.updateDynamicTexture(this._texture, canvasElement, invertY === null ? true : invertY, false);
+            engine.updateDynamicTexture(this._texture, canvasElement, invertY === null ? true : invertY, false, this._format);
         }
 
         if (!wasReady && this.isReady()) {

--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -154,7 +154,7 @@ export class VideoTexture extends Texture {
         samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
         settings: Partial<VideoTextureSettings> = {},
         onError?: Nullable<(message?: string, exception?: any) => void>,
-        format: number = Constants.TEXTUREFORMAT_RGBA,
+        format: number = Constants.TEXTUREFORMAT_RGBA
     ) {
         super(null, scene, !generateMipMaps, invertY);
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/videotexture-memory-leak-in-firefox/34876