### PR TITLE
InputManager: Add call to update transformation matrix on move

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -238,6 +238,10 @@ export class InputManager {
         }
 
         if (scene.onPointerObservable.hasObservers()) {
+            // Normally, the transform matrix (and also the view matrix) are updated when the
+            // picking ray is created. But in this case, the picking ray may not be created so
+            // we need to update the transform matrix here.
+            scene.updateTransformMatrix();
             scene.onPointerObservable.notifyObservers(pointerInfo, type);
         }
     }


### PR DESCRIPTION
An issue was found on the forums where a custom render loop no longer had a moving camera when interacted with.  It was determined that `camera.onViewMatrixChangedObservable` was no longer notifying observers when it should.  While this functionality is present in the standard `scene.render` function, it was also called as a part of the picking ray generation for a move.  With new changes to how picking is handled, the notify could be missed if `scene.render` isn't called.  This PR adds a call to scene.updateTransformMatrix to update the matrices without generating a picking ray.

Forum Link: https://forum.babylonjs.com/t/on-demand-rendering-solution-broken-since-5-29/36379/4