### PR TITLE
MultiRenderTarget extended support

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -257,6 +257,15 @@ export class Constants {
     /** UNDEFINED */
     public static readonly TEXTURETYPE_UNDEFINED = 16;
 
+    /** 2D Texture target*/
+    public static readonly TEXTURE_2D = 3553;
+    /** 2D Array Texture target */
+    public static readonly TEXTURE_2D_ARRAY = 35866;
+    /** Cube Map Texture target */
+    public static readonly TEXTURE_CUBE_MAP = 34067;
+    /** 3D Texture target */
+    public static readonly TEXTURE_3D = 32879;
+
     /** nearest is mag = nearest and min = nearest and no mip */
     public static readonly TEXTURE_NEAREST_SAMPLINGMODE = 1;
     /** mag = nearest and min = nearest and mip = none */

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1832,16 +1832,18 @@ export class ThinEngine {
         this._bindUnboundFramebuffer(webglRTWrapper._MSAAFramebuffer ? webglRTWrapper._MSAAFramebuffer : webglRTWrapper._framebuffer);
 
         const gl = this._gl;
-        if (texture.is2DArray) {
-            gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, texture.texture!._hardwareTexture?.underlyingResource, lodLevel, layer);
-        } else if (texture.isCube) {
-            gl.framebufferTexture2D(
-                gl.FRAMEBUFFER,
-                gl.COLOR_ATTACHMENT0,
-                gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex,
-                texture.texture!._hardwareTexture?.underlyingResource,
-                lodLevel
-            );
+        if (!texture.isMulti) {
+            if (texture.is2DArray) {
+                gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, texture.texture!._hardwareTexture?.underlyingResource, lodLevel, layer);
+            } else if (texture.isCube) {
+                gl.framebufferTexture2D(
+                    gl.FRAMEBUFFER,
+                    gl.COLOR_ATTACHMENT0,
+                    gl.TEXTURE_CUBE_MAP_POSITIVE_X + faceIndex,
+                    texture.texture!._hardwareTexture?.underlyingResource,
+                    lodLevel
+                );
+            }
         }
 
         const depthStencilTexture = texture._depthStencilTexture;


### PR DESCRIPTION
Minimally added support for MultiRenderTarget binding 2D, 2D Array, Cube Map, and (soon) 3D textures to different draw buffers.

From the following [forum post](https://forum.babylonjs.com/t/multirendertarget-with-2d-array-textures/37185).

Additional considerations from the forum:
* MRT w/ 3D textures
* MRT w/ Cube map array textures (WebGPU)
* Hardware maximum draw buffers (`gl.MAX_DRAW_BUFFERS`)