### PR TITLE
Fix bug rendering transparent meshes using their own materials in effect layer

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -884,7 +884,7 @@ export abstract class EffectLayer {
         this.onBeforeRenderMeshToEffect.notifyObservers(ownerMesh);
 
         if (this._useMeshMaterial(renderingMesh)) {
-            renderingMesh.render(subMesh, hardwareInstancedRendering, replacementMesh || undefined);
+            renderingMesh.render(subMesh, enableAlphaMode, replacementMesh || undefined);
         } else if (this._isReady(subMesh, hardwareInstancedRendering, this._emissiveTextureAndColor.texture)) {
             const renderingMaterial = effectiveMesh._internalAbstractMeshDataInfo._materialForRenderPass?.[engine.currentRenderPassId];
 


### PR DESCRIPTION
I believe I found a corner-case bug in effectLayer.ts. I've posted about it on the forum here:

https://forum.babylonjs.com/t/bug-and-proposed-fix-effectlayer-with-meshes-using-their-own-materials-ignores-transparency/35194

Since (I think) I have found the fix already and it's just a one-liner, here is a PR with the fix. I've run "npm run test:unit" and "npm run build:dev" in GitPod, both were OK. The one-line change fixed the bug in my local repro.

Details of the bug (copied from the forum post):

1. Add two meshes to a scene, add both to the glow layer, set both to use their own material (referenceMeshToUseItsOwnMaterial).
2. Make the meshes partially transparent.
3. Move the camera so it is looking through transparent parts of one mesh to see the other.
4. The far-away mesh will lose its glow effect when seen through the transparent parts of the close mesh.

Demo: https://playground.babylonjs.com/#SRZRWV#1139
(Move the camera so that you are looking at parts of one glowing ball through the transparent parts of another ball. Observe that the parts of the far-away ball seen through the close-up ball do not glow.)