### PR TITLE
Extend dragPlanePoint doc on onDrag*Observables

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -82,14 +82,22 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      *  * dragDistance along the drag axis
      *  * dragPlaneNormal normal of the current drag plane used during the drag
      *  * dragPlanePoint in world space where the drag intersects the drag plane
+     *  
+     *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragObservable = new Observable<{ delta: Vector3; dragPlanePoint: Vector3; dragPlaneNormal: Vector3; dragDistance: number; pointerId: number }>();
     /**
      *  Fires each time a drag begins (eg. mouse down on mesh)
+     *  * dragPlanePoint in world space where the drag intersects the drag plane
+     *  
+     *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragStartObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();
     /**
      *  Fires each time a drag ends (eg. mouse release after drag)
+     *  * dragPlanePoint in world space where the drag intersects the drag plane 
+     *  
+     *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragEndObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();
     /**

--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -82,21 +82,21 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      *  * dragDistance along the drag axis
      *  * dragPlaneNormal normal of the current drag plane used during the drag
      *  * dragPlanePoint in world space where the drag intersects the drag plane
-     *  
+     *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragObservable = new Observable<{ delta: Vector3; dragPlanePoint: Vector3; dragPlaneNormal: Vector3; dragDistance: number; pointerId: number }>();
     /**
      *  Fires each time a drag begins (eg. mouse down on mesh)
      *  * dragPlanePoint in world space where the drag intersects the drag plane
-     *  
+     *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragStartObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();
     /**
      *  Fires each time a drag ends (eg. mouse release after drag)
-     *  * dragPlanePoint in world space where the drag intersects the drag plane 
-     *  
+     *  * dragPlanePoint in world space where the drag intersects the drag plane
+     *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
     public onDragEndObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();


### PR DESCRIPTION
Copied dragPlanePoint description to onDragStartObservable and onDragEndObservable Furthermore added a comment stating, that the dragPlanePoint does not necessarily equal the attached mesh position if validatedDrag is used.