### PR TITLE
Test babylon mesh lod 2

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -923,15 +923,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             return this;
         }
 
-        let bSphere: BoundingSphere;
-
-        if (boundingSphere) {
-            bSphere = boundingSphere;
-        } else {
-            const boundingInfo = this.getBoundingInfo();
-
-            bSphere = boundingInfo.boundingSphere;
-        }
+        const bSphere = boundingSphere || this.getBoundingInfo().boundingSphere;
 
         const distanceToCamera = camera.mode === Camera.ORTHOGRAPHIC_CAMERA ? camera.minZ : bSphere.centerWorld.subtract(camera.globalPosition).length();
         const useScreenCoverage = internalDataInfo._useLODScreenCoverage;

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -926,11 +926,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         const bSphere = boundingSphere || this.getBoundingInfo().boundingSphere;
 
         const distanceToCamera = camera.mode === Camera.ORTHOGRAPHIC_CAMERA ? camera.minZ : bSphere.centerWorld.subtract(camera.globalPosition).length();
-        const useScreenCoverage = internalDataInfo._useLODScreenCoverage;
         let compareValue = distanceToCamera;
         let compareSign = 1;
 
-        if (useScreenCoverage) {
+        if (internalDataInfo._useLODScreenCoverage) {
             const screenArea = camera.screenArea;
             let meshArea = (bSphere.radiusWorld * camera.minZ) / distanceToCamera;
             meshArea = meshArea * meshArea * Math.PI;

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -895,7 +895,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @param mesh defines the mesh to be removed
      * @returns This mesh (for chaining)
      */
-    public removeLODLevel(mesh: Mesh): Mesh {
+    public removeLODLevel(mesh: Nullable<Mesh>): Mesh {
         const internalDataInfo = this._internalMeshDataInfo;
         for (let index = 0; index < internalDataInfo._LODLevels.length; index++) {
             if (internalDataInfo._LODLevels[index].mesh === mesh) {

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -381,4 +381,66 @@ describe("Babylon Mesh Levels of Details", () => {
             expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
         });
     });
+
+    describe("getLODLevelAtDistance", () => {
+        let scene: Scene;
+
+        let knot0: Mesh;
+        let knot1: Mesh;
+        let knot2: Mesh;
+
+        beforeEach(() => {
+            scene = new Scene(subject);
+
+            knot0 = MeshBuilder.CreateTorusKnot(
+                "Knot0",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 128,
+                    tubularSegments: 64,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot1 = MeshBuilder.CreateTorusKnot(
+                "Knot1",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 64,
+                    tubularSegments: 32,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot2 = MeshBuilder.CreateTorusKnot(
+                "Knot2",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 32,
+                    tubularSegments: 16,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+        });
+
+        it("should return the lod level at distance", () => {
+            knot0.addLODLevel(10, knot1);
+            knot0.addLODLevel(20, knot2);
+            knot0.addLODLevel(30, null);
+
+            expect(knot0.getLODLevelAtDistance(9)).toBeNull();
+            expect(knot0.getLODLevelAtDistance(10)).toEqual(knot1);
+            expect(knot0.getLODLevelAtDistance(19)).toBeNull();
+            expect(knot0.getLODLevelAtDistance(20)).toEqual(knot2);
+            expect(knot0.getLODLevelAtDistance(29)).toBeNull();
+            expect(knot0.getLODLevelAtDistance(30)).toBeNull();
+        });
+    });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -280,7 +280,6 @@ describe("Babylon Mesh Levels of Details", () => {
     describe("removeLODLevel", () => {
         let scene: Scene;
         let cameraArc: ArcRotateCamera;
-        let cameraOrthographic: ArcRotateCamera;
 
         let knot0: Mesh;
         let knot1: Mesh;
@@ -290,9 +289,6 @@ describe("Babylon Mesh Levels of Details", () => {
             scene = new Scene(subject);
 
             cameraArc = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
-
-            cameraOrthographic = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
-            cameraOrthographic.mode = Camera.ORTHOGRAPHIC_CAMERA;
 
             knot0 = MeshBuilder.CreateTorusKnot(
                 "Knot0",

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -75,6 +75,16 @@ describe("Babylon Mesh Levels of Details", () => {
             );
         });
 
+        it("should return self mesh when lods are not defined", () => {
+            cameraArc.radius = 15;
+            scene.render();
+            expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
+
+            cameraArc.radius = 25;
+            scene.render();
+            expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
+        });
+
         describe("check LOD by distance", () => {
             beforeEach(() => {
                 knot0.addLODLevel(10, knot1);

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -276,4 +276,89 @@ describe("Babylon Mesh Levels of Details", () => {
             });
         });
     });
+
+    describe("removeLODLevel", () => {
+        let scene: Scene;
+        let cameraArc: ArcRotateCamera;
+        let cameraOrthographic: ArcRotateCamera;
+
+        let knot0: Mesh;
+        let knot1: Mesh;
+        let knot2: Mesh;
+
+        beforeEach(() => {
+            scene = new Scene(subject);
+
+            cameraArc = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
+
+            cameraOrthographic = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
+            cameraOrthographic.mode = Camera.ORTHOGRAPHIC_CAMERA;
+
+            knot0 = MeshBuilder.CreateTorusKnot(
+                "Knot0",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 128,
+                    tubularSegments: 64,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot1 = MeshBuilder.CreateTorusKnot(
+                "Knot1",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 64,
+                    tubularSegments: 32,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot2 = MeshBuilder.CreateTorusKnot(
+                "Knot2",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 32,
+                    tubularSegments: 16,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+        });
+
+        it("should remove lod level", () => {
+            knot0.addLODLevel(10, knot1);
+            knot0.addLODLevel(20, knot2);
+
+            knot0.removeLODLevel(knot1);
+            knot0.removeLODLevel(knot2);
+
+            // After remove lod levels, the LOD should be the original mesh with any radius
+            [5, 15, 25].forEach((radius) => {
+                cameraArc.radius = radius;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
+            });
+        });
+
+        it("should remove lod levels with chaining", () => {
+            knot0.addLODLevel(10, knot1);
+            knot0.addLODLevel(20, knot2);
+
+            knot0.removeLODLevel(knot1).removeLODLevel(knot2);
+
+            // After remove lod levels, the LOD should be the original mesh with any radius
+            [5, 15, 25].forEach((radius) => {
+                cameraArc.radius = radius;
+                scene.render();
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
+            });
+        });
+    });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -9,6 +9,11 @@ import { Scene } from "core/scene";
 
 describe("Babylon Mesh Levels of Details", () => {
     let subject: Engine;
+    let scene: Scene;
+
+    let knot0: Mesh;
+    let knot1: Mesh;
+    let knot2: Mesh;
 
     beforeEach(() => {
         subject = new NullEngine({
@@ -18,61 +23,56 @@ describe("Babylon Mesh Levels of Details", () => {
             deterministicLockstep: false,
             lockstepMaxSteps: 1,
         });
+
+        scene = new Scene(subject);
+
+        knot0 = MeshBuilder.CreateTorusKnot(
+            "Knot0",
+            {
+                radius: 10,
+                tube: 3,
+                radialSegments: 128,
+                tubularSegments: 64,
+                p: 2,
+                q: 3,
+            },
+            scene
+        );
+        knot1 = MeshBuilder.CreateTorusKnot(
+            "Knot1",
+            {
+                radius: 10,
+                tube: 3,
+                radialSegments: 64,
+                tubularSegments: 32,
+                p: 2,
+                q: 3,
+            },
+            scene
+        );
+        knot2 = MeshBuilder.CreateTorusKnot(
+            "Knot2",
+            {
+                radius: 10,
+                tube: 3,
+                radialSegments: 32,
+                tubularSegments: 16,
+                p: 2,
+                q: 3,
+            },
+            scene
+        );
     });
 
     describe("getLOD method", () => {
-        let scene: Scene;
         let cameraArc: ArcRotateCamera;
         let cameraOrthographic: ArcRotateCamera;
 
-        let knot0: Mesh;
-        let knot1: Mesh;
-        let knot2: Mesh;
-
         beforeEach(() => {
-            scene = new Scene(subject);
-
             cameraArc = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
 
             cameraOrthographic = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
             cameraOrthographic.mode = Camera.ORTHOGRAPHIC_CAMERA;
-
-            knot0 = MeshBuilder.CreateTorusKnot(
-                "Knot0",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 128,
-                    tubularSegments: 64,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot1 = MeshBuilder.CreateTorusKnot(
-                "Knot1",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 64,
-                    tubularSegments: 32,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot2 = MeshBuilder.CreateTorusKnot(
-                "Knot2",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 32,
-                    tubularSegments: 16,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
         });
 
         it("should return self mesh when lods are not defined", () => {
@@ -278,54 +278,10 @@ describe("Babylon Mesh Levels of Details", () => {
     });
 
     describe("removeLODLevel", () => {
-        let scene: Scene;
         let cameraArc: ArcRotateCamera;
 
-        let knot0: Mesh;
-        let knot1: Mesh;
-        let knot2: Mesh;
-
         beforeEach(() => {
-            scene = new Scene(subject);
-
             cameraArc = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
-
-            knot0 = MeshBuilder.CreateTorusKnot(
-                "Knot0",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 128,
-                    tubularSegments: 64,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot1 = MeshBuilder.CreateTorusKnot(
-                "Knot1",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 64,
-                    tubularSegments: 32,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot2 = MeshBuilder.CreateTorusKnot(
-                "Knot2",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 32,
-                    tubularSegments: 16,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
         });
 
         it("should remove lod level", () => {
@@ -383,53 +339,6 @@ describe("Babylon Mesh Levels of Details", () => {
     });
 
     describe("getLODLevelAtDistance", () => {
-        let scene: Scene;
-
-        let knot0: Mesh;
-        let knot1: Mesh;
-        let knot2: Mesh;
-
-        beforeEach(() => {
-            scene = new Scene(subject);
-
-            knot0 = MeshBuilder.CreateTorusKnot(
-                "Knot0",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 128,
-                    tubularSegments: 64,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot1 = MeshBuilder.CreateTorusKnot(
-                "Knot1",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 64,
-                    tubularSegments: 32,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-            knot2 = MeshBuilder.CreateTorusKnot(
-                "Knot2",
-                {
-                    radius: 10,
-                    tube: 3,
-                    radialSegments: 32,
-                    tubularSegments: 16,
-                    p: 2,
-                    q: 3,
-                },
-                scene
-            );
-        });
-
         it("should return the lod level at distance", () => {
             knot0.addLODLevel(10, knot1);
             knot0.addLODLevel(20, knot2);

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -1,4 +1,5 @@
 import { ArcRotateCamera, Camera } from "core/Cameras";
+import { BoundingSphere } from "core/Culling";
 import type { Engine } from "core/Engines";
 import { Constants, NullEngine } from "core/Engines";
 import { Vector3 } from "core/Maths";
@@ -228,6 +229,28 @@ describe("Babylon Mesh Levels of Details", () => {
                 cameraArc.radius = 380;
                 scene.render();
                 expect(knot0.getLOD(cameraArc)).toBeNull();
+            });
+        });
+
+        describe("check custom boundingSphere", () => {
+            it("should use custom boundingSphere", () => {
+                const customBoundingSphere = new BoundingSphere(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+
+                // Set LOD meshes
+                knot0.addLODLevel(10, knot1);
+                knot0.addLODLevel(20, knot2);
+
+                cameraArc.radius = 10;
+                scene.render();
+                expect(knot0.getLOD(cameraArc, customBoundingSphere)!.name).toEqual("Knot0");
+
+                cameraArc.radius = 11;
+                scene.render();
+                expect(knot0.getLOD(cameraArc, customBoundingSphere)!.name).toEqual("Knot1");
+
+                cameraArc.radius = 21;
+                scene.render();
+                expect(knot0.getLOD(cameraArc, customBoundingSphere)!.name).toEqual("Knot2");
             });
         });
     });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -366,5 +366,23 @@ describe("Babylon Mesh Levels of Details", () => {
             // And no one lod level should be left
             expect(knot0.getLODLevels().length).toEqual(0);
         });
+
+        it("should remove lod level with null mesh", () => {
+            knot0.addLODLevel(10, knot1);
+            knot0.addLODLevel(20, knot2);
+            knot0.addLODLevel(30, null);
+
+            knot0.removeLODLevel(knot1);
+            knot0.removeLODLevel(knot2);
+            knot0.removeLODLevel(null);
+
+            // And no one lod level should be left
+            expect(knot0.getLODLevels().length).toEqual(0);
+
+            // And the getLOD should return the original mesh with radius relative to null by previous LOD level
+            cameraArc.radius = 35;
+            scene.render();
+            expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
+        });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -85,6 +85,18 @@ describe("Babylon Mesh Levels of Details", () => {
             expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
         });
 
+        it("should add lod level by chaining", () => {
+            knot0.addLODLevel(10, knot1).addLODLevel(20, knot2);
+
+            cameraArc.radius = 15;
+            scene.render();
+            expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot1");
+
+            cameraArc.radius = 25;
+            scene.render();
+            expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot2");
+        });
+
         describe("check LOD by distance", () => {
             beforeEach(() => {
                 knot0.addLODLevel(10, knot1);

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -352,4 +352,14 @@ describe("Babylon Mesh Levels of Details", () => {
             expect(knot0.getLODLevelAtDistance(30)).toBeNull();
         });
     });
+
+    describe("addLODLevel", () => {
+        it("should not possible add one mesh twice", () => {
+            knot0.addLODLevel(10, knot1);
+            knot0.addLODLevel(20, knot1);
+            knot0.addLODLevel(30, knot1);
+
+            expect(knot0.getLODLevels().length).toEqual(1);
+        });
+    });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -345,6 +345,9 @@ describe("Babylon Mesh Levels of Details", () => {
                 scene.render();
                 expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
             });
+
+            // And no one lod level should be left
+            expect(knot0.getLODLevels().length).toEqual(0);
         });
 
         it("should remove lod levels with chaining", () => {
@@ -359,6 +362,9 @@ describe("Babylon Mesh Levels of Details", () => {
                 scene.render();
                 expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
             });
+
+            // And no one lod level should be left
+            expect(knot0.getLODLevels().length).toEqual(0);
         });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.mesh.lod.test.ts
@@ -1,13 +1,12 @@
-import { ArcRotateCamera, Camera } from 'core/Cameras';
-import type { Engine } from 'core/Engines';
-import { Constants, NullEngine } from 'core/Engines';
-import { Vector3 } from 'core/Maths';
-import type { Mesh } from 'core/Meshes';
-import { MeshBuilder } from 'core/Meshes';
-import { Scene } from 'core/scene';
+import { ArcRotateCamera, Camera } from "core/Cameras";
+import type { Engine } from "core/Engines";
+import { Constants, NullEngine } from "core/Engines";
+import { Vector3 } from "core/Maths";
+import type { Mesh } from "core/Meshes";
+import { MeshBuilder } from "core/Meshes";
+import { Scene } from "core/scene";
 
-
-describe('Babylon Mesh Levels of Details', () => {
+describe("Babylon Mesh Levels of Details", () => {
     let subject: Engine;
 
     beforeEach(() => {
@@ -20,7 +19,7 @@ describe('Babylon Mesh Levels of Details', () => {
         });
     });
 
-    describe('getLOD method', () => {
+    describe("getLOD method", () => {
         let scene: Scene;
         let cameraArc: ArcRotateCamera;
         let cameraOrthographic: ArcRotateCamera;
@@ -32,81 +31,93 @@ describe('Babylon Mesh Levels of Details', () => {
         beforeEach(() => {
             scene = new Scene(subject);
 
-            cameraArc = new ArcRotateCamera('Camera', 0, 0, 5, new Vector3(0, 0, 0), scene);
+            cameraArc = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
 
-            cameraOrthographic = new ArcRotateCamera('Camera', 0, 0, 5, new Vector3(0, 0, 0), scene);
+            cameraOrthographic = new ArcRotateCamera("Camera", 0, 0, 5, new Vector3(0, 0, 0), scene);
             cameraOrthographic.mode = Camera.ORTHOGRAPHIC_CAMERA;
 
-            knot0 = MeshBuilder.CreateTorusKnot('Knot0', {
-                radius: 10,
-                tube: 3,
-                radialSegments: 128,
-                tubularSegments: 64,
-                p: 2,
-                q: 3,
-            }, scene);
-            knot1 = MeshBuilder.CreateTorusKnot('Knot1', {
-                radius: 10,
-                tube: 3,
-                radialSegments: 64,
-                tubularSegments: 32,
-                p: 2,
-                q: 3,
-            }, scene);
-            knot2 = MeshBuilder.CreateTorusKnot('Knot2', {
-                radius: 10,
-                tube: 3,
-                radialSegments: 32,
-                tubularSegments: 16,
-                p: 2,
-                q: 3,
-            }, scene);
+            knot0 = MeshBuilder.CreateTorusKnot(
+                "Knot0",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 128,
+                    tubularSegments: 64,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot1 = MeshBuilder.CreateTorusKnot(
+                "Knot1",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 64,
+                    tubularSegments: 32,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
+            knot2 = MeshBuilder.CreateTorusKnot(
+                "Knot2",
+                {
+                    radius: 10,
+                    tube: 3,
+                    radialSegments: 32,
+                    tubularSegments: 16,
+                    p: 2,
+                    q: 3,
+                },
+                scene
+            );
         });
 
-        describe('check LOD by distance', () => {
+        describe("check LOD by distance", () => {
             beforeEach(() => {
                 knot0.addLODLevel(10, knot1);
                 knot0.addLODLevel(20, knot2);
             });
 
-            it('should select lod with correct distance', () => {
+            it("should select lod with correct distance", () => {
                 expect(knot0.getLOD(cameraArc)).not.toBeNull();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
 
                 cameraArc.radius = 15;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot1");
 
                 cameraArc.radius = 25;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot2");
             });
 
-            it('should select lod with correct distance for orthographic camera', () => {
+            it("should select lod with correct distance for orthographic camera", () => {
                 expect(knot0.getLOD(cameraOrthographic)).not.toBeNull();
-                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual("Knot0");
 
                 cameraOrthographic.minZ = 15;
                 scene.render();
-                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot1');
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual("Knot1");
 
                 cameraOrthographic.minZ = 25;
                 scene.render();
-                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual('Knot2');
+                expect(knot0.getLOD(cameraOrthographic)!.name).toEqual("Knot2");
             });
 
-            it('should select loaded mesh while target lod mesh is not loaded yet', () => {
+            it("should select loaded mesh while target lod mesh is not loaded yet", () => {
                 // not loaded yet
                 knot1.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
                 knot2.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
 
                 cameraArc.radius = 15;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
 
                 cameraArc.radius = 25;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
 
                 // while loading
                 knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADING;
@@ -114,11 +125,11 @@ describe('Babylon Mesh Levels of Details', () => {
 
                 cameraArc.radius = 15;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
 
                 cameraArc.radius = 25;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot0');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot0");
 
                 // after loaded
                 knot1.delayLoadState = Constants.DELAYLOADSTATE_LOADED;
@@ -126,14 +137,14 @@ describe('Babylon Mesh Levels of Details', () => {
 
                 cameraArc.radius = 15;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot1");
 
                 cameraArc.radius = 25;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot2");
             });
 
-            it('should call user function with selected LOD', () => {
+            it("should call user function with selected LOD", () => {
                 const onLODLevelSelectionArgs: {
                     distance?: number;
                     meshName?: string;
@@ -153,26 +164,26 @@ describe('Babylon Mesh Levels of Details', () => {
                 scene.render();
                 expect(registerSpy).toBeCalledTimes(1);
                 expect(onLODLevelSelectionArgs.distance).toBeCloseTo(5.23, 2);
-                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot0');
+                expect(onLODLevelSelectionArgs.meshName).toEqual("Knot0");
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual("Knot0");
 
                 cameraArc.radius = 15;
                 scene.render();
                 expect(registerSpy).toBeCalledTimes(2);
                 expect(onLODLevelSelectionArgs.distance).toBeCloseTo(15.07, 2);
-                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot1');
+                expect(onLODLevelSelectionArgs.meshName).toEqual("Knot0");
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual("Knot1");
 
                 cameraArc.radius = 25;
                 scene.render();
                 expect(registerSpy).toBeCalledTimes(3);
                 expect(onLODLevelSelectionArgs.distance).toBeCloseTo(25.03, 2);
-                expect(onLODLevelSelectionArgs.meshName).toEqual('Knot0');
-                expect(onLODLevelSelectionArgs.selectedLevel).toEqual('Knot2');
+                expect(onLODLevelSelectionArgs.meshName).toEqual("Knot0");
+                expect(onLODLevelSelectionArgs.selectedLevel).toEqual("Knot2");
             });
         });
 
-        describe('check LOD by screen coverage', () => {
+        describe("check LOD by screen coverage", () => {
             beforeEach(() => {
                 knot0.useLODScreenCoverage = true;
                 knot0.addLODLevel(0.5, knot1);
@@ -180,14 +191,14 @@ describe('Babylon Mesh Levels of Details', () => {
                 knot0.addLODLevel(0.02, null);
             });
 
-            it('should select lod with correct screen coverage', () => {
+            it("should select lod with correct screen coverage", () => {
                 cameraArc.radius = 80;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot1");
 
                 cameraArc.radius = 120;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot2");
 
                 cameraArc.radius = 380;
                 scene.render();
@@ -196,7 +207,7 @@ describe('Babylon Mesh Levels of Details', () => {
         });
 
         describe("useLODScreenCoverage", () => {
-            it('should work correctly when set to true at any time relative to addLODLevel mesh', () => {
+            it("should work correctly when set to true at any time relative to addLODLevel mesh", () => {
                 // Set LOD meshes
                 knot0.addLODLevel(0.5, knot1);
                 knot0.addLODLevel(0.2, knot2);
@@ -208,11 +219,11 @@ describe('Babylon Mesh Levels of Details', () => {
                 // And it should work correctly
                 cameraArc.radius = 80;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot1');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot1");
 
                 cameraArc.radius = 120;
                 scene.render();
-                expect(knot0.getLOD(cameraArc)!.name).toEqual('Knot2');
+                expect(knot0.getLOD(cameraArc)!.name).toEqual("Knot2");
 
                 cameraArc.radius = 380;
                 scene.render();


### PR DESCRIPTION
Hi!

Here I found some trouble with `removeLODLevel` method — in the doc presented example where we can remove `null` from LOD, but the method didn't have ability to do it.

https://doc.babylonjs.com/features/featuresDeepDive/mesh/LOD

![image](https://user-images.githubusercontent.com/2697890/201533219-ac2de092-4ab7-4d81-8c6c-a68a661c41fa.png)

---

Also I did not found the way how to reach this code part:
![image](https://user-images.githubusercontent.com/2697890/201533270-3e95e367-52f3-4a5d-921f-974b3ccc4a99.png)

It's necessary? In which cases?

---

And one thing more. I dont know is it trouble or not, but the `addLODLevel` method allows to add multiple meshes to the same distance. There are no any checks to this case.
Probably have reaseon to add Logger Warn at least?