### PR TITLE
simplier isBlocked check for Mesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1165,7 +1165,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     }
 
     public get isBlocked(): boolean {
-        return this._masterMesh !== null && this._masterMesh !== undefined;
+        return this._masterMesh != null;
     }
 
     /**


### PR DESCRIPTION
item != null works same as item !== null && item !== undefined, it's easier to read and probably faster