### PR TITLE
InputManager: Fix scenario where click can occur when ExclusiveDoubleClickMode = true

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -518,7 +518,7 @@ export class InputManager {
 
             if (!clickInfo.hasSwiped && !this._skipPointerTap && !this._isMultiTouchGesture) {
                 let type = 0;
-                if (clickInfo.singleClick) {
+                if (clickInfo.singleClick && !InputManager.ExclusiveDoubleClickMode) {
                     type = PointerEventTypes.POINTERTAP;
                 } else if (clickInfo.doubleClick) {
                     type = PointerEventTypes.POINTERDOUBLETAP;


### PR DESCRIPTION
A user in the forum found an issue where clicks could occur ExclusiveDoubleClickMode was set to true.  This PR adds a change to the logic to prevent this from happening.  A test was also added to prevent this in the future.

Forum Link: https://forum.babylonjs.com/t/bug-with-babylon-scene-exclusivedoubleclickmode/38541/