### PR TITLE
OIT fix : clearing front render target when no transparent mesh are rendered

### DIFF
--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -438,6 +438,11 @@ export class DepthPeelingRenderer {
         }
 
         if (!this._candidateSubMeshes.length) {
+            this._engine.bindFramebuffer(this._colorMrts[1].renderTarget!);
+            this._engine.bindAttachments(this._layoutCache[1]);
+            this._engine.clear(this._colorCache[2], true, false, false);
+            this._engine.unBindFramebuffer(this._colorMrts[1].renderTarget!);
+
             this._finalCompose(1);
             return this._excludedSubMeshes;
         }


### PR DESCRIPTION
Not clearing was causing ghost meshes being composed with the opaque texture when they shouldn't