### PR TITLE
ADT: Added check to attachToMesh to prevent potential memory leak

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1036,7 +1036,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (!scene) {
             return;
         }
-        
+
         if (this._pointerObserver) {
             scene.onPointerObservable.remove(this._pointerObserver);
         }

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1036,6 +1036,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (!scene) {
             return;
         }
+        
+        if (this._pointerObserver) {
+            scene.onPointerObservable.remove(this._pointerObserver);
+        }
+
         this._pointerObserver = scene.onPointerObservable.add((pi) => {
             if (
                 pi.type !== PointerEventTypes.POINTERMOVE &&


### PR DESCRIPTION
While investigating an issue with the AdvancedDynamicTexture, I found that if `attachToMesh` is called after it's been called previously, it will not purge the previous observer used for mesh interaction.  This PR adds a check to remove the obsolete observer.