### PR TITLE
[Suggestion] Notify added observer if observable was triggered.

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1279,7 +1279,7 @@ export class Engine extends ThinEngine {
     public _renderLoop(): void {
         if (!this._contextWasLost) {
             let shouldRender = true;
-            if (!this.renderEvenInBackground && this._windowIsBackground) {
+            if (this.isDisposed || (!this.renderEvenInBackground && this._windowIsBackground)) {
                 shouldRender = false;
             }
 
@@ -1874,7 +1874,7 @@ export class Engine extends ThinEngine {
         }
 
         // Release audio engine
-        if (Engine.Instances.length === 1 && Engine.audioEngine) {
+        if (EngineStore.Instances.length === 1 && Engine.audioEngine) {
             Engine.audioEngine.dispose();
             Engine.audioEngine = null;
         }
@@ -1910,10 +1910,16 @@ export class Engine extends ThinEngine {
         super.dispose();
 
         // Remove from Instances
-        const index = Engine.Instances.indexOf(this);
+        const index = EngineStore.Instances.indexOf(this);
 
         if (index >= 0) {
-            Engine.Instances.splice(index, 1);
+            EngineStore.Instances.splice(index, 1);
+        }
+
+        // no more engines left in the engine store? Notify!
+        if (!Engine.Instances.length) {
+            EngineStore.OnEnginesDisposedObservable.notifyObservers(this);
+            EngineStore.OnEnginesDisposedObservable.clear();
         }
 
         // Observables

--- a/packages/dev/core/src/Engines/engineStore.ts
+++ b/packages/dev/core/src/Engines/engineStore.ts
@@ -1,3 +1,4 @@
+import { Observable } from "../Misc/observable";
 import type { Nullable } from "../types";
 
 declare type Engine = import("./engine").Engine;
@@ -10,6 +11,12 @@ declare type Scene = import("../scene").Scene;
 export class EngineStore {
     /** Gets the list of created engines */
     public static Instances = new Array<Engine>();
+
+    /**
+     * Notifies when an engine was disposed.
+     * Mainly used for static/cache cleanup
+     */
+    public static OnEnginesDisposedObservable = new Observable<Engine>();
 
     /** @internal */
     public static _LastCreatedScene: Nullable<Scene> = null;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -266,6 +266,12 @@ export class ThinEngine {
         return this._webGLVersion;
     }
 
+    private _isDisposed = false;
+
+    public get isDisposed(): boolean {
+        return this._isDisposed;
+    }
+
     // Updatable statics so stick with vars here
 
     /**
@@ -1529,7 +1535,8 @@ export class ThinEngine {
      */
     public stopRenderLoop(renderFunction?: () => void): void {
         if (!renderFunction) {
-            this._activeRenderLoops = [];
+            cancelAnimationFrame(this._boundRenderFunction);
+            this._activeRenderLoops.length = 0;
             return;
         }
 
@@ -1544,7 +1551,7 @@ export class ThinEngine {
     public _renderLoop(): void {
         if (!this._contextWasLost) {
             let shouldRender = true;
-            if (!this.renderEvenInBackground && this._windowIsBackground) {
+            if (this._isDisposed || (!this.renderEvenInBackground && this._windowIsBackground)) {
                 shouldRender = false;
             }
 
@@ -5346,6 +5353,7 @@ export class ThinEngine {
      * Dispose and release all associated resources
      */
     public dispose(): void {
+        this._isDisposed = true;
         this.stopRenderLoop();
 
         // Clear observables

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1535,7 +1535,6 @@ export class ThinEngine {
      */
     public stopRenderLoop(renderFunction?: () => void): void {
         if (!renderFunction) {
-            cancelAnimationFrame(this._boundRenderFunction);
             this._activeRenderLoops.length = 0;
             return;
         }

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -905,6 +905,7 @@ SceneLoader.RegisterPlugin({
             if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
                 Logger.Log(logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));
             }
+            tempMaterialIndexContainer = {};
         }
 
         return false;

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -1057,7 +1057,7 @@ export class BackgroundMaterial extends PushMaterial {
      * @param world The world matrix to bind.
      */
     public bindOnlyWorldMatrix(world: Matrix): void {
-        this._activeEffect.setMatrix("world", world);
+        this._activeEffect!.setMatrix("world", world);
     }
 
     /**

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -202,6 +202,12 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     public static OnEventObservable = new Observable<Material>();
 
+    static {
+        EngineStore.OnEnginesDisposedObservable.addOnce(() => {
+            Material.OnEventObservable.clear();
+        });
+    }
+
     /**
      * Custom callback helping to override the default shader used in the material.
      */

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -70,6 +70,9 @@ export class MaterialPluginBase {
 
         if (!material.pluginManager) {
             material.pluginManager = new MaterialPluginManager(material);
+            material.onDisposeObservable.add(() => {
+                material.pluginManager = undefined;
+            })
         }
 
         this._pluginDefineNames = defines;

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -72,7 +72,7 @@ export class MaterialPluginBase {
             material.pluginManager = new MaterialPluginManager(material);
             material.onDisposeObservable.add(() => {
                 material.pluginManager = undefined;
-            })
+            });
         }
 
         this._pluginDefineNames = defines;

--- a/packages/dev/core/src/Materials/pushMaterial.ts
+++ b/packages/dev/core/src/Materials/pushMaterial.ts
@@ -11,7 +11,7 @@ import type { SubMesh } from "../Meshes/subMesh";
  * @internal
  */
 export class PushMaterial extends Material {
-    protected _activeEffect: Effect;
+    protected _activeEffect?: Effect;
 
     protected _normalMatrix: Matrix = new Matrix();
 
@@ -21,7 +21,7 @@ export class PushMaterial extends Material {
     }
 
     public getEffect(): Effect {
-        return this._storeEffectOnSubMeshes ? this._activeEffect : super.getEffect()!;
+        return this._storeEffectOnSubMeshes ? this._activeEffect! : super.getEffect()!;
     }
 
     public isReady(mesh?: AbstractMesh, useInstances?: boolean): boolean {
@@ -57,7 +57,7 @@ export class PushMaterial extends Material {
      * @param world the matrix to bind
      */
     public bindOnlyWorldMatrix(world: Matrix): void {
-        this._activeEffect.setMatrix("world", world);
+        this._activeEffect!.setMatrix("world", world);
     }
 
     /**
@@ -66,7 +66,7 @@ export class PushMaterial extends Material {
      * @param normalMatrix the matrix to bind
      */
     public bindOnlyNormalMatrix(normalMatrix: Matrix): void {
-        this._activeEffect.setMatrix("normalMatrix", normalMatrix);
+        this._activeEffect!.setMatrix("normalMatrix", normalMatrix);
     }
 
     public bind(world: Matrix, mesh?: Mesh): void {
@@ -87,5 +87,10 @@ export class PushMaterial extends Material {
 
     protected _mustRebind(scene: Scene, effect: Effect, visibility: number = 1) {
         return scene.isCachedMaterialInvalid(this, effect, visibility);
+    }
+
+    public dispose(forceDisposeEffect?: boolean, forceDisposeTextures?: boolean, notBoundToMesh?: boolean) {
+        this._activeEffect = undefined;
+        super.dispose(forceDisposeEffect, forceDisposeTextures, notBoundToMesh);
     }
 }

--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -399,6 +399,13 @@ export class Observable<T> {
         this._observers.length = 0;
         this._onObserverAdded = null;
         this._numObserversMarkedAsDeleted = 0;
+        this.cleanLastNotifiedState();
+    }
+
+    /**
+     * Clean the last notified state - both the internal last value and the has-notified flag
+     */
+    public cleanLastNotifiedState(): void {
         this._hasNotified = false;
         this._lastNotifiedValue = undefined;
     }

--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -396,9 +396,11 @@ export class Observable<T> {
      * Clear the list of observers
      */
     public clear(): void {
-        this._observers = new Array<Observer<T>>();
+        this._observers.length = 0;
         this._onObserverAdded = null;
         this._numObserversMarkedAsDeleted = 0;
+        this._hasNotified = false;
+        this._lastNotifiedValue = undefined;
     }
 
     /**

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -314,7 +314,7 @@ export class Node implements IBehaviorAware<Node> {
     /**
      * An event triggered when the mesh is disposed
      */
-    public onDisposeObservable = new Observable<Node>();
+    public onDisposeObservable = new Observable<Node>(undefined, true);
 
     private _onDisposeObserver: Nullable<Observer<Node>> = null;
     /**

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -314,7 +314,7 @@ export class Node implements IBehaviorAware<Node> {
     /**
      * An event triggered when the mesh is disposed
      */
-    public onDisposeObservable = new Observable<Node>(undefined, true);
+    public onDisposeObservable = new Observable<Node>();
 
     private _onDisposeObserver: Nullable<Observer<Node>> = null;
     /**

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4694,53 +4694,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             console.error("An error occurred while calling onDisposeObservable!", e);
         }
 
-        this.onDisposeObservable.clear();
-        this.onBeforeRenderObservable.clear();
-        this.onAfterRenderObservable.clear();
-        this.onBeforeRenderTargetsRenderObservable.clear();
-        this.onAfterRenderTargetsRenderObservable.clear();
-        this.onAfterStepObservable.clear();
-        this.onBeforeStepObservable.clear();
-        this.onBeforeActiveMeshesEvaluationObservable.clear();
-        this.onAfterActiveMeshesEvaluationObservable.clear();
-        this.onBeforeParticlesRenderingObservable.clear();
-        this.onAfterParticlesRenderingObservable.clear();
-        this.onBeforeDrawPhaseObservable.clear();
-        this.onAfterDrawPhaseObservable.clear();
-        this.onBeforeAnimationsObservable.clear();
-        this.onAfterAnimationsObservable.clear();
-        this.onDataLoadedObservable.clear();
-        this.onBeforeRenderingGroupObservable.clear();
-        this.onAfterRenderingGroupObservable.clear();
-        this.onMeshImportedObservable.clear();
-        this.onBeforeCameraRenderObservable.clear();
-        this.onAfterCameraRenderObservable.clear();
-        this.onAfterRenderCameraObservable.clear();
-        this.onReadyObservable.clear();
-        this.onNewCameraAddedObservable.clear();
-        this.onCameraRemovedObservable.clear();
-        this.onNewLightAddedObservable.clear();
-        this.onLightRemovedObservable.clear();
-        this.onNewGeometryAddedObservable.clear();
-        this.onGeometryRemovedObservable.clear();
-        this.onNewTransformNodeAddedObservable.clear();
-        this.onTransformNodeRemovedObservable.clear();
-        this.onNewMeshAddedObservable.clear();
-        this.onMeshRemovedObservable.clear();
-        this.onNewSkeletonAddedObservable.clear();
-        this.onSkeletonRemovedObservable.clear();
-        this.onNewMaterialAddedObservable.clear();
-        this.onNewMultiMaterialAddedObservable.clear();
-        this.onMaterialRemovedObservable.clear();
-        this.onMultiMaterialRemovedObservable.clear();
-        this.onNewTextureAddedObservable.clear();
-        this.onTextureRemovedObservable.clear();
-        this.onPrePointerObservable.clear();
-        this.onPointerObservable.clear();
-        this.onPreKeyboardObservable.clear();
-        this.onKeyboardObservable.clear();
-        this.onActiveCameraChanged.clear();
-
         this.detachControl();
 
         // Detach cameras
@@ -4820,6 +4773,52 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
 
         this._engine.wipeCaches(true);
+        this.onDisposeObservable.clear();
+        this.onBeforeRenderObservable.clear();
+        this.onAfterRenderObservable.clear();
+        this.onBeforeRenderTargetsRenderObservable.clear();
+        this.onAfterRenderTargetsRenderObservable.clear();
+        this.onAfterStepObservable.clear();
+        this.onBeforeStepObservable.clear();
+        this.onBeforeActiveMeshesEvaluationObservable.clear();
+        this.onAfterActiveMeshesEvaluationObservable.clear();
+        this.onBeforeParticlesRenderingObservable.clear();
+        this.onAfterParticlesRenderingObservable.clear();
+        this.onBeforeDrawPhaseObservable.clear();
+        this.onAfterDrawPhaseObservable.clear();
+        this.onBeforeAnimationsObservable.clear();
+        this.onAfterAnimationsObservable.clear();
+        this.onDataLoadedObservable.clear();
+        this.onBeforeRenderingGroupObservable.clear();
+        this.onAfterRenderingGroupObservable.clear();
+        this.onMeshImportedObservable.clear();
+        this.onBeforeCameraRenderObservable.clear();
+        this.onAfterCameraRenderObservable.clear();
+        this.onAfterRenderCameraObservable.clear();
+        this.onReadyObservable.clear();
+        this.onNewCameraAddedObservable.clear();
+        this.onCameraRemovedObservable.clear();
+        this.onNewLightAddedObservable.clear();
+        this.onLightRemovedObservable.clear();
+        this.onNewGeometryAddedObservable.clear();
+        this.onGeometryRemovedObservable.clear();
+        this.onNewTransformNodeAddedObservable.clear();
+        this.onTransformNodeRemovedObservable.clear();
+        this.onNewMeshAddedObservable.clear();
+        this.onMeshRemovedObservable.clear();
+        this.onNewSkeletonAddedObservable.clear();
+        this.onSkeletonRemovedObservable.clear();
+        this.onNewMaterialAddedObservable.clear();
+        this.onNewMultiMaterialAddedObservable.clear();
+        this.onMaterialRemovedObservable.clear();
+        this.onMultiMaterialRemovedObservable.clear();
+        this.onNewTextureAddedObservable.clear();
+        this.onTextureRemovedObservable.clear();
+        this.onPrePointerObservable.clear();
+        this.onPointerObservable.clear();
+        this.onPreKeyboardObservable.clear();
+        this.onKeyboardObservable.clear();
+        this.onActiveCameraChanged.clear();
         this._isDisposed = true;
     }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -453,7 +453,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * An event triggered when the scene is disposed.
      */
-    public onDisposeObservable = new Observable<Scene>(undefined, true);
+    public onDisposeObservable = new Observable<Scene>();
 
     private _onDisposeObserver: Nullable<Observer<Scene>> = null;
     /** Sets a function to be executed when this scene is disposed. */
@@ -526,7 +526,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * An event triggered when the scene is ready
      */
-    public onReadyObservable = new Observable<Scene>(undefined, true);
+    public onReadyObservable = new Observable<Scene>();
 
     /**
      * An event triggered before rendering a camera

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -453,7 +453,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * An event triggered when the scene is disposed.
      */
-    public onDisposeObservable = new Observable<Scene>();
+    public onDisposeObservable = new Observable<Scene>(undefined, true);
 
     private _onDisposeObserver: Nullable<Observer<Scene>> = null;
     /** Sets a function to be executed when this scene is disposed. */
@@ -526,7 +526,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * An event triggered when the scene is ready
      */
-    public onReadyObservable = new Observable<Scene>();
+    public onReadyObservable = new Observable<Scene>(undefined, true);
 
     /**
      * An event triggered before rendering a camera
@@ -2150,7 +2150,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
     /**
      * Registers a function to be executed when the scene is ready
-     * @param {Function} func - the function to be executed
+     * @param func - the function to be executed
      * @param checkRenderTargets true to also check that the meshes rendered as part of a render target are ready (default: false)
      */
     public executeWhenReady(func: () => void, checkRenderTargets = false): void {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4715,6 +4715,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.onMeshImportedObservable.clear();
         this.onBeforeCameraRenderObservable.clear();
         this.onAfterCameraRenderObservable.clear();
+        this.onAfterRenderCameraObservable.clear();
         this.onReadyObservable.clear();
         this.onNewCameraAddedObservable.clear();
         this.onCameraRemovedObservable.clear();


### PR DESCRIPTION
This is done to avoid the pattern of adding an observer after checking if the state requires that.
As an example let's take the scene's onReadyObservable which has a simple state - it will only notify once when the scene is ready. If a new observer will be added after the observable was triggered (and has notified existing observers) it will not be possible to trigger new observers that were added to is.
If `notifyIfTriggered` is set to true and the observable has already triggered it will automatically trigger newly added observers whenever they are added.

It's also recommended to add that to onDispose observables, which are the same.
A different solution would be to define an onObserverAdded function, but that would require setting this function to every observable that requires it. Instead - this is a more generic solution.