### PR TITLE
Force the control's old rect position to be invalidated before moving

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -696,6 +696,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                     continue;
                 }
                 control.notRenderable = false;
+                if (this.useInvalidateRectOptimization) {
+                    control.invalidateRect();
+                }
 
                 control._moveToProjectedPosition(projectedPosition);
             }

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1552,7 +1552,7 @@ export class Control implements IAnimatable {
 
     /** @internal */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    protected invalidateRect() {
+    public invalidateRect() {
         this._transform();
         if (this.host && this.host.useInvalidateRectOptimization) {
             // Rotate by transform to get the measure transformed to global space


### PR DESCRIPTION
This fixes an issue exposed by: https://github.com/BabylonJS/Babylon.js/pull/13372, where the control's previous rect was not invalidated and some remains of the rendering would be in the initial position:
(Refer to https://playground.babylonjs.com/#FX4EEA#4) for an example
![image](https://user-images.githubusercontent.com/6002144/210425124-332a9026-7105-49c6-a12a-a3a1debe87fd.png)
