### PR TITLE
PBR: Fix realtime filtering for refraction

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -260,7 +260,7 @@ struct subSurfaceOutParams
                 float requestedRefractionLOD = refractionLOD;
             #endif
 
-            #ifdef REALTIME_FILTERING
+            #if defined(REALTIME_FILTERING) && defined(SS_REFRACTIONMAP_3D)
                 environmentRefraction = vec4(radiance(alphaG, refractionSampler, refractionCoords, vRefractionFilteringInfo), 1.0);
             #else
                 environmentRefraction = sampleRefractionLod(refractionSampler, refractionCoords, requestedRefractionLOD);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/es6-import-of-babylonjs-core-ignoring-side-effects-required-for-khr-materials-transmission/38198

Realtime filtering can only work if the refraction texture is a cube (the `radiance` function is expecting a `CubeSampler`). So, we should disable realtime filtering when the refraction texture is a 2D texture.