### PR TITLE
Set imageprocessingconfiguration for pbrbasematerial

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -808,6 +808,9 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      */
     public set imageProcessingConfiguration(value: ImageProcessingConfiguration) {
         this._attachImageProcessingConfiguration(value);
+
+        // Ensure the effect will be rebuilt.
+        this._markAllSubMeshesAsTexturesDirty();
     }
 
     /**

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -806,7 +806,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      *
      * If sets to null, the scene one is in use.
      */
-     public set imageProcessingConfiguration(value: ImageProcessingConfiguration) {
+    public set imageProcessingConfiguration(value: ImageProcessingConfiguration) {
         this._attachImageProcessingConfiguration(value);
     }
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -802,6 +802,13 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     }
 
     /**
+     * Gets the image processing configuration used either in this material.
+     */
+    public get imageProcessingConfiguration(): ImageProcessingConfiguration {
+        return this._imageProcessingConfiguration;
+    }
+
+    /**
      * Sets the Default image processing configuration used either in the this material.
      *
      * If sets to null, the scene one is in use.

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -802,6 +802,15 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     }
 
     /**
+     * Sets the Default image processing configuration used either in the this material.
+     *
+     * If sets to null, the scene one is in use.
+     */
+     public set imageProcessingConfiguration(value: ImageProcessingConfiguration) {
+        this._attachImageProcessingConfiguration(value);
+    }
+
+    /**
      * Stores the available render targets.
      */
     private _renderTargets = new SmartArray<RenderTargetTexture>(16);

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -627,18 +627,6 @@ export class PBRMaterial extends PBRBaseMaterial {
     }
 
     /**
-     * Sets the Default image processing configuration used either in the this material.
-     *
-     * If sets to null, the scene one is in use.
-     */
-    public set imageProcessingConfiguration(value: ImageProcessingConfiguration) {
-        this._attachImageProcessingConfiguration(value);
-
-        // Ensure the effect will be rebuilt.
-        this._markAllSubMeshesAsTexturesDirty();
-    }
-
-    /**
      * Gets whether the color curves effect is enabled.
      */
     public get cameraColorCurvesEnabled(): boolean {

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -3,7 +3,6 @@ import { GetEnvironmentBRDFTexture } from "../../Misc/brdfTextureTools";
 import type { Nullable } from "../../types";
 import type { Scene } from "../../scene";
 import { Color3 } from "../../Maths/math.color";
-import type { ImageProcessingConfiguration } from "../../Materials/imageProcessingConfiguration";
 import type { ColorCurves } from "../../Materials/colorCurves";
 import type { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { PBRBaseMaterial } from "./pbrBaseMaterial";

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -620,13 +620,6 @@ export class PBRMaterial extends PBRBaseMaterial {
     public unlit = false;
 
     /**
-     * Gets the image processing configuration used either in this material.
-     */
-    public get imageProcessingConfiguration(): ImageProcessingConfiguration {
-        return this._imageProcessingConfiguration;
-    }
-
-    /**
      * Gets whether the color curves effect is enabled.
      */
     public get cameraColorCurvesEnabled(): boolean {


### PR DESCRIPTION

We can disable "toGammaSpace" by setting imageProcessingConfiguration
```
mat.imageProcessingConfiguration = new BABYLON.ImageProcessingConfiguration();
mat.imageProcessingConfiguration.applyByPostProcess = true;
```
See: 
[Is there any way to disable “toGammaSpace” when using PBRMaterial or StandardMaterial](https://forum.babylonjs.com/t/is-there-any-way-to-disable-togammaspace-when-using-pbrmaterial-or-standardmaterial/39020)



But I found that it doesn't work for PBRBaseMaterial PBRMetallicRoughnessMaterial PBRSpecularGlossinessMaterial [playground](https://playground.babylonjs.com/#CP3FAA#1)

This PR add support for this situation