### PR TITLE
[XR] Remove a 180 degree flip (an old relic)

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -159,8 +159,6 @@ export class WebXRCamera extends FreeCamera {
         this._lastXRViewerPose = undefined;
     }
 
-    private _rotate180 = new Quaternion(0, 1, 0, 0);
-
     private _updateFromXRSession() {
         const pose = this._xrSessionManager.currentFrame && this._xrSessionManager.currentFrame.getViewerPose(this._xrSessionManager.referenceSpace);
         this._lastXRViewerPose = pose || undefined;
@@ -246,8 +244,6 @@ export class WebXRCamera extends FreeCamera {
                 currentRig.position.z *= -1;
                 currentRig.rotationQuaternion.z *= -1;
                 currentRig.rotationQuaternion.w *= -1;
-            } else {
-                currentRig.rotationQuaternion.multiplyInPlace(this._rotate180);
             }
             Matrix.FromFloat32ArrayToRefScaled(view.projectionMatrix, 0, 1, currentRig._projectionMatrix);
 


### PR DESCRIPTION
Fixes #13447

When initially implemented, right-handed scenes needed a 180 degrees flip because of the way teleportation was working. This code was revamped, but the 180 flip was never removed. I have tested it in different scenarios (and will continue testing it), but it does seem like this is an old relic and technically a bug that needs to be fixed.