### PR TITLE
Fix sound play function not accepting zero as a valid offset

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -813,7 +813,7 @@ export class Sound {
                         if (Engine.audioEngine?.audioContext) {
                             length = length || this._length;
 
-                            if (offset) {
+                            if (offset !== undefined) {
                                 this._offset = offset;
                             }
 


### PR DESCRIPTION
The `Sound.play` function is not accepting zero as a valid offset. This makes resetting the offset to zero not work after previously setting it to a non-zero value.

Reported on forum here: https://forum.babylonjs.com/t/pausing-and-playing-an-audio-with-offset-restarts-it-from-the-beginning-instead-of-the-current-position/36668/12

This change fixes the issue by comparing the given `offset` argument to `undefined` instead of using JavaScript truthy/falsey.

This bug was caused by the change I made in https://github.com/BabylonJS/Babylon.js/pull/13373.