### PR TITLE
Cameras: Modified cameras to work under onPointerObservable

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraMouseWheelInput.ts
@@ -80,7 +80,7 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
             }
         };
 
-        this._observer = this.camera.getScene()._onCameraInputObservable.add(this._wheel, PointerEventTypes.POINTERWHEEL);
+        this._observer = this.camera.getScene()._inputManager._addCameraPointerObserver(this._wheel, PointerEventTypes.POINTERWHEEL);
     }
 
     /**
@@ -88,7 +88,7 @@ export abstract class BaseCameraMouseWheelInput implements ICameraInput<Camera> 
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
             this._observer = null;
             this._wheel = null;
         }

--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -216,7 +216,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
 
         this._observer = this.camera
             .getScene()
-            ._onCameraInputObservable.add(
+            ._inputManager._addCameraPointerObserver(
                 this._pointerInput,
                 PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE | PointerEventTypes.POINTERDOUBLETAP
             );
@@ -251,7 +251,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         }
 
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
             this._observer = null;
 
             if (this._contextMenuBind) {

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -128,7 +128,7 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
             }
         };
 
-        this._observer = this.camera.getScene()._onCameraInputObservable.add(this._wheel, PointerEventTypes.POINTERWHEEL);
+        this._observer = this.camera.getScene()._inputManager._addCameraPointerObserver(this._wheel, PointerEventTypes.POINTERWHEEL);
 
         if (this.zoomToMouseLocation) {
             this._inertialPanning.setAll(0);
@@ -140,7 +140,7 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
             this._observer = null;
             this._wheel = null;
         }

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
@@ -84,7 +84,7 @@ export class FlyCameraMouseInput implements ICameraInput<FlyCamera> {
         noPreventDefault = Tools.BackCompatCameraNoPreventDefault(arguments);
         this._noPreventDefault = noPreventDefault;
 
-        this._observer = this.camera.getScene()._onCameraInputObservable.add((p: any) => {
+        this._observer = this.camera.getScene()._inputManager._addCameraPointerObserver((p: any) => {
             this._pointerInput(p);
         }, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
@@ -101,7 +101,7 @@ export class FlyCameraMouseInput implements ICameraInput<FlyCamera> {
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
 
             this.camera.getScene().onBeforeRenderObservable.remove(this._rollObserver);
 

--- a/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/followCameraMouseWheelInput.ts
@@ -111,7 +111,7 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
             }
         };
 
-        this._observer = this.camera.getScene()._onCameraInputObservable.add(this._wheel, PointerEventTypes.POINTERWHEEL);
+        this._observer = this.camera.getScene()._inputManager._addCameraPointerObserver(this._wheel, PointerEventTypes.POINTERWHEEL);
     }
 
     /**
@@ -119,7 +119,7 @@ export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
             this._observer = null;
             this._wheel = null;
         }

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -203,7 +203,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
 
         this._observer = this.camera
             .getScene()
-            ._onCameraInputObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
+            ._inputManager._addCameraPointerObserver(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
         if (element) {
             this._contextMenuBind = this.onContextMenu.bind(this);
@@ -225,7 +225,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
      */
     public detachControl(): void {
         if (this._observer) {
-            this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+            this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
 
             if (this._contextMenuBind) {
                 const engine = this.camera.getEngine();

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -141,7 +141,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
 
         this._observer = this.camera
             .getScene()
-            ._onCameraInputObservable.add(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
+            ._inputManager._addCameraPointerObserver(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
         if (this._onLostFocus) {
             const engine = this.camera.getEngine();
@@ -156,7 +156,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
     public detachControl(): void {
         if (this._pointerInput) {
             if (this._observer) {
-                this.camera.getScene()._onCameraInputObservable.remove(this._observer);
+                this.camera.getScene()._inputManager._removeCameraPointerObserver(this._observer);
                 this._observer = null;
             }
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -566,7 +566,8 @@ export class InputManager {
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
             if (!this._meshPickProceed) {
                 const pickResult =
-                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerUp))
+                    scene.skipPointerUpPicking ||
+                    (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerUp))
                         ? null
                         : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
@@ -806,7 +807,10 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerDown))) {
+            if (
+                scene.skipPointerDownPicking ||
+                (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerDown))
+            ) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
@@ -884,7 +888,10 @@ export class InputManager {
                 // Meshes
                 if (
                     !this._meshPickProceed &&
-                    ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerUp)
+                    ((AbstractActionManager && AbstractActionManager.HasTriggers) ||
+                        scene.onPointerObservable.observers.length > this._cameraObserverCount ||
+                        scene.onPointerPick ||
+                        scene.onPointerUp)
                 ) {
                     this._initActionManager(null, clickInfo);
                 }

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -1,4 +1,4 @@
-import type { Observable } from "../Misc/observable";
+import type { EventState, Observable, Observer } from "../Misc/observable";
 import { PointerInfoPre, PointerInfo, PointerEventTypes } from "../Events/pointerEvents";
 import type { Nullable } from "../types";
 import { AbstractActionManager } from "../Actions/abstractActionManager";
@@ -108,6 +108,7 @@ export class InputManager {
     private _pointerCaptures: { [pointerId: number]: boolean } = {};
     private _meshUnderPointerId: { [pointerId: number]: Nullable<AbstractMesh> } = {};
     private _movePointerInfo: Nullable<PointerInfo> = null;
+    private _cameraObserverCount = 0;
 
     // Keyboard
     private _onKeyDown: (evt: IKeyboardEvent) => void;
@@ -235,7 +236,6 @@ export class InputManager {
             this._movePointerInfo = pointerInfo;
         }
 
-        scene._onCameraInputObservable.notifyObservers(pointerInfo, type);
         if (scene.onPointerObservable.hasObservers()) {
             scene.onPointerObservable.notifyObservers(pointerInfo, type);
         }
@@ -250,6 +250,18 @@ export class InputManager {
                 pickInfo.ray = scene.createPickingRay(event.offsetX, event.offsetY, Matrix.Identity(), scene.activeCamera);
             }
         }
+    }
+
+    /** @internal */
+    public _addCameraPointerObserver(observer: (p: PointerInfo, s: EventState) => void, mask?: number): Nullable<Observer<PointerInfo>> {
+        this._cameraObserverCount++;
+        return this._scene.onPointerObservable.add(observer, mask);
+    }
+
+    /** @internal */
+    public _removeCameraPointerObserver(observer: Observer<PointerInfo>): boolean {
+        this._cameraObserverCount--;
+        return this._scene.onPointerObservable.remove(observer);
     }
 
     private _checkPrePointerObservable(pickResult: Nullable<PickingInfo>, evt: IPointerEvent, type: number) {
@@ -407,7 +419,6 @@ export class InputManager {
             pointerInfo = new PointerInfo(type, evt, null, this);
         }
 
-        scene._onCameraInputObservable.notifyObservers(pointerInfo, type);
         if (scene.onPointerObservable.hasObservers()) {
             scene.onPointerObservable.notifyObservers(pointerInfo, type);
         }
@@ -454,7 +465,7 @@ export class InputManager {
                 if (scene.onPointerPick) {
                     scene.onPointerPick(evt, pickResult);
                 }
-                if (clickInfo.singleClick && !clickInfo.ignore && scene.onPointerObservable.hasObservers()) {
+                if (clickInfo.singleClick && !clickInfo.ignore && scene.onPointerObservable.observers.length > this._cameraObserverCount) {
                     const type = PointerEventTypes.POINTERPICK;
                     const pi = new PointerInfo(type, evt, pickResult);
                     this._setRayOnPointerInfo(pickResult, evt);
@@ -501,7 +512,6 @@ export class InputManager {
                 if (type) {
                     const pi = new PointerInfo(type, evt, pickResult);
                     this._setRayOnPointerInfo(pickResult, evt);
-                    scene._onCameraInputObservable.notifyObservers(pi, type);
                     if (scene.onPointerObservable.hasObservers() && scene.onPointerObservable.hasSpecificMask(type)) {
                         scene.onPointerObservable.notifyObservers(pi, type);
                     }
@@ -511,7 +521,6 @@ export class InputManager {
             type = PointerEventTypes.POINTERUP;
             const pi = new PointerInfo(type, evt, pickResult);
             this._setRayOnPointerInfo(pickResult, evt);
-            scene._onCameraInputObservable.notifyObservers(pi, type);
             scene.onPointerObservable.notifyObservers(pi, type);
         }
 
@@ -557,7 +566,7 @@ export class InputManager {
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
             if (!this._meshPickProceed) {
                 const pickResult =
-                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp))
+                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerUp))
                         ? null
                         : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
@@ -797,7 +806,7 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerDown))) {
+            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !(scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerDown))) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
@@ -875,7 +884,7 @@ export class InputManager {
                 // Meshes
                 if (
                     !this._meshPickProceed &&
-                    ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.hasObservers() || scene.onPointerPick || scene.onPointerUp)
+                    ((AbstractActionManager && AbstractActionManager.HasTriggers) || scene.onPointerObservable.observers.length > this._cameraObserverCount || scene.onPointerPick || scene.onPointerUp)
                 ) {
                     this._initActionManager(null, clickInfo);
                 }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -798,12 +798,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public onPointerObservable = new Observable<PointerInfo>();
 
     /**
-     * Observable to handle camera pointer inputs
-     * @internal
-     */
-    public _onCameraInputObservable = new Observable<PointerInfo>();
-
-    /**
      * Gets the pointer coordinates without any translation (ie. straight out of the pointer event)
      */
     public get unTranslatedPointer(): Vector2 {
@@ -4737,7 +4731,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.onTextureRemovedObservable.clear();
         this.onPrePointerObservable.clear();
         this.onPointerObservable.clear();
-        this._onCameraInputObservable.clear();
         this.onPreKeyboardObservable.clear();
         this.onKeyboardObservable.clear();
         this.onActiveCameraChanged.clear();

--- a/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
@@ -86,19 +86,19 @@ describe("FreeCameraMouseInput", () => {
         const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
 
         // With the first touch, the camera should rotate
-        scene?._onCameraInputObservable.notifyObservers(downPI1);
-        scene?._onCameraInputObservable.notifyObservers(movePI1);
+        scene?.onPointerObservable.notifyObservers(downPI1);
+        scene?.onPointerObservable.notifyObservers(movePI1);
         expect(camera?.cameraRotation.x).not.toEqual(cameraRotation.x);
         expect(camera?.cameraRotation.y).not.toEqual(cameraRotation.y);
 
         // With the second touch, the camera should not rotate because the first touch is still active
         cameraRotation = camera!.cameraRotation.clone();
-        scene?._onCameraInputObservable.notifyObservers(downPI2);
-        scene?._onCameraInputObservable.notifyObservers(movePI2);
+        scene?.onPointerObservable.notifyObservers(downPI2);
+        scene?.onPointerObservable.notifyObservers(movePI2);
         expect(camera?.cameraRotation.x).toEqual(cameraRotation.x);
         expect(camera?.cameraRotation.y).toEqual(cameraRotation.y);
-        scene?._onCameraInputObservable.notifyObservers(upPI2);
-        scene?._onCameraInputObservable.notifyObservers(upPI1);
+        scene?.onPointerObservable.notifyObservers(upPI2);
+        scene?.onPointerObservable.notifyObservers(upPI1);
     });
 
     it("can work with pointer lock", () => {
@@ -126,7 +126,7 @@ describe("FreeCameraMouseInput", () => {
         engine!.isPointerLock = true;
 
         // Try to move the camera with the first event, it should move
-        scene?._onCameraInputObservable.notifyObservers(movePI);
+        scene?.onPointerObservable.notifyObservers(movePI);
         expect(camera?.cameraRotation.x).not.toEqual(cameraRotation.x);
         expect(camera?.cameraRotation.y).not.toEqual(cameraRotation.y);
 
@@ -135,7 +135,7 @@ describe("FreeCameraMouseInput", () => {
         engine!.isPointerLock = false;
 
         // It should not move the camera
-        scene?._onCameraInputObservable.notifyObservers(movePI2);
+        scene?.onPointerObservable.notifyObservers(movePI2);
         expect(camera?.cameraRotation.x).toEqual(cameraRotation.x);
         expect(camera?.cameraRotation.y).toEqual(cameraRotation.y);
     });


### PR DESCRIPTION
A user on the forums recently found an issue related to `onPointerObservable` where skipNextObservers weren't working as they used to.  This issue was a side effect of an optimization make in support of Lazy Picking.  This optimization would take all internal camera inputs and remove them from the user-facing `onPointerObservable`.  This would cause the camera input observers to be inaccessible in the same way.  This PR will add them back to `onPointerObservable` but keep track of how many camera input observers have been added and require either user-defined observer as part of the criteria for picking.

Forum Post: https://forum.babylonjs.com/t/no-longer-able-to-cancel-camera-inputs-with-new-oncamerainputobservable/35793