### PR TITLE
Fix Camera Order Back Compat

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -4,6 +4,7 @@ import { Scene } from "../scene";
 import { Engine } from "../Engines/engine";
 import { EngineStore } from "../Engines/engineStore";
 import type { IInspectable } from "../Misc/iInspectable";
+import type { Camera } from "../Cameras/camera";
 
 // declare INSPECTOR namespace for compilation issue
 declare let INSPECTOR: any;
@@ -123,6 +124,10 @@ export interface IInspectorOptions {
      * Optional initial tab (default to DebugLayerTab.Properties)
      */
     initialTab?: DebugLayerTab;
+    /**
+     * Optional camera to use to render the gizmos from the inspector (default to the scene.activeCamera or the latest from scene.activeCameras)
+     */
+    gizmoCamera?: Camera;
 }
 
 declare module "../scene" {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4540,8 +4540,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         // Multi-cameras?
-        // save current active camera, following calls will change it, discarding user settings
-        const activeCamera = this._activeCamera;
         if (this.activeCameras && this.activeCameras.length > 0) {
             for (let cameraIndex = 0; cameraIndex < this.activeCameras.length; cameraIndex++) {
                 this._processSubCameras(this.activeCameras[cameraIndex], cameraIndex > 0);
@@ -4553,7 +4551,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
             this._processSubCameras(this.activeCamera, !!this.activeCamera.outputRenderTarget);
         }
-        this._activeCamera = activeCamera;
 
         // Intersection checks
         this._checkIntersections();

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -16,10 +16,12 @@ import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
 import { PropertyChangedEvent } from "../../../components/propertyChangedEvent";
 import type { LightGizmo } from "core/Gizmos/lightGizmo";
 import type { CameraGizmo } from "core/Gizmos/cameraGizmo";
+import type { Camera } from "core/Cameras/camera";
 import { TmpVectors, Vector3 } from "core/Maths/math";
 
 interface ISceneTreeItemComponentProps {
     scene: Scene;
+    gizmoCamera?: Camera;
     onRefresh: () => void;
     selectedEntity?: any;
     extensibilityGroups?: IExplorerExtensibilityGroup[];
@@ -233,7 +235,10 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
 
         if (!scene.reservedDataStore.gizmoManager) {
             scene.reservedDataStore.gizmoManager = new GizmoManager(scene);
-            scene.reservedDataStore.gizmoManager.utilityLayer.setRenderCamera(scene.activeCamera);
+        }
+
+        if (this.props.gizmoCamera) {
+            scene.reservedDataStore.gizmoManager.utilityLayer.setRenderCamera(this.props.gizmoCamera);
         }
 
         const manager: GizmoManager = scene.reservedDataStore.gizmoManager;

--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -26,6 +26,7 @@ import { StandardMaterial } from "core/Materials/standardMaterial";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { SpriteManager } from "core/Sprites/spriteManager";
 import type { TargetCamera } from "core/Cameras/targetCamera";
+import type { Camera } from "core/Cameras/camera";
 
 // side effects
 import "core/Sprites/spriteSceneComponent";
@@ -54,6 +55,7 @@ export class SceneExplorerFilterComponent extends React.Component<ISceneExplorer
 
 interface ISceneExplorerComponentProps {
     scene: Scene;
+    gizmoCamera?: Camera,
     noCommands?: boolean;
     noHeader?: boolean;
     noExpand?: boolean;
@@ -441,6 +443,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
                 <SceneExplorerFilterComponent onFilter={(filter) => this.filterContent(filter)} />
                 <SceneTreeItemComponent
                     globalState={this.props.globalState}
+                    gizmoCamera={this.props.gizmoCamera}
                     extensibilityGroups={this.props.extensibilityGroups}
                     selectedEntity={this.state.selectedEntity}
                     scene={scene}

--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -55,7 +55,7 @@ export class SceneExplorerFilterComponent extends React.Component<ISceneExplorer
 
 interface ISceneExplorerComponentProps {
     scene: Scene;
-    gizmoCamera?: Camera,
+    gizmoCamera?: Camera;
     noCommands?: boolean;
     noHeader?: boolean;
     noExpand?: boolean;

--- a/packages/dev/inspector/src/inspector.ts
+++ b/packages/dev/inspector/src/inspector.ts
@@ -105,6 +105,7 @@ export class Inspector {
                 enablePopup: options.enablePopup,
                 enableClose: options.enableClose,
                 explorerExtensibility: options.explorerExtensibility,
+                gizmoCamera: options.gizmoCamera,
             };
         }
 
@@ -131,6 +132,7 @@ export class Inspector {
             this._OpenedPane++;
             const sceneExplorerElement = React.createElement(SceneExplorerComponent, {
                 scene,
+                gizmoCamera: options.gizmoCamera,
                 globalState: this._GlobalState,
                 extensibilityGroups: options.explorerExtensibility,
                 noClose: !options.enableClose,


### PR DESCRIPTION
Following this: https://github.com/BabylonJS/Babylon.js/pull/12779

Some back compat issues were detected. Reverting in favor of a manual option to chose the gizmo Camera.

This playground will be working accordingly: https://www.babylonjs-playground.com/#XQ729G#3

