### PR TITLE
Fix aliasing issue in webxr multiview

### DIFF
--- a/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
@@ -12,6 +12,10 @@ export class MultiviewRenderTarget extends RenderTargetTexture {
         this._samples = value;
     }
 
+    public get samples(): number {
+        return this._samples;
+    }
+
     /**
      * Creates a multiview render target
      * @param scene scene used with the render target


### PR DESCRIPTION
If a setter is set, the getter is not inherited from the parent class.