### PR TITLE
Mesh: Fix crash with instanced rendering

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1689,7 +1689,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
      * @internal
      */
-    public _bind(subMesh: SubMesh, effect: Effect, fillMode: number): Mesh {
+    public _bind(subMesh: SubMesh, effect: Effect, fillMode: number, allowInstancedRendering = true): Mesh {
         if (!this._geometry) {
             return this;
         }
@@ -1722,7 +1722,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // VBOs
-        if (!this._userInstancedBuffersStorage || this.hasThinInstances) {
+        if (!allowInstancedRendering || !this._userInstancedBuffersStorage || this.hasThinInstances) {
             this._geometry._bind(effect, indexToBind);
         } else {
             this._geometry._bind(effect, indexToBind, this._userInstancedBuffersStorage.vertexBuffers, this._userInstancedBuffersStorage.vertexArrayObjects);
@@ -2311,7 +2311,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         if (!hardwareInstancedRendering) {
             // Binding will be done later because we need to add more info to the VB
-            this._bind(subMesh, effect, fillMode);
+            this._bind(subMesh, effect, fillMode, false);
         }
 
         const effectiveMaterial = this._internalMeshDataInfo._effectiveMaterial;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/changing-visibility-for-individual-instances/38820

This PG is crashing: https://playground.babylonjs.com/#WGZLGJ#7983

It is creating an instance of the boombox with a color instance buffer.

It is crashing because:
* the instance is considered as a regular mesh (`_internalAbstractMeshDataInfo._actAsRegularMesh = true`) because the sign of its determinant is different from the sign of the determinant of its source mesh
* we are calling `this._geometry._bind(effect, indexToBind, this._userInstancedBuffersStorage.vertexBuffers, this._userInstancedBuffersStorage.vertexArrayObjects)` in `Mesh._bind`, but `this._userInstancedBuffersStorage.vertexBuffers` only contains the `color` buffer and not the `world0/.../world3` buffers because the mesh is managed as an instance in this case

The PG would work if we don't create the color instance buffer, because in that case we take the `this._geometry._bind(effect, indexToBind)` branch.