### PR TITLE
Fix restore context in WebGL1 when using non POT textures

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -496,7 +496,7 @@ export class Engine extends ThinEngine {
 
     private _loadingScreen: ILoadingScreen;
     private _pointerLockRequested: boolean;
-    private _rescalePostProcess: PostProcess;
+    private _rescalePostProcess: Nullable<PostProcess>;
 
     // Deterministic lockstepMaxSteps
     protected _deterministicLockstep: boolean = false;
@@ -640,6 +640,12 @@ export class Engine extends ThinEngine {
         if (options.autoEnableWebVR) {
             this.initWebVR();
         }
+    }
+
+    protected _initGLContext(): void {
+        super._initGLContext();
+
+        this._rescalePostProcess = null;
     }
 
     /**
@@ -1636,29 +1642,31 @@ export class Engine extends ThinEngine {
             this._rescalePostProcess = Engine._RescalePostProcessFactory(this);
         }
 
-        this._rescalePostProcess.externalTextureSamplerBinding = true;
-        this._rescalePostProcess.getEffect().executeWhenCompiled(() => {
-            this._rescalePostProcess.onApply = function (effect) {
-                effect._bindTexture("textureSampler", source);
-            };
+        if (this._rescalePostProcess) {
+            this._rescalePostProcess.externalTextureSamplerBinding = true;
+            this._rescalePostProcess.getEffect().executeWhenCompiled(() => {
+                this._rescalePostProcess!.onApply = function (effect) {
+                    effect._bindTexture("textureSampler", source);
+                };
 
-            let hostingScene: Scene = scene;
+                let hostingScene: Scene = scene;
 
-            if (!hostingScene) {
-                hostingScene = this.scenes[this.scenes.length - 1];
-            }
-            hostingScene.postProcessManager.directRender([this._rescalePostProcess], rtt, true);
+                if (!hostingScene) {
+                    hostingScene = this.scenes[this.scenes.length - 1];
+                }
+                hostingScene.postProcessManager.directRender([this._rescalePostProcess!], rtt, true);
 
-            this._bindTextureDirectly(this._gl.TEXTURE_2D, destination, true);
-            this._gl.copyTexImage2D(this._gl.TEXTURE_2D, 0, internalFormat, 0, 0, destination.width, destination.height, 0);
+                this._bindTextureDirectly(this._gl.TEXTURE_2D, destination, true);
+                this._gl.copyTexImage2D(this._gl.TEXTURE_2D, 0, internalFormat, 0, 0, destination.width, destination.height, 0);
 
-            this.unBindFramebuffer(rtt);
-            rtt.dispose();
+                this.unBindFramebuffer(rtt);
+                rtt.dispose();
 
-            if (onComplete) {
-                onComplete();
-            }
-        });
+                if (onComplete) {
+                    onComplete();
+                }
+            });
+        }
     }
 
     // FPS

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1036,12 +1036,17 @@ export class ThinEngine {
             // Rebuild effects
             this._rebuildEffects();
             this._rebuildComputeEffects?.();
+
+            // Note:
+            //  The call to _rebuildBuffers must be made before the call to _rebuildInternalTextures because in the process of _rebuildBuffers the buffers used by the post process managers will be rebuilt
+            //  and we may need to use the post process manager of the scene during _rebuildInternalTextures (in WebGL1, non-POT textures are rescaled using a post process + post process manager of the scene)
+
+            // Rebuild buffers
+            this._rebuildBuffers();
             // Rebuild textures
             this._rebuildInternalTextures();
             // Rebuild textures
             this._rebuildRenderTargetWrappers();
-            // Rebuild buffers
-            this._rebuildBuffers();
 
             // Reset engine states after all the buffer/textures/... have been rebuilt
             this.wipeCaches(true);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/context-restore-for-textures-with-bloburl-not-working/36114/7