### PR TITLE
Fix GLTF Variants Clone

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -632,6 +632,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             } else {
                 this.metadata = source.metadata;
             }
+            this._internalMetadata = source._internalMetadata;
 
             // Tags
             if (Tags && Tags.HasTags(source)) {


### PR DESCRIPTION
https://forum.babylonjs.com/t/khr-materials-variants-got-lost-during-clone-of-mesh/37611/2