### PR TITLE
Cache loaded dom images on Image class so the playground-editor doesn't have to reload them often

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -30,7 +30,6 @@ import type { IPointerEvent, IWheelEvent } from "core/Events/deviceInputEvents";
 import { RandomGUID } from "core/Misc/guid";
 import { GetClass } from "core/Misc/typeStore";
 import { DecodeBase64ToBinary } from "core/Misc/stringTools";
-import type { IImage } from "core/Engines/ICanvas";
 
 declare type StandardMaterial = import("core/Materials/standardMaterial").StandardMaterial;
 
@@ -59,7 +58,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _canvasBlurObserver: Nullable<Observer<Engine>>;
     private _controlAddedObserver: Nullable<Observer<Nullable<Control>>>;
     private _background: string;
-    private _imgElementCache: Map<string, IImage> = new Map();
     /** @internal */
     public _rootContainer = new Container("root");
     /** @internal */
@@ -594,7 +592,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this.onEndRenderObservable.clear();
         this.onBeginLayoutObservable.clear();
         this.onEndLayoutObservable.clear();
-        this._imgElementCache.clear();
         super.dispose();
     }
     private _onResize(): void {
@@ -1197,23 +1194,6 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             this.focusedControl = null;
             this._lastControlDown = {};
         });
-    }
-
-    /** @internal */
-    public _getCanvasImage(src: Nullable<string>): { fromCache: boolean; img: IImage } {
-        if (src && this._imgElementCache.has(src)) {
-            return { fromCache: true, img: this._imgElementCache.get(src)! };
-        } else if (this._engine) {
-            const img = this._engine.createCanvasImage();
-
-            if (src) {
-                this._imgElementCache.set(src, img);
-            }
-
-            return { fromCache: false, img };
-        }
-
-        throw new Error("Invalid engine. Unable to create a canvas.");
     }
 
     /**

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -30,6 +30,7 @@ import type { IPointerEvent, IWheelEvent } from "core/Events/deviceInputEvents";
 import { RandomGUID } from "core/Misc/guid";
 import { GetClass } from "core/Misc/typeStore";
 import { DecodeBase64ToBinary } from "core/Misc/stringTools";
+import type { IImage } from "core/Engines/ICanvas";
 
 declare type StandardMaterial = import("core/Materials/standardMaterial").StandardMaterial;
 
@@ -58,6 +59,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _canvasBlurObserver: Nullable<Observer<Engine>>;
     private _controlAddedObserver: Nullable<Observer<Nullable<Control>>>;
     private _background: string;
+    private _imgElementCache: Map<string, IImage> = new Map();
     /** @internal */
     public _rootContainer = new Container("root");
     /** @internal */
@@ -592,6 +594,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this.onEndRenderObservable.clear();
         this.onBeginLayoutObservable.clear();
         this.onEndLayoutObservable.clear();
+        this._imgElementCache.clear();
         super.dispose();
     }
     private _onResize(): void {
@@ -1194,6 +1197,23 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             this.focusedControl = null;
             this._lastControlDown = {};
         });
