### PR TITLE
Attempting to fix missing renderingManager() typescript definition

### DIFF
--- a/packages/dev/core/src/Rendering/renderingManager.ts
+++ b/packages/dev/core/src/Rendering/renderingManager.ts
@@ -135,7 +135,10 @@ export class RenderingManager {
         }
     }
 
-    public getRenderingGroup(id: number) {
+    /**
+     * Gets the rendering group with the specified id.
+     */
+    public getRenderingGroup(id: number): RenderingGroup {
         const renderingGroupId = id || 0;
 
         this._prepareRenderingGroup(renderingGroupId);

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1335,7 +1335,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * Gets the scene's rendering manager
      */
-    public get renderingManager() {
+    public get renderingManager(): RenderingManager {
         return this._renderingManager;
     }
 


### PR DESCRIPTION
I don't see the scene's `get renderingManager()` property in the scene.d.ts after npm installing Babylon.js into my project. Oddly, I'm not sure how to repro it when building Babylon.js locally (on master) as my local build includes the `renderingManager` getter definition. :/

I doubt adding a return type (ie. this change) will actually fix the missing definition, but it seemed like worthwhile cleanup either way.

If there is another change that needs to be made to fix the missing definition, let me know and I can include it here.

