### PR TITLE
Different ports for our hosted tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -132,7 +132,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Sandbox development (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1339",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Sandbox Serve (Dev)"
         },
@@ -144,7 +144,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Sandbox development (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1339",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Sandbox Serve (Dev)"
         },
@@ -155,7 +155,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Launch Sandbox (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1339",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Sandbox Serve for core (Dev)"
         },
@@ -166,7 +166,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch Sandbox (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1339",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Sandbox Serve for core (Dev)"
         },
@@ -174,7 +174,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "GUI Editor development (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1341",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "GUI Editor Serve (Dev)"
         },
@@ -182,7 +182,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "GUI Editor development (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1341",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "GUI Editor Serve (Dev)"
         },
@@ -193,7 +193,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Launch GUI Editor (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1341",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "GUI Editor Serve for core (Dev)"
         },
@@ -204,7 +204,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch GUI Editor (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1341",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "GUI Editor Serve for core (Dev)"
         },
@@ -212,7 +212,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Node Editor development (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1340",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Node Editor Serve (Dev)"
         },
@@ -220,7 +220,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Node Editor development (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1340",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Node Editor Serve (Dev)"
         },
@@ -231,7 +231,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Launch Node Editor (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1340",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Node Editor Serve for core (Dev)"
         },
@@ -242,7 +242,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch Node Editor (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1340",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "Node Editor Serve for core (Dev)"
         },
@@ -250,7 +250,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "VSM development (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1342",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "VSM Serve (Dev)"
         },
@@ -258,7 +258,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "VSM development (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1342",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "VSM Serve (Dev)"
         },
@@ -266,7 +266,7 @@
             "type": "pwa-msedge",
             "request": "launch",
             "name": "Launch VSM (Edge)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1342",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "VSM Serve for core (Dev)"
         },
@@ -274,7 +274,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch VSM (Chrome)",
-            "url": "http://localhost:1338",
+            "url": "http://localhost:1342",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "VSM Serve for core (Dev)"
         },

--- a/packages/tools/guiEditor/webpack.config.js
+++ b/packages/tools/guiEditor/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = (env) => {
                 watch: false,
             },
             // hot: true,
-            port: env.TOOLS_PORT || 1338,
+            port: env.GUIEDITOR_PORT || 1341,
             server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
             hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
             liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,

--- a/packages/tools/nodeEditor/webpack.config.js
+++ b/packages/tools/nodeEditor/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = (env) => {
                 watch: false,
             },
             // hot: true,
-            port: process.env.TOOLS_PORT || 1338,
+            port: process.env.NME_PORT || 1340,
             server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
             hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
             liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -79,7 +79,7 @@ module.exports = (env) => {
                 watch: false,
             },
             // hot: true,
-            port: process.env.TOOLS_PORT || 1338,
+            port: process.env.PLAYGROUND_PORT || 1338,
             server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
             hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
             liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,

--- a/packages/tools/sandbox/webpack.config.js
+++ b/packages/tools/sandbox/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env) => {
                 watch: false,
             },
             // hot: true,
-            port: process.env.TOOLS_PORT || 1338,
+            port: process.env.SANDBOX_PORT || 1339,
             server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
             hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
             liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,

--- a/packages/tools/vsm/webpack.config.js
+++ b/packages/tools/vsm/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = (env) => {
                 watch: false,
             },
             // hot: true,
-            port: env.TOOLS_PORT || 1338,
+            port: env.VSM_PORT || 1342,
             server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
             hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
             liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,


### PR DESCRIPTION
Every tool in the local dev environment now has a different port. They all depend on the babylon server at port 1337.
Playground: 1338
Sandbox: 1339
NME: 1340
GUI: 1341
VSM: 1342

All can be overwritten by an environment variable, if needed.