### PR TITLE
Fix Sound current time when stop is called while paused

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -905,14 +905,17 @@ export class Sound {
                 this._soundSource.stop(stopTime);
                 if (stopTime === undefined) {
                     this.isPlaying = false;
+                    this.isPaused = false;
+                    this._startOffset = 0;
+                    this._startTime = Engine.audioEngine!.audioContext!.currentTime;
                     this._soundSource.onended = () => void 0;
                 } else {
                     this._soundSource.onended = () => {
                         this.isPlaying = false;
+                        this.isPaused = false;
+                        this._startOffset = 0;
+                        this._startTime = Engine.audioEngine!.audioContext!.currentTime;
                     };
-                }
-                if (!this.isPaused) {
-                    this._startOffset = 0;
                 }
             }
         }
@@ -923,7 +926,6 @@ export class Sound {
      */
     public pause(): void {
         if (this.isPlaying) {
-            this.isPaused = true;
             if (this._streaming) {
                 if (this._htmlAudioElement) {
                     this._htmlAudioElement.pause();
@@ -931,8 +933,10 @@ export class Sound {
                     this._streamingSource.disconnect();
                 }
                 this.isPlaying = false;
+                this.isPaused = true;
             } else if (Engine.audioEngine?.audioContext) {
                 this.stop(0);
+                this.isPaused = true;
                 this._startOffset += Engine.audioEngine.audioContext.currentTime - this._startTime;
             }
         }


### PR DESCRIPTION
When stop is called while paused, the current time includes the start offset set by the pause function. This is not the case when stop is called while **not** paused. This is confusing. When stop is called, the current time should be the same, whether the sound is paused or not paused.

This change fixes the issue by always resetting the start offset when the sound is stopped, even if the sound is paused.

Reported on forum here: https://forum.babylonjs.com/t/pausing-and-playing-an-audio-with-offset-restarts-it-from-the-beginning-instead-of-the-current-position/36668/16