### PR TITLE
Fix broken use of TmpVectors in BoundingBoxGizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -4,7 +4,7 @@ import { Logger } from "../Misc/logger";
 import type { Nullable } from "../types";
 import type { PointerInfo } from "../Events/pointerEvents";
 import type { Scene } from "../scene";
-import { TmpVectors, Quaternion, Vector3 } from "../Maths/math.vector";
+import { Quaternion, Matrix, Vector3 } from "../Maths/math.vector";
 import { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
@@ -108,6 +108,9 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
     protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     protected _scaleDragSpeed = 0.2;
 
+    private _tmpQuaternion = new Quaternion();
+    private _tmpVector = new Vector3(0, 0, 0);
+    private _tmpRotationMatrix = new Matrix();
     /**
      * If child meshes should be ignored when calculating the bounding box. This should be set to true to avoid perf hits with heavily nested meshes (Default: false)
      */
@@ -242,7 +245,6 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
     public get hoverMaterial() {
         return this._hoverColoredMaterial;
     }
-
     /**
      * Get the pointerDragBehavior
      */
@@ -438,19 +440,19 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                     totalTurnAmountOfDrag += projectDist;
                     if (Math.abs(totalTurnAmountOfDrag) <= 2 * Math.PI) {
                         if (i >= 8) {
-                            Quaternion.RotationYawPitchRollToRef(0, 0, projectDist, TmpVectors.Quaternion[0]);
+                            Quaternion.RotationYawPitchRollToRef(0, 0, projectDist, this._tmpQuaternion);
                         } else if (i >= 4) {
-                            Quaternion.RotationYawPitchRollToRef(projectDist, 0, 0, TmpVectors.Quaternion[0]);
+                            Quaternion.RotationYawPitchRollToRef(projectDist, 0, 0, this._tmpQuaternion);
                         } else {
-                            Quaternion.RotationYawPitchRollToRef(0, projectDist, 0, TmpVectors.Quaternion[0]);
+                            Quaternion.RotationYawPitchRollToRef(0, projectDist, 0, this._tmpQuaternion);
                         }
 
                         // Rotate around center of bounding box
                         this._anchorMesh.addChild(this.attachedMesh, Gizmo.PreserveScaling);
                         if (this._anchorMesh.getScene().useRightHandedSystem) {
-                            TmpVectors.Quaternion[0].conjugateInPlace();
+                            this._tmpQuaternion.conjugateInPlace();
                         }
-                        this._anchorMesh.rotationQuaternion!.multiplyToRef(TmpVectors.Quaternion[0], this._anchorMesh.rotationQuaternion!);
+                        this._anchorMesh.rotationQuaternion!.multiplyToRef(this._tmpQuaternion, this._anchorMesh.rotationQuaternion!);
                         this._anchorMesh.removeChild(this.attachedMesh, Gizmo.PreserveScaling);
                         this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);
                     }
@@ -520,18 +522,18 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                             deltaScale.multiplyInPlace(this._axisFactor);
                             this.updateBoundingBox();
                             if (this.scalePivot) {
-                                this.attachedMesh.getWorldMatrix().getRotationMatrixToRef(TmpVectors.Matrix[0]);
+                                this.attachedMesh.getWorldMatrix().getRotationMatrixToRef(this._tmpRotationMatrix);
                                 // Move anchor to desired pivot point (Bottom left corner + dimension/2)
-                                this._boundingDimensions.scaleToRef(0.5, TmpVectors.Vector3[0]);
-                                Vector3.TransformCoordinatesToRef(TmpVectors.Vector3[0], TmpVectors.Matrix[0], TmpVectors.Vector3[0]);
-                                this._anchorMesh.position.subtractInPlace(TmpVectors.Vector3[0]);
-                                this._boundingDimensions.multiplyToRef(this.scalePivot, TmpVectors.Vector3[0]);
-                                Vector3.TransformCoordinatesToRef(TmpVectors.Vector3[0], TmpVectors.Matrix[0], TmpVectors.Vector3[0]);
-                                this._anchorMesh.position.addInPlace(TmpVectors.Vector3[0]);
+                                this._boundingDimensions.scaleToRef(0.5, this._tmpVector);
+                                Vector3.TransformCoordinatesToRef(this._tmpVector, this._tmpRotationMatrix, this._tmpVector);
+                                this._anchorMesh.position.subtractInPlace(this._tmpVector);
+                                this._boundingDimensions.multiplyToRef(this.scalePivot, this._tmpVector);
+                                Vector3.TransformCoordinatesToRef(this._tmpVector, this._tmpRotationMatrix, this._tmpVector);
+                                this._anchorMesh.position.addInPlace(this._tmpVector);
                             } else {
                                 // Scale from the position of the opposite corner
-                                box.absolutePosition.subtractToRef(this._anchorMesh.position, TmpVectors.Vector3[0]);
-                                this._anchorMesh.position.subtractInPlace(TmpVectors.Vector3[0]);
+                                box.absolutePosition.subtractToRef(this._anchorMesh.position, this._tmpVector);
+                                this._anchorMesh.position.subtractInPlace(this._tmpVector);
                             }
 
                             this._anchorMesh.addChild(this.attachedMesh, Gizmo.PreserveScaling);
