### PR TITLE
Move the viewer to the /viewer/ directory

### DIFF
--- a/packages/dev/buildTools/src/packageMapping.ts
+++ b/packages/dev/buildTools/src/packageMapping.ts
@@ -110,19 +110,19 @@ export const umdPackageMapping: { [key in UMDPackageName]: { baseDir: string; ba
         baseFilename: "babylonjs.postProcess",
     },
     "babylonjs-ktx2decoder": {
-        baseDir: "",
+        baseDir: "", // keep in root of the cdn
         baseFilename: "babylon.ktx2Decoder",
     },
     "babylonjs-viewer": {
-        baseDir: "",
+        baseDir: "viewer",
         baseFilename: "babylon.viewer",
     },
     "babylonjs-shared-ui-components": {
-        baseDir: "",
+        baseDir: "shared-ui-components",
         baseFilename: "",
     },
     "babylonjs-gltf2interface": {
-        baseDir: "",
+        baseDir: "", // keep in root of the cdn
         baseFilename: "",
     },
 };


### PR DESCRIPTION
The viewer was uploaded to the CDN, but to the wrong directory (was in the base directory and not the /viewer/ directory. This fixes the issue.