### PR TITLE
Add touch release detection to draggable parts of BoundingBoxGizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -466,10 +466,11 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                 this.onDragStartObservable.notifyObservers({});
                 this._selectNode(sphere);
             });
-            _dragBehavior.onDragEndObservable.add(() => {
+            _dragBehavior.onDragEndObservable.add((event) => {
                 this.onRotationSphereDragEndObservable.notifyObservers({});
                 this._selectNode(null);
                 this._updateDummy();
+                this._unhoverMeshOnTouchUp(event.pointerId, sphere);
             });
 
             this._rotateSpheresParent.addChild(sphere);
@@ -551,10 +552,11 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         this.onDragStartObservable.notifyObservers({});
                         this._selectNode(box);
                     });
-                    _dragBehavior.onDragEndObservable.add(() => {
+                    _dragBehavior.onDragEndObservable.add((event) => {
                         this.onScaleBoxDragEndObservable.notifyObservers({});
                         this._selectNode(null);
                         this._updateDummy();
+                        this._unhoverMeshOnTouchUp(event.pointerId, box);
                     });
 
                     this._scaleBoxesParent.addChild(box);
@@ -633,6 +635,17 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                 m.isVisible = !selectedMesh || m == selectedMesh;
             });
     }
+
+    protected _unhoverMeshOnTouchUp(pointerId: number, selectedMesh: AbstractMesh) {
+        const engine = this.gizmoLayer.originalScene.getEngine();
+        const isMobileSafari = engine._badOS || (engine._badDesktopOS && typeof document === "object" && "ontouchend" in document);
+
+        // force unhover mesh if not a mouse event
+        if (pointerId > 2 || isMobileSafari) {
+            selectedMesh.material = this._coloredMaterial;
+        }
+    }
+
     /**
      * returns an array containing all boxes used for scaling (in increasing x, y and z orders)
      */

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -638,7 +638,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
 
     protected _unhoverMeshOnTouchUp(pointerId: number, selectedMesh: AbstractMesh) {
         const engine = this.gizmoLayer.originalScene.getEngine();
-        const isMobileSafari = engine._badOS || (engine._badDesktopOS && typeof document === "object" && "ontouchend" in document);
+        const isMobileSafari = engine._badOS || (engine._badDesktopOS && document && "ontouchend" in document);
 
         // force unhover mesh if not a mouse event
         if (pointerId > 2 || isMobileSafari) {

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -470,7 +470,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                 this.onRotationSphereDragEndObservable.notifyObservers({});
                 this._selectNode(null);
                 this._updateDummy();
-                this._unhoverMeshOnTouchUp(event.pointerId, sphere);
+                this._unhoverMeshOnTouchUp(event.pointerInfo, sphere);
             });
 
             this._rotateSpheresParent.addChild(sphere);
@@ -556,7 +556,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         this.onScaleBoxDragEndObservable.notifyObservers({});
                         this._selectNode(null);
                         this._updateDummy();
-                        this._unhoverMeshOnTouchUp(event.pointerId, box);
+                        this._unhoverMeshOnTouchUp(event.pointerInfo, box);
                     });
 
                     this._scaleBoxesParent.addChild(box);
@@ -636,12 +636,9 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             });
     }
 
-    protected _unhoverMeshOnTouchUp(pointerId: number, selectedMesh: AbstractMesh) {
-        const engine = this.gizmoLayer.originalScene.getEngine();
-        const isMobileSafari = engine._badOS || (engine._badDesktopOS && document && "ontouchend" in document);
-
+    protected _unhoverMeshOnTouchUp(pointerInfo: Nullable<PointerInfo>, selectedMesh: AbstractMesh) {
         // force unhover mesh if not a mouse event
-        if (pointerId > 2 || isMobileSafari) {
+        if (pointerInfo?.event instanceof PointerEvent && pointerInfo?.event.pointerType === "touch") {
             selectedMesh.material = this._coloredMaterial;
         }
     }


### PR DESCRIPTION
As a followup from [this thread on the BabylonJS forums](https://forum.babylonjs.com/t/boundingboxgizmo-displays-unexpected-highlighting-behavior-on-touch-devices/37197), this PR adds touch release detection to the draggable components (scale boxes, rotation spheres) of the `BoundingBoxGizmo` such that those parts will now unhighlight correctly when releasing touch while dragging said parts.