### PR TITLE
Add overrideMaterialFillMode property to Mesh

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -888,7 +888,7 @@ export abstract class EffectLayer {
 
             engine.enableEffect(drawWrapper);
             if (!hardwareInstancedRendering) {
-                const fillMode = subMesh.getFillMode(material, scene);
+                const fillMode = scene.forcePointsCloud ? Material.PointFillMode : scene.forceWireframe ? Material.WireFrameFillMode : renderingMesh.getFillMode(material);
                 renderingMesh._bind(subMesh, effect, fillMode);
             }
 
@@ -971,7 +971,7 @@ export abstract class EffectLayer {
             }
 
             // Draw
-            renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
+            renderingMesh._processRendering(effectiveMesh, subMesh, effect, renderingMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
                 effect.setMatrix("world", world)
             );
         } else {

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -888,7 +888,7 @@ export abstract class EffectLayer {
 
             engine.enableEffect(drawWrapper);
             if (!hardwareInstancedRendering) {
-                const fillMode = scene.forcePointsCloud ? Material.PointFillMode : scene.forceWireframe ? Material.WireFrameFillMode : material.fillMode;
+                const fillMode = subMesh.getFillMode(material, scene);
                 renderingMesh._bind(subMesh, effect, fillMode);
             }
 
@@ -971,7 +971,7 @@ export abstract class EffectLayer {
             }
 
             // Draw
-            renderingMesh._processRendering(effectiveMesh, subMesh, effect, material.fillMode, batch, hardwareInstancedRendering, (isInstance, world) =>
+            renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
                 effect.setMatrix("world", world)
             );
         } else {

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1194,7 +1194,7 @@ export class ShadowGenerator implements IShadowGenerator {
             engine.enableEffect(drawWrapper);
 
             if (!hardwareInstancedRendering) {
-                renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
+                renderingMesh._bind(subMesh, effect, renderingMesh.getFillMode(material));
             }
 
             this.getTransformMatrix(); // make sure _cachedDirection et _cachedPosition are up to date
@@ -1293,7 +1293,7 @@ export class ShadowGenerator implements IShadowGenerator {
             this.onBeforeShadowMapRenderObservable.notifyObservers(effect);
 
             // Draw
-            renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, worldOverride) => {
+            renderingMesh._processRendering(effectiveMesh, subMesh, effect, renderingMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, worldOverride) => {
                 if (effectiveMesh !== renderingMesh && !isInstance) {
                     renderingMesh.getMeshUniformBuffer().bindToEffect(effect, "Mesh");
                     renderingMesh.transferToEffect(worldOverride);

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1194,7 +1194,7 @@ export class ShadowGenerator implements IShadowGenerator {
             engine.enableEffect(drawWrapper);
 
             if (!hardwareInstancedRendering) {
-                renderingMesh._bind(subMesh, effect, material.fillMode);
+                renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
             }
 
             this.getTransformMatrix(); // make sure _cachedDirection et _cachedPosition are up to date
@@ -1293,7 +1293,7 @@ export class ShadowGenerator implements IShadowGenerator {
             this.onBeforeShadowMapRenderObservable.notifyObservers(effect);
 
             // Draw
-            renderingMesh._processRendering(effectiveMesh, subMesh, effect, material.fillMode, batch, hardwareInstancedRendering, (isInstance, worldOverride) => {
+            renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, worldOverride) => {
                 if (effectiveMesh !== renderingMesh && !isInstance) {
                     renderingMesh.getMeshUniformBuffer().bindToEffect(effect, "Mesh");
                     renderingMesh.transferToEffect(worldOverride);

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1781,6 +1781,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         }
 
         // Collide
+        const material = subMesh.getMaterial();
         collider._collide(
             subMesh._trianglePlanes,
             subMesh._lastColliderWorldVertices,
@@ -1788,10 +1789,10 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             subMesh.indexStart,
             subMesh.indexStart + subMesh.indexCount,
             subMesh.verticesStart,
-            !!subMesh.getMaterial(),
+            !!material,
             this,
             this._shouldConvertRHS(),
-            subMesh.getMaterial()?.fillMode === Constants.MATERIAL_TriangleStripDrawMode
+            !!material && subMesh.getFillMode(material) === Constants.MATERIAL_TriangleStripDrawMode
         );
         return this;
     }
@@ -1903,12 +1904,13 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             if (!material) {
                 continue;
             }
+            const fillMode = subMesh.getFillMode(material);
             if (
-                material.fillMode == Constants.MATERIAL_TriangleStripDrawMode ||
-                material.fillMode == Constants.MATERIAL_TriangleFillMode ||
-                material.fillMode == Constants.MATERIAL_WireFrameFillMode ||
-                material.fillMode == Constants.MATERIAL_PointFillMode ||
-                material.fillMode == Constants.MATERIAL_LineListDrawMode
+                fillMode == Constants.MATERIAL_TriangleStripDrawMode ||
+                fillMode == Constants.MATERIAL_TriangleFillMode ||
+                fillMode == Constants.MATERIAL_WireFrameFillMode ||
+                fillMode == Constants.MATERIAL_PointFillMode ||
+                fillMode == Constants.MATERIAL_LineListDrawMode
             ) {
                 anySubmeshSupportIntersect = true;
                 break;

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1792,7 +1792,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             !!material,
             this,
             this._shouldConvertRHS(),
-            !!material && subMesh.getFillMode(material) === Constants.MATERIAL_TriangleStripDrawMode
+            !!material && subMesh.getRenderingMesh().getFillMode(material) === Constants.MATERIAL_TriangleStripDrawMode
         );
         return this;
     }
@@ -1904,7 +1904,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             if (!material) {
                 continue;
             }
-            const fillMode = subMesh.getFillMode(material);
+            const fillMode = subMesh.getRenderingMesh().getFillMode(material);
             if (
                 fillMode == Constants.MATERIAL_TriangleStripDrawMode ||
                 fillMode == Constants.MATERIAL_TriangleFillMode ||

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -143,6 +143,8 @@ class _InternalMeshDataInfo {
     public _effectiveMaterial: Nullable<Material> = null;
 
     public _forcedInstanceCount: number = 0;
+
+    public _overrideMaterialFillMode: Nullable<number> = null;
 }
 
 /**
@@ -442,7 +444,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
      * Use this property to override Material's fillMode value
      */
-    public overrideMaterialFillMode: Nullable<number> = null;
+    public get overrideMaterialFillMode(): Nullable<number> {
+        return this._internalMeshDataInfo._overrideMaterialFillMode;
+    }
+
+    public set overrideMaterialFillMode(fillMode: Nullable<number>) {
+        this._internalMeshDataInfo._overrideMaterialFillMode = fillMode;
+    }
 
     /**
      * Gets or sets a boolean indicating whether to render ignoring the active camera's max z setting. (false by default)

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1201,6 +1201,14 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         return this._geometry.getIndices(copyWhenShared, forceCopy);
     }
 
+    /**
+     * @internal
+     * Get active fillMode for specified material with override applied
+     * */
+    public getFillMode(material: Material): number {
+        return this.overrideMaterialFillMode ?? material.fillMode;
+    }
+
     public get isBlocked(): boolean {
         return this._masterMesh !== null && this._masterMesh !== undefined;
     }
@@ -2333,7 +2341,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Bind
-        const fillMode = subMesh.getFillMode(this._internalMeshDataInfo._effectiveMaterial, scene);
+        const fillMode = scene.forcePointsCloud
+            ? Material.PointFillMode
+            : scene.forceWireframe
+            ? Material.WireFrameFillMode
+            : this.getFillMode(this._internalMeshDataInfo._effectiveMaterial);
 
         if (this._internalMeshDataInfo._onBeforeBindObservable) {
             this._internalMeshDataInfo._onBeforeBindObservable.notifyObservers(this);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -440,6 +440,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     public overrideMaterialSideOrientation: Nullable<number> = null;
 
     /**
+     * Use this property to override Material's fillMode value
+     */
+    public overrideMaterialFillMode: Nullable<number> = null;
+
+    /**
      * Gets or sets a boolean indicating whether to render ignoring the active camera's max z setting. (false by default)
      * Note this will reduce performance when set to true.
      */
@@ -2320,11 +2325,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Bind
-        const fillMode = scene.forcePointsCloud
-            ? Material.PointFillMode
-            : scene.forceWireframe
-            ? Material.WireFrameFillMode
-            : this._internalMeshDataInfo._effectiveMaterial.fillMode;
+        const fillMode = subMesh.getFillMode(this._internalMeshDataInfo._effectiveMaterial, scene);
 
         if (this._internalMeshDataInfo._onBeforeBindObservable) {
             this._internalMeshDataInfo._onBeforeBindObservable.notifyObservers(this);
@@ -3631,6 +3632,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         serializationObject.checkCollisions = this.checkCollisions;
         serializationObject.isBlocker = this.isBlocker;
         serializationObject.overrideMaterialSideOrientation = this.overrideMaterialSideOrientation;
+        serializationObject.overrideMaterialFillMode = this.overrideMaterialFillMode;
 
         // Parent
         if (this.parent) {
@@ -3979,6 +3981,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         mesh.checkCollisions = parsedMesh.checkCollisions;
         mesh.overrideMaterialSideOrientation = parsedMesh.overrideMaterialSideOrientation;
+        mesh.overrideMaterialFillMode = parsedMesh.overrideMaterialFillMode;
 
         if (parsedMesh.isBlocker !== undefined) {
             mesh.isBlocker = parsedMesh.isBlocker;

--- a/packages/dev/core/src/Meshes/subMesh.project.ts
+++ b/packages/dev/core/src/Meshes/subMesh.project.ts
@@ -95,8 +95,9 @@ SubMesh.prototype.projectToRef = function (vector: Vector3, positions: Vector3[]
     }
     let step = 3;
     let checkStopper = false;
+    const fillMode = this.getFillMode(material);
 
-    switch (material.fillMode) {
+    switch (fillMode) {
         case Constants.MATERIAL_PointListDrawMode:
         case Constants.MATERIAL_LineLoopDrawMode:
         case Constants.MATERIAL_LineStripDrawMode:
@@ -111,7 +112,7 @@ SubMesh.prototype.projectToRef = function (vector: Vector3, positions: Vector3[]
     }
 
     // LineMesh first as it's also a Mesh...
-    if (material.fillMode === Constants.MATERIAL_LineListDrawMode) {
+    if (fillMode === Constants.MATERIAL_LineListDrawMode) {
         return -1;
     } else {
         // Check if mesh is unindexed

--- a/packages/dev/core/src/Meshes/subMesh.project.ts
+++ b/packages/dev/core/src/Meshes/subMesh.project.ts
@@ -95,7 +95,7 @@ SubMesh.prototype.projectToRef = function (vector: Vector3, positions: Vector3[]
     }
     let step = 3;
     let checkStopper = false;
-    const fillMode = this.getFillMode(material);
+    const fillMode = this.getRenderingMesh().getFillMode(material);
 
     switch (fillMode) {
         case Constants.MATERIAL_PointListDrawMode:

--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -12,7 +12,6 @@ import { extractMinAndMaxIndexed } from "../Maths/math.functions";
 import type { Plane } from "../Maths/math.plane";
 import { DrawWrapper } from "../Materials/drawWrapper";
 import type { IMaterialContext } from "../Engines/IMaterialContext";
-import type { Scene } from "../scene";
 
 declare type Collider = import("../Collisions/collider").Collider;
 declare type Material = import("../Materials/material").Material;
@@ -320,22 +319,6 @@ export class SubMesh implements ICullable {
         return (material as MultiMaterial).getSubMaterial !== undefined;
     }
 
-    /**
-     * @internal
-     * Get active fillMode for specified material and optional scene for global overrides
-     * */
-    public getFillMode(material: Material, scene?: Scene): number {
-        if (scene) {
-            if (scene.forcePointsCloud) {
-                return Constants.MATERIAL_PointFillMode;
-            }
-            if (scene.forceWireframe) {
-                return Constants.MATERIAL_WireFrameFillMode;
-            }
-        }
-        return this._renderingMesh.overrideMaterialFillMode ?? material.fillMode;
-    }
-
     // Methods
 
     /**
@@ -490,7 +473,7 @@ export class SubMesh implements ICullable {
         if (!material) {
             return null;
         }
-        const fillMode = this.getFillMode(material);
+        const fillMode = this.getRenderingMesh().getFillMode(material);
         let step = 3;
         let checkStopper = false;
 

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -390,7 +390,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
                 engine.enableEffect(drawWrapper);
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, material.fillMode);
+                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
                 }
 
                 if (renderingMesh === this.mesh) {

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -390,7 +390,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
                 engine.enableEffect(drawWrapper);
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
+                    renderingMesh._bind(subMesh, effect, renderingMesh.getFillMode(material));
                 }
 
                 if (renderingMesh === this.mesh) {

--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -425,10 +425,10 @@ export class DepthPeelingRenderer {
         for (let i = 0; i < transparentSubMeshes.length; i++) {
             const subMesh = transparentSubMeshes.data[i];
             const material = subMesh.getMaterial();
+            const fillMode = material && subMesh.getFillMode(material);
 
             if (
-                material &&
-                (material.fillMode === Material.TriangleFanDrawMode || material.fillMode === Material.TriangleFillMode || material.fillMode === Material.TriangleStripDrawMode) &&
+                (fillMode === Material.TriangleFanDrawMode || fillMode === Material.TriangleFillMode || fillMode === Material.TriangleStripDrawMode) &&
                 this._excludedMeshes.indexOf(subMesh.getMesh().uniqueId) === -1
             ) {
                 this._candidateSubMeshes.push(subMesh);

--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -425,7 +425,7 @@ export class DepthPeelingRenderer {
         for (let i = 0; i < transparentSubMeshes.length; i++) {
             const subMesh = transparentSubMeshes.data[i];
             const material = subMesh.getMaterial();
-            const fillMode = material && subMesh.getFillMode(material);
+            const fillMode = material && subMesh.getRenderingMesh().getFillMode(material);
 
             if (
                 (fillMode === Material.TriangleFanDrawMode || fillMode === Material.TriangleFillMode || fillMode === Material.TriangleStripDrawMode) &&

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -234,7 +234,7 @@ export class DepthRenderer {
                 engine.enableEffect(drawWrapper);
 
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, material.fillMode);
+                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
                 }
 
                 if (!renderingMaterial) {
@@ -298,7 +298,7 @@ export class DepthRenderer {
                 }
 
                 // Draw
-                renderingMesh._processRendering(effectiveMesh, subMesh, effect, material.fillMode, batch, hardwareInstancedRendering, (isInstance, world) =>
+                renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
                     effect.setMatrix("world", world)
                 );
             }

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -234,7 +234,7 @@ export class DepthRenderer {
                 engine.enableEffect(drawWrapper);
 
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
+                    renderingMesh._bind(subMesh, effect, renderingMesh.getFillMode(material));
                 }
 
                 if (!renderingMaterial) {
@@ -298,7 +298,7 @@ export class DepthRenderer {
                 }
 
                 // Draw
-                renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
+                renderingMesh._processRendering(effectiveMesh, subMesh, effect, renderingMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) =>
                     effect.setMatrix("world", world)
                 );
             }

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -804,7 +804,7 @@ export class GeometryBufferRenderer {
 
                 engine.enableEffect(drawWrapper);
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, material.fillMode);
+                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
                 }
 
                 if (!this._useUbo) {
@@ -960,7 +960,7 @@ export class GeometryBufferRenderer {
                 }
 
                 // Draw
-                renderingMesh._processRendering(effectiveMesh, subMesh, effect, material.fillMode, batch, hardwareInstancedRendering, (isInstance, w) => {
+                renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, w) => {
                     if (!isInstance) {
                         effect.setMatrix("world", w);
                     }

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -804,7 +804,7 @@ export class GeometryBufferRenderer {
 
                 engine.enableEffect(drawWrapper);
                 if (!hardwareInstancedRendering) {
-                    renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
+                    renderingMesh._bind(subMesh, effect, renderingMesh.getFillMode(material));
                 }
 
                 if (!this._useUbo) {
@@ -960,7 +960,7 @@ export class GeometryBufferRenderer {
                 }
 
                 // Draw
-                renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, w) => {
+                renderingMesh._processRendering(effectiveMesh, subMesh, effect, renderingMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, w) => {
                     if (!isInstance) {
                         effect.setMatrix("world", w);
                     }

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -219,7 +219,7 @@ export class OutlineRenderer implements ISceneComponent {
         MaterialHelper.BindMorphTargetParameters(renderingMesh, effect);
 
         if (!hardwareInstancedRendering) {
-            renderingMesh._bind(subMesh, effect, material.fillMode);
+            renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
         }
 
         // Alpha test
@@ -237,7 +237,7 @@ export class OutlineRenderer implements ISceneComponent {
         engine.setZOffset(-this.zOffset);
         engine.setZOffsetUnits(-this.zOffsetUnits);
 
-        renderingMesh._processRendering(effectiveMesh, subMesh, effect, material.fillMode, batch, hardwareInstancedRendering, (isInstance, world) => {
+        renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) => {
             effect.setMatrix("world", world);
         });
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -219,7 +219,7 @@ export class OutlineRenderer implements ISceneComponent {
         MaterialHelper.BindMorphTargetParameters(renderingMesh, effect);
 
         if (!hardwareInstancedRendering) {
-            renderingMesh._bind(subMesh, effect, subMesh.getFillMode(material));
+            renderingMesh._bind(subMesh, effect, renderingMesh.getFillMode(material));
         }
 
         // Alpha test
@@ -237,7 +237,7 @@ export class OutlineRenderer implements ISceneComponent {
         engine.setZOffset(-this.zOffset);
         engine.setZOffsetUnits(-this.zOffsetUnits);
 
-        renderingMesh._processRendering(effectiveMesh, subMesh, effect, subMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) => {
+        renderingMesh._processRendering(effectiveMesh, subMesh, effect, renderingMesh.getFillMode(material), batch, hardwareInstancedRendering, (isInstance, world) => {
             effect.setMatrix("world", world);
         });
 

--- a/packages/dev/core/test/unit/Meshes/babylon.dictionaryMode.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.dictionaryMode.test.ts
@@ -22,7 +22,7 @@ describe("Babylon Mesh", () => {
     });
 
     describe("#Mesh dictionary mode threshold", () => {
-        it("No more than 144 own properties on a mesh", () => {
+        it("No more than 128 own properties on a mesh", () => {
             const scene = new Scene(subject);
             const mesh = MeshBuilder.CreateGround("ground1", { width: 6, height: 6, subdivisions: 2 }, scene);
 
@@ -33,7 +33,7 @@ describe("Babylon Mesh", () => {
                 }
             }
 
-            expect(count).toBeLessThan(144);
+            expect(count).toBeLessThan(128);
         });
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.dictionaryMode.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.dictionaryMode.test.ts
@@ -22,7 +22,7 @@ describe("Babylon Mesh", () => {
     });
 
     describe("#Mesh dictionary mode threshold", () => {
-        it("No more than 128 own properties on a mesh", () => {
+        it("No more than 144 own properties on a mesh", () => {
             const scene = new Scene(subject);
             const mesh = MeshBuilder.CreateGround("ground1", { width: 6, height: 6, subdivisions: 2 }, scene);
 
@@ -33,7 +33,7 @@ describe("Babylon Mesh", () => {
                 }
             }
 
-            expect(count).toBeLessThan(128);
+            expect(count).toBeLessThan(144);
         });
     });
 });

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1547,6 +1547,12 @@ export class _Exporter {
         if (babylonMesh instanceof LinesMesh) {
             return Material.LineListDrawMode;
         }
+        if (babylonMesh instanceof InstancedMesh || babylonMesh instanceof Mesh) {
+            const baseMesh = babylonMesh instanceof Mesh ? babylonMesh : babylonMesh.sourceMesh;
+            if (typeof baseMesh.overrideMaterialFillMode === 'number') {
+                return baseMesh.overrideMaterialFillMode;
+            }
+        }
         return babylonMesh.material ? babylonMesh.material.fillMode : Material.TriangleFillMode;
     }
 

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1549,7 +1549,7 @@ export class _Exporter {
         }
         if (babylonMesh instanceof InstancedMesh || babylonMesh instanceof Mesh) {
             const baseMesh = babylonMesh instanceof Mesh ? babylonMesh : babylonMesh.sourceMesh;
-            if (typeof baseMesh.overrideMaterialFillMode === 'number') {
+            if (typeof baseMesh.overrideMaterialFillMode === "number") {
                 return baseMesh.overrideMaterialFillMode;
             }
         }


### PR DESCRIPTION
As discussed in forum thread here: https://forum.babylonjs.com/t/add-mesh-overridematerialfillmode/39475/

It seems to work fine for playground `/#WX0F9G`. The model has 2 meshes, each with bunch of instances, both share same material. The playground example changes `overrideMaterialFillMode` on the other mesh only.