### PR TITLE
Fix crash when calling getGlowLayerByName when no effects have been created yet

### DIFF
--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -38,7 +38,7 @@ declare module "../abstractScene" {
 }
 
 AbstractScene.prototype.getGlowLayerByName = function (name: string): Nullable<GlowLayer> {
-    for (let index = 0; index < this.effectLayers.length; index++) {
+    for (let index = 0; index < this.effectLayers?.length; index++) {
         if (this.effectLayers[index].name === name && this.effectLayers[index].getEffectName() === GlowLayer.EffectName) {
             return (<any>this.effectLayers[index]) as GlowLayer;
         }

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -29,9 +29,9 @@ import "../Layers/effectLayerSceneComponent";
 declare module "../abstractScene" {
     export interface AbstractScene {
         /**
-         * Return a the first highlight layer of the scene with a given name.
-         * @param name The name of the highlight layer to look for.
-         * @returns The highlight layer if found otherwise null.
+         * Return the first glow layer of the scene with a given name.
+         * @param name The name of the glow layer to look for.
+         * @returns The glow layer if found otherwise null.
          */
         getGlowLayerByName(name: string): Nullable<GlowLayer>;
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/scene-getglowlayerbyname-throws-undefined-reading-length-exception/36849