### PR TITLE
Change Judgment mode of _isBinary

### DIFF
--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -159,15 +159,16 @@ export class STLFileLoader implements ISceneLoaderPlugin {
             return true;
         }
 
-        // check characters higher than ASCII to confirm binary
-        const fileLength = reader.byteLength;
-        for (let index = 0; index < fileLength; index++) {
-            if (reader.getUint8(index) > 127) {
-                return true;
+        // US-ASCII begin with 's', 'o', 'l', 'i', 'd'
+        const ascll = [ 115, 111, 108, 105, 100 ];
+        for ( let off = 0; off < 5; off ++ ) {
+            if(reader.getUint8(off) != ascll[off]){
+                return true
             }
+            if(off === 4 ) return false
         }
-
-        return false;
+        
+        return true;
     }
 
     private _parseBinary(mesh: Mesh, data: ArrayBuffer, rightHanded: boolean) {

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -162,10 +162,10 @@ export class STLFileLoader implements ISceneLoaderPlugin {
         // US-ASCII begin with 's', 'o', 'l', 'i', 'd'
         const ascll = [ 115, 111, 108, 105, 100 ];
         for ( let off = 0; off < 5; off ++ ) {
-            if(reader.getUint8(off) != ascll[off]){
-                return true
+            if( reader.getUint8(off) != ascll[off]){
+                return true;
             }
-            if(off === 4 ) return false
+            if( off === 4 ) return false;
         }
         
         return true;

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -160,9 +160,9 @@ export class STLFileLoader implements ISceneLoaderPlugin {
         }
 
         // US-ASCII begin with 's', 'o', 'l', 'i', 'd'
-        const ascll = [ 115, 111, 108, 105, 100 ];
+        const ascii = [ 115, 111, 108, 105, 100 ];
         for ( let off = 0; off < 5; off ++ ) {
-            if( reader.getUint8(off) != ascll[off]){
+            if( reader.getUint8(off) !== ascii[off]){
                 return true;
             }
             if( off === 4 ) return false;

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -165,10 +165,9 @@ export class STLFileLoader implements ISceneLoaderPlugin {
             if( reader.getUint8(off) !== ascii[off]){
                 return true;
             }
-            if( off === 4 ) return false;
         }
         
-        return true;
+        return false;
     }
 
     private _parseBinary(mesh: Mesh, data: ArrayBuffer, rightHanded: boolean) {


### PR DESCRIPTION
Some ASCII File begin with next code 
will judge ASCII  to Binary

```
solid 中间部分
   facet normal 9.969174e-01 0.000000e+00 -7.845839e-02
      outer loop
         vertex 4.995691e+01 1.566911e+01 2.952479e+00
         vertex 5.000000e+01 1.566911e+01 3.500000e+00
         vertex 5.000000e+01 9.669109e+00 3.500000e+00
      endloop
   endfacet
....
```