### PR TITLE
Support KHR_materials_emissive_stength in glTF export

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -62,6 +62,7 @@ export class KHR_materials_emissive_strength implements IGLTFLoaderExtension {
 
         if (properties.emissiveStrength !== undefined) {
             babylonMaterial.emissiveColor.scaleToRef(properties.emissiveStrength, babylonMaterial.emissiveColor);
+            babylonMaterial.metadata.emissiveStrength = properties.emissiveStrength;
         }
     }
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -62,7 +62,6 @@ export class KHR_materials_emissive_strength implements IGLTFLoaderExtension {
 
         if (properties.emissiveStrength !== undefined) {
             babylonMaterial.emissiveColor.scaleToRef(properties.emissiveStrength, babylonMaterial.emissiveColor);
-            babylonMaterial.metadata.emissiveStrength = properties.emissiveStrength;
         }
     }
 }

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -1,8 +1,7 @@
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
 import { _Exporter } from "../glTFExporter";
-import type { Material } from 'core/Materials';
-import { PBRMaterial } from 'core/Materials';
-import * as _ from 'lodash';
+import type { Material } from 'core/Materials/material';
+import { PBRMaterial } from 'core/Materials/PBR/pbrMaterial';
 import type { IMaterial, IKHRMaterialsEmissiveStrength } from 'babylonjs-gltf2interface';
 
 const NAME = "KHR_materials_emissive_strength";

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -1,13 +1,13 @@
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
-import type { Nullable } from "core/types";
 import { _Exporter } from "../glTFExporter";
-import { Material } from 'core/Materials';
+import type { Material } from 'core/Materials';
 import { PBRMaterial } from 'core/Materials';
 import * as _ from 'lodash';
 import type { IMaterial, IKHRMaterialsEmissiveStrength } from 'babylonjs-gltf2interface';
 
 const NAME = "KHR_materials_emissive_strength";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2 {
     /** Name of this extension */
     public readonly name = NAME;
@@ -27,7 +27,7 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
         return this._wasUsed;
     }
 
-    public postExportMaterialAsync(context: string, node: IMaterial, babylonMaterial: Material): Promise<Nullable<BABYLON.GLTF2.IMaterial>> {
+    public postExportMaterialAsync(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
       return new Promise((resolve) => {
         if (!(babylonMaterial instanceof PBRMaterial)) {
           return resolve(node);

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -33,18 +33,22 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
           return resolve(node);
         }
 
-        if (babylonMaterial.metadata.emissiveStrength !== undefined) {
+        const emissiveColor = babylonMaterial.emissiveColor.asArray();
+        const tempEmissiveStrength = Math.max(...emissiveColor);
+
+        if (tempEmissiveStrength > 1) {
           this._wasUsed = true;
 
-          if (node.extensions == null){
+          if (node.extensions == null) {
             node.extensions = {};
           }
 
           const emissiveStrengthInfo: IKHRMaterialsEmissiveStrength = {
-            emissiveStrength: babylonMaterial.metadata.emissiveStrength
-          }
+            emissiveStrength: tempEmissiveStrength
+          };
 
-          const newEmissiveFactor = babylonMaterial.emissiveColor.scale((1 / emissiveStrengthInfo.emissiveStrength));
+          // Normalize each value of the emissive factor to have a max value of 1
+          const newEmissiveFactor = babylonMaterial.emissiveColor.scale((1 / emissiveStrengthInfo.emissiveStrength))
 
           node.emissiveFactor = newEmissiveFactor.asArray();
           node.extensions[NAME] = emissiveStrengthInfo;

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -1,11 +1,14 @@
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
 import { _Exporter } from "../glTFExporter";
-import type { Material } from 'core/Materials/material';
-import { PBRMaterial } from 'core/Materials/PBR/pbrMaterial';
-import type { IMaterial, IKHRMaterialsEmissiveStrength } from 'babylonjs-gltf2interface';
+import type { Material } from "core/Materials/material";
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import type { IMaterial, IKHRMaterialsEmissiveStrength } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_emissive_strength";
 
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md)
+ */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2 {
     /** Name of this extension */
@@ -27,34 +30,34 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
     }
 
     public postExportMaterialAsync(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
-      return new Promise((resolve) => {
-        if (!(babylonMaterial instanceof PBRMaterial)) {
-          return resolve(node);
-        }
+        return new Promise((resolve) => {
+            if (!(babylonMaterial instanceof PBRMaterial)) {
+                return resolve(node);
+            }
 
-        const emissiveColor = babylonMaterial.emissiveColor.asArray();
-        const tempEmissiveStrength = Math.max(...emissiveColor);
+            const emissiveColor = babylonMaterial.emissiveColor.asArray();
+            const tempEmissiveStrength = Math.max(...emissiveColor);
 
-        if (tempEmissiveStrength > 1) {
-          this._wasUsed = true;
+            if (tempEmissiveStrength > 1) {
+                this._wasUsed = true;
 
-          if (node.extensions == null) {
-            node.extensions = {};
-          }
+                if (node.extensions == null) {
+                    node.extensions = {};
+                }
 
-          const emissiveStrengthInfo: IKHRMaterialsEmissiveStrength = {
-            emissiveStrength: tempEmissiveStrength
-          };
+                const emissiveStrengthInfo: IKHRMaterialsEmissiveStrength = {
+                    emissiveStrength: tempEmissiveStrength,
+                };
 
-          // Normalize each value of the emissive factor to have a max value of 1
-          const newEmissiveFactor = babylonMaterial.emissiveColor.scale((1 / emissiveStrengthInfo.emissiveStrength))
+                // Normalize each value of the emissive factor to have a max value of 1
+                const newEmissiveFactor = babylonMaterial.emissiveColor.scale(1 / emissiveStrengthInfo.emissiveStrength);
 
-          node.emissiveFactor = newEmissiveFactor.asArray();
-          node.extensions[NAME] = emissiveStrengthInfo;
-        }
+                node.emissiveFactor = newEmissiveFactor.asArray();
+                node.extensions[NAME] = emissiveStrengthInfo;
+            }
 
-        return resolve(node);
-      })
+            return resolve(node);
+        });
     }
 }
 

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -41,9 +41,7 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
             if (tempEmissiveStrength > 1) {
                 this._wasUsed = true;
 
-                if (node.extensions == null) {
-                    node.extensions = {};
-                }
+                node.extensions ||= {};
 
                 const emissiveStrengthInfo: IKHRMaterialsEmissiveStrength = {
                     emissiveStrength: tempEmissiveStrength,

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
@@ -9,3 +9,4 @@ export * from "./KHR_materials_specular";
 export * from "./KHR_materials_volume";
 export * from "./KHR_materials_transmission";
 export * from "./EXT_mesh_gpu_instancing";
+export * from "./KHR_materials_emissive_strength";


### PR DESCRIPTION
This PR adds support for the glTF extension KHR_materials_emissive_strength to be exported.

Model used for testing: [link](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/EmissiveStrengthTest)