### PR TITLE
NativeEngine: Override updateRenderTargetTextureSampleCount to prevent crashes

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2180,7 +2180,13 @@ export class NativeEngine extends Engine {
         return rtWrapper;
     }
 
+    // This function is being added for the sole purpose of overriding the ThinEngine version.  The reason
+    // for this is that the ThinEngine version of this function uses a WebGL2RenderingContext, which is not
+    // available in Babylon Native.  The return value is just a hard-coded value that is not used anywhere
+    // in Babylon Native's code.  This is effectively a hack/workaround so that Babylon Native doesn't crash
+    // This function should be updated once the maxMSAASamples is updated as well.
     public updateRenderTargetTextureSampleCount(rtWrapper: RenderTargetWrapper, samples: number): number {
+        // TODO: Implement this function once the maxMSAASamples is updated.
         return 1;
     }
 

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2148,13 +2148,13 @@ export class NativeEngine extends Engine {
         let generateStencilBuffer = false;
         let noColorAttachment = false;
         let colorAttachment: InternalTexture | undefined = undefined;
-        //let samples = 1;
+        let samples = 1;
         if (options !== undefined && typeof options === "object") {
             generateDepthBuffer = options.generateDepthBuffer ?? true;
             generateStencilBuffer = !!options.generateStencilBuffer;
             noColorAttachment = !!options.noColorAttachment;
             colorAttachment = options.colorAttachment;
-            //samples = options.samples ?? 1;
+            samples = options.samples ?? 1;
         }
 
         const texture = colorAttachment || (noColorAttachment ? null : this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget));
@@ -2175,10 +2175,13 @@ export class NativeEngine extends Engine {
 
         rtWrapper.setTextures(texture);
 
-        // TODO: handle this in native
-        //this.updateRenderTargetTextureSampleCount(rtWrapper, samples);
+        this.updateRenderTargetTextureSampleCount(rtWrapper, samples);
 
         return rtWrapper;
+    }
+
+    public updateRenderTargetTextureSampleCount(rtWrapper: RenderTargetWrapper, samples: number): number {
+        return 1;
     }
 
     public updateTextureSamplingMode(samplingMode: number, texture: InternalTexture): void {


### PR DESCRIPTION
A bug was found where Babylon Native would crash when opening files with certain extensions like Transmission.  The issue was that functions were being called within the ThinEngine that required the presence of a WebGL2RenderingContext (which the NativeEngine has no context for).  The code in this PR serves as a workaround so that this object be will avoided.  This allows Babylon Native to open previously unopenable files.  It should be noted that these file will render accurately when IBL is active.  When IBL is not active, the transmission extension will not render properly.  This issue will be addressed in a later PR.

Bug: https://github.com/BabylonJS/BabylonNative/issues/1166