### PR TITLE
Fix word wrap ellipsis algorithm.

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -554,7 +554,7 @@ export class TextBlock extends Control {
             if (currentHeight > height && n > 1) {
                 const lastLine = lines[n - 2] as { text: string; width: number };
                 const currentLine = lines[n - 1] as { text: string; width: number };
-                lines[n - 2] = this._parseLineEllipsis(`${lastLine.text + currentLine.text}`, width, context);
+                lines[n - 2] = this._parseLineEllipsis(lastLine.text + this._wordDivider + currentLine.text, width, context);
                 const linesToRemove = lines.length - n + 1;
                 for (let i = 0; i < linesToRemove; i++) {
                     lines.pop();


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-text-wrapping/39299

The points where the last lines were rejoined to run the ellipsis calculation was missing the wordDivider.

With the fix:
![image](https://user-images.githubusercontent.com/6002144/227340753-7a68832d-e995-4c35-822e-a3166d3dfa7d.png)
