### PR TITLE
Playground: Fix engine displayed when using ?webgpu

### DIFF
--- a/packages/tools/playground/src/components/commandDropdownComponent.tsx
+++ b/packages/tools/playground/src/components/commandDropdownComponent.tsx
@@ -25,7 +25,7 @@ interface ICommandDropdownComponentProps {
     toRight?: boolean;
 }
 
-export class CommandDropdownComponent extends React.Component<ICommandDropdownComponentProps, { isExpanded: boolean; }> {
+export class CommandDropdownComponent extends React.Component<ICommandDropdownComponentProps, { isExpanded: boolean }> {
     public constructor(props: ICommandDropdownComponentProps) {
         super(props);
 
@@ -77,9 +77,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                 <img src={"imgs/" + this.props.icon + ".svg"} />
                             </div>
                         )}
-                        {(!this.props.icon || this.props.hamburgerMode) && (
-                            <div className="command-dropdown-active">{activeState === "Latest" ? engineVersion : activeState}</div>
-                        )}
+                        {(!this.props.icon || this.props.hamburgerMode) && <div className="command-dropdown-active">{activeState === "Latest" ? engineVersion : activeState}</div>}
                     </div>
                     {this.state.isExpanded && (
                         <div className={"command-dropdown-content sub1" + (this.props.toRight ? " toRight" : "")}>

--- a/packages/tools/playground/src/components/commandDropdownComponent.tsx
+++ b/packages/tools/playground/src/components/commandDropdownComponent.tsx
@@ -25,13 +25,12 @@ interface ICommandDropdownComponentProps {
     toRight?: boolean;
 }
 
-export class CommandDropdownComponent extends React.Component<ICommandDropdownComponentProps, { isExpanded: boolean; activeState: string }> {
+export class CommandDropdownComponent extends React.Component<ICommandDropdownComponentProps, { isExpanded: boolean; }> {
     public constructor(props: ICommandDropdownComponentProps) {
         super(props);
 
         this.state = {
             isExpanded: false,
-            activeState: Utilities.ReadStringFromStore(this.props.storeKey || this.props.tooltip, this.props.defaultValue!, this.props.useSessionStorage),
         };
 
         this.props.globalState.onNewDropdownButtonClicked.add((source) => {
@@ -45,6 +44,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
 
     public render() {
         const engineVersion = Engine.Version.split("-")[0];
+        const activeState = Utilities.ReadStringFromStore(this.props.storeKey || this.props.tooltip, this.props.defaultValue!, this.props.useSessionStorage);
 
         return (
             <>
@@ -78,7 +78,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                             </div>
                         )}
                         {(!this.props.icon || this.props.hamburgerMode) && (
-                            <div className="command-dropdown-active">{this.state.activeState === "Latest" ? engineVersion : this.state.activeState}</div>
+                            <div className="command-dropdown-active">{activeState === "Latest" ? engineVersion : activeState}</div>
                         )}
                     </div>
                     {this.state.isExpanded && (
@@ -103,7 +103,7 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                             if (!m.subItems) {
                                                 m.onClick();
                                                 Utilities.StoreStringToStore(this.props.storeKey || this.props.tooltip, m.label);
-                                                this.setState({ isExpanded: false, activeState: m.label });
+                                                this.setState({ isExpanded: false });
                                             }
                                         }}
                                         title={m.tooltip || m.label}


### PR DESCRIPTION
Fixes #13660

Issue was that the state is not updated on redraw. The state changes outside of the context of the component, but the component is not updated.
Setting the call to load the data from the local storage on each render won't hurt performance (as it happend only once and when changing the engine, but not on every frame)