### PR TITLE
NME: Add a CSS class to all graph nodes

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
@@ -617,6 +617,8 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
         // Graph
         const node = this.appendNode(nodeData);
 
+        node.addClassToVisual(nodeData.getClassName());
+
         // Links
         if (nodeData.inputs.length && recursion) {
             for (const input of nodeData.inputs) {

--- a/packages/tools/nodeEditor/src/graphEditor.tsx
+++ b/packages/tools/nodeEditor/src/graphEditor.tsx
@@ -427,6 +427,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
 
             block.autoConfigure(this.props.globalState.nodeMaterial);
             newNode = this.appendBlock(block);
+            newNode.addClassToVisual(block.getClassName());
         }
 
         // Size exceptions

--- a/packages/tools/nodeEditor/src/main.scss
+++ b/packages/tools/nodeEditor/src/main.scss
@@ -356,4 +356,8 @@
         grid-row: 2;
         grid-column: 3;
     }
+
+    .LightInformationBlock {
+        width: 280px;
+    }
 }


### PR DESCRIPTION
Use this new feature to widen the `LightInformationBlock`.

Closes #13329 