### PR TITLE
InputManager: Modified Logic for ExclusiveDoubleClickMode For Click/DoubleClick Mutual Exclusivity

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -51,10 +51,10 @@ class _ClickInfo {
 }
 
 /** @internal */
-class _ClickEvent {
-    public clickInfo: _ClickInfo;
-    public evt: IPointerEvent;
-    public timeoutId: number;
+interface _IClickEvent {
+    clickInfo: _ClickInfo;
+    evt: IPointerEvent;
+    timeoutId: number;
 }
 
 /**
@@ -120,7 +120,7 @@ export class InputManager {
     private _meshUnderPointerId: { [pointerId: number]: Nullable<AbstractMesh> } = {};
     private _movePointerInfo: Nullable<PointerInfo> = null;
     private _cameraObserverCount = 0;
-    private _delayedClicks: Array<Nullable<_ClickEvent>> = [null, null, null, null, null];
+    private _delayedClicks: Array<Nullable<_IClickEvent>> = [null, null, null, null, null];
 
     // Keyboard
     private _onKeyDown: (evt: IKeyboardEvent) => void;
@@ -670,10 +670,15 @@ export class InputManager {
                     // at least one double click is required to be check and exclusive double click is enabled
                     else {
                         // Queue up a delayed click, just in case this isn't a double click
-                        const delayedClick = new _ClickEvent();
-                        delayedClick.evt = evt;
-                        delayedClick.clickInfo = clickInfo;
-                        delayedClick.timeoutId = window.setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay);
+                        // It should be noted that while this delayed event happens
+                        // because of user input, it shouldn't be considered as a direct,
+                        // timing-dependent result of that input.  It's meant to just fire the TAP event
+                        const delayedClick = {
+                            evt: evt,
+                            clickInfo: clickInfo,
+                            timeoutId: window.setTimeout(this._delayedSimpleClick.bind(this, btn, clickInfo, cb), InputManager.DoubleClickDelay),
+                        };
+
                         this._delayedClicks[btn] = delayedClick;
                     }
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -60,7 +60,11 @@ export class InputManager {
     public static LongPressDelay = 500; // in milliseconds
     /** Time in milliseconds with two consecutive clicks will be considered as a double click */
     public static DoubleClickDelay = 300; // in milliseconds
-    /** If you need to check double click without raising a single click at first click, enable this flag */
+    /**
+     * This flag will modify the behavior so that, when true, a click will happen if and only if
+     * another click DOES NOT happen within the DoubleClickDelay time frame.  If another click does
+     * happen within that time frame, the first click will not fire an event and and a double click will occur.
+     */
     public static ExclusiveDoubleClickMode = false;
 
     /** This is a defensive check to not allow control attachment prior to an already active one. If already attached, previous control is unattached before attaching the new one. */
@@ -518,7 +522,7 @@ export class InputManager {
 
             if (!clickInfo.hasSwiped && !this._skipPointerTap && !this._isMultiTouchGesture) {
                 let type = 0;
-                if (clickInfo.singleClick && !InputManager.ExclusiveDoubleClickMode) {
+                if (clickInfo.singleClick) {
                     type = PointerEventTypes.POINTERTAP;
                 } else if (clickInfo.doubleClick) {
                     type = PointerEventTypes.POINTERDOUBLETAP;
@@ -706,7 +710,10 @@ export class InputManager {
                 }
             }
 
-            if (!needToIgnoreNext) {
+            // The follow callback should only be executed when needToIgnoreNext is false
+            // and when ExclusiveDoubleClickMode is false.  This is because the
+            // callback is already executed in the double click case when true
+            if (!needToIgnoreNext && !InputManager.ExclusiveDoubleClickMode) {
                 cb(clickInfo, this._currentPickResult);
             }
         };

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -527,7 +527,7 @@ describe("InputManager", () => {
         expect(tapCt).toBe(1);
     });
 
-    it("Doesn't fire onPointerOberservable for POINTERTAP when ExclusiveDoubleClickMode is enabled", () => {
+    it("Doesn't fire onPointerOberservable for POINTERTAP when ExclusiveDoubleClickMode is enabled", async () => {
         let tapCt = 0;
         let dblTapCt = 0;
 
@@ -552,11 +552,26 @@ describe("InputManager", () => {
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Because the input manager uses the system clock, we need to use real timers
+            // and wait for the double click delay to pass so that we can work with a clean slate
+            jest.useRealTimers();
+            await new Promise(resolve => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
+            // Expect a single tap only
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            // Wait for the double click delay to pass again
+            await new Promise(resolve => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+            
+            // Reset to fake timers
+            jest.useFakeTimers();
         }
         // Since this is static, we should reset it to false for other tests
         InputManager.ExclusiveDoubleClickMode = false;
 
-        expect(tapCt).toBe(1);
+        expect(tapCt).toBe(2);
         expect(dblTapCt).toBe(2);
     });
 

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -429,7 +429,7 @@ describe("InputManager", () => {
     it("Does not fire POINTERTAP events during multi-touch gesture", () => {
         let tapCt = 0;
 
-        scene?.onPointerObservable.add((eventData) => {
+        scene?.onPointerObservable.add(() => {
             tapCt++;
         }, PointerEventTypes.POINTERTAP);
 
@@ -556,23 +556,62 @@ describe("InputManager", () => {
             // Because the input manager uses the system clock, we need to use real timers
             // and wait for the double click delay to pass so that we can work with a clean slate
             jest.useRealTimers();
-            await new Promise(resolve => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
 
             // Expect a single tap only
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
 
             // Wait for the double click delay to pass again
-            await new Promise(resolve => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
-            
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
+            // Expect two single taps
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
+
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
+            // Double click, immediately followed by a single click, should still fire a double click and a single click
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
+
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
+            // Single click, immediately followed by a double click, should still fire a single click and a double click
+            // With no additional clicks
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
+            // Three single clicks alternating between left and right
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+
+            await new Promise((resolve) => setTimeout(resolve, InputManager.DoubleClickDelay + 1));
+
             // Reset to fake timers
             jest.useFakeTimers();
         }
         // Since this is static, we should reset it to false for other tests
         InputManager.ExclusiveDoubleClickMode = false;
 
-        expect(tapCt).toBe(2);
-        expect(dblTapCt).toBe(2);
+        expect(tapCt).toBe(9);
+        expect(dblTapCt).toBe(4);
     });
 
     it("can fire onViewMatrixObservable on camera.update", () => {


### PR DESCRIPTION
In a previous PR, there was a fix done to the logic for handling the ExclusiveDoubleClickMode flag to omit single clicks when this flag was active.  This fix was done in error based off of a misinterpretation of the original comment for the flag.  This PR fixes the logic and further clarifies the full behavior when this flag is active.  Test has also been updated to properly test this.

Previous PR: https://github.com/BabylonJS/Babylon.js/pull/13577