### PR TITLE
InputManager: Fixed up/down picking on callback

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -873,7 +873,10 @@ export class InputManager {
                 }
 
                 // Meshes
-                if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp)) {
+                if (
+                    !this._meshPickProceed &&
+                    ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp)
+                ) {
                     this._initActionManager(null, clickInfo);
                 }
                 if (!pickResult) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -557,7 +557,7 @@ export class InputManager {
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
             if (!this._meshPickProceed) {
                 const pickResult =
-                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick))
+                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp))
                         ? null
                         : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
@@ -797,7 +797,7 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick))) {
+            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerDown))) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
@@ -873,7 +873,7 @@ export class InputManager {
                 }
 
                 // Meshes
-                if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers() || scene.onPointerPick)) {
+                if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp)) {
                     this._initActionManager(null, clickInfo);
                 }
                 if (!pickResult) {

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -7,13 +7,13 @@ import { DeviceType, PointerInput } from "core/DeviceInput";
 import { InternalDeviceSourceManager } from "core/DeviceInput/internalDeviceSourceManager";
 import { NullEngine } from "core/Engines";
 import type { Engine } from "core/Engines/engine";
-import type { IUIEvent} from "core/Events";
+import type { IUIEvent } from "core/Events";
 import { PointerEventTypes } from "core/Events";
 import { Vector3 } from "core/Maths/math.vector";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { Scene } from "core/scene";
 import type { Nullable } from "core/types";
-import type { ITestDeviceInputSystem} from "./testDeviceInputSystem";
+import type { ITestDeviceInputSystem } from "./testDeviceInputSystem";
 import { TestDeviceInputSystem } from "./testDeviceInputSystem";
 
 // Add function to NullEngine to allow for getting the canvas rect properties
@@ -112,10 +112,6 @@ describe("InputManager", () => {
             upCt++;
         };
 
-        scene!.onPointerPick = () => {
-            pickCt++;
-        };
-
         if (deviceInputSystem) {
             // Perform single move over mesh, then click
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
@@ -137,16 +133,29 @@ describe("InputManager", () => {
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 15, false);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Since the pick checks for up and down also include checking for onPointerPick, we need to check with the callback not defined
+            // This is the check with the callback defined
+            scene!.onPointerPick = () => {
+                pickCt++;
+            };
+
+            // Repeat the above tests with the onPointerPick callback defined
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
         }
 
-        expect(downCt).toBe(3);
-        expect(upCt).toBe(3);
-        expect(moveCt).toBe(3);
+        expect(downCt).toBe(4);
+        expect(upCt).toBe(4);
+        expect(moveCt).toBe(4);
         expect(pickCt).toBe(1);
         // Check that picking on other callbacks is working
-        expect(downHitCt).toBe(1);
-        expect(upHitCt).toBe(1);
-        expect(moveHitCt).toBe(1);
+        expect(downHitCt).toBe(2);
+        expect(upHitCt).toBe(2);
+        expect(moveHitCt).toBe(2);
     });
 
     it("onPointerObservable can pick only when necessary", () => {
@@ -171,8 +180,7 @@ describe("InputManager", () => {
                     if (!eventData.pickInfo) {
                         throw "Error: pickInfo should not be null";
                     }
-                }
-                else {
+                } else {
                     throw "Error: Tried to lazy pick twice";
                 }
             };


### PR DESCRIPTION
This PR addresses a bug where the check for picking to occur for onPointerUp and onPointerDown were being checked incorrectly.  The test was also updated to catch this in the future.

Forum Link with Bug Info: https://forum.babylonjs.com/t/scene-onpointerup-issues/35729