### PR TITLE
InputManager: Update logic for detecting when to pick

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -266,7 +266,7 @@ export class InputManager {
     }
 
     private _checkForPicking(): boolean {
-        return !!(this._scene.onPointerObservable.observers.length > this._cameraObserverCount || this._scene.onPointerPick || this._scene.onPointerUp);
+        return !!(this._scene.onPointerObservable.observers.length > this._cameraObserverCount || this._scene.onPointerPick);
     }
 
     private _checkPrePointerObservable(pickResult: Nullable<PickingInfo>, evt: IPointerEvent, type: number) {
@@ -570,7 +570,7 @@ export class InputManager {
         this._initActionManager = (act: Nullable<AbstractActionManager>): Nullable<AbstractActionManager> => {
             if (!this._meshPickProceed) {
                 const pickResult =
-                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !this._checkForPicking())
+                    scene.skipPointerUpPicking || (scene._registeredActions === 0 && !this._checkForPicking() && !scene.onPointerUp)
                         ? null
                         : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, false, scene.cameraToUseForPointers);
                 this._currentPickResult = pickResult;
@@ -810,7 +810,7 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !this._checkForPicking())) {
+            if (scene.skipPointerDownPicking  || (scene._registeredActions === 0 && !this._checkForPicking() && !scene.onPointerDown)) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);
@@ -887,7 +887,7 @@ export class InputManager {
                 }
 
                 // Meshes
-                if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || this._checkForPicking())) {
+                if (!this._meshPickProceed && ((AbstractActionManager && AbstractActionManager.HasTriggers) || this._checkForPicking() || scene.onPointerUp)) {
                     this._initActionManager(null, clickInfo);
                 }
                 if (!pickResult) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -810,7 +810,7 @@ export class InputManager {
             // Meshes
             this._pickedDownMesh = null;
             let pickResult;
-            if (scene.skipPointerDownPicking  || (scene._registeredActions === 0 && !this._checkForPicking() && !scene.onPointerDown)) {
+            if (scene.skipPointerDownPicking || (scene._registeredActions === 0 && !this._checkForPicking() && !scene.onPointerDown)) {
                 pickResult = new PickingInfo();
             } else {
                 pickResult = scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerDownPredicate, false, scene.cameraToUseForPointers);

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -3,11 +3,12 @@
  */
 
 import { FreeCamera } from "core/Cameras";
+import type { PickingInfo } from "core/Collisions/pickingInfo";
 import { DeviceType, PointerInput } from "core/DeviceInput";
 import { InternalDeviceSourceManager } from "core/DeviceInput/internalDeviceSourceManager";
 import { NullEngine } from "core/Engines";
 import type { Engine } from "core/Engines/engine";
-import type { IUIEvent } from "core/Events";
+import type { IPointerEvent, IUIEvent } from "core/Events";
 import { PointerEventTypes } from "core/Events";
 import { Vector3 } from "core/Maths/math.vector";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
@@ -90,31 +91,34 @@ describe("InputManager", () => {
         let upCt = 0;
         let upHitCt = 0;
         let pickCt = 0;
-        const box = MeshBuilder.CreateBox("box", { size: 1 }, scene);
-        box.enablePointerMoveEvents = true;
-
-        scene!.onPointerDown = (evt, pickInfo) => {
+        const downFn = (evt: IPointerEvent, pickInfo: PickingInfo) => {
             if (pickInfo.hit) {
                 downHitCt++;
             }
             downCt++;
         };
-
-        scene!.onPointerMove = (evt, pickInfo) => {
+        const moveFn = (evt: IPointerEvent, pickInfo: PickingInfo) => {
             if (pickInfo.hit) {
                 moveHitCt++;
             }
             moveCt++;
         };
-
-        scene!.onPointerUp = (evt, pickInfo) => {
+        const upFn = (evt: IPointerEvent, pickInfo: Nullable<PickingInfo>, type: PointerEventTypes) => {
             if (pickInfo?.hit) {
                 upHitCt++;
             }
             upCt++;
         };
+        const pickFn = () => {
+            pickCt++;
+        };
+        const box = MeshBuilder.CreateBox("box", { size: 1 }, scene);
+        box.enablePointerMoveEvents = true;
 
-        if (deviceInputSystem) {
+        if (deviceInputSystem && scene) {
+            scene.onPointerDown = downFn;
+            scene.onPointerMove = moveFn;
+            scene.onPointerUp = upFn;
             // Perform single move over mesh, then click
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 128, false);
@@ -138,9 +142,7 @@ describe("InputManager", () => {
 
             // Since the pick checks for up and down also include checking for onPointerPick, we need to check with the callback not defined
             // This is the check with the callback defined
-            scene!.onPointerPick = () => {
-                pickCt++;
-            };
+            scene.onPointerPick = pickFn;
 
             // Repeat the above tests with the onPointerPick callback defined
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
@@ -148,16 +150,65 @@ describe("InputManager", () => {
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Test just down
+            scene.onPointerUp = undefined;
+            scene.onPointerMove = undefined;
+            scene.onPointerPick = undefined;
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Test just move
+            scene.onPointerDown = undefined;
+            scene.onPointerMove = moveFn;
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Test just up
+            scene.onPointerUp = upFn;
+            scene.onPointerMove = undefined;
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 128, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
         }
 
-        expect(downCt).toBe(4);
-        expect(upCt).toBe(4);
-        expect(moveCt).toBe(4);
+        expect(downCt).toBe(6);
+        expect(upCt).toBe(6);
+        expect(moveCt).toBe(6);
         expect(pickCt).toBe(1);
         // Check that picking on other callbacks is working
-        expect(downHitCt).toBe(2);
-        expect(upHitCt).toBe(2);
-        expect(moveHitCt).toBe(2);
+        expect(downHitCt).toBe(3);
+        expect(upHitCt).toBe(3);
+        expect(moveHitCt).toBe(3);
     });
 
     it("onPointerObservable can pick only when necessary", () => {


### PR DESCRIPTION
In the forum, there was an issue found where particle picking wasn't working properly.  It was determined that there was an issue with the function used to define when picking would happen.  This PR fixes that issue.  Additionally, tests have been added to check for this in future PRs.

Forum Link: https://forum.babylonjs.com/t/picking-particles-in-sps-bug/36259/6