### PR TITLE
Fix infinite sprites draw in frozen scenes

### DIFF
--- a/packages/dev/core/src/Rendering/renderingGroup.ts
+++ b/packages/dev/core/src/Rendering/renderingGroup.ts
@@ -368,9 +368,16 @@ export class RenderingGroup {
         this._alphaTestSubMeshes.reset();
         this._depthOnlySubMeshes.reset();
         this._particleSystems.reset();
-        this._spriteManagers.reset();
+        this.prepareSprites();
         this._edgesRenderers.reset();
         this._empty = true;
+    }
+
+    /**
+     * Resets the different lists of sprites to prepare a new frame.
+     */
+    public prepareSprites(): void {
+        this._spriteManagers.reset();
     }
 
     public dispose(): void {

--- a/packages/dev/core/src/Rendering/renderingManager.ts
+++ b/packages/dev/core/src/Rendering/renderingManager.ts
@@ -240,7 +240,7 @@ export class RenderingManager {
      * Resets the sprites information of the group to prepare a new frame
      * @internal
      */
-     public resetSprites(): void {
+    public resetSprites(): void {
         if (this.maintainStateBetweenFrames) {
             return;
         }

--- a/packages/dev/core/src/Rendering/renderingManager.ts
+++ b/packages/dev/core/src/Rendering/renderingManager.ts
@@ -237,6 +237,23 @@ export class RenderingManager {
     }
 
     /**
+     * Resets the sprites information of the group to prepare a new frame
+     * @internal
+     */
+     public resetSprites(): void {
+        if (this.maintainStateBetweenFrames) {
+            return;
+        }
+
+        for (let index = RenderingManager.MIN_RENDERINGGROUPS; index < RenderingManager.MAX_RENDERINGGROUPS; index++) {
+            const renderingGroup = this._renderingGroups[index];
+            if (renderingGroup) {
+                renderingGroup.prepareSprites();
+            }
+        }
+    }
+
+    /**
      * Dispose and release the group and its associated resources.
      * @internal
      */

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -3893,6 +3893,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 }
             }
 
+            this._renderingManager.resetSprites();
+
             return;
         }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/spritemanager-infinite-drawcalls-bug/34948