### PR TITLE
Add some comments on docs reinforcing that it's only possible to upda…

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -179,6 +179,7 @@ export class Gizmo implements IGizmo {
 
     /**
      * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
+     * NOTE: This is only possible for meshes with uniform scaling, as otherwise it's not possible to decompose the rotation
      */
     public set updateGizmoRotationToMatchAttachedMesh(value: boolean) {
         this._updateGizmoRotationToMatchAttachedMesh = value;

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -201,6 +201,10 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         return this._planarGizmoEnabled;
     }
 
+    /**
+     * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
+     * NOTE: This is only possible for meshes with uniform scaling, as otherwise it's not possible to decompose the rotation
+     */
     public set updateGizmoRotationToMatchAttachedMesh(value: boolean) {
         this._updateGizmoRotationToMatchAttachedMesh = value;
         [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -204,6 +204,10 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         }
     }
 
+    /**
+     * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
+     * NOTE: This is only possible for meshes with uniform scaling, as otherwise it's not possible to decompose the rotation
+     */
     public set updateGizmoRotationToMatchAttachedMesh(value: boolean) {
         if (this.xGizmo) {
             this.xGizmo.updateGizmoRotationToMatchAttachedMesh = value;


### PR DESCRIPTION
…te gizmo rotation on mesh when scaling is uniform.

Related forum issue: https://forum.babylonjs.com/t/unable-to-use-a-rotation-gizmo-matching-mesh-rotation-with-non-uniform-scaling/36910