### PR TITLE
ADT: Fix default cursor change

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -209,7 +209,7 @@ export class InputManager {
 
             // Restore pointer
             if (!scene.doNotHandleCursors) {
-                canvas.style.cursor = scene.defaultCursor;
+                scene._setCursor(scene.defaultCursor);
             }
         }
 
@@ -315,7 +315,8 @@ export class InputManager {
             if (!scene.doNotHandleCursors && canvas && this._pointerOverMesh) {
                 const actionManager = this._pointerOverMesh._getActionManagerForTrigger();
                 if (actionManager && actionManager.hasPointerTriggers) {
-                    canvas.style.cursor = actionManager.hoverCursor || scene.hoverCursor;
+                    const cursor = actionManager.hoverCursor || scene.hoverCursor;
+                    scene._setCursor(cursor);
                 }
             }
         } else {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -417,6 +417,24 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * Defines whether cursors are handled by the scene.
      */
     public doNotHandleCursors = false;
+
+    /** @internal */
+    public _lastUsedCursor: string = "";
+
+    /** @internal */
+    public _setCursor(cursor: string) {
+        if (this.doNotHandleCursors) {
+            return;
+        }
+
+        const canvas = this._engine.getInputElement();
+
+        if (canvas) {
+            this._lastUsedCursor = canvas.style.cursor;
+            canvas.style.cursor = cursor !== "" ? cursor : this.defaultCursor;
+        }
+    }
+
     /**
      * This is used to call preventDefault() on pointer down
      * in order to block unwanted artifacts like system double clicks

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -419,9 +419,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public doNotHandleCursors = false;
 
     /** @internal */
-    public _lastUsedCursor: string = "";
-
-    /** @internal */
     public _setCursor(cursor: string) {
         if (this.doNotHandleCursors) {
             return;
@@ -430,7 +427,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         const canvas = this._engine.getInputElement();
 
         if (canvas) {
-            this._lastUsedCursor = canvas.style.cursor;
             canvas.style.cursor = cursor || this.defaultCursor;
         }
     }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -431,7 +431,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         if (canvas) {
             this._lastUsedCursor = canvas.style.cursor;
-            canvas.style.cursor = cursor !== "" ? cursor : this.defaultCursor;
+            canvas.style.cursor = cursor || this.defaultCursor;
         }
     }
 

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -744,10 +744,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      */
     public _changeCursor(cursor: string) {
         const scene = this.getScene();
-        if (this._rootElement && scene) {
-            scene._lastUsedCursor = this._rootElement.style.cursor;
-            const cursorToSet = cursor || scene._lastUsedCursor;
-            scene._setCursor(cursorToSet);
+        if (this._rootElement && scene && cursor) {
+            scene._setCursor(cursor);
             this._cursorChanged = true;
         }
     }

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -746,7 +746,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         const scene = this.getScene();
         if (this._rootElement && scene) {
             scene._lastUsedCursor = this._rootElement.style.cursor;
-            this._rootElement.style.cursor = cursor !== "" ? cursor : scene._lastUsedCursor;
+            const cursorToSet = cursor || scene._lastUsedCursor;
+            scene._setCursor(cursorToSet);
             this._cursorChanged = true;
         }
     }

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -743,8 +743,10 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * @internal
      */
     public _changeCursor(cursor: string) {
-        if (this._rootElement) {
-            this._rootElement.style.cursor = cursor;
+        const scene = this.getScene();
+        if (this._rootElement && scene) {
+            scene._lastUsedCursor = this._rootElement.style.cursor;
+            this._rootElement.style.cursor = cursor !== "" ? cursor : scene._lastUsedCursor;
             this._cursorChanged = true;
         }
     }


### PR DESCRIPTION
An issue was recently found where a manually defined hover cursor was being overwritten when clicking a specific mesh.  It was determined that there was a function that was updating the cursor without accounting for the perviously defined hover cursor.  This issue was only present when an AdvancedDynamicTexture object was created.  This PR will store the previous cursor and restore it after ADT picking was complete.
Forum Link: https://forum.babylonjs.com/t/actionmanager-hovercursor-conflict-with-gui-adv-gui-action-manager/36270