### PR TITLE
NME Texture block: Add support for 2DArrayTexture

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -152,6 +152,7 @@ export class TextureBlock extends NodeMaterialBlock {
             NodeMaterialBlockTargets.VertexAndFragment,
             new NodeMaterialConnectionPointCustomObject("source", this, NodeMaterialConnectionPointDirection.Input, ImageSourceBlock, "ImageSourceBlock")
         );
+        this.registerInput("layer", NodeMaterialBlockConnectionPointTypes.Float, true);
 
         this.registerOutput("rgba", NodeMaterialBlockConnectionPointTypes.Color4, NodeMaterialBlockTargets.Neutral);
         this.registerOutput("rgb", NodeMaterialBlockConnectionPointTypes.Color3, NodeMaterialBlockTargets.Neutral);
@@ -189,6 +190,13 @@ export class TextureBlock extends NodeMaterialBlock {
      */
     public get source(): NodeMaterialConnectionPoint {
         return this._inputs[1];
+    }
+
+    /**
+     * Gets the layer input component
+     */
+    public get layer(): NodeMaterialConnectionPoint {
+        return this._inputs[2];
     }
 
     /**
@@ -418,13 +426,28 @@ export class TextureBlock extends NodeMaterialBlock {
         }
     }
 
+    private _getUVW(uvName: string): string {
+        let coords = uvName;
+
+        const is2DArrayTexture = this._texture?._texture?.is2DArray ?? false;
+
+        if (is2DArrayTexture) {
+            const layerValue = this.layer.isConnected ? this.layer.associatedVariableName : "0";
+            coords = `vec3(${uvName}, ${layerValue})`;
+        }
+
+        return coords;
+    }
+
     private _generateTextureLookup(state: NodeMaterialBuildState): void {
         const samplerName = this.samplerName;
 
         state.compilationString += `#ifdef ${this._defineName}\r\n`;
-        state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${samplerName}, ${this._transformedUVName});\r\n`;
+        state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${samplerName}, ${this._getUVW(this._transformedUVName)});\r\n`;
         state.compilationString += `#elif defined(${this._mainUVDefineName})\r\n`;
-        state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${samplerName}, ${this._mainUVName ? this._mainUVName : this.uv.associatedVariableName});\r\n`;
+        state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${samplerName}, ${this._getUVW(
+            this._mainUVName ? this._mainUVName : this.uv.associatedVariableName
+        )});\r\n`;
         state.compilationString += `#endif\r\n`;
     }
 
@@ -441,7 +464,7 @@ export class TextureBlock extends NodeMaterialBlock {
         }
 
         if (this.uv.ownerBlock.target === NodeMaterialBlockTargets.Fragment) {
-            state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${this.samplerName}, ${uvInput.associatedVariableName});\r\n`;
+            state.compilationString += `vec4 ${this._tempTextureRead} = texture2D(${this.samplerName}, ${this._getUVW(uvInput.associatedVariableName)});\r\n`;
             return;
         }
 
@@ -510,7 +533,11 @@ export class TextureBlock extends NodeMaterialBlock {
             if (!this._imageSource) {
                 this._samplerName = state._getFreeVariableName(this.name + "Sampler");
 
-                state._emit2DSampler(this._samplerName);
+                if (this._texture?._texture?.is2DArray) {
+                    state._emit2DArraySampler(this._samplerName);
+                } else {
+                    state._emit2DSampler(this._samplerName);
+                }
             }
 
             // Declarations
@@ -533,7 +560,11 @@ export class TextureBlock extends NodeMaterialBlock {
 
         if (this._isMixed && !this._imageSource) {
             // Reexport the sampler
-            state._emit2DSampler(this._samplerName);
+            if (this._texture?._texture?.is2DArray) {
+                state._emit2DArraySampler(this._samplerName);
+            } else {
+                state._emit2DSampler(this._samplerName);
+            }
         }
 
         const comments = `//${this.name}`;

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -120,7 +120,7 @@ export class NodeMaterialBuildState {
         }
 
         this.compilationString = "precision highp float;\r\n" + this.compilationString;
-        this.compilationString = "precision highp sampler2DArray;\r\n" + this.compilationString;
+        this.compilationString = "#if defined(WEBGL2) || defines(WEBGPU)\r\nprecision highp sampler2DArray;\r\n#endif\r\n" + this.compilationString;
 
         for (const extensionName in this.extensions) {
             const extension = this.extensions[extensionName];

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -120,6 +120,7 @@ export class NodeMaterialBuildState {
         }
 
         this.compilationString = "precision highp float;\r\n" + this.compilationString;
+        this.compilationString = "precision highp sampler2DArray;\r\n" + this.compilationString;
 
         for (const extensionName in this.extensions) {
             const extension = this.extensions[extensionName];
@@ -182,6 +183,16 @@ export class NodeMaterialBuildState {
     public _emit2DSampler(name: string) {
         if (this.samplers.indexOf(name) < 0) {
             this._samplerDeclaration += `uniform sampler2D ${name};\r\n`;
+            this.samplers.push(name);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public _emit2DArraySampler(name: string) {
+        if (this.samplers.indexOf(name) < 0) {
+            this._samplerDeclaration += `uniform sampler2DArray ${name};\r\n`;
             this.samplers.push(name);
         }
     }

--- a/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.modules.scss
+++ b/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.modules.scss
@@ -1,5 +1,5 @@
 .regular-texture-block {
-    margin-top: 60px;
+    margin-top: 80px;
 }
 
 .reduced-texture-block {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-can-i-load-rawtexture2darray-in-nme/38809

This PR adds a layer **input** to the `Texture` block:

![image](https://user-images.githubusercontent.com/4152247/223408971-e80368b9-9aeb-424f-a3a7-37890bc1b3bb.png)

The input is not used if the texture is not a **2DArrayTexture**. If it is, the layer value is read from the **layer** input if provided, else a default value of 0 is used.