### PR TITLE
Test babylon mesh baking

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -491,7 +491,7 @@ export class Geometry implements IGetSetVerticesData {
      * @returns true if data is present
      */
     public isVerticesDataPresent(kind: string): boolean {
-        if (!this._vertexBuffers || !this.getVerticesData(kind)) {
+        if (!this._vertexBuffers) {
             if (this._delayInfo) {
                 return this._delayInfo.indexOf(kind) !== -1;
             }

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -491,7 +491,7 @@ export class Geometry implements IGetSetVerticesData {
      * @returns true if data is present
      */
     public isVerticesDataPresent(kind: string): boolean {
-        if (!this._vertexBuffers) {
+        if (!this._vertexBuffers || !this.getVerticesData(kind)) {
             if (this._delayInfo) {
                 return this._delayInfo.indexOf(kind) !== -1;
             }

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2693,12 +2693,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * This method returns nothing but really modifies the mesh even if it's originally not set as updatable.
      * Note that, under the hood, this method sets a new VertexBuffer each call.
      * @see https://doc.babylonjs.com/resources/baking_transformations
-     * @param bakeIndependenlyOfChildren indicates whether to preserve all child nodes' World Matrix during baking
+     * @param bakeIndependentlyOfChildren indicates whether to preserve all child nodes' World Matrix during baking
      * @returns the current mesh
      */
-    public bakeCurrentTransformIntoVertices(bakeIndependenlyOfChildren: boolean = true): Mesh {
+    public bakeCurrentTransformIntoVertices(bakeIndependentlyOfChildren: boolean = true): Mesh {
         this.bakeTransformIntoVertices(this.computeWorldMatrix(true));
-        this.resetLocalMatrix(bakeIndependenlyOfChildren);
+        this.resetLocalMatrix(bakeIndependentlyOfChildren);
         return this;
     }
 

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2642,7 +2642,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * The mesh normals are modified using the same transformation.
      * Note that, under the hood, this method sets a new VertexBuffer each call.
      * @param transform defines the transform matrix to use
-     * @see https://doc.babylonjs.com/resources/baking_transformations
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/center_origin/bakingTransforms
      * @returns the current mesh
      */
     public bakeTransformIntoVertices(transform: Matrix): Mesh {

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2638,7 +2638,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /**
      * Modifies the mesh geometry according to the passed transformation matrix.
-     * This method returns nothing but it really modifies the mesh even if it's originally not set as updatable.
+     * This method returns nothing, but it really modifies the mesh even if it's originally not set as updatable.
      * The mesh normals are modified using the same transformation.
      * Note that, under the hood, this method sets a new VertexBuffer each call.
      * @param transform defines the transform matrix to use

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -111,5 +111,49 @@ describe("Mesh Baking", () => {
 
             expect(vPositionsResult).toStrictEqual(expectedBoxVerticesShifted);
         });
+
+        it("should flip faces for inverted transform", () => {
+            // Bake transform into vertices with inverted transform
+            const inverseTransform = Matrix.Scaling(-1, -1, -1);
+            box.bakeTransformIntoVertices(inverseTransform);
+            const vPositionsResult = box.getVerticesData(VertexBuffer.PositionKind);
+
+            // prettier-ignore
+            const expectedBoxVerticesInverted: ReadonlyArray<number> = [
+                -0.5, 0.5, -0.5,
+                0.5, 0.5, -0.5,
+                0.5, -0.5, -0.5,
+
+                -0.5, -0.5, -0.5,
+                -0.5, -0.5, 0.5,
+                0.5, -0.5, 0.5,
+
+                0.5, 0.5, 0.5,
+                -0.5, 0.5, 0.5,
+                -0.5, -0.5, 0.5,
+
+                -0.5, 0.5, 0.5,
+                -0.5, 0.5, -0.5,
+                -0.5, -0.5, -0.5,
+
+                0.5, -0.5, -0.5,
+                0.5, 0.5, -0.5,
+                0.5, 0.5, 0.5,
+
+                0.5, -0.5, 0.5,
+                0.5, -0.5, -0.5,
+                0.5, -0.5, 0.5,
+
+                -0.5, -0.5, 0.5,
+                -0.5, -0.5, -0.5,
+                -0.5, 0.5, -0.5,
+
+                -0.5, 0.5, 0.5,
+                0.5, 0.5, 0.5,
+                0.5, 0.5, -0.5,
+            ];
+
+            expect(vPositionsResult).toEqual(expectedBoxVerticesInverted);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -158,7 +158,7 @@ describe("Mesh Baking", () => {
 
         it("should skip transforms when vertices are not exist and return source mesh", () => {
             // Remove vertices from mesh
-            box.getVertexBuffer(VertexBuffer.PositionKind)?.dispose();
+            box.removeVerticesData(VertexBuffer.PositionKind);
 
             // And after it the box should not have vertices
             const vPositionsResult = box.getVerticesData(VertexBuffer.PositionKind);

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -237,5 +237,38 @@ describe("Mesh Baking", () => {
             expect(child2.position.y).toEqual(5);
             expect(child2.rotation.x).toEqual(Math.PI / 2);
         });
+
+        it("should save children transforms without affecting by parent", () => {
+            // Set some children of the box
+            const child = MeshBuilder.CreateBox("child", { size: 1 }, scene);
+            const child2 = MeshBuilder.CreateBox("child2", { size: 1 }, scene);
+
+            child.parent = box;
+            child2.parent = box;
+
+            // Set some transform to the box and children
+            box.scaling.z = 2;
+            box.position.y = 5;
+            box.rotation.x = Math.PI / 2;
+
+            child.scaling.z = 1.5;
+            child.position.y = -2;
+            child.rotation.x = Math.PI / 4;
+
+            child2.scaling.z = 1.2;
+            child2.position.y = -3;
+            child2.rotation.x = Math.PI / 5;
+
+            box.bakeCurrentTransformIntoVertices(false);
+
+            // And mesh children transforms should save as is
+            expect(child.scaling.z).toEqual(1.5);
+            expect(child.position.y).toEqual(-2);
+            expect(child.rotation.x).toEqual(Math.PI / 4);
+
+            expect(child2.scaling.z).toEqual(1.2);
+            expect(child2.position.y).toEqual(-3);
+            expect(child2.rotation.x).toEqual(Math.PI / 5);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -204,5 +204,38 @@ describe("Mesh Baking", () => {
             expect(box.position).toEqual(Vector3.Zero());
             expect(box.rotation).toEqual(Vector3.Zero());
         });
+
+        it("should set children transforms from their parent", () => {
+            // Set some children of the box
+            const child = MeshBuilder.CreateBox("child", { size: 1 }, scene);
+            const child2 = MeshBuilder.CreateBox("child2", { size: 1 }, scene);
+
+            child.parent = box;
+            child2.parent = box;
+
+            // Set some transform to the box and children
+            box.scaling.z = 2.5;
+            box.position.y = 5;
+            box.rotation.x = Math.PI / 2;
+
+            child.scaling.z = 1.5;
+            child.position.y = -1;
+            child.rotation.x = Math.PI / 4;
+
+            child2.scaling.z = 1.5;
+            child2.position.y = -1;
+            child2.rotation.x = Math.PI / 4;
+
+            box.bakeCurrentTransformIntoVertices();
+
+            // And children transforms should be set by parent
+            expect(child.scaling.z).toEqual(2.5);
+            expect(child.position.y).toEqual(5);
+            expect(child.rotation.x).toEqual(Math.PI / 2);
+
+            expect(child2.scaling.z).toEqual(2.5);
+            expect(child2.position.y).toEqual(5);
+            expect(child2.rotation.x).toEqual(Math.PI / 2);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -155,5 +155,19 @@ describe("Mesh Baking", () => {
 
             expect(vPositionsResult).toEqual(expectedBoxVerticesInverted);
         });
+
+        it("should skip transforms when vertices are not exist and return source mesh", () => {
+            // Remove vertices from mesh
+            box.getVertexBuffer(VertexBuffer.PositionKind)?.dispose();
+
+            // And after it the box should not have vertices
+            const vPositionsResult = box.getVerticesData(VertexBuffer.PositionKind);
+            expect(vPositionsResult).toBeFalsy();
+
+            // Bake the box without vertices should return original mesh
+            const inverseTransform = Matrix.Scaling(-1, -1, -1);
+            const modifiedMesh = box.bakeTransformIntoVertices(inverseTransform);
+            expect(modifiedMesh).toBe(box);
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.bake.test.ts
@@ -1,0 +1,115 @@
+import { VertexBuffer } from "core/Buffers";
+import type { Engine } from "core/Engines";
+import { NullEngine } from "core/Engines";
+import { Matrix } from "core/Maths";
+import type { Mesh } from "core/Meshes";
+import { MeshBuilder } from "core/Meshes";
+import { Scene } from "core/scene";
+
+describe("Mesh Baking", () => {
+    describe("bakeTransformIntoVertices", () => {
+        let subject: Engine;
+        let scene: Scene;
+        let box: Mesh;
+
+        // prettier-ignore
+        // Box vertices for box with size 1, centered at origin, it contains 8 vertices [x, y, z].
+        const boxVerticesDefault: ReadonlyArray<number> = [
+            0.5, -0.5, 0.5,
+            -0.5, -0.5, 0.5,
+            -0.5, 0.5, 0.5,
+
+            0.5, 0.5, 0.5,
+            0.5, 0.5, -0.5,
+            -0.5, 0.5, -0.5,
+
+            -0.5, -0.5, -0.5,
+            0.5, -0.5, -0.5,
+            0.5, 0.5, -0.5,
+
+            0.5, -0.5, -0.5,
+            0.5, -0.5, 0.5,
+            0.5, 0.5, 0.5,
+
+            -0.5, 0.5, 0.5,
+            -0.5, -0.5, 0.5,
+            -0.5, -0.5, -0.5,
+
+            -0.5, 0.5, -0.5,
+            -0.5, 0.5, 0.5,
+            -0.5, 0.5, -0.5,
+
+            0.5, 0.5, -0.5,
+            0.5, 0.5, 0.5,
+            0.5, -0.5, 0.5,
+
+            0.5, -0.5, -0.5,
+            -0.5, -0.5, -0.5,
+            -0.5, -0.5, 0.5,
+        ];
+
+        beforeEach(() => {
+            subject = new NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+            scene = new Scene(subject);
+            box = MeshBuilder.CreateBox("box", { size: 1 }, scene);
+        });
+
+        it("should be able to bake transform into vertices", () => {
+            // At start, vertices should be the same as boxVerticesDefault
+            const vPositions0 = box.getVerticesData(VertexBuffer.PositionKind);
+            expect(vPositions0).toEqual(boxVerticesDefault);
+
+            // Bake transform into vertices with shift by 5 units on Y axis
+            const modifiedMesh = box.bakeTransformIntoVertices(Matrix.Translation(0, 5, 0));
+
+            // Method should return same mesh
+            expect(modifiedMesh).toBe(box);
+
+            // After baking, vertices should be shifted by 5 units on Y axis
+            const vPositionsResult = box.getVerticesData(VertexBuffer.PositionKind);
+
+            // prettier-ignore
+            const expectedBoxVerticesShifted: ReadonlyArray<number> = [
+                0.5, 4.5, 0.5,
+                -0.5, 4.5, 0.5,
+                -0.5, 5.5, 0.5,
+
+                0.5, 5.5, 0.5,
+                0.5, 5.5, -0.5,
+                -0.5, 5.5, -0.5,
+
+                -0.5, 4.5, -0.5,
+                0.5, 4.5, -0.5,
+                0.5, 5.5, -0.5,
+
+                0.5, 4.5, -0.5,
+                0.5, 4.5, 0.5,
+                0.5, 5.5, 0.5,
+
+                -0.5, 5.5, 0.5,
+                -0.5, 4.5, 0.5,
+                -0.5, 4.5, -0.5,
+
+                -0.5, 5.5, -0.5,
+                -0.5, 5.5, 0.5,
+                -0.5, 5.5, -0.5,
+
+                0.5, 5.5, -0.5,
+                0.5, 5.5, 0.5,
+                0.5, 4.5, 0.5,
+
+                0.5, 4.5, -0.5,
+                -0.5, 4.5, -0.5,
+                -0.5, 4.5, 0.5,
+            ];
+
+            expect(vPositionsResult).toStrictEqual(expectedBoxVerticesShifted);
+        });
+    });
+});


### PR DESCRIPTION
Here I found one bug in the `isVerticesDataPresent` method.

Test case:
```ts
const box = BABYLON.MeshBuilder.CreateBox("box", { size: 1 }, scene);
box.getVertexBuffer(BABYLON.VertexBuffer.PositionKind)?.dispose();
box.bakeTransformIntoVertices(BABYLON.Matrix.Scaling(-1, -1, -1));
```
Playground: https://playground.babylonjs.com/#YFTMIL

Error in the console:
```
TypeError: Cannot read properties of null (reading 'length')
```

So I add a check into the method: `if (!this._vertexBuffers || !this.getVerticesData(kind)) {`


And also I add test cases for baking methods — `bakeTransformIntoVertices` and `bakeCurrentTransformIntoVertices`.