### PR TITLE
Add support for unsigned int uniform

### DIFF
--- a/packages/dev/core/src/Engines/IPipelineContext.ts
+++ b/packages/dev/core/src/Engines/IPipelineContext.ts
@@ -105,6 +105,68 @@ export interface IPipelineContext {
     setIntArray4(uniformName: string, array: Int32Array): void;
 
     /**
+     * Sets an unsigned integer value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param value Value to be set.
+     */
+    setUInt(uniformName: string, value: number): void;
+
+    /**
+     * Sets an unsigned int2 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint2.
+     * @param y Second unsigned int in uint2.
+     */
+    setUInt2(uniformName: string, x: number, y: number): void;
+
+    /**
+     * Sets an unsigned int3 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint3.
+     * @param y Second unsigned int in uint3.
+     * @param z Third unsigned int in uint3.
+     */
+    setUInt3(uniformName: string, x: number, y: number, z: number): void;
+
+    /**
+     * Sets an unsigned int4 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint4.
+     * @param y Second unsigned int in uint4.
+     * @param z Third unsigned int in uint4.
+     * @param w Fourth unsigned int in uint4.
+     */
+    setUInt4(uniformName: string, x: number, y: number, z: number, w: number): void;
+
+    /**
+     * Sets an unsigned int array on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    setUIntArray(uniformName: string, array: Uint32Array): void;
+
+    /**
+     * Sets an unsigned int array 2 on a uniform variable. (Array is specified as single array eg. [1,2,3,4] will result in [[1,2],[3,4]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    setUIntArray2(uniformName: string, array: Uint32Array): void;
+
+    /**
+     * Sets an unsigned int array 3 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6] will result in [[1,2,3],[4,5,6]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    setUIntArray3(uniformName: string, array: Uint32Array): void;
+
+    /**
+     * Sets an unsigned int array 4 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6,7,8] will result in [[1,2,3,4],[5,6,7,8]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    setUIntArray4(uniformName: string, array: Uint32Array): void;
+
+    /**
      * Sets an array on a uniform variable.
      * @param uniformName Name of the variable.
      * @param array array to be set.

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -283,7 +283,7 @@ export class NativePipelineContext implements IPipelineContext {
      * @param uniformName Name of the variable.
      * @param value Value to be set.
      */
-     public setUInt(uniformName: string, value: number): void {
+    public setUInt(uniformName: string, value: number): void {
         const cache = this._valueCache[uniformName];
         if (cache !== undefined && cache === value) {
             return;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -279,6 +279,107 @@ export class NativePipelineContext implements IPipelineContext {
     }
 
     /**
+     * Sets an unsigned integer value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param value Value to be set.
+     */
+     public setUInt(uniformName: string, value: number): void {
+        const cache = this._valueCache[uniformName];
+        if (cache !== undefined && cache === value) {
+            return;
+        }
+
+        if (this._engine.setUInt(this._uniforms[uniformName]!, value)) {
+            this._valueCache[uniformName] = value;
+        }
+    }
+
+    /**
+     * Sets a unsigned int2 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint2.
+     * @param y Second unsigned int in uint2.
+     */
+    public setUInt2(uniformName: string, x: number, y: number): void {
+        if (this._cacheFloat2(uniformName, x, y)) {
+            if (!this._engine.setUInt2(this._uniforms[uniformName], x, y)) {
+                this._valueCache[uniformName] = null;
+            }
+        }
+    }
+
+    /**
+     * Sets a unsigned int3 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint3.
+     * @param y Second unsigned int in uint3.
+     * @param z Third unsigned int in uint3.
+     */
+    public setUInt3(uniformName: string, x: number, y: number, z: number): void {
+        if (this._cacheFloat3(uniformName, x, y, z)) {
+            if (!this._engine.setUInt3(this._uniforms[uniformName], x, y, z)) {
+                this._valueCache[uniformName] = null;
+            }
+        }
+    }
+
+    /**
+     * Sets a unsigned int4 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint4.
+     * @param y Second unsigned int in uint4.
+     * @param z Third unsigned int in uint4.
+     * @param w Fourth unsigned int in uint4.
+     */
+    public setUInt4(uniformName: string, x: number, y: number, z: number, w: number): void {
+        if (this._cacheFloat4(uniformName, x, y, z, w)) {
+            if (!this._engine.setUInt4(this._uniforms[uniformName], x, y, z, w)) {
+                this._valueCache[uniformName] = null;
+            }
+        }
+    }
+
+    /**
+     * Sets an unsigned int array on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray(uniformName: string, array: Uint32Array): void {
+        this._valueCache[uniformName] = null;
+        this._engine.setUIntArray(this._uniforms[uniformName]!, array);
+    }
+
+    /**
+     * Sets an unsigned int array 2 on a uniform variable. (Array is specified as single array eg. [1,2,3,4] will result in [[1,2],[3,4]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray2(uniformName: string, array: Uint32Array): void {
+        this._valueCache[uniformName] = null;
+        this._engine.setUIntArray2(this._uniforms[uniformName]!, array);
+    }
+
+    /**
+     * Sets an unsigned int array 3 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6] will result in [[1,2,3],[4,5,6]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray3(uniformName: string, array: Uint32Array): void {
+        this._valueCache[uniformName] = null;
+        this._engine.setUIntArray3(this._uniforms[uniformName]!, array);
+    }
+
+    /**
+     * Sets an unsigned int array 4 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6,7,8] will result in [[1,2,3,4],[5,6,7,8]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray4(uniformName: string, array: Uint32Array): void {
+        this._valueCache[uniformName] = null;
+        this._engine.setUIntArray4(this._uniforms[uniformName]!, array);
+    }
+
+    /**
      * Sets an float array on a uniform variable.
      * @param uniformName Name of the variable.
      * @param array array to be set.

--- a/packages/dev/core/src/Engines/WebGL/webGLPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGL/webGLPipelineContext.ts
@@ -5,10 +5,14 @@ import type { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like
 import type { ThinEngine } from "../thinEngine";
 
 const floatNCache: string[] = [
-    "Int2",
     "Int",
+    "Int2",
     "Int3",
     "Int4",
+    "UInt",
+    "UInt2",
+    "UInt3",
+    "UInt4",
     "Vector2",
     "Vector3",
     "Vector4",
@@ -72,7 +76,7 @@ export class WebGLPipelineContext implements IPipelineContext {
                 };
             }
         };
-        ["Int?", "IntArray?", "Array?", "Float?", "Matrices", "Matrix3x3", "Matrix2x2"].forEach((functionName) => {
+        ["Int?", "UInt?", "IntArray?", "UIntArray?", "Array?", "Float?", "Matrices", "Matrix3x3", "Matrix2x2"].forEach((functionName) => {
             const name = `set${functionName}`;
             if (this[name as keyof this]) {
                 return;
@@ -278,6 +282,68 @@ export class WebGLPipelineContext implements IPipelineContext {
      * @param array array to be set.
      */
     public setIntArray4: (uniformName: string, array: Int32Array) => void;
+
+    /**
+     * Sets an unsigned integer value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param value Value to be set.
+     */
+    public setUInt: (uniformName: string, value: number) => void;
+
+    /**
+     * Sets a unsigned int2 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint2.
+     * @param y Second unsigned int in uint2.
+     */
+    public setUInt2: (uniformName: string, x: number, y: number) => void;
+
+    /**
+     * Sets a unsigned int3 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint3.
+     * @param y Second unsigned int in uint3.
+     * @param z Third unsigned int in uint3.
+     */
+    public setUInt3: (uniformName: string, x: number, y: number, z: number) => void;
+
+    /**
+     * Sets a unsigned int4 on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint4.
+     * @param y Second unsigned int in uint4.
+     * @param z Third unsigned int in uint4.
+     * @param w Fourth unsigned int in uint4.
+     */
+    public setUInt4: (uniformName: string, x: number, y: number, z: number, w: number) => void;
+
+    /**
+     * Sets an unsigned int array on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray: (uniformName: string, array: Uint32Array) => void;
+
+    /**
+     * Sets an unsigned int array 2 on a uniform variable. (Array is specified as single array eg. [1,2,3,4] will result in [[1,2],[3,4]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray2: (uniformName: string, array: Uint32Array) => void;
+
+    /**
+     * Sets an unsigned int array 3 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6] will result in [[1,2,3],[4,5,6]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray3: (uniformName: string, array: Uint32Array) => void;
+
+    /**
+     * Sets an unsigned int array 4 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6,7,8] will result in [[1,2,3,4],[5,6,7,8]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray4: (uniformName: string, array: Uint32Array) => void;
 
     /**
      * Sets an array on a uniform variable.

--- a/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
@@ -246,7 +246,7 @@ export class WebGPUPipelineContext implements IPipelineContext {
      * @param uniformName Name of the variable.
      * @param value Value to be set.
      */
-     public setUInt(uniformName: string, value: number): void {
+    public setUInt(uniformName: string, value: number): void {
         if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
             return;
         }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
@@ -242,6 +242,99 @@ export class WebGPUPipelineContext implements IPipelineContext {
     }
 
     /**
+     * Sets an unsigned integer value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param value Value to be set.
+     */
+     public setUInt(uniformName: string, value: number): void {
+        if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
+            return;
+        }
+        this.uniformBuffer.updateUInt(uniformName, value);
+    }
+
+    /**
+     * Sets an unsigned int2 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint2.
+     * @param y Second unsigned int in uint2.
+     */
+    public setUInt2(uniformName: string, x: number, y: number): void {
+        if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
+            return;
+        }
+        this.uniformBuffer.updateUInt2(uniformName, x, y);
+    }
+
+    /**
+     * Sets an unsigned int3 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint3.
+     * @param y Second unsigned int in uint3.
+     * @param z Third unsigned int in uint3.
+     */
+    public setUInt3(uniformName: string, x: number, y: number, z: number): void {
+        if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
+            return;
+        }
+        this.uniformBuffer.updateUInt3(uniformName, x, y, z);
+    }
+
+    /**
+     * Sets an unsigned int4 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint4.
+     * @param y Second unsigned int in uint4.
+     * @param z Third unsigned int in uint4.
+     * @param w Fourth unsigned int in uint4.
+     */
+    public setUInt4(uniformName: string, x: number, y: number, z: number, w: number): void {
+        if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
+            return;
+        }
+        this.uniformBuffer.updateUInt4(uniformName, x, y, z, w);
+    }
+
+    /**
+     * Sets an unsigned int array on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray(uniformName: string, array: Uint32Array): void {
+        if (!this.uniformBuffer || !this._leftOverUniformsByName[uniformName]) {
+            return;
+        }
+        this.uniformBuffer.updateUIntArray(uniformName, array);
+    }
+
+    /**
+     * Sets an unsigned int array 2 on a uniform variable. (Array is specified as single array eg. [1,2,3,4] will result in [[1,2],[3,4]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray2(uniformName: string, array: Uint32Array): void {
+        this.setUIntArray(uniformName, array);
+    }
+
+    /**
+     * Sets an unsigned int array 3 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6] will result in [[1,2,3],[4,5,6]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray3(uniformName: string, array: Uint32Array): void {
+        this.setUIntArray(uniformName, array);
+    }
+
+    /**
+     * Sets an unsigned int array 4 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6,7,8] will result in [[1,2,3,4],[5,6,7,8]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     */
+    public setUIntArray4(uniformName: string, array: Uint32Array): void {
+        this.setUIntArray(uniformName, array);
+    }
+
+    /**
      * Sets an array on a uniform variable.
      * @param uniformName Name of the variable.
      * @param array array to be set.

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3325,6 +3325,137 @@ export class ThinEngine {
     }
 
     /**
+     * Set the value of an uniform to a number (unsigned int)
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param value defines the unsigned int number to store
+     * @returns true if the value was set
+     */
+     public setUInt(uniform: Nullable<WebGLUniformLocation>, value: number): boolean {
+        if (!uniform || this.webGLVersion === 1) {
+            return false;
+        }
+
+        this._gl.uniform1ui(uniform, value);
+
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to a unsigned int2
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param x defines the 1st component of the value
+     * @param y defines the 2nd component of the value
+     * @returns true if the value was set
+     */
+    public setUInt2(uniform: Nullable<WebGLUniformLocation>, x: number, y: number): boolean {
+        if (!uniform) {
+            return false;
+        }
+
+        this._gl.uniform2ui(uniform, x, y);
+
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to a unsigned int3
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param x defines the 1st component of the value
+     * @param y defines the 2nd component of the value
+     * @param z defines the 3rd component of the value
+     * @returns true if the value was set
+     */
+    public setUInt3(uniform: Nullable<WebGLUniformLocation>, x: number, y: number, z: number): boolean {
+        if (!uniform) {
+            return false;
+        }
+
+        this._gl.uniform3ui(uniform, x, y, z);
+
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to a unsigned int4
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param x defines the 1st component of the value
+     * @param y defines the 2nd component of the value
+     * @param z defines the 3rd component of the value
+     * @param w defines the 4th component of the value
+     * @returns true if the value was set
+     */
+    public setUInt4(uniform: Nullable<WebGLUniformLocation>, x: number, y: number, z: number, w: number): boolean {
+        if (!uniform) {
+            return false;
+        }
+
+        this._gl.uniform4ui(uniform, x, y, z, w);
+
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to an array of unsigned int32
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param array defines the array of unsigned int32 to store
+     * @returns true if the value was set
+     */
+    public setUIntArray(uniform: Nullable<WebGLUniformLocation>, array: Uint32Array): boolean {
+        if (!uniform) {
+            return false;
+        }
+
+        this._gl.uniform1uiv(uniform, array);
+
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to an array of unsigned int32 (stored as vec2)
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param array defines the array of unsigned int32 to store
+     * @returns true if the value was set
+     */
+    public setUIntArray2(uniform: Nullable<WebGLUniformLocation>, array: Uint32Array): boolean {
+        if (!uniform || array.length % 2 !== 0) {
+            return false;
+        }
+
+        this._gl.uniform2uiv(uniform, array);
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to an array of unsigned int32 (stored as vec3)
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param array defines the array of unsigned int32 to store
+     * @returns true if the value was set
+     */
+    public setUIntArray3(uniform: Nullable<WebGLUniformLocation>, array: Uint32Array): boolean {
+        if (!uniform || array.length % 3 !== 0) {
+            return false;
+        }
+
+        this._gl.uniform3uiv(uniform, array);
+        return true;
+    }
+
+    /**
+     * Set the value of an uniform to an array of unsigned int32 (stored as vec4)
+     * @param uniform defines the webGL uniform location where to store the value
+     * @param array defines the array of unsigned int32 to store
+     * @returns true if the value was set
+     */
+    public setUIntArray4(uniform: Nullable<WebGLUniformLocation>, array: Uint32Array): boolean {
+        if (!uniform || array.length % 4 !== 0) {
+            return false;
+        }
+
+        this._gl.uniform4uiv(uniform, array);
+        return true;
+    }
+
+    /**
      * Set the value of an uniform to an array of number
      * @param uniform defines the webGL uniform location where to store the value
      * @param array defines the array of number to store

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3330,7 +3330,7 @@ export class ThinEngine {
      * @param value defines the unsigned int number to store
      * @returns true if the value was set
      */
-     public setUInt(uniform: Nullable<WebGLUniformLocation>, value: number): boolean {
+    public setUInt(uniform: Nullable<WebGLUniformLocation>, value: number): boolean {
         if (!uniform || this.webGLVersion === 1) {
             return false;
         }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3331,7 +3331,7 @@ export class ThinEngine {
      * @returns true if the value was set
      */
     public setUInt(uniform: Nullable<WebGLUniformLocation>, value: number): boolean {
-        if (!uniform || this.webGLVersion === 1) {
+        if (!uniform) {
             return false;
         }
 

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -402,16 +402,18 @@ export class Effect implements IDisposable {
                 return this;
             };
         };
-        ["Int?", "IntArray?", "Array?", "Color?", "Vector?", "Float?", "Matrices", "Matrix", "Matrix3x3", "Matrix2x2", "Quaternion", "DirectColor4"].forEach((functionName) => {
-            const name = `set${functionName}`;
-            if (name.endsWith("?")) {
-                ["", 2, 3, 4].forEach((n) => {
-                    this[(name.slice(0, -1) + n) as keyof this] = this[(name.slice(0, -1) + n) as keyof this] || proxyFunction(name.slice(0, -1) + n).bind(this);
-                });
-            } else {
-                this[name as keyof this] = this[name as keyof this] || proxyFunction(name).bind(this);
+        ["Int?", "UInt?", "IntArray?", "UIntArray?", "Array?", "Color?", "Vector?", "Float?", "Matrices", "Matrix", "Matrix3x3", "Matrix2x2", "Quaternion", "DirectColor4"].forEach(
+            (functionName) => {
+                const name = `set${functionName}`;
+                if (name.endsWith("?")) {
+                    ["", 2, 3, 4].forEach((n) => {
+                        this[(name.slice(0, -1) + n) as keyof this] = this[(name.slice(0, -1) + n) as keyof this] || proxyFunction(name.slice(0, -1) + n).bind(this);
+                    });
+                } else {
+                    this[name as keyof this] = this[name as keyof this] || proxyFunction(name).bind(this);
+                }
             }
-        });
+        );
     }
 
     private _useFinalCode(migratedVertexCode: string, migratedFragmentCode: string, baseName: any) {
@@ -1121,6 +1123,76 @@ export class Effect implements IDisposable {
      * @returns this effect.
      */
     public setIntArray4: (uniformName: string, array: Int32Array) => Effect;
+
+    /**
+     * Sets an unsigned integer value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param value Value to be set.
+     * @returns this effect.
+     */
+    public setUInt: (uniformName: string, value: number) => Effect;
+
+    /**
+     * Sets an unsigned int2 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint2.
+     * @param y Second unsigned int in uint2.
+     * @returns this effect.
+     */
+    public setUInt2: (uniformName: string, x: number, y: number) => Effect;
+
+    /**
+     * Sets an unsigned int3 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint3.
+     * @param y Second unsigned int in uint3.
+     * @param z Third unsigned int in uint3.
+     * @returns this effect.
+     */
+    public setUInt3: (uniformName: string, x: number, y: number, z: number) => Effect;
+
+    /**
+     * Sets an unsigned int4 value on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param x First unsigned int in uint4.
+     * @param y Second unsigned int in uint4.
+     * @param z Third unsigned int in uint4.
+     * @param w Fourth unsigned int in uint4.
+     * @returns this effect.
+     */
+    public setUInt4: (uniformName: string, x: number, y: number, z: number, w: number) => Effect;
+
+    /**
+     * Sets an unsigned int array on a uniform variable.
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     * @returns this effect.
+     */
+    public setUIntArray: (uniformName: string, array: Uint32Array) => Effect;
+
+    /**
+     * Sets an unsigned int array 2 on a uniform variable. (Array is specified as single array eg. [1,2,3,4] will result in [[1,2],[3,4]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     * @returns this effect.
+     */
+    public setUIntArray2: (uniformName: string, array: Uint32Array) => Effect;
+
+    /**
+     * Sets an unsigned int array 3 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6] will result in [[1,2,3],[4,5,6]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     * @returns this effect.
+     */
+    public setUIntArray3: (uniformName: string, array: Uint32Array) => Effect;
+
+    /**
+     * Sets an unsigned int array 4 on a uniform variable. (Array is specified as single array eg. [1,2,3,4,5,6,7,8] will result in [[1,2,3,4],[5,6,7,8]] in the shader)
+     * @param uniformName Name of the variable.
+     * @param array array to be set.
+     * @returns this effect.
+     */
+    public setUIntArray4: (uniformName: string, array: Uint32Array) => Effect;
 
     /**
      * Sets an float array on a uniform variable.

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -308,7 +308,7 @@ export class ShaderMaterial extends PushMaterial {
      * @param value Define the value to give to the uniform
      * @return the material itself allowing "fluent" like uniform updates
      */
-     public setUInt(name: string, value: number): ShaderMaterial {
+    public setUInt(name: string, value: number): ShaderMaterial {
         this._checkUniform(name);
         this._uints[name] = value;
 

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -107,6 +107,7 @@ export class ShaderMaterial extends PushMaterial {
     private _externalTextures: { [name: string]: ExternalTexture } = {};
     private _floats: { [name: string]: number } = {};
     private _ints: { [name: string]: number } = {};
+    private _uints: { [name: string]: number } = {};
     private _floatsArrays: { [name: string]: number[] } = {};
     private _colors3: { [name: string]: Color3 } = {};
     private _colors3Arrays: { [name: string]: number[] } = {};
@@ -297,6 +298,19 @@ export class ShaderMaterial extends PushMaterial {
     public setInt(name: string, value: number): ShaderMaterial {
         this._checkUniform(name);
         this._ints[name] = value;
+
+        return this;
+    }
+
+    /**
+     * Set a unsigned int in the shader.
+     * @param name Define the name of the uniform as defined in the shader
+     * @param value Define the value to give to the uniform
+     * @return the material itself allowing "fluent" like uniform updates
+     */
+     public setUInt(name: string, value: number): ShaderMaterial {
+        this._checkUniform(name);
+        this._uints[name] = value;
 
         return this;
     }
@@ -989,6 +1003,11 @@ export class ShaderMaterial extends PushMaterial {
                 effect.setInt(name, this._ints[name]);
             }
 
+            // UInt
+            for (name in this._uints) {
+                effect.setUInt(name, this._uints[name]);
+            }
+
             // Float
             for (name in this._floats) {
                 effect.setFloat(name, this._floats[name]);
@@ -1214,6 +1233,11 @@ export class ShaderMaterial extends PushMaterial {
             result.setInt(key, this._ints[key]);
         }
 
+        // UInt
+        for (const key in this._uints) {
+            result.setUInt(key, this._uints[key]);
+        }
+
         // Float
         for (const key in this._floats) {
             result.setFloat(key, this._floats[key]);
@@ -1388,6 +1412,12 @@ export class ShaderMaterial extends PushMaterial {
             serializationObject.ints[name] = this._ints[name];
         }
 
+        // UInt
+        serializationObject.uints = {};
+        for (name in this._uints) {
+            serializationObject.uints[name] = this._uints[name];
+        }
+
         // Float
         serializationObject.floats = {};
         for (name in this._floats) {
@@ -1540,6 +1570,11 @@ export class ShaderMaterial extends PushMaterial {
         // Int
         for (name in source.ints) {
             material.setInt(name, source.ints[name]);
+        }
+
+        // UInt
+        for (name in source.uints) {
+            material.setUInt(name, source.uints[name]);
         }
 
         // Float

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -111,6 +111,13 @@ export class UniformBuffer {
     public updateIntArray: (name: string, array: Int32Array) => void;
 
     /**
+     * Lambda to Update an array of number in a uniform buffer.
+     * This is dynamic to allow compat with webgl 1 and 2.
+     * You will need to pass the name of the uniform as well as the value.
+     */
+     public updateUIntArray: (name: string, array: Uint32Array) => void;
+
+    /**
      * Lambda to Update a 4x4 Matrix in a uniform buffer.
      * This is dynamic to allow compat with webgl 1 and 2.
      * You will need to pass the name of the uniform as well as the value.
@@ -186,6 +193,34 @@ export class UniformBuffer {
      * You will need to pass the name of the uniform as well as the value.
      */
     public updateInt4: (name: string, x: number, y: number, z: number, w: number, suffix?: string) => void;
+
+    /**
+     * Lambda to Update a unsigned int a uniform buffer.
+     * This is dynamic to allow compat with webgl 1 and 2.
+     * You will need to pass the name of the uniform as well as the value.
+     */
+     public updateUInt: (name: string, x: number, suffix?: string) => void;
+
+     /**
+      * Lambda to Update a vec2 of unsigned int in a uniform buffer.
+      * This is dynamic to allow compat with webgl 1 and 2.
+      * You will need to pass the name of the uniform as well as the value.
+      */
+     public updateUInt2: (name: string, x: number, y: number, suffix?: string) => void;
+
+     /**
+      * Lambda to Update a vec3 of unsigned int in a uniform buffer.
+      * This is dynamic to allow compat with webgl 1 and 2.
+      * You will need to pass the name of the uniform as well as the value.
+      */
+     public updateUInt3: (name: string, x: number, y: number, z: number, suffix?: string) => void;
+
+     /**
+      * Lambda to Update a vec4 of unsigned int in a uniform buffer.
+      * This is dynamic to allow compat with webgl 1 and 2.
+      * You will need to pass the name of the uniform as well as the value.
+      */
+     public updateUInt4: (name: string, x: number, y: number, z: number, w: number, suffix?: string) => void;
 
     /**
      * Instantiates a new Uniform buffer objects.

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -115,7 +115,7 @@ export class UniformBuffer {
      * This is dynamic to allow compat with webgl 1 and 2.
      * You will need to pass the name of the uniform as well as the value.
      */
-     public updateUIntArray: (name: string, array: Uint32Array) => void;
+    public updateUIntArray: (name: string, array: Uint32Array) => void;
 
     /**
      * Lambda to Update a 4x4 Matrix in a uniform buffer.
@@ -199,28 +199,28 @@ export class UniformBuffer {
      * This is dynamic to allow compat with webgl 1 and 2.
      * You will need to pass the name of the uniform as well as the value.
      */
-     public updateUInt: (name: string, x: number, suffix?: string) => void;
+    public updateUInt: (name: string, x: number, suffix?: string) => void;
 
-     /**
-      * Lambda to Update a vec2 of unsigned int in a uniform buffer.
-      * This is dynamic to allow compat with webgl 1 and 2.
-      * You will need to pass the name of the uniform as well as the value.
-      */
-     public updateUInt2: (name: string, x: number, y: number, suffix?: string) => void;
+    /**
+     * Lambda to Update a vec2 of unsigned int in a uniform buffer.
+     * This is dynamic to allow compat with webgl 1 and 2.
+     * You will need to pass the name of the uniform as well as the value.
+     */
+    public updateUInt2: (name: string, x: number, y: number, suffix?: string) => void;
 
-     /**
-      * Lambda to Update a vec3 of unsigned int in a uniform buffer.
-      * This is dynamic to allow compat with webgl 1 and 2.
-      * You will need to pass the name of the uniform as well as the value.
-      */
-     public updateUInt3: (name: string, x: number, y: number, z: number, suffix?: string) => void;
+    /**
+     * Lambda to Update a vec3 of unsigned int in a uniform buffer.
+     * This is dynamic to allow compat with webgl 1 and 2.
+     * You will need to pass the name of the uniform as well as the value.
+     */
+    public updateUInt3: (name: string, x: number, y: number, z: number, suffix?: string) => void;
 
-     /**
-      * Lambda to Update a vec4 of unsigned int in a uniform buffer.
-      * This is dynamic to allow compat with webgl 1 and 2.
-      * You will need to pass the name of the uniform as well as the value.
-      */
-     public updateUInt4: (name: string, x: number, y: number, z: number, w: number, suffix?: string) => void;
+    /**
+     * Lambda to Update a vec4 of unsigned int in a uniform buffer.
+     * This is dynamic to allow compat with webgl 1 and 2.
+     * You will need to pass the name of the uniform as well as the value.
+     */
+    public updateUInt4: (name: string, x: number, y: number, z: number, w: number, suffix?: string) => void;
 
     /**
      * Instantiates a new Uniform buffer objects.

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -45,7 +45,8 @@ export class UniformBuffer {
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
     private static _TempBuffer = new Float32Array(UniformBuffer._MAX_UNIFORM_SIZE);
-    private static _TempBufferInt32View = new Uint32Array(UniformBuffer._TempBuffer.buffer);
+    private static _TempBufferInt32View = new Int32Array(UniformBuffer._TempBuffer.buffer);
+    private static _TempBufferUInt32View = new Uint32Array(UniformBuffer._TempBuffer.buffer);
 
     /**
      * Lambda to Update a 3x3 Matrix in a uniform buffer.
@@ -268,6 +269,7 @@ export class UniformBuffer {
             this.updateFloatArray = this._updateFloatArrayForEffect;
             this.updateArray = this._updateArrayForEffect;
             this.updateIntArray = this._updateIntArrayForEffect;
+            this.updateUIntArray = this._updateUIntArrayForEffect;
             this.updateMatrix = this._updateMatrixForEffect;
             this.updateMatrices = this._updateMatricesForEffect;
             this.updateVector3 = this._updateVector3ForEffect;
@@ -279,6 +281,10 @@ export class UniformBuffer {
             this.updateInt2 = this._updateInt2ForEffect;
             this.updateInt3 = this._updateInt3ForEffect;
             this.updateInt4 = this._updateInt4ForEffect;
+            this.updateUInt = this._updateUIntForEffect;
+            this.updateUInt2 = this._updateUInt2ForEffect;
+            this.updateUInt3 = this._updateUInt3ForEffect;
+            this.updateUInt4 = this._updateUInt4ForEffect;
         } else {
             this._engine._uniformBuffers.push(this);
 
@@ -291,6 +297,7 @@ export class UniformBuffer {
             this.updateFloatArray = this._updateFloatArrayForUniform;
             this.updateArray = this._updateArrayForUniform;
             this.updateIntArray = this._updateIntArrayForUniform;
+            this.updateUIntArray = this._updateUIntArrayForUniform;
             this.updateMatrix = this._updateMatrixForUniform;
             this.updateMatrices = this._updateMatricesForUniform;
             this.updateVector3 = this._updateVector3ForUniform;
@@ -302,6 +309,10 @@ export class UniformBuffer {
             this.updateInt2 = this._updateInt2ForUniform;
             this.updateInt3 = this._updateInt3ForUniform;
             this.updateInt4 = this._updateInt4ForUniform;
+            this.updateUInt = this._updateUIntForUniform;
+            this.updateUInt2 = this._updateUInt2ForUniform;
+            this.updateUInt3 = this._updateUInt3ForUniform;
+            this.updateUInt4 = this._updateUInt4ForUniform;
         }
     }
 
@@ -883,6 +894,15 @@ export class UniformBuffer {
         this.updateUniformArray(name, UniformBuffer._TempBuffer, array.length);
     }
 
+    private _updateUIntArrayForEffect(name: string, array: Uint32Array) {
+        this._currentEffect.setUIntArray(name, array);
+    }
+
+    private _updateUIntArrayForUniform(name: string, array: Uint32Array) {
+        UniformBuffer._TempBufferUInt32View.set(array);
+        this.updateUniformArray(name, UniformBuffer._TempBuffer, array.length);
+    }
+
     private _updateMatrixForEffect(name: string, mat: IMatrixLike) {
         this._currentEffect.setMatrix(name, mat);
     }
@@ -998,6 +1018,48 @@ export class UniformBuffer {
         UniformBuffer._TempBufferInt32View[1] = y;
         UniformBuffer._TempBufferInt32View[2] = z;
         UniformBuffer._TempBufferInt32View[3] = w;
+        this.updateUniform(name, UniformBuffer._TempBuffer, 4);
+    }
+
+    private _updateUIntForEffect(name: string, x: number, suffix = "") {
+        this._currentEffect.setUInt(name + suffix, x);
+    }
+
+    private _updateUIntForUniform(name: string, x: number) {
+        UniformBuffer._TempBufferUInt32View[0] = x;
+        this.updateUniform(name, UniformBuffer._TempBuffer, 1);
+    }
+
+    private _updateUInt2ForEffect(name: string, x: number, y: number, suffix = "") {
+        this._currentEffect.setUInt2(name + suffix, x, y);
+    }
+
+    private _updateUInt2ForUniform(name: string, x: number, y: number) {
+        UniformBuffer._TempBufferUInt32View[0] = x;
+        UniformBuffer._TempBufferUInt32View[1] = y;
+        this.updateUniform(name, UniformBuffer._TempBuffer, 2);
+    }
+
+    private _updateUInt3ForEffect(name: string, x: number, y: number, z: number, suffix = "") {
+        this._currentEffect.setUInt3(name + suffix, x, y, z);
+    }
+
+    private _updateUInt3ForUniform(name: string, x: number, y: number, z: number) {
+        UniformBuffer._TempBufferUInt32View[0] = x;
+        UniformBuffer._TempBufferUInt32View[1] = y;
+        UniformBuffer._TempBufferUInt32View[2] = z;
+        this.updateUniform(name, UniformBuffer._TempBuffer, 3);
+    }
+
+    private _updateUInt4ForEffect(name: string, x: number, y: number, z: number, w: number, suffix = "") {
+        this._currentEffect.setUInt4(name + suffix, x, y, z, w);
+    }
+
+    private _updateUInt4ForUniform(name: string, x: number, y: number, z: number, w: number) {
+        UniformBuffer._TempBufferUInt32View[0] = x;
+        UniformBuffer._TempBufferUInt32View[1] = y;
+        UniformBuffer._TempBufferUInt32View[2] = z;
+        UniformBuffer._TempBufferUInt32View[3] = w;
         this.updateUniform(name, UniformBuffer._TempBuffer, 4);
     }
 


### PR DESCRIPTION
Current version can not pass unsigned int uniform to shader when using ShaderMaterial
[Example](https://playground.babylonjs.com/#1OH09K#1727)
This PR add support for passing unsigned int uniform