### PR TITLE
Improve pointerDragBehavior customization

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -31,6 +31,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
     private static _PlaneScene: Scene;
     private _useAlternatePickedPointAboveMaxDragAngleDragSpeed = -1.1;
     private _activeDragButton: number = -1;
+    private _activePointerInfo: Nullable<PointerInfo>;
     /**
      * The maximum tolerated angle between the drag plane and dragging pointer rays to trigger pointer events. Set to 0 to allow any angle (default: 0)
      */
@@ -85,21 +86,28 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
-    public onDragObservable = new Observable<{ delta: Vector3; dragPlanePoint: Vector3; dragPlaneNormal: Vector3; dragDistance: number; pointerId: number }>();
+    public onDragObservable = new Observable<{
+        delta: Vector3;
+        dragPlanePoint: Vector3;
+        dragPlaneNormal: Vector3;
+        dragDistance: number;
+        pointerId: number;
+        pointerInfo: Nullable<PointerInfo>;
+    }>();
     /**
      *  Fires each time a drag begins (eg. mouse down on mesh)
      *  * dragPlanePoint in world space where the drag intersects the drag plane
      *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
-    public onDragStartObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();
+    public onDragStartObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number; pointerInfo: Nullable<PointerInfo> }>();
     /**
      *  Fires each time a drag ends (eg. mouse release after drag)
      *  * dragPlanePoint in world space where the drag intersects the drag plane
      *
      *  (if validatedDrag is used, the position of the attached mesh might not equal dragPlanePoint)
      */
-    public onDragEndObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number }>();
+    public onDragEndObservable = new Observable<{ dragPlanePoint: Vector3; pointerId: number; pointerInfo: Nullable<PointerInfo> }>();
     /**
      *  Fires each time behavior enabled state changes
      */
@@ -263,6 +271,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                 ) {
                     if (this._activeDragButton === -1 && this.dragButtons.indexOf(pointerInfo.event.button) !== -1) {
                         this._activeDragButton = pointerInfo.event.button;
+                        this._activePointerInfo = pointerInfo;
                         this._startDrag((<IPointerEvent>pointerInfo.event).pointerId, pointerInfo.pickInfo.ray, pointerInfo.pickInfo.pickedPoint);
                     }
                 }
@@ -331,11 +340,12 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
     public releaseDrag() {
         if (this.dragging) {
             this.dragging = false;
-            this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerId });
+            this.onDragEndObservable.notifyObservers({ dragPlanePoint: this.lastDragPosition, pointerId: this.currentDraggingPointerId, pointerInfo: this._activePointerInfo });
         }
 
         this.currentDraggingPointerId = -1;
         this._activeDragButton = -1;
+        this._activePointerInfo = null;
         this._moving = false;
 
         // Reattach camera controls
@@ -399,7 +409,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this.dragging = true;
             this.currentDraggingPointerId = pointerId;
             this.lastDragPosition.copyFrom(pickedPoint);
-            this.onDragStartObservable.notifyObservers({ dragPlanePoint: pickedPoint, pointerId: this.currentDraggingPointerId });
+            this.onDragStartObservable.notifyObservers({ dragPlanePoint: pickedPoint, pointerId: this.currentDraggingPointerId, pointerInfo: this._activePointerInfo });
             this._targetPosition.copyFrom(this.attachedNode.getAbsolutePosition());
 
             // Detatch camera controls
@@ -451,6 +461,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                 dragPlanePoint: pickedPoint,
                 dragPlaneNormal: this._dragPlane.forward,
                 pointerId: this.currentDraggingPointerId,
+                pointerInfo: this._activePointerInfo,
             });
             this.lastDragPosition.copyFrom(pickedPoint);
 

--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -411,6 +411,8 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                     this._attachedToElement = false;
                 }
             }
+        } else {
+            this.releaseDrag();
         }
         PivotTools._RestorePivotPoint(this.attachedNode);
     }

--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -24,7 +24,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
      * Abstract mesh the behavior is set on
      */
     public attachedNode: AbstractMesh;
-    private _dragPlane: Mesh;
+    protected _dragPlane: Mesh;
     private _scene: Scene;
     private _pointerObserver: Nullable<Observer<PointerInfo>>;
     private _beforeRenderObserver: Nullable<Observer<Scene>>;


### PR DESCRIPTION
As the details in [Babylonjs forum](https://forum.babylonjs.com/t/change-accessibility-of-dragplane-in-pointerdragbehavior-class-to-protected-to-make-it-more-extendable/37082), I have a need to customize the `pointerDragBehavior` in such a way that will allow more customization in its inherited class and remove a pitfall on how  the dragging state was handled. In order to achieve that, there're a few changes I need to make:

1. Change the visibility of `_dragPlane` field from private to protected to allow more customization in the inherited class.
2. Force calling `releaseDrag` if the start dragging failed to prevent the freezing (not be able to drag) due to how the dragging state is handled
3. Pass the information of the active pointer in the drag observables in addition to the `pointerId`, this is to let the user have  access to more information about the pointer and it especially useful when detecting the type of the event (e.g. click, touch)