### PR TITLE
Scene optimizer: Don't merge meshes without positions

### DIFF
--- a/packages/dev/core/src/Misc/sceneOptimizer.ts
+++ b/packages/dev/core/src/Misc/sceneOptimizer.ts
@@ -385,6 +385,10 @@ export class MergeMeshesOptimization extends SceneOptimization {
             return false;
         }
 
+        if (mesh.getTotalVertices() === 0) {
+            return false;
+        }
+
         return true;
     };
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/positions-are-required-error-from-merge-mesh-optimization-sceneoptimizer/39423