### PR TITLE
Animation: Fix infinite loop when mutating scene._activeAnimatables

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -479,7 +479,14 @@ export class AnimationGroup implements IDisposable {
         }
 
         // We will take care of removing all stopped animatables
-        this._scene._activeAnimatables = this._scene._activeAnimatables.filter((anim) => anim._runtimeAnimations.length > 0);
+        let curIndex = 0;
+        for (let index = 0; index < this._scene._activeAnimatables.length; index++) {
+            const animatable = this._scene._activeAnimatables[index];
+            if (animatable._runtimeAnimations.length > 0) {
+                this._scene._activeAnimatables[curIndex++] = animatable;
+            }
+        }
+        this._scene._activeAnimatables.length = curIndex;
 
         this._isStarted = false;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/endanimationobs-death-loop/39584

`Scene._animate` is doing:
```typesccript
const animatables = this._activeAnimatables;

for (let index = 0; index < animatables.length; index++) {
    const animatable = animatables[index];

    if (!animatable._animate(animationTime) && animatable.disposeOnEnd) {
        index--; // Array was updated
    }
}
```
and `AnimationGroup.stop` was doing:
```typescript
this._scene._activeAnimatables = this._scene._activeAnimatables.filter((anim) => anim._runtimeAnimations.length > 0);
```
It was therefore possible for `Scene._activeAnimatables` to be modified (replaced by another array) while `Scene._animate` was looping over it (when `AnimationGroup.stop` is called in a `onAnimationEndObservable` event, for example).

A possible fix would have been to do `for (let index = 0; index < this._activeAnimatables.length; index++) {`, but I think it's safer not to mutate the array, because mutating it was done 2 or 3 weeks ago, and maybe we could get other bugs because of that...