### PR TITLE
Pass clipContent/clipChildren down to Grid's internal containers

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -179,19 +179,39 @@ export class Control implements IAnimatable {
     @serialize()
     public isFocusInvisible = false;
 
+    private _clipChildren = true;
     /**
-     * Gets or sets a boolean indicating if the children are clipped to the current control bounds.
+     * Sets a boolean indicating if the children are clipped to the current control bounds.
+     * Please note that not clipping children may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
+     */
+    public set clipChildren(value: boolean) {
+        this._clipChildren = value;
+    }
+    /**
+     * Gets a boolean indicating if the children are clipped to the current control bounds.
      * Please note that not clipping children may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
      */
     @serialize()
-    public clipChildren = true;
+    public get clipChildren() {
+        return this._clipChildren;        
+    }
 
+    private _clipContent = true;
     /**
-     * Gets or sets a boolean indicating that control content must be clipped
-     * Please note that not clipping children may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
+     * Sets a boolean indicating that control content must be clipped
+     * Please note that not clipping content may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
+     */
+    public set clipContent(value: boolean) {
+        this._clipContent = value;
+    } 
+    /**
+     * Gets a boolean indicating that control content must be clipped
+     * Please note that not clipping content may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
      */
     @serialize()
-    public clipContent = true;
+    public get clipContent() {
+        return this._clipContent;
+    }
 
     /**
      * Gets or sets a boolean indicating that the current control should cache its rendering (useful when the control does not change often)

--- a/packages/dev/gui/src/2D/controls/grid.ts
+++ b/packages/dev/gui/src/2D/controls/grid.ts
@@ -22,6 +22,32 @@ export class Grid extends Container {
     private _childControls = new Array<Control>();
 
     /**
+     * Sets a boolean indicating that control content must be clipped
+     * Please note that not clipping content may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
+     */
+    public set clipContent(value: boolean) {
+        super.clipContent = value;
+
+        // This value has to be replicated on all of the container cells
+        for (const key in this._cells) {
+            this._cells[key].clipContent = value;
+        }
+    }
+
+    /**
+     * Sets a boolean indicating if the children are clipped to the current control bounds.
+     * Please note that not clipping children may generate issues with adt.useInvalidateRectOptimization so it is recommended to turn this optimization off if you want to use unclipped children
+     */
+    public set clipChildren(value: boolean) {
+        super.clipChildren = value;
+
+        // This value has to be replicated on all of the container cells
+        for (const key in this._cells) {
+            this._cells[key].clipChildren = value;
+        }
+    }
+
+    /**
      * Gets the number of columns
      */
     public get columnCount(): number {
@@ -311,6 +337,8 @@ export class Grid extends Container {
             this._cells[key] = goodContainer;
             goodContainer.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_LEFT;
             goodContainer.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
+            goodContainer.clipContent = this.clipContent;
+            goodContainer.clipChildren = this.clipChildren;
             super.addControl(goodContainer);
         }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/clipped-text-while-creating-tree-view-using-grid/38890/8