### PR TITLE
WebGPU: Fix stencil buffer creation with RTT

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
@@ -56,7 +56,8 @@ WebGPUEngine.prototype.createRenderTargetTexture = function (size: TextureSize, 
                     fullOptions.samplingMode === Constants.TEXTURE_NEAREST_LINEAR ||
                     fullOptions.samplingMode === Constants.TEXTURE_LINEAR_LINEAR_MIPNEAREST),
             rtWrapper._generateStencilBuffer,
-            rtWrapper.samples
+            rtWrapper.samples,
+            fullOptions.generateStencilBuffer ? Constants.TEXTUREFORMAT_DEPTH24_STENCIL8 : Constants.TEXTUREFORMAT_DEPTH32_FLOAT
         );
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-higlightlayer-and-fxaa-issue/37730