### PR TITLE
Animations: storing key frames in typed arrays

### DIFF
--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -7,6 +7,7 @@ import type { Nullable } from "../types";
 import type { Scene } from "../scene";
 import { SerializationHelper } from "../Misc/decorators";
 import { RegisterClass } from "../Misc/typeStore";
+import { InstantiationTools } from "../Misc/instantiationTools";
 import type { IAnimationKey } from "./animationKey";
 import { AnimationKeyInterpolation } from "./animationKey";
 import { AnimationRange } from "./animationRange";
@@ -93,7 +94,7 @@ export class Animation {
     /**
      * Stores the animation ranges for the animation
      */
-    private _ranges: { [name: string]: Nullable<AnimationRange> } = {};
+    protected _ranges: { [name: string]: Nullable<AnimationRange> } = {};
 
     /**
      * @internal Internal use
@@ -1302,6 +1303,13 @@ export class Animation {
      * @returns Animation object
      */
     public static Parse(parsedAnimation: any): Animation {
+        if (parsedAnimation.customType) {
+            const customType = InstantiationTools.Instantiate(parsedAnimation.customType);
+            if (customType?.Parse) {
+                return customType.Parse(parsedAnimation);
+            }
+        }
+
         const animation = new Animation(parsedAnimation.name, parsedAnimation.property, parsedAnimation.framePerSecond, parsedAnimation.dataType, parsedAnimation.loopBehavior);
 
         const dataType = parsedAnimation.dataType;

--- a/packages/dev/core/src/Animations/animationTools.ts
+++ b/packages/dev/core/src/Animations/animationTools.ts
@@ -1,0 +1,306 @@
+import type { Scene } from "../scene";
+import type { Animation } from "./animation";
+import type { IAnimatable } from "./animatable.interface";
+
+/**
+ * The callback for animation iteration in scene
+ */
+export interface IterateAnimationCallback {
+    /**
+     * The callback for animation iteration in scene
+     * @param animation current animation
+     * @param key key of context
+     * @param context object holding this animation
+     * @returns false to stop the iteration
+     */
+    (animation: Animation, key: number | string, context: any): void | boolean;
+}
+
+/**
+ * Iterate through all animations of scene, could iterate an animation many times
+ * @param scene The scene holding animations
+ * @param callBack function to be called on any animation
+ */
+export function iterateAnimations(scene: Scene, callBack: IterateAnimationCallback): void {
+    const {
+        animations,
+        animatables,
+        animationGroups,
+        transformNodes,
+        meshes,
+        materials,
+        textures,
+        cameras,
+        particleSystems,
+        morphTargetManagers,
+        skeletons,
+        spriteManagers,
+        postProcesses,
+    } = scene;
+
+    let len = animations?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            if (callBack(animations[i], i, animations) === false) {
+                return;
+            }
+        }
+    }
+
+    len = animatables?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const animatable = animatables[i];
+            const runtimeAnimations = animatable.getAnimations();
+            const length = runtimeAnimations?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const runtimeAnimation = runtimeAnimations[i];
+                    const animation = runtimeAnimation?.animation;
+                    if (animation && callBack(animation, "_animation", runtimeAnimation) === false) {
+                        return;
+                    }
+                    const target = runtimeAnimation?.target;
+                    if (target?.animations) {
+                        const iAnimatable = target as IAnimatable;
+                        const animations = iAnimatable.animations;
+                        const animationsLength = animations?.length;
+                        if (animations && animationsLength) {
+                            for (let k = 0; k < animationsLength; k++) {
+                                const animation = animations[k];
+                                if (animation && callBack(animation, k, animations) === false) {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    len = animationGroups?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const group = animationGroups[i];
+            const targetedAnimations = group?.targetedAnimations;
+            let length = targetedAnimations?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const targetedAnimation = targetedAnimations[j];
+                    const animation = targetedAnimation?.animation;
+                    if (animation && callBack(animation, "animation", targetedAnimation)) {
+                        return;
+                    }
+                    const target = targetedAnimation.target;
+                    if (target?.animations) {
+                        const iAnimatable = target as IAnimatable;
+                        const animations = iAnimatable.animations;
+                        const animationsLength = animations?.length;
+                        if (animations && animationsLength) {
+                            for (let k = 0; k < animationsLength; k++) {
+                                const animation = animations[k];
+                                if (animation && callBack(animation, k, animations) === false) {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            const animatables = group?.animatables;
+            length = animatables?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const animatable = animatables[j];
+                    const runtimeAnimations = animatable.getAnimations();
+                    const length = runtimeAnimations?.length;
+                    if (length) {
+                        for (let k = 0; k < length; k++) {
+                            const runtimeAnimation = runtimeAnimations[k];
+                            if (runtimeAnimation?.animation && callBack(runtimeAnimation.animation, "_animation", runtimeAnimation) === false) {
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    len = morphTargetManagers?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const morphTargetManager = morphTargetManagers[i];
+            const targetsLength = morphTargetManager.numTargets;
+            if (!targetsLength) {
+                continue;
+            }
+            for (let j = 0; j < targetsLength; j++) {
+                const target = morphTargetManager.getTarget(j);
+                const animations = target?.animations;
+                const length = animations?.length;
+                if (!length) {
+                    continue;
+                }
+                for (let k = 0; k < length; k++) {
+                    const animation = animations[k];
+                    if (animation && callBack(animation, k, animations) === false) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    len = skeletons?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const skeleton = skeletons[i];
+            const bones = skeleton?.bones;
+            const length = bones?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const target = bones[j];
+                    const animations = target?.animations;
+                    const animationsLength = animations?.length;
+                    if (!animationsLength) {
+                        continue;
+                    }
+                    for (let k = 0; k < animationsLength; k++) {
+                        const animation = animations[k];
+                        if (animation && callBack(animation, k, animations) === false) {
+                            return;
+                        }
+                    }
+                }
+            }
+            const animations = skeleton?.animations;
+            const animationsLength = animations?.length;
+            if (animationsLength) {
+                for (let j = 0; j < animationsLength; j++) {
+                    const animation = animations[j];
+                    if (animation && callBack(animation, j, animations) === false) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    len = spriteManagers?.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const spriteManager = spriteManagers[i];
+            const sprites = spriteManager?.sprites;
+            const length = sprites?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const target = sprites[j];
+                    const animations = target?.animations;
+                    const animationsLength = animations?.length;
+                    if (!animationsLength) {
+                        continue;
+                    }
+                    for (let k = 0; k < animationsLength; k++) {
+                        const animation = animations[k];
+                        if (animation && callBack(animation, k, animations) === false) {
+                            return;
+                        }
+                    }
+                }
+            }
+            const animations = spriteManager?.texture?.animations;
+            const animationsLength = animations?.length;
+            if (animationsLength) {
+                for (let j = 0; j < animationsLength; j++) {
+                    const animation = animations[j];
+                    if (animation && callBack(animation, j, animations) === false) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    let iAnimatables: IAnimatable[] = [];
+
+    len = transformNodes?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(transformNodes);
+    }
+    len = meshes?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(meshes);
+    }
+    len = cameras?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(cameras);
+    }
+    len = materials?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(materials);
+    }
+    len = textures?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(textures);
+    }
+    len = particleSystems?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(particleSystems);
+    }
+    len = postProcesses?.length;
+    if (len) {
+        iAnimatables = iAnimatables.concat(postProcesses);
+    }
+
+    len = iAnimatables.length;
+    if (len) {
+        for (let i = 0; i < len; i++) {
+            const iAnimatable = iAnimatables[i];
+            const animations = iAnimatable?.animations;
+            const length = animations?.length;
+            if (length) {
+                for (let j = 0; j < length; j++) {
+                    const animation = animations[j];
+                    if (animation && callBack(animation, j, animations) === false) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Replace animation from scene
+ * @param scene The scene holding animation
+ * @param animation The animation to be replaced
+ * @param replacement The animation to be replaced to
+ */
+export function replaceAnimation(scene: Scene, animation: Animation, replacement: Animation): number {
+    let count = 0;
+    iterateAnimations(scene, (current, key, context) => {
+        if (animation === current) {
+            context[key] = replacement;
+            count++;
+        }
+    });
+    return count;
+}
+
+/**
+ * Replace multiple animations from scene
+ * @param scene The scene holding animation
+ * @param map Map of animations where key holding the animation to be replaced, value holding replacement
+ */
+export function replaceAnimations(scene: Scene, map: Map<Animation, Animation>): number {
+    let count = 0;
+    iterateAnimations(scene, (current, key, context) => {
+        const replacement = map.get(current);
+        if (replacement) {
+            context[key] = replacement;
+            count++;
+        }
+    });
+    return count;
+}

--- a/packages/dev/core/src/Animations/compactAnimation.ts
+++ b/packages/dev/core/src/Animations/compactAnimation.ts
@@ -1,0 +1,1677 @@
+import type { _IAnimationState } from "./animation";
+import type { IAnimationKey } from "./animationKey";
+import type { DeepImmutable } from "../types";
+import { Animation } from "./animation";
+import { AnimationKeyInterpolation } from "./animationKey";
+import { Matrix, Quaternion, Vector2, Vector3 } from "../Maths/math.vector";
+import { Color3, Color4 } from "../Maths/math.color";
+import { Size } from "../Maths/math.size";
+import { DecodeBase64ToBinary, EncodeArrayBufferToBase64 } from "../Misc/stringTools";
+import { RegisterClass } from "../Misc/typeStore";
+
+export const strideMap: DeepImmutable<Record<number, number>> = {
+    [Animation.ANIMATIONTYPE_FLOAT]: 1,
+    [Animation.ANIMATIONTYPE_VECTOR3]: 3,
+    [Animation.ANIMATIONTYPE_QUATERNION]: 4,
+    [Animation.ANIMATIONTYPE_MATRIX]: 16,
+    [Animation.ANIMATIONTYPE_COLOR3]: 3,
+    [Animation.ANIMATIONTYPE_COLOR4]: 4,
+    [Animation.ANIMATIONTYPE_VECTOR2]: 2,
+    [Animation.ANIMATIONTYPE_SIZE]: 2,
+};
+
+type TypedArray = Int8Array | Int16Array | Int32Array | Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Float32Array | Float64Array;
+
+type TypedArrayConstructor =
+    | typeof Int8Array
+    | typeof Int16Array
+    | typeof Int32Array
+    | typeof Uint8Array
+    | typeof Uint8ClampedArray
+    | typeof Uint16Array
+    | typeof Uint32Array
+    | typeof Float32Array
+    | typeof Float64Array;
+
+const typedArrayMap: Record<string, TypedArrayConstructor> = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Int8Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Int16Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Int32Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Uint8Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Uint8ClampedArray,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Uint16Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Uint32Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Float32Array,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Float64Array,
+};
+
+type CompactAnimationTypes =
+    | typeof FloatCompactAnimation
+    | typeof Vector3CompactAnimation
+    | typeof QuaternionCompactAnimation
+    | typeof MatrixCompactAnimation
+    | typeof Color3CompactAnimation
+    | typeof Color4CompactAnimation
+    | typeof Vector2CompactAnimation
+    | typeof SizeCompactAnimation;
+
+/**
+ * The base class for animation with keyframes stored as typed array.
+ */
+export abstract class CompactAnimation<T> extends Animation {
+    /**
+     * Whether to clone frames and values on {@link CompactAnimation#clone}
+     * Defaults to false
+     */
+    public static DeepCloneBuffers: boolean;
+
+    /**
+     * Set this to true to serialize frames and values to base64.
+     * Set this to false to get TypedArrays in serialized result.
+     * Defaults to true
+     */
+    public static SerializeBuffersToBase64: boolean;
+
+    /**
+     * Whether to compact buffers for frames and values on {@link CompactAnimation#serialize}
+     * Note this would clone the CompactAnimation and return serialized compacted clone
+     * Defaults to false
+     */
+    public static SerializeCompactBuffers: boolean;
+
+    /**
+     * The `input` of GLTF animation sampler
+     */
+    protected _frames: null | TypedArray;
+    /**
+     * The `output` of GLTF animation sampler
+     */
+    protected _values: null | TypedArray;
+    /**
+     * The stride for {@link CompactAnimation#frames}, not byte stride
+     */
+    public frameStride: number;
+    /**
+     * The stride for {@link CompactAnimation#values}, not byte stride
+     */
+    public stride: number;
+    /**
+     * The initial offset for {@link CompactAnimation#values}, not byte offset
+     */
+    public valueOffset: number;
+    /**
+     * The scalar for {@link CompactAnimation#values},
+     * mainly for normalized values, 0 to not use a scalar
+     */
+    public normalizeScalar: number;
+
+    /**
+     * The animation key frame interpolation type, can not be set per-frame
+     */
+    public interpolation: AnimationKeyInterpolation;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._frames = null;
+        this.frameStride = 1;
+        this._values = null;
+        this.stride = strideMap[dataType] || 1;
+        this.valueOffset = 0;
+        this.normalizeScalar = 0;
+        this.interpolation = AnimationKeyInterpolation.NONE;
+    }
+
+    /**
+     * Gets the frames
+     */
+    public get frames() {
+        return this._frames;
+    }
+
+    /**
+     * Sets the frames
+     * @param value Array of frame numbers multiplied by {@link Animation#framePerSecond}
+     */
+    public set frames(value) {
+        this._frames = value;
+    }
+
+    /**
+     * Gets the values
+     */
+    public get values() {
+        return this._values;
+    }
+
+    /**
+     * Sets the values
+     * @param value Array of values
+     */
+    public set values(value) {
+        this._values = value;
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.CompactAnimation";
+    }
+
+    /**
+     * Converts the animation to a string
+     * @param fullDetails support for multiple levels of logging within scene loading
+     * @returns String form of the animation
+     */
+    public toString(fullDetails: boolean): string {
+        let ret = "Name: " + this.name + ", property: " + this.targetProperty;
+        ret += ", datatype: " + ["Float", "Vector3", "Quaternion", "Matrix", "Color3", "Vector2"][this.dataType];
+        ret += ", nKeys: " + (this._frames ? this._frames.length / this.frameStride : "none");
+        ret += ", nRanges: " + (this._ranges ? Object.keys(this._ranges).length : "none");
+        if (fullDetails) {
+            ret += ", Ranges: {";
+            let first = true;
+            for (const name in this._ranges) {
+                if (first) {
+                    ret += ", ";
+                    first = false;
+                }
+                ret += name;
+            }
+            ret += "}";
+        }
+        return ret;
+    }
+
+    /**
+     * Deletes an animation range by name
+     * @param name Name of the animation range to delete
+     * @param deleteFrames Specifies if the key frames for the range should also be deleted (true) or not (false)
+     */
+    public deleteRange(name: string, deleteFrames = true): void {
+        const range = this._ranges[name];
+        if (!range) {
+            return;
+        }
+        if (deleteFrames) {
+            const from = range.from;
+            const to = range.to;
+            let keepFrames = 0;
+
+            const frames = this._frames;
+            const values = this._values;
+            if (frames && values) {
+                const frameStride = this.frameStride;
+                // this should be faster that double allocations
+                for (let key = 0, frame = 0, nKeys = frames.length; key < nKeys; key += frameStride) {
+                    frame = frames[key];
+                    // why not math.max?
+                    if (frame >= from && frame <= to) {
+                        continue;
+                    }
+                    keepFrames++;
+                }
+                const writeFrames = new (frames.constructor as TypedArrayConstructor)(keepFrames);
+                let writeFrameIndex = writeFrames.length - 1;
+
+                const stride = this.stride;
+                const writeStride = strideMap[this.dataType] || stride;
+                const valueOffset = this.valueOffset;
+                const writeValues = new (frames.constructor as TypedArrayConstructor)(keepFrames * writeStride);
+                let writeValueIndex = writeValues.length - 1;
+                let readIndex = 0;
+
+                for (let key = 0, frame = 0, nKeys = frames.length; key < nKeys; key += frameStride) {
+                    frame = frames[key];
+                    // why not math.max?
+                    if (frame >= from && frame <= to) {
+                        continue;
+                    }
+                    readIndex = (key + 1) * stride - 1 + valueOffset;
+                    writeFrames[writeFrameIndex--] = frame;
+                    for (let i = writeStride - 1; i >= 0; i--) {
+                        writeValues[writeValueIndex--] = values[readIndex--];
+                    }
+                }
+                this._frames = writeFrames;
+                this.frameStride = 1;
+                this._values = writeValues;
+                this.stride = writeStride;
+                this.valueOffset = 0;
+                // recalculate keys if removed first or last key
+                this.recalculateKeys();
+            }
+        }
+        this._ranges[name] = null; // said much faster than 'delete this._range[name]'
+    }
+
+    /**
+     * Gets the highest frame rate of the animation
+     * @returns Highest frame rate of the animation
+     */
+    public getHighestFrame(): number {
+        let ret = 0;
+        const frames = this._frames;
+        if (frames) {
+            const frameStride = this.frameStride;
+            for (let key = 0, frame = 0, nKeys = frames.length; key < nKeys; key += frameStride) {
+                frame = frames[key];
+                // why not math.max?
+                if (ret < frame) {
+                    ret = frame;
+                }
+            }
+            return ret;
+        } else {
+            return super.getHighestFrame();
+        }
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public abstract _cloneValueAt(offset: number, stride: number): T;
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public abstract _startValueAt(offset: number, stride: number): T;
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public abstract _endValueAt(offset: number, stride: number): T;
+
+    /**
+     * Recalculate this._keys with the first and last frame
+     * for compatibility with AnimationGroup after frames or values changed
+     */
+    public recalculateKeys(): void {
+        const frames = this._frames;
+        const values = this._values;
+        if (!frames || !values) {
+            return;
+        }
+        const framePerSecond = this.framePerSecond;
+        const firstFrameIndex = 0;
+        const frameStride = this.frameStride;
+        const stride = this.stride;
+        const lastFrameIndex = Math.floor(frames.length / frameStride) - 1;
+        const newKeys: IAnimationKey[] = [
+            {
+                frame: frames[firstFrameIndex] * framePerSecond,
+                value: this._cloneValueAt(firstFrameIndex, stride),
+                interpolation: this.interpolation,
+            },
+            {
+                frame: frames[lastFrameIndex * frameStride] * framePerSecond,
+                value: this._cloneValueAt(lastFrameIndex, stride),
+                interpolation: this.interpolation,
+            },
+        ];
+        this.setKeys(newKeys);
+    }
+
+    /**
+     * @internal Internal use only
+     */
+    public _interpolate(currentFrame: number, state: _IAnimationState): T {
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_CONSTANT && state.repeatCount > 0) {
+            return state.highLimitValue.clone ? state.highLimitValue.clone() : state.highLimitValue;
+        }
+        const frames = this._frames;
+        if (!frames) {
+            throw new TypeError("CompactAnimation: frames is required for _interpolate");
+        }
+        const frameStride = this.frameStride;
+        const framesLength = frames.length / frameStride;
+        let key = state.key;
+        currentFrame /= this.framePerSecond;
+
+        // would binary search works better here?
+        while (key >= 0 && currentFrame < frames[key * frameStride]) {
+            --key;
+        }
+        while (key + 1 <= framesLength - 1 && currentFrame >= frames[(key + 1) * frameStride]) {
+            ++key;
+        }
+
+        state.key = key;
+        const valueStride = this.stride;
+        if (key < 0) {
+            return this._startValueAt(0, valueStride);
+        } else if (key + 1 > framesLength - 1) {
+            return this._startValueAt(framesLength - 1, valueStride);
+        }
+        const startFrame = frames[key * frameStride];
+        const endFrame = frames[(key + 1) * frameStride];
+        const startValue = this._startValueAt(key, valueStride);
+        const endValue = this._endValueAt(key + 1, valueStride);
+        if (this.interpolation === AnimationKeyInterpolation.STEP) {
+            if (endFrame > currentFrame) {
+                return startValue;
+            } else {
+                return endValue;
+            }
+        }
+        const frameDelta = endFrame - startFrame;
+        // gradient : percent of currentFrame between the frame inf and the frame sup
+        let gradient = (currentFrame - startFrame) / frameDelta;
+        // check for easingFunction and correction of gradient
+        const easingFunction = this.getEasingFunction();
+        if (easingFunction !== null) {
+            gradient = easingFunction.ease(gradient);
+        }
+        return this._interpolateInternal(startValue, endValue, gradient, state);
+    }
+
+    /**
+     * Interpolates a value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public abstract _interpolateInternal(startValue: T, endValue: T, gradient: number, state: _IAnimationState): T;
+
+    /**
+     * Makes a copy of the animation
+     * @returns Cloned animation
+     */
+    public clone(): this {
+        const clone: this = new (this.constructor as any)(this.name, this.targetPropertyPath.join("."), this.framePerSecond, this.dataType, this.loopMode);
+
+        // implicitly clones the keys
+        clone.setKeys(this.getKeys());
+
+        clone.enableBlending = this.enableBlending;
+        clone.blendingSpeed = this.blendingSpeed;
+        clone.frameStride = this.frameStride;
+        clone.stride = this.stride;
+        clone.valueOffset = this.valueOffset;
+
+        if (this._frames && this._values) {
+            if (CompactAnimation.DeepCloneBuffers) {
+                clone._frames = this._frames.slice();
+                clone._values = this._values.slice();
+            } else {
+                clone._frames = this._frames;
+                clone._values = this._values;
+            }
+        }
+
+        if (this._ranges) {
+            clone._ranges = {};
+            for (const name in this._ranges) {
+                const range = this._ranges[name];
+                if (!range) {
+                    continue;
+                }
+                clone._ranges[name] = range.clone();
+            }
+        }
+
+        return clone;
+    }
+
+    /**
+     * Interpolates a quaternion using a spherical linear interpolation
+     * In CompactAnimation is is rewritten to write the result to `endValue`
+     * to reduce memory allocations.
+     *
+     * @param startValue Start value of the animation curve
+     * @param endValue End value of the animation curve
+     * @param gradient Scalar amount to interpolate
+     * @returns Interpolated quaternion value
+     */
+    public quaternionInterpolateFunction(startValue: Quaternion, endValue: Quaternion, gradient: number): Quaternion {
+        Quaternion.SlerpToRef(startValue, endValue, gradient, endValue);
+        return endValue;
+    }
+
+    /**
+     * Interpolates a Vector3 linearly
+     * In CompactAnimation is is rewritten to write the result to `endValue`
+     * to reduce memory allocations.
+     *
+     * @param startValue Start value of the animation curve
+     * @param endValue End value of the animation curve
+     * @param gradient Scalar amount to interpolate (value between 0 and 1)
+     * @returns Interpolated scalar value
+     */
+    public vector3InterpolateFunction(startValue: Vector3, endValue: Vector3, gradient: number): Vector3 {
+        Vector3.LerpToRef(startValue, endValue, gradient, endValue);
+        return endValue;
+    }
+    /**
+     * Interpolates a Color3 linearly
+     * In CompactAnimation is is rewritten to write the result to `endValue`
+     * to reduce memory allocations.
+     *
+     * @param startValue Start value of the animation curve
+     * @param endValue End value of the animation curve
+     * @param gradient Scalar amount to interpolate
+     * @returns Interpolated Color3 value
+     */
+    public color3InterpolateFunction(startValue: Color3, endValue: Color3, gradient: number): Color3 {
+        Color3.LerpToRef(startValue, endValue, gradient, endValue);
+        return endValue;
+    }
+
+    /**
+     * Interpolates a Color4 linearly
+     * In CompactAnimation is is rewritten to write the result to `endValue`
+     * to reduce memory allocations.
+     *
+     * @param startValue Start value of the animation curve
+     * @param endValue End value of the animation curve
+     * @param gradient Scalar amount to interpolate
+     * @returns Interpolated Color3 value
+     */
+    public color4InterpolateFunction(startValue: Color4, endValue: Color4, gradient: number): Color4 {
+        Color4.LerpToRef(startValue, endValue, gradient, endValue);
+        return endValue;
+    }
+
+    /**
+     * Keep the first key and last key for AnimationGroup
+     * Note in CompactAnimation this is only kept to be compatible with AnimationGroups
+     * @param values The animation key frames to set
+     */
+    public setKeys(values: IAnimationKey[]): void {
+        if (values.length > 2) {
+            values = [values[0], values[values.length - 1]];
+            super.setKeys(values);
+            return;
+        }
+        super.setKeys(values);
+    }
+
+    /**
+     * Check if the buffers is compact
+     */
+    public isBuffersCompact(): boolean {
+        return this.frameStride === 1 && strideMap[this.dataType] === this.stride;
+    }
+
+    /**
+     * Compact the frames and values buffers
+     * TODO: compact for gltf with 4-bytes alignment for each item for quantized values
+     * @returns success or not
+     */
+    public compactBuffers(): boolean {
+        const compactFrames = this.compactFrames();
+        const compactValues = this.compactValues();
+        return compactFrames || compactValues;
+    }
+
+    /**
+     * Compact the frames buffer
+     * @returns success or not
+     */
+    public compactFrames(): boolean {
+        const frameStride = this.frameStride;
+        if (frameStride === 1) {
+            return false;
+        }
+        let writeIndex = 0;
+        const frames = this._frames;
+        if (!frames) {
+            return false;
+        }
+        const length = frames.length;
+        const writeFrames = new (frames.constructor as TypedArrayConstructor)(length / frameStride);
+
+        for (let i = 0; i < length; i += frameStride) {
+            writeFrames[writeIndex++] = frames[i];
+        }
+
+        this._frames = writeFrames;
+        this.frameStride = 1;
+        return true;
+    }
+
+    /**
+     * Compact the values buffer
+     * @returns success or not
+     */
+    public compactValues(): boolean {
+        const stride = this.stride;
+        const compactStride = strideMap[this.dataType] || stride;
+        if (compactStride === stride) {
+            return false;
+        }
+        let writeIndex = 0;
+        const values = this._values;
+        if (!values) {
+            return false;
+        }
+        const length = values.length;
+        const valueOffset = this.valueOffset;
+        const compactLength = (length * compactStride) / stride;
+        const writeValues = new (values.constructor as TypedArrayConstructor)(compactLength);
+
+        for (let i = 0; i < length; i += stride) {
+            for (let j = 0; j < compactStride; j++) {
+                writeValues[writeIndex++] = values[i + j + valueOffset];
+            }
+        }
+
+        this._values = writeValues;
+        this.stride = compactStride;
+        this.valueOffset = 0;
+        return true;
+    }
+
+    /**
+     * Serializes the animation to an object
+     * @returns Serialized object
+     */
+    public serialize(): any {
+        if (CompactAnimation.SerializeCompactBuffers && !this.isBuffersCompact()) {
+            const clone = this.clone();
+            clone.compactBuffers();
+            return clone.serialize();
+        }
+        const serializationObject = super.serialize();
+        serializationObject.customType = this.getClassName();
+        serializationObject.frameStride = this.frameStride;
+        serializationObject.stride = this.stride;
+        serializationObject.interpolation = this.interpolation;
+        serializationObject.normalizeScalar = this.normalizeScalar;
+        serializationObject.valueOffset = this.valueOffset;
+        if (this._frames) {
+            // The name of TypedArray constructor is defined is spec
+            // https://262.ecma-international.org/13.0/#table-the-typedarray-constructors
+            serializationObject._framesType = this._frames.constructor.name;
+        }
+        if (this._values) {
+            serializationObject._valuesType = this._values.constructor.name;
+        }
+        if (CompactAnimation.SerializeBuffersToBase64) {
+            if (this._frames) {
+                serializationObject._frames = EncodeArrayBufferToBase64(this._frames);
+            }
+            if (this._values) {
+                serializationObject._values = EncodeArrayBufferToBase64(this._values);
+            }
+        } else {
+            if (this._frames) {
+                serializationObject._frames = this._frames;
+            }
+            if (this._values) {
+                serializationObject._values = this._values;
+            }
+        }
+        return serializationObject;
+    }
+
+    /**
+     * This is a copy of {@link Animation.Parse}, removed tangent related code,
+     * for parsing data from serialized subclasses of CompactAnimation
+     *
+     * @param parsedAnimation The serialized animation object
+     * @param animation The instance of {@link Animation} to write parsed data to
+     * @internal
+     */
+    public static _ParseAnimation(parsedAnimation: any, animation: Animation): Animation {
+        const dataType = parsedAnimation.dataType;
+        const keys: IAnimationKey[] = [];
+        let data;
+        let index: number;
+        if (parsedAnimation.enableBlending) {
+            animation.enableBlending = parsedAnimation.enableBlending;
+        }
+        if (parsedAnimation.blendingSpeed) {
+            animation.blendingSpeed = parsedAnimation.blendingSpeed;
+        }
+        for (index = 0; index < parsedAnimation.keys.length; index++) {
+            const key = parsedAnimation.keys[index];
+            let interpolation: any = undefined;
+            switch (dataType) {
+                case Animation.ANIMATIONTYPE_FLOAT:
+                    data = key.values[0];
+                    if (key.values.length >= 4) {
+                        interpolation = key.values[3];
+                    }
+                    break;
+                case Animation.ANIMATIONTYPE_QUATERNION:
+                    data = Quaternion.FromArray(key.values);
+                    if (key.values.length >= 13) {
+                        interpolation = key.values[12];
+                    }
+                    break;
+                case Animation.ANIMATIONTYPE_MATRIX:
+                    data = Matrix.FromArray(key.values);
+                    if (key.values.length >= 17) {
+                        interpolation = key.values[16];
+                    }
+                    break;
+                case Animation.ANIMATIONTYPE_COLOR3:
+                    data = Color3.FromArray(key.values);
+                    if (key.values[5]) {
+                        interpolation = key.values[5];
+                    }
+                    break;
+                case Animation.ANIMATIONTYPE_COLOR4:
+                    data = Color4.FromArray(key.values);
+                    if (key.values[6]) {
+                        interpolation = Color4.FromArray(key.values[6]);
+                    }
+                    break;
+                case Animation.ANIMATIONTYPE_VECTOR3:
+                default:
+                    data = Vector3.FromArray(key.values);
+                    if (key.values[5]) {
+                        interpolation = key.values[5];
+                    }
+                    break;
+            }
+            const keyData: IAnimationKey = {
+                frame: key.frame,
+                value: data,
+            };
+            if (interpolation != undefined) {
+                keyData.interpolation = interpolation;
+            }
+            keys.push(keyData);
+        }
+        animation.setKeys(keys);
+        if (parsedAnimation.ranges) {
+            for (index = 0; index < parsedAnimation.ranges.length; index++) {
+                data = parsedAnimation.ranges[index];
+                animation.createRange(data.name, data.from, data.to);
+            }
+        }
+        return animation;
+    }
+
+    /**
+     * Parses serialized animation object and creates an instance of CompactAnimation
+     *
+     * @param parsedAnimation The serialized animation object
+     * @param constructor The constructor of type of CompactAnimation
+     * @internal
+     */
+    public static ParseInternal<T>(parsedAnimation: any, constructor: CompactAnimationTypes): CompactAnimation<T> {
+        const animation: CompactAnimation<T> = new (constructor as any)(
+            parsedAnimation.name,
+            parsedAnimation.property,
+            parsedAnimation.framePerSecond,
+            parsedAnimation.dataType,
+            parsedAnimation.loopBehavior
+        );
+        CompactAnimation._ParseAnimation(parsedAnimation, animation);
+
+        animation.frameStride = parsedAnimation.frameStride || 1;
+        animation.stride = parsedAnimation.stride || strideMap[parsedAnimation.dataType];
+        animation.interpolation = parsedAnimation.interpolation;
+        animation.normalizeScalar = parsedAnimation.normalizeScalar;
+        animation.valueOffset = parsedAnimation.valueOffset;
+
+        if (typeof parsedAnimation._frames === "string") {
+            const arrayBuffer = DecodeBase64ToBinary(parsedAnimation._frames);
+            animation._frames = new typedArrayMap[parsedAnimation._framesType](arrayBuffer);
+        } else {
+            animation._frames = parsedAnimation._frames;
+        }
+        if (typeof parsedAnimation._values === "string") {
+            const arrayBuffer = DecodeBase64ToBinary(parsedAnimation._values);
+            animation._values = new typedArrayMap[parsedAnimation._valuesType](arrayBuffer);
+        } else {
+            animation._values = parsedAnimation._values;
+        }
+        return animation;
+    }
+}
+
+/**
+ * Set this to true to serialize frames and values to base64.
+ * Set this to false to get TypedArrays in serialized result.
+ */
+CompactAnimation.SerializeBuffersToBase64 = true;
+
+/**
+ * Whether to clone frames and values on {@link CompactAnimation#clone}
+ */
+CompactAnimation.DeepCloneBuffers = false;
+
+/**
+ * Whether to compact buffers for frames and values on {@link CompactAnimation#serialize}
+ * Note this would clone the CompactAnimation and return serialized compacted clone
+ * Defaults to false
+ */
+CompactAnimation.SerializeCompactBuffers = false;
+
+RegisterClass("BABYLON.CompactAnimation", CompactAnimation);
+
+/**
+ * Float number based {@link CompactAnimation}
+ */
+export class FloatCompactAnimation extends CompactAnimation<number> {
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.FloatCompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): number {
+        return this._startValueAt(offset, stride);
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): number {
+        const valueOffset = this.valueOffset;
+        let val = this._values![offset * stride + valueOffset];
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val *= normalizeScalar;
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): number {
+        const valueOffset = this.valueOffset;
+        let val = this._values![offset * stride + valueOffset];
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val *= normalizeScalar;
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a float value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: number, endValue: number, gradient: number, state: _IAnimationState): number {
+        const floatValue = this.floatInterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            return state.offsetValue * state.repeatCount + floatValue;
+        }
+        return floatValue;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized FloatCompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): FloatCompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, FloatCompactAnimation);
+    }
+}
+
+RegisterClass("BABYLON.FloatCompactAnimation", FloatCompactAnimation);
+
+/**
+ * {@link Quaternion} based {@link CompactAnimation}
+ */
+export class QuaternionCompactAnimation extends CompactAnimation<Quaternion> {
+    /** @internal */
+    public _tmpVal0: Quaternion;
+    /** @internal */
+    public _tmpVal1: Quaternion;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Quaternion();
+        this._tmpVal1 = new Quaternion();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.QuaternionCompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Quaternion {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns Quaternion at offset and stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Quaternion {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Quaternion.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning Quaternion must be writable and may be written to
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Quaternion {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Quaternion.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Quaternion, endValue: Quaternion, gradient: number, state: _IAnimationState): Quaternion {
+        const quaternion = this.quaternionInterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            state.offsetValue.scaleAndAddToRef(state.repeatCount, quaternion);
+        }
+        return quaternion;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized QuaternionCompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): QuaternionCompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, QuaternionCompactAnimation) as QuaternionCompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.QuaternionCompactAnimation", QuaternionCompactAnimation);
+
+/**
+ * {@link Vector3} based {@link CompactAnimation}
+ */
+export class Vector3CompactAnimation extends CompactAnimation<Vector3> {
+    /** @internal */
+    public _tmpVal0: Vector3;
+    /** @internal */
+    public _tmpVal1: Vector3;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Vector3();
+        this._tmpVal1 = new Vector3();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.Vector3CompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Vector3 {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Vector3 {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Vector3.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Vector3 {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Vector3.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a Vector3 value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Vector3, endValue: Vector3, gradient: number, state: _IAnimationState): Vector3 {
+        const vec3Value = this.vector3InterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            state.offsetValue.scaleAndAddToRef(state.repeatCount, vec3Value);
+        }
+        return vec3Value;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized Vector3CompactAnimation
+     * @returns Animation object
+     */
+    static Parse(parsedAnimation: any): Vector3CompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, Vector3CompactAnimation) as Vector3CompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.Vector3CompactAnimation", Vector3CompactAnimation);
+
+/**
+ * {@link Vector2} based {@link CompactAnimation}
+ */
+export class Vector2CompactAnimation extends CompactAnimation<Vector2> {
+    /** @internal */
+    public _tmpVal0: Vector2;
+    /** @internal */
+    public _tmpVal1: Vector2;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Vector2();
+        this._tmpVal1 = new Vector2();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.Vector2CompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Vector2 {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Vector2 {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Vector2.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Vector2 {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Vector2.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a Vector2 value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Vector2, endValue: Vector2, gradient: number, state: _IAnimationState): Vector2 {
+        const vec2Value = this.vector2InterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            state.offsetValue.scaleAndAddToRef(state.repeatCount, vec2Value);
+        }
+        return vec2Value;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized Vector2CompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): Animation {
+        return CompactAnimation.ParseInternal(parsedAnimation, Vector2CompactAnimation);
+    }
+}
+
+RegisterClass("BABYLON.Vector2CompactAnimation", Vector2CompactAnimation);
+
+/**
+ * {@link Size} based {@link CompactAnimation}
+ */
+export class SizeCompactAnimation extends CompactAnimation<Size> {
+    /** @internal */
+    public _tmpVal0: Size;
+    /** @internal */
+    public _tmpVal1: Size;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Size(0, 0);
+        this._tmpVal1 = new Size(0, 0);
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.SizeCompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Size {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Size {
+        const val = this._tmpVal0;
+        const array = this._values!;
+        const valueOffset = this.valueOffset;
+        let arrayOffset = stride * offset + valueOffset;
+        val.width = array[arrayOffset++];
+        val.height = array[arrayOffset];
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.width = val.width * normalizeScalar;
+            val.height = val.height * normalizeScalar;
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Size {
+        const val = this._tmpVal1;
+        const array = this._values!;
+        const valueOffset = this.valueOffset;
+        let arrayOffset = stride * offset + valueOffset;
+        val.width = array[arrayOffset++];
+        val.height = array[arrayOffset];
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.width = val.width * normalizeScalar;
+            val.height = val.height * normalizeScalar;
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a Size value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Size, endValue: Size, gradient: number, state: _IAnimationState): Size {
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            return this.sizeInterpolateFunction(startValue, endValue, gradient).add(state.offsetValue.scale(state.repeatCount));
+        }
+        return this.sizeInterpolateFunction(startValue, endValue, gradient);
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized SizeCompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): SizeCompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, SizeCompactAnimation) as SizeCompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.SizeCompactAnimation", SizeCompactAnimation);
+
+/**
+ * {@link Color3} based {@link CompactAnimation}
+ */
+export class Color3CompactAnimation extends CompactAnimation<Color3> {
+    /** @internal */
+    public _tmpVal0: Color3;
+    /** @internal */
+    public _tmpVal1: Color3;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Color3();
+        this._tmpVal1 = new Color3();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.Color3CompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Color3 {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Color3 {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Color3.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Color3 {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Color3.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a Color3 value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Color3, endValue: Color3, gradient: number, state: _IAnimationState): Color3 {
+        const color3Value = this.color3InterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            state.offsetValue.scaleAndAddToRef(color3Value);
+        }
+        return color3Value;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized Color3CompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): Color3CompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, Color3CompactAnimation) as Color3CompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.Color3CompactAnimation", Color3CompactAnimation);
+
+/**
+ * {@link Color4} based {@link CompactAnimation}
+ */
+export class Color4CompactAnimation extends CompactAnimation<Color4> {
+    /** @internal */
+    public _tmpVal0: Color4;
+    /** @internal */
+    public _tmpVal1: Color4;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Color4();
+        this._tmpVal1 = new Color4();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.Color4CompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Color4 {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Color4 {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Color4.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Color4 {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Color4.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleInPlace(normalizeScalar);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a Color4 value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Color4, endValue: Color4, gradient: number, state: _IAnimationState): Color4 {
+        const color4Value = this.color4InterpolateFunction(startValue, endValue, gradient);
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            state.offsetValue.scaleAndAddToRef(state.repeatCount, color4Value);
+        }
+        return color4Value;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized Color4CompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): Color4CompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, Color4CompactAnimation) as Color4CompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.Color4CompactAnimation", Color4CompactAnimation);
+
+/**
+ * {@link Matrix} based {@link CompactAnimation}
+ */
+export class MatrixCompactAnimation extends CompactAnimation<Matrix> {
+    /** @internal */
+    public _tmpVal0: Matrix;
+    /** @internal */
+    public _tmpVal1: Matrix;
+
+    /**
+     * Initializes the animation
+     * @param name Name of the animation
+     * @param targetProperty Property to animate
+     * @param framePerSecond The frames per second of the animation
+     * @param dataType The data type of the animation
+     * @param loopMode The loop mode of the animation
+     * @param enableBlending Specifies if blending should be enabled
+     */
+    constructor(
+        /**Name of the animation */
+        name: string,
+        /**Property to animate */
+        targetProperty: string,
+        /**The frames per second of the animation */
+        framePerSecond: number,
+        /**The data type of the animation */
+        dataType: number,
+        /**The loop mode of the animation */
+        loopMode?: number,
+        /**Specifies if blending should be enabled */
+        enableBlending?: boolean
+    ) {
+        super(name, targetProperty, framePerSecond, dataType, loopMode, enableBlending);
+        this._tmpVal0 = new Matrix();
+        this._tmpVal1 = new Matrix();
+    }
+
+    /**
+     * Get the current class name of the animation useful for serialization or dynamic coding.
+     */
+    public getClassName(): string {
+        return "BABYLON.MatrixCompactAnimation";
+    }
+
+    /**
+     * Gets and clone value at offset and stride for external usage
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _cloneValueAt(offset: number, stride: number): Matrix {
+        return this._startValueAt(offset, stride).clone();
+    }
+
+    /**
+     * Gets the start value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @internal Internal use only
+     */
+    public _startValueAt(offset: number, stride: number): Matrix {
+        const val = this._tmpVal0;
+        const valueOffset = this.valueOffset;
+        Matrix.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleToRef(normalizeScalar, val);
+        }
+        return val;
+    }
+
+    /**
+     * Gets the end value at offset and stride for interpolation
+     * @param offset
+     * @param stride
+     * @returns The returning value must be writable and may be written
+     * @internal Internal use only
+     */
+    public _endValueAt(offset: number, stride: number): Matrix {
+        const val = this._tmpVal1;
+        const valueOffset = this.valueOffset;
+        Matrix.FromArrayToRef(this._values!, stride * offset + valueOffset, val);
+        const normalizeScalar = this.normalizeScalar;
+        if (normalizeScalar) {
+            val.scaleToRef(normalizeScalar, val);
+        }
+        return val;
+    }
+
+    /**
+     * Interpolates a value linearly, could write result to endValue
+     * @internal Internal use only
+     */
+    public _interpolateInternal(startValue: Matrix, endValue: Matrix, gradient: number, state: _IAnimationState): Matrix {
+        if (state.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            return startValue;
+        }
+        if (Animation.AllowMatricesInterpolation) {
+            return this.matrixInterpolateFunction(startValue, endValue, gradient, state.workValue || endValue);
+        }
+        return startValue;
+    }
+
+    /**
+     * Parses an animation object and creates an animation
+     * @param parsedAnimation Parsed animation object of serialized MatrixCompactAnimation
+     * @returns Animation object
+     */
+    public static Parse(parsedAnimation: any): MatrixCompactAnimation {
+        return CompactAnimation.ParseInternal(parsedAnimation, MatrixCompactAnimation) as MatrixCompactAnimation;
+    }
+}
+
+RegisterClass("BABYLON.MatrixCompactAnimation", MatrixCompactAnimation);
+
+/**
+ * Mapping from animation type to CompactAnimation classes
+ */
+export const compactAnimationTypeMap: Record<number, CompactAnimationTypes> = {
+    [Animation.ANIMATIONTYPE_FLOAT]: FloatCompactAnimation,
+    [Animation.ANIMATIONTYPE_VECTOR3]: Vector3CompactAnimation,
+    [Animation.ANIMATIONTYPE_QUATERNION]: QuaternionCompactAnimation,
+    [Animation.ANIMATIONTYPE_MATRIX]: MatrixCompactAnimation,
+    [Animation.ANIMATIONTYPE_COLOR3]: Color3CompactAnimation,
+    [Animation.ANIMATIONTYPE_COLOR4]: Color4CompactAnimation,
+    [Animation.ANIMATIONTYPE_VECTOR2]: Vector2CompactAnimation,
+    [Animation.ANIMATIONTYPE_SIZE]: SizeCompactAnimation,
+};

--- a/packages/dev/core/src/Animations/compactAnimationTools.ts
+++ b/packages/dev/core/src/Animations/compactAnimationTools.ts
@@ -1,0 +1,242 @@
+import { Animation } from "./animation";
+import type { IAnimationKey } from "./animationKey";
+import { AnimationKeyInterpolation } from "./animationKey";
+import { Matrix, Quaternion, Vector3 } from "../Maths/math.vector";
+import { Color3, Color4 } from "../Maths/math.color";
+import { CompactAnimation, compactAnimationTypeMap, QuaternionCompactAnimation, strideMap } from "./compactAnimation";
+
+/**
+ * Clone range to another animation
+ * @param src Animation
+ * @param target Animation
+ */
+function cloneRanges(src: any, target: any): void {
+    if (src._ranges) {
+        target._ranges = {};
+        for (const name in src._ranges) {
+            const range = src._ranges[name];
+            if (!range) {
+                continue;
+            }
+            target._ranges[name] = range.clone();
+        }
+    }
+}
+
+/**
+ * Convert {@link Animation} to {@link CompactAnimation}
+ *
+ * @param animation The animation to convert
+ * @returns The converted CompactAnimation, false for failed
+ */
+export function animationToCompactAnimation(animation: Animation): CompactAnimation<any> | false {
+    if (animation instanceof CompactAnimation) {
+        return animation;
+    }
+    const dataType = animation.dataType;
+    const stride = strideMap[dataType];
+    if (!stride) {
+        return false;
+    }
+    const constructor = compactAnimationTypeMap[dataType];
+    if (!constructor) {
+        return false;
+    }
+    const keys = animation.getKeys();
+    let interpolation = undefined;
+    for (let i = 0, length = keys.length, key; i < length; i++) {
+        key = keys[i];
+        if (key.interpolation !== undefined) {
+            if (interpolation === undefined) {
+                interpolation = key.interpolation;
+            } else if (interpolation !== key.interpolation) {
+                // per frame interpolation not supported
+                return false;
+            }
+        }
+        if (key.inTangent !== undefined || key.outTangent !== undefined || key.lockedTangent !== undefined) {
+            // CUBICSPLINE not supported
+            return false;
+        }
+    }
+    const frames = new Float32Array(keys.length);
+    const values = new Float32Array(frames.length * stride);
+    let writeIndex = 0;
+    const framePerSecond = animation.framePerSecond;
+
+    for (let i = 0, length = keys.length, key; i < length; i++) {
+        key = keys[i];
+        frames[i] = key.frame / framePerSecond;
+        if (dataType === Animation.ANIMATIONTYPE_FLOAT) {
+            values[writeIndex++] = key.value;
+        } else if (dataType === Animation.ANIMATIONTYPE_SIZE) {
+            values[writeIndex++] = key.value.width;
+            values[writeIndex++] = key.value.height;
+        } else if (dataType === Animation.ANIMATIONTYPE_MATRIX) {
+            values.set(key.value.toArray(), writeIndex);
+            writeIndex += stride;
+        } else {
+            key.value.toArray(values, writeIndex);
+            writeIndex += stride;
+        }
+    }
+    const compact = new constructor(animation.name, animation.targetProperty, animation.framePerSecond, dataType, animation.loopMode, animation.enableBlending);
+
+    if (animation.blendingSpeed) {
+        compact.blendingSpeed = animation.blendingSpeed;
+    }
+    cloneRanges(animation, compact);
+    // this would internally keep first and last keys
+    compact.setKeys(keys);
+    compact.frames = frames;
+    compact.values = values;
+    compact.stride = stride;
+    compact.interpolation = interpolation || AnimationKeyInterpolation.NONE;
+    return compact;
+}
+
+/**
+ * Convert {@link CompactAnimation} to {@link Animation}
+ * @param animation The CompactAnimation to convert
+ * @returns The converted {@link Animation}
+ */
+export function compactAnimationToAnimation(animation: Animation | CompactAnimation<any>): Animation {
+    if (!(animation instanceof CompactAnimation)) {
+        return animation;
+    }
+    const dataType = animation.dataType;
+    const framePerSecond = animation.framePerSecond;
+    const result = new Animation(animation.name, animation.targetProperty, framePerSecond, dataType, animation.loopMode, animation.enableBlending);
+
+    if (animation.blendingSpeed) {
+        result.blendingSpeed = animation.blendingSpeed;
+    }
+
+    cloneRanges(animation, result);
+
+    const frames = animation.frames;
+    const values = animation.values;
+
+    if (!frames || !values) {
+        // empty animation supported
+        result.setKeys([]);
+        return result;
+    }
+
+    const stride = animation.stride;
+    const frameStride = animation.frameStride;
+    const frameLength = frames.length / frameStride;
+    const keys: IAnimationKey[] = new Array(frameLength);
+    const interpolation = animation.interpolation;
+
+    let index = 0;
+    let frameIndex = 0;
+    let valueIndex = animation.valueOffset;
+    if (dataType === Animation.ANIMATIONTYPE_FLOAT) {
+        for (; index < frameLength; index++) {
+            const keyData: IAnimationKey = {
+                frame: frames[frameIndex] * framePerSecond,
+                value: values[valueIndex],
+            };
+            if (interpolation) {
+                keyData.interpolation = interpolation;
+            }
+            keys[index] = keyData;
+            frameIndex += frameStride;
+            valueIndex += stride;
+        }
+    } else {
+        let valueClass;
+        switch (dataType) {
+            case Animation.ANIMATIONTYPE_QUATERNION:
+                valueClass = Quaternion;
+                break;
+            case Animation.ANIMATIONTYPE_MATRIX:
+                valueClass = Matrix;
+                break;
+            case Animation.ANIMATIONTYPE_COLOR3:
+                valueClass = Color3;
+                break;
+            case Animation.ANIMATIONTYPE_COLOR4:
+                valueClass = Color4;
+                break;
+            case Animation.ANIMATIONTYPE_VECTOR3:
+            default:
+                valueClass = Vector3;
+                break;
+        }
+        for (; index < frameLength; index++) {
+            const keyData: IAnimationKey = {
+                frame: frames[frameIndex] * framePerSecond,
+                value: valueClass.FromArray(values, valueIndex),
+            };
+            if (interpolation) {
+                keyData.interpolation = interpolation;
+            }
+            keys[index] = keyData;
+            frameIndex += frameStride;
+            valueIndex += stride;
+        }
+    }
+
+    result.setKeys(keys);
+    return result;
+}
+
+/**
+ * Convert rotation {@link CompactAnimation} to
+ * {@link Quaternion}-based {@link CompactAnimation},
+ * for gltf serializing
+ * @param animation The CompactAnimation to convert
+ * @returns the converted {@link CompactAnimation}, false for fail
+ */
+export function rotationCompactAnimationToQuaternion(animation: CompactAnimation<Vector3>): QuaternionCompactAnimation | false {
+    if (animation.dataType === Animation.ANIMATIONTYPE_QUATERNION) {
+        return animation as any;
+    }
+    if (animation.dataType !== Animation.ANIMATIONTYPE_VECTOR3 && animation.targetProperty !== "rotation") {
+        return false;
+    }
+    if (!animation.frames || !animation.values) {
+        return false;
+    }
+    const newAnimation = new QuaternionCompactAnimation(
+        animation.name,
+        "rotationQuaternion",
+        animation.framePerSecond,
+        Animation.ANIMATIONTYPE_QUATERNION,
+        animation.loopMode,
+        animation.enableBlending
+    );
+    newAnimation.blendingSpeed = animation.blendingSpeed;
+
+    if (CompactAnimation.DeepCloneBuffers) {
+        newAnimation.frames = animation.frames.slice();
+    } else {
+        newAnimation.frames = animation.frames;
+    }
+    newAnimation.frameStride = animation.frameStride;
+
+    const values = new Float32Array(animation.frames.length / animation.frameStride);
+    newAnimation.stride = 4;
+    newAnimation.valueOffset = 0;
+    newAnimation.normalizeScalar = 0;
+    newAnimation.values = values;
+
+    const source = animation.values;
+    const tempQuaternion = Quaternion.Identity();
+    let readOffset = animation.valueOffset;
+    const readStride = animation.stride;
+    let writeOffset = 0;
+    for (; writeOffset < values.length; writeOffset += 4) {
+        // Vector3#toQuaternion
+        Quaternion.RotationYawPitchRollToRef(source[readOffset], source[readOffset + 1], source[readOffset + 2], tempQuaternion);
+        tempQuaternion.toArray(values, writeOffset);
+        readOffset += readStride;
+        writeOffset += 4;
+    }
+
+    cloneRanges(animation, newAnimation);
+
+    return newAnimation;
+}

--- a/packages/dev/core/src/Animations/index.ts
+++ b/packages/dev/core/src/Animations/index.ts
@@ -9,3 +9,6 @@ export * from "./animationKey";
 export * from "./animationRange";
 export * from "./animatable.interface";
 export * from "./pathCursor";
+export * from "./animationTools";
+export * from "./compactAnimation";
+export * from "./compactAnimationTools";

--- a/packages/dev/serializers/src/glTF/2.0/glTFCompactAnimation.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFCompactAnimation.ts
@@ -1,0 +1,356 @@
+import { Animation } from "core/Animations/animation";
+import { AnimationKeyInterpolation } from "core/Animations/animationKey";
+import type { CompactAnimation } from "core/Animations/compactAnimation";
+import { FloatCompactAnimation } from "core/Animations/compactAnimation";
+import { _GLTFUtilities } from "./glTFUtilities";
+import type { IAccessor, IAnimation, IBufferView } from "babylonjs-gltf2interface";
+import { AccessorComponentType, AccessorType, AnimationChannelTargetPath, AnimationSamplerInterpolation } from "babylonjs-gltf2interface";
+import type { Node } from "core/node";
+import type { _BinaryWriter } from "./glTFExporter";
+import type { Nullable } from "core/types";
+import type { MorphTarget } from "core/Morph/morphTarget";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type _IAnimationInfo = import("./glTFAnimation")._IAnimationInfo;
+
+/**
+ * The in-memory auto-expending float32 writing buffer without reallocating on writing
+ * @internal
+ */
+class _Float32Buffer {
+    /**
+     * Size of next auto-expending memory block
+     */
+    blockSize: number;
+    /**
+     * Last written value
+     */
+    lastValue: number;
+    /**
+     * Written length
+     */
+    length: number;
+    /**
+     * Allocated memory size
+     */
+    capacity: number;
+    /**
+     * Write offset of current buffer
+     * @internal
+     */
+    _offset: number;
+    /**
+     * Allocated memory buffers
+     */
+    buf: Float32Array[];
+
+    /**
+     * Creates a new buffer
+     * Note no memory blocks are allocated here
+     *
+     * @param blockSize Initial block size
+     */
+    constructor(blockSize = 1024) {
+        this.blockSize = blockSize;
+        this.lastValue = 0;
+        this.length = 0;
+        this.capacity = 0;
+        this._offset = 0;
+        this.buf = [];
+    }
+
+    /**
+     * Get next buffer writable for specified size
+     * @internal
+     * @param size
+     */
+    _nextBuf(size: number): Float32Array {
+        const capacity = this.capacity;
+        const length = this.length;
+        const buf = this.buf;
+        if (capacity >= length + size) {
+            // buf.at(-1);
+            return buf[buf.length - 1];
+        }
+        const blockSize = this.blockSize;
+        const newBuf = new Float32Array(blockSize);
+        buf.push(newBuf);
+        this.capacity += blockSize;
+        this._offset = 0;
+        return newBuf;
+    }
+
+    /**
+     * Append a value to buffer
+     * @param value the value to append
+     */
+    append(value: number): void {
+        const buf = this._nextBuf(1);
+        const offset = this._offset;
+        buf[offset] = value;
+        this._offset++;
+        this.lastValue = value;
+        this.length++;
+    }
+
+    /**
+     * Concat all written values to a Float32Array
+     */
+    toArray(): Float32Array {
+        const length = this.length;
+        const f32a = new Float32Array(length);
+        let offset = 0;
+        const buf = this.buf;
+        let remaining = length;
+        let index = 0;
+        while (remaining > 0) {
+            let curr = buf[index++];
+            if (remaining < curr.length) {
+                curr = curr.subarray(0, remaining);
+            }
+            f32a.set(curr, offset);
+            offset += curr.length;
+            remaining -= curr.length;
+        }
+        return f32a;
+    }
+}
+
+function getFrame<T>(animation: CompactAnimation<T>, index: number) {
+    return animation.frames![index * animation.frameStride];
+}
+
+function getValue<T>(animation: CompactAnimation<T>, index: number): T {
+    return animation._startValueAt(index, animation.stride);
+}
+
+/**
+ * Holder for info needed for merging CompactAnimation for morph target
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+interface _MergeMorphTargetCompactAnimationInfo {
+    /**
+     * Current frame
+     */
+    frame: number;
+    /**
+     * Index of {@link _MergeMorphTargetCompactAnimationInfo#frame}
+     */
+    index: number;
+    /**
+     * The CompactAnimation
+     */
+    animation: CompactAnimation<any>;
+}
+
+/**
+ * Find next morph target animation with next frame
+ * @param mergeInfos array containing info of all animations
+ * @returns The next animation info or null
+ */
+function findNext(mergeInfos: _MergeMorphTargetCompactAnimationInfo[]): Nullable<_MergeMorphTargetCompactAnimationInfo> {
+    let min = Infinity,
+        next = null;
+    for (let i = 0, length = mergeInfos.length, info; i < length; i++) {
+        info = mergeInfos[i];
+        if (info.frame < min) {
+            min = info.frame;
+            next = info;
+        }
+    }
+    return next;
+}
+
+/**
+ * Seek to next frame of morph target animation
+ */
+function nextFrame(next: _MergeMorphTargetCompactAnimationInfo): void {
+    const nextFrame = getFrame(next.animation, next.index + 1);
+    if (nextFrame === undefined) {
+        next.frame = Infinity;
+    } else {
+        next.frame = nextFrame;
+        next.index++;
+    }
+}
+
+/**
+ * Build a dummy FloatCompactAnimation for merging morph target animations
+ * @param target The provided morph target
+ * @param frame The specified frame, defaults to 0
+ * @returns a dummy FloatCompactAnimation with one frame and one value
+ */
+export function buildDummyMorphTargetCompactAnimation(target: MorphTarget, frame: number): FloatCompactAnimation {
+    const animation = new FloatCompactAnimation(`${target.name}_MorphWeightAnimation`, "influence", 60, Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_RELATIVE);
+    animation.stride = 1;
+    animation.frames = new Float32Array(1);
+    animation.frames[0] = frame || 0;
+    animation.values = new Float32Array(1);
+    animation.values[0] = target.influence;
+    return animation;
+}
+
+/**
+ * Merge morph target CompactAnimations for GLTF serializing
+ * @param animations Array of CompactAnimations to merge
+ * @returns the exported data of CompactAnimation for {@link gltfAddCompactAnimation}, null for fail
+ */
+export function mergeMorphTargetCompactAnimations(animations: CompactAnimation<any>[]): Nullable<_ICompactAnimationData> {
+    const targetSize = animations.length;
+    const mergeInfos: _MergeMorphTargetCompactAnimationInfo[] = [];
+    let interpolation = undefined;
+    for (let i = 0; i < targetSize; i++) {
+        const animation = animations[i];
+        if (animation.dataType !== Animation.ANIMATIONTYPE_FLOAT || !animation.frames || !animation.values) {
+            return null;
+        }
+        if (interpolation === undefined) {
+            interpolation = animation.interpolation;
+        } else if (interpolation !== animation.interpolation) {
+            return null;
+        }
+        mergeInfos[i] = {
+            frame: getFrame(animation, 0),
+            index: 0,
+            animation,
+        };
+    }
+    const inputWriter = new _Float32Buffer();
+    const outputWriter = new _Float32Buffer();
+    let min = Infinity,
+        max = -Infinity;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const next = findNext(mergeInfos);
+        if (!next) {
+            break;
+        }
+        const frame = next.frame;
+        if (frame === Infinity) {
+            break;
+        }
+        if (inputWriter.lastValue === frame) {
+            nextFrame(next);
+            continue;
+        }
+        min = Math.min(min, frame);
+        max = Math.max(max, frame);
+        inputWriter.append(frame);
+
+        for (let i = 0; i < targetSize; i++) {
+            const info = mergeInfos[i];
+            outputWriter.append(getValue(info.animation, info.index));
+        }
+        nextFrame(next);
+    }
+    return {
+        dataAccessorType: AccessorType.SCALAR,
+        animationChannelTargetPath: AnimationChannelTargetPath.WEIGHTS,
+        useQuaternion: false,
+        samplerInterpolation: interpolation === AnimationKeyInterpolation.NONE ? AnimationSamplerInterpolation.LINEAR : AnimationSamplerInterpolation.STEP,
+        inputs: inputWriter.toArray(),
+        inputsMin: min,
+        inputsMax: max,
+        outputs: outputWriter.toArray(),
+    };
+}
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+interface _ICompactAnimationData extends _IAnimationInfo {
+    samplerInterpolation: AnimationSamplerInterpolation;
+    inputs: NonNullable<CompactAnimation<any>["frames"]>;
+    inputsMin: number;
+    inputsMax: number;
+    outputs: NonNullable<CompactAnimation<any>["values"]>;
+}
+
+/**
+ * The _GLTFAnimation._AddAnimation for CompactAnimation
+ * @internal
+ */
+export function gltfAddCompactAnimation(
+    name: string,
+    glTFAnimation: IAnimation,
+    babylonTransformNode: Node,
+    animationData: _ICompactAnimationData,
+    nodeMap: { [key: number]: number },
+    binaryWriter: _BinaryWriter,
+    bufferViews: IBufferView[],
+    accessors: IAccessor[]
+): void {
+    let bufferView;
+    let accessor;
+    let keyframeAccessorIndex;
+    let dataAccessorIndex;
+    let outputLength;
+    let animationSampler;
+    let animationChannel;
+    if (animationData) {
+        const { dataAccessorType, animationChannelTargetPath } = animationData;
+        const nodeIndex = nodeMap[babylonTransformNode.uniqueId];
+        // Creates buffer view and accessor for key frames.
+        let byteLength = animationData.inputs.length * 4;
+        bufferView = _GLTFUtilities._CreateBufferView(0, binaryWriter.getByteOffset(), byteLength, undefined, `${name}  keyframe data view`);
+        bufferViews.push(bufferView);
+        animationData.inputs.forEach(function (input) {
+            // Note: this is benchmarked to be slow, should there be some kind of bulk writing method?
+            binaryWriter.setFloat32(input);
+        });
+
+        accessor = _GLTFUtilities._CreateAccessor(
+            bufferViews.length - 1,
+            `${name}  keyframes`,
+            AccessorType.SCALAR,
+            AccessorComponentType.FLOAT,
+            animationData.inputs.length,
+            null,
+            [animationData.inputsMin],
+            [animationData.inputsMax]
+        );
+        accessors.push(accessor);
+        keyframeAccessorIndex = accessors.length - 1;
+        // create bufferview and accessor for keyed values.
+        outputLength = animationData.outputs.length;
+        byteLength = animationData.outputs.length * 4;
+        // check for in and out tangents
+        bufferView = _GLTFUtilities._CreateBufferView(0, binaryWriter.getByteOffset(), byteLength, undefined, `${name}  data view`);
+        bufferViews.push(bufferView);
+        animationData.outputs.forEach(function (output) {
+            // Note: this is benchmarked to be slow, should there be some kind of bulk writing method?
+            binaryWriter.setFloat32(output);
+        });
+        accessor = _GLTFUtilities._CreateAccessor(
+            bufferViews.length - 1,
+            `${name}  data`,
+            dataAccessorType,
+            AccessorComponentType.FLOAT,
+            outputLength / _GLTFUtilities._GetDataAccessorElementCount(dataAccessorType),
+            null,
+            null,
+            null
+        );
+
+        accessors.push(accessor);
+        dataAccessorIndex = accessors.length - 1;
+        // create sampler
+        animationSampler = {
+            interpolation: animationData.samplerInterpolation,
+            input: keyframeAccessorIndex,
+            output: dataAccessorIndex,
+        };
+        glTFAnimation.samplers.push(animationSampler);
+        // create channel
+        animationChannel = {
+            sampler: glTFAnimation.samplers.length - 1,
+            target: {
+                node: nodeIndex,
+                path: animationChannelTargetPath,
+            },
+        };
+        glTFAnimation.channels.push(animationChannel);
+    }
+}


### PR DESCRIPTION
Keyframes in Babylon.js are stored with array of objects. Some animations exported with millions of key frames, with the object mode, it would take more memory than stored with typed arrays, like Float32Array.
Without the object per frame, it would be much harder for features like per-frame interpolation and tangent to be implemented, so this could be an optional feature for those suffering too many keyframes without these advanced features.
For AnimationCurveEditor it is hard to fully adapt it to CompactAnimation, maybe the fast way it to convert CompactAnimation to Animation, and replace all possible usage to converted animation.

Not supported yet:
* CUBICSPLINE animation with tangent
* per-frame interpolation or tangent
* serializing GLTF animation with quantization and 4-bytes alignment

Forum link:
https://forum.babylonjs.com/t/animations-storing-key-frames-in-typed-arrays/36566