### PR TITLE
RTT: Use same logic for particle systems than in the main path

### DIFF
--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1103,13 +1103,12 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             const particleSystem = scene.particleSystems[particleIndex];
 
             const emitter: any = particleSystem.emitter;
-            if (!particleSystem.isStarted() || !emitter || !emitter.position || !emitter.isEnabled()) {
+
+            if (!particleSystem.isStarted() || !emitter || (emitter.position && !emitter.isEnabled())) {
                 continue;
             }
 
-            if (currentRenderList.indexOf(emitter) >= 0) {
-                this._renderingManager.dispatchParticles(particleSystem);
-            }
+            this._renderingManager.dispatchParticles(particleSystem);
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/rendertargettexture-problems-rendering-a-scene-to-a-texture/25908/10

In the past, we have had several problems with the rendering of particle systems in RTT (see https://forum.babylonjs.com/t/rain-effect-causes-screenshots-to-fail/18003/4 for eg).

The code in the scene to dispatch a particle system is:
```typescript
if (!particleSystem.isStarted() || !particleSystem.emitter) {
    continue;
}

const emitter = <any>particleSystem.emitter;
if (!emitter.position || emitter.isEnabled()) {
    this._activeParticleSystems.push(particleSystem);
    particleSystem.animate();
    this._renderingManager.dispatchParticles(particleSystem);
}
```
whereas in `RenderTargetTexture` it is:
```typescript
const emitter: any = particleSystem.emitter;
if (!particleSystem.isStarted() || !emitter || !emitter.position || !emitter.isEnabled()) {
    continue;
}

if (currentRenderList.indexOf(emitter) >= 0) {
    this._renderingManager.dispatchParticles(particleSystem);
}
```
I don't understand why the checks/conditions are not the same, so this PR is to align the code in RTT with the code in the scene:
```typescript
if (!particleSystem.isStarted() || !emitter || emitter.position && !emitter.isEnabled()) {
    continue;
}

this._renderingManager.dispatchParticles(particleSystem);
```
It's a breaking change, in a w ay, but I think it's more of a bug fix than anything else.