### PR TITLE
Forum issues fix

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -237,7 +237,6 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                 // If behavior is disabled before releaseDrag is ever called, call it now.
                 if (this._attachedToElement) {
                     this.releaseDrag();
-                    this._activeDragButton = -1;
                 }
 
                 return;
@@ -266,7 +265,6 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                     this._activeDragButton === pointerInfo.event.button
                 ) {
                     this.releaseDrag();
-                    this._activeDragButton = -1;
                 }
             } else if (pointerInfo.type == PointerEventTypes.POINTERMOVE) {
                 const pointerId = (<IPointerEvent>pointerInfo.event).pointerId;
@@ -329,6 +327,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
         }
 
         this.currentDraggingPointerId = -1;
+        this._activeDragButton = -1;
         this._moving = false;
 
         // Reattach camera controls
@@ -561,6 +560,5 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this._dragPlane.dispose();
         }
         this.releaseDrag();
-        this._activeDragButton = -1;
     }
 }

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -175,6 +175,7 @@ export class Gizmo implements IGizmo {
     }
 
     protected _updateGizmoRotationToMatchAttachedMesh = true;
+    protected _updateGizmoPositionToMatchAttachedMesh = true;
 
     /**
      * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
@@ -188,7 +189,12 @@ export class Gizmo implements IGizmo {
     /**
      * If set the gizmo's position will be updated to match the attached mesh each frame (Default: true)
      */
-    public updateGizmoPositionToMatchAttachedMesh = true;
+    public set updateGizmoPositionToMatchAttachedMesh(value: boolean) {
+        this._updateGizmoPositionToMatchAttachedMesh = value;
+    }
+    public get updateGizmoPositionToMatchAttachedMesh() {
+        return this._updateGizmoPositionToMatchAttachedMesh;
+    }
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
      */

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -236,10 +236,12 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 const nodeQuaternion = new Quaternion(0, 0, 0, 1);
                 const nodeTranslation = new Vector3(0, 0, 0);
                 this._handlePivot();
+
                 this.attachedNode.getWorldMatrix().decompose(nodeScale, nodeQuaternion, nodeTranslation);
 
-                const newVector = event.dragPlanePoint.subtract(nodeTranslation).normalize();
-                const originalVector = lastDragPosition.subtract(nodeTranslation).normalize();
+                const nodeTranslationForOperation = this.updateGizmoPositionToMatchAttachedMesh ? nodeTranslation : this._rootMesh.absolutePosition;
+                const newVector = event.dragPlanePoint.subtract(nodeTranslationForOperation).normalize();
+                const originalVector = lastDragPosition.subtract(nodeTranslationForOperation).normalize();
                 const cross = Vector3.Cross(newVector, originalVector);
                 const dot = Vector3.Dot(newVector, originalVector);
                 let angle = Math.atan2(cross.length(), dot);
@@ -252,7 +254,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 // Flip up vector depending on which side the camera is on
                 let cameraFlipped = false;
                 if (gizmoLayer.utilityLayerScene.activeCamera) {
-                    const camVec = gizmoLayer.utilityLayerScene.activeCamera.position.subtract(nodeTranslation).normalize();
+                    const camVec = gizmoLayer.utilityLayerScene.activeCamera.position.subtract(nodeTranslationForOperation).normalize();
                     if (Vector3.Dot(camVec, localPlaneNormalTowardsCamera) > 0) {
                         planeNormalTowardsCamera.scaleInPlace(-1);
                         localPlaneNormalTowardsCamera.scaleInPlace(-1);

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -213,6 +213,18 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         return this._updateGizmoRotationToMatchAttachedMesh;
     }
 
+    public set updateGizmoPositionToMatchAttachedMesh(value: boolean) {
+        this._updateGizmoPositionToMatchAttachedMesh = value;
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
+            if (gizmo) {
+                gizmo.updateGizmoPositionToMatchAttachedMesh = value;
+            }
+        });
+    }
+    public get updateGizmoPositionToMatchAttachedMesh() {
+        return this._updateGizmoPositionToMatchAttachedMesh;
+    }
+
     /**
      * Drag distance in babylon units that the gizmo will snap to when dragged (Default: 0)
      */

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -215,6 +215,16 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         return this.xGizmo.updateGizmoRotationToMatchAttachedMesh;
     }
 
+    public set updateGizmoPositionToMatchAttachedMesh(value: boolean) {
+        if (this.xGizmo) {
+            this.xGizmo.updateGizmoPositionToMatchAttachedMesh = value;
+            this.yGizmo.updateGizmoPositionToMatchAttachedMesh = value;
+            this.zGizmo.updateGizmoPositionToMatchAttachedMesh = value;
+        }
+    }
+    public get updateGizmoPositionToMatchAttachedMesh() {
+        return this.xGizmo.updateGizmoPositionToMatchAttachedMesh;
+    }
     /**
      * Drag distance in babylon units that the gizmo will snap to when dragged (Default: 0)
      */


### PR DESCRIPTION
Fixes for :

https://forum.babylonjs.com/t/positiongizmo-does-not-respect-update-gizmo-position-to-match-attached-mesh/35673/3
Forward properties `updateGizmoPositionToMatchAttachedMesh` and `updateGizmoRotationToMatchAttachedMesh` to agregated gizmos. And uses gizmo rootmesh postion for rotation angle computation

https://forum.babylonjs.com/t/gizmomanager-releasedrag-cant-drag-anymore-after/35289
`_activeDragButton` was not reset in `releaseDrag`. so when calling that method, it was impossible to start a new drag operation after.
