### PR TITLE
Add overrideRenderingFillMode property to Mesh

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -888,8 +888,7 @@ export abstract class EffectLayer {
 
             engine.enableEffect(drawWrapper);
             if (!hardwareInstancedRendering) {
-                const fillMode = scene.forcePointsCloud ? Material.PointFillMode : scene.forceWireframe ? Material.WireFrameFillMode : material.fillMode;
-                renderingMesh._bind(subMesh, effect, fillMode);
+                renderingMesh._bind(subMesh, effect, material.fillMode);
             }
 
             if (!renderingMaterial) {

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2333,11 +2333,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         // Bind
-        const fillMode = scene.forcePointsCloud
-            ? Material.PointFillMode
-            : scene.forceWireframe
-            ? Material.WireFrameFillMode
-            : this._internalMeshDataInfo._effectiveMaterial.fillMode;
+        const effectiveMaterial = this._internalMeshDataInfo._effectiveMaterial;
+        const fillMode = effectiveMaterial.fillMode;
 
         if (this._internalMeshDataInfo._onBeforeBindObservable) {
             this._internalMeshDataInfo._onBeforeBindObservable.notifyObservers(this);
@@ -2348,7 +2345,6 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this._bind(subMesh, effect, fillMode, false);
         }
 
-        const effectiveMaterial = this._internalMeshDataInfo._effectiveMaterial;
         const world = effectiveMesh.getWorldMatrix();
         if (effectiveMaterial._storeEffectOnSubMeshes) {
             effectiveMaterial.bindForSubMesh(world, this, subMesh);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -143,6 +143,8 @@ class _InternalMeshDataInfo {
     public _effectiveMaterial: Nullable<Material> = null;
 
     public _forcedInstanceCount: number = 0;
+
+    public _overrideRenderingFillMode: Nullable<number> = null;
 }
 
 /**
@@ -438,6 +440,17 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * Use this property to change the original side orientation defined at construction time
      */
     public overrideMaterialSideOrientation: Nullable<number> = null;
+
+    /**
+     * Use this property to override the Material's fillMode value
+     */
+    public get overrideRenderingFillMode(): Nullable<number> {
+        return this._internalMeshDataInfo._overrideRenderingFillMode;
+    }
+
+    public set overrideRenderingFillMode(fillMode: Nullable<number>) {
+        this._internalMeshDataInfo._overrideRenderingFillMode = fillMode;
+    }
 
     /**
      * Gets or sets a boolean indicating whether to render ignoring the active camera's max z setting. (false by default)
@@ -1724,11 +1737,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         // Wireframe
         let indexToBind;
-
         if (this._unIndexed) {
             indexToBind = null;
         } else {
-            switch (fillMode) {
+            switch (this._getRenderingFillMode(fillMode)) {
                 case Material.PointFillMode:
                     indexToBind = null;
                     break;
@@ -2076,6 +2088,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     ): Mesh {
         const scene = this.getScene();
         const engine = scene.getEngine();
+        fillMode = this._getRenderingFillMode(fillMode);
 
         if (hardwareInstancedRendering && subMesh.getRenderingMesh().hasThinInstances) {
             this._renderWithThinInstances(subMesh, fillMode, effect, engine);
@@ -4740,6 +4753,17 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /** @internal */
     public _shouldConvertRHS() {
         return this.overrideMaterialSideOrientation === Material.CounterClockWiseSideOrientation;
+    }
+
+    /** @internal */
+    public _getRenderingFillMode(fillMode: number): number {
+        const scene = this.getScene();
+
+        if (scene.forcePointsCloud) return Material.PointFillMode;
+
+        if (scene.forceWireframe) return Material.WireFrameFillMode;
+
+        return this.overrideRenderingFillMode ?? fillMode;
     }
 }
 

--- a/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthPeelingRenderer.ts
@@ -427,10 +427,11 @@ export class DepthPeelingRenderer {
         for (let i = 0; i < transparentSubMeshes.length; i++) {
             const subMesh = transparentSubMeshes.data[i];
             const material = subMesh.getMaterial();
+            const fillMode = material && subMesh.getRenderingMesh()._getRenderingFillMode(material.fillMode);
 
             if (
                 material &&
-                (material.fillMode === Material.TriangleFanDrawMode || material.fillMode === Material.TriangleFillMode || material.fillMode === Material.TriangleStripDrawMode) &&
+                (fillMode === Material.TriangleFanDrawMode || fillMode === Material.TriangleFillMode || fillMode === Material.TriangleStripDrawMode) &&
                 this._excludedMeshes.indexOf(subMesh.getMesh().uniqueId) === -1
             ) {
                 this._candidateSubMeshes.push(subMesh);

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1547,6 +1547,12 @@ export class _Exporter {
         if (babylonMesh instanceof LinesMesh) {
             return Material.LineListDrawMode;
         }
+        if (babylonMesh instanceof InstancedMesh || babylonMesh instanceof Mesh) {
+            const baseMesh = babylonMesh instanceof Mesh ? babylonMesh : babylonMesh.sourceMesh;
+            if (typeof baseMesh.overrideRenderingFillMode === "number") {
+                return baseMesh.overrideRenderingFillMode;
+            }
+        }
         return babylonMesh.material ? babylonMesh.material.fillMode : Material.TriangleFillMode;
     }
 


### PR DESCRIPTION
Supersedes https://github.com/BabylonJS/Babylon.js/pull/13688

As discussed in forum thread here: https://forum.babylonjs.com/t/add-mesh-overridematerialfillmode/39475/

cc @MiikaH to review

The main difference is use the override only within the rendering scope as the flag is only used as a visual tool. It also fixes some of the scene override levels inconsistencies.