### PR TITLE
InputManager: Fix for POINTERTAP firing during multi-touch gesture

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -92,7 +92,6 @@ export class InputManager {
     private _isSwiping: boolean = false;
     private _swipeButtonPressed: number = -1;
     private _skipPointerTap: boolean = false;
-    private _activeTouchCount: number = 0;
     private _isMultiTouchGesture: boolean = false;
 
     private _pointerOverMesh: Nullable<AbstractMesh>;
@@ -980,14 +979,12 @@ export class InputManager {
                     if (eventData.inputIndex === PointerInput.LeftClick) {
                         if (attachDown && deviceSource.getInput(eventData.inputIndex) === 1) {
                             this._onPointerDown(eventData);
-                            this._activeTouchCount++;
-                            if (this._activeTouchCount > 1) {
+                            if (this._totalPointersPressed > 1) {
                                 this._isMultiTouchGesture = true;
                             }
                         } else if (attachUp && deviceSource.getInput(eventData.inputIndex) === 0) {
                             this._onPointerUp(eventData);
-                            this._activeTouchCount = Math.max(0, this._activeTouchCount - 1);
-                            if (this._activeTouchCount === 0) {
+                            if (this._totalPointersPressed === 0) {
                                 this._isMultiTouchGesture = false;
                             }
                         }

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -92,6 +92,8 @@ export class InputManager {
     private _isSwiping: boolean = false;
     private _swipeButtonPressed: number = -1;
     private _skipPointerTap: boolean = false;
+    private _activeTouchCount: number = 0;
+    private _isMultiTouchGesture: boolean = false;
 
     private _pointerOverMesh: Nullable<AbstractMesh>;
 
@@ -515,7 +517,7 @@ export class InputManager {
                 scene.onPointerUp(evt, pickResult, PointerEventTypes.POINTERUP);
             }
 
-            if (!clickInfo.hasSwiped && !this._skipPointerTap) {
+            if (!clickInfo.hasSwiped && !this._skipPointerTap && !this._isMultiTouchGesture) {
                 let type = 0;
                 if (clickInfo.singleClick) {
                     type = PointerEventTypes.POINTERTAP;
@@ -978,8 +980,16 @@ export class InputManager {
                     if (eventData.inputIndex === PointerInput.LeftClick) {
                         if (attachDown && deviceSource.getInput(eventData.inputIndex) === 1) {
                             this._onPointerDown(eventData);
+                            this._activeTouchCount++;
+                            if (this._activeTouchCount > 1) {
+                                this._isMultiTouchGesture = true;
+                            }
                         } else if (attachUp && deviceSource.getInput(eventData.inputIndex) === 0) {
                             this._onPointerUp(eventData);
+                            this._activeTouchCount = Math.max(0, this._activeTouchCount - 1);
+                            if (this._activeTouchCount === 0) {
+                                this._isMultiTouchGesture = false;
+                            }
                         }
                     }
 

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -423,4 +423,66 @@ describe("InputManager", () => {
         expect(tapCt).toBe(4);
         expect(dblTapCt).toBe(3);
     });
+
+    it("Does not fire POINTERTAP events during multi-touch gesture", () => {
+        let tapCt = 0;
+
+        scene?.onPointerObservable.add((eventData) => {
+            tapCt++;
+        }, PointerEventTypes.POINTERTAP);
+
+        if (deviceInputSystem) {
+            // Connect touches
+            deviceInputSystem.connectDevice(DeviceType.Touch, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            deviceInputSystem.connectDevice(DeviceType.Touch, 1, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            // Perform Single Tap
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+
+            // Perform Multi-Touch Gesture (2 fingers; FIFO release order)
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0);
+
+            // Perform Single Tap
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+
+            // Perform Multi-Touch Gesture (2 fingers; LIFO release order)
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+
+            // Perform Single Tap
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+
+            // Perform Single Touch Move (no tap)
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+
+            // Perform Pinch Gesture
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 63, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 63, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 127, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 127, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0);
+        }
+
+        expect(tapCt).toBe(3);
+    });
 });


### PR DESCRIPTION
A user found an issue on the forum where a POINTERTAP event was being fired after a pinch.  This issue appears to have been caused by code to check for swiping that didn't account for multi-touch.  This PR will fix that logic by checking if at any point from an initial touch to the last touch to be released in an interaction, there were multiple touches active.  If so, no TAPs will occur.  Furthermore, a test has been added to check for changes to this in the future.

Forum Post: https://forum.babylonjs.com/t/unexpected-pointertap-firing-in-touchscreen-when-zooming-by-two-finger-movement/36922