### PR TITLE
Test babylon transform node

### DIFF
--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -751,7 +751,7 @@ export class TransformNode extends Node {
      * Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
      * In that case the node will not remain in the same space as it is, as the pivot will be applied.
      * To avoid this, you can set updatePivot to true and the pivot will be updated to identity
-     * @see https://doc.babylonjs.com/how_to/parenting
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
      * @param node the node ot set as the parent
      * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
      * @param updatePivot if true, update the pivot matrix to keep the node in the same space as before

--- a/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
@@ -30,5 +30,16 @@ describe("TransformNode", () => {
             expect(child.parent).toBeTruthy();
             expect(child.parent?.name).toEqual("Parent");
         });
+
+        it('should work with nullable node', () => {
+            const scene = new Scene(subject);
+            const child = new AbstractMesh("Child", scene);
+            const parent = new AbstractMesh("Parent", scene);
+
+            child.setParent(parent);
+            child.setParent(null);
+
+            expect(child.parent).toBeFalsy();
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
@@ -1,5 +1,6 @@
-import type { Engine} from 'core/Engines';
+import type { Engine } from 'core/Engines';
 import { NullEngine } from 'core/Engines';
+import { Matrix } from 'core/Maths';
 import { AbstractMesh } from 'core/Meshes';
 import { Scene } from 'core/scene';
 
@@ -40,6 +41,34 @@ describe("TransformNode", () => {
             child.setParent(null);
 
             expect(child.parent).toBeFalsy();
+        });
+
+        it('should update pivot when it need', () => {
+            const scene = new Scene(subject);
+            const child = new AbstractMesh("Child", scene);
+            const parent = new AbstractMesh("Parent", scene);
+
+            // set not default pivot
+            child.setPivotMatrix(Matrix.Translation(1, -1, -0.5));
+
+            expect(child.getPivotMatrix().toArray()).not.toEqual(Matrix.Identity().toArray());
+
+            child.setParent(parent, true, true);
+
+            expect(child.getPivotMatrix().toArray()).toEqual(Matrix.Identity().toArray());
+        });
+
+        it('should not update pivot when it no need', () => {
+            const scene = new Scene(subject);
+            const child = new AbstractMesh("Child", scene);
+            const parent = new AbstractMesh("Parent", scene);
+
+            // set not default pivot
+            child.setPivotMatrix(Matrix.Translation(1, -1, -0.5));
+
+            child.setParent(parent, true, false);
+
+            expect(child.getPivotMatrix().toArray()).not.toEqual(Matrix.Identity().toArray());
         });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.transformNode.test.ts
@@ -1,0 +1,34 @@
+import type { Engine} from 'core/Engines';
+import { NullEngine } from 'core/Engines';
+import { AbstractMesh } from 'core/Meshes';
+import { Scene } from 'core/scene';
+
+
+describe("TransformNode", () => {
+    let subject: Engine;
+
+    beforeEach(function () {
+        subject = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+    });
+
+    describe("setParent", () => {
+        it("should have a parent after call setParent method", () => {
+            const scene = new Scene(subject);
+            const child = new AbstractMesh("Child", scene);
+            const parent = new AbstractMesh("Parent", scene);
+
+            expect(child.parent).toBeFalsy();
+
+            child.setParent(parent, true, true);
+
+            expect(child.parent).toBeTruthy();
+            expect(child.parent?.name).toEqual("Parent");
+        });
+    });
+});


### PR DESCRIPTION
Hi!
The url `https://doc.babylonjs.com/how_to/parenting` currently is 404, so I updated it.

And one strange momemnt to me. I tried to write test case like this:
```
const scene = new Scene(subject);
const child = new AbstractMesh("Child", scene);
const parent = new AbstractMesh("Parent", scene);

child.rotationQuaternion = new Quaternion(0.1, 0.2, 0.3, 1);
child.setParent(parent);
```

After `setParent` the `child.rotationQuaternion` equals to `{"_isDirty": true, "_w": 0.9193215324678584, "_x": 0.10613875217731637, "_y": 0.21264414489225805, "_z": 0.31622577190124856}`
It happens after call `composedMatrix.decompose()` in the `setParent()` method.
I don't know, is this behaviour correct?