### PR TITLE
Fix font style options on gui editor.

### DIFF
--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -322,7 +322,7 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
         };
 
         const fontStyleOptions = [
-            { label: "regular", value: "regular", id: "0" },
+            { label: "normal", value: "normal", id: "0" },
             { label: "italic", value: "italic", id: "1" },
             { label: "oblique", value: "oblique", id: "2" },
         ];


### PR DESCRIPTION
Font style should follow the CSS spec: https://developer.mozilla.org/en-US/docs/Web/CSS/font-style, so it should be "normal" instead of regular.