### PR TITLE
docs: ES6 packages installation note in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ BabylonJS and its modules are published on npm with full typing support. To inst
 npm install babylonjs --save
 ```
 
+> alternatively, you can now rely on our Babylon.js [ES6 packages](https://doc.babylonjs.com/setup/frameworkPackages/npmSupport#es6). Using the ES6 version will allow tree shaking among other bundling benefits.
+
 This will allow you to import BabylonJS entirely using:
 
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ BabylonJS and its modules are published on npm with full typing support. To inst
 npm install babylonjs --save
 ```
 
-> alternatively, you can now rely on our Babylon.js [ES6 packages](https://doc.babylonjs.com/setup/frameworkPackages/npmSupport#es6). Using the ES6 version will allow tree shaking among other bundling benefits.
+> alternatively, you can now rely on our [ES6 packages](https://doc.babylonjs.com/setup/frameworkPackages/npmSupport#es6). Using the ES6 version will allow tree shaking among other bundling benefits.
 
 This will allow you to import BabylonJS entirely using:
 


### PR DESCRIPTION
IMO, this added note in the installation documentation can clear possible confusion between using 'babylonjs' and using its '@babylonjs/core' counterpart.

An example for this possible confusion can be seen in [this](https://forum.babylonjs.com/t/difference-between-babylonjs-and-babylonjs-npm-packages/28380/4) forum question.

I think the reason this can be confusing is that some NPM packages use a none-scoped package such as 'package-name' that uses a scoped package ('@scope/package-name') behind the scenes. With `Babylon.js`, this is not the case, you can use one or the other, the original package or its ES6 counterpart, not both.

This note clears this up. 

Perhaps even add a complete section to emphasis the ES6 version installation process? Will the ES6 version be the recommended go-to version in the near future?