### PR TITLE
DeviceInputSystem: Use correct pointerId for touch inputs on blur and pointercancel event

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -72,7 +72,7 @@ export class DeviceEventFactory {
             evt.pointerType = "mouse";
         } else {
             evt.deviceType = DeviceType.Touch;
-            evt.pointerId = pointerId || deviceSlot;
+            evt.pointerId = pointerId ?? deviceSlot;
             evt.pointerType = "touch";
         }
 

--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -26,7 +26,8 @@ export class DeviceEventFactory {
         inputIndex: number,
         currentState: Nullable<number>,
         deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo?: any
+        elementToAttachTo?: any,
+        pointerId?: number
     ): IUIEvent {
         switch (deviceType) {
             case DeviceType.Keyboard:
@@ -37,7 +38,7 @@ export class DeviceEventFactory {
                 }
             // eslint-disable-next-line no-fallthrough
             case DeviceType.Touch:
-                return this._CreatePointerEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
+                return this._CreatePointerEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo, pointerId);
             default:
                 throw `Unable to generate event for device ${DeviceType[deviceType]}`;
         }
@@ -60,7 +61,8 @@ export class DeviceEventFactory {
         inputIndex: number,
         currentState: Nullable<number>,
         deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo?: any
+        elementToAttachTo?: any,
+        pointerId?: number
     ): any {
         const evt = this._CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
 
@@ -70,7 +72,7 @@ export class DeviceEventFactory {
             evt.pointerType = "mouse";
         } else {
             evt.deviceType = DeviceType.Touch;
-            evt.pointerId = deviceSlot;
+            evt.pointerId = pointerId || deviceSlot;
             evt.pointerType = "touch";
         }
 

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -591,7 +591,15 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 this._inputs[DeviceType.Touch][deviceSlot][PointerInput.LeftClick] = 0;
 
-                const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
+                const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(
+                    DeviceType.Touch,
+                    deviceSlot,
+                    PointerInput.LeftClick,
+                    0,
+                    this,
+                    this._elementToAttachTo,
+                    evt.pointerId
+                );
 
                 this._onInputChanged(DeviceType.Touch, deviceSlot, deviceEvent);
 
@@ -662,7 +670,15 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointerId !== -1 && pointer[deviceSlot]?.[PointerInput.LeftClick] === 1) {
                         pointer[deviceSlot][PointerInput.LeftClick] = 0;
 
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo);
+                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(
+                            DeviceType.Touch,
+                            deviceSlot,
+                            PointerInput.LeftClick,
+                            0,
+                            this,
+                            this._elementToAttachTo,
+                            pointerId
+                        );
 
                         this._onInputChanged(DeviceType.Touch, deviceSlot, deviceEvent);
 


### PR DESCRIPTION
A forum user recently found an issue where the pointerId was incorrect for `blur` and `pointercancel` events fired from a touch input.  This PR adds a small change to the DeviceEventFactory to use the pointerId, if available.

Forum Link: https://forum.babylonjs.com/t/distinguish-between-onbuttonup-events-in-basecamerapointersinput/37985/1