### PR TITLE
spriteManagers array is optional

### DIFF
--- a/packages/dev/core/src/Rendering/renderingManager.ts
+++ b/packages/dev/core/src/Rendering/renderingManager.ts
@@ -113,8 +113,10 @@ export class RenderingManager {
                 }
             }
 
-            for (const spriteManager of this._scene.spriteManagers) {
-                spriteManager._wasDispatched = false;
+            if (this._scene.spriteManagers) {
+                for (const spriteManager of this._scene.spriteManagers) {
+                    spriteManager._wasDispatched = false;
+                }
             }
 
             for (const particleSystem of this._scene.particleSystems) {

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -294,7 +294,7 @@ export class SpriteManager implements ISpriteManager {
             return;
         }
 
-        this._scene.spriteManagers.push(this);
+        this._scene.spriteManagers && this._scene.spriteManagers.push(this);
         this.uniqueId = this.scene.getUniqueId();
 
         if (imgUrl) {
@@ -628,8 +628,10 @@ export class SpriteManager implements ISpriteManager {
         this._textureContent = null;
 
         // Remove from scene
-        const index = this._scene.spriteManagers.indexOf(this);
-        this._scene.spriteManagers.splice(index, 1);
+        if (this._scene.spriteManagers) {
+            const index = this._scene.spriteManagers.indexOf(this);
+            this._scene.spriteManagers.splice(index, 1);
+        }
 
         // Callback
         this.onDisposeObservable.notifyObservers(this);

--- a/packages/dev/core/src/Sprites/spriteSceneComponent.ts
+++ b/packages/dev/core/src/Sprites/spriteSceneComponent.ts
@@ -27,7 +27,7 @@ declare module "../scene" {
          * All of the sprite managers added to this scene
          * @see https://doc.babylonjs.com/features/featuresDeepDive/sprites
          */
-        spriteManagers: Array<ISpriteManager>;
+        spriteManagers?: Array<ISpriteManager>;
 
         /**
          * An event triggered when sprites rendering is about to start
@@ -111,7 +111,7 @@ Scene.prototype._internalPickSprites = function (ray: Ray, predicate?: (sprite: 
         camera = this.activeCamera;
     }
 
-    if (this.spriteManagers.length > 0) {
+    if (this.spriteManagers && this.spriteManagers.length > 0) {
         for (let spriteIndex = 0; spriteIndex < this.spriteManagers.length; spriteIndex++) {
             const spriteManager = this.spriteManagers[spriteIndex];
 
@@ -153,7 +153,7 @@ Scene.prototype._internalMultiPickSprites = function (ray: Ray, predicate?: (spr
         camera = this.activeCamera;
     }
 
-    if (this.spriteManagers.length > 0) {
+    if (this.spriteManagers && this.spriteManagers.length > 0) {
         for (let spriteIndex = 0; spriteIndex < this.spriteManagers.length; spriteIndex++) {
             const spriteManager = this.spriteManagers[spriteIndex];
 
@@ -312,6 +312,9 @@ export class SpriteSceneComponent implements ISceneComponent {
         this.scene.onAfterSpritesRenderingObservable.clear();
 
         const spriteManagers = this.scene.spriteManagers;
+        if (!spriteManagers) {
+            return;
+        }
         while (spriteManagers.length) {
             spriteManagers[0].dispose();
         }
@@ -358,7 +361,7 @@ export class SpriteSceneComponent implements ISceneComponent {
     private _pointerDown(unTranslatedPointerX: number, unTranslatedPointerY: number, pickResult: Nullable<PickingInfo>, evt: IPointerEvent): Nullable<PickingInfo> {
         const scene = this.scene;
         scene._pickedDownSprite = null;
-        if (scene.spriteManagers.length > 0) {
+        if (scene.spriteManagers && scene.spriteManagers.length > 0) {
             pickResult = scene.pickSprite(unTranslatedPointerX, unTranslatedPointerY, this._spritePredicate, false, scene.cameraToUseForPointers || undefined);
 
             if (pickResult && pickResult.hit && pickResult.pickedSprite) {
@@ -405,7 +408,7 @@ export class SpriteSceneComponent implements ISceneComponent {
         doubleClick: boolean
     ): Nullable<PickingInfo> {
         const scene = this.scene;
-        if (scene.spriteManagers.length > 0) {
+        if (scene.spriteManagers && scene.spriteManagers.length > 0) {
             const spritePickResult = scene.pickSprite(unTranslatedPointerX, unTranslatedPointerY, this._spritePredicate, false, scene.cameraToUseForPointers || undefined);
 
             if (spritePickResult) {


### PR DESCRIPTION
The `scene.spriteManagers` array is only initialized if a psrite manager is being constructor (using the dedicated scene component). This causes an exception when changing the `maintainStateBetweenFrames` flag in the rendering manager to true and then false.

In many places in the framework there is already a check to see if it is initialized or not - this PR forces the typings to be correct and adds checks to see if the sprite manager array exists.