### PR TITLE
WebDeviceInputSystem: Add pointerId to WheelEvents when dispatching to InputManager

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -106,6 +106,10 @@ export class DeviceEventFactory {
     ): any {
         const evt = this._CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
 
+        // While WheelEvents don't generally have a pointerId, we used to add one in the InputManager
+        // This line has been added to make the InputManager more platform-agnostic
+        // Similar code exists in the WebDeviceInputSystem to handle browser created events
+        evt.pointerId = 1;
         evt.type = "wheel";
         evt.deltaMode = EventConstants.DOM_DELTA_PIXEL;
         evt.deltaX = 0;

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -709,6 +709,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 pointer[PointerInput.MouseWheelZ] = evt.deltaZ || 0;
 
                 const deviceEvent = evt as IUIEvent;
+                // By default, there is no pointerId for mouse wheel events so we'll add one here
+                if (!evt.pointerId) {
+                    evt.pointerId = this._isUsingFirefox ? 0 : 1;
+                }
 
                 if (pointer[PointerInput.MouseWheelX] !== 0) {
                     deviceEvent.inputIndex = PointerInput.MouseWheelX;

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -710,6 +710,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 const deviceEvent = evt as IUIEvent;
                 // By default, there is no pointerId for mouse wheel events so we'll add one here
+                // This logic was originally in the InputManager but was added here to make the
+                // InputManager more platform-agnostic
                 if (!evt.pointerId) {
                     evt.pointerId = this._isUsingFirefox ? 0 : 1;
                 }

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -84,7 +84,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._onInputChanged = onInputChanged;
 
         // If we need a pointerId, set one for future use
-        this._mouseId = this._isUsingFirefox || this._usingSafari ? 0 : 1;
+        this._mouseId = this._isUsingFirefox ? 0 : 1;
 
         this._enableEvents();
 

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -83,6 +83,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         this._onDeviceDisconnected = onDeviceDisconnected;
         this._onInputChanged = onInputChanged;
 
+        // If we need a pointerId, set one for future use
+        this._mouseId = this._isUsingFirefox || this._usingSafari ? 0 : 1;
+
         this._enableEvents();
 
         if (this._usingMacOS) {
@@ -426,6 +429,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 pointer[PointerInput.Horizontal] = evt.clientX;
                 pointer[PointerInput.Vertical] = evt.clientY;
 
+                if (evt.pointerId === undefined) {
+                    evt.pointerId = this._mouseId;
+                }
+
                 this._onInputChanged(deviceType, deviceSlot, deviceEvent);
 
                 // Lets Propagate the event for move with same position.
@@ -470,14 +477,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 const previousVertical = pointer[PointerInput.Vertical];
 
                 if (deviceType === DeviceType.Mouse) {
-                    // Mouse; Among supported browsers, value is either 1 or 0 for mouse
-                    if (this._mouseId === -1) {
-                        if (evt.pointerId === undefined) {
-                            // If there is no pointerId (eg. manually dispatched MouseEvent)
-                            this._mouseId = this._isUsingFirefox ? 0 : 1;
-                        } else {
-                            this._mouseId = evt.pointerId;
-                        }
+                    // Mouse; Set pointerId if undefined
+                    if (evt.pointerId === undefined) {
+                        evt.pointerId = this._mouseId;
                     }
 
                     if (!document.pointerLockElement) {
@@ -540,6 +542,10 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 pointer[evt.button + 2] = 0;
 
                 const deviceEvent = evt as IUIEvent;
+
+                if (evt.pointerId === undefined) {
+                    evt.pointerId = this._mouseId;
+                }
 
                 if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
                     deviceEvent.inputIndex = PointerInput.Move;
@@ -712,8 +718,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 // By default, there is no pointerId for mouse wheel events so we'll add one here
                 // This logic was originally in the InputManager but was added here to make the
                 // InputManager more platform-agnostic
-                if (!evt.pointerId) {
-                    evt.pointerId = this._isUsingFirefox ? 0 : 1;
+                if (evt.pointerId === undefined) {
+                    evt.pointerId = this._mouseId;
                 }
 
                 if (pointer[PointerInput.MouseWheelX] !== 0) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -794,11 +794,6 @@ export class InputManager {
             this._pickedDownMesh = null;
             this._meshPickProceed = false;
 
-            // preserve compatibility with Safari when pointerId is not present
-            if (evt.pointerId === undefined) {
-                (evt as any).pointerId = 0;
-            }
-
             // If ExclusiveDoubleClickMode is true, we need to resolve any pending delayed clicks
             if (InputManager.ExclusiveDoubleClickMode) {
                 for (let i = 0; i < this._delayedClicks.length; i++) {
@@ -887,11 +882,6 @@ export class InputManager {
             this._totalPointersPressed--;
             this._pickedUpMesh = null;
             this._meshPickProceed = false;
-
-            // preserve compatibility with Safari when pointerId is not present
-            if (evt.pointerId === undefined) {
-                (evt as any).pointerId = 0;
-            }
 
             this._updatePointerPosition(evt);
 

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -746,11 +746,6 @@ export class InputManager {
         };
 
         this._onPointerMove = (evt: IMouseEvent) => {
-            // preserve compatibility with Safari when pointerId is not present
-            if ((evt as IPointerEvent).pointerId === undefined) {
-                (evt as IPointerEvent as any).pointerId = 0;
-            }
-
             this._updatePointerPosition(evt as IPointerEvent);
 
             // Check if pointer leaves DragMovementThreshold range to determine if swipe is occurring

--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -78,9 +78,9 @@ describe("safari", () => {
     // This test just verifies that pointer capture is being set and released correctly
     // It should be noted that we can't move the cursor outside of the window so we have to test the
     // pointer capture functions (eg. hasPointerCapture)
-    // PG: https://playground.babylonjs.com/#5NMCCT
+    // PG: https://playground.babylonjs.com/#5NMCCT#2
     it("check pointerCapture", async () => {
-        await LoadPlayground(driver, "#5NMCCT", getGlobalConfig(), 1000);
+        await LoadPlayground(driver, "#5NMCCT#2", getGlobalConfig(), 1000);
         const el = await driver.findElement(By.id("babylon-canvas"));
 
         // With allowMouse = true, touch controls should move camera forward if isMouseEvent is true


### PR DESCRIPTION
A user in the forum found an issue where pointerout was being executed twice for an ActionManager event.  Upon closer inspection, it was determined that the WheelEvent was being given an erroneous pointerId, causing two different meshes under pointers to be stored.  This PR will fix the logic and remove the offending check from the InputManager to make it more platform-agnostic.

For Safari, all mouse pointerIds will be set to 1, if undefined.  This is because 1 is the current pointerId recognized when a pointercapture is active.  The pointercapture test for Safari has been updated to properly check this.

Forum Link: https://forum.babylonjs.com/t/triggering-pointer-out-actions-when-camera-change-causes-pointer-to-exit-mesh/39061