### PR TITLE
Add location to glFragColor in WebGL preprocessor

### DIFF
--- a/packages/dev/core/src/Engines/WebGL/webGL2ShaderProcessors.ts
+++ b/packages/dev/core/src/Engines/WebGL/webGL2ShaderProcessors.ts
@@ -29,7 +29,7 @@ export class WebGL2ShaderProcessor implements IShaderProcessor {
             code = code.replace(/gl_FragDepthEXT/g, "gl_FragDepth");
             code = code.replace(/gl_FragColor/g, "glFragColor");
             code = code.replace(/gl_FragData/g, "glFragData");
-            code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension ? "" : "out vec4 glFragColor;\n") + "void main(");
+            code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension ? "" : "layout(location = 0) out vec4 glFragColor;\n") + "void main(");
         } else {
             const hasMultiviewExtension = defines.indexOf("#define MULTIVIEW") !== -1;
             if (hasMultiviewExtension) {


### PR DESCRIPTION
To simplify some specific uses of MultiRenderTarget it would be handy to have `layout(location = 0) prepended to the glFragColor output. Without this you cannot declare another output buffer as in OpenGL ES 3 all output locations must be specified.

This change shouldn't have any impact on typical use but makes it easier for custom MRT/Deferred shading situations.