### PR TITLE
PointerDragBehavior: Added check to force releaseDrag to fire when no active button is present

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -279,7 +279,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                 if (
                     this.startAndReleaseDragOnPointerEvents &&
                     this.currentDraggingPointerId == (<IPointerEvent>pointerInfo.event).pointerId &&
-                    this._activeDragButton === pointerInfo.event.button
+                    (this._activeDragButton === pointerInfo.event.button || this._activeDragButton === -1)
                 ) {
                     this.releaseDrag();
                 }


### PR DESCRIPTION
A user on the forum found an issue where if a user programmatically started a drag event, they could not release it with a click.  Using their provided solution, this PR contains the following fix.  A check was added to the POINTERUP section to just force the release if there is no active button (thanks to mattdmorgan for the fix recommendation).

Forum Link: https://forum.babylonjs.com/t/programmatically-started-drags-can-no-longer-be-completed-by-clicking/38228