### PR TITLE
Asynchronous shader compilation in Babylon Native

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -40,6 +40,7 @@ export interface INativeEngine {
 
     createProgram(vertexShader: string, fragmentShader: string): NativeProgram;
     createProgramAsync(vertexShader: string, fragmentShader: string, onSuccess: () => void, onError: () => void): NativeProgram;
+    isProgramReady(program: NativeProgram): boolean;
     getUniforms(shaderProgram: NativeProgram, uniformsNames: string[]): WebGLUniformLocation[];
     getAttributes(shaderProgram: NativeProgram, attributeNames: string[]): number[];
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -38,7 +38,7 @@ export interface INativeEngine {
     ): void;
     updateDynamicVertexBuffer(vertexBuffer: NativeData, bytes: ArrayBuffer, byteOffset: number, byteLength: number): void;
 
-    createProgram(vertexShader: string, fragmentShader: string): NativeProgram;
+    createProgram(vertexShader: string, fragmentShader: string, isAsync: boolean, onSuccess: () => void, onError: () => void): NativeProgram;
     getUniforms(shaderProgram: NativeProgram, uniformsNames: string[]): WebGLUniformLocation[];
     getAttributes(shaderProgram: NativeProgram, attributeNames: string[]): number[];
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -39,7 +39,7 @@ export interface INativeEngine {
     updateDynamicVertexBuffer(vertexBuffer: NativeData, bytes: ArrayBuffer, byteOffset: number, byteLength: number): void;
 
     createProgram(vertexShader: string, fragmentShader: string): NativeProgram;
-    createProgramAsync(vertexShader: string, fragmentShader: string, onSuccess: () => void, onError: () => void): NativeProgram;
+    createProgramAsync(vertexShader: string, fragmentShader: string, onSuccess: () => void, onError: (error: Error) => void): NativeProgram;
     getUniforms(shaderProgram: NativeProgram, uniformsNames: string[]): WebGLUniformLocation[];
     getAttributes(shaderProgram: NativeProgram, attributeNames: string[]): number[];
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -40,7 +40,6 @@ export interface INativeEngine {
 
     createProgram(vertexShader: string, fragmentShader: string): NativeProgram;
     createProgramAsync(vertexShader: string, fragmentShader: string, onSuccess: () => void, onError: () => void): NativeProgram;
-    isProgramReady(program: NativeProgram): boolean;
     getUniforms(shaderProgram: NativeProgram, uniformsNames: string[]): WebGLUniformLocation[];
     getAttributes(shaderProgram: NativeProgram, attributeNames: string[]): number[];
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -38,7 +38,8 @@ export interface INativeEngine {
     ): void;
     updateDynamicVertexBuffer(vertexBuffer: NativeData, bytes: ArrayBuffer, byteOffset: number, byteLength: number): void;
 
-    createProgram(vertexShader: string, fragmentShader: string, isAsync: boolean, onSuccess: () => void, onError: () => void): NativeProgram;
+    createProgram(vertexShader: string, fragmentShader: string): NativeProgram;
+    createProgramAsync(vertexShader: string, fragmentShader: string, onSuccess: () => void, onError: () => void): NativeProgram;
     getUniforms(shaderProgram: NativeProgram, uniformsNames: string[]): WebGLUniformLocation[];
     getAttributes(shaderProgram: NativeProgram, attributeNames: string[]): number[];
 

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -6,20 +6,14 @@ import type { NativeEngine } from "../nativeEngine";
 
 export class NativePipelineContext implements IPipelineContext {
     public isParallelCompiled: boolean = true;
+    public isCompilationComplete: boolean = false;
 
     public get isAsync(): boolean {
         return this.isParallelCompiled;
     }
 
     public get isReady(): boolean {
-        if (this.nativeProgram) {
-            if (this.isParallelCompiled) {
-                return this._engine._isRenderingStateCompiled(this);
-            }
-            return true;
-        }
-
-        return false;
+        return this.isCompilationComplete;
     }
 
     public onCompiled?: () => void;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -5,8 +5,23 @@ import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
 
 export class NativePipelineContext implements IPipelineContext {
-    public isAsync = true;
-    public isReady = false;
+    public isParallelCompiled: boolean;
+
+    public get isAsync(): boolean {
+        return this.isParallelCompiled;
+    }
+
+    public get isReady(): boolean {
+        if (this.nativeProgram) {
+            if (this.isParallelCompiled) {
+                return this._engine._isRenderingStateCompiled(this);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
     public onCompiled?: () => void;
 
     public _getVertexShaderCode(): string | null {
@@ -30,6 +45,7 @@ export class NativePipelineContext implements IPipelineContext {
 
     constructor(engine: NativeEngine) {
         this._engine = engine;
+        this.isParallelCompiled = true;
     }
 
     public _fillEffectInformation(

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -5,7 +5,7 @@ import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
 
 export class NativePipelineContext implements IPipelineContext {
-    public isParallelCompiled: boolean;
+    public isParallelCompiled: boolean = true;
 
     public get isAsync(): boolean {
         return this.isParallelCompiled;
@@ -45,7 +45,6 @@ export class NativePipelineContext implements IPipelineContext {
 
     constructor(engine: NativeEngine) {
         this._engine = engine;
-        this.isParallelCompiled = true;
     }
 
     public _fillEffectInformation(

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -4,16 +4,26 @@ import type { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like
 import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
 
+export enum CompilationState {
+    uncompiled,
+    compiled,
+    error,
+}
+
 export class NativePipelineContext implements IPipelineContext {
     public isParallelCompiled: boolean = true;
-    public isCompilationComplete: boolean = false;
+    public compilationState: CompilationState = CompilationState.uncompiled;
+    public compilationError?: Error;
 
     public get isAsync(): boolean {
         return this.isParallelCompiled;
     }
 
     public get isReady(): boolean {
-        return this.isCompilationComplete;
+        if (this.compilationState === CompilationState.error) {
+            throw new Error("SHADER ERROR" + (this.compilationError?.message ? " " + this.compilationError.message : ""));
+        }
+        return this.compilationState === CompilationState.compiled;
     }
 
     public onCompiled?: () => void;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -4,15 +4,9 @@ import type { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like
 import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
 
-export enum CompilationState {
-    uncompiled,
-    compiled,
-    error,
-}
-
 export class NativePipelineContext implements IPipelineContext {
     public isParallelCompiled: boolean = true;
-    public compilationState: CompilationState = CompilationState.uncompiled;
+    public isCompiled: boolean = false;
     public compilationError?: Error;
 
     public get isAsync(): boolean {
@@ -20,11 +14,11 @@ export class NativePipelineContext implements IPipelineContext {
     }
 
     public get isReady(): boolean {
-        if (this.compilationState === CompilationState.error) {
-            const message = this.compilationError?.message;
+        if (this.compilationError) {
+            const message = this.compilationError.message;
             throw new Error("SHADER ERROR" + (typeof message === "string" ? "\n" + message : ""));
         }
-        return this.compilationState === CompilationState.compiled;
+        return this.isCompiled;
     }
 
     public onCompiled?: () => void;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -8,6 +8,7 @@ export class NativePipelineContext implements IPipelineContext {
     // TODO: async should be true?
     public isAsync = false;
     public isReady = false;
+    public onCompiled?: () => void;
 
     public _getVertexShaderCode(): string | null {
         return null;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -21,7 +21,8 @@ export class NativePipelineContext implements IPipelineContext {
 
     public get isReady(): boolean {
         if (this.compilationState === CompilationState.error) {
-            throw new Error("SHADER ERROR" + (this.compilationError?.message ? " " + this.compilationError.message : ""));
+            const message = this.compilationError?.message;
+            throw new Error("SHADER ERROR" + (typeof message === "string" ? "\n" + message : ""));
         }
         return this.compilationState === CompilationState.compiled;
     }

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -5,8 +5,7 @@ import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
 
 export class NativePipelineContext implements IPipelineContext {
-    // TODO: async should be true?
-    public isAsync = false;
+    public isAsync = true;
     public isReady = false;
     public onCompiled?: () => void;
 

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -649,13 +649,6 @@ export class NativeEngine extends Engine {
     /**
      * @internal
      */
-    public _isRenderingStateCompiled(pipelineContext: IPipelineContext): boolean {
-        return this._engine.isProgramReady((pipelineContext as NativePipelineContext).nativeProgram);
-    }
-
-    /**
-     * @internal
-     */
     public _executeWhenRenderingStateIsCompiled(pipelineContext: IPipelineContext, action: () => void) {
         const nativePipelineContext = pipelineContext as NativePipelineContext;
 
@@ -701,6 +694,7 @@ export class NativeEngine extends Engine {
         fragmentCode = ThinEngine._ConcatenateShader(fragmentCode, defines);
 
         const onSuccess = () => {
+            nativePipelineContext.isCompilationComplete = true;
             nativePipelineContext.onCompiled?.();
             this.onAfterShaderCompilationObservable.notifyObservers(this);
         };

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -646,13 +646,17 @@ export class NativeEngine extends Engine {
         }
     }
 
+    public isAsync(pipelineContext: IPipelineContext): boolean {
+        return !!(pipelineContext.isAsync && this._engine.createProgramAsync);
+    }
+
     /**
      * @internal
      */
     public _executeWhenRenderingStateIsCompiled(pipelineContext: IPipelineContext, action: () => void) {
         const nativePipelineContext = pipelineContext as NativePipelineContext;
 
-        if (!nativePipelineContext.isAsync) {
+        if (!this.isAsync(pipelineContext)) {
             action();
             return;
         }
@@ -699,7 +703,7 @@ export class NativeEngine extends Engine {
             this.onAfterShaderCompilationObservable.notifyObservers(this);
         };
 
-        if (pipelineContext.isAsync && this._engine.createProgramAsync) {
+        if (this.isAsync(pipelineContext)) {
             return this._engine.createProgramAsync(vertexCode, fragmentCode, onSuccess, () => {}) as WebGLProgram;
         } else {
             const program = (nativePipelineContext.nativeProgram = this._engine.createProgram(vertexCode, fragmentCode));

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -697,16 +697,18 @@ export class NativeEngine extends Engine {
         vertexCode = ThinEngine._ConcatenateShader(vertexCode, defines);
         fragmentCode = ThinEngine._ConcatenateShader(fragmentCode, defines);
 
-        const program = this._engine.createProgram(
-            vertexCode,
-            fragmentCode,
-            pipelineContext.isAsync,
-            () => {
-                nativePipelineContext.isReady = true;
-                nativePipelineContext.onCompiled?.();
-            },
-            () => {}
-        );
+        const program =
+            pipelineContext.isAsync && this._engine.createProgramAsync
+                ? this._engine.createProgramAsync(
+                      vertexCode,
+                      fragmentCode,
+                      () => {
+                          nativePipelineContext.isReady = true;
+                          nativePipelineContext.onCompiled?.();
+                      },
+                      () => {}
+                  )
+                : this._engine.createProgram(vertexCode, fragmentCode);
         this.onAfterShaderCompilationObservable.notifyObservers(this);
         return program as WebGLProgram;
     }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -36,7 +36,7 @@ import type { NativeData } from "./Native/nativeDataStream";
 import { NativeDataStream } from "./Native/nativeDataStream";
 import type { INative, INativeCamera, INativeEngine, NativeFramebuffer, NativeProgram, NativeTexture, NativeUniform, NativeVertexArrayObject } from "./Native/nativeInterfaces";
 import { RuntimeError, ErrorCodes } from "../Misc/error";
-import { CompilationState, NativePipelineContext } from "./Native/nativePipelineContext";
+import { NativePipelineContext } from "./Native/nativePipelineContext";
 import { NativeRenderTargetWrapper } from "./Native/nativeRenderTargetWrapper";
 import { NativeHardwareTexture } from "./Native/nativeHardwareTexture";
 import type { HardwareTextureWrapper } from "../Materials/Textures/hardwareTextureWrapper";
@@ -698,14 +698,13 @@ export class NativeEngine extends Engine {
         fragmentCode = ThinEngine._ConcatenateShader(fragmentCode, defines);
 
         const onSuccess = () => {
-            nativePipelineContext.compilationState = CompilationState.compiled;
+            nativePipelineContext.isCompiled = true;
             nativePipelineContext.onCompiled?.();
             this.onAfterShaderCompilationObservable.notifyObservers(this);
         };
 
         if (this.isAsync(pipelineContext)) {
             return this._engine.createProgramAsync(vertexCode, fragmentCode, onSuccess, (error: Error) => {
-                nativePipelineContext.compilationState = CompilationState.error;
                 nativePipelineContext.compilationError = error;
             }) as WebGLProgram;
         } else {

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -709,9 +709,14 @@ export class NativeEngine extends Engine {
                 nativePipelineContext.compilationError = error;
             }) as WebGLProgram;
         } else {
-            const program = (nativePipelineContext.nativeProgram = this._engine.createProgram(vertexCode, fragmentCode));
-            onSuccess();
-            return program as WebGLProgram;
+            try {
+                const program = (nativePipelineContext.nativeProgram = this._engine.createProgram(vertexCode, fragmentCode));
+                onSuccess();
+                return program as WebGLProgram;
+            } catch (e: any) {
+                const message = e?.message;
+                throw new Error("SHADER ERROR" + (typeof message === "string" ? "\n" + message : ""));
+            }
         }
     }
 


### PR DESCRIPTION
This code supports interfacing with a feature I wrote for Babylon Native allowing asynchronous shader compilation. It's intended to be reverse-compatible with Babylon Native as of commit [08cec4cacf4d187eb839b6318a7414860f8fde77](https://github.com/BabylonJS/BabylonNative/commit/08cec4cacf4d187eb839b6318a7414860f8fde77) on master, but that version of Babylon Native doesn't have the asynchronous shader compilation yet; I will make another PR into Babylon Native with the necessary C++ code to support asynchronous shader compilation, and the shader compilation will be asynchronous only when both updates are used together.

Here's the issue on the Babylon Native side for this feature:
https://github.com/BabylonJS/BabylonNative/issues/402

The PR for the Babylon Native side has now been opened:
https://github.com/BabylonJS/BabylonNative/pull/1209