### PR TITLE
Rework Scene and GUI Editor connection

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2323,6 +2323,11 @@ export class Control implements IAnimatable {
         this.getDescendants().forEach((child) => child._markAllAsDirty());
     }
 
+    /**
+     * Clones a control and its descendants
+     * @param host the texture where the control will be instantiated. Can be empty, in which case the control will be created on the same texture
+     * @returns the cloned control
+     */
     public clone(host?: AdvancedDynamicTexture): Control {
         const serialization: any = {};
         this.serialize(serialization);
@@ -2334,6 +2339,12 @@ export class Control implements IAnimatable {
         return cloned;
     }
 
+    /**
+     * Parses a serialized object into this control
+     * @param serializedObject the object with the serialized properties
+     * @param host the texture where the control will be instantiated. Can be empty, in which case the control will be created on the same texture
+     * @returns this control
+     */
     public parse(serializedObject: any, host?: AdvancedDynamicTexture): Control {
         SerializationHelper.Parse(() => this, serializedObject, null);
 

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2323,6 +2323,27 @@ export class Control implements IAnimatable {
         this.getDescendants().forEach((child) => child._markAllAsDirty());
     }
 
+    public clone(host?: AdvancedDynamicTexture): Control {
+        const serialization: any = {};
+        this.serialize(serialization);
+
+        const controlType = Tools.Instantiate("BABYLON.GUI." + serialization.className);
+        const cloned = new controlType();
+        cloned.parse(serialization, host);
+
+        return cloned;
+    }
+
+    public parse(serializedObject: any, host?: AdvancedDynamicTexture): Control {
+        SerializationHelper.Parse(() => this, serializedObject, null);
+
+        this.name = serializedObject.name;
+
+        this._parseFromContent(serializedObject, host ?? this._host);
+
+        return this;
+    }
+
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object

--- a/packages/tools/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/tools/guiEditor/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -217,7 +217,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
             return null;
         }
 
-        const guiElements = scene.textures.filter((t) => t.getClassName() === "AdvancedDynamicTexture");
+        const guiElements = [this.props.globalState.guiTexture];
 
         return (
             <div

--- a/packages/tools/guiEditor/src/diagram/gizmoGeneric.tsx
+++ b/packages/tools/guiEditor/src/diagram/gizmoGeneric.tsx
@@ -206,7 +206,6 @@ export class GizmoGeneric extends React.Component<IGuiGizmoProps, IGuiGizmoState
             const inNodeSpace = CoordinateHelper.RttToLocalNodeSpace(node, inRTT.x, inRTT.y, undefined, this._storedValues);
             this._dragLocalBounds(inNodeSpace);
             this._updateNodeFromLocalBounds();
-            this.props.globalState.workbench._liveGuiTextureRerender = false;
             this.props.globalState.onPropertyGridUpdateRequiredObservable.notifyObservers();
         }
         if (this.state.isRotating) {


### PR DESCRIPTION
Currently, when a GUI Editor instance is opened through the Inspector, all existing controls on the Scene are removed and then re-added to both the "live" scene and the editor scene. This has been causing variety of problems, such as:

- When a control in the editor is scaled, it doesn't update visually on the live scene
- If a control in the live scene is linked to a mesh, it loses that connection after the editor is opened
- Scroll viewers on the live scene lose scroll functionality once the editor is opened
- Controls on the live scene changed size because the editor scene could have a different size 

This PR introduces a new approach, such as when the editor is opened, the "live" scene's Controls are cloned and the clones added to the editor scene. Then, it periodically executes the opposite operation, cloning the editor controllers and adding them to the live scene.  