### PR TITLE
Allow FilesInput to append to scene (instead of creating a new one)

### DIFF
--- a/packages/dev/core/src/Misc/filesInput.ts
+++ b/packages/dev/core/src/Misc/filesInput.ts
@@ -24,6 +24,8 @@ export class FilesInput {
         return true;
     };
 
+    public displyLoadingUI: boolean = true;
+
     /**
      * Function used when loading the scene file
      * @param sceneFile
@@ -298,7 +300,9 @@ export class FilesInput {
             }
 
             SceneLoader.ShowLoadingScreen = false;
-            this._engine.displayLoadingUI();
+            if (this.displyLoadingUI) {
+                this._engine.displayLoadingUI();
+            }
 
             this.loadAsync(this._sceneFileToLoad, this._progressCallback)
                 .then((scene) => {
@@ -312,20 +316,26 @@ export class FilesInput {
 
                         // Wait for textures and shaders to be ready
                         this._currentScene.executeWhenReady(() => {
-                            this._engine.hideLoadingUI();
+                            if (this.displyLoadingUI) {
+                                this._engine.hideLoadingUI();
+                            }
                             this._engine.runRenderLoop(() => {
                                 this._renderFunction();
                             });
                         });
                     } else {
-                        this._engine.hideLoadingUI();
+                        if (this.displyLoadingUI) {
+                            this._engine.hideLoadingUI();
+                        }
                     }
                     if (this._sceneLoadedCallback && this._currentScene) {
                         this._sceneLoadedCallback(this._sceneFileToLoad, this._currentScene);
                     }
                 })
                 .catch((error) => {
-                    this._engine.hideLoadingUI();
+                    if (this.displyLoadingUI) {
+                        this._engine.hideLoadingUI();
+                    }
                     if (this._errorCallback) {
                         this._errorCallback(this._sceneFileToLoad, this._currentScene, error.message);
                     }

--- a/packages/dev/core/src/Misc/filesInput.ts
+++ b/packages/dev/core/src/Misc/filesInput.ts
@@ -50,7 +50,7 @@ export class FilesInput {
      * Creates a new FilesInput
      * @param engine defines the rendering engine
      * @param scene defines the hosting scene
-     * @param sceneLoadedCallback callback called when scene is loaded
+     * @param sceneLoadedCallback callback called when scene (files provided) is loaded
      * @param progressCallback callback called to track progress
      * @param additionalRenderLoopLogicCallback callback called to add user logic to the rendering loop
      * @param textureLoadingCallback callback called when a texture is loading
@@ -288,11 +288,13 @@ export class FilesInput {
     public reload() {
         // If a scene file has been provided
         if (this._sceneFileToLoad) {
-            if (this._currentScene) {
-                if (Logger.errorsCount > 0) {
-                    Logger.ClearLogCache();
+            if (!this.useAppend) {
+                if (this._currentScene) {
+                    if (Logger.errorsCount > 0) {
+                        Logger.ClearLogCache();
+                    }
+                    this._engine.stopRenderLoop();
                 }
-                this._engine.stopRenderLoop();
             }
 
             SceneLoader.ShowLoadingScreen = false;
@@ -315,6 +317,8 @@ export class FilesInput {
                                 this._renderFunction();
                             });
                         });
+                    } else {
+                        this._engine.hideLoadingUI();
                     }
                     if (this._sceneLoadedCallback && this._currentScene) {
                         this._sceneLoadedCallback(this._sceneFileToLoad, this._currentScene);


### PR DESCRIPTION
At the moment filesinput use LoadAsync, which creates a new scene and disposes the old one.