### PR TITLE
Handle pointerlock rejections, if promise based

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -2026,8 +2026,11 @@ export class Engine extends ThinEngine {
      */
     static _RequestPointerlock(element: HTMLElement): void {
         if (element.requestPointerLock) {
-            element.requestPointerLock();
-            element.focus();
+            // In some browsers, requestPointerLock returns a promise.
+            // Handle possible rejections to avoid an unhandled top-level exception.
+            const promise: unknown = element.requestPointerLock();
+            if (promise instanceof Promise) promise.then(() => { element.focus(); }).catch(() => {});
+            else element.focus();
         }
     }
 

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -2029,7 +2029,12 @@ export class Engine extends ThinEngine {
             // In some browsers, requestPointerLock returns a promise.
             // Handle possible rejections to avoid an unhandled top-level exception.
             const promise: unknown = element.requestPointerLock();
-            if (promise instanceof Promise) promise.then(() => { element.focus(); }).catch(() => {});
+            if (promise instanceof Promise)
+                promise
+                    .then(() => {
+                        element.focus();
+                    })
+                    .catch(() => {});
             else element.focus();
         }
     }


### PR DESCRIPTION
This should get rid of the unhandled top-level exception if requesting pointer lock fails.

I think the intended way to use pointer lock in Babylon is to sub to `onCanvasBlurObservable` and `onCanvasFocusObservable`, so `element.focus()` probably belongs into the resolved handler.

The alternative would be to focus regardless, but this is probably not desired:
```js
if (promise instanceof Promise) promise.catch(() => {});
element.focus();
```

A good way to try this behaviour is to enter and exit pointerlock in quick succession on a chromium based browser.