### PR TITLE
Add iridescence configuration to PBR material cloning

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -775,6 +775,7 @@ export class PBRMaterial extends PBRBaseMaterial {
         this.brdf.copyTo(clone.brdf);
         this.sheen.copyTo(clone.sheen);
         this.subSurface.copyTo(clone.subSurface);
+        this.iridescence.copyTo(clone.iridescence);
 
         return clone;
     }

--- a/packages/dev/core/src/Materials/Textures/cubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/cubeTexture.ts
@@ -1,4 +1,4 @@
-import { serialize, serializeAsMatrix, SerializationHelper } from "../../Misc/decorators";
+import { serialize, serializeAsMatrix, SerializationHelper, serializeAsVector3 } from "../../Misc/decorators";
 import { Tools } from "../../Misc/tools";
 import type { Nullable } from "../../types";
 import type { Scene } from "../../scene";
@@ -37,6 +37,7 @@ export class CubeTexture extends BaseTexture {
      * It must define where the camera used to render the texture was set
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/reflectionTexture#using-local-cubemap-mode
      */
+    @serializeAsVector3()
     public boundingBoxPosition = Vector3.Zero();
 
     private _boundingBoxSize: Vector3;
@@ -61,6 +62,7 @@ export class CubeTexture extends BaseTexture {
      * Returns the bounding box size
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/reflectionTexture#using-local-cubemap-mode
      */
+    @serializeAsVector3()
     public get boundingBoxSize(): Vector3 {
         return this._boundingBoxSize;
     }


### PR DESCRIPTION
Add serialize decorators to boundingBox properties on CubeTexture

Related forum issue: https://forum.babylonjs.com/t/problem-cloning-pbrmaterial-with-iridescence-subconfiguration/39240