### PR TITLE
[Bugfix] Respect options.powerPreference without doNotHandleContextLost flag

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -906,7 +906,7 @@ export class ThinEngine {
                 canvas.addEventListener("webglcontextlost", this._onContextLost, false);
                 canvas.addEventListener("webglcontextrestored", this._onContextRestored, false);
 
-                options.powerPreference = "high-performance";
+                options.powerPreference = options.powerPreference || "high-performance";
             }
 
             // Detect if we are running on a faulty buggy desktop OS.


### PR DESCRIPTION
Based on the discussion: https://forum.babylonjs.com/t/engine-creation-options-probably-small-bug/33522

The engine should respect user's value for `powerPreference` even without `doNotHandleContextLost` flag.