### PR TITLE
Test babylon mesh lod screen coverage

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -251,7 +251,6 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /**
      * Determines if the LOD levels are intended to be calculated using screen coverage (surface area ratio) instead of distance.
-     * Should be set before calling `addLODLevel()`.
      */
     public get useLODScreenCoverage() {
         return this._internalMeshDataInfo._useLODScreenCoverage;
@@ -259,6 +258,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     public set useLODScreenCoverage(value: boolean) {
         this._internalMeshDataInfo._useLODScreenCoverage = value;
+        this._sortLODLevels();
     }
 
     /**

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -848,6 +848,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @see https://doc.babylonjs.com/how_to/how_to_use_lod
      * @param distanceOrScreenCoverage Either distance from the center of the object to show this level or the screen coverage if `useScreenCoverage` is set to `true`.
      * If screen coverage, value is a fraction of the screen's total surface, between 0 and 1.
+     * Example Playground for distance https://playground.babylonjs.com/#QE7KM#197
+     * Example Playground for screen coverage https://playground.babylonjs.com/#QE7KM#196
      * @param mesh The mesh to be added as LOD level (can be null)
      * @returns This mesh (for chaining)
      */

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -250,7 +250,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     private _internalMeshDataInfo = new _InternalMeshDataInfo();
 
     /**
-     * Determines if the LOD levels are intended to be calculated using screen coverage (surface area ratio) instead of distance
+     * Determines if the LOD levels are intended to be calculated using screen coverage (surface area ratio) instead of distance.
+     * Should be set before calling `addLODLevel()`.
      */
     public get useLODScreenCoverage() {
         return this._internalMeshDataInfo._useLODScreenCoverage;

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -61,112 +61,138 @@ describe('Babylon Mesh Levels of Details', () => {
                 p: 2,
                 q: 3,
             }, scene);
-
-            knot0.addLODLevel(10, knot1);
-            knot0.addLODLevel(20, knot2);
         });
 
