### PR TITLE
DepthRenderer: Allow passing the sampling mode to the scene depth renderer

### DIFF
--- a/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
@@ -18,9 +18,10 @@ declare module "../scene" {
          * @param camera The camera to create the depth renderer on (default: scene's active camera)
          * @param storeNonLinearDepth Defines whether the depth is stored linearly like in Babylon Shadows or directly like glFragCoord.z
          * @param force32bitsFloat Forces 32 bits float when supported (else 16 bits float is prioritized over 32 bits float if supported)
+         * @param samplingMode The sampling mode to be used with the render target (Linear, Nearest...)
          * @returns the created depth renderer
          */
-        enableDepthRenderer(camera?: Nullable<Camera>, storeNonLinearDepth?: boolean, force32bitsFloat?: boolean): DepthRenderer;
+        enableDepthRenderer(camera?: Nullable<Camera>, storeNonLinearDepth?: boolean, force32bitsFloat?: boolean, samplingMode?: number): DepthRenderer;
 
         /**
          * Disables a depth renderer for a given camera
@@ -30,7 +31,12 @@ declare module "../scene" {
     }
 }
 
-Scene.prototype.enableDepthRenderer = function (camera?: Nullable<Camera>, storeNonLinearDepth = false, force32bitsFloat: boolean = false): DepthRenderer {
+Scene.prototype.enableDepthRenderer = function (
+    camera?: Nullable<Camera>,
+    storeNonLinearDepth = false,
+    force32bitsFloat: boolean = false,
+    samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE
+): DepthRenderer {
     camera = camera || this.activeCamera;
     if (!camera) {
         throw "No camera available to enable depth renderer";
@@ -48,7 +54,7 @@ Scene.prototype.enableDepthRenderer = function (camera?: Nullable<Camera>, store
         } else {
             textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
-        this._depthRenderer[camera.id] = new DepthRenderer(this, textureType, camera, storeNonLinearDepth);
+        this._depthRenderer[camera.id] = new DepthRenderer(this, textureType, camera, storeNonLinearDepth, samplingMode);
     }
 
     return this._depthRenderer[camera.id];


### PR DESCRIPTION
See https://forum.babylonjs.com/t/flickering-issue-when-sampling-depth-in-chromium-browsers-but-not-other-browsers/36299/4