@@ -596,8 +598,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
 
             // If drag mesh is enabled and dragging, update the attached mesh pose to match the drag mesh
             if (this._dragMesh && this.attachedMesh && this._pointerDragBehavior.dragging) {
-                this._lineBoundingBox.position.rotateByQuaternionToRef(this._rootMesh.rotationQuaternion!, TmpVectors.Vector3[0]);
-                this.attachedMesh.setAbsolutePosition(this._dragMesh.position.add(TmpVectors.Vector3[0].scale(-1)));
+                this._lineBoundingBox.position.rotateByQuaternionToRef(this._rootMesh.rotationQuaternion!, this._tmpVector);
+                this.attachedMesh.setAbsolutePosition(this._dragMesh.position.add(this._tmpVector.scale(-1)));
             }
         });
         this.updateBoundingBox();
@@ -663,8 +665,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             this._anchorMesh.rotationQuaternion.copyFrom(this.attachedMesh.rotationQuaternion);
 
             // Store original position and reset mesh to origin before computing the bounding box
-            TmpVectors.Quaternion[0].copyFrom(this.attachedMesh.rotationQuaternion);
-            TmpVectors.Vector3[0].copyFrom(this.attachedMesh.position);
+            this._tmpQuaternion.copyFrom(this.attachedMesh.rotationQuaternion);
+            this._tmpVector.copyFrom(this.attachedMesh.position);
             this.attachedMesh.rotationQuaternion.set(0, 0, 0, 1);
             this.attachedMesh.position.set(0, 0, 0);
 
@@ -687,8 +689,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             this._anchorMesh.position.copyFrom(this._lineBoundingBox.absolutePosition);
 
             // Restore position/rotation values
-            this.attachedMesh.rotationQuaternion.copyFrom(TmpVectors.Quaternion[0]);
-            this.attachedMesh.position.copyFrom(TmpVectors.Vector3[0]);
+            this.attachedMesh.rotationQuaternion.copyFrom(this._tmpQuaternion);
+            this.attachedMesh.position.copyFrom(this._tmpVector);
 
             // Restore original parent
             this.attachedMesh.setParent(originalParent, Gizmo.PreserveScaling);
@@ -731,8 +733,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         );
                     }
                     if (this.fixedDragMeshScreenSize && this.gizmoLayer.utilityLayerScene.activeCamera) {
-                        rotateSpheres[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.position, TmpVectors.Vector3[0]);
-                        const distanceFromCamera = (this.rotationSphereSize * TmpVectors.Vector3[0].length()) / this.fixedDragMeshScreenSizeDistanceFactor;
+                        rotateSpheres[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.position, this._tmpVector);
+                        const distanceFromCamera = (this.rotationSphereSize * this._tmpVector.length()) / this.fixedDragMeshScreenSizeDistanceFactor;
                         rotateSpheres[index].scaling.set(distanceFromCamera, distanceFromCamera, distanceFromCamera);
                     } else if (this.fixedDragMeshBoundsSize) {
                         rotateSpheres[index].scaling.set(
@@ -762,8 +764,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         scaleBoxes[index].position.set(this._boundingDimensions.x * (i / 2), this._boundingDimensions.y * (j / 2), this._boundingDimensions.z * (k / 2));
                         scaleBoxes[index].position.addInPlace(new Vector3(-this._boundingDimensions.x / 2, -this._boundingDimensions.y / 2, -this._boundingDimensions.z / 2));
                         if (this.fixedDragMeshScreenSize && this.gizmoLayer.utilityLayerScene.activeCamera) {
-                            scaleBoxes[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.position, TmpVectors.Vector3[0]);
-                            const distanceFromCamera = (this.scaleBoxSize * TmpVectors.Vector3[0].length()) / this.fixedDragMeshScreenSizeDistanceFactor;
+                            scaleBoxes[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.position, this._tmpVector);
+                            const distanceFromCamera = (this.scaleBoxSize * this._tmpVector.length()) / this.fixedDragMeshScreenSizeDistanceFactor;
                             scaleBoxes[index].scaling.set(distanceFromCamera, distanceFromCamera, distanceFromCamera);
                         } else if (this.fixedDragMeshBoundsSize) {
                             scaleBoxes[index].scaling.set(


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/bounding-box-rotation-in-gizmo-is-not-working/37245

