### PR TITLE
Cube textures: Fix updating data with engine.updateTextureData

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
@@ -124,6 +124,8 @@ WebGPUEngine.prototype.createRawCubeTexture = function (
     if (!this._doNotHandleContextLost) {
         texture._bufferViewArray = data;
     }
+    texture.invertY = invertY;
+    texture._compression = compression;
     texture._cachedWrapU = Constants.TEXTURE_CLAMP_ADDRESSMODE;
     texture._cachedWrapV = Constants.TEXTURE_CLAMP_ADDRESSMODE;
 
@@ -132,6 +134,8 @@ WebGPUEngine.prototype.createRawCubeTexture = function (
     if (data) {
         this.updateRawCubeTexture(texture, data, format, type, invertY, compression);
     }
+
+    texture.isReady = true;
 
     return texture;
 };

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4618,12 +4618,14 @@ export class ThinEngine {
 
         this._unpackFlipY(texture.invertY);
 
+        let targetForBinding = gl.TEXTURE_2D;
         let target = gl.TEXTURE_2D;
         if (texture.isCube) {
             target = gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex;
+            targetForBinding = gl.TEXTURE_CUBE_MAP;
         }
 
-        this._bindTextureDirectly(target, texture, true);
+        this._bindTextureDirectly(targetForBinding, texture, true);
 
         gl.texSubImage2D(target, lod, xOffset, yOffset, width, height, format, textureType, imageData);
 
@@ -4631,7 +4633,7 @@ export class ThinEngine {
             this._gl.generateMipmap(target);
         }
 
-        this._bindTextureDirectly(target, null);
+        this._bindTextureDirectly(targetForBinding, null);
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/updatetexturedata-does-not-work-correctly-for-cubetextures/35418

It also fixes passing null for the `data` parameter of `RawCubeTexture.constructor`. So, if you don't have data at texture creation, you can now avoid creating dummy buffers and simply pass `null`.