### PR TITLE
accessibility package not following the same version as core

### DIFF
--- a/packages/public/@babylonjs/accessibility/package.json
+++ b/packages/public/@babylonjs/accessibility/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@babylonjs/accessibility",
-    "version": "5.19.2",
+    "version": "5.31.2",
     "main": "dist/babylon.accessibility.max.js",
     "module": "dist/babylon.accessibility.max.js",
     "esnext": "dist/babylon.accessibility.max.js",
@@ -18,8 +18,8 @@
         "clean": "rimraf dist"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
-        "@babylonjs/gui": "^5.0.0",
+        "@babylonjs/core": "^5.22.0",
+        "@babylonjs/gui": "^5.22.0",
         "@types/react": ">=16.7.3",
         "@types/react-dom": ">=16.0.9"
     },

--- a/packages/public/@babylonjs/accessibility/package.json
+++ b/packages/public/@babylonjs/accessibility/package.json
@@ -6,9 +6,9 @@
     "esnext": "dist/babylon.accessibility.max.js",
     "typings": "dist/babylon.accessibility.module.d.ts",
     "files": [
-        "dist",
         "readme.md",
-        "license.md"
+        "license.md",
+        "dist/**/*.*"
     ],
     "scripts": {
         "build": "npm run clean && npm run build:dev && npm run build:prod && npm run build:declaration",

--- a/packages/public/umd/babylonjs-accessibility/package.json
+++ b/packages/public/umd/babylonjs-accessibility/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylonjs-accessibility",
-    "version": "5.19.2",
+    "version": "5.31.2",
     "main": "babylon.accessibility.max.js",
     "types": "babylon.accessibility.module.d.ts",
     "files": [


### PR DESCRIPTION
Package version was manually released to NPM.
Starting next minor version it will fit the core versioning schema