### PR TITLE
Delay resize event listener to after video internal texture is created.

### DIFF
--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -201,7 +201,6 @@ export class VideoTexture extends Texture {
             this.video.addEventListener("paused", this._updateInternalTexture);
             this.video.addEventListener("seeked", this._updateInternalTexture);
             this.video.addEventListener("emptied", this._reset);
-            this.video.addEventListener("resize", this._resizeInternalTexture);
 
             if (this._settings.autoPlay) {
                 this._handlePlay();
@@ -301,6 +300,7 @@ export class VideoTexture extends Texture {
             }
         }
 
+        this.video.addEventListener("resize", this._resizeInternalTexture);
         this._resizeInternalTexture();
 
         if (!this.video.autoplay && !this._settings.poster && !this._settings.independentVideoSource) {


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/issue-with-video-texture-loading-onloadobservable-not-called/38052

The issue happens for videos with autoplay. Example PG: https://playground.babylonjs.com/#ZMCFYA#83