### PR TITLE
Add shouldExportAnimation option on GLTF exporter to filter out animations

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFAnimation.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFAnimation.ts
@@ -263,12 +263,16 @@ export class _GLTFAnimation {
         bufferViews: IBufferView[],
         accessors: IAccessor[],
         convertToRightHandedSystem: boolean,
-        animationSampleRate: number
+        animationSampleRate: number,
+        shouldExportAnimation?: (animation: Animation) => boolean
     ) {
         let glTFAnimation: IAnimation;
         if (_GLTFAnimation._IsTransformable(babylonNode)) {
             if (babylonNode.animations) {
                 for (const animation of babylonNode.animations) {
+                    if (shouldExportAnimation && !shouldExportAnimation(animation)) {
+                        continue;
+                    }
                     const animationInfo = _GLTFAnimation._DeduceAnimationInfo(animation);
                     if (animationInfo) {
                         glTFAnimation = {
@@ -324,7 +328,8 @@ export class _GLTFAnimation {
         bufferViews: IBufferView[],
         accessors: IAccessor[],
         convertToRightHandedSystem: boolean,
-        animationSampleRate: number
+        animationSampleRate: number,
+        shouldExportAnimation?: (animation: Animation) => boolean
     ) {
         let glTFAnimation: IAnimation;
         if (babylonNode instanceof Mesh) {
@@ -333,6 +338,9 @@ export class _GLTFAnimation {
                 for (let i = 0; i < morphTargetManager.numTargets; ++i) {
                     const morphTarget = morphTargetManager.getTarget(i);
                     for (const animation of morphTarget.animations) {
+                        if (shouldExportAnimation && !shouldExportAnimation(animation)) {
+                            continue;
+                        }
                         const combinedAnimation = new Animation(
                             `${animation.name}`,
                             "influence",
@@ -410,7 +418,8 @@ export class _GLTFAnimation {
         bufferViews: IBufferView[],
         accessors: IAccessor[],
         convertToRightHandedSystemMap: { [nodeId: number]: boolean },
-        animationSampleRate: number
+        animationSampleRate: number,
+        shouldExportAnimation?: (animation: Animation) => boolean
     ) {
         let glTFAnimation: IAnimation;
         if (babylonScene.animationGroups) {
@@ -429,6 +438,9 @@ export class _GLTFAnimation {
                     const targetAnimation = animationGroup.targetedAnimations[i];
                     const target = targetAnimation.target;
                     const animation = targetAnimation.animation;
+                    if (shouldExportAnimation && !shouldExportAnimation(animation)) {
+                        continue;
+                    }
                     if (this._IsTransformable(target) || (target.length === 1 && this._IsTransformable(target[0]))) {
                         const animationInfo = _GLTFAnimation._DeduceAnimationInfo(targetAnimation.animation);
                         if (animationInfo) {

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -2138,7 +2138,8 @@ export class _Exporter {
                                     this._bufferViews,
                                     this._accessors,
                                     convertToRightHandedSystem,
-                                    this._animationSampleRate
+                                    this._animationSampleRate,
+                                    this._options.shouldExportAnimation
                                 );
                                 if (babylonNode.animations.length) {
                                     _GLTFAnimation._CreateNodeAnimationFromNodeAnimations(
@@ -2151,7 +2152,8 @@ export class _Exporter {
                                         this._bufferViews,
                                         this._accessors,
                                         convertToRightHandedSystem,
-                                        this._animationSampleRate
+                                        this._animationSampleRate,
+                                        this._options.shouldExportAnimation
                                     );
                                 }
                             }
@@ -2181,7 +2183,8 @@ export class _Exporter {
                     this._bufferViews,
                     this._accessors,
                     this._convertToRightHandedSystemMap,
-                    this._animationSampleRate
+                    this._animationSampleRate,
+                    this._options.shouldExportAnimation
                 );
             }
 

--- a/packages/dev/serializers/src/glTF/2.0/glTFSerializer.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFSerializer.ts
@@ -1,5 +1,6 @@
 import type { Node } from "core/node";
 import type { Scene } from "core/scene";
+import type { Animation } from "core/Animations";
 import type { GLTFData } from "./glTFData";
 import { _Exporter } from "./glTFExporter";
 
@@ -13,6 +14,13 @@ export interface IExportOptions {
      * @returns boolean, which indicates whether the node should be exported (true) or not (false)
      */
     shouldExportNode?(node: Node): boolean;
+
+    /**
+     * Function which indicates whether an animation on the scene should be exported or not
+     * @param animation source animation
+     * @returns boolean, which indicates whether the animation should be exported (true) or not (false)
+     */
+    shouldExportAnimation?(animation: Animation): boolean;
 
     /**
      * Function used to extract the part of node's metadata that will be exported into glTF node extras


### PR DESCRIPTION
This add the possibility of the user choosing which animations will be in the exported GLTF.

Related forum issue: https://forum.babylonjs.com/t/how-to-exclude-all-disabled-nodes-from-export/38780/9