### PR TITLE
Fix: Animation Groups not showing the correct current frame value in …

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
@@ -37,13 +37,15 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
         const animationGroup = this.props.animationGroup;
         this.state = { playButtonText: animationGroup.isPlaying ? "Pause" : "Play", currentFrame: 0 };
 
+        this._timelineRef = React.createRef();
+    }
+
+    componentDidMount(): void {
         this.connect(this.props.animationGroup);
 
         this._onBeforeRenderObserver = this.props.scene.onBeforeRenderObservable.add(() => {
             this.updateCurrentFrame(this.props.animationGroup);
         });
-
-        this._timelineRef = React.createRef();
     }
 
     disconnect(animationGroup: AnimationGroup) {
@@ -73,9 +75,9 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
     updateCurrentFrame(animationGroup: AnimationGroup) {
         const targetedAnimations = animationGroup.targetedAnimations;
         if (targetedAnimations.length > 0) {
-            const runtimeAnimations = animationGroup.targetedAnimations[0].animation.runtimeAnimations;
-            if (runtimeAnimations.length > 0) {
-                this.setState({ currentFrame: runtimeAnimations[0].currentFrame });
+            const runtimeAnimation = animationGroup.targetedAnimations[0].animation.runtimeAnimations.find((rA) => rA.target === animationGroup.targetedAnimations[0].target);
+            if (runtimeAnimation) {
+                this.setState({ currentFrame: runtimeAnimation.currentFrame });
             } else {
                 this.setState({ currentFrame: 0 });
             }
@@ -107,7 +109,6 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
             animationGroup.pause();
         } else {
             this.setState({ playButtonText: "Pause" });
-            this.props.scene.animationGroups.forEach((grp) => grp.pause());
             animationGroup.play(true);
         }
     }


### PR DESCRIPTION
…the Inspector. Fix: When playing an animation group in the Inspector, other groups in the same scene were being paused.

Related forum issue: https://forum.babylonjs.com/t/loading-character-with-animations-to-scene-and-cloning-it-with-animation-groups/19685/14