### PR TITLE
Allow adding a dynamic @since tag that adjusts automatically

### DIFF
--- a/scripts/updateSinceTag.js
+++ b/scripts/updateSinceTag.js
@@ -19,9 +19,6 @@ const updateSinceTag = (version) => {
         try {
             // check if file contains @since\n
             const data = fs.readFileSync(file, "utf-8").replace(/\r/gm, "");
-            if (file.indexOf("engine.ts") !== -1) {
-                console.log(data.indexOf("* @since\n"));
-            }
             if (data.indexOf("* @since\n") !== -1) {
                 console.log(`Updating @since tag in ${file} to ${version}`);
                 // replace @since with @since version

--- a/scripts/updateSinceTag.js
+++ b/scripts/updateSinceTag.js
@@ -16,22 +16,26 @@ const updateSinceTag = (version) => {
     // get all typescript files in the dev folder
     const files = glob.sync(path.join(baseDirectory, "packages", "dev", "**", "*.ts"));
     files.forEach((file) => {
-        // check if file contains @since\n
-        const data = fs.readFileSync(file, "utf-8").replace(/\r/gm, "");
-        if(file.indexOf("engine.ts") !== -1) {
-            console.log(data.indexOf("* @since\n"));
-        }
-        if (data.indexOf("* @since\n") !== -1) {
-            console.log(`Updating @since tag in ${file} to ${version}`)
-            // replace @since with @since version
-            const newData = data.replace(
-                /\* @since\n/gm,
-                `* @since ${version}
-`
-            );
+        try {
+            // check if file contains @since\n
+            const data = fs.readFileSync(file, "utf-8").replace(/\r/gm, "");
+            if (file.indexOf("engine.ts") !== -1) {
+                console.log(data.indexOf("* @since\n"));
+            }
+            if (data.indexOf("* @since\n") !== -1) {
+                console.log(`Updating @since tag in ${file} to ${version}`);
+                // replace @since with @since version
+                const newData = data.replace(
+                    /\* @since\n/gm,
+                    `* @since ${version}
+    `
+                );
 
-            // write file
-            fs.writeFileSync(file, newData);
+                // write file
+                fs.writeFileSync(file, newData);
+            }
+        } catch (e) {
+            console.log(e);
         }
     });
 };

--- a/scripts/updateSinceTag.js
+++ b/scripts/updateSinceTag.js
@@ -1,0 +1,40 @@
+const path = require("path");
+const fs = require("fs");
+const glob = require("glob");
+
+const baseDirectory = path.resolve(".");
+
+const getNewVersion = () => {
+    // get @dev/core package.json
+    const rawdata = fs.readFileSync(path.join(baseDirectory, "packages", "public", "umd", "babylonjs", "package.json"), "utf-8");
+    const packageJson = JSON.parse(rawdata);
+    const version = packageJson.version;
+    return version;
+};
+
+const updateSinceTag = (version) => {
+    // get all typescript files in the dev folder
+    const files = glob.sync(path.join(baseDirectory, "packages", "dev", "**", "*.ts"));
+    files.forEach((file) => {
+        // check if file contains @since\n
+        const data = fs.readFileSync(file, "utf-8").replace(/\r/gm, "");
+        if(file.indexOf("engine.ts") !== -1) {
+            console.log(data.indexOf("* @since\n"));
+        }
+        if (data.indexOf("* @since\n") !== -1) {
+            console.log(`Updating @since tag in ${file} to ${version}`)
+            // replace @since with @since version
+            const newData = data.replace(
+                /\* @since\n/gm,
+                `* @since ${version}
+`
+            );
+
+            // write file
+            fs.writeFileSync(file, newData);
+        }
+    });
+};
+
+const version = getNewVersion();
+updateSinceTag(version);

--- a/scripts/updateSinceTag.js
+++ b/scripts/updateSinceTag.js
@@ -28,7 +28,7 @@ const updateSinceTag = (version) => {
                 const newData = data.replace(
                     /\* @since\n/gm,
                     `* @since ${version}
-    `
+`
                 );
 
                 // write file


### PR DESCRIPTION
Fixes #13209

This script will be running during the publish CI process and update all tags marked with @since with nothing after (newline only) something like this:

```javascript
/**
 * This function does nothing, please use it as much as you want
 * @since
 */
buyNFT();
```

If there is anything after the @since tag it will not be processed.