### PR TITLE
[GUI] If a new control is added on root, call the camera update function to…

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -56,6 +56,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _canvasPointerOutObserver: Nullable<Observer<PointerEvent>>;
     private _canvasBlurObserver: Nullable<Observer<Engine>>;
+    private _controlAddedObserver: Nullable<Observer<Nullable<Control>>>;
     private _background: string;
     /** @internal */
     public _rootContainer = new Container("root");
@@ -384,6 +385,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this.applyYInversionOnUpdate = invertY;
         this._rootElement = scene.getEngine().getInputElement();
         this._renderObserver = scene.onBeforeCameraRenderObservable.add((camera: Camera) => this._checkUpdate(camera));
+        this._controlAddedObserver = this._rootContainer.onControlAddedObservable.add((control) => {
+            if (control && this._scene && this._scene.activeCamera) {
+                this._checkUpdate(this._scene.activeCamera);
+            }
+        });
         this._preKeyboardObserver = scene.onPreKeyboardObservable.add((info) => {
             if (!this._focusedControl) {
                 return;
@@ -570,6 +576,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         }
         if (this._canvasBlurObserver) {
             scene.getEngine().onCanvasBlurObservable.remove(this._canvasBlurObserver);
+        }
+        if (this._controlAddedObserver) {
+            this._rootContainer.onControlAddedObservable.remove(this._controlAddedObserver);
         }
         if (this._layerToDispose) {
             this._layerToDispose.texture = null;


### PR DESCRIPTION
… update the positions of controls linked to meshes.

This is to fix a issue when the camera is moved while new controls are being added, and some of them are linked to a mesh, their positions have to be properly updated again.

Example PG: https://playground.babylonjs.com/#XCPP9Y#16922