### PR TITLE
Optimizing performance of _BinaryWriter._resizeBuffer

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -2344,11 +2344,10 @@ export class _BinaryWriter {
      */
     private _resizeBuffer(byteLength: number): ArrayBuffer {
         const newBuffer = new ArrayBuffer(byteLength);
-        const oldUint8Array = new Uint8Array(this._arrayBuffer);
+        const copyOldBufferSize = Math.min(this._arrayBuffer.byteLength, byteLength);
+        const oldUint8Array = new Uint8Array(this._arrayBuffer, 0, copyOldBufferSize);
         const newUint8Array = new Uint8Array(newBuffer);
-        for (let i = 0, length = newUint8Array.byteLength; i < length; ++i) {
-            newUint8Array[i] = oldUint8Array[i];
-        }
+        newUint8Array.set(oldUint8Array, 0);
         this._arrayBuffer = newBuffer;
         this._dataView = new DataView(this._arrayBuffer);
 


### PR DESCRIPTION
In class _BinaryWriter of the gltf exporter, a loop is used to copy contents in old buffer to new buffer, which is benchmarked to be slow. TypedArray.prototype.set() can be used for faster memory copying while having the same Browser compatibility of TypedArray.

Forum link:
https://forum.babylonjs.com/t/optimizing-performance-of-binarywriter-resizebuffer/37516

Benchmark before:
[playground.babylonjs.com](https://playground.babylonjs.com/#VEC2SK%231)
![image](https://user-images.githubusercontent.com/17702502/213600777-fc89c180-96ea-4581-94f4-330ba39508de.png)

Benchmark after:
[playground.babylonjs.com](https://playground.babylonjs.com/#2JZECM)
![image](https://user-images.githubusercontent.com/17702502/213600783-4ff6186d-9116-4d36-8fe9-18f294ee9e8e.png)


