### PR TITLE
Fixed NativeEngine render target assignment

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2746,6 +2746,12 @@ export class NativeEngine extends Engine {
     public bindFramebuffer(texture: RenderTargetWrapper, faceIndex?: number, requiredWidth?: number, requiredHeight?: number, forceFullscreenViewport?: boolean): void {
         const nativeRTWrapper = texture as NativeRenderTargetWrapper;
 
+        if (this._currentRenderTarget) {
+            this.unBindFramebuffer(this._currentRenderTarget);
+        }
+
+        this._currentRenderTarget = texture;
+
         if (faceIndex) {
             throw new Error("Cuboid frame buffers are not yet supported in NativeEngine.");
         }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2773,6 +2773,8 @@ export class NativeEngine extends Engine {
 
     public unBindFramebuffer(texture: RenderTargetWrapper, disableGenerateMipMaps = false, onBeforeUnbind?: () => void): void {
         // NOTE: Disabling mipmap generation is not yet supported in NativeEngine.
+        
+        this._currentRenderTarget = null;
 
         if (onBeforeUnbind) {
             onBeforeUnbind();

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2773,7 +2773,7 @@ export class NativeEngine extends Engine {
 
     public unBindFramebuffer(texture: RenderTargetWrapper, disableGenerateMipMaps = false, onBeforeUnbind?: () => void): void {
         // NOTE: Disabling mipmap generation is not yet supported in NativeEngine.
-        
+
         this._currentRenderTarget = null;
 
         if (onBeforeUnbind) {


### PR DESCRIPTION
Native engine is currently not assingning the new texture passed in bindFrameBuffer to its _currentRenderTarget. This will result in NaN values for camera's projection matrix since it uses the engine.getRenderWidth() and engine.getRenderHeight() and those values will be zero. 

Storing _currentRenderTarget fixes the problem. 