### PR TITLE
InputManager: Reset Swipe Status if we skip the next Observable notify

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -836,6 +836,11 @@ export class InputManager {
                             }
                         }
                         if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERUP)) {
+                            // If we're skipping the next observable, we need to reset the swipe state before returning
+                            if (this._swipeButtonPressed === evt.button) {
+                                this._isSwiping = false;
+                                this._swipeButtonPressed = -1;
+                            }
                             return;
                         }
                     }


### PR DESCRIPTION
Recently, there was a bug fix put out that addressed an issue where a POINTERTAP event was occurring if the cursor happened to return to the same position after moving outside of the tap range.  Unfortunately, there was a missed scenario where the swipe state wasn't being properly reset if we skipped the next observable call (like when clicking on a UI element).  This PR adds a check to make sure that we reset the swipe state if we are skipping said call.  

Related Forum Post: https://forum.babylonjs.com/t/first-pointerpick-event-is-not-emitted-immediately-after-interacting-with-gui-control-that-is-a-pointerblocker/35008