### PR TITLE
PBR material: Add missing test for the emissive texture in hasTexture

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -2453,6 +2453,10 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             return true;
         }
 
+        if (this._emissiveTexture === texture) {
+            return true;
+        }
+
         if (this._reflectivityTexture === texture) {
             return true;
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/weird-result-when-setting-texture-offset/35769