### PR TITLE
Decal maps: Don't throw an error if the decal map plugin can't be instantiated

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.decalMap.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.decalMap.ts
@@ -1,21 +1,28 @@
+import type { Nullable } from "core/types";
 import { DecalMapConfiguration } from "../material.decalMapConfiguration";
 import { PBRBaseMaterial } from "./pbrBaseMaterial";
 
 declare module "./pbrBaseMaterial" {
     export interface PBRBaseMaterial {
         /** @internal */
-        _decalMap: DecalMapConfiguration;
+        _decalMap: Nullable<DecalMapConfiguration>;
 
         /**
          * Defines the decal map parameters for the material.
          */
-        decalMap: DecalMapConfiguration;
+        decalMap: Nullable<DecalMapConfiguration>;
     }
 }
 
 Object.defineProperty(PBRBaseMaterial.prototype, "decalMap", {
     get: function (this: PBRBaseMaterial) {
         if (!this._decalMap) {
+            if (this._uniformBufferLayoutBuilt) {
+                // Material already used to display a mesh, so it's invalid to add the decal map plugin at that point
+                // Returns null instead of having new DecalMapConfiguration throws an exception
+                return null;
+            }
+
             this._decalMap = new DecalMapConfiguration(this);
         }
         return this._decalMap;

--- a/packages/dev/core/src/Materials/standardMaterial.decalMap.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.decalMap.ts
@@ -1,21 +1,28 @@
+import type { Nullable } from "core/types";
 import { DecalMapConfiguration } from "./material.decalMapConfiguration";
 import { StandardMaterial } from "./standardMaterial";
 
 declare module "./standardMaterial" {
     export interface StandardMaterial {
         /** @internal */
-        _decalMap: DecalMapConfiguration;
+        _decalMap: Nullable<DecalMapConfiguration>;
 
         /**
          * Defines the decal map parameters for the material.
          */
-        decalMap: DecalMapConfiguration;
+        decalMap: Nullable<DecalMapConfiguration>;
     }
 }
 
 Object.defineProperty(StandardMaterial.prototype, "decalMap", {
     get: function (this: StandardMaterial) {
         if (!this._decalMap) {
+            if (this._uniformBufferLayoutBuilt) {
+                // Material already used to display a mesh, so it's invalid to add the decal map plugin at that point
+                // Returns null instead of having new DecalMapConfiguration throws an exception
+                return null;
+            }
+
             this._decalMap = new DecalMapConfiguration(this);
         }
         return this._decalMap;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/sandbox-inspector-not-opening-for-textures/38711/5

Fix #13562 