### PR TITLE
Fix bad uniform scale check for rotation gizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -240,6 +240,8 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 this._handlePivot();
 
                 this.attachedNode.getWorldMatrix().decompose(nodeScale, nodeQuaternion, nodeTranslation);
+                // uniform scaling of absolute value of components
+                // (-1,1,1) is uniform but (1,1.001,1) is not
                 const uniformScaling = Math.abs(Math.abs(nodeScale.x) - Math.abs(nodeScale.y)) <= Epsilon && Math.abs(Math.abs(nodeScale.x) - Math.abs(nodeScale.z)) <= Epsilon;
                 if (!uniformScaling && this.updateGizmoRotationToMatchAttachedMesh) {
                     Logger.Warn(

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -240,7 +240,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 this._handlePivot();
 
                 this.attachedNode.getWorldMatrix().decompose(nodeScale, nodeQuaternion, nodeTranslation);
-                const uniformScaling = Math.abs(nodeScale.x - nodeScale.y) <= Epsilon && Math.abs(nodeScale.x - nodeScale.z) <= Epsilon;
+                const uniformScaling = Math.abs(Math.abs(nodeScale.x) - Math.abs(nodeScale.y)) <= Epsilon && Math.abs(Math.abs(nodeScale.x) - Math.abs(nodeScale.z)) <= Epsilon;
                 if (!uniformScaling && this.updateGizmoRotationToMatchAttachedMesh) {
                     Logger.Warn(
                         "Unable to use a rotation gizmo matching mesh rotation with non uniform scaling. Use uniform scaling or set updateGizmoRotationToMatchAttachedMesh to false."


### PR DESCRIPTION
fixes #13315 

uniform scaling check was not taking negative component properly. Added a comment for future me.