### PR TITLE
Fix sound source `onended` handling

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -905,9 +905,12 @@ export class Sound {
                     this.isPaused = false;
                     this._startTime = 0;
                     this._currentTime = 0;
-                    this._soundSource!.onended = () => void 0;
+                    if (this._soundSource) {
+                        this._soundSource.onended = () => void 0;
+                    }
+                    this._onended();
                 };
-                this._stopSoundSource(stopTime);
+                this._soundSource.stop(stopTime);
             }
         } else if (this.isPaused) {
             this.isPaused = false;
@@ -929,8 +932,9 @@ export class Sound {
                 }
                 this.isPlaying = false;
                 this.isPaused = true;
-            } else if (Engine.audioEngine?.audioContext) {
-                this._stopSoundSource();
+            } else if (Engine.audioEngine?.audioContext && this._soundSource) {
+                this._soundSource.onended = () => void 0;
+                this._soundSource.stop();
                 this.isPlaying = false;
                 this.isPaused = true;
                 this._currentTime += Engine.audioEngine.audioContext.currentTime - this._startTime;
@@ -1241,12 +1245,5 @@ export class Sound {
             this.isPaused = false;
         }
         this._offset = value;
-    }
-
-    private _stopSoundSource(stopTime?: number) {
-        if (this._soundSource) {
-            this._soundSource.stop(stopTime);
-            this._soundSource.disconnect();
-        }
     }
 }


### PR DESCRIPTION
When pause is called the `onEndedObservable` is being fired, but it should only be fired when stop is called.

This change fixes the issue.

Reported on forum here: https://forum.babylonjs.com/t/pausing-and-playing-an-audio-with-offset-restarts-it-from-the-beginning-instead-of-the-current-position/36668/23