### PR TITLE
Prevent Uncaught Exception from `ThinEngine.runRenderLoop` when `window.SetTimeout` in not defined

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -355,7 +355,7 @@ export class Sound {
                             this._isReadyToPlay = true;
                             // Simulating a ready to play event to avoid breaking code path
                             if (this._readyToPlayCallback) {
-                                window.setTimeout(() => {
+                                setTimeout(() => {
                                     if (this._readyToPlayCallback) {
                                         this._readyToPlayCallback();
                                     }
@@ -377,7 +377,7 @@ export class Sound {
             }
             // Simulating a ready to play event to avoid breaking code for non web audio browsers
             if (this._readyToPlayCallback) {
-                window.setTimeout(() => {
+                setTimeout(() => {
                     if (this._readyToPlayCallback) {
                         this._readyToPlayCallback();
                     }
@@ -1050,7 +1050,7 @@ export class Sound {
                         clonedSound.play(0, this._offset, this._length);
                     }
                 } else {
-                    window.setTimeout(setBufferAndRun, 300);
+                    setTimeout(setBufferAndRun, 300);
                 }
             };
 
@@ -1199,7 +1199,7 @@ export class Sound {
                         newSound.play(0, newSound._offset, newSound._length);
                     }
                 } else {
-                    window.setTimeout(setBufferAndRun, 300);
+                    setTimeout(setBufferAndRun, 300);
                 }
             };
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5866,13 +5866,12 @@ export class ThinEngine {
             if (typeof requestAnimationFrame === "function") {
                 return requestAnimationFrame(func);
             }
-        }
-        else {
+        } else {
             const { requestPostAnimationFrame, requestAnimationFrame } = requester || window;
-            if (typeof requestPostAnimationFrame === 'function') {
+            if (typeof requestPostAnimationFrame === "function") {
                 return requestPostAnimationFrame(func);
             }
-            if (typeof requestAnimationFrame === 'function') {
+            if (typeof requestAnimationFrame === "function") {
                 return requestAnimationFrame(func);
             }
         }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5859,24 +5859,23 @@ export class ThinEngine {
      */
     public static QueueNewFrame(func: () => void, requester?: any): number {
         if (!IsWindowObjectExist()) {
-            if (typeof requestAnimationFrame !== "undefined") {
+            if (typeof requestAnimationFrame === "function") {
                 return requestAnimationFrame(func);
             }
+        }
+        else {
+            const { requestPostAnimationFrame, requestAnimationFrame } = requester || window;
 
-            return setTimeout(func, 16) as unknown as number;
+            if (typeof requestPostAnimationFrame === 'function') {
+                return requestPostAnimationFrame(func);
+            }
+            if (typeof requestAnimationFrame === 'function') {
+                return requestAnimationFrame(func);
+            }
         }
 
-        if (!requester) {
-            requester = window;
-        }
-
-        if (requester.requestPostAnimationFrame) {
-            return requester.requestPostAnimationFrame(func);
-        } else if (requester.requestAnimationFrame) {
-            return requester.requestAnimationFrame(func);
-        } else {
-            return window.setTimeout(func, 16);
-        }
+        // fallback to the global setTimeout which is the same as window.setTimeout in the general case
+        return setTimeout(func, 16) as unknown as number;
     }
 
     /**

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5852,12 +5852,16 @@ export class ThinEngine {
     }
 
     /**
-     * Queue a new function into the requested animation frame pool (ie. this function will be executed byt the browser for the next frame)
+     * Queue a new function into the requested animation frame pool (ie. this function will be executed by the browser (or the javascript engine) for the next frame)
      * @param func - the function to be called
      * @param requester - the object that will request the next frame. Falls back to window.
      * @returns frame number
      */
     public static QueueNewFrame(func: () => void, requester?: any): number {
+        // Note that there is kind of a typing issue here, as `setTimeout` might return something else than a number (NodeJs returns a NodeJS.Timeout object).
+        // Also if the global `requestAnimationFrame`'s returnType is number, `requester.requestPostAnimationFrame` and `requester.requestAnimationFrame` types
+        // are `any`.
+
         if (!IsWindowObjectExist()) {
             if (typeof requestAnimationFrame === "function") {
                 return requestAnimationFrame(func);
@@ -5865,7 +5869,6 @@ export class ThinEngine {
         }
         else {
             const { requestPostAnimationFrame, requestAnimationFrame } = requester || window;
-
             if (typeof requestPostAnimationFrame === 'function') {
                 return requestPostAnimationFrame(func);
             }
@@ -5874,7 +5877,8 @@ export class ThinEngine {
             }
         }
 
-        // fallback to the global setTimeout which is the same as window.setTimeout in the general case
+        // fallback to the global `setTimeout`.
+        // In most cases (aka in the browser), `window` is the global object, so instead of calling `window.setTimeout` we could call the global `setTimeout`.
         return setTimeout(func, 16) as unknown as number;
     }
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -648,7 +648,7 @@ export class InputManager {
                     else {
                         // wait that no double click has been raised during the double click delay
                         this._previousDelayedSimpleClickTimeout = this._delayedSimpleClickTimeout;
-                        this._delayedSimpleClickTimeout = setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay);
+                        this._delayedSimpleClickTimeout = window.setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay);
                     }
 
                     let checkDoubleClick = obs1.hasSpecificMask(PointerEventTypes.POINTERDOUBLETAP) || obs2.hasSpecificMask(PointerEventTypes.POINTERDOUBLETAP);

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -378,7 +378,7 @@ export class InputManager {
                 }
 
                 if (actionManager.hasSpecificTrigger(Constants.ACTION_OnLongPressTrigger)) {
-                    setTimeout(() => {
+                    window.setTimeout(() => {
                         const pickResult = scene.pick(
                             this._unTranslatedPointerX,
                             this._unTranslatedPointerY,

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -378,7 +378,7 @@ export class InputManager {
                 }
 
                 if (actionManager.hasSpecificTrigger(Constants.ACTION_OnLongPressTrigger)) {
-                    window.setTimeout(() => {
+                    setTimeout(() => {
                         const pickResult = scene.pick(
                             this._unTranslatedPointerX,
                             this._unTranslatedPointerY,
@@ -648,7 +648,7 @@ export class InputManager {
                     else {
                         // wait that no double click has been raised during the double click delay
                         this._previousDelayedSimpleClickTimeout = this._delayedSimpleClickTimeout;
-                        this._delayedSimpleClickTimeout = window.setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay);
+                        this._delayedSimpleClickTimeout = setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay);
                     }
 
                     let checkDoubleClick = obs1.hasSpecificMask(PointerEventTypes.POINTERDOUBLETAP) || obs2.hasSpecificMask(PointerEventTypes.POINTERDOUBLETAP);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
@@ -202,7 +202,7 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
         if (this._timer != null) {
             clearTimeout(this._timer);
         }
-        this._timer = window.setTimeout(() => {
+        this._timer = setTimeout(() => {
             this.props.onUpdate();
             this._timer = null;
         }, TextureEditorComponent._PREVIEW_UPDATE_DELAY_MS);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/textures/textureEditorComponent.tsx
@@ -200,9 +200,9 @@ export class TextureEditorComponent extends React.Component<ITextureEditorCompon
 
     textureDidUpdate() {
         if (this._timer != null) {
-            clearTimeout(this._timer);
+            window.clearTimeout(this._timer);
         }
-        this._timer = setTimeout(() => {
+        this._timer = window.setTimeout(() => {
             this.props.onUpdate();
             this._timer = null;
         }, TextureEditorComponent._PREVIEW_UPDATE_DELAY_MS);


### PR DESCRIPTION
I am having an uncaught exception when using BaylonJs in a NodeJs environment because of a call to `window.setTimeout`.

It is not very clear in the code what is the standard, as sometime we call the global `setTimeout` and sometime we call `window.setTimeout`. 

My take on this is that it should be ok to always call the globals `setTimeout`/ `clearTimeout` as they are bound to be defined and are the very same functions as `window.setTimeout`/ `window.clearTimeout` in most cases.

Though this PR do not change them all. I just make some 2 files more consistent where we used to use a mix of both, and I updated the `ThinEngine.QueueNewFrame` to NOT call `window.setTimeout`, but to fall back on the global `setTimeout`.


To really be "environment  independant", we should never call a function that is "environment  dependant" directly, and put them all behind a configurable callback registry. This registry would be initialized with default values, and could be customizes by the user depending on its needs. But I'm not sure how it is doable, and anyway that's another story :)
