### PR TITLE
Fix stopAllAnimatables stop loop order.

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -866,8 +866,8 @@ Scene.prototype.stopAnimation = function (target: any, animationName?: string, t
  */
 Scene.prototype.stopAllAnimations = function (): void {
     if (this._activeAnimatables) {
-        for (let i = this._activeAnimatables.length - 1; i >= 0; i--) {
-            this._activeAnimatables[i].stop();
+        for (let i = 0; i < this._activeAnimatables.length; i++) {
+            this._activeAnimatables[i].stop(undefined, undefined, true);
         }
         this._activeAnimatables.length = 0;
     }

--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -866,7 +866,7 @@ Scene.prototype.stopAnimation = function (target: any, animationName?: string, t
  */
 Scene.prototype.stopAllAnimations = function (): void {
     if (this._activeAnimatables) {
-        for (let i = 0; i < this._activeAnimatables.length; i++) {
+        for (let i = this._activeAnimatables.length - 1; i >= 0; i--) {
             this._activeAnimatables[i].stop();
         }
         this._activeAnimatables.length = 0;


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/using-scene-stopallanimations-does-not-remove-all-animatables-from-animationgroup-and-stops-the-onanimationgroupendobservable-callback-from-being-called/39409

`Animatable.stop` calls splice on the _activeAnimatables array, so we should call it in reverse order to ensure proper iteration.