### PR TITLE
FreeCameraMouseInput: Fix for PointerLock Movement

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -91,7 +91,12 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
 
                 const srcElement = <HTMLElement>evt.target;
 
-                if (p.type === PointerEventTypes.POINTERDOWN && (this._currentActiveButton === -1 || isTouch) && this._activePointerId === -1) {
+                if (p.type === PointerEventTypes.POINTERDOWN) {
+                    // If the input is touch with more than one touch OR if the input is mouse and there is already an active button, return
+                    if ((isTouch && this._activePointerId !== -1) || (!isTouch && this._currentActiveButton !== -1)) {
+                        return;
+                    }
+
                     this._activePointerId = evt.pointerId;
                     try {
                         srcElement?.setPointerCapture(evt.pointerId);
@@ -117,7 +122,12 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     }
-                } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch) && this._activePointerId === evt.pointerId) {
+                } else if (p.type === PointerEventTypes.POINTERUP) {
+                    // If input is touch with a different touch id OR if input is mouse with a different button, return
+                    if ((isTouch && this._activePointerId !== evt.pointerId) || (!isTouch && this._currentActiveButton !== evt.button)) {
+                        return;
+                    }
+
                     try {
                         srcElement?.releasePointerCapture(evt.pointerId);
                     } catch (e) {
@@ -131,7 +141,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     }
 
                     this._activePointerId = -1;
-                } else if (p.type === PointerEventTypes.POINTERMOVE && this._activePointerId === evt.pointerId) {
+                } else if (p.type === PointerEventTypes.POINTERMOVE && (this._activePointerId === evt.pointerId || !isTouch)) {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     } else if (this._previousPosition) {

--- a/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
@@ -36,7 +36,7 @@ describe("FreeCameraMouseInput", () => {
         engine?.dispose();
     });
 
-    it("use only one touch input at a time", async () => {
+    it("use only one touch input at a time", () => {
         let cameraRotation = camera!.cameraRotation.clone();
         const testDeviceInputSystem = new TestDeviceInputSystem(
             engine!,
@@ -99,5 +99,44 @@ describe("FreeCameraMouseInput", () => {
         expect(camera?.cameraRotation.y).toEqual(cameraRotation.y);
         scene?._onCameraInputObservable.notifyObservers(upPI2);
         scene?._onCameraInputObservable.notifyObservers(upPI1);
+    });
+
+    it("can work with pointer lock", () => {
+        let cameraRotation = camera!.cameraRotation.clone();
+        const testDeviceInputSystem = new TestDeviceInputSystem(
+            engine!,
+            () => {},
+            () => {},
+            () => {}
+        );
+        testDeviceInputSystem.connectDevice(DeviceType.Mouse, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+        
+        // Create two events with different movement values
+        const moveEvt = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
+        moveEvt.movementX = 10;
+        moveEvt.movementY = 10;
+        const movePI = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt, new PickingInfo());
+
+        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
+        moveEvt2.movementX = -15;
+        moveEvt2.movementY = -15;
+        const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2, new PickingInfo());
+
+        // Set pointer lock
+        engine!.isPointerLock = true;
+
+        // Try to move the camera with the first event, it should move
+        scene?._onCameraInputObservable.notifyObservers(movePI);
+        expect(camera?.cameraRotation.x).not.toEqual(cameraRotation.x);
+        expect(camera?.cameraRotation.y).not.toEqual(cameraRotation.y);
+
+        // Remove pointer lock
+        cameraRotation = camera!.cameraRotation.clone();
+        engine!.isPointerLock = false;
+
+        // It should not move the camera
+        scene?._onCameraInputObservable.notifyObservers(movePI2);
+        expect(camera?.cameraRotation.x).toEqual(cameraRotation.x);
+        expect(camera?.cameraRotation.y).toEqual(cameraRotation.y);
     });
 });


### PR DESCRIPTION
A bug was identified in the forums where the camera wasn't moving while a pointer lock was active.  The issue was determined to be caused by a previous bug fix that tracked active pointer ids but the logic for ignoring input was incorrect.  This PR corrects that input and adds a test to verify that movementX/Y will move the camera for pointer lock but not standard input.

Forum Post: https://forum.babylonjs.com/t/camera-rotate-broken/35752