### PR TITLE
Observable: Fix wrong value returned by hasObservers

### DIFF
--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -266,6 +266,9 @@ export class Observable<T> {
      * @internal
      */
     public _deferUnregister(observer: Observer<T>): void {
+        if (observer._willBeUnregistered) {
+            return;
+        }
         this._numObserversMarkedAsDeleted++;
         observer.unregisterOnNextCall = false;
         observer._willBeUnregistered = true;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/observable-hasobservers-can-incorrectly-report-false-even-though-there-are-observers/39232/2