### PR TITLE
PBR: Fix crash when enabling/disabling anisotropy

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
@@ -116,7 +116,6 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
             defines.ANISOTROPIC = false;
             defines.ANISOTROPIC_TEXTURE = false;
             defines.ANISOTROPIC_TEXTUREDIRECTUV = 0;
-            defines.MAINUV1 = false;
         }
     }
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1538,6 +1538,9 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         defines.METALLICWORKFLOW = this.isMetallicWorkflow();
         if (defines._areTexturesDirty) {
             defines._needUVs = false;
+            for (let i = 1; i <= Constants.MAX_SUPPORTED_UV_SETS; ++i) {
+                defines["MAINUV" + i] = false;
+            }
             if (scene.texturesEnabled) {
                 defines.ALBEDODIRECTUV = 0;
                 defines.AMBIENTDIRECTUV = 0;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/inpsector-switching-anisotropic-does-not-have-an-effect-its-only-enables/39637