### PR TITLE
PBRMaterial: Fix INVERTCUBICMAP not being reset

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1595,10 +1595,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                         defines.REALTIME_FILTERING = false;
                     }
 
-                    if (reflectionTexture.coordinatesMode === Texture.INVCUBIC_MODE) {
-                        defines.INVERTCUBICMAP = true;
-                    }
-
+                    defines.INVERTCUBICMAP = reflectionTexture.coordinatesMode === Texture.INVCUBIC_MODE;
                     defines.REFLECTIONMAP_3D = reflectionTexture.isCube;
                     defines.REFLECTIONMAP_OPPOSITEZ = defines.REFLECTIONMAP_3D && this.getScene().useRightHandedSystem ? !reflectionTexture.invertZ : reflectionTexture.invertZ;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/changing-reflectiontexture-to-probe-then-revert-causes-inverted-reflectiontexture/38160