### PR TITLE
Camera: Add code to update View and Projection Matrices in update function

### DIFF
--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -672,6 +672,9 @@ export class Camera extends Node {
      * Update the camera state according to the different inputs gathered during the frame.
      */
     public update(): void {
+        this.getViewMatrix();
+        this.getProjectionMatrix();
+
         this._checkInputs();
         if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
             this._updateRigCameras();

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -672,13 +672,16 @@ export class Camera extends Node {
      * Update the camera state according to the different inputs gathered during the frame.
      */
     public update(): void {
-        this.getViewMatrix();
-        this.getProjectionMatrix();
-
         this._checkInputs();
         if (this.cameraRigMode !== Camera.RIG_MODE_NONE) {
             this._updateRigCameras();
         }
+
+        // Attempt to update the camera's view and projection matrices.
+        // This call is being made because these matrices are no longer being updated
+        // as a part of the picking ray process (in addition to scene.render).
+        this.getViewMatrix();
+        this.getProjectionMatrix();
     }
 
     /** @internal */


### PR DESCRIPTION
A user on the forums had recently found an issue when performing input while using an on-demand rendering loop.  The issue was that the `onViewMatrixChangedObservable` wasn't firing as a part of pointer input.  This behavior was present in previous versions.  It was determined that the Lazy Picking changes may have caused this change because the aforementioned observable only fires during `getViewMatrix()` calls.  Before the Lazy Picking implementation, this function was called as a part of the creation and assignment of the picking ray for a PickingInfo object.  Since this ray is only created when picking happens, a pointer event that doesn't require picking info won't ever get to the point where `getViewMatrix` is called.  Technically, these get functions should be called as a part of the camera's update function so the fix is to do just that.

Tests have been added to verify that `onViewMatrixObservable` and `onProjectionMatrixObservable` are firing properly.

Forum Link: https://forum.babylonjs.com/t/on-demand-rendering-solution-broken-since-5-29/36379/1
Issue Link: https://github.com/BabylonJS/Babylon.js/issues/13551