### PR TITLE
Button3D: Allow setting the dimensions at creation time

### DIFF
--- a/packages/dev/gui/src/3D/controls/button3D.ts
+++ b/packages/dev/gui/src/3D/controls/button3D.ts
@@ -17,12 +17,20 @@ export class Button3D extends AbstractButton3D {
     /** @internal */
     protected _currentMaterial: Material;
 
+    protected _width: number;
+    protected _height: number;
+    protected _depth: number;
+
     /**
      * Creates a new button
      * @param name defines the control name
      */
-    constructor(name?: string) {
+    constructor(name?: string, width = 1, height = 1, depth = 0.08) {
         super(name);
+
+        this._width = width;
+        this._height = height;
+        this._depth = depth;
 
         // Default animations
 
@@ -83,14 +91,17 @@ export class Button3D extends AbstractButton3D {
         const mesh = CreateBox(
             this.name + "_rootMesh",
             {
-                width: 1.0,
-                height: 1.0,
-                depth: 0.08,
+                width: this._width,
+                height: this._height,
+                depth: this._depth,
                 faceUV: faceUV,
                 wrap: true,
             },
             scene
         );
+
+        this._contentScaleRatioY = (this._contentScaleRatio * this._width) / this._height;
+        this._setFacadeTextureScaling();
 
         return mesh;
     }

--- a/packages/dev/gui/src/3D/controls/button3D.ts
+++ b/packages/dev/gui/src/3D/controls/button3D.ts
@@ -11,13 +11,33 @@ import type { AdvancedDynamicTexture } from "../../2D/advancedDynamicTexture";
 import { Color3 } from "core/Maths/math.color";
 
 /**
+ * Options used to create a button in 3D
+ */
+export interface IButton3DCreationOptions {
+    /**
+     * Width of the button. Default: 1
+     */
+    width?: number;
+
+    /**
+     * Height of the button. Default: 1
+     */
+    height?: number;
+
+    /**
+     * Depth of the button. Default: 0.08
+     */
+    depth?: number;
+}
+
+/**
  * Class used to create a button in 3D
  */
 export class Button3D extends AbstractButton3D {
     /** @internal */
     protected _currentMaterial: Material;
 
-    protected _width: number;
+    protected _options: IButton3DCreationOptions;
     protected _height: number;
     protected _depth: number;
 
@@ -25,12 +45,15 @@ export class Button3D extends AbstractButton3D {
      * Creates a new button
      * @param name defines the control name
      */
-    constructor(name?: string, width = 1, height = 1, depth = 0.08) {
+    constructor(name?: string, options?: IButton3DCreationOptions) {
         super(name);
 
-        this._width = width;
-        this._height = height;
-        this._depth = depth;
+        this._options = {
+            width: 1,
+            height: 1,
+            depth: 0.08,
+            ...options,
+        };
 
         // Default animations
 
@@ -91,16 +114,16 @@ export class Button3D extends AbstractButton3D {
         const mesh = CreateBox(
             this.name + "_rootMesh",
             {
-                width: this._width,
-                height: this._height,
-                depth: this._depth,
+                width: this._options.width,
+                height: this._options.height,
+                depth: this._options.depth,
                 faceUV: faceUV,
                 wrap: true,
             },
             scene
         );
 
-        this._contentScaleRatioY = (this._contentScaleRatio * this._width) / this._height;
+        this._contentScaleRatioY = (this._contentScaleRatio * this._options.width!) / this._options.height!;
         this._setFacadeTextureScaling();
 
         return mesh;

--- a/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
+++ b/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
@@ -12,6 +12,7 @@ export class ContentDisplay3D extends Control3D {
     private _facadeTexture: Nullable<AdvancedDynamicTexture>;
     protected _contentResolution = 512;
     protected _contentScaleRatio = 2;
+    protected _contentScaleRatioY: number | undefined;
 
     /**
      * Gets or sets the GUI 2D content used to display the button's facade
@@ -36,8 +37,7 @@ export class ContentDisplay3D extends Control3D {
                 true,
                 Texture.TRILINEAR_SAMPLINGMODE
             );
-            this._facadeTexture.rootContainer.scaleX = this._contentScaleRatio;
-            this._facadeTexture.rootContainer.scaleY = this._contentScaleRatio;
+            this._setFacadeTextureScaling();
             this._facadeTexture.premulAlpha = true;
         } else {
             this._facadeTexture.rootContainer.clearControls();
@@ -46,6 +46,13 @@ export class ContentDisplay3D extends Control3D {
         this._facadeTexture.addControl(value);
 
         this._applyFacade(this._facadeTexture);
+    }
+
+    protected _setFacadeTextureScaling() {
+        if (this._facadeTexture) {
+            this._facadeTexture.rootContainer.scaleX = this._contentScaleRatio;
+            this._facadeTexture.rootContainer.scaleY = this._contentScaleRatioY ?? this._contentScaleRatio;
+        }
     }
 
     /**

--- a/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
+++ b/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
@@ -12,7 +12,7 @@ export class ContentDisplay3D extends Control3D {
     private _facadeTexture: Nullable<AdvancedDynamicTexture>;
     protected _contentResolution = 512;
     protected _contentScaleRatio = 2;
-    protected _contentScaleRatioY: number | undefined;
+    protected _contentScaleRatioY?: number;
 
     /**
      * Gets or sets the GUI 2D content used to display the button's facade


### PR DESCRIPTION
See https://forum.babylonjs.com/t/holographicbutton-button3d-sizes/39134/3

The dimensions can be set at creation time only because it has an impact on the creation of the mesh. I would have to recreate the mesh if we allowed the dimensions to be changed at any time, but `_createNode` (which creates the mesh) is called by `Control3D`, and the result of that call is stored in a private variable. If the user wants to change the dimensions afterwards, he will have to recreate the button.