### PR TITLE
Fix sound current time after it ends on its own

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -875,6 +875,8 @@ export class Sound {
 
     private _onended() {
         this.isPlaying = false;
+        this._startTime = 0;
+        this._currentTime = 0;
         if (this.onended) {
             this.onended();
         }


### PR DESCRIPTION
The sound pause function assumes the start time and current time are reset to zero when the sound stops, but they are currently only being reset when the stop function is called. If the sound stops on its own when reaching the end of the sound source, the start time and current time are not reset. This causes the `currentTime` property to report the wrong time when the sound is restarted after stopping on its own, and then being paused.

This change fixes the issue by resetting the start time and current time when the sound source ends on its own.

Reported on forum here: https://forum.babylonjs.com/t/sound-currenttime-exceeds-total-duration-in-some-cases/37668