### PR TITLE
Fix broken sound offset backward compatibility

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -1232,7 +1232,6 @@ export class Sound {
         return newSound;
     }
 
-
     private _setOffset(value?: number) {
         if (this._offset === value) {
             return;

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -104,7 +104,7 @@ export class Sound {
             return this._htmlAudioElement.currentTime;
         }
 
-        let currentTime: number = this._startOffset + (this._offset ? this._offset : 0);
+        let currentTime: number = this._startOffset;
         if (this.isPlaying && Engine.audioEngine?.audioContext) {
             currentTime += Engine.audioEngine.audioContext.currentTime - this._startTime;
         }

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -501,7 +501,7 @@ export class Sound {
             this.distanceModel = options.distanceModel ?? this.distanceModel;
             this._playbackRate = options.playbackRate ?? this._playbackRate;
             this._length = options.length ?? undefined;
-            this._offset = options.offset ?? undefined;
+            this._setOffset(options.offset ?? undefined);
             this.setVolume(options.volume ?? this._volume);
             this._updateSpatialParameters();
             if (this.isPlaying) {
@@ -814,7 +814,7 @@ export class Sound {
                             length = length || this._length;
 
                             if (offset !== undefined) {
-                                this._offset = offset;
+                                this._setOffset(offset);
                             }
 
                             if (this._soundSource) {
@@ -1230,5 +1230,17 @@ export class Sound {
         }
 
         return newSound;
+    }
+
+
+    private _setOffset(value?: number) {
+        if (this._offset === value) {
+            return;
+        }
+        if (this.isPaused) {
+            this.stop();
+            this.isPaused = false;
+        }
+        this._offset = value;
     }
 }


### PR DESCRIPTION
Prior to my changes in PR https://github.com/BabylonJS/Babylon.js/pull/13373, when a sound's offset was set while paused, playback resumed from the given offset, not the time it was paused at.

This change fixes that break in backward compatibility while preserving the fix in PR https://github.com/BabylonJS/Babylon.js/pull/13373.

This change also reverts adding the offset in the currentTime property to preserve backward compatibility.

Reported on forum here: https://forum.babylonjs.com/t/sound-currenttime/37290