### PR TITLE
NME : Use flag IgnoreTexturesAtLoadTime in ReflectionTextureBaseBlock

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -4,7 +4,8 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { BaseTexture } from "../../../Textures/baseTexture";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
-import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
+import type { NodeMaterialDefines } from "../../nodeMaterial";
+import { NodeMaterial } from "../../nodeMaterial";
 import type { Effect } from "../../../effect";
 import type { Mesh } from "../../../../Meshes/mesh";
 import type { Nullable } from "../../../../types";
@@ -537,7 +538,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
     public _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
         super._deserialize(serializationObject, scene, rootUrl);
 
-        if (serializationObject.texture) {
+        if (serializationObject.texture && !NodeMaterial.IgnoreTexturesAtLoadTime) {
             rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;
             if (serializationObject.texture.isCube) {
                 this.texture = CubeTexture.Parse(serializationObject.texture, scene, rootUrl);


### PR DESCRIPTION
When creating ReflectionTextureBaseBlock from a JSON NME material, if the flag NodeMaterial.IgnoreTexturesAtLoadTime is activated, this pull request prevents texture loading.

This new behavior is similar to the ones already existing in TextureBlock, ImageSourceBlock or TriPlanarBlock.