### PR TITLE
InputManager: Fix for onPointerMove

### DIFF
--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -650,7 +650,7 @@ declare module "../scene" {
             fastCheck?: boolean,
             onlyBoundingInfo?: boolean,
             trianglePredicate?: TrianglePickingPredicate
-        ): Nullable<PickingInfo>;
+        ): PickingInfo;
 
         /** @internal */
         _internalMultiPick(
@@ -784,11 +784,7 @@ Scene.prototype._internalPick = function (
     fastCheck?: boolean,
     onlyBoundingInfo?: boolean,
     trianglePredicate?: TrianglePickingPredicate
-): Nullable<PickingInfo> {
-    if (!PickingInfo) {
-        return null;
-    }
-
+): PickingInfo {
     let pickingInfo = null;
 
     for (let meshIndex = 0; meshIndex < this.meshes.length; meshIndex++) {
@@ -939,10 +935,7 @@ Scene.prototype.pick = function (
     camera?: Nullable<Camera>,
     trianglePredicate?: TrianglePickingPredicate,
     _enableDistantPicking = false
-): Nullable<PickingInfo> {
-    if (!PickingInfo) {
-        return null;
-    }
+): PickingInfo {
     const result = this._internalPick(
         (world, enableDistantPicking) => {
             if (!this._tempPickingRay) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -219,9 +219,9 @@ export class InputManager {
         const type = evt.inputIndex >= PointerInput.MouseWheelX && evt.inputIndex <= PointerInput.MouseWheelZ ? PointerEventTypes.POINTERWHEEL : PointerEventTypes.POINTERMOVE;
 
         if (scene.onPointerMove) {
+            // Because of lazy picking, we need to force a pick to update the pickResult
             const pr = pickResult ? pickResult : this._pickMove(evt.pointerId);
-            // We know that _pick will return a PickingInfo because _internalPick always returns a PickingInfo
-            scene.onPointerMove(evt, pr!, type);
+            scene.onPointerMove(evt, pr, type);
         }
 
         let pointerInfo: PointerInfo;
@@ -269,7 +269,7 @@ export class InputManager {
     }
 
     /** @internal */
-    public _pickMove(pointerId: number): Nullable<PickingInfo> {
+    public _pickMove(pointerId: number): PickingInfo {
         const scene = this._scene;
         const pickResult = scene.pick(
             this._unTranslatedPointerX,

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -218,8 +218,10 @@ export class InputManager {
 
         const type = evt.inputIndex >= PointerInput.MouseWheelX && evt.inputIndex <= PointerInput.MouseWheelZ ? PointerEventTypes.POINTERWHEEL : PointerEventTypes.POINTERMOVE;
 
-        if (scene.onPointerMove && pickResult) {
-            scene.onPointerMove(evt, pickResult, type);
+        if (scene.onPointerMove) {
+            const pr = pickResult ? pickResult : this._pickMove(evt.pointerId);
+            // We know that _pick will return a PickingInfo because _internalPick always returns a PickingInfo
+            scene.onPointerMove(evt, pr!, type);
         }
 
         let pointerInfo: PointerInfo;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4997,7 +4997,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         fastCheck?: boolean,
         camera?: Nullable<Camera>,
         trianglePredicate?: TrianglePickingPredicate
-    ): Nullable<PickingInfo> {
+    ): PickingInfo {
         // Dummy info if picking as not been imported
         return new PickingInfo();
     }


### PR DESCRIPTION
In the latest release, there was a check that was erroneously checking for pickResult on onPointerMove that would make that callback not function as intended, this PR will fix that by removing the check and forcing a pick before executing the callback.

Note: Scene.pick has been changed to return `PickingInfo` as opposed to `Nullable<PickingInfo>` because it has been determined that pick will never return null.