### PR TITLE
Add support for node 18 by updating node-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "webpack-cli": "^4.10.0"
             },
             "engines": {
-                "node": ">=12.0.0 <17.0.0",
+                "node": ">=14.0.0 <=18.0.0",
                 "npm": ">=7.0.0"
             },
             "optionalDependencies": {
@@ -8080,16 +8080,16 @@
         },
         "node_modules/asn1": {
             "version": "0.2.6",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
         },
         "node_modules/assert-plus": {
             "version": "1.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -8166,16 +8166,16 @@
         },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "optional": true,
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/aws4": {
             "version": "1.11.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/axios": {
             "version": "1.2.1",
@@ -8667,8 +8667,8 @@
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
-            "devOptional": true,
             "license": "BSD-3-Clause",
+            "optional": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -9269,8 +9269,8 @@
         },
         "node_modules/caseless": {
             "version": "0.12.0",
-            "devOptional": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "optional": true
         },
         "node_modules/chalk": {
             "version": "4.1.0",
@@ -10161,8 +10161,8 @@
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -10685,8 +10685,8 @@
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -12117,11 +12117,11 @@
         },
         "node_modules/extsprintf": {
             "version": "1.3.0",
-            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -12535,8 +12535,8 @@
         },
         "node_modules/forever-agent": {
             "version": "0.6.1",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "optional": true,
             "engines": {
                 "node": "*"
             }
@@ -12898,8 +12898,8 @@
         },
         "node_modules/getpass": {
             "version": "0.1.7",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -13191,16 +13191,16 @@
         },
         "node_modules/har-schema": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "ISC",
+            "optional": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/har-validator": {
             "version": "5.1.5",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -13211,8 +13211,8 @@
         },
         "node_modules/har-validator/node_modules/ajv": {
             "version": "6.12.6",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -13226,8 +13226,8 @@
         },
         "node_modules/har-validator/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/hard-rejection": {
             "version": "2.1.0",
@@ -13669,8 +13669,8 @@
         },
         "node_modules/http-signature": {
             "version": "1.2.0",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -14422,8 +14422,8 @@
         },
         "node_modules/isstream": {
             "version": "0.1.2",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -17537,8 +17537,8 @@
         },
         "node_modules/jsbn": {
             "version": "0.1.1",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/jscodeshift": {
             "version": "0.13.1",
@@ -17805,8 +17805,8 @@
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
-            "devOptional": true,
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
+            "license": "(AFL-2.1 OR BSD-3-Clause)",
+            "optional": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -17820,8 +17820,8 @@
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
-            "devOptional": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -17852,8 +17852,8 @@
         },
         "node_modules/jsprim": {
             "version": "1.4.2",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -19209,10 +19209,11 @@
             "license": "MIT"
         },
         "node_modules/node-sass": {
-            "version": "7.0.3",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
+            "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^4.1.2",
@@ -19221,20 +19222,112 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "lodash": "^4.17.15",
+                "make-fetch-happen": "^10.0.4",
                 "meow": "^9.0.0",
-                "nan": "^2.13.2",
+                "nan": "^2.17.0",
                 "node-gyp": "^8.4.1",
-                "npmlog": "^5.0.0",
-                "request": "^2.88.0",
                 "sass-graph": "^4.0.1",
                 "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
+                "true-case-path": "^2.2.1"
             },
             "bin": {
                 "node-sass": "bin/node-sass"
             },
             "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/node-sass/node_modules/@npmcli/fs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+            "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+            "dev": true,
+            "dependencies": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/@npmcli/move-file": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+            "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "dev": true,
+            "dependencies": {
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/node-sass/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/cacache": {
+            "version": "16.1.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+            "dev": true,
+            "dependencies": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/cacache/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/node-sass/node_modules/chalk": {
@@ -19250,6 +19343,174 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/node-sass/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/node-sass/node_modules/lru-cache": {
+            "version": "7.14.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+            "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/node-sass/node_modules/make-fetch-happen": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+            "dev": true,
+            "dependencies": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.1.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^9.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-sass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/node-sass/node_modules/minipass-fetch": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+            "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/node-sass/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-sass/node_modules/semver/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-sass/node_modules/socks-proxy-agent": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/node-sass/node_modules/ssri": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+            "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/unique-filename": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+            "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+            "dev": true,
+            "dependencies": {
+                "unique-slug": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/node-sass/node_modules/unique-slug": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+            "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+            "dev": true,
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/nopt": {
@@ -19433,8 +19694,8 @@
         },
         "node_modules/oauth-sign": {
             "version": "0.9.0",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "optional": true,
             "engines": {
                 "node": "*"
             }
@@ -19963,8 +20224,8 @@
         },
         "node_modules/performance-now": {
             "version": "2.1.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -21078,8 +21339,8 @@
         },
         "node_modules/request": {
             "version": "2.88.2",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -21108,8 +21369,8 @@
         },
         "node_modules/request/node_modules/form-data": {
             "version": "2.3.3",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -21121,16 +21382,16 @@
         },
         "node_modules/request/node_modules/qs": {
             "version": "6.5.3",
-            "devOptional": true,
             "license": "BSD-3-Clause",
+            "optional": true,
             "engines": {
                 "node": ">=0.6"
             }
         },
         "node_modules/request/node_modules/tough-cookie": {
             "version": "2.5.0",
-            "devOptional": true,
             "license": "BSD-3-Clause",
+            "optional": true,
             "dependencies": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -21141,8 +21402,8 @@
         },
         "node_modules/request/node_modules/uuid": {
             "version": "3.4.0",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -22336,8 +22597,8 @@
         },
         "node_modules/sshpk": {
             "version": "1.17.0",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -23121,12 +23382,10 @@
             }
         },
         "node_modules/true-case-path": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "glob": "^7.1.2"
