### PR TITLE
Fix adaptToDeviceRatio for native engine

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -81,7 +81,7 @@ export interface INativeEngine {
 
     getRenderWidth(): number;
     getRenderHeight(): number;
-    getHardwareScalingLevel(): number;
+
     setHardwareScalingLevel(level: number): void;
 
     setViewPort(x: number, y: number, width: number, height: number): void;

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -201,11 +201,8 @@ export class NativeEngine extends Engine {
     private _zOffsetUnits: number = 0;
     private _depthWrite: boolean = true;
 
-    public getHardwareScalingLevel(): number {
-        return this._engine.getHardwareScalingLevel();
-    }
-
     public setHardwareScalingLevel(level: number): void {
+        super.setHardwareScalingLevel(level);
         this._engine.setHardwareScalingLevel(level);
     }
 
@@ -357,10 +354,13 @@ export class NativeEngine extends Engine {
                 writable: true,
             });
         }
+
         // Currently we do not fully configure the ThinEngine on construction of NativeEngine.
         // Setup resolution scaling based on display settings.
         const devicePixelRatio = window ? window.devicePixelRatio || 1.0 : 1.0;
-        this._hardwareScalingLevel = options.adaptToDeviceRatio ? devicePixelRatio : 1.0;
+        this._hardwareScalingLevel = options.adaptToDeviceRatio ? 1.0 / devicePixelRatio : 1.0;
+        this._engine.setHardwareScalingLevel(this._hardwareScalingLevel);
+        this._lastDevicePixelRatio = devicePixelRatio;
         this.resize();
 
         const currentDepthFunction = this.getDepthFunction();

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -579,7 +579,7 @@ export class ThinEngine {
      */
     public adaptToDeviceRatio: boolean = false;
     /** @internal */
-    private _lastDevicePixelRatio: number = 1.0;
+    protected _lastDevicePixelRatio: number = 1.0;
 
     /** @internal */
     public _transformTextureUrl: Nullable<(url: string) => string> = null;
@@ -4522,7 +4522,7 @@ export class ThinEngine {
      */
     public updateTextureSamplingMode(samplingMode: number, texture: InternalTexture, generateMipMaps: boolean = false): void {
         const target = this._getTextureTarget(texture);
-        const filters = this._getSamplingParameters(samplingMode, texture.generateMipMaps || generateMipMaps);
+        const filters = this._getSamplingParameters(samplingMode, texture.useMipMaps || generateMipMaps);
 
         this._setTextureParameterInteger(target, this._gl.TEXTURE_MAG_FILTER, filters.mag, texture);
         this._setTextureParameterInteger(target, this._gl.TEXTURE_MIN_FILTER, filters.min);


### PR DESCRIPTION
Setting `adaptToDeviceRatio` is broken in Babylon Native. This change fixes the problem.