### PR TITLE
KTX2 decoding: Add default KTX2 decoder configuration

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -33,6 +33,9 @@ export const externalsFunction = (excludePackages: string[] = [], type: BuildTyp
             if (directoryToExpect && context.replace(/\\/g, "/").includes("/" + directoryToExpect + "/")) {
                 return callback(null);
             }
+            if (request.indexOf("ktx2decoderTypes") !== -1) {
+                return callback(null);
+            }
             if (type === "umd" || type === "es6") {
                 return callback(null, {
                     root: namespaceName.indexOf(".") !== -1 ? namespaceName.split(".") : namespaceName,

--- a/packages/dev/core/src/Materials/Textures/index.ts
+++ b/packages/dev/core/src/Materials/Textures/index.ts
@@ -28,3 +28,4 @@ export * from "./texture";
 export * from "./thinTexture";
 export * from "./thinRenderTargetTexture";
 export * from "./videoTexture";
+export * from "./ktx2decoderTypes";

--- a/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
+++ b/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
@@ -1,0 +1,251 @@
+export enum SourceTextureFormat {
+    ETC1S,
+    UASTC4x4,
+}
+
+export enum TranscodeTarget {
+    ASTC_4X4_RGBA,
+    BC7_RGBA,
+    BC3_RGBA,
+    BC1_RGB,
+    PVRTC1_4_RGBA,
+    PVRTC1_4_RGB,
+    ETC2_RGBA,
+    ETC1_RGB,
+    RGBA32,
+    R8,
+    RG8,
+}
+
+export enum EngineFormat {
+    COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8e8c,
+    COMPRESSED_RGBA_ASTC_4X4_KHR = 0x93b0,
+    COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83f0,
+    COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83f3,
+    COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8c02,
+    COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8c00,
+    COMPRESSED_RGBA8_ETC2_EAC = 0x9278,
+    COMPRESSED_RGB8_ETC2 = 0x9274,
+    COMPRESSED_RGB_ETC1_WEBGL = 0x8d64,
+    RGBA8Format = 0x8058,
+    R8Format = 0x8229,
+    RG8Format = 0x822b,
+}
+
+/**
+ * Leaf node of a decision tree
+ * It defines the transcoding format to use to transcode the texture as well as the corresponding format to use at the engine level when creating the texture
+ */
+export interface ILeaf {
+    /**
+     * The format to transcode to
+     */
+    transcodeFormat: TranscodeTarget;
+
+    /**
+     * The format to use when creating the texture at the engine level after it has been transcoded to transcodeFormat
+     */
+    engineFormat: EngineFormat;
+
+    /**
+     * Whether the texture must be rounded to a multiple of 4 (should normally be the case for all compressed formats). Default: true
+     */
+    roundToMultiple4?: boolean;
+}
+
+/**
+ * Regular node of a decision tree
+ *
+ * Each property (except for "yes" and "no"), if not empty, will be checked in order to determine the next node to select.
+ * If all checks are successful, the "yes" node will be selected, else the "no" node will be selected.
+ */
+export interface INode {
+    /**
+     * The name of the capability to check. Can be one of the following:
+     *      astc
+     *      bptc
+     *      s3tc
+     *      pvrtc
+     *      etc2
+     *      etc1
+     */
+    cap?: string;
+
+    /**
+     * The name of the option to check from the options object passed to the KTX2 decode function. {@link IKTX2DecoderOptions}
+     */
+    option?: string;
+
+    /**
+     * Checks if alpha is present in the texture
+     */
+    alpha?: boolean;
+
+    /**
+     * Checks the currently selected transcoding format.
+     */
+    transcodeFormat?: TranscodeTarget | TranscodeTarget[];
+
+    /**
+     * Checks that the texture is a power of two
+     */
+    needsPowerOfTwo?: boolean;
+
+    /**
+     * The node to select if all checks are successful
+     */
+    yes?: INode | ILeaf;
+
+    /**
+     * The node to select if at least one check is not successful
+     */
+    no?: INode | ILeaf;
+}
+
+/**
+ * Decision tree used to determine the transcoding format to use for a given source texture format
+ */
+export interface IDecisionTree {
+    /**
+     * textureFormat can be either UASTC or ETC1S
+     */
+    [textureFormat: string]: INode;
+}
+
+/**
+ * Result of the KTX2 decode function
+ */
+export interface IDecodedData {
+    /**
+     * Width of the texture
+     */
+    width: number;
+
+    /**
+     * Height of the texture
+     */
+    height: number;
+
+    /**
+     * The format to use when creating the texture at the engine level
+     * This corresponds to the engineFormat property of the leaf node of the decision tree
+     */
+    transcodedFormat: number;
+
+    /**
+     * List of mipmap levels.
+     * The first element is the base level, the last element is the smallest mipmap level (if more than one mipmap level is present)
+     */
+    mipmaps: Array<IMipmap>;
+
+    /**
+     * Whether the texture data is in gamma space or not
+     */
+    isInGammaSpace: boolean;
+
+    /**
+     * Whether the texture has an alpha channel or not
+     */
+    hasAlpha: boolean;
+
+    /**
+     * The name of the transcoder used to transcode the texture
+     */
+    transcoderName: string;
+
+    /**
+     * The errors (if any) encountered during the decoding process
+     */
+    errors?: string;
+}
+
+/**
+ * Defines a mipmap level
+ */
+export interface IMipmap {
+    /**
+     * The data of the mipmap level
+     */
+    data: Uint8Array | null;
+
+    /**
+     * The width of the mipmap level
+     */
+    width: number;
+
+    /**
+     * The height of the mipmap level
+     */
+    height: number;
+}
+
+/**
+ * The compressed texture formats supported by the browser
+ */
+export interface ICompressedFormatCapabilities {
+    /**
+     * Whether the browser supports ASTC
+     */
+    astc?: boolean;
+
+    /**
+     * Whether the browser supports BPTC
+     */
+    bptc?: boolean;
+
+    /**
+     * Whether the browser supports S3TC
+     */
+    s3tc?: boolean;
+
+    /**
+     * Whether the browser supports PVRTC
+     */
+    pvrtc?: boolean;
+
+    /**
+     * Whether the browser supports ETC2
+     */
+    etc2?: boolean;
+
+    /**
+     * Whether the browser supports ETC1
+     */
+    etc1?: boolean;
+}
+
+/**
+ * Options passed to the KTX2 decode function
+ */
+export interface IKTX2DecoderOptions {
+    /** use RGBA format if ASTC and BC7 are not available as transcoded format */
+    useRGBAIfASTCBC7NotAvailableWhenUASTC?: boolean;
+
+    /** force to always use (uncompressed) RGBA for transcoded format */
+    forceRGBA?: boolean;
+
+    /** force to always use (uncompressed) R8 for transcoded format */
+    forceR8?: boolean;
+
+    /** force to always use (uncompressed) RG8 for transcoded format */
+    forceRG8?: boolean;
+
+    /**
+     * list of transcoders to bypass when looking for a suitable transcoder. The available transcoders are:
+     *      UniversalTranscoder_UASTC_ASTC
+     *      UniversalTranscoder_UASTC_BC7
+     *      UniversalTranscoder_UASTC_RGBA_UNORM
+     *      UniversalTranscoder_UASTC_RGBA_SRGB
+     *      UniversalTranscoder_UASTC_R8_UNORM
+     *      UniversalTranscoder_UASTC_RG8_UNORM
+     *      MSCTranscoder
+     */
+    bypassTranscoders?: string[];
+
+    /**
+     * Custom decision tree to apply after the default decision tree has selected a transcoding format.
+     * Allows the user to override the default decision tree selection.
+     * The decision tree can use the INode.transcodeFormat property to base its decision on the transcoding format selected by the default decision tree.
+     */
+    transcodeFormatDecisionTree?: IDecisionTree;
+}

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -83,15 +83,17 @@ export class DefaultKTX2DecoderOptions {
         this._isDirty = true;
     }
 
-    private _useRGBAIfOnlyBC1BC3AvailableWhenUASTC?: boolean;
+    private _useRGBAIfOnlyBC1BC3AvailableWhenUASTC = true;
     /**
-     * force a (uncompressed) RGBA transcoded format if transcoding a UASTC source format and only BC1 or BC3 are available as a compressed transcoded format
+     * force a (uncompressed) RGBA transcoded format if transcoding a UASTC source format and only BC1 or BC3 are available as a compressed transcoded format.
+     * This property is true by default to favor speed over memory, because currently transcoding from UASTC to BC1/3 is slow because the transcoder transcodes
+     * to uncompressed and then recompresses the texture
      */
     public get useRGBAIfOnlyBC1BC3AvailableWhenUASTC() {
         return this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC;
     }
 
-    public set useRGBAIfOnlyBC1BC3AvailableWhenUASTC(value: boolean | undefined) {
+    public set useRGBAIfOnlyBC1BC3AvailableWhenUASTC(value: boolean) {
         if (this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC === value) {
             return;
         }

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -5,6 +5,8 @@ import { Constants } from "../Engines/constants";
 import { AutoReleaseWorkerPool } from "./workerPool";
 import { Tools } from "./tools";
 import type { Nullable } from "../types";
+import type { ICompressedFormatCapabilities, IDecodedData, IKTX2DecoderOptions } from "core/Materials/Textures/ktx2decoderTypes";
+import { EngineFormat, TranscodeTarget } from "core/Materials/Textures/ktx2decoderTypes";
 
 declare let KTX2DECODER: any;
 
@@ -47,6 +49,161 @@ function applyConfig(urls: typeof KhronosTextureContainer2.URLConfig): void {
 
     if (urls.wasmZSTDDecoder !== null) {
         KTX2DECODER.ZSTDDecoder.WasmModuleURL = urls.wasmZSTDDecoder;
+    }
+}
+
+/**
+ * Class that defines the default KTX2 decoder options.
+ *
+ * This class is useful for providing options to the KTX2 decoder to control how the source data is transcoded.
+ */
+export class DefaultKTX2DecoderOptions {
+    private _isDirty = true;
+
+    /**
+     * Gets the dirty flag
+     */
+    public get isDirty() {
+        return this._isDirty;
+    }
+
+    private _useRGBAIfASTCBC7NotAvailableWhenUASTC?: boolean;
+    /**
+     * force a (uncompressed) RGBA transcoded format if transcoding a UASTC source format and ASTC + BC7 are not available as a compressed transcoded format
+     */
+    public get useRGBAIfASTCBC7NotAvailableWhenUASTC() {
+        return this._useRGBAIfASTCBC7NotAvailableWhenUASTC;
+    }
+
+    public set useRGBAIfASTCBC7NotAvailableWhenUASTC(value: boolean | undefined) {
+        if (this._useRGBAIfASTCBC7NotAvailableWhenUASTC === value) {
+            return;
+        }
+        this._useRGBAIfASTCBC7NotAvailableWhenUASTC = value;
+        this._isDirty = true;
+    }
+
+    private _useRGBAIfOnlyBC1BC3AvailableWhenUASTC?: boolean;
+    /**
+     * force a (uncompressed) RGBA transcoded format if transcoding a UASTC source format and only BC1 or BC3 are available as a compressed transcoded format
+     */
+    public get useRGBAIfOnlyBC1BC3AvailableWhenUASTC() {
+        return this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC;
+    }
+
+    public set useRGBAIfOnlyBC1BC3AvailableWhenUASTC(value: boolean | undefined) {
+        if (this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC === value) {
+            return;
+        }
+        this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC = value;
+        this._isDirty = true;
+    }
+
+    private _forceRGBA?: boolean;
+    /**
+     * force to always use (uncompressed) RGBA for transcoded format
+     */
+    public get forceRGBA() {
+        return this._forceRGBA;
+    }
+
+    public set forceRGBA(value: boolean | undefined) {
+        if (this._forceRGBA === value) {
+            return;
+        }
+        this._forceRGBA = value;
+        this._isDirty = true;
+    }
+
+    private _forceR8?: boolean;
+    /**
+     * force to always use (uncompressed) R8 for transcoded format
+     */
+    public get forceR8() {
+        return this._forceR8;
+    }
+
+    public set forceR8(value: boolean | undefined) {
+        if (this._forceR8 === value) {
+            return;
+        }
+        this._forceR8 = value;
+        this._isDirty = true;
+    }
+
+    private _forceRG8?: boolean;
+    /**
+     * force to always use (uncompressed) RG8 for transcoded format
+     */
+    public get forceRG8() {
+        return this._forceRG8;
+    }
+
+    public set forceRG8(value: boolean | undefined) {
+        if (this._forceRG8 === value) {
+            return;
+        }
+        this._forceRG8 = value;
+        this._isDirty = true;
+    }
+
+    private _bypassTranscoders?: string[];
+    /**
+     * list of transcoders to bypass when looking for a suitable transcoder. The available transcoders are:
+     *      UniversalTranscoder_UASTC_ASTC
+     *      UniversalTranscoder_UASTC_BC7
+     *      UniversalTranscoder_UASTC_RGBA_UNORM
+     *      UniversalTranscoder_UASTC_RGBA_SRGB
+     *      UniversalTranscoder_UASTC_R8_UNORM
+     *      UniversalTranscoder_UASTC_RG8_UNORM
+     *      MSCTranscoder
+     */
+    public get bypassTranscoders() {
+        return this._bypassTranscoders;
+    }
+
+    public set bypassTranscoders(value: string[] | undefined) {
+        if (this._bypassTranscoders === value) {
+            return;
+        }
+        this._bypassTranscoders = value;
+        this._isDirty = true;
+    }
+
+    private _ktx2DecoderOptions: IKTX2DecoderOptions = {};
+
+    /** @internal */
+    public _getKTX2DecoderOptions(): IKTX2DecoderOptions {
+        if (!this._isDirty) {
+            return this._ktx2DecoderOptions;
+        }
+
+        this._isDirty = false;
+
+        const options: IKTX2DecoderOptions = {
+            useRGBAIfASTCBC7NotAvailableWhenUASTC: this._useRGBAIfASTCBC7NotAvailableWhenUASTC,
+            forceRGBA: this._forceRGBA,
+            forceR8: this._forceR8,
+            forceRG8: this._forceRG8,
+            bypassTranscoders: this._bypassTranscoders,
+        };
+
+        if (this.useRGBAIfOnlyBC1BC3AvailableWhenUASTC) {
+            options.transcodeFormatDecisionTree = {
+                UASTC: {
+                    transcodeFormat: [TranscodeTarget.BC1_RGB, TranscodeTarget.BC3_RGBA],
+                    yes: {
+                        transcodeFormat: TranscodeTarget.RGBA32,
+                        engineFormat: EngineFormat.RGBA8Format,
+                        roundToMultiple4: false,
+                    },
+                },
+            };
+        }
+
+        this._ktx2DecoderOptions = options;
+
+        return options;
     }
 }
 
@@ -102,6 +259,12 @@ export class KhronosTextureContainer2 {
      * Default number of workers used to handle data decoding
      */
     public static DefaultNumWorkers = KhronosTextureContainer2.GetDefaultNumWorkers();
+
+    /**
+     * Default configuration for the KTX2 decoder.
+     * The options defined in this way have priority over those passed when creating a KTX2 texture with new Texture(...).
+     */
+    public static DefaultDecoderOptions = new DefaultKTX2DecoderOptions();
 
     private static GetDefaultNumWorkers(): number {
         if (typeof navigator !== "object" || !navigator.hardwareConcurrency) {
@@ -196,10 +359,10 @@ export class KhronosTextureContainer2 {
     /**
      * @internal
      */
-    public uploadAsync(data: ArrayBufferView, internalTexture: InternalTexture, options?: any): Promise<void> {
+    public uploadAsync(data: ArrayBufferView, internalTexture: InternalTexture, options?: IKTX2DecoderOptions & IDecodedData): Promise<void> {
         const caps = this._engine.getCaps();
 
-        const compressedTexturesCaps = {
+        const compressedTexturesCaps: ICompressedFormatCapabilities = {
             astc: !!caps.astc,
             bptc: !!caps.bptc,
             s3tc: !!caps.s3tc,
@@ -243,6 +406,12 @@ export class KhronosTextureContainer2 {
                         const dataCopy = new Uint8Array(data.byteLength);
                         dataCopy.set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
 
+                        if (KhronosTextureContainer2.DefaultDecoderOptions.isDirty) {
+                            worker.postMessage({ action: "setDefaultDecoderOptions", options: KhronosTextureContainer2.DefaultDecoderOptions._getKTX2DecoderOptions() }, [
+                                dataCopy.buffer,
+                            ]);
+                        }
+
                         worker.postMessage({ action: "decode", data: dataCopy, caps: compressedTexturesCaps, options }, [dataCopy.buffer]);
                     });
                 });
@@ -252,7 +421,7 @@ export class KhronosTextureContainer2 {
                 return new Promise((resolve, reject) => {
                     decoder
                         .decode(data, caps)
-                        .then((data: any) => {
+                        .then((data: IDecodedData) => {
                             this._createTexture(data, internalTexture);
                             resolve();
                         })
@@ -266,7 +435,7 @@ export class KhronosTextureContainer2 {
         throw new Error("KTX2 decoder module is not available");
     }
 
-    protected _createTexture(data: any /* IEncodedData */, internalTexture: InternalTexture, options?: any): void {
+    protected _createTexture(data: IDecodedData, internalTexture: InternalTexture, options?: IKTX2DecoderOptions & IDecodedData): void {
         const oglTexture2D = 3553; // gl.TEXTURE_2D
 
         this._engine._bindTextureDirectly(oglTexture2D, internalTexture);
@@ -383,10 +552,14 @@ function workerFunc(): void {
                 postMessage({ action: "init" });
                 break;
             }
+            case "setDefaultDecoderOptions": {
+                KTX2DECODER.KTX2Decoder.DefaultDecoderOptions = event.data.options;
+                break;
+            }
             case "decode":
                 ktx2Decoder
                     .decode(event.data.data, event.data.caps, event.data.options)
-                    .then((data: any) => {
+                    .then((data: IDecodedData) => {
                         const buffers = [];
                         for (let mip = 0; mip < data.mipmaps.length; ++mip) {
                             const mipmap = data.mipmaps[mip];

--- a/packages/public/umd/babylonjs-ktx2decoder/webpack.config.js
+++ b/packages/public/umd/babylonjs-ktx2decoder/webpack.config.js
@@ -8,6 +8,18 @@ module.exports = (env) => {
         maxMode: true,
         outputPath: path.resolve(__dirname),
         devPackageAliasPath: `../../../tools/ktx2Decoder/dist`,
+        alias: {
+            "core": path.resolve(__dirname, "../../../dev/core/dist"),
+        },
+        extendedWebpackConfig: {
+            externals: {},
+            module: {
+                rules: require("@dev/build-tools").webpackTools.getRules({
+                    sideEffects: true,
+                    includeCSS: true,
+                }),
+            },
+        }
     });
     return commonConfig;
 };

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder.ts
@@ -1,4 +1,5 @@
-import type { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import type * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { Transcoder } from "../transcoder";
 import { WASMMemoryManager } from "../wasmMemoryManager";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
@@ -51,8 +52,8 @@ export class LiteTranscoder extends Transcoder {
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 
 /**
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_ASTC extends LiteTranscoder {
     public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_astc.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.ASTC_4x4_RGBA;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.ASTC_4X4_RGBA;
     }
 
     public static Name = "UniversalTranscoder_UASTC_ASTC";

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 
 /**
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_BC7 extends LiteTranscoder {
     public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_bc7.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.BC7_RGBA;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.BC7_RGBA;
     }
 
     public static Name = "UniversalTranscoder_UASTC_BC7";

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
 
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_R8_UNORM extends LiteTranscoder {
      */
     public static WasmModuleURL = "https://preview.babylonjs.com/1/uastc_r8_unorm.wasm";
 
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.R8;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.R8;
     }
 
     public static Name = "UniversalTranscoder_UASTC_R8_UNORM";
@@ -29,8 +30,8 @@ export class LiteTranscoder_UASTC_R8_UNORM extends LiteTranscoder {
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
 
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_RG8_UNORM extends LiteTranscoder {
      */
     public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rg8_unorm.wasm";
 
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.RG8;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RG8;
     }
 
     public static Name = "UniversalTranscoder_UASTC_RG8_UNORM";
@@ -29,8 +30,8 @@ export class LiteTranscoder_UASTC_RG8_UNORM extends LiteTranscoder {
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
 
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_RGBA_SRGB extends LiteTranscoder {
      */
     public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm";
 
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.RGBA32 && isInGammaSpace;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && isInGammaSpace;
     }
 
     public static Name = "UniversalTranscoder_UASTC_RGBA_SRGB";
@@ -29,8 +30,8 @@ export class LiteTranscoder_UASTC_RGBA_SRGB extends LiteTranscoder {
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
@@ -1,4 +1,5 @@
-import { sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { LiteTranscoder } from "./liteTranscoder";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
 
@@ -12,8 +13,8 @@ export class LiteTranscoder_UASTC_RGBA_UNORM extends LiteTranscoder {
      */
     public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm";
 
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
-        return src === sourceTextureFormat.UASTC4x4 && dst === transcodeTarget.RGBA32 && !isInGammaSpace;
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
+        return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && !isInGammaSpace;
     }
 
     public static Name = "UniversalTranscoder_UASTC_RGBA_UNORM";
@@ -29,8 +30,8 @@ export class LiteTranscoder_UASTC_RGBA_UNORM extends LiteTranscoder {
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -1,4 +1,6 @@
-import { Transcoder, sourceTextureFormat, transcodeTarget } from "../transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
+import { Transcoder } from "../transcoder";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "../ktx2FileReader";
 import { WASMMemoryManager } from "../wasmMemoryManager";
 
@@ -76,13 +78,13 @@ export class MSCTranscoder extends Transcoder {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return true;
     }
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,
@@ -102,18 +104,20 @@ export class MSCTranscoder extends Transcoder {
             let textureData: any = null;
 
             try {
-                transcoder = src === sourceTextureFormat.UASTC4x4 ? new basisModule.UastcImageTranscoder() : new basisModule.BasisLzEtc1sImageTranscoder();
-                const texFormat = src === sourceTextureFormat.UASTC4x4 ? basisModule.TextureFormat.UASTC4x4 : basisModule.TextureFormat.ETC1S;
+                transcoder = src === KTX2.SourceTextureFormat.UASTC4x4 ? new basisModule.UastcImageTranscoder() : new basisModule.BasisLzEtc1sImageTranscoder();
+                const texFormat = src === KTX2.SourceTextureFormat.UASTC4x4 ? basisModule.TextureFormat.UASTC4x4 : basisModule.TextureFormat.ETC1S;
 
                 imageInfo = new basisModule.ImageInfo(texFormat, width, height, level);
 
-                const targetFormat = basisModule.TranscodeTarget[transcodeTarget[dst]]; // works because the labels of the sourceTextureFormat enum are the same as the property names used in TranscodeTarget!
+                const targetFormat = basisModule.TranscodeTarget[KTX2.TranscodeTarget[dst]]; // works because the labels of the sourceTextureFormat enum are the same as the property names used in TranscodeTarget!
 
                 if (!basisModule.isFormatSupported(targetFormat, texFormat)) {
-                    throw new Error(`MSCTranscoder: Transcoding from "${sourceTextureFormat[src]}" to "${transcodeTarget[dst]}" not supported by current transcoder build.`);
+                    throw new Error(
+                        `MSCTranscoder: Transcoding from "${KTX2.SourceTextureFormat[src]}" to "${KTX2.TranscodeTarget[dst]}" not supported by current transcoder build.`
+                    );
                 }
 
-                if (src === sourceTextureFormat.ETC1S) {
+                if (src === KTX2.SourceTextureFormat.ETC1S) {
                     const sgd = ktx2Reader.supercompressionGlobalData;
 
                     transcoder.decodePalettes(sgd.endpointCount, sgd.endpointsData, sgd.selectorCount, sgd.selectorsData);

--- a/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
+++ b/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
@@ -7,6 +7,7 @@
  *  - KTX specification: https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html
  *  - KTX-Software: https://github.com/KhronosGroup/KTX-Software
  */
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
 
 import type { IKTX2_ImageDesc } from "./ktx2FileReader";
 import { KTX2FileReader, SupercompressionScheme } from "./ktx2FileReader";
@@ -18,61 +19,8 @@ import { LiteTranscoder_UASTC_RGBA_SRGB } from "./Transcoders/liteTranscoder_UAS
 import { LiteTranscoder_UASTC_R8_UNORM } from "./Transcoders/liteTranscoder_UASTC_R8_UNORM";
 import { LiteTranscoder_UASTC_RG8_UNORM } from "./Transcoders/liteTranscoder_UASTC_RG8_UNORM";
 import { MSCTranscoder } from "./Transcoders/mscTranscoder";
-import { transcodeTarget, sourceTextureFormat } from "./transcoder";
 import { ZSTDDecoder } from "./zstddec";
 import { TranscodeDecisionTree } from "./transcodeDecisionTree";
-
-export interface IDecodedData {
-    width: number;
-    height: number;
-    transcodedFormat: number;
-    mipmaps: Array<IMipmap>;
-    isInGammaSpace: boolean;
-    hasAlpha: boolean;
-    errors?: string;
-    transcoderName?: string;
-}
-
-export interface IMipmap {
-    data: Uint8Array | null;
-    width: number;
-    height: number;
-}
-
-export interface ICompressedFormatCapabilities {
-    astc?: boolean;
-    bptc?: boolean;
-    s3tc?: boolean;
-    pvrtc?: boolean;
-    etc2?: boolean;
-    etc1?: boolean;
-}
-
-export interface IKTX2DecoderOptions {
-    /** use RGBA format if ASTC and BC7 are not available as transcoded format */
-    useRGBAIfASTCBC7NotAvailableWhenUASTC?: boolean;
-
-    /** force to always use (uncompressed) RGBA for transcoded format */
-    forceRGBA?: boolean;
-
-    /** force to always use (uncompressed) R8 for transcoded format */
-    forceR8?: boolean;
-
-    /** force to always use (uncompressed) RG8 for transcoded format */
-    forceRG8?: boolean;
-
-    /**
-     * list of transcoders to bypass when looking for a suitable transcoder. The available transcoders are:
-     *      UniversalTranscoder_UASTC_ASTC
-     *      UniversalTranscoder_UASTC_BC7
-     *      UniversalTranscoder_UASTC_RGBA_UNORM
-     *      UniversalTranscoder_UASTC_RGBA_SRGB
-     *      UniversalTranscoder_UASTC_R8_UNORM
-     *      UniversalTranscoder_UASTC_RG8_UNORM
-     *      MSCTranscoder
-     */
-    bypassTranscoders?: string[];
-}
 
 const isPowerOfTwo = (value: number) => {
     return (value & (value - 1)) === 0 && value !== 0;
@@ -86,11 +34,15 @@ export class KTX2Decoder {
     private _transcoderMgr: TranscoderManager;
     private _zstdDecoder: ZSTDDecoder;
 
+    public static DefaultDecoderOptions: KTX2.IKTX2DecoderOptions = {};
+
     constructor() {
         this._transcoderMgr = new TranscoderManager();
     }
 
-    public decode(data: Uint8Array, caps: ICompressedFormatCapabilities, options?: IKTX2DecoderOptions): Promise<IDecodedData | null> {
+    public decode(data: Uint8Array, caps: KTX2.ICompressedFormatCapabilities, options?: KTX2.IKTX2DecoderOptions): Promise<KTX2.IDecodedData> {
+        const finalOptions = { ...options, ...KTX2Decoder.DefaultDecoderOptions };
+
         return Promise.resolve().then(() => {
             const kfr = new KTX2FileReader(data);
 
@@ -106,20 +58,24 @@ export class KTX2Decoder {
                 }
 
                 return this._zstdDecoder.init().then(() => {
-                    return this._decodeData(kfr, caps, options);
+                    return this._decodeData(kfr, caps, finalOptions);
                 });
             }
 
-            return this._decodeData(kfr, caps, options);
+            return this._decodeData(kfr, caps, finalOptions);
         });
     }
 
-    private _decodeData(kfr: KTX2FileReader, caps: ICompressedFormatCapabilities, options?: IKTX2DecoderOptions): Promise<IDecodedData> {
+    private _decodeData(kfr: KTX2FileReader, caps: KTX2.ICompressedFormatCapabilities, options?: KTX2.IKTX2DecoderOptions): Promise<KTX2.IDecodedData> {
         const width = kfr.header.pixelWidth;
         const height = kfr.header.pixelHeight;
         const srcTexFormat = kfr.textureFormat;
 
         const decisionTree = new TranscodeDecisionTree(srcTexFormat, kfr.hasAlpha, isPowerOfTwo(width) && isPowerOfTwo(height), caps, options);
+
+        if (options?.transcodeFormatDecisionTree) {
+            decisionTree.parseTree(options?.transcodeFormatDecisionTree);
+        }
 
         const transcodeFormat = decisionTree.transcodeFormat;
         const engineFormat = decisionTree.engineFormat;
@@ -128,12 +84,14 @@ export class KTX2Decoder {
         const transcoder = this._transcoderMgr.findTranscoder(srcTexFormat, transcodeFormat, kfr.isInGammaSpace, options?.bypassTranscoders);
 
         if (transcoder === null) {
-            throw new Error(`no transcoder found to transcode source texture format "${sourceTextureFormat[srcTexFormat]}" to format "${transcodeTarget[transcodeFormat]}"`);
+            throw new Error(
+                `no transcoder found to transcode source texture format "${KTX2.SourceTextureFormat[srcTexFormat]}" to format "${KTX2.TranscodeTarget[transcodeFormat]}"`
+            );
         }
 
-        const mipmaps: Array<IMipmap> = [];
+        const mipmaps: Array<KTX2.IMipmap> = [];
         const dataPromises: Array<Promise<Uint8Array | null>> = [];
-        const decodedData: IDecodedData = {
+        const decodedData: KTX2.IDecodedData = {
             width: 0,
             height: 0,
             transcodedFormat: engineFormat,
@@ -187,7 +145,7 @@ export class KTX2Decoder {
                     imageOffsetInLevel += levelImageByteLength;
                 }
 
-                const mipmap: IMipmap = {
+                const mipmap: KTX2.IMipmap = {
                     data: null,
                     width: levelWidth,
                     height: levelHeight,

--- a/packages/tools/ktx2Decoder/src/ktx2FileReader.ts
+++ b/packages/tools/ktx2Decoder/src/ktx2FileReader.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import { DataReader } from "./Misc/dataReader";
-import { sourceTextureFormat } from "./transcoder";
 
 /** @internal */
 export enum SupercompressionScheme {
@@ -321,21 +322,21 @@ export class KTX2FileReader {
         return Math.max(this._header.layerCount, 1) * this._header.faceCount * layerPixelDepth;
     }
 
-    public get textureFormat(): sourceTextureFormat {
-        return this._dfdBlock.colorModel === DFDModel.UASTC ? sourceTextureFormat.UASTC4x4 : sourceTextureFormat.ETC1S;
+    public get textureFormat(): KTX2.SourceTextureFormat {
+        return this._dfdBlock.colorModel === DFDModel.UASTC ? KTX2.SourceTextureFormat.UASTC4x4 : KTX2.SourceTextureFormat.ETC1S;
     }
 
     public get hasAlpha(): boolean {
         const tformat = this.textureFormat;
 
         switch (tformat) {
-            case sourceTextureFormat.ETC1S:
+            case KTX2.SourceTextureFormat.ETC1S:
                 return (
                     this._dfdBlock.numSamples === 2 &&
                     (this._dfdBlock.samples[0].channelType === DFDChannel_ETC1S.AAA || this._dfdBlock.samples[1].channelType === DFDChannel_ETC1S.AAA)
                 );
 
-            case sourceTextureFormat.UASTC4x4:
+            case KTX2.SourceTextureFormat.UASTC4x4:
                 return this._dfdBlock.samples[0].channelType === DFDChannel_UASTC.RGBA;
         }
 

--- a/packages/tools/ktx2Decoder/src/transcodeDecisionTree.ts
+++ b/packages/tools/ktx2Decoder/src/transcodeDecisionTree.ts
@@ -1,44 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { sourceTextureFormat, transcodeTarget } from "./transcoder";
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
 
-const COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8e8c;
-const COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93b0;
-const COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83f0;
-const COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83f3;
-const COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8c02;
-const COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8c00;
-const COMPRESSED_RGBA8_ETC2_EAC = 0x9278;
-const COMPRESSED_RGB8_ETC2 = 0x9274;
-const COMPRESSED_RGB_ETC1_WEBGL = 0x8d64;
-const RGBA8Format = 0x8058;
-const R8Format = 0x8229;
-const RG8Format = 0x822b;
-
-interface ILeaf {
-    transcodeFormat: number;
-    engineFormat: number;
-    roundToMultiple4?: boolean;
-}
-
-interface INode {
-    cap?: string;
-    option?: string;
-    alpha?: boolean;
-    needsPowerOfTwo?: boolean;
-    yes?: INode | ILeaf;
-    no?: INode | ILeaf;
-}
-
-interface IDecisionTree {
-    [textureFormat: string]: INode;
-}
-
-const DecisionTree: IDecisionTree = {
+const DecisionTree: KTX2.IDecisionTree = {
     ETC1S: {
         option: "forceRGBA",
         yes: {
-            transcodeFormat: transcodeTarget.RGBA32,
-            engineFormat: RGBA8Format,
+            transcodeFormat: KTX2.TranscodeTarget.RGBA32,
+            engineFormat: KTX2.EngineFormat.RGBA8Format,
             roundToMultiple4: false,
         },
         no: {
@@ -46,38 +14,38 @@ const DecisionTree: IDecisionTree = {
             yes: {
                 alpha: true,
                 yes: {
-                    transcodeFormat: transcodeTarget.ETC2_RGBA,
-                    engineFormat: COMPRESSED_RGBA8_ETC2_EAC,
+                    transcodeFormat: KTX2.TranscodeTarget.ETC2_RGBA,
+                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA8_ETC2_EAC,
                 },
                 no: {
-                    transcodeFormat: transcodeTarget.ETC1_RGB,
-                    engineFormat: COMPRESSED_RGB8_ETC2,
+                    transcodeFormat: KTX2.TranscodeTarget.ETC1_RGB,
+                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGB8_ETC2,
                 },
             },
             no: {
                 cap: "etc1",
                 alpha: false,
                 yes: {
-                    transcodeFormat: transcodeTarget.ETC1_RGB,
-                    engineFormat: COMPRESSED_RGB_ETC1_WEBGL,
+                    transcodeFormat: KTX2.TranscodeTarget.ETC1_RGB,
+                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_ETC1_WEBGL,
                 },
                 no: {
                     cap: "bptc",
                     yes: {
-                        transcodeFormat: transcodeTarget.BC7_RGBA,
-                        engineFormat: COMPRESSED_RGBA_BPTC_UNORM_EXT,
+                        transcodeFormat: KTX2.TranscodeTarget.BC7_RGBA,
+                        engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_BPTC_UNORM_EXT,
                     },
                     no: {
                         cap: "s3tc",
                         yes: {
                             alpha: true,
                             yes: {
-                                transcodeFormat: transcodeTarget.BC3_RGBA,
-                                engineFormat: COMPRESSED_RGBA_S3TC_DXT5_EXT,
+                                transcodeFormat: KTX2.TranscodeTarget.BC3_RGBA,
+                                engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_S3TC_DXT5_EXT,
                             },
                             no: {
-                                transcodeFormat: transcodeTarget.BC1_RGB,
-                                engineFormat: COMPRESSED_RGB_S3TC_DXT1_EXT,
+                                transcodeFormat: KTX2.TranscodeTarget.BC1_RGB,
+                                engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_S3TC_DXT1_EXT,
                             },
                         },
                         no: {
@@ -86,17 +54,17 @@ const DecisionTree: IDecisionTree = {
                             yes: {
                                 alpha: true,
                                 yes: {
-                                    transcodeFormat: transcodeTarget.PVRTC1_4_RGBA,
-                                    engineFormat: COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
+                                    transcodeFormat: KTX2.TranscodeTarget.PVRTC1_4_RGBA,
+                                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
                                 },
                                 no: {
-                                    transcodeFormat: transcodeTarget.PVRTC1_4_RGB,
-                                    engineFormat: COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
+                                    transcodeFormat: KTX2.TranscodeTarget.PVRTC1_4_RGB,
+                                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
                                 },
                             },
                             no: {
-                                transcodeFormat: transcodeTarget.RGBA32,
-                                engineFormat: RGBA8Format,
+                                transcodeFormat: KTX2.TranscodeTarget.RGBA32,
+                                engineFormat: KTX2.EngineFormat.RGBA8Format,
                                 roundToMultiple4: false,
                             },
                         },
@@ -109,41 +77,41 @@ const DecisionTree: IDecisionTree = {
     UASTC: {
         option: "forceRGBA",
         yes: {
-            transcodeFormat: transcodeTarget.RGBA32,
-            engineFormat: RGBA8Format,
+            transcodeFormat: KTX2.TranscodeTarget.RGBA32,
+            engineFormat: KTX2.EngineFormat.RGBA8Format,
             roundToMultiple4: false,
         },
         no: {
             option: "forceR8",
             yes: {
-                transcodeFormat: transcodeTarget.R8,
-                engineFormat: R8Format,
+                transcodeFormat: KTX2.TranscodeTarget.R8,
+                engineFormat: KTX2.EngineFormat.R8Format,
                 roundToMultiple4: false,
             },
             no: {
                 option: "forceRG8",
                 yes: {
-                    transcodeFormat: transcodeTarget.RG8,
-                    engineFormat: RG8Format,
+                    transcodeFormat: KTX2.TranscodeTarget.RG8,
+                    engineFormat: KTX2.EngineFormat.RG8Format,
                     roundToMultiple4: false,
                 },
                 no: {
                     cap: "astc",
                     yes: {
-                        transcodeFormat: transcodeTarget.ASTC_4x4_RGBA,
-                        engineFormat: COMPRESSED_RGBA_ASTC_4x4_KHR,
+                        transcodeFormat: KTX2.TranscodeTarget.ASTC_4X4_RGBA,
+                        engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_ASTC_4X4_KHR,
                     },
                     no: {
                         cap: "bptc",
                         yes: {
-                            transcodeFormat: transcodeTarget.BC7_RGBA,
-                            engineFormat: COMPRESSED_RGBA_BPTC_UNORM_EXT,
+                            transcodeFormat: KTX2.TranscodeTarget.BC7_RGBA,
+                            engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_BPTC_UNORM_EXT,
                         },
                         no: {
                             option: "useRGBAIfASTCBC7NotAvailableWhenUASTC",
                             yes: {
-                                transcodeFormat: transcodeTarget.RGBA32,
-                                engineFormat: RGBA8Format,
+                                transcodeFormat: KTX2.TranscodeTarget.RGBA32,
+                                engineFormat: KTX2.EngineFormat.RGBA8Format,
                                 roundToMultiple4: false,
                             },
                             no: {
@@ -151,31 +119,31 @@ const DecisionTree: IDecisionTree = {
                                 yes: {
                                     alpha: true,
                                     yes: {
-                                        transcodeFormat: transcodeTarget.ETC2_RGBA,
-                                        engineFormat: COMPRESSED_RGBA8_ETC2_EAC,
+                                        transcodeFormat: KTX2.TranscodeTarget.ETC2_RGBA,
+                                        engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA8_ETC2_EAC,
                                     },
                                     no: {
-                                        transcodeFormat: transcodeTarget.ETC1_RGB,
-                                        engineFormat: COMPRESSED_RGB8_ETC2,
+                                        transcodeFormat: KTX2.TranscodeTarget.ETC1_RGB,
+                                        engineFormat: KTX2.EngineFormat.COMPRESSED_RGB8_ETC2,
                                     },
                                 },
                                 no: {
                                     cap: "etc1",
                                     yes: {
-                                        transcodeFormat: transcodeTarget.ETC1_RGB,
-                                        engineFormat: COMPRESSED_RGB_ETC1_WEBGL,
+                                        transcodeFormat: KTX2.TranscodeTarget.ETC1_RGB,
+                                        engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_ETC1_WEBGL,
                                     },
                                     no: {
                                         cap: "s3tc",
                                         yes: {
                                             alpha: true,
                                             yes: {
-                                                transcodeFormat: transcodeTarget.BC3_RGBA,
-                                                engineFormat: COMPRESSED_RGBA_S3TC_DXT5_EXT,
+                                                transcodeFormat: KTX2.TranscodeTarget.BC3_RGBA,
+                                                engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_S3TC_DXT5_EXT,
                                             },
                                             no: {
-                                                transcodeFormat: transcodeTarget.BC1_RGB,
-                                                engineFormat: COMPRESSED_RGB_S3TC_DXT1_EXT,
+                                                transcodeFormat: KTX2.TranscodeTarget.BC1_RGB,
+                                                engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_S3TC_DXT1_EXT,
                                             },
                                         },
                                         no: {
@@ -184,17 +152,17 @@ const DecisionTree: IDecisionTree = {
                                             yes: {
                                                 alpha: true,
                                                 yes: {
-                                                    transcodeFormat: transcodeTarget.PVRTC1_4_RGBA,
-                                                    engineFormat: COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
+                                                    transcodeFormat: KTX2.TranscodeTarget.PVRTC1_4_RGBA,
+                                                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
                                                 },
                                                 no: {
-                                                    transcodeFormat: transcodeTarget.PVRTC1_4_RGB,
-                                                    engineFormat: COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
+                                                    transcodeFormat: KTX2.TranscodeTarget.PVRTC1_4_RGB,
+                                                    engineFormat: KTX2.EngineFormat.COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
                                                 },
                                             },
                                             no: {
-                                                transcodeFormat: transcodeTarget.RGBA32,
-                                                engineFormat: RGBA8Format,
+                                                transcodeFormat: KTX2.TranscodeTarget.RGBA32,
+                                                engineFormat: KTX2.EngineFormat.RGBA8Format,
                                                 roundToMultiple4: false,
                                             },
                                         },
@@ -210,14 +178,15 @@ const DecisionTree: IDecisionTree = {
 };
 
 export class TranscodeDecisionTree {
-    private static _IsLeafNode(node: INode | ILeaf): node is ILeaf {
-        return (node as ILeaf).transcodeFormat !== undefined;
+    private static _IsLeafNode(node: KTX2.INode | KTX2.ILeaf): node is KTX2.ILeaf {
+        return (node as KTX2.ILeaf).engineFormat !== undefined;
     }
 
+    private _textureFormat: KTX2.SourceTextureFormat;
     private _hasAlpha: boolean;
     private _isPowerOfTwo: boolean;
-    private _caps: any;
-    private _options: any;
+    private _caps: KTX2.ICompressedFormatCapabilities;
+    private _options: KTX2.IKTX2DecoderOptions;
     private _transcodeFormat: number;
     private _engineFormat: number;
     private _roundToMultiple4: boolean;
@@ -234,16 +203,29 @@ export class TranscodeDecisionTree {
         return this._roundToMultiple4;
     }
 
-    constructor(textureFormat: sourceTextureFormat, hasAlpha: boolean, isPowerOfTwo: boolean, caps: any, options?: any) {
+    constructor(textureFormat: KTX2.SourceTextureFormat, hasAlpha: boolean, isPowerOfTwo: boolean, caps: KTX2.ICompressedFormatCapabilities, options?: KTX2.IKTX2DecoderOptions) {
+        this._textureFormat = textureFormat;
         this._hasAlpha = hasAlpha;
         this._isPowerOfTwo = isPowerOfTwo;
         this._caps = caps;
         this._options = options ?? {};
 
-        this._parseNode(textureFormat === sourceTextureFormat.UASTC4x4 ? DecisionTree.UASTC : DecisionTree.ETC1S);
+        this.parseTree(DecisionTree);
     }
 
-    private _parseNode(node: INode | ILeaf): void {
+    public parseTree(tree: KTX2.IDecisionTree): boolean {
+        const node = this._textureFormat === KTX2.SourceTextureFormat.UASTC4x4 ? tree.UASTC : tree.ETC1S;
+        if (node) {
+            this._parseNode(node);
+        }
+        return node !== undefined;
+    }
+
+    private _parseNode(node: KTX2.INode | KTX2.ILeaf | undefined): void {
+        if (!node) {
+            return;
+        }
+
         if (TranscodeDecisionTree._IsLeafNode(node)) {
             this._transcodeFormat = node.transcodeFormat;
             this._engineFormat = node.engineFormat;
@@ -252,16 +234,23 @@ export class TranscodeDecisionTree {
             let condition = true;
 
             if (node.cap !== undefined) {
-                condition = condition && this._caps[node.cap];
+                condition = condition && !!this._caps[node.cap as keyof typeof this._caps];
             }
             if (node.option !== undefined) {
-                condition = condition && this._options[node.option];
+                condition = condition && !!this._options[node.option as keyof typeof this._options];
             }
             if (node.alpha !== undefined) {
                 condition = condition && this._hasAlpha === node.alpha;
             }
             if (node.needsPowerOfTwo !== undefined) {
                 condition = condition && this._isPowerOfTwo === node.needsPowerOfTwo;
+            }
+            if (node.transcodeFormat !== undefined) {
+                if (Array.isArray(node.transcodeFormat)) {
+                    condition = condition && node.transcodeFormat.indexOf(this._transcodeFormat) !== -1;
+                } else {
+                    condition = condition && node.transcodeFormat === this._transcodeFormat;
+                }
             }
 
             this._parseNode(condition ? node.yes! : node.no!);

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -1,38 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
+import type * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import type { WASMMemoryManager } from "./wasmMemoryManager";
 import type { KTX2FileReader, IKTX2_ImageDesc } from "./ktx2FileReader";
 
 /**
  * @internal
  */
-export enum sourceTextureFormat {
-    ETC1S,
-    UASTC4x4,
-}
-
-/**
- * @internal
- */
-export enum transcodeTarget {
-    ASTC_4x4_RGBA,
-    BC7_RGBA,
-    BC3_RGBA,
-    BC1_RGB,
-    PVRTC1_4_RGBA,
-    PVRTC1_4_RGB,
-    ETC2_RGBA,
-    ETC1_RGB,
-    RGBA32,
-    R8,
-    RG8,
-}
-
-/**
- * @internal
- */
 export class Transcoder {
-    public static CanTranscode(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean): boolean {
+    public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return false;
     }
 
@@ -51,8 +28,8 @@ export class Transcoder {
     public setMemoryManager(memoryMgr: WASMMemoryManager): void {}
 
     public transcode(
-        src: sourceTextureFormat,
-        dst: transcodeTarget,
+        src: KTX2.SourceTextureFormat,
+        dst: KTX2.TranscodeTarget,
         level: number,
         width: number,
         height: number,

--- a/packages/tools/ktx2Decoder/src/transcoderManager.ts
+++ b/packages/tools/ktx2Decoder/src/transcoderManager.ts
@@ -1,5 +1,6 @@
+import * as KTX2 from "core/Materials/Textures/ktx2decoderTypes";
+
 import type { Transcoder } from "./transcoder";
-import { transcodeTarget, sourceTextureFormat } from "./transcoder";
 import { WASMMemoryManager } from "./wasmMemoryManager";
 
 /**
@@ -16,10 +17,10 @@ export class TranscoderManager {
 
     private _wasmMemoryManager: WASMMemoryManager;
 
-    public findTranscoder(src: sourceTextureFormat, dst: transcodeTarget, isInGammaSpace: boolean, bypass?: string[]): Transcoder | null {
+    public findTranscoder(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean, bypass?: string[]): Transcoder | null {
         let transcoder: Transcoder | null = null;
 
-        const key = sourceTextureFormat[src] + "_" + transcodeTarget[dst];
+        const key = KTX2.SourceTextureFormat[src] + "_" + KTX2.TranscodeTarget[dst];
 
         for (let i = 0; i < TranscoderManager._Transcoders.length; ++i) {
             if (TranscoderManager._Transcoders[i].CanTranscode(src, dst, isInGammaSpace) && (!bypass || bypass.indexOf(TranscoderManager._Transcoders[i].Name) < 0)) {

--- a/packages/tools/ktx2Decoder/webpack.config.js
+++ b/packages/tools/ktx2Decoder/webpack.config.js
@@ -1,10 +1,23 @@
 const commonConfigGenerator = require("@dev/build-tools").webpackTools.commonUMDWebpackConfiguration;
+const path = require("path");
 
 module.exports = (env) => {
     const commonConfig = commonConfigGenerator({
         mode: env.production ? "production" : "development",
         devPackageName: "ktx2decoder",
         namespace: "KTX2DECODER",
+        alias: {
+            "core": path.resolve(__dirname, "../../dev/core/dist"),
+        },
+        extendedWebpackConfig: {
+            externals: {},
+            module: {
+                rules: require("@dev/build-tools").webpackTools.getRules({
+                    sideEffects: true,
+                    includeCSS: true,
+                }),
+            },
+        }
     });
     return commonConfig;
 };


### PR DESCRIPTION
See https://forum.babylonjs.com/t/supporting-bc5-and-bc7-device-specific-compression-formats/35045/31

With this PR, the new object `KhronosTextureContainer2.DefaultKTX2DecoderOptions` can be used to set global options for the KTX2 decoder process. The options defined in this way have priority over those passed when creating a KTX2 texture with `new Texture(...)`. This way you can easily force certain behaviors for the decoder without altering the way KTX2 textures are created.

To resolve the issue raised in the forum thread linked above, proceed as follows:
```javascript
BABYLON.KhronosTextureContainer2.DefaultKTX2DecoderOptions.useRGBAIfOnlyBC1BC3AvailableWhenUASTC = true;
```
which will force the use of uncompressed RGBA if only BC1 and BC3 are available as compressed formats.

Note that `ktx2decoderTypes.ts` is defined in the core and not in the **ktx2Decoder** package to avoid an external dependency for the core and I'm not sure that `Materials/Textures/` is the best location for this file...