### PR TITLE
NME: fix wrong perturbed normals when using pre-existing tangents

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -171,13 +171,15 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         defines.setValue("PARALLAXOCCLUSION", this.useParallaxOcclusion, true);
     }
 
-    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh: Mesh) {
+    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh?: Mesh) {
         if (nodeMaterial.getScene()._mirroredCameraPosition) {
             effect.setFloat2(this._tangentSpaceParameterName, this.invertX ? 1.0 : -1.0, this.invertY ? 1.0 : -1.0);
         } else {
             effect.setFloat2(this._tangentSpaceParameterName, this.invertX ? -1.0 : 1.0, this.invertY ? -1.0 : 1.0);
         }
-        effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
+        if (mesh) {
+            effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
+        }
     }
 
     public autoConfigure(material: NodeMaterial) {

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -7,6 +7,7 @@ import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockCon
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
+import type { Mesh } from "../../../../Meshes/mesh";
 import { InputBlock } from "../Input/inputBlock";
 import type { Effect } from "../../../effect";
 import type { Scene } from "../../../../scene";
@@ -24,6 +25,7 @@ import "../../../../Shaders/ShadersInclude/bumpFragment";
  */
 export class PerturbNormalBlock extends NodeMaterialBlock {
     private _tangentSpaceParameterName = "";
+    private _tangentCorrectionFactorName = "";
 
     /** Gets or sets a boolean indicating that normal should be inverted on X axis */
     @editableInPropertyPage("Invert X axis", PropertyTypeForEdition.Boolean, "PROPERTIES", { notifiers: { update: false } })
@@ -169,12 +171,13 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         defines.setValue("PARALLAXOCCLUSION", this.useParallaxOcclusion, true);
     }
 
-    public bind(effect: Effect, nodeMaterial: NodeMaterial) {
+    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh: Mesh) {
         if (nodeMaterial.getScene()._mirroredCameraPosition) {
             effect.setFloat2(this._tangentSpaceParameterName, this.invertX ? 1.0 : -1.0, this.invertY ? 1.0 : -1.0);
         } else {
             effect.setFloat2(this._tangentSpaceParameterName, this.invertX ? -1.0 : 1.0, this.invertY ? -1.0 : 1.0);
         }
+        effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
     }
 
     public autoConfigure(material: NodeMaterial) {
@@ -211,6 +214,10 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
 
         state._emitUniformFromString(this._tangentSpaceParameterName, "vec2");
 
+        this._tangentCorrectionFactorName = state._getFreeDefineName("tangentCorrectionFactor");
+
+        state._emitUniformFromString(this._tangentCorrectionFactorName, "float");
+
         let normalSamplerName = null;
         if (this.normalMapColor.connectedPoint) {
             normalSamplerName = (this.normalMapColor.connectedPoint!._ownerBlock as TextureBlock).samplerName;
@@ -243,7 +250,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         } else if (worldTangent.isConnected) {
             state.compilationString += `vec3 tbnNormal = normalize(${worldNormal.associatedVariableName}.xyz);\r\n`;
             state.compilationString += `vec3 tbnTangent = normalize(${worldTangent.associatedVariableName}.xyz);\r\n`;
-            state.compilationString += `vec3 tbnBitangent = cross(tbnNormal, tbnTangent);\r\n`;
+            state.compilationString += `vec3 tbnBitangent = cross(tbnNormal, tbnTangent) * ${this._tangentCorrectionFactorName};\r\n`;
             state.compilationString += `mat3 vTBN = mat3(tbnTangent, tbnBitangent, tbnNormal);\r\n`;
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -9,11 +9,15 @@ import { RegisterClass } from "../../../../Misc/typeStore";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { TBNBlock } from "../Fragment/TBNBlock";
+import type { Mesh } from "../../../../Meshes/mesh";
+import type { Effect } from "../../../effect";
 
 /**
  * Block used to implement the anisotropy module of the PBR material
  */
 export class AnisotropyBlock extends NodeMaterialBlock {
+    private _tangentCorrectionFactorName = "";
+
     /**
      * The two properties below are set by the main PBR block prior to calling methods of this class.
      * This is to avoid having to add them as inputs here whereas they are already inputs of the main block, so already known.
@@ -144,7 +148,7 @@ export class AnisotropyBlock extends NodeMaterialBlock {
         } else if (worldTangent.isConnected) {
             code += `vec3 tbnNormal = normalize(${worldNormal.associatedVariableName}.xyz);\r\n`;
             code += `vec3 tbnTangent = normalize(${worldTangent.associatedVariableName}.xyz);\r\n`;
-            code += `vec3 tbnBitangent = cross(tbnNormal, tbnTangent);\r\n`;
+            code += `vec3 tbnBitangent = cross(tbnNormal, tbnTangent) * ${this._tangentCorrectionFactorName};\r\n`;
             code += `mat3 vTBN = mat3(tbnTangent, tbnBitangent, tbnNormal);\r\n`;
         }
 
@@ -202,9 +206,17 @@ export class AnisotropyBlock extends NodeMaterialBlock {
         defines.setValue("ANISOTROPIC_TEXTURE", false, true);
     }
 
+    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh: Mesh) {
+        effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
+    }
+
     protected _buildBlock(state: NodeMaterialBuildState) {
         if (state.target === NodeMaterialBlockTargets.Fragment) {
             state.sharedData.blocksWithDefines.push(this);
+            state.sharedData.bindableBlocks.push(this);
+
+            this._tangentCorrectionFactorName = state._getFreeDefineName("tangentCorrectionFactor");
+            state._emitUniformFromString(this._tangentCorrectionFactorName, "float");
         }
 
         return this;

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -206,8 +206,12 @@ export class AnisotropyBlock extends NodeMaterialBlock {
         defines.setValue("ANISOTROPIC_TEXTURE", false, true);
     }
 
-    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh: Mesh) {
-        effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
+    public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh?: Mesh) {
+        super.bind(effect, nodeMaterial, mesh);
+
+        if (mesh) {
+            effect.setFloat(this._tangentCorrectionFactorName, mesh.getWorldMatrix().determinant() < 0 ? -1 : 1);
+        }
     }
 
     protected _buildBlock(state: NodeMaterialBuildState) {


### PR DESCRIPTION
Fix #13182 

Note that regarding tangents in the bump context we don't take into account the w component of the vector.

In the regular bump code, we use this component as a factor to negate the bitangent (the w component is normally either 1 or -1):

From `bumpVertex.fx`:

```typescript
#if defined(BUMP) || defined(PARALLAX) || defined(CLEARCOAT_BUMP) || defined(ANISOTROPIC)
	#if defined(TANGENT) && defined(NORMAL)
		vec3 tbnNormal = normalize(normalUpdated);
		vec3 tbnTangent = normalize(tangentUpdated.xyz);
		vec3 tbnBitangent = cross(tbnNormal, tbnTangent) * tangentUpdated.w;
		vTBN = mat3(finalWorld) * mat3(tbnTangent, tbnBitangent, tbnNormal);
	#endif
#endif
```

We don't do it in the NME: should we? If yes, we need to discuss it, I don't see a way to do it without a breaking change...