### PR TITLE
Engine: Modified isPointerLock to update when called instead of during pointerlockchange event

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -421,7 +421,22 @@ export class Engine extends ThinEngine {
     /**
      * Gets a boolean indicating if the pointer is currently locked
      */
-    public isPointerLock = false;
+    public get isPointerLock() {
+        let canvasCheck = false;
+        // Check if document exists and update canvasCheck if it does
+        if (IsDocumentAvailable() && this._renderingCanvas) {
+            canvasCheck = document.pointerLockElement === this._renderingCanvas;
+        }
+        // Return either manual pointerlock state or canvas pointerlock state
+        return this._isPointerLock || canvasCheck;
+    }
+
+    public set isPointerLock(value: boolean) {
+        this._isPointerLock = value;
+    }
+
+    // Store manual pointerlock state, if specified
+    private _isPointerLock = false;
 
     // Observables
 
@@ -540,7 +555,6 @@ export class Engine extends ThinEngine {
     private _onCanvasContextMenu: (evt: Event) => void;
 
     private _onFullscreenChange: () => void;
-    private _onPointerLockChange: () => void;
 
     protected _compatibilityMode = true;
 
@@ -690,14 +704,6 @@ export class Engine extends ThinEngine {
 
             document.addEventListener("fullscreenchange", this._onFullscreenChange, false);
             document.addEventListener("webkitfullscreenchange", this._onFullscreenChange, false);
-
-            // Pointer lock
-            this._onPointerLockChange = () => {
-                this.isPointerLock = document.pointerLockElement === canvas;
-            };
-
-            document.addEventListener("pointerlockchange", this._onPointerLockChange, false);
-            document.addEventListener("webkitpointerlockchange", this._onPointerLockChange, false);
         }
 
         this.enableOfflineSupport = Engine.OfflineProviderFactory !== undefined;
@@ -1905,10 +1911,6 @@ export class Engine extends ThinEngine {
             document.removeEventListener("mozfullscreenchange", this._onFullscreenChange);
             document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
             document.removeEventListener("msfullscreenchange", this._onFullscreenChange);
-            document.removeEventListener("pointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("mspointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("mozpointerlockchange", this._onPointerLockChange);
-            document.removeEventListener("webkitpointerlockchange", this._onPointerLockChange);
         }
 
         super.dispose();

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -422,13 +422,8 @@ export class Engine extends ThinEngine {
      * Gets a boolean indicating if the pointer is currently locked
      */
     public get isPointerLock() {
-        let canvasCheck = false;
-        // Check if document exists and update canvasCheck if it does
-        if (IsDocumentAvailable() && this._renderingCanvas) {
-            canvasCheck = document.pointerLockElement === this._renderingCanvas;
-        }
         // Return either manual pointerlock state or canvas pointerlock state
-        return this._isPointerLock || canvasCheck;
+        return this._isPointerLock || (this._isCanvasPresent && document.pointerLockElement === this._renderingCanvas);
     }
 
     public set isPointerLock(value: boolean) {
@@ -437,6 +432,8 @@ export class Engine extends ThinEngine {
 
     // Store manual pointerlock state, if specified
     private _isPointerLock = false;
+    // Check for document and canvas before using pointerlock
+    private _isCanvasPresent = false;
 
     // Observables
 
@@ -609,7 +606,8 @@ export class Engine extends ThinEngine {
 
         if ((<any>canvasOrContext).getContext) {
             const canvas = <HTMLCanvasElement>canvasOrContext;
-
+            // Since we know that there's a canvas, check for document existence
+            this._isCanvasPresent = IsDocumentAvailable();
             this._sharedInit(canvas);
 
             this._connectVREvents();

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -760,7 +760,7 @@ export class InputManager {
                     Math.abs(this._startingPointerPosition.y - this._pointerY) > InputManager.DragMovementThreshold;
             }
 
-            // Because there's a race condition between pointermove and pointerlockchange events, we need to 
+            // Because there's a race condition between pointermove and pointerlockchange events, we need to
             // verify that the pointer is still locked after each pointermove event.
             if (engine.isPointerLock) {
                 engine._verifyPointerLock();

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -760,6 +760,12 @@ export class InputManager {
                     Math.abs(this._startingPointerPosition.y - this._pointerY) > InputManager.DragMovementThreshold;
             }
 
+            // Because there's a race condition between pointermove and pointerlockchange events, we need to 
+            // verify that the pointer is still locked after each pointermove event.
+            if (engine.isPointerLock) {
+                engine._verifyPointerLock();
+            }
+
             // PreObservable support
             if (
                 this._checkPrePointerObservable(

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -743,7 +743,7 @@ describe("InputManager", () => {
                 },
                 writable: true,
             });
-            
+
             // Manually set isPointerLock to true
             engine.isPointerLock = true;
 


### PR DESCRIPTION
A user in the forum found an issue where they were starting and stopping a pointerlock during a drag motion.  At the end of their movement, it was found that there was a strange rotation made in an unintended angle.  It was determined that `isPointerLock` wasn't being updated during the first move to occur after the lock was released.  The `pointerlockchange` event was being fired after the move was being handled so the camera input thought that a pointerlock was actinve and moved accordingly.  This PR will change the behavior of isPointerLock to check and update isPointerLock during a `pointermove` event when a pointerlock is active.

Forum Link: https://forum.babylonjs.com/t/camera-does-a-strange-rotation-on-cursor-lock/37904