### PR TITLE
ArcRotateCamera: Force unsynchronized meshes to update their world matrices when zoomOn is called

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1210,6 +1210,13 @@ export class ArcRotateCamera extends TargetCamera {
     public zoomOn(meshes?: AbstractMesh[], doNotUpdateMaxZ = false): void {
         meshes = meshes || this.getScene().meshes;
 
+        // Verify that mesh data is sync'd and force a compute if it's not so that we can get the correct bounding info.
+        for (let i = 0; i < meshes.length; i++) {
+            if (!meshes[i].isSynchronized()) {
+                meshes[i].computeWorldMatrix(true);
+            }
+        }
+
         const minMaxVector = Mesh.MinMax(meshes);
         const distance = Vector3.Distance(minMaxVector.min, minMaxVector.max);
 


### PR DESCRIPTION
A user found an issue in the forum where the zoomOn function wasn't properly zooming on a given mesh.  Upon further inspection, it was determined that one of the parameters of the mesh's position was changed during the same frame so the world matrix was outdated.  This fix will allow the zoomOn function to check to see if the mesh needs to make this update and call `computeWorldMatrix(true)`, if necessary.

Forum Link: https://forum.babylonjs.com/t/arcrotate-camera-zoomon-not-working-as-expected/38130/14