### PR TITLE
Morph targets: Workaround for Mali-G72 and morph target texture

### DIFF
--- a/packages/dev/core/src/Engines/engineCapabilities.ts
+++ b/packages/dev/core/src/Engines/engineCapabilities.ts
@@ -111,4 +111,6 @@ export interface EngineCapabilities {
 
     /** Defines the maximum layer count for a 2D Texture array. */
     texture2DArrayMaxLayerCount: number;
+    /** Defines if the morph target texture is supported. */
+    disableMorphTargetTexture: boolean;
 }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -265,6 +265,7 @@ export class NativeEngine extends Engine {
             supportTransformFeedbacks: false,
             textureMaxLevel: false,
             texture2DArrayMaxLayerCount: _native.Engine.CAPS_LIMITS_MAX_TEXTURE_LAYERS,
+            disableMorphTargetTexture: false,
         };
 
         this._features = {

--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -154,6 +154,7 @@ export class NullEngine extends Engine {
             supportTransformFeedbacks: false,
             textureMaxLevel: false,
             texture2DArrayMaxLayerCount: 128,
+            disableMorphTargetTexture: false,
         };
 
         this._features = {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1206,6 +1206,7 @@ export class ThinEngine {
             supportTransformFeedbacks: this._webGLVersion > 1,
             textureMaxLevel: this._webGLVersion > 1,
             texture2DArrayMaxLayerCount: this._webGLVersion > 1 ? this._gl.getParameter(this._gl.MAX_ARRAY_TEXTURE_LAYERS) : 128,
+            disableMorphTargetTexture: false,
         };
 
         // Infos
@@ -1390,6 +1391,11 @@ export class ThinEngine {
         this._maxSimultaneousTextures = this._caps.maxCombinedTexturesImageUnits;
         for (let slot = 0; slot < this._maxSimultaneousTextures; slot++) {
             this._nextFreeTextureSlots.push(slot);
+        }
+
+        if (this._glRenderer === "Mali-G72") {
+            // Overcome a bug when using a texture to store morph targets on Mali-G72
+            this._caps.disableMorphTargetTexture = true;
         }
     }
 

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -796,6 +796,7 @@ export class WebGPUEngine extends Engine {
             supportTransformFeedbacks: false,
             textureMaxLevel: true,
             texture2DArrayMaxLayerCount: this._deviceLimits.maxTextureArrayLayers,
+            disableMorphTargetTexture: false,
         };
 
         this._caps.parallelShaderCompile = null as any;

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -181,7 +181,12 @@ export class MorphTargetManager implements IDisposable {
      * Gets a boolean indicating that the targets are stored into a texture (instead of as attributes)
      */
     public get isUsingTextureForTargets() {
-        return MorphTargetManager.EnableTextureStorage && this.useTextureToStoreTargets && this._canUseTextureForTargets;
+        return (
+            MorphTargetManager.EnableTextureStorage &&
+            this.useTextureToStoreTargets &&
+            this._canUseTextureForTargets &&
+            !this._scene?.getEngine().getCaps().disableMorphTargetTexture
+        );
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/morph-targets-on-samsung-s9-exynos-9810-is-broken/32701/52