### PR TITLE
EXT_texture_avif implementation

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
@@ -149,6 +149,11 @@ export class GLTFComponent extends React.Component<IGLTFComponentProps> {
                         onSelect={(value) => (extensionStates["EXT_texture_webp"].enabled = value)}
                     />
                     <CheckBoxLineComponent
+                        label="EXT_texture_avif"
+                        isSelected={() => extensionStates["EXT_texture_avif"].enabled}
+                        onSelect={(value) => (extensionStates["EXT_texture_avif"].enabled = value)}
+                    />
+                    <CheckBoxLineComponent
                         label="KHR_draco_mesh_compression"
                         isSelected={() => extensionStates["KHR_draco_mesh_compression"].enabled}
                         onSelect={(value) => (extensionStates["KHR_draco_mesh_compression"].enabled = value)}

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -59,6 +59,7 @@ export class GlobalState {
         EXT_lights_image_based: { enabled: true },
         EXT_mesh_gpu_instancing: { enabled: true },
         EXT_texture_webp: { enabled: true },
+        EXT_texture_avif: { enabled: true },
     };
 
     public glTFLoaderDefaults: { [key: string]: any } = {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
@@ -8,6 +8,7 @@ import type { IEXTTextureAVIF } from "babylonjs-gltf2interface";
 const NAME = "EXT_texture_avif";
 
 /**
+ * [glTF PR](https://github.com/KhronosGroup/glTF/pull/2235)
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_avif/README.md)
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
@@ -1,0 +1,57 @@
+import type { IGLTFLoaderExtension } from "../glTFLoaderExtension";
+import { GLTFLoader, ArrayItem } from "../glTFLoader";
+import type { ITexture } from "../glTFLoaderInterfaces";
+import type { BaseTexture } from "core/Materials/Textures/baseTexture";
+import type { Nullable } from "core/types";
+import type { IEXTTextureAVIF } from "babylonjs-gltf2interface";
+
+const NAME = "EXT_texture_avif";
+
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_avif/README.md)
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class EXT_texture_avif implements IGLTFLoaderExtension {
+    /** The name of this extension. */
+    public readonly name = NAME;
+
+    /** Defines whether this extension is enabled. */
+    public enabled: boolean;
+
+    private _loader: GLTFLoader;
+
+    /**
+     * @internal
+     */
+    constructor(loader: GLTFLoader) {
+        this._loader = loader;
+        this.enabled = loader.isExtensionUsed(NAME);
+    }
+
+    /** @internal */
+    public dispose() {
+        (this._loader as any) = null;
+    }
+
+    /**
+     * @internal
+     */
+    public _loadTextureAsync(context: string, texture: ITexture, assign: (babylonTexture: BaseTexture) => void): Nullable<Promise<BaseTexture>> {
+        return GLTFLoader.LoadExtensionAsync<IEXTTextureAVIF, BaseTexture>(context, texture, this.name, (extensionContext, extension) => {
+            const sampler = texture.sampler == undefined ? GLTFLoader.DefaultSampler : ArrayItem.Get(`${context}/sampler`, this._loader.gltf.samplers, texture.sampler);
+            const image = ArrayItem.Get(`${extensionContext}/source`, this._loader.gltf.images, extension.source);
+            return this._loader._createTextureAsync(
+                context,
+                sampler,
+                image,
+                (babylonTexture) => {
+                    assign(babylonTexture);
+                },
+                undefined,
+                !texture._textureInfo.nonColorData
+            );
+        });
+    }
+}
+
+GLTFLoader.RegisterExtension(NAME, (loader) => new EXT_texture_avif(loader));

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
@@ -2,6 +2,7 @@ export * from "./EXT_lights_image_based";
 export * from "./EXT_mesh_gpu_instancing";
 export * from "./EXT_meshopt_compression";
 export * from "./EXT_texture_webp";
+export * from "./EXT_texture_avif";
 export * from "./KHR_draco_mesh_compression";
 export * from "./KHR_lights_punctual";
 export * from "./KHR_materials_pbrSpecularGlossiness";

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -78,6 +78,8 @@ function getFileExtensionFromMimeType(mimeType: ImageMimeType): string {
             return ".png";
         case ImageMimeType.WEBP:
             return ".webp";
+        case ImageMimeType.AVIF:
+            return ".avif";
     }
 }
 

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -1189,6 +1189,15 @@ declare module BABYLON.GLTF2 {
     }
 
     /**
+     * Interfaces from the EXT_texture_avif extension
+     */
+
+    /** @internal */
+    interface IEXTTextureAVIF {
+        source: number;
+    }
+
+    /**
      * Interfaces from the KHR_texture_transform extension
      */
 

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -148,6 +148,10 @@ declare module BABYLON.GLTF2 {
          * WEBP Mime-type
          */
         WEBP = "image/webp",
+        /**
+         * AVIF Mime-type
+         */
+        AVIF = "image/avif",
     }
 
     /**
@@ -1224,7 +1228,6 @@ declare module BABYLON.GLTF2 {
     interface IKHRXmpJsonLd_Node {
         packet: number;
     }
-
 
     /**
      * Interfaces from the KHR_animation_pointer extension


### PR DESCRIPTION
My Christmas contribution is trying to get AVIF support in GLTF, Babylon and Three.

I Did a PR for the GLTF spec which you can find here
https://github.com/KhronosGroup/glTF/pull/2235

I have also done a PR for three here
https://github.com/mrdoob/three.js/issues/25171

My thoughts are the following.
Chrome recently gave up on jpeg xl which I personally thought was the superior replacement for gif, png, jpeg, webp.

The next best format after jpeg xl is avif, and since jpeg xl isn't happening I thought I could do a drive trying to improve the file size of gltf files by getting avif support.

Solution
Add the not yet merged https://github.com/KhronosGroup/glTF/pull/2235 EXT_texture_avif as a supported extension.