### PR TITLE
fixing billboardMode mode for instanced meshes

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3930,7 +3930,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         mesh.receiveShadows = parsedMesh.receiveShadows;
 
-        mesh.billboardMode = parsedMesh.billboardMode;
+        if (parsedMesh.billboardMode !== undefined) {
+            mesh.billboardMode = parsedMesh.billboardMode;
+        }
 
         if (parsedMesh.visibility !== undefined) {
             mesh.visibility = parsedMesh.visibility;


### PR DESCRIPTION
Hi.
This PR is fixing an issue with the `billboardMode` for instanced objects.
It was sometimes `undefined` which was causing the `instancedMesh` to use the rotation of the source transformation.

Here is a simple demo of this issue:
https://playground.babylonjs.com/#9NN1BK#1

If you uncomment the "FIX" it's working as expected (only the source mesh is rotating)