### PR TITLE
LineMesh: Fix the signature of dispose

### DIFF
--- a/packages/dev/core/src/Meshes/linesMesh.ts
+++ b/packages/dev/core/src/Meshes/linesMesh.ts
@@ -207,9 +207,11 @@ export class LinesMesh extends Mesh {
     /**
      * Disposes of the line mesh
      * @param doNotRecurse If children should be disposed
+     * @param disposeMaterialAndTextures This parameter is not used by the LineMesh class
      * @param doNotDisposeMaterial If the material should not be disposed (default: false, meaning the material is disposed)
      */
-    public dispose(doNotRecurse?: boolean, doNotDisposeMaterial?: boolean): void {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public dispose(doNotRecurse?: boolean, disposeMaterialAndTextures = false, doNotDisposeMaterial?: boolean): void {
         if (!doNotDisposeMaterial) {
             this._lineMaterial.dispose(false, false, true);
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/best-way-to-keep-dash-size-constant/36631/19

I added the `disposeMaterialAndTextures` parameter to be in line with the base class signature but don't use it to keep backward compatibility.

Follow-up to #13358 