### PR TITLE
Geometry Buffer Renderer: Fix specular color not in linear space

### DIFF
--- a/packages/dev/core/src/Shaders/geometry.fragment.fx
+++ b/packages/dev/core/src/Shaders/geometry.fragment.fx
@@ -164,7 +164,7 @@ void main() {
                 #endif
             #else 
                 #ifdef REFLECTIVITYCOLOR
-                    reflectivity.rgb = reflectivityColor.xyz;
+                    reflectivity.rgb = toLinearSpace(reflectivityColor.xyz);
                     reflectivity.a = 1.0;
                 // #else
                     // We never reach this case since even if the reflectivity color is not defined


### PR DESCRIPTION
That was forgotten as part of #13336.