### PR TITLE
Improved SSAO2 when samples <16. Added more control over SSAO2 denoising filter.

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -298,11 +298,11 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
 
         this._createRandomTexture();
 
-        this._originalColorPostProcess = new PassPostProcess("SSAOOriginalSceneColor", 1.0, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), undefined, textureType);
+        this._originalColorPostProcess = new PassPostProcess("SSAOOriginalSceneColor", 1.0, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), undefined, this._textureType);
         this._originalColorPostProcess.samples = this.textureSamples;
         this._createSSAOPostProcess(1.0, textureType);
-        this._createBlurPostProcess(ssaoRatio, blurRatio, textureType);
-        this._createSSAOCombinePostProcess(blurRatio, textureType);
+        this._createBlurPostProcess(ssaoRatio, blurRatio, this._textureType);
+        this._createSSAOCombinePostProcess(blurRatio, this._textureType);
 
         // Set up pipeline
         this.addEffect(

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -421,7 +421,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
         this._blurVPostProcess = this._createBlurFilter("BlurV", samplers, blurRatio, defines.v, textureType, false);
     }
 
-    private _createBlurFilter(name: string, samplers: Array<string>, ratio: number, defines: string, textureType: number, vertical: boolean): PostProcess {
+    private _createBlurFilter(name: string, samplers: Array<string>, ratio: number, defines: string, textureType: number, horizontal: boolean): PostProcess {
         const blurFilter = new PostProcess(
             name,
             "ssao2",
@@ -441,8 +441,8 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 return;
             }
 
-            const ssaoCombineSize = vertical ? this._ssaoCombinePostProcess.width : this._ssaoCombinePostProcess.height;
-            const originalColorSize = vertical ? this._originalColorPostProcess.width : this._originalColorPostProcess.height;
+            const ssaoCombineSize = horizontal ? this._ssaoCombinePostProcess.width : this._ssaoCombinePostProcess.height;
+            const originalColorSize = horizontal ? this._originalColorPostProcess.width : this._originalColorPostProcess.height;
 
             effect.setFloat("outSize", ssaoCombineSize > 0 ? ssaoCombineSize : originalColorSize);
             effect.setInt("samples", this.bilateralSamples);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -429,7 +429,6 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             const ssaoCombineSize = vertical ? this._ssaoCombinePostProcess.width : this._ssaoCombinePostProcess.height;
             const originalColorSize = vertical ? this._originalColorPostProcess.width : this._originalColorPostProcess.height;
 
-            // TODO!
             effect.setFloat("outSize", ssaoCombineSize > 0 ? ssaoCombineSize : originalColorSize);
             effect.setFloat("near", this._scene.activeCamera.minZ);
             effect.setFloat("far", this._scene.activeCamera.maxZ);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -124,6 +124,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
     /**
      * Force rendering the geometry through geometry buffer.
      */
+    @serialize()
     private _forceGeometryBuffer: boolean = false;
     private get _geometryBufferRenderer(): Nullable<GeometryBufferRenderer> {
         if (!this._forceGeometryBuffer) {
@@ -143,6 +144,12 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
      */
     @serialize()
     private _ratio: any;
+
+    /*
+     * The texture type used by the different post processes created by SSAO
+     */
+    @serialize()
+    private _textureType: number;
 
     /**
      * Dynamically generated sphere sampler.
@@ -271,6 +278,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
 
         this._scene = scene;
         this._ratio = ratio;
+        this._textureType = textureType;
         this._forceGeometryBuffer = forceGeometryBuffer;
 
         if (!this.isSupported) {
@@ -676,7 +684,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
      * @returns An instantiated pipeline from the serialized object.
      */
     public static Parse(source: any, scene: Scene, rootUrl: string): SSAO2RenderingPipeline {
-        return SerializationHelper.Parse(() => new SSAO2RenderingPipeline(source._name, scene, source._ratio), source, scene, rootUrl);
+        return SerializationHelper.Parse(() => new SSAO2RenderingPipeline(source._name, scene, source._ratio, undefined, source._forceGeometryBuffer, source._textureType) , source, scene, rootUrl);
     }
 }
 

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -684,7 +684,12 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
      * @returns An instantiated pipeline from the serialized object.
      */
     public static Parse(source: any, scene: Scene, rootUrl: string): SSAO2RenderingPipeline {
-        return SerializationHelper.Parse(() => new SSAO2RenderingPipeline(source._name, scene, source._ratio, undefined, source._forceGeometryBuffer, source._textureType) , source, scene, rootUrl);
+        return SerializationHelper.Parse(
+            () => new SSAO2RenderingPipeline(source._name, scene, source._ratio, undefined, source._forceGeometryBuffer, source._textureType),
+            source,
+            scene,
+            rootUrl
+        );
     }
 }
 

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -74,6 +74,21 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
     @serialize()
     public minZAspect: number = 0.2;
 
+    @serialize("epsilon")
+    private _epsilon: number = 0.02;
+    /**
+     * Used in SSAO calculations to compensate for accuracy issues with depth values. Default 0.02.
+     *
+     * Normally you do not need to change this value, but you can experiment with it if you get a lot of in false self-occlusion on flat surfaces when using fewer than 16 samples. Useful range is normally [0..0.1] but higher values is allowed.
+     */
+    public set epsilon(n: number) {
+        this._epsilon = n;
+        this._ssaoPostProcess.updateEffect(this._getDefinesForSSAO());
+    }
+    public get epsilon(): number {
+        return this._epsilon;
+    }
+
     @serialize("samples")
     private _samples: number = 8;
     /**
@@ -491,7 +506,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
     }
 
     private _getDefinesForSSAO() {
-        const defines = "#define SAMPLES " + this.samples + "\n#define SSAO";
+        const defines = `#define SSAO\n#define SAMPLES ${this.samples}\n#define EPSILON ${this.epsilon.toFixed(4)}`;
 
         return defines;
     }

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -410,7 +410,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
         const blurFilter = new PostProcess(
             name,
             "ssao2",
-            ["outSize", "near", "far", "radius", "samples", "soften", "tolerance"],
+            ["outSize", "samples", "soften", "tolerance"],
             samplers,
             ratio,
             null,
@@ -430,9 +430,6 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             const originalColorSize = vertical ? this._originalColorPostProcess.width : this._originalColorPostProcess.height;
 
             effect.setFloat("outSize", ssaoCombineSize > 0 ? ssaoCombineSize : originalColorSize);
-            effect.setFloat("near", this._scene.activeCamera.minZ);
-            effect.setFloat("far", this._scene.activeCamera.maxZ);
-            effect.setFloat("radius", this.radius);
             effect.setInt("samples", this.bilateralSamples);
             effect.setFloat("soften", this.bilateralSoften);
             effect.setFloat("tolerance", this.bilateralTolerance);
@@ -522,7 +519,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 "range",
                 "projection",
                 "near",
-                "far",
+                // "far", // Not actually used in the shader
                 "texelSize",
                 "xViewport",
                 "yViewport",
@@ -555,7 +552,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             effect.setFloat("minZAspect", this.minZAspect);
             effect.setFloat("base", this.base);
             effect.setFloat("near", this._scene.activeCamera.minZ);
-            effect.setFloat("far", this._scene.activeCamera.maxZ);
+            // effect.setFloat("far", this._scene.activeCamera.maxZ);
             if (this._scene.activeCamera.mode === Camera.PERSPECTIVE_CAMERA) {
                 effect.setMatrix3x3("depthProjection", SSAO2RenderingPipeline.PERSPECTIVE_DEPTH_PROJECTION);
                 effect.setFloat("xViewport", Math.tan(this._scene.activeCamera.fov / 2) * this._scene.getEngine().getAspectRatio(this._scene.activeCamera, true));
@@ -615,7 +612,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
     private _createRandomTexture(): void {
         const size = 128;
 
-        this._randomTexture = new DynamicTexture("SSAORandomTexture", size, this._scene, false, Texture.TRILINEAR_SAMPLINGMODE);
+        this._randomTexture = new DynamicTexture("SSAORandomTexture", size, this._scene, false, Texture.BILINEAR_SAMPLINGMODE);
         this._randomTexture.wrapU = Texture.WRAP_ADDRESSMODE;
         this._randomTexture.wrapV = Texture.WRAP_ADDRESSMODE;
 

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -519,7 +519,6 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 "range",
                 "projection",
                 "near",
-                // "far", // Not actually used in the shader
                 "texelSize",
                 "xViewport",
                 "yViewport",
@@ -552,7 +551,6 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
             effect.setFloat("minZAspect", this.minZAspect);
             effect.setFloat("base", this.base);
             effect.setFloat("near", this._scene.activeCamera.minZ);
-            // effect.setFloat("far", this._scene.activeCamera.maxZ);
             if (this._scene.activeCamera.mode === Camera.PERSPECTIVE_CAMERA) {
                 effect.setMatrix3x3("depthProjection", SSAO2RenderingPipeline.PERSPECTIVE_DEPTH_PROJECTION);
                 effect.setFloat("xViewport", Math.tan(this._scene.activeCamera.fov / 2) * this._scene.getEngine().getAspectRatio(this._scene.activeCamera, true));

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -89,8 +89,13 @@ varying vec2 vUV;
 		    float sampleDepth = abs(textureLod(depthSampler, offset.xy, 0.0).r);
 			// range check & accumulate:
 		    difference = depthSign * samplePosition.z - sampleDepth;
+
+			// Ignore samples that has a diff < 0 since they are behind our
+			// point and can't be occluding it. Also ignore diff smaller than
+			// Epsilon due to accuracy issues, otherwise we will get a ton of
+			// incorrect occlusions with low sample counts.
 		    float rangeCheck = 1.0 - smoothstep(correctedRadius*0.5, correctedRadius, difference);
-		    occlusion += (difference >= 0.0 ? 1.0 : 0.0) * rangeCheck;
+		    occlusion += (difference >= EPSILON ? 1.0 : 0.0) * rangeCheck;
 		}
 		occlusion = occlusion*(1.0 - smoothstep(maxZ * 0.75, maxZ, depth));
 		float ao = 1.0 - totalStrength * occlusion * samplesFactor;

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -23,20 +23,20 @@ varying vec2 vUV;
 	1.0
 	);
 
-	float perspectiveDepthToViewZ(in float invClipZ, in float near, in float far ) {
-		return ( near * far ) / ( ( far - near ) * invClipZ - far );
-	}
+	// float perspectiveDepthToViewZ(in float invClipZ, in float near, in float far ) {
+	// 	return ( near * far ) / ( ( far - near ) * invClipZ - far );
+	// }
 
-	float viewZToPerspectiveDepth( in float viewZ, in float near, in float far ) {
-		return ( near * far / viewZ + far) / ( far - near );
-	}
+	// float viewZToPerspectiveDepth( in float viewZ, in float near, in float far ) {
+	// 	return ( near * far / viewZ + far) / ( far - near );
+	// }
 
-	float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
-		return ( viewZ + near ) / ( near - far );
-	}
+	// float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
+	// 	return ( viewZ + near ) / ( near - far );
+	// }
 
 	uniform float near;
-	uniform float far;
+	// uniform float far;
 	uniform float radius;
 
 	uniform sampler2D depthSampler;

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -1,47 +1,46 @@
 // SSAO 2 Shader
 precision highp float;
 uniform sampler2D textureSampler;
-uniform float near;
-uniform float far;
-uniform float radius;
-
-float scales[16] = float[16](
-0.1,
-0.11406250000000001,
-0.131640625,
-0.15625,
-0.187890625,
-0.2265625,
-0.272265625,
-0.325,
-0.384765625,
-0.4515625,
-0.525390625,
-0.60625,
-0.694140625,
-0.7890625,
-0.891015625,
-1.0
-);
-
 varying vec2 vUV;
 
-float perspectiveDepthToViewZ(in float invClipZ, in float near, in float far ) {
-	return ( near * far ) / ( ( far - near ) * invClipZ - far );
-}
-
-float viewZToPerspectiveDepth( in float viewZ, in float near, in float far ) {
-	return ( near * far / viewZ + far) / ( far - near );
-}
-
-float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
-	return ( viewZ + near ) / ( near - far );
-}
-
 #ifdef SSAO
-	uniform sampler2D randomSampler;
+	float scales[16] = float[16](
+	0.1,
+	0.11406250000000001,
+	0.131640625,
+	0.15625,
+	0.187890625,
+	0.2265625,
+	0.272265625,
+	0.325,
+	0.384765625,
+	0.4515625,
+	0.525390625,
+	0.60625,
+	0.694140625,
+	0.7890625,
+	0.891015625,
+	1.0
+	);
+
+	float perspectiveDepthToViewZ(in float invClipZ, in float near, in float far ) {
+		return ( near * far ) / ( ( far - near ) * invClipZ - far );
+	}
+
+	float viewZToPerspectiveDepth( in float viewZ, in float near, in float far ) {
+		return ( near * far / viewZ + far) / ( far - near );
+	}
+
+	float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
+		return ( viewZ + near ) / ( near - far );
+	}
+
+	uniform float near;
+	uniform float far;
+	uniform float radius;
 
 	uniform sampler2D depthSampler;
+	uniform sampler2D randomSampler;
 	uniform sampler2D normalSampler;
 
 	uniform float randTextureTiles;
@@ -61,11 +60,11 @@ float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
 
 	void main()
 	{
-		vec3 random = texture2D(randomSampler, vUV * randTextureTiles).rgb;
-		float depth = texture2D(depthSampler, vUV).r;
+		vec3 random = textureLod(randomSampler, vUV * randTextureTiles, 0.0).rgb;
+		float depth = textureLod(depthSampler, vUV, 0.0).r;
 		float depthSign = depth / abs(depth);
 		depth = depth * depthSign;
-		vec3 normal = texture2D(normalSampler, vUV).rgb;
+		vec3 normal = textureLod(normalSampler, vUV, 0.0).rgb;
 		float occlusion = 0.0;
 		float correctedRadius = min(radius, minZAspect * depth / near);
 
@@ -88,7 +87,7 @@ float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
 			// get sample position:
 		    vec3 samplePosition = scales[(i + int(random.x * 16.0)) % 16] * tbn * sampleSphere[(i + int(random.y * 16.0)) % 16];
 		    samplePosition = samplePosition * correctedRadius + origin;
-		  
+
 			// project sample position:
 		    vec4 offset = vec4(samplePosition, 1.0);
 		    offset = projection * offset;
@@ -98,9 +97,9 @@ float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
 		    if (offset.x < 0.0 || offset.y < 0.0 || offset.x > 1.0 || offset.y > 1.0) {
 		        continue;
 		    }
-		  
+
 			// get sample linearDepth:
-		    float sampleDepth = abs(texture2D(depthSampler, offset.xy).r);
+		    float sampleDepth = abs(textureLod(depthSampler, offset.xy, 0.0).r);
 			// range check & accumulate:
 		    difference = depthSign * samplePosition.z - sampleDepth;
 		    float rangeCheck = 1.0 - smoothstep(correctedRadius*0.5, correctedRadius, difference);
@@ -113,125 +112,121 @@ float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
 	}
 #endif
 
-#ifdef BILATERAL_BLUR
-	uniform sampler2D depthSampler;
+#ifdef BLUR
 	uniform float outSize;
-	uniform float samplerOffsets[SAMPLES];
 
-	vec4 blur9(sampler2D image, vec2 uv, float resolution, vec2 direction) {
-	  vec4 color = vec4(0.0);
-	  vec2 off1 = vec2(1.3846153846) * direction;
-	  vec2 off2 = vec2(3.2307692308) * direction;
-	  color += texture2D(image, uv) * 0.2270270270;
-	  color += texture2D(image, uv + (off1 / resolution)) * 0.3162162162;
-	  color += texture2D(image, uv - (off1 / resolution)) * 0.3162162162;
-	  color += texture2D(image, uv + (off2 / resolution)) * 0.0702702703;
-	  color += texture2D(image, uv - (off2 / resolution)) * 0.0702702703;
-	  return color;
+	// These three controls the non-legacy bilateral filter
+	uniform float soften;
+	uniform float tolerance;
+	uniform int samples;
+
+#ifndef BLUR_BYPASS
+	uniform sampler2D depthSampler;
+#ifdef BLUR_LEGACY
+	float blur13Bilateral(sampler2D image, vec2 uv, vec2 step) {
+		float result = 0.0;
+		vec2 off1 = vec2(1.411764705882353) * step;
+		vec2 off2 = vec2(3.2941176470588234) * step;
+		vec2 off3 = vec2(5.176470588235294) * step;
+
+		float compareDepth = abs(textureLod(depthSampler, uv, 0.0).r);
+		float sampleDepth;
+		float weight;
+		float weightSum = 30.0;
+
+		result += textureLod(image, uv, 0.0).r * 30.0;
+
+		sampleDepth = abs(textureLod(depthSampler, uv + off1, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum +=  weight;
+		result += textureLod(image, uv + off1, 0.0).r * weight;
+
+		sampleDepth = abs(textureLod(depthSampler, uv - off1, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum +=  weight;
+		result += textureLod(image, uv - off1, 0.0).r * weight;
+
+		sampleDepth = abs(textureLod(depthSampler, uv + off2, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum += weight;
+		result += textureLod(image, uv + off2, 0.0).r * weight;
+
+		sampleDepth = abs(textureLod(depthSampler, uv - off2, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum += weight;
+		result += textureLod(image, uv - off2, 0.0).r * weight;
+
+		sampleDepth = abs(textureLod(depthSampler, uv + off3, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum += weight;
+		result += textureLod(image, uv + off3, 0.0).r * weight;
+
+		sampleDepth = abs(textureLod(depthSampler, uv - off3, 0.0).r);
+		weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
+		weightSum += weight;
+		result += textureLod(image, uv - off3, 0.0).r * weight;
+
+		return result / weightSum;
 	}
-
-	vec4 blur13(sampler2D image, vec2 uv, float resolution, vec2 direction) {
-	  vec4 color = vec4(0.0);
-	  vec2 off1 = vec2(1.411764705882353) * direction;
-	  vec2 off2 = vec2(3.2941176470588234) * direction;
-	  vec2 off3 = vec2(5.176470588235294) * direction;
-	  color += texture2D(image, uv) * 0.1964825501511404;
-	  color += texture2D(image, uv + (off1 / resolution)) * 0.2969069646728344;
-	  color += texture2D(image, uv - (off1 / resolution)) * 0.2969069646728344;
-	  color += texture2D(image, uv + (off2 / resolution)) * 0.09447039785044732;
-	  color += texture2D(image, uv - (off2 / resolution)) * 0.09447039785044732;
-	  color += texture2D(image, uv + (off3 / resolution)) * 0.010381362401148057;
-	  color += texture2D(image, uv - (off3 / resolution)) * 0.010381362401148057;
-	  return color;
-	}
-
-	vec4 blur13Bilateral(sampler2D image, vec2 uv, float resolution, vec2 direction) {
-	  vec4 color = vec4(0.0);
-	  vec2 off1 = vec2(1.411764705882353) * direction;
-	  vec2 off2 = vec2(3.2941176470588234) * direction;
-	  vec2 off3 = vec2(5.176470588235294) * direction;
-
-	  float compareDepth = abs(texture2D(depthSampler, uv).r);
-	  float sampleDepth;
-	  float weight;
-	  float weightSum = 30.0;
-
-	  color += texture2D(image, uv) * 30.0;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv + (off1 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum +=  weight;
-	  color += texture2D(image, uv + (off1 / resolution)) * weight;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv - (off1 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum +=  weight;
-	  color += texture2D(image, uv - (off1 / resolution)) * weight;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv + (off2 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum += weight;
-	  color += texture2D(image, uv + (off2 / resolution)) * weight;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv - (off2 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum += weight;
-	  color += texture2D(image, uv - (off2 / resolution)) * weight;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv + (off3 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum += weight;
-	  color += texture2D(image, uv + (off3 / resolution)) * weight;
-
-	  sampleDepth = abs(texture2D(depthSampler, uv - (off3 / resolution)).r);
-	  weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30.0);
-	  weightSum += weight;
-	  color += texture2D(image, uv - (off3 / resolution)) * weight;
-
-	  return color / weightSum;
-	}
+#endif
+#endif
 
 	void main()
 	{
-		#if EXPENSIVE
-		float compareDepth = abs(texture2D(depthSampler, vUV).r);
-		float texelsize = 1.0 / outSize;
 		float result = 0.0;
-		float weightSum = 0.0;
-
-		for (int i = 0; i < SAMPLES; ++i)
-		{
-			#ifdef BILATERAL_BLUR_H
-			vec2 direction = vec2(1.0, 0.0);
-			vec2 sampleOffset = vec2(texelsize * samplerOffsets[i], 0.0);
+		#ifdef BLUR_BYPASS
+			result = textureLod(textureSampler, vUV, 0.0).r;
+		#else
+			#ifdef BLUR_H
+				vec2 step = vec2(1.0 / outSize, 0.0);
 			#else
-			vec2 direction = vec2(0.0, 1.0);
-			vec2 sampleOffset = vec2(0.0, texelsize * samplerOffsets[i]);
+				vec2 step = vec2(0.0, 1.0 / outSize);
 			#endif
-			vec2 samplePos = vUV + sampleOffset;
 
-			float sampleDepth = abs(texture2D(depthSampler, samplePos).r);
-			float weight = clamp(1.0 / ( 0.003 + abs(compareDepth - sampleDepth)), 0.0, 30000.0);
+			#ifdef BLUR_LEGACY
+				result = blur13Bilateral(textureSampler, vUV, step);
+			#else
+				float compareDepth = abs(textureLod(depthSampler, vUV, 0.0).r);
+				float weightSum = 0.0;
+				for (int i = -samples; i < samples; i += 2)
+				{
+					// Step over the texels two at a time, sampling both by sampling the position
+					// directly between them. The graphics hardware will thus read both.
+					//
+					// Note that we really should sample the center position seperately, but to
+					// minimize the risk of regressions, we keep doing it like this for now.
+					vec2 samplePos = vUV + step * (float(i) + 0.5);
 
-			result += texture2D(textureSampler, samplePos).r * weight;
-			weightSum += weight;
-		}
+					float sampleDepth = abs(textureLod(depthSampler, samplePos, 0.0).r);
 
-		result /= weightSum;
+					// The falloff is used to optionally give samples further from the center
+					// gradually lower weights. The value at the center is always 1.0, but the
+					// value at the edge varies depending on the "soften" control input.
+					//
+					// Note: soften === 0 => fallof === 1 for all i, legacy that needs to be kept.
+					// float falloff = smoothstep(0.0, float(samples), 0.00001 + abs(float(samples - i)*soften));
+					float falloff = smoothstep(0.0,
+											   float(samples),
+											   float(samples) - abs(float(i)) * soften);
+
+					// minDivider affects how much a sample's depth need to differ before it is
+					// more or less rejected. A higher value results in the bilateral filter
+					// being more forgiving when rejecting samples, letting the denoiser work on
+					// slanted and curved surfaces.
+					//
+					// Note: tolerance === 0 => minDivider === 0.003, legacy that needs to be kept.
+					float minDivider = tolerance * 0.5 + 0.003;
+					float weight = falloff / ( minDivider + abs(compareDepth - sampleDepth));
+
+					result += textureLod(textureSampler, samplePos, 0.0).r * weight;
+					weightSum += weight;
+				}
+				result /= weightSum;
+			#endif
+		#endif
+
 		gl_FragColor.rgb = vec3(result);
 		gl_FragColor.a = 1.0;
-		#else
-		vec4 color;
-		#ifdef BILATERAL_BLUR_H
-		vec2 direction = vec2(1.0, 0.0);
-		color = blur13Bilateral(textureSampler, vUV, outSize, direction);
-		#else
-		vec2 direction = vec2(0.0, 1.0);
-		color = blur13Bilateral(textureSampler, vUV, outSize, direction);
-		#endif
-
-		gl_FragColor.rgb = vec3(color.r);
-		gl_FragColor.a = 1.0;
-		#endif
 	}
+
 #endif

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -23,20 +23,7 @@ varying vec2 vUV;
 	1.0
 	);
 
-	// float perspectiveDepthToViewZ(in float invClipZ, in float near, in float far ) {
-	// 	return ( near * far ) / ( ( far - near ) * invClipZ - far );
-	// }
-
-	// float viewZToPerspectiveDepth( in float viewZ, in float near, in float far ) {
-	// 	return ( near * far / viewZ + far) / ( far - near );
-	// }
-
-	// float viewZToOrthographicDepth( in float viewZ, in float near, in float far ) {
-	// 	return ( viewZ + near ) / ( near - far );
-	// }
-
 	uniform float near;
-	// uniform float far;
 	uniform float radius;
 
 	uniform sampler2D depthSampler;
@@ -204,7 +191,6 @@ varying vec2 vUV;
 					// value at the edge varies depending on the "soften" control input.
 					//
 					// Note: soften === 0 => fallof === 1 for all i, legacy that needs to be kept.
-					// float falloff = smoothstep(0.0, float(samples), 0.00001 + abs(float(samples - i)*soften));
 					float falloff = smoothstep(0.0,
 											   float(samples),
 											   float(samples) - abs(float(i)) * soften);

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -95,7 +95,7 @@ varying vec2 vUV;
 			// Epsilon due to accuracy issues, otherwise we will get a ton of
 			// incorrect occlusions with low sample counts.
 		    float rangeCheck = 1.0 - smoothstep(correctedRadius*0.5, correctedRadius, difference);
-		    occlusion += (difference >= EPSILON ? 1.0 : 0.0) * rangeCheck;
+		    occlusion += step(EPSILON, difference) * rangeCheck;
 		}
 		occlusion = occlusion*(1.0 - smoothstep(maxZ * 0.75, maxZ, depth));
 		float ao = 1.0 - totalStrength * occlusion * samplesFactor;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
@@ -87,50 +87,50 @@ export class SSAO2RenderingPipelinePropertyGridComponent extends React.Component
                         propertyName="radius"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
-                    <LineContainerComponent title="Denoiser">
-                        <CheckBoxLineComponent
-                            label="Bypass Blur"
-                            propertyName="bypassBlur"
-                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                            target={renderPipeline}
-                        />
-                        <CheckBoxLineComponent
-                            label="Expensive Blur"
-                            propertyName="expensiveBlur"
-                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                            target={renderPipeline}
-                        />
-                        <SliderLineComponent
-                            lockObject={this.props.lockObject}
-                            label="Samples"
-                            minimum={2}
-                            maximum={32}
-                            step={1}
-                            target={renderPipeline}
-                            propertyName="bilateralSamples"
-                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                        />
-                        <SliderLineComponent
-                            lockObject={this.props.lockObject}
-                            label="Soften"
-                            minimum={0}
-                            maximum={1}
-                            step={0.01}
-                            target={renderPipeline}
-                            propertyName="bilateralSoften"
-                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                        />
-                        <SliderLineComponent
-                            lockObject={this.props.lockObject}
-                            label="Tolerance"
-                            minimum={0}
-                            maximum={1}
-                            step={0.01}
-                            target={renderPipeline}
-                            propertyName="bilateralTolerance"
-                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                        />
-                    </LineContainerComponent>
+                </LineContainerComponent>
+                <LineContainerComponent title="Denoiser">
+                    <CheckBoxLineComponent
+                        label="Bypass Blur"
+                        propertyName="bypassBlur"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        target={renderPipeline}
+                    />
+                    <CheckBoxLineComponent
+                        label="Expensive Blur"
+                        propertyName="expensiveBlur"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        target={renderPipeline}
+                    />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Samples"
+                        minimum={2}
+                        maximum={32}
+                        step={1}
+                        target={renderPipeline}
+                        propertyName="bilateralSamples"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Soften"
+                        minimum={0}
+                        maximum={1}
+                        step={0.01}
+                        target={renderPipeline}
+                        propertyName="bilateralSoften"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Tolerance"
+                        minimum={0}
+                        maximum={1}
+                        step={0.01}
+                        target={renderPipeline}
+                        propertyName="bilateralTolerance"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                 </LineContainerComponent>
             </div>
         );

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
@@ -87,6 +87,16 @@ export class SSAO2RenderingPipelinePropertyGridComponent extends React.Component
                         propertyName="radius"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Epsilon"
+                        minimum={0}
+                        maximum={1}
+                        step={0.001}
+                        target={renderPipeline}
+                        propertyName="epsilon"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                 </LineContainerComponent>
                 <LineContainerComponent title="Denoiser">
                     <CheckBoxLineComponent

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/postProcesses/ssao2RenderingPipelinePropertyGridComponent.tsx
@@ -9,6 +9,7 @@ import { SliderLineComponent } from "shared-ui-components/lines/sliderLineCompon
 import { LineContainerComponent } from "shared-ui-components/lines/lineContainerComponent";
 import type { SSAO2RenderingPipeline } from "core/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline";
 import type { GlobalState } from "../../../../globalState";
+import { CheckBoxLineComponent } from "shared-ui-components/lines/checkBoxLineComponent";
 
 interface ISSAO2RenderingPipelinePropertyGridComponentProps {
     globalState: GlobalState;
@@ -86,6 +87,50 @@ export class SSAO2RenderingPipelinePropertyGridComponent extends React.Component
                         propertyName="radius"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
+                    <LineContainerComponent title="Denoiser">
+                        <CheckBoxLineComponent
+                            label="Bypass Blur"
+                            propertyName="bypassBlur"
+                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                            target={renderPipeline}
+                        />
+                        <CheckBoxLineComponent
+                            label="Expensive Blur"
+                            propertyName="expensiveBlur"
+                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                            target={renderPipeline}
+                        />
+                        <SliderLineComponent
+                            lockObject={this.props.lockObject}
+                            label="Samples"
+                            minimum={2}
+                            maximum={32}
+                            step={1}
+                            target={renderPipeline}
+                            propertyName="bilateralSamples"
+                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        />
+                        <SliderLineComponent
+                            lockObject={this.props.lockObject}
+                            label="Soften"
+                            minimum={0}
+                            maximum={1}
+                            step={0.01}
+                            target={renderPipeline}
+                            propertyName="bilateralSoften"
+                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        />
+                        <SliderLineComponent
+                            lockObject={this.props.lockObject}
+                            label="Tolerance"
+                            minimum={0}
+                            maximum={1}
+                            step={0.01}
+                            target={renderPipeline}
+                            propertyName="bilateralTolerance"
+                            onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                        />
+                    </LineContainerComponent>
                 </LineContainerComponent>
             </div>
         );


### PR DESCRIPTION
Related to this thread in the forums:
https://forum.babylonjs.com/t/ssao2-blur-shader-issues/38924/25

## SSAO calculation fix
Fixes an error in SSAO2 calculations that caused massive amounts of incorrect occlusions on flat surfaces when samples were <16. This change is automatically applied with the new `epsilon` parameter defaulting to 0.02, demonstrated below with samples = 8 (fixed on the right). Setting the new parameter to 0.0 will revert back to the old behavior.

See #13652 for discussions and more screenshots.

#### Terrain (#N96NXC#127)
<img src="https://user-images.githubusercontent.com/984279/226774799-e9c31bac-3701-42e3-b7ac-787d005ca85b.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/984279/226774815-c77ae725-930e-4bb3-ac6e-3b1ea2669862.png" width=50% height=50%>

#### Cat (#T3K2SA#1)
<img src="https://user-images.githubusercontent.com/984279/226775071-8d1056be-688b-4026-b31c-807259ae2464.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/984279/226775079-5fd547b9-0daf-43b6-a522-d04ebef5e986.png" width=50% height=50%>

#### Room (#LCUPCU#14)
<img src="https://user-images.githubusercontent.com/984279/226775164-10d8d6fa-8717-470f-9196-cf6c6312735d.png" width=50% height=50%><img src="https://user-images.githubusercontent.com/984279/226775175-3cc2ca52-6de8-4ec2-b085-e93f8c9b4ab0.png" width=50% height=50%>

## Denoising / Blur filter is more configurable

The "expensiveBlur" filter has been improved with new features and their associated parameters. 

This change was done with care so that the new code keeps all the quirks and bugs in the current code, while adding options to mitigate them on a per scene/project basis. This was none of the existing deployments are affected since they might have already tried to compensate for them in other ways.

### Summary of changes
- Adds option to disable the blur filters for easier tuning of the SSAO2 parameters.
- Made the "expensive filter" configurable (number of samples, shape of kernel, tolerance when rejecting samples) while keeping the defaults to be exactly like before the PR.
- Exposed the new settings in the Inspector.
- Cleaned up the code, reducing rather big code duplication.
- Added and updated comments and documentation.
- Added some optimizations based on feedback from @Popov72.



This is the first time I contribute to Babylon.js, so please let me know if I need to do or change something.