### PR TITLE
Materials: Fix depth state not set correctly with transparent meshes

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.alpha.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.alpha.ts
@@ -47,6 +47,13 @@ ThinEngine.prototype.setAlphaConstants = function (r: number, g: number, b: numb
 
 ThinEngine.prototype.setAlphaMode = function (mode: number, noDepthWriteChange: boolean = false): void {
     if (this._alphaMode === mode) {
+        if (!noDepthWriteChange) {
+            // Make sure we still have the correct depth mask according to the alpha mode (a transparent material could have forced writting to the depth buffer, for instance)
+            const depthMask = mode === Constants.ALPHA_DISABLE;
+            if (this.depthCullingState.depthMask !== depthMask) {
+                this.depthCullingState.depthMask = depthMask;
+            }
+        }
         return;
     }
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.alpha.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.alpha.ts
@@ -4,6 +4,14 @@ import { WebGPUEngine } from "../../webgpuEngine";
 
 WebGPUEngine.prototype.setAlphaMode = function (mode: number, noDepthWriteChange: boolean = false): void {
     if (this._alphaMode === mode && ((mode === Constants.ALPHA_DISABLE && !this._alphaState.alphaBlend) || (mode !== Constants.ALPHA_DISABLE && this._alphaState.alphaBlend))) {
+        if (!noDepthWriteChange) {
+            // Make sure we still have the correct depth mask according to the alpha mode (a transparent material could have forced writting to the depth buffer, for instance)
+            const depthMask = mode === Constants.ALPHA_DISABLE;
+            if (this.depthCullingState.depthMask !== depthMask) {
+                this.setDepthWrite(depthMask);
+                this._cacheRenderPipeline.setDepthWriteEnabled(depthMask);
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/flag-depth-writemask-not-reset-after-draw-mesh/38377

The depth write mask was not reset correctly when a transparent material was forcing depth writting.