-            }
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
+            "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
+            "dev": true
         },
         "node_modules/ts-debounce": {
             "version": "4.0.0",
@@ -23426,8 +23685,8 @@
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -23437,8 +23696,8 @@
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
-            "devOptional": true,
-            "license": "Unlicense"
+            "license": "Unlicense",
+            "optional": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -24169,11 +24428,11 @@
         },
         "node_modules/verror": {
             "version": "1.10.0",
-            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -24182,8 +24441,8 @@
         },
         "node_modules/verror/node_modules/core-util-is": {
             "version": "1.0.2",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
@@ -24941,7 +25200,7 @@
                 "@types/react": "^17.0.30",
                 "@types/react-dom": "^17.0.10",
                 "gif.js.optimized": "^1.0.1",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "re-resizable": "^4.9.1",
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
@@ -25023,7 +25282,7 @@
                 "@storybook/testing-library": "^0.0.11",
                 "babel-loader": "^8.2.5",
                 "esbuild": "^0.15.12",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "rimraf": "^3.0.2",
                 "rollup": "^2.58.3",
                 "rollup-plugin-scss": "^3.0.0",
@@ -25672,7 +25931,7 @@
                 "@dev/loaders": "^1.0.0",
                 "@types/react": "^17.0.30",
                 "@types/react-dom": "^17.0.10",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
@@ -25932,7 +26191,7 @@
                 "@types/react-dom": "^17.0.10",
                 "jest": "^27.4.7",
                 "jest-puppeteer": "^6.0.3",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "puppeteer": "^13.1.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
@@ -27380,7 +27639,7 @@
                 "@types/react": "^17.0.30",
                 "@types/react-dom": "^17.0.10",
                 "gif.js.optimized": "^1.0.1",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "re-resizable": "^4.9.1",
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
@@ -27456,7 +27715,7 @@
                 "@storybook/testing-library": "^0.0.11",
                 "babel-loader": "^8.2.5",
                 "esbuild": "^0.15.12",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "rimraf": "^3.0.2",
                 "rollup": "^2.58.3",
                 "rollup-plugin-scss": "^3.0.0",
@@ -30555,7 +30814,7 @@
                 "@dev/loaders": "^1.0.0",
                 "@types/react": "^17.0.30",
                 "@types/react-dom": "^17.0.10",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "rimraf": "^3.0.2",
@@ -30801,7 +31060,7 @@
                 "jest": "^27.4.7",
                 "jest-puppeteer": "^6.0.3",
                 "jest-screenshot": "^0.3.5",
-                "node-sass": "^7.0.1",
+                "node-sass": "^8.0.0",
                 "puppeteer": "^13.1.2",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.4.4"
@@ -31787,14 +32046,14 @@
         },
         "asn1": {
             "version": "0.2.6",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
             "version": "1.0.0",
-            "devOptional": true
+            "optional": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -31836,11 +32095,11 @@
         },
         "aws-sign2": {
             "version": "0.7.0",
-            "devOptional": true
+            "optional": true
         },
         "aws4": {
             "version": "1.11.0",
-            "devOptional": true
+            "optional": true
         },
         "axios": {
             "version": "1.2.1",
@@ -32400,7 +32659,7 @@
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -32778,7 +33037,7 @@
         },
         "caseless": {
             "version": "0.12.0",
-            "devOptional": true
+            "optional": true
         },
         "chalk": {
             "version": "4.1.0",
@@ -33356,7 +33615,7 @@
         },
         "dashdash": {
             "version": "1.14.1",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -33679,7 +33938,7 @@
         },
         "ecc-jsbn": {
             "version": "0.1.2",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -34632,7 +34891,7 @@
         },
         "extsprintf": {
             "version": "1.3.0",
-            "devOptional": true
+            "optional": true
         },
         "fast-deep-equal": {
             "version": "3.1.3"
@@ -34907,7 +35166,7 @@
         },
         "forever-agent": {
             "version": "0.6.1",
-            "devOptional": true
+            "optional": true
         },
         "fork-ts-checker-webpack-plugin": {
             "version": "7.2.13",
@@ -35119,7 +35378,7 @@
         },
         "getpass": {
             "version": "0.1.7",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -35319,11 +35578,11 @@
         },
         "har-schema": {
             "version": "2.0.0",
-            "devOptional": true
+            "optional": true
         },
         "har-validator": {
             "version": "5.1.5",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -35331,7 +35590,7 @@
             "dependencies": {
                 "ajv": {
                     "version": "6.12.6",
-                    "devOptional": true,
+                    "optional": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -35341,7 +35600,7 @@
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
-                    "devOptional": true
+                    "optional": true
                 }
             }
         },
