### PR TITLE
Fix LoadScriptAsync to reject with proper error

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -480,7 +480,7 @@ export class Tools {
                     resolve();
                 },
                 (message, exception) => {
-                    reject(exception);
+                    reject(exception || new Error(message));
                 }
             );
         });


### PR DESCRIPTION
See https://forum.babylonjs.com/t/importasyncmesh-on-server-side-without-scene/34151/39