### PR TITLE
[XR] Hide teleportation mesh on creation

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -794,6 +794,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         }
 
         this._options.teleportationTargetMesh = teleportationTarget;
+        // hide the teleportation target mesh right after creating it.
+        this._setTargetMeshVisibility(false);
     }
 
     private _detachController(xrControllerUniqueId: string) {


### PR DESCRIPTION
This makes sure it is invisible even if the next XR frame throws an exception for any reason.