### PR TITLE
adt.useInvalidateRectOptimization using scale incorrectly when toggling visibility and redrawing invalidated parts of canvas

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -14,6 +14,7 @@ import { Constants } from "core/Engines/constants";
 import { Observable } from "core/Misc/observable";
 import type { BaseGradient } from "./gradient/BaseGradient";
 import { Tools } from "core/Misc/tools";
+import { Matrix2D } from "../math2D";
 
 /**
  * Root class for 2D containers
@@ -502,6 +503,9 @@ export class Container extends Control {
         // Do nothing by default
     }
 
+    private _inverseTransformMatrix = Matrix2D.Identity();
+    private _inverseMeasure = new Measure(0, 0, 0, 0);
+
     /**
      * @internal
      */
@@ -513,7 +517,9 @@ export class Container extends Control {
             contextToDrawTo.save();
             contextToDrawTo.translate(-this._currentMeasure.left, -this._currentMeasure.top);
             if (invalidatedRectangle) {
-                contextToDrawTo.clearRect(invalidatedRectangle.left, invalidatedRectangle.top, invalidatedRectangle.width, invalidatedRectangle.height);
+                this._transformMatrix.invertToRef(this._inverseTransformMatrix);
+                invalidatedRectangle.transformToRef(this._inverseTransformMatrix, this._inverseMeasure);
+                contextToDrawTo.clearRect(this._inverseMeasure.left, this._inverseMeasure.top, this._inverseMeasure.width, this._inverseMeasure.height);
             } else {
                 contextToDrawTo.clearRect(this._currentMeasure.left, this._currentMeasure.top, this._currentMeasure.width, this._currentMeasure.height);
             }

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1576,11 +1576,9 @@ export class Control implements IAnimatable {
     public invalidateRect() {
         this._transform();
         if (this.host && this.host.useInvalidateRectOptimization) {
-            // Rotate by transform to get the measure transformed to global space
-            this._currentMeasure.transformToRef(this._transformMatrix, this._tmpMeasureA);
             // get the boudning box of the current measure and last frames measure in global space and invalidate it
             // the previous measure is used to properly clear a control that is scaled down
-            Measure.CombineToRef(this._tmpMeasureA, this._prevCurrentMeasureTransformedIntoGlobalSpace, this._tmpMeasureA);
+            Measure.CombineToRef(this._currentMeasure, this._prevCurrentMeasureTransformedIntoGlobalSpace, this._tmpMeasureA);
 
             // Expand rect based on shadows
             const shadowOffsetX = this.shadowOffsetX;

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1576,9 +1576,11 @@ export class Control implements IAnimatable {
     public invalidateRect() {
         this._transform();
         if (this.host && this.host.useInvalidateRectOptimization) {
+            // Rotate by transform to get the measure transformed to global space
+            this._currentMeasure.transformToRef(this._transformMatrix, this._tmpMeasureA);
             // get the boudning box of the current measure and last frames measure in global space and invalidate it
             // the previous measure is used to properly clear a control that is scaled down
-            Measure.CombineToRef(this._currentMeasure, this._prevCurrentMeasureTransformedIntoGlobalSpace, this._tmpMeasureA);
+            Measure.CombineToRef(this._tmpMeasureA, this._prevCurrentMeasureTransformedIntoGlobalSpace, this._tmpMeasureA);
 
             // Expand rect based on shadows
             const shadowOffsetX = this.shadowOffsetX;


### PR DESCRIPTION
Fixes #13622
Current measure already has the right measure. when applying the transform again it applies scale twice.