-        it('should select lod with correct distance', () => {
-            expect(knot0.getLOD(cameraArc)).not.toBeNull();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+        describe('check LOD by distance', () => {
+            beforeEach(() => {
+                knot0.addLODLevel(10, knot1);
+                knot0.addLODLevel(20, knot2);
+            });
 
-            cameraArc.radius = 15;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+            it('should select lod with correct distance', () => {
+                expect(knot0.getLOD(cameraArc)).not.toBeNull();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
 
-            cameraArc.radius = 25;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+                cameraArc.radius = 15;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+
+                cameraArc.radius = 25;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+            });
+
+            it('should select lod with correct distance for orthographic camera', () => {
+                expect(knot0.getLOD(cameraOrthographic)).not.toBeNull();
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot0');
+
+                cameraOrthographic.minZ = 15;
+                scene.render();
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot1');
+
+                cameraOrthographic.minZ = 25;
+                scene.render();
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot2');
+            });
+
+            it('should select loaded mesh while target lod mesh is not loaded yet', () => {
+                // not loaded yet
+                knot1.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
+                knot2.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
+
+                cameraArc.radius = 15;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+
+                cameraArc.radius = 25;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+
+                // while loading
+                knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADING;
+                knot2.delayLoadState = Constants.DELAYLOADSTATE_LOADING;
+
+                cameraArc.radius = 15;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+
+                cameraArc.radius = 25;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+
+                // after loaded
+                knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADED;
+                knot2.delayLoadState = Constants.DELAYLOADSTATE_LOADED;
+
+                cameraArc.radius = 15;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+
+                cameraArc.radius = 25;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+            });
+
+            it('should call user function with selected LOD', () => {
+                const onLODLevelSelectionArgs: {
+                    distance?: number;
+                    meshName?: string;
+                    selectedLevel?: string | null;
+                } = {};
+                knot0.onLODLevelSelection = (_distance, _mesh, _selectedLevel) => {
+                    onLODLevelSelectionArgs.distance = _distance;
+                    onLODLevelSelectionArgs.meshName = _mesh.name;
+                    onLODLevelSelectionArgs.selectedLevel = _selectedLevel?.name;
+                    return null;
+                };
+
+                const registerSpy = jest.spyOn(knot0, "onLODLevelSelection");
+
+                expect(registerSpy).toBeCalledTimes(0);
+
+                scene.render();
+                expect(registerSpy).toBeCalledTimes(1);
+                expect(onLODLevelSelectionArgs.distance).toBeCloseTo(5.23, 2);
+                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot0');
+
+                cameraArc.radius = 15;
+                scene.render();
+                expect(registerSpy).toBeCalledTimes(2);
+                expect(onLODLevelSelectionArgs.distance).toBeCloseTo(15.07, 2);
+                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot1');
+
+                cameraArc.radius = 25;
+                scene.render();
+                expect(registerSpy).toBeCalledTimes(3);
+                expect(onLODLevelSelectionArgs.distance).toBeCloseTo(25.03, 2);
+                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot2');
+            });
         });
 
-        it('should select lod with correct distance for orthographic camera', () => {
-            expect(knot0.getLOD(cameraOrthographic)).not.toBeNull();
-            expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot0');
+        describe('check LOD by screen coverage', () => {
+            beforeEach(() => {
+                knot0.useLODScreenCoverage = true;
+                knot0.addLODLevel(0.5, knot1);
+                knot0.addLODLevel(0.2, knot2);
+                knot0.addLODLevel(0.02, null);
+            });
 
-            cameraOrthographic.minZ = 15;
-            scene.render();
-            expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot1');
+            it('should select lod with correct screen coverage', () => {
+                cameraArc.radius = 80;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
 
-            cameraOrthographic.minZ = 25;
-            scene.render();
-            expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot2');
+                cameraArc.radius = 120;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+
+                cameraArc.radius = 380;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)).toBeNull();
+            });
         });
-
-        it('should select loaded mesh while target lod mesh is not loaded yet', () => {
-            // not loaded yet
-            knot1.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
-            knot2.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
-
-            cameraArc.radius = 15;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
-
-            cameraArc.radius = 25;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
-
-            // while loading
-            knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADING;
-            knot2.delayLoadState = Constants.DELAYLOADSTATE_LOADING;
-
-            cameraArc.radius = 15;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
-
-            cameraArc.radius = 25;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
-
-            // after loaded
-            knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADED;
-            knot2.delayLoadState = Constants.DELAYLOADSTATE_LOADED;
-
-            cameraArc.radius = 15;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
-
-            cameraArc.radius = 25;
-            scene.render();
-            expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
-        });
-
-        it('should call user function with selected LOD', () => {
-            const onLODLevelSelectionArgs: {
-                distance?: number;
-                meshName?: string;
-                selectedLevel?: string | null;
-            } = {};
-            knot0.onLODLevelSelection = (_distance, _mesh, _selectedLevel) => {
-                onLODLevelSelectionArgs.distance = _distance;
-                onLODLevelSelectionArgs.meshName = _mesh.name;
-                onLODLevelSelectionArgs.selectedLevel = _selectedLevel?.name;
-                return null;
-            };
-
-            const registerSpy = jest.spyOn(knot0, "onLODLevelSelection");
-
-            expect(registerSpy).toBeCalledTimes(0);
-
-            scene.render();
-            expect(registerSpy).toBeCalledTimes(1);
-            expect(onLODLevelSelectionArgs.distance).toBeCloseTo(5.23, 2);
-            expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-            expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot0');
-
-            cameraArc.radius = 15;
-            scene.render();
-            expect(registerSpy).toBeCalledTimes(2);
-            expect(onLODLevelSelectionArgs.distance).toBeCloseTo(15.07, 2);
-            expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-            expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot1');
-
-            cameraArc.radius = 25;
-            scene.render();
-            expect(registerSpy).toBeCalledTimes(3);
-            expect(onLODLevelSelectionArgs.distance).toBeCloseTo(25.03, 2);
-            expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-            expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot2');
-        });
-
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -194,5 +194,30 @@ describe('Babylon Mesh Levels of Details', () => {
                 expect(knot0.getLOD(cameraArc)).toBeNull();
             });
         });
+
+        describe("useLODScreenCoverage", () => {
+            it('should work correctly when set to true at any time relative to addLODLevel mesh', () => {
+                // Set LOD meshes
+                knot0.addLODLevel(0.5, knot1);
+                knot0.addLODLevel(0.2, knot2);
+                knot0.addLODLevel(0.02, null);
+
+                // Then set useLODScreenCoverage to true
+                knot0.useLODScreenCoverage = true;
+
+                // And it should work correctly
+                cameraArc.radius = 80;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+
+                cameraArc.radius = 120;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+
+                cameraArc.radius = 380;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)).toBeNull();
+            });
+        });
     });
 });


### PR DESCRIPTION
Hi!
I added a note to `useLODScreenCoverage`. As I found, it's not working after LODs was added, so, useLODScreenCoverage should be set before LODs adding if it neccessary.

Also I added two playground links to show how LODs works with distance or screen coverage.

And one test case to check `addLODLevel` and `getLOD` with the screen coverage feature.