### PR TITLE
added logNodeWhenPicking setting, state and function

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/settingsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/settingsTabComponent.tsx
@@ -16,6 +16,7 @@ export class SettingsTabComponent extends PaneComponent {
                 <LineContainerComponent title="UI" selection={this.props.globalState}>
                     <CheckBoxLineComponent label="Only display Euler values" target={state} propertyName="onlyUseEulers" />
                     <CheckBoxLineComponent label="Ignore backfaces when picking" target={state} propertyName="ignoreBackfacesForPicking" />
+                    <CheckBoxLineComponent label="Log Node when picking" target={state} propertyName="logNodeWhenPicking" />
                 </LineContainerComponent>
             </div>
         );

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -118,6 +118,22 @@ export class GlobalState {
         DataStorage.WriteBoolean("settings_ignoreBackfacesForPicking", value);
     }
 
+    private _logNodeWhenPicking: Nullable<boolean> = null;
+
+    public get logNodeWhenPicking(): boolean {
+        if (this._logNodeWhenPicking === null) {
+            this._logNodeWhenPicking = DataStorage.ReadBoolean("settings_logNodeWhenPicking", false);
+        }
+
+        return this._logNodeWhenPicking!;
+    }
+
+    public set logNodeWhenPicking(value: boolean) {
+        this._logNodeWhenPicking = value;
+
+        DataStorage.WriteBoolean("settings_logNodeWhenPicking", value);
+    }
+
     public init(propertyChangedObservable: Observable<PropertyChangedEvent>) {
         this.onPropertyChangedObservable = propertyChangedObservable;
 

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -91,6 +91,9 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
         const scene = this.props.scene;
         this._onSelectionChangeObserver = this.props.onSelectionChangedObservable.add((entity) => {
             this._selectedEntity = entity;
+
+            if (entity && this.props.globalState.logNodeWhenPicking) console.log(entity);
+
             if (entity && scene.reservedDataStore && scene.reservedDataStore.gizmoManager) {
                 const manager: GizmoManager = scene.reservedDataStore.gizmoManager;
 


### PR DESCRIPTION
I've added a setting for inspector: `Log Node when picking` in Settings > UI pane. It also works on tree selection. It simply logs the node to console. I've seen a few requests and I think this is a sensible start. Putting it in the UI pane is questionable but didn't want to clutter other areas & keep it alongside the other picking toggle setting.

![screenBlur](https://user-images.githubusercontent.com/34647206/226564194-28f89b61-f545-422d-a94b-088ff4e819f2.png)

https://forum.babylonjs.com/t/read-write-metadata-using-the-inspector/34208

Closes #13027 