### PR TITLE
Always pass default KTX2 decoder options

### DIFF
--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -83,7 +83,7 @@ export class DefaultKTX2DecoderOptions {
         this._isDirty = true;
     }
 
-    private _useRGBAIfOnlyBC1BC3AvailableWhenUASTC = true;
+    private _useRGBAIfOnlyBC1BC3AvailableWhenUASTC?: boolean = true;
     /**
      * force a (uncompressed) RGBA transcoded format if transcoding a UASTC source format and only BC1 or BC3 are available as a compressed transcoded format.
      * This property is true by default to favor speed over memory, because currently transcoding from UASTC to BC1/3 is slow because the transcoder transcodes
@@ -93,7 +93,7 @@ export class DefaultKTX2DecoderOptions {
         return this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC;
     }
 
-    public set useRGBAIfOnlyBC1BC3AvailableWhenUASTC(value: boolean) {
+    public set useRGBAIfOnlyBC1BC3AvailableWhenUASTC(value: boolean | undefined) {
         if (this._useRGBAIfOnlyBC1BC3AvailableWhenUASTC === value) {
             return;
         }

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -404,10 +404,7 @@ export class KhronosTextureContainer2 {
 
                         worker.addEventListener("error", onError);
                         worker.addEventListener("message", onMessage);
-
-                        if (KhronosTextureContainer2.DefaultDecoderOptions.isDirty) {
-                            worker.postMessage({ action: "setDefaultDecoderOptions", options: KhronosTextureContainer2.DefaultDecoderOptions._getKTX2DecoderOptions() });
-                        }
+                        worker.postMessage({ action: "setDefaultDecoderOptions", options: KhronosTextureContainer2.DefaultDecoderOptions._getKTX2DecoderOptions() });
 
                         const dataCopy = new Uint8Array(data.byteLength);
                         dataCopy.set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -418,6 +418,9 @@ export class KhronosTextureContainer2 {
             });
         } else if (KhronosTextureContainer2._DecoderModulePromise) {
             return KhronosTextureContainer2._DecoderModulePromise.then((decoder) => {
+                if (KhronosTextureContainer2.DefaultDecoderOptions.isDirty) {
+                    KTX2DECODER.KTX2Decoder.DefaultDecoderOptions = KhronosTextureContainer2.DefaultDecoderOptions._getKTX2DecoderOptions();
+                }
                 return new Promise((resolve, reject) => {
                     decoder
                         .decode(data, caps)


### PR DESCRIPTION
There is more discussion about this in the topic on the forum: https://forum.babylonjs.com/t/banding-when-viewing-uastc-ktx2-in-babylon-js-sandbox/38540

The long story short is that on second invocation of the worker, the default options are no longer being set, as the `isDirty` on the main thread that is being relied on for setting those options, is no longer `true`, due to the first time those options are sent over in: https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Misc/khronosTextureContainer2.ts#L408

The worker, however, no longer contains these options on second invocation, since, if I'm reading this correctly, it gets created anew for each job: https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Misc/khronosTextureContainer2.ts#L309

This results in a wrongly transcoded texture the second time, for example this is how it should look:
![image](https://user-images.githubusercontent.com/238667/221824322-a493eb4b-b2f0-48c1-8195-0fd48721fdd2.png)
But this is how it looks (notice the extreme banding, flipped Y too?):
![image](https://user-images.githubusercontent.com/238667/221824399-6afb9862-21c8-499a-b953-4df4bd029fec.png)

If there are no workers, i.e. `numWorkers = 0`, the same issue appears, since in the second `if` branch, we never set the default options of the decoder: https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Misc/khronosTextureContainer2.ts#L421

This PR fixes both of those situations.

The issue was reproduced only on macOS running either Chrome, Firefox or Edge, but not on Safari or other platforms, namely Windows. The reason for this is that by default, the capabilities of e.g. Safari include ASTC, so the ASTC transcoder is selected even without the default options, e.g.:
```js
> console.log(gl.getExtension('WEBGL_compressed_texture_astc'))
[Log] WebGLCompressedTextureASTC {getSupportedProfiles: function, COMPRESSED_RGBA_ASTC_4x4_KHR: 37808, COMPRESSED_RGBA_ASTC_5x4_KHR: 37809, COMPRESSED_RGBA_ASTC_5x5_KHR: 37810, COMPRESSED_RGBA_ASTC_6x5_KHR: 37811, …}
```
But in Chrome, for example, this extension does not exist (that's weird, no?), so the caps of the engine do not have `astc` set:
```js
console.log(gl.getExtension('WEBGL_compressed_texture_astc'));
null
```

This resolves my issue, but I'm not familiar with the inner workings of this subsystem and the potential other implications of these changes, so I would like to ask for comments & feedback. Thank you!