### PR TITLE
Make sure BONETEXTURE is always set with a value when supported

### DIFF
--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -202,6 +202,9 @@ export class MaterialHelper {
         } else {
             defines["NUM_BONE_INFLUENCERS"] = 0;
             defines["BonesPerMesh"] = 0;
+            if (defines["BONETEXTURE"] !== undefined) {
+                defines["BONETEXTURE"] = false;
+            }
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/chrome-visual-glitch-when-baking-and-nulling-mesh-skeleton/36372