@@ -35626,7 +35885,7 @@
         },
         "http-signature": {
             "version": "1.2.0",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -36043,7 +36302,7 @@
         },
         "isstream": {
             "version": "0.1.2",
-            "devOptional": true
+            "optional": true
         },
         "istanbul-lib-coverage": {
             "version": "3.2.0"
@@ -38292,7 +38551,7 @@
         },
         "jsbn": {
             "version": "0.1.1",
-            "devOptional": true
+            "optional": true
         },
         "jscodeshift": {
             "version": "0.13.1",
@@ -38487,7 +38746,7 @@
         },
         "json-schema": {
             "version": "0.4.0",
-            "devOptional": true
+            "optional": true
         },
         "json-schema-traverse": {
             "version": "1.0.0",
@@ -38499,7 +38758,7 @@
         },
         "json-stringify-safe": {
             "version": "5.0.1",
-            "devOptional": true
+            "optional": true
         },
         "json5": {
             "version": "2.2.3",
@@ -38520,7 +38779,7 @@
         },
         "jsprim": {
             "version": "1.4.2",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -39411,7 +39670,9 @@
             "version": "2.0.7"
         },
         "node-sass": {
-            "version": "7.0.3",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
+            "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -39421,22 +39682,226 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "lodash": "^4.17.15",
+                "make-fetch-happen": "^10.0.4",
                 "meow": "^9.0.0",
-                "nan": "^2.13.2",
+                "nan": "^2.17.0",
                 "node-gyp": "^8.4.1",
-                "npmlog": "^5.0.0",
-                "request": "^2.88.0",
                 "sass-graph": "^4.0.1",
                 "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
+                "true-case-path": "^2.2.1"
             },
             "dependencies": {
+                "@npmcli/fs": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+                    "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+                    "dev": true,
+                    "requires": {
+                        "@gar/promisify": "^1.1.3",
+                        "semver": "^7.3.5"
+                    }
+                },
+                "@npmcli/move-file": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+                    "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+                    "dev": true,
+                    "requires": {
+                        "mkdirp": "^1.0.4",
+                        "rimraf": "^3.0.2"
+                    }
+                },
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+                    "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "cacache": {
+                    "version": "16.1.3",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+                    "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/fs": "^2.1.0",
+                        "@npmcli/move-file": "^2.0.0",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.1.0",
+                        "glob": "^8.0.1",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "mkdirp": "^1.0.4",
+                        "p-map": "^4.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^9.0.0",
+                        "tar": "^6.1.11",
+                        "unique-filename": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "8.1.0",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+                            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^5.0.1",
+                                "once": "^1.3.0"
+                            }
+                        }
+                    }
+                },
                 "chalk": {
                     "version": "4.1.2",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+                    "dev": true,
+                    "requires": {
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
+                "lru-cache": {
+                    "version": "7.14.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+                    "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+                    "dev": true
+                },
+                "make-fetch-happen": {
+                    "version": "10.2.1",
+                    "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+                    "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+                    "dev": true,
+                    "requires": {
+                        "agentkeepalive": "^4.2.1",
+                        "cacache": "^16.1.0",
+                        "http-cache-semantics": "^4.1.0",
+                        "http-proxy-agent": "^5.0.0",
+                        "https-proxy-agent": "^5.0.0",
+                        "is-lambda": "^1.0.1",
+                        "lru-cache": "^7.7.1",
+                        "minipass": "^3.1.6",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-fetch": "^2.0.3",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.4",
+                        "negotiator": "^0.6.3",
+                        "promise-retry": "^2.0.1",
+                        "socks-proxy-agent": "^7.0.0",
+                        "ssri": "^9.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minipass-fetch": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+                    "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+                    "dev": true,
+                    "requires": {
+                        "encoding": "^0.1.13",
+                        "minipass": "^3.1.6",
+                        "minipass-sized": "^1.0.3",
+                        "minizlib": "^2.1.2"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        }
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+                    "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^6.0.2",
+                        "debug": "^4.3.3",
+                        "socks": "^2.6.2"
+                    }
+                },
+                "ssri": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+                    "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^3.1.1"
+                    }
+                },
+                "unique-filename": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+                    "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+                    "dev": true,
+                    "requires": {
+                        "unique-slug": "^3.0.0"
+                    }
+                },
+                "unique-slug": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+                    "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4"
                     }
                 }
             }
