### PR TITLE
[GUI] Fix 2 slider3D issues

### DIFF
--- a/packages/dev/gui/src/3D/controls/slider3D.ts
+++ b/packages/dev/gui/src/3D/controls/slider3D.ts
@@ -200,6 +200,10 @@ export class Slider3D extends Control3D {
         sliderBackplate.scaling = new Vector3(1, 0.5, 0.8);
 
         SceneLoader.ImportMeshAsync(undefined, Slider3D.MODEL_BASE_URL, Slider3D.MODEL_FILENAME, scene).then((result) => {
+            // make all meshes not pickable. Required meshes' pickable state will be set later.
+            result.meshes.forEach((m) => {
+                m.isPickable = false;
+            });
             const sliderBackplateModel = result.meshes[1];
             const sliderBarModel = result.meshes[1].clone(`${this.name}_sliderbar`, sliderBackplate);
             const sliderThumbModel = result.meshes[1].clone(`${this.name}_sliderthumb`, sliderBackplate);
@@ -208,7 +212,6 @@ export class Slider3D extends Control3D {
             if (this._sliderBackplateVisible) {
                 sliderBackplateModel.visibility = 1;
                 sliderBackplateModel.name = `${this.name}_sliderbackplate`;
-                sliderBackplateModel.isPickable = false;
                 sliderBackplateModel.scaling.x = 1;
                 sliderBackplateModel.scaling.z = 0.2;
                 sliderBackplateModel.parent = sliderBackplate;
@@ -222,7 +225,6 @@ export class Slider3D extends Control3D {
                 sliderBarModel.parent = sliderBackplate;
                 sliderBarModel.position.z = -0.1;
                 sliderBarModel.scaling = new Vector3(SLIDER_SCALING - SLIDER_MARGIN, 0.04, 0.3);
-                sliderBarModel.isPickable = false;
                 if (this._sliderBarMaterial) {
                     sliderBarModel.material = this._sliderBarMaterial;
                 }

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
@@ -488,6 +488,9 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
         this._blueGradientTexture = new Texture(MRDLSliderThumbMaterial.BLUE_GRADIENT_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._decalTexture = new Texture("", this.getScene());
+        this._reflectionMapTexture = new Texture("", this.getScene());
+        this._indirectEnvTexture = new Texture("", this.getScene());
     }
 
     public needAlphaBlending(): boolean {


### PR DESCRIPTION
The mesh used by the slider had meshes set to pickable that should not be pickable.
There was also an issue disposing the material as the textures were not created during construction.

See https://forum.babylonjs.com/t/xr-motion-controller-unwanted-picking-of-3d-buttons-meshes/36056/14