### PR TITLE
Fix for sprite rendering for ios 14 and lower

### DIFF
--- a/packages/dev/core/src/Shaders/sprites.fragment.fx
+++ b/packages/dev/core/src/Shaders/sprites.fragment.fx
@@ -17,8 +17,10 @@ void main(void) {
 #define CUSTOM_FRAGMENT_MAIN_BEGIN
 
 	vec4 color = texture2D(diffuseSampler, vUV);
+	// Fix for ios14 and lower
+	float fAlphaTest = float(alphaTest);
 
-	if (float(alphaTest) != 0.)
+	if (fAlphaTest != 0.)
 	{
 		if (color.a < 0.95)
 			discard;


### PR DESCRIPTION
Fixes https://forum.babylonjs.com/t/sprites-are-not-being-rendered-for-ios14-and-lower/37973