### PR TITLE
Revert "Use the latest CDN nightly version and not unpkg"

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -1,6 +1,7 @@
 import { Tools } from "../Misc/tools";
 import { Observable } from "../Misc/observable";
 import { Scene } from "../scene";
+import { Engine } from "../Engines/engine";
 import { EngineStore } from "../Engines/engineStore";
 import type { IInspectable } from "../Misc/iInspectable";
 import type { Camera } from "../Cameras/camera";
@@ -192,7 +193,7 @@ export class DebugLayer {
      * By default it uses the babylonjs CDN.
      * @ignoreNaming
      */
-    public static InspectorURL = `https://cdn.babylonjs.com/inspector/babylon.inspector.bundle.js`;
+    public static InspectorURL = `https://unpkg.com/babylonjs-inspector@${Engine.Version}/babylon.inspector.bundle.js`;
 
     private _scene: Scene;
 

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -1,10 +1,11 @@
 import type { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
+import { Engine } from "core/Engines/engine";
 import { Tools } from "core/Misc/tools";
 import { GUIEditor } from "gui-editor/guiEditor";
 
 declare let BABYLON: any;
 
-let editorUrl = `https://cdn.babylonjs.com/guiEditor/babylon.guiEditor.js`;
+let editorUrl = `https://unpkg.com/babylonjs-gui-editor@${Engine.Version}/babylon.guiEditor.js`;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 let guiEditorContainer: { GUIEditor: typeof GUIEditor };
 /** Get the inspector from bundle or global */


### PR DESCRIPTION
Reverts BabylonJS/Babylon.js#13169

CC @sebavan 

This might cause issues with peopole using the inspector with older versions. We will find a cleaner solution