### PR TITLE
RTT: Make sure we increment scene frameId even in "check readiness" mode

### DIFF
--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -879,15 +879,20 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                     if (this.customIsReadyFunction) {
                         if (!this.customIsReadyFunction(mesh, this.refreshRate, checkReadiness)) {
                             returnValue = false;
-                            break;
+                            continue;
                         }
                     } else if (!mesh.isReady(true)) {
                         returnValue = false;
-                        break;
+                        continue;
                     }
                 }
 
                 this.onAfterRenderObservable.notifyObservers(layer);
+
+                if (this.is2DArray || this.isCube) {
+                    scene.incrementRenderId();
+                    scene.resetCachedMaterial();
+                }
             }
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/cube-rendertargettexture-cameras-inverty-and-rendering/35999/6