### PR TITLE
Set back the checkReadyOnlyOnce when reverting performance mode

### DIFF
--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -13,7 +13,6 @@ import type { Observer } from "../../Misc/observable";
 import { Logger } from "../../Misc/logger";
 import type { Nullable, int, float } from "../../types";
 import type { Scene } from "../../scene";
-import { ScenePerformancePriority } from "../../scene";
 import type { Matrix } from "../../Maths/math.vector";
 import { Vector3, Vector4 } from "../../Maths/math.vector";
 import { VertexBuffer } from "../../Buffers/buffer";

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -968,12 +968,7 @@ export class BackgroundMaterial extends PushMaterial {
         subMesh.effect._wasPreviouslyReady = true;
         subMesh.effect._wasPreviouslyUsingInstances = useInstances;
 
-        if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
-            this.checkReadyOnlyOnce = true;
-            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
-                this.checkReadyOnlyOnce = false;
-            });
-        }
+        this._checkScenePerformancePriority();
 
         return true;
     }

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -970,6 +970,9 @@ export class BackgroundMaterial extends PushMaterial {
 
         if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
             this.checkReadyOnlyOnce = true;
+            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
+                this.checkReadyOnlyOnce = false;
+            });
         }
 
         return true;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1391,12 +1391,7 @@ export class NodeMaterial extends PushMaterial {
         subMesh.effect._wasPreviouslyReady = true;
         subMesh.effect._wasPreviouslyUsingInstances = useInstances;
 
-        if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
-            this.checkReadyOnlyOnce = true;
-            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
-                this.checkReadyOnlyOnce = false;
-            });
-        }
+        this._checkScenePerformancePriority();
 
         return true;
     }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2,7 +2,6 @@
 import type { NodeMaterialBlock } from "./nodeMaterialBlock";
 import { PushMaterial } from "../pushMaterial";
 import type { Scene } from "../../scene";
-import { ScenePerformancePriority } from "../../scene";
 import { AbstractMesh } from "../../Meshes/abstractMesh";
 import { Matrix, Vector2 } from "../../Maths/math.vector";
 import { Color3, Color4 } from "../../Maths/math.color";

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1393,6 +1393,9 @@ export class NodeMaterial extends PushMaterial {
 
         if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
             this.checkReadyOnlyOnce = true;
+            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
+                this.checkReadyOnlyOnce = false;
+            });
         }
 
         return true;

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1207,12 +1207,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         subMesh.effect._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
         subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
 
-        if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
-            this.checkReadyOnlyOnce = true;
-            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
-                this.checkReadyOnlyOnce = false;
-            });
-        }
+        this._checkScenePerformancePriority();
 
         return true;
     }

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1209,6 +1209,9 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
         if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
             this.checkReadyOnlyOnce = true;
+            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
+                this.checkReadyOnlyOnce = false;
+            });
         }
 
         return true;

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -5,7 +5,7 @@ import { Logger } from "../../Misc/logger";
 import { SmartArray } from "../../Misc/smartArray";
 import { GetEnvironmentBRDFTexture } from "../../Misc/brdfTextureTools";
 import type { Nullable } from "../../types";
-import { Scene, ScenePerformancePriority } from "../../scene";
+import { Scene } from "../../scene";
 import type { Matrix } from "../../Maths/math.vector";
 import { Vector4 } from "../../Maths/math.vector";
 import { VertexBuffer } from "../../Buffers/buffer";

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -24,6 +24,7 @@ import { MaterialHelper } from "./materialHelper";
 import type { IMaterialContext } from "../Engines/IMaterialContext";
 import { DrawWrapper } from "./drawWrapper";
 import { MaterialStencilState } from "./materialStencilState";
+import { ScenePerformancePriority } from "../scene";
 import type { Scene } from "../scene";
 import type { AbstractScene } from "../abstractScene";
 import type {
@@ -1703,6 +1704,20 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     protected _markAllSubMeshesAsTexturesAndMiscDirty() {
         this._markAllSubMeshesAsDirty(Material._TextureAndMiscDirtyCallBack);
+    }
+
+    protected _checkScenePerformancePriority() {
+        if (this._scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
+            this.checkReadyOnlyOnce = true;
+            // re-set the flag when the perf priority changes
+            const observer = this._scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
+                this.checkReadyOnlyOnce = false;
+            });
+            // if this material is disposed before the scene is disposed, cleanup the observer
+            this.onDisposeObservable.add(() => {
+                this._scene.onScenePerformancePriorityChangedObservable.remove(observer);
+            });
+        }
     }
 
     /**

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1467,12 +1467,7 @@ export class StandardMaterial extends PushMaterial {
         subMesh.effect._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
         subMesh.effect._wasPreviouslyUsingInstances = useInstances;
 
-        if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
-            this.checkReadyOnlyOnce = true;
-            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
-                this.checkReadyOnlyOnce = false;
-            });
-        }
+        this._checkScenePerformancePriority();
 
         return true;
     }

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -5,7 +5,7 @@ import { SmartArray } from "../Misc/smartArray";
 import type { IAnimatable } from "../Animations/animatable.interface";
 
 import type { Nullable } from "../types";
-import { Scene, ScenePerformancePriority } from "../scene";
+import { Scene } from "../scene";
 import { Matrix } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import { VertexBuffer } from "../Buffers/buffer";

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1469,6 +1469,9 @@ export class StandardMaterial extends PushMaterial {
 
         if (scene.performancePriority !== ScenePerformancePriority.BackwardCompatible) {
             this.checkReadyOnlyOnce = true;
+            scene.onScenePerformancePriorityChangedObservable.addOnce(() => {
+                this.checkReadyOnlyOnce = false;
+            });
         }
 
         return true;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4826,6 +4826,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.onPreKeyboardObservable.clear();
         this.onKeyboardObservable.clear();
         this.onActiveCameraChanged.clear();
+        this.onScenePerformancePriorityChangedObservable.clear();
         this._isDisposed = true;
     }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -266,6 +266,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     }
 
     private _performancePriority = ScenePerformancePriority.BackwardCompatible;
+
+    /**
+     * Observable triggered when the performance priority is changed
+     */
+    public onScenePerformancePriorityChangedObservable = new Observable<ScenePerformancePriority>();
     /**
      * Gets or sets a value indicating how to treat performance relatively to ease of use and backward compatibility
      */
@@ -300,6 +305,8 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
                 this.autoClear = false;
                 break;
         }
+
+        this.onScenePerformancePriorityChangedObservable.notifyObservers(value);
     }
 
     private _forceWireframe = false;


### PR DESCRIPTION
The idea behind this PR is to reset the material state when going back to backward compatibility mode.
At the moment, setting the performance mode to advanced and gong back to backwards will keep the material frozen. The observable was added to make sure only materials that were set due to the performance change mode will revert back to their older state.