### PR TITLE
Don't serialize internal shader materials

### DIFF
--- a/packages/dev/core/src/Meshes/linesMesh.ts
+++ b/packages/dev/core/src/Meshes/linesMesh.ts
@@ -113,6 +113,7 @@ export class LinesMesh extends Mesh {
             this.material = material;
         } else {
             this.material = new ShaderMaterial("colorShader", this.getScene(), "color", options, false);
+            this.material.doNotSerialize = true;
         }
     }
 

--- a/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
+++ b/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
@@ -223,6 +223,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
             },
             false
         );
+        this._colorShader.doNotSerialize = true;
 
         this._colorShader.reservedDataStore = {
             hidden: true,
@@ -239,6 +240,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
             },
             true
         );
+        this._colorShaderForOcclusionQuery.doNotSerialize = true;
 
         this._colorShaderForOcclusionQuery.reservedDataStore = {
             hidden: true,


### PR DESCRIPTION
See https://forum.babylonjs.com/t/colorshader-and-colorshaderoccquery-kept-after-serialize/36870

We should not serialize those materials as they will be recreated automatically when needed.