### PR TITLE
Change GUI Editor default image URL

### DIFF
--- a/packages/tools/guiEditor/src/guiNodeTools.ts
+++ b/packages/tools/guiEditor/src/guiNodeTools.ts
@@ -18,7 +18,7 @@ import { RadioButton } from "gui/2D/controls/radioButton";
 import { ImageBasedSlider } from "gui/2D/controls/sliders/imageBasedSlider";
 
 export class GUINodeTools {
-    public static ImageControlDefaultUrl = "./imageControlDefault.jpg";
+    public static ImageControlDefaultUrl = "https://assets.babylonjs.com/textures/Checker_albedo.png";
 
     public static CreateControlFromString(data: string) {
         let element;


### PR DESCRIPTION
The previous URL couldn't be accessed if the GE was opened through the Playground, leading to an invalid image.