### PR TITLE
Fix for FreeCameraMouseInput fluxuating input on multi-touch

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -131,7 +131,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     }
 
                     this._activePointerId = -1;
-                } else if (p.type === PointerEventTypes.POINTERMOVE  && this._activePointerId === evt.pointerId) {
+                } else if (p.type === PointerEventTypes.POINTERMOVE && this._activePointerId === evt.pointerId) {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     } else if (this._previousPosition) {

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -47,7 +47,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
     public _allowCameraRotation = true;
 
     private _currentActiveButton: number = -1;
-
+    private _activePointerId: number = -1;
     private _contextMenuBind: () => void;
 
     /**
@@ -91,7 +91,8 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
 
                 const srcElement = <HTMLElement>evt.target;
 
-                if (p.type === PointerEventTypes.POINTERDOWN && (this._currentActiveButton === -1 || isTouch)) {
+                if (p.type === PointerEventTypes.POINTERDOWN && (this._currentActiveButton === -1 || isTouch) && this._activePointerId === -1) {
+                    this._activePointerId = evt.pointerId;
                     try {
                         srcElement?.setPointerCapture(evt.pointerId);
                     } catch (e) {
@@ -116,7 +117,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     }
-                } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch)) {
+                } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch) && this._activePointerId === evt.pointerId) {
                     try {
                         srcElement?.releasePointerCapture(evt.pointerId);
                     } catch (e) {
@@ -128,7 +129,9 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (!noPreventDefault) {
                         evt.preventDefault();
                     }
-                } else if (p.type === PointerEventTypes.POINTERMOVE) {
+
+                    this._activePointerId = -1;
+                } else if (p.type === PointerEventTypes.POINTERMOVE  && this._activePointerId === evt.pointerId) {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     } else if (this._previousPosition) {

--- a/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
@@ -1,0 +1,103 @@
+import { FreeCamera } from "core/Cameras/freeCamera";
+import { PickingInfo } from "core/Collisions";
+import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
+import { DeviceType, PointerInput } from "core/DeviceInput/InputDevices/deviceEnums";
+import { NullEngine } from "core/Engines/nullEngine";
+import { PointerEventTypes, PointerInfo } from "core/Events";
+import type { IMouseEvent } from "core/Events/deviceInputEvents";
+import { Vector3 } from "core/Maths/math.vector";
+import { Scene } from "core/scene";
+import type { Nullable } from "core/types";
+import { TestDeviceInputSystem } from "../DeviceInput/testDeviceInputSystem";
+
+describe("FreeCameraMouseInput", () => {
+    let engine: Nullable<NullEngine> = null;
+    let scene: Nullable<Scene> = null;
+    let camera: Nullable<FreeCamera> = null;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        //engine!._deviceSourceManager = new InternalDeviceSourceManager(engine!);
+        scene = new Scene(engine);
+        camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
+        camera.setTarget(Vector3.Zero());
+        camera.attachControl();
+    });
+
+    afterEach(() => {
+        camera?.dispose();
+        scene?.dispose();
+        engine?.dispose();
+    });
+
+    it("use only one touch input at a time", async () => {
+        let cameraRotation = camera!.cameraRotation.clone();
+        const testDeviceInputSystem = new TestDeviceInputSystem(
+            engine!,
+            () => {},
+            () => {},
+            () => {}
+        );
+        testDeviceInputSystem.connectDevice(DeviceType.Touch, 2, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+        testDeviceInputSystem.connectDevice(DeviceType.Touch, 3, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+
+        // First touch
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 1, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 0, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 0, false);
+
+        const downEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downPI1 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt1 as IMouseEvent, new PickingInfo());
+
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 10, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 10, false);
+
+        const moveEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const movePI1 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt1 as IMouseEvent, new PickingInfo());
+
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
+
+        const upEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upPI1 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt1 as IMouseEvent, new PickingInfo());
+
+        // Second touch
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.LeftClick, 1, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Horizontal, 20, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Vertical, 20, false);
+
+        const downEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 3, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downPI2 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt2 as IMouseEvent, new PickingInfo());
+
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Horizontal, 0, false);
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Vertical, 0, false);
+
+        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2 as IMouseEvent, new PickingInfo());
+
+        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
+
+        const upEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
+
+        // With the first touch, the camera should rotate
+        scene?._onCameraInputObservable.notifyObservers(downPI1);
+        scene?._onCameraInputObservable.notifyObservers(movePI1);
+        expect(camera?.cameraRotation.x).not.toEqual(cameraRotation.x);
+        expect(camera?.cameraRotation.y).not.toEqual(cameraRotation.y);
+
+        // With the second touch, the camera should not rotate because the first touch is still active
+        cameraRotation = camera!.cameraRotation.clone();
+        scene?._onCameraInputObservable.notifyObservers(downPI2);
+        scene?._onCameraInputObservable.notifyObservers(movePI2);
+        expect(camera?.cameraRotation.x).toEqual(cameraRotation.x);
+        expect(camera?.cameraRotation.y).toEqual(cameraRotation.y);
+        scene?._onCameraInputObservable.notifyObservers(upPI2);
+        scene?._onCameraInputObservable.notifyObservers(upPI1);
+    });
+});


### PR DESCRIPTION
This PR contains a fix for the FreeCameraMouseInput, when touch is enabled, to prevent multiple touch inputs from providing conflicting inputs.  This is accomplished by tracking the first touch pointerId and ignoring the other inputs while its active.  This approach is being taken because the FreeCameraMouseInput only supports one pointer at a time.

Forum Link with Bug info: https://forum.babylonjs.com/t/free-camera-multi-touch-bug/35536