### PR TITLE
MorphTargetMgr: Fallback to vertex attribute mode if too many targets

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1202,7 +1202,7 @@ export class ThinEngine {
             supportSRGBBuffers: false,
             supportTransformFeedbacks: this._webGLVersion > 1,
             textureMaxLevel: this._webGLVersion > 1,
-            texture2DArrayMaxLayerCount: this._webGLVersion > 1 ? 256 : 128,
+            texture2DArrayMaxLayerCount: this._webGLVersion > 1 ? this._gl.getParameter(this._gl.MAX_ARRAY_TEXTURE_LAYERS) : 128,
         };
 
         // Infos


### PR DESCRIPTION
As we store the morph targets in the depth dimension of a 2DArrayTexture, we should revert to the "non texture" mode (i.e. use vertex attributes) if there are too many targets.

Also, limit the max number of vertex attributes to 8 by default.