### PR TITLE
fix alpha in glow layer

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -884,7 +884,7 @@ export abstract class EffectLayer {
         this.onBeforeRenderMeshToEffect.notifyObservers(ownerMesh);
 
         if (this._useMeshMaterial(renderingMesh)) {
-            renderingMesh.render(subMesh, hardwareInstancedRendering, replacementMesh || undefined);
+            renderingMesh.render(subMesh, true, replacementMesh || undefined);
         } else if (this._isReady(subMesh, hardwareInstancedRendering, this._emissiveTextureAndColor.texture)) {
             const renderingMaterial = effectiveMesh._internalAbstractMeshDataInfo._materialForRenderPass?.[engine.currentRenderPassId];
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/bug-and-proposed-fix-effectlayer-with-meshes-using-their-own-materials-ignores-transparency/35194