### PR TITLE
NME: Add a rgb output to the ImageProcessing block

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
@@ -26,10 +26,16 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
     public constructor(name: string) {
         super(name, NodeMaterialBlockTargets.Fragment);
 
-        this.registerInput("color", NodeMaterialBlockConnectionPointTypes.Color4);
+        this.registerInput("color", NodeMaterialBlockConnectionPointTypes.AutoDetect);
         this.registerOutput("output", NodeMaterialBlockConnectionPointTypes.Color4);
+        this.registerOutput("rgb", NodeMaterialBlockConnectionPointTypes.Color3);
 
-        this._inputs[0].acceptedConnectionPointTypes.push(NodeMaterialBlockConnectionPointTypes.Color3);
+        this._inputs[0].addExcludedConnectionPointFromAllowedTypes(
+            NodeMaterialBlockConnectionPointTypes.Color3 |
+                NodeMaterialBlockConnectionPointTypes.Color4 |
+                NodeMaterialBlockConnectionPointTypes.Vector3 |
+                NodeMaterialBlockConnectionPointTypes.Vector4
+        );
     }
 
     /**
@@ -58,6 +64,13 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
      */
     public get output(): NodeMaterialConnectionPoint {
         return this._outputs[0];
+    }
+
+    /**
+     * Gets the rgb component
+     */
+    public get rgb(): NodeMaterialConnectionPoint {
+        return this._outputs[1];
     }
 
     /**
@@ -139,23 +152,29 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
         state._emitFunctionFromInclude("imageProcessingDeclaration", comments);
         state._emitFunctionFromInclude("imageProcessingFunctions", comments);
 
-        if (color.connectedPoint!.type === NodeMaterialBlockConnectionPointTypes.Color4 || color.connectedPoint!.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
-            state.compilationString += `${this._declareOutput(output, state)} = ${color.associatedVariableName};\r\n`;
-        } else {
-            state.compilationString += `${this._declareOutput(output, state)} = vec4(${color.associatedVariableName}, 1.0);\r\n`;
+        if (color.connectedPoint?.isConnected) {
+            if (color.connectedPoint!.type === NodeMaterialBlockConnectionPointTypes.Color4 || color.connectedPoint!.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
+                state.compilationString += `${this._declareOutput(output, state)} = ${color.associatedVariableName};\r\n`;
+            } else {
+                state.compilationString += `${this._declareOutput(output, state)} = vec4(${color.associatedVariableName}, 1.0);\r\n`;
+            }
+            state.compilationString += `#ifdef IMAGEPROCESSINGPOSTPROCESS\r\n`;
+            if (this.convertInputToLinearSpace) {
+                state.compilationString += `${output.associatedVariableName}.rgb = toLinearSpace(${color.associatedVariableName}.rgb);\r\n`;
+            }
+            state.compilationString += `#else\r\n`;
+            state.compilationString += `#ifdef IMAGEPROCESSING\r\n`;
+            if (this.convertInputToLinearSpace) {
+                state.compilationString += `${output.associatedVariableName}.rgb = toLinearSpace(${color.associatedVariableName}.rgb);\r\n`;
+            }
+            state.compilationString += `${output.associatedVariableName} = applyImageProcessing(${output.associatedVariableName});\r\n`;
+            state.compilationString += `#endif\r\n`;
+            state.compilationString += `#endif\r\n`;
+
+            if (this.rgb.hasEndpoints) {
+                state.compilationString += this._declareOutput(this.rgb, state) + ` = ${this.output.associatedVariableName}.xyz;\r\n`;
+            }
         }
-        state.compilationString += `#ifdef IMAGEPROCESSINGPOSTPROCESS\r\n`;
-        if (this.convertInputToLinearSpace) {
-            state.compilationString += `${output.associatedVariableName}.rgb = toLinearSpace(${color.associatedVariableName}.rgb);\r\n`;
-        }
-        state.compilationString += `#else\r\n`;
-        state.compilationString += `#ifdef IMAGEPROCESSING\r\n`;
-        if (this.convertInputToLinearSpace) {
-            state.compilationString += `${output.associatedVariableName}.rgb = toLinearSpace(${color.associatedVariableName}.rgb);\r\n`;
-        }
-        state.compilationString += `${output.associatedVariableName} = applyImageProcessing(${output.associatedVariableName});\r\n`;
-        state.compilationString += `#endif\r\n`;
-        state.compilationString += `#endif\r\n`;
 
         return this;
     }

--- a/packages/dev/core/src/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes.ts
+++ b/packages/dev/core/src/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes.ts
@@ -3,25 +3,27 @@
  */
 export enum NodeMaterialBlockConnectionPointTypes {
     /** Float */
-    Float = 1,
+    Float = 0x0001,
     /** Int */
-    Int = 2,
+    Int = 0x0002,
     /** Vector2 */
-    Vector2 = 4,
+    Vector2 = 0x0004,
     /** Vector3 */
-    Vector3 = 8,
+    Vector3 = 0x0008,
     /** Vector4 */
-    Vector4 = 16,
+    Vector4 = 0x0010,
     /** Color3 */
-    Color3 = 32,
+    Color3 = 0x0020,
     /** Color4 */
-    Color4 = 64,
+    Color4 = 0x0040,
     /** Matrix */
-    Matrix = 128,
+    Matrix = 0x0080,
     /** Custom object */
-    Object = 256,
+    Object = 0x0100,
     /** Detect type based on connection */
-    AutoDetect = 1024,
+    AutoDetect = 0x0400,
     /** Output type that will be defined by input type */
-    BasedOnInput = 2048,
+    BasedOnInput = 0x0800,
+    /** Bitmask of all types */
+    All = 0x0fff,
 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -516,6 +516,20 @@ export class NodeMaterialConnectionPoint {
     }
 
     /**
+     * Fill the list of excluded connection point types with all types other than those passed in the parameter
+     * @param mask Types (ORed values of NodeMaterialBlockConnectionPointTypes) that are allowed, and thus will not be pushed to the excluded list
+     */
+    public addExcludedConnectionPointFromAllowedTypes(mask: number): void {
+        let bitmask = 1;
+        while (bitmask < NodeMaterialBlockConnectionPointTypes.All) {
+            if (!(mask & bitmask)) {
+                this.excludedConnectionPointTypes.push(bitmask);
+            }
+            bitmask = bitmask << 1;
+        }
+    }
+
+    /**
      * Serializes this point in a JSON representation
      * @param isInput defines if the connection point is an input (default is true)
      * @returns the serialized point object


### PR DESCRIPTION
The PR also changes the `color` input type to **AutoDetect** to make it clear that it accepts multiple types.

Closes BabylonJS/ThePirateCove#296