### PR TITLE
Test babylon camera inputs manager

### DIFF
--- a/packages/dev/core/src/Cameras/cameraInputsManager.ts
+++ b/packages/dev/core/src/Cameras/cameraInputsManager.ts
@@ -105,7 +105,7 @@ export class CameraInputsManager<TCamera extends Camera> {
     /**
      * Add an input method to a camera
      * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras/customizingCameraInputs
-     * @param input camera input method
+     * @param input Camera input method
      */
     public add(input: ICameraInput<TCamera>): void {
         const type = input.getSimpleName();
@@ -118,8 +118,8 @@ export class CameraInputsManager<TCamera extends Camera> {
 
         input.camera = this.camera;
 
-        //for checkInputs, we are dynamically creating a function
-        //the goal is to avoid the performance penalty of looping for inputs in the render loop
+        // for checkInputs, we are dynamically creating a function
+        // the goal is to avoid the performance penalty of looping for inputs in the render loop
         if (input.checkInputs) {
             this.checkInputs = this._addCheckInputs(input.checkInputs.bind(input));
         }

--- a/packages/dev/core/src/Cameras/cameraInputsManager.ts
+++ b/packages/dev/core/src/Cameras/cameraInputsManager.ts
@@ -104,7 +104,7 @@ export class CameraInputsManager<TCamera extends Camera> {
 
     /**
      * Add an input method to a camera
-     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras/customizingCameraInputs
      * @param input camera input method
      */
     public add(input: ICameraInput<TCamera>): void {

--- a/packages/dev/core/src/Cameras/cameraInputsManager.ts
+++ b/packages/dev/core/src/Cameras/cameraInputsManager.ts
@@ -142,6 +142,8 @@ export class CameraInputsManager<TCamera extends Camera> {
                 input.camera = null;
                 delete this.attached[cam];
                 this.rebuildInputCheck();
+
+                return;
             }
         }
     }

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -144,5 +144,37 @@ describe("CameraInputsManager", () => {
             // manager should not have attached input
             expect(manager.attached[input.getSimpleName()]).toBeUndefined();
         });
+
+        it('should not remove not attached input with same name', () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // add input
+            const input: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            // now create a new input with same name
+            const newInput: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+
+            // try to remove the new input with same name
+            manager.remove(newInput);
+
+            // manager should stay have attached initial input
+            expect(manager.attached[newInput.getSimpleName()]).toEqual(input);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -120,12 +120,14 @@ describe("CameraInputsManager", () => {
     });
 
     describe("remove", () => {
-        it("should remove attached input", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
+        let camera: FreeCamera;
+        let manager: CameraInputsManager<FreeCamera>;
+        let input: ICameraInput<FreeCamera>;
 
-            // add new input
-            const input: ICameraInput<FreeCamera> = {
+        beforeEach(() => {
+            camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            manager = new CameraInputsManager(camera);
+            input = {
                 camera: null,
                 getClassName: () => "CustomInput",
                 getSimpleName: () => "SimpleCustomInput",
@@ -133,6 +135,9 @@ describe("CameraInputsManager", () => {
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
             };
+        });
+
+        it("should remove attached input", () => {
             manager.add(input);
 
             // manager should have attached input
@@ -146,18 +151,6 @@ describe("CameraInputsManager", () => {
         });
 
         it("should not remove not attached input with same name", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            // add input
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             manager.add(input);
 
             // now create a new input with same name
@@ -178,20 +171,8 @@ describe("CameraInputsManager", () => {
         });
 
         it("should call rebuild input check after remove the input", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
             const managerRebuildInputCheckSpy = jest.spyOn(manager, "rebuildInputCheck");
 
-            // add input
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             manager.add(input);
 
             // now remove the input
@@ -202,19 +183,8 @@ describe("CameraInputsManager", () => {
         });
 
         it("should detach control from input", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            // add input
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             const detachControlSpy = jest.spyOn(input, "detachControl");
+
             manager.add(input);
 
             // now remove the input
@@ -225,18 +195,6 @@ describe("CameraInputsManager", () => {
         });
 
         it("should remove camera from input", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            // add input
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             manager.add(input);
 
             expect(input.camera).toEqual(camera);

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -78,5 +78,44 @@ describe("CameraInputsManager", () => {
             // manager should stay an old input
             expect(manager.attached[newInput.getSimpleName()]).not.toEqual(newInput);
         });
+
+        it('should attach control when it required', () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            const input = {
+                camera: null,
+                getClassName: () => 'CustomInput',
+                getSimpleName: () => 'SimpleCustomInput',
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            const attachControlSpy = jest.spyOn(input, 'attachControl');
+            manager.attachedToElement = true;
+            manager.add(input);
+
+            expect(attachControlSpy).toHaveBeenCalledWith(undefined);
+        });
+
+        it('should attach control when it required with preventDefault', () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            const input = {
+                camera: null,
+                getClassName: () => 'CustomInput',
+                getSimpleName: () => 'SimpleCustomInput',
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            const attachControlSpy = jest.spyOn(input, 'attachControl');
+            manager.attachedToElement = true;
+            manager.noPreventDefault = true;
+            manager.add(input);
+
+            expect(attachControlSpy).toHaveBeenCalledWith(true);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -9,7 +9,7 @@ describe("CameraInputsManager", () => {
     let subject: Engine;
     let scene: Scene;
 
-    beforeEach(function () {
+    beforeEach(() => {
         subject = new NullEngine({
             renderHeight: 256,
             renderWidth: 256,
@@ -21,15 +21,14 @@ describe("CameraInputsManager", () => {
     });
 
     describe("add", () => {
-        it("should add a new input", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
+        let camera: FreeCamera;
+        let manager: CameraInputsManager<FreeCamera>;
+        let input: ICameraInput<FreeCamera>;
 
-            // initially the manager should not have any input attached
-            expect(manager.attached).toEqual({});
-
-            // after add new input the manager should have the new input attached
-            const input: ICameraInput<FreeCamera> = {
+        beforeEach(() => {
+            camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            manager = new CameraInputsManager(camera);
+            input = {
                 camera: null,
                 getClassName: () => "CustomInput",
                 getSimpleName: () => "SimpleCustomInput",
@@ -37,6 +36,13 @@ describe("CameraInputsManager", () => {
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
             };
+        });
+
+        it("should add a new input", () => {
+            // initially the manager should not have any input attached
+            expect(manager.attached).toEqual({});
+
+            // after add new input the manager should have the new input attached
             manager.add(input);
 
             expect(Object.keys(manager.attached).length).toEqual(1);
@@ -47,18 +53,6 @@ describe("CameraInputsManager", () => {
         });
 
         it("should not override existed input with same type", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            // add new input
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             manager.add(input);
 
             // manager should have attached input
@@ -80,17 +74,6 @@ describe("CameraInputsManager", () => {
         });
 
         it("should attach control when it required", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             const attachControlSpy = jest.spyOn(input, "attachControl");
             manager.attachedToElement = true;
             manager.add(input);
@@ -99,17 +82,6 @@ describe("CameraInputsManager", () => {
         });
 
         it("should attach control when it required with preventDefault", () => {
-            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
-            const manager = new CameraInputsManager(camera);
-
-            const input: ICameraInput<FreeCamera> = {
-                camera: null,
-                getClassName: () => "CustomInput",
-                getSimpleName: () => "SimpleCustomInput",
-                attachControl: () => undefined,
-                detachControl: () => undefined,
-                checkInputs: () => undefined,
-            };
             const attachControlSpy = jest.spyOn(input, "attachControl");
             manager.attachedToElement = true;
             manager.noPreventDefault = true;

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -1,0 +1,49 @@
+import { CameraInputsManager, FreeCamera } from 'core/Cameras';
+import type { Engine } from 'core/Engines';
+import { NullEngine } from 'core/Engines';
+import { Vector3 } from 'core/Maths';
+import { Scene } from 'core/scene';
+
+
+describe("CameraInputsManager", () => {
+    let subject: Engine;
+    let scene: Scene;
+
+    beforeEach(function () {
+        subject = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(subject);
+    });
+
+    describe("add", () => {
+        it("should add a new input", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // initially the manager should not have any input attached
+            expect(manager.attached).toEqual({});
+
+            // after add new input the manager should have the new input attached
+            const input = {
+                camera: null,
+                getClassName: () => 'CustomInput',
+                getSimpleName: () => 'SimpleCustomInput',
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            expect(Object.keys(manager.attached).length).toEqual(1);
+            expect(manager.attached[input.getSimpleName()]).toEqual(input);
+
+            // added input should have actual camera attached
+            expect(input.camera).toEqual(camera);
+        });
+    });
+});

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -223,5 +223,27 @@ describe("CameraInputsManager", () => {
             // manager should call detach control
             expect(detachControlSpy).toHaveBeenCalledTimes(1);
         });
+
+        it("should remove camera from input", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // add input
+            const input: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            expect(input.camera).toEqual(camera);
+
+            // now remove the input and check the camera
+            manager.remove(input);
+            expect(input.camera).toBeFalsy();
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -145,7 +145,7 @@ describe("CameraInputsManager", () => {
             expect(manager.attached[input.getSimpleName()]).toBeUndefined();
         });
 
-        it('should not remove not attached input with same name', () => {
+        it("should not remove not attached input with same name", () => {
             const camera = new FreeCamera("camera", Vector3.Zero(), scene);
             const manager = new CameraInputsManager(camera);
 

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -200,5 +200,28 @@ describe("CameraInputsManager", () => {
             // manager should call rebuild input check, and only once
             expect(managerRebuildInputCheckSpy).toHaveBeenCalledTimes(1);
         });
+
+        it("should detach control from input", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // add input
+            const input: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            const detachControlSpy = jest.spyOn(input, "detachControl");
+            manager.add(input);
+
+            // now remove the input
+            manager.remove(input);
+
+            // manager should call detach control
+            expect(detachControlSpy).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -45,5 +45,38 @@ describe("CameraInputsManager", () => {
             // added input should have actual camera attached
             expect(input.camera).toEqual(camera);
         });
+
+        it("should not override existed input with same type", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // add new input
+            const input = {
+                camera: null,
+                getClassName: () => 'CustomInput',
+                getSimpleName: () => 'SimpleCustomInput',
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            // manager should have attached input
+            expect(manager.attached[input.getSimpleName()]).toEqual(input);
+
+            // now add a new input with same type
+            const newInput = {
+                camera: null,
+                getClassName: () => 'CustomInput',
+                getSimpleName: () => 'SimpleCustomInput',
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(newInput);
+
+            // manager should stay an old input
+            expect(manager.attached[newInput.getSimpleName()]).not.toEqual(newInput);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -176,5 +176,29 @@ describe("CameraInputsManager", () => {
             // manager should stay have attached initial input
             expect(manager.attached[newInput.getSimpleName()]).toEqual(input);
         });
+
+        it("should call rebuild input check after remove the input", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            const managerRebuildInputCheckSpy = jest.spyOn(manager, "rebuildInputCheck");
+
+            // add input
+            const input: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            // now remove the input
+            manager.remove(input);
+
+            // manager should call rebuild input check, and only once
+            expect(managerRebuildInputCheckSpy).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -118,4 +118,31 @@ describe("CameraInputsManager", () => {
             expect(attachControlSpy).toHaveBeenCalledWith(true);
         });
     });
+
+    describe("remove", () => {
+        it("should remove attached input", () => {
+            const camera = new FreeCamera("camera", Vector3.Zero(), scene);
+            const manager = new CameraInputsManager(camera);
+
+            // add new input
+            const input: ICameraInput<FreeCamera> = {
+                camera: null,
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
+                attachControl: () => undefined,
+                detachControl: () => undefined,
+                checkInputs: () => undefined,
+            };
+            manager.add(input);
+
+            // manager should have attached input
+            expect(manager.attached[input.getSimpleName()]).toEqual(input);
+
+            // now remove the input
+            manager.remove(input);
+
+            // manager should not have attached input
+            expect(manager.attached[input.getSimpleName()]).toBeUndefined();
+        });
+    });
 });

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -1,10 +1,9 @@
-import type { ICameraInput } from 'core/Cameras';
-import { CameraInputsManager, FreeCamera } from 'core/Cameras';
-import type { Engine } from 'core/Engines';
-import { NullEngine } from 'core/Engines';
-import { Vector3 } from 'core/Maths';
-import { Scene } from 'core/scene';
-
+import type { ICameraInput } from "core/Cameras";
+import { CameraInputsManager, FreeCamera } from "core/Cameras";
+import type { Engine } from "core/Engines";
+import { NullEngine } from "core/Engines";
+import { Vector3 } from "core/Maths";
+import { Scene } from "core/scene";
 
 describe("CameraInputsManager", () => {
     let subject: Engine;
@@ -32,8 +31,8 @@ describe("CameraInputsManager", () => {
             // after add new input the manager should have the new input attached
             const input: ICameraInput<FreeCamera> = {
                 camera: null,
-                getClassName: () => 'CustomInput',
-                getSimpleName: () => 'SimpleCustomInput',
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
                 attachControl: () => undefined,
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
@@ -54,8 +53,8 @@ describe("CameraInputsManager", () => {
             // add new input
             const input: ICameraInput<FreeCamera> = {
                 camera: null,
-                getClassName: () => 'CustomInput',
-                getSimpleName: () => 'SimpleCustomInput',
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
                 attachControl: () => undefined,
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
@@ -68,8 +67,8 @@ describe("CameraInputsManager", () => {
             // now add a new input with same type
             const newInput: ICameraInput<FreeCamera> = {
                 camera: null,
-                getClassName: () => 'CustomInput',
-                getSimpleName: () => 'SimpleCustomInput',
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
                 attachControl: () => undefined,
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
@@ -80,38 +79,38 @@ describe("CameraInputsManager", () => {
             expect(manager.attached[newInput.getSimpleName()]).not.toEqual(newInput);
         });
 
-        it('should attach control when it required', () => {
+        it("should attach control when it required", () => {
             const camera = new FreeCamera("camera", Vector3.Zero(), scene);
             const manager = new CameraInputsManager(camera);
 
             const input: ICameraInput<FreeCamera> = {
                 camera: null,
-                getClassName: () => 'CustomInput',
-                getSimpleName: () => 'SimpleCustomInput',
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
                 attachControl: () => undefined,
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
             };
-            const attachControlSpy = jest.spyOn(input, 'attachControl');
+            const attachControlSpy = jest.spyOn(input, "attachControl");
             manager.attachedToElement = true;
             manager.add(input);
 
             expect(attachControlSpy).toHaveBeenCalledWith(undefined);
         });
 
-        it('should attach control when it required with preventDefault', () => {
+        it("should attach control when it required with preventDefault", () => {
             const camera = new FreeCamera("camera", Vector3.Zero(), scene);
             const manager = new CameraInputsManager(camera);
 
             const input: ICameraInput<FreeCamera> = {
                 camera: null,
-                getClassName: () => 'CustomInput',
-                getSimpleName: () => 'SimpleCustomInput',
+                getClassName: () => "CustomInput",
+                getSimpleName: () => "SimpleCustomInput",
                 attachControl: () => undefined,
                 detachControl: () => undefined,
                 checkInputs: () => undefined,
             };
-            const attachControlSpy = jest.spyOn(input, 'attachControl');
+            const attachControlSpy = jest.spyOn(input, "attachControl");
             manager.attachedToElement = true;
             manager.noPreventDefault = true;
             manager.add(input);

--- a/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.cameraInputsManager.test.ts
@@ -1,3 +1,4 @@
+import type { ICameraInput } from 'core/Cameras';
 import { CameraInputsManager, FreeCamera } from 'core/Cameras';
 import type { Engine } from 'core/Engines';
 import { NullEngine } from 'core/Engines';
@@ -29,7 +30,7 @@ describe("CameraInputsManager", () => {
             expect(manager.attached).toEqual({});
 
             // after add new input the manager should have the new input attached
-            const input = {
+            const input: ICameraInput<FreeCamera> = {
                 camera: null,
                 getClassName: () => 'CustomInput',
                 getSimpleName: () => 'SimpleCustomInput',
@@ -51,7 +52,7 @@ describe("CameraInputsManager", () => {
             const manager = new CameraInputsManager(camera);
 
             // add new input
-            const input = {
+            const input: ICameraInput<FreeCamera> = {
                 camera: null,
                 getClassName: () => 'CustomInput',
                 getSimpleName: () => 'SimpleCustomInput',
@@ -65,7 +66,7 @@ describe("CameraInputsManager", () => {
             expect(manager.attached[input.getSimpleName()]).toEqual(input);
 
             // now add a new input with same type
-            const newInput = {
+            const newInput: ICameraInput<FreeCamera> = {
                 camera: null,
                 getClassName: () => 'CustomInput',
                 getSimpleName: () => 'SimpleCustomInput',
@@ -83,7 +84,7 @@ describe("CameraInputsManager", () => {
             const camera = new FreeCamera("camera", Vector3.Zero(), scene);
             const manager = new CameraInputsManager(camera);
 
-            const input = {
+            const input: ICameraInput<FreeCamera> = {
                 camera: null,
                 getClassName: () => 'CustomInput',
                 getSimpleName: () => 'SimpleCustomInput',
@@ -102,7 +103,7 @@ describe("CameraInputsManager", () => {
             const camera = new FreeCamera("camera", Vector3.Zero(), scene);
             const manager = new CameraInputsManager(camera);
 
-            const input = {
+            const input: ICameraInput<FreeCamera> = {
                 camera: null,
                 getClassName: () => 'CustomInput',
                 getSimpleName: () => 'SimpleCustomInput',


### PR DESCRIPTION
Hi!

I updated links to the docs.

And in the `remove` method added the `return` statement. Looks like the whole loop is not neccessary when target are found. At least no one added test case not failed here. So it probably a little perfomance improve :D
But in this case there are not possible to add one CameraInput multiple times one camera. Is it correct?