+    }
+
+    /** @internal */
+    public _getCanvasImage(src: Nullable<string>): { fromCache: boolean; img: IImage } {
+        if (src && this._imgElementCache.has(src)) {
+            return { fromCache: true, img: this._imgElementCache.get(src)! };
+        } else if (this._engine) {
+            const img = this._engine.createCanvasImage();
+
+            if (src) {
+                this._imgElementCache.set(src, img);
+            }
+
+            return { fromCache: false, img };
+        }
+
+        throw new Error("Invalid engine. Unable to create a canvas.");
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -53,9 +53,6 @@ export class Image extends Control {
         key: string;
     } = { data: null, key: "" };
 
-    public static SourceImgCache = new Map<string, { img: IImage; lastUsed: number }>();
-    public static SourceImgCacheMaxSize = 100;
-
     /**
      * Observable notified when the content is loaded
      */
@@ -528,44 +525,34 @@ export class Image extends Control {
         }
 
         // Should abstract platform instead of using LastCreatedEngine
-        const engine = this._host?.getScene()?.getEngine() || EngineStore.LastCreatedEngine;
-        if (!engine) {
-            throw new Error("Invalid engine. Unable to create a canvas.");
-        }
-        if (value && Image.SourceImgCache.has(value)) {
-            const cachedData = Image.SourceImgCache.get(value)!;
-            this._domImage = cachedData.img;
-            // Update the last used time
-            cachedData.lastUsed = Date.now();
-            this._onImageLoaded();
-            return;
-        }
-        this._domImage = engine.createCanvasImage();
-        if (value) {
-            if (Image.SourceImgCache.size > Image.SourceImgCacheMaxSize) {
-                // If the cache is at max capacity, delete the oldest image
-                let oldestKey = "";
-                let oldestTime = -Number.MAX_VALUE;
 
-                Image.SourceImgCache.forEach((value, key) => {
-                    if (value.lastUsed < oldestTime) {
-                        oldestTime = value.lastUsed;
-                        oldestKey = key;
-                    }
-                });
-
-                Image.SourceImgCache.delete(oldestKey);
+        let fromCache, img;
+        if (this._host) {
+            const creationResult = this._host._getCanvasImage(value);
+            fromCache = creationResult.fromCache;
+            img = creationResult.img;
+        } else {
+            const engine = EngineStore.LastCreatedEngine;
+            if (!engine) {
+                throw new Error("Invalid engine. Unable to create a canvas.");
             }
-            Image.SourceImgCache.set(value, { img: this._domImage, lastUsed: Date.now() });
+            fromCache = false;
+            img = engine.createCanvasImage();
         }
 
-        this._domImage.onload = () => {
+        this._domImage = img;
+
+        if (fromCache) {
             this._onImageLoaded();
-        };
-        if (value) {
-            Tools.SetCorsBehavior(value, this._domImage);
-            Tools.SetReferrerPolicyBehavior(this.referrerPolicy, this._domImage);
-            this._domImage.src = value;
+        } else {
+            this._domImage.onload = () => {
+                this._onImageLoaded();
+            };
+            if (value) {
+                Tools.SetCorsBehavior(value, this._domImage);
+                Tools.SetReferrerPolicyBehavior(this.referrerPolicy, this._domImage);
+                this._domImage.src = value;
+            }
         }
     }
 

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -53,6 +53,8 @@ export class Image extends Control {
         key: string;
     } = { data: null, key: "" };
 
+    public static SourceImgCache = new Map<string, IImage>();
+
     /**
      * Observable notified when the content is loaded
      */
@@ -482,6 +484,7 @@ export class Image extends Control {
     }
 
     private _onImageLoaded(): void {
+        console.log(this.name, "image loaded");
         this._imageDataCache.data = null;
         this._imageWidth = this._domImage.width;
         this._imageHeight = this._domImage.height;
@@ -529,7 +532,21 @@ export class Image extends Control {
         if (!engine) {
             throw new Error("Invalid engine. Unable to create a canvas.");
         }
+        if (value && Image.SourceImgCache.has(value)) {
+            console.log("cache hit for", value);
+            this._domImage = Image.SourceImgCache.get(value)!;
+            this._onImageLoaded();
+            return;
+            // this._domImage.onload = () => {
+            //     this._onImageLoaded();
+            // };
+            return;
+        }
         this._domImage = engine.createCanvasImage();
+        if (value) {
+            console.log("populate image cache");
+            Image.SourceImgCache.set(value, this._domImage);
+        }
 
         this._domImage.onload = () => {
             this._onImageLoaded();


### PR DESCRIPTION
Without the change:
![ge-no-cache](https://user-images.githubusercontent.com/6002144/209851133-13453ef9-8178-423f-9721-4dd7bbd53ca0.gif)
With the change:
![ge-cache](https://user-images.githubusercontent.com/6002144/209851145-ac34937f-d94b-4ca1-af94-dc758257f1a8.gif)
