### PR TITLE
More defensive handling of name property in Inspector

### DIFF
--- a/packages/dev/inspector/src/tools.ts
+++ b/packages/dev/inspector/src/tools.ts
@@ -31,6 +31,13 @@ export class Tools {
         return result;
     }
 
+    public static GetNameString(obj: any) {
+        if (obj?.name?.toString) {
+            return obj.name.toString();
+        }
+        return "";
+    }
+
     public static SortAndFilter(parent: any, items: any[]): any[] {
         if (!items) {
             return [];
@@ -43,8 +50,8 @@ export class Tools {
         }
 
         return finalArray.sort((a: any, b: any) => {
-            const lowerCaseA = (a.name || "").toLowerCase();
-            const lowerCaseB = (b.name || "").toLowerCase();
+            const lowerCaseA = Tools.GetNameString(a).toLowerCase();
+            const lowerCaseB = Tools.GetNameString(b).toLowerCase();
 
             if (lowerCaseA === lowerCaseB) {
                 return 0;


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/debugger-layout-inspector-crash-after-opening-material-tab/36895