### PR TITLE
The STL loader flips the faces

### DIFF
--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -61,7 +61,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
             if (this._isBinary(data)) {
                 // binary .stl
                 const babylonMesh = new Mesh("stlmesh", scene);
-                this._parseBinary(babylonMesh, data, scene.useRightHandedSystem);
+                this._parseBinary(babylonMesh, data);
                 if (meshes) {
                     meshes.push(babylonMesh);
                 }
@@ -106,7 +106,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
             meshName = meshName || "stlmesh";
 
             const babylonMesh = new Mesh(meshName, scene);
-            this._parseASCII(babylonMesh, matches[2], scene.useRightHandedSystem);
+            this._parseASCII(babylonMesh, matches[2]);
             if (meshes) {
                 meshes.push(babylonMesh);
             }
@@ -170,7 +170,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
         return false;
     }
 
-    private _parseBinary(mesh: Mesh, data: ArrayBuffer, rightHanded: boolean) {
+    private _parseBinary(mesh: Mesh, data: ArrayBuffer) {
         const reader = new DataView(data);
         const faces = reader.getUint32(80, true);
 
@@ -232,7 +232,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
         mesh.computeWorldMatrix(true);
     }
 
-    private _parseASCII(mesh: Mesh, solidData: string, rightHanded: boolean) {
+    private _parseASCII(mesh: Mesh, solidData: string) {
         const positions = [];
         const normals = [];
         const indices = [];

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -214,7 +214,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
                 offset += 3;
             }
 
-            if (rightHanded) {
+            if (STLFileLoader.DO_NOT_ALTER_FILE_COORDINATES) {
                 indices[indicesCount] = indicesCount;
                 indices[indicesCount + 1] = indicesCount + 2;
                 indices[indicesCount + 2] = indicesCount + 1;
@@ -263,7 +263,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
                     normals.push(normal[0], normal[2], normal[1]);
                 }
             }
-            if (rightHanded) {
+            if (STLFileLoader.DO_NOT_ALTER_FILE_COORDINATES) {
                 indices.push(indicesCount, indicesCount + 2, indicesCount + 1);
                 indicesCount += 3;
             } else {


### PR DESCRIPTION
The current code loads STL files with faces flipped for the following combinations (RH for `useRightHandedSystem`, NO_ALTER for `DO_NOT_ALTER_FILE_COORDINATES`):
|&nbsp;|NO_ALTER-true | NO_ALTER-false |
|---|---|---|
| RH-true | good | bad |
| RH-false | bad | good |

The correct combination for whether flip the face indices is like the following table, which means, we should only detect `DO_NOT_ALTER_FILE_COORDINATES` but not `useRightHandedSystem`:
|&nbsp;|NO_ALTER-true | NO_ALTER-false |
|---|---|---|
| RH-true | flip | no-flip |
| RH-false | flip | no-flip |