@@ -39562,7 +40027,7 @@
         },
         "oauth-sign": {
             "version": "0.9.0",
-            "devOptional": true
+            "optional": true
         },
         "object-assign": {
             "version": "4.1.1"
@@ -39885,7 +40350,7 @@
         },
         "performance-now": {
             "version": "2.1.0",
-            "devOptional": true
+            "optional": true
         },
         "picocolors": {
             "version": "1.0.0"
@@ -40586,7 +41051,7 @@
         },
         "request": {
             "version": "2.88.2",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -40612,7 +41077,7 @@
             "dependencies": {
                 "form-data": {
                     "version": "2.3.3",
-                    "devOptional": true,
+                    "optional": true,
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.6",
@@ -40621,11 +41086,11 @@
                 },
                 "qs": {
                     "version": "6.5.3",
-                    "devOptional": true
+                    "optional": true
                 },
                 "tough-cookie": {
                     "version": "2.5.0",
-                    "devOptional": true,
+                    "optional": true,
                     "requires": {
                         "psl": "^1.1.28",
                         "punycode": "^2.1.1"
@@ -40633,7 +41098,7 @@
                 },
                 "uuid": {
                     "version": "3.4.0",
-                    "devOptional": true
+                    "optional": true
                 }
             }
         },
@@ -41404,7 +41869,7 @@
         },
         "sshpk": {
             "version": "1.17.0",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -41914,11 +42379,10 @@
             "dev": true
         },
         "true-case-path": {
-            "version": "1.0.3",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2"
-            }
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
+            "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
+            "dev": true
         },
         "ts-debounce": {
             "version": "4.0.0",
@@ -42104,14 +42568,14 @@
         },
         "tunnel-agent": {
             "version": "0.6.0",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
             "version": "0.14.5",
-            "devOptional": true
+            "optional": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -42551,7 +43015,7 @@
         },
         "verror": {
             "version": "1.10.0",
-            "devOptional": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -42560,7 +43024,7 @@
             "dependencies": {
                 "core-util-is": {
                     "version": "1.0.2",
-                    "devOptional": true
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "start": "concurrently --kill-others -m 2 -n dev-watch,cdn-server \"npm run watch:dev:skip-compile\" \"npm run serve -w @tools/babylon-server\""
     },
     "engines": {
-        "node": ">=12.0.0 <17.0.0",
+        "node": ">=14.0.0 <=18.0.0",
         "npm": ">=7.0.0"
     },
     "changelog": {

--- a/packages/dev/inspector/package.json
+++ b/packages/dev/inspector/package.json
@@ -37,7 +37,7 @@
         "@types/react": "^17.0.30",
         "@types/react-dom": "^17.0.10",
         "gif.js.optimized": "^1.0.1",
-        "node-sass": "^7.0.1",
+        "node-sass": "^8.0.0",
         "re-resizable": "^4.9.1",
         "react": "^17.0.2",
         "react-contextmenu": "RaananW/react-contextmenu",

--- a/packages/dev/sharedUiComponents/package.json
+++ b/packages/dev/sharedUiComponents/package.json
@@ -52,7 +52,7 @@
         "@storybook/cli": "^7.0.0-alpha.47",
         "@storybook/testing-library": "^0.0.11",
         "babel-loader": "^8.2.5",
-        "node-sass": "^7.0.1",
+        "node-sass": "^8.0.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.58.3",
         "rollup-plugin-scss": "^3.0.0",

--- a/packages/tools/accessibility/package.json
+++ b/packages/tools/accessibility/package.json
@@ -27,7 +27,7 @@
         "@dev/loaders": "^1.0.0",
         "@types/react": "^17.0.30",
         "@types/react-dom": "^17.0.10",
-        "node-sass": "^7.0.1",
+        "node-sass": "^8.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",

--- a/packages/tools/tests/package.json
+++ b/packages/tools/tests/package.json
@@ -30,7 +30,7 @@
         "@types/react-dom": "^17.0.10",
         "jest": "^27.4.7",
         "jest-puppeteer": "^6.0.3",
-        "node-sass": "^7.0.1",
+        "node-sass": "^8.0.0",
         "puppeteer": "^13.1.2",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"


### PR DESCRIPTION
And drop support for node 12.

It's probably time, it's the next LTS :)

I have not fully tested it (too reliant on CI maybe), but it works in dev. It's possible it'll also work with node 19, but I did not try.