### PR TITLE
Screenshot: Add finalWidth and finalHeight to the size object

### DIFF
--- a/packages/dev/core/src/Misc/interfaces/screenshotSize.ts
+++ b/packages/dev/core/src/Misc/interfaces/screenshotSize.ts
@@ -4,18 +4,34 @@
  */
 export interface IScreenshotSize {
     /**
-     * number in pixels for canvas height
+     * number in pixels for canvas height. It is the height of the texture used to render the scene
      */
     height?: number;
 
     /**
      * multiplier allowing render at a higher or lower resolution
-     * If value is defined then height and width will be ignored and taken from camera
+     * If value is defined then width and height will be multiplied by this value
      */
     precision?: number;
 
     /**
-     * number in pixels for canvas width
+     * number in pixels for canvas width. It is the width of the texture used to render the scene
      */
     width?: number;
+
+    /**
+     * Width of the final screenshot image.
+     * If only one of the two values is provided, the other will be calculated based on the camera's aspect ratio.
+     * If both finalWidth and finalHeight are not provided, width and height will be used instead.
+     * finalWidth and finalHeight are used only by CreateScreenshotUsingRenderTarget, not by CreateScreenshot!
+     */
+    finalWidth?: number;
+
+    /**
+     * Height of the final screenshot image.
+     * If only one of the two values is provided, the other will be calculated based on the camera's aspect ratio.
+     * If both finalWidth and finalHeight are not provided, width and height will be used instead
+     * finalWidth and finalHeight are used only by CreateScreenshotUsingRenderTarget, not by CreateScreenshot!
+     */
+    finalHeight?: number;
 }

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -96,7 +96,9 @@ export function ApplyPostProcess(
     scene: Scene,
     type?: number,
     samplingMode?: number,
-    format?: number
+    format?: number,
+    width?: number,
+    height?: number
 ): Promise<InternalTexture> {
     // Gets everything ready.
     const engine = internalTexture.getEngine() as Engine;
@@ -106,6 +108,8 @@ export function ApplyPostProcess(
     samplingMode = samplingMode ?? internalTexture.samplingMode;
     type = type ?? internalTexture.type;
     format = format ?? internalTexture.format;
+    width = width ?? internalTexture.width;
+    height = height ?? internalTexture.height;
 
     if (type === -1) {
         type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
@@ -118,7 +122,7 @@ export function ApplyPostProcess(
 
         // Hold the output of the decoding.
         const encodedTexture = engine.createRenderTargetTexture(
-            { width: internalTexture.width, height: internalTexture.height },
+            { width: width as number, height: height as number },
             {
                 generateDepthBuffer: false,
                 generateMipMaps: false,


### PR DESCRIPTION
See https://forum.babylonjs.com/t/create-screenshot-using-render-target-ignores-hardware-scaling-level/39626/3