### PR TITLE
VideoTexture - Fix texture refresh bug

### DIFF
--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -286,6 +286,10 @@ export class VideoTexture extends Texture {
 
         this._texture = this._getEngine()!.createDynamicTexture(this.video.videoWidth, this.video.videoHeight, this._generateMipMaps, this.samplingMode);
         this._texture.format = this._format ?? Constants.TEXTUREFORMAT_RGBA;
+
+        // Reset the frame ID and update the new texture to ensure it pulls in the current video frame
+        this._frameId = -1;
+        this._updateInternalTexture();
     };
 
     private _createInternalTexture = (): void => {


### PR DESCRIPTION
My last PR: #13513 introduced logic to refresh the the VideoTexture's internal texture when the underlying video changed sizes.

I missed an edge case where the resize event can occur on the same frame that the texture was already updated from. When that happens the new texture was not getting hooked up to the video feed because of a no-op condition that avoids updating the texture twice in one frame. This change ensures that when swapping out the internal texture it also gets re-registered with the video feed.