### PR TITLE
Inspector. Add custom items to context menus or override them

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -72,6 +72,23 @@ export interface IExplorerAdditionalNode {
     getContent(): IExplorerAdditionalChild[];
 }
 
+export type IInspectorContextMenuType = "pipeline" | "node" | "materials" | "spriteManagers" | "particleSystems";
+
+/**
+ * Context menu item
+ */
+export interface IInspectorContextMenuItem {
+    /**
+     * Display label - menu item
+     */
+    label: string;
+    /**
+     * Callback function that will be called when the menu item is selected
+     * @param entity the entity that is currently selected in the scene explorer
+     */
+    action: (entity?: unknown) => void;
+}
+
 /**
  * Interface used to define the options to use to create the Inspector
  */
@@ -128,6 +145,14 @@ export interface IInspectorOptions {
      * Optional camera to use to render the gizmos from the inspector (default to the scene.activeCamera or the latest from scene.activeCameras)
      */
     gizmoCamera?: Camera;
+    /**
+     * Context menu for inspector tools such as "Post Process", "Nodes", "Materials", etc.
+     */
+    contextMenu?: Partial<Record<IInspectorContextMenuType, IInspectorContextMenuItem[]>>;
+    /**
+     * List of context menu items that should be completely overridden by custom items from the contextMenu property.
+     */
+    contextMenuOverride?: IInspectorContextMenuType[];
 }
 
 declare module "../scene" {

--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -1,9 +1,8 @@
-import { IInspectorOptions } from "core/Debug/debugLayer";
 import * as React from "react";
 
 import type { Nullable } from "core/types";
 import type { Observer } from "core/Misc/observable";
-import type { IExplorerAdditionalNode, IExplorerExtensibilityGroup, IInspectorContextMenuItem } from "core/Debug/debugLayer";
+import type { IExplorerAdditionalNode, IExplorerExtensibilityGroup, IInspectorContextMenuItem, IInspectorOptions } from "core/Debug/debugLayer";
 import type { Scene } from "core/scene";
 import { EngineStore } from "core/Engines/engineStore";
 

--- a/packages/dev/inspector/src/components/sceneExplorer/treeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeItemComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import type { Nullable } from "core/types";
-import type { IExplorerExtensibilityGroup } from "core/Debug/debugLayer";
+import type { IInspectorContextMenuItem, IExplorerExtensibilityGroup } from "core/Debug/debugLayer";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faMinus, faBan, faExpandArrowsAlt, faCompress } from "@fortawesome/free-solid-svg-icons";
@@ -79,7 +79,7 @@ export interface ITreeItemComponentProps {
     entity?: any;
     selectedEntity: any;
     extensibilityGroups?: IExplorerExtensibilityGroup[];
-    contextMenuItems?: { label: string; action: () => void }[];
+    contextMenuItems?: IInspectorContextMenuItem[];
 }
 
 export class TreeItemComponent extends React.Component<ITreeItemComponentProps, { isExpanded: boolean; mustExpand: boolean }> {

--- a/packages/dev/inspector/src/inspector.ts
+++ b/packages/dev/inspector/src/inspector.ts
@@ -107,6 +107,8 @@ export class Inspector {
                 enableClose: options.enableClose,
                 explorerExtensibility: options.explorerExtensibility,
                 gizmoCamera: options.gizmoCamera,
+                contextMenu: options.contextMenu,
+                contextMenuOverride: options.contextMenuOverride,
             };
         }
 
@@ -133,6 +135,8 @@ export class Inspector {
             this._OpenedPane++;
             const sceneExplorerElement = React.createElement(SceneExplorerComponent, {
                 scene,
+                contextMenu: options.contextMenu,
+                contextMenuOverride: options.contextMenuOverride,
                 gizmoCamera: options.gizmoCamera,
                 globalState: this._GlobalState,
                 extensibilityGroups: options.explorerExtensibility,


### PR DESCRIPTION
Example of new options, here we can add new menu items:
```
scene.debugLayer.show({
    contextMenu: {
        pipeline: [
            {
                label: "Add new Custom pipeline",
                action: (e: any) => console.log(">>> Custom action", e),
            },
        ],
        node: [
            {
                label: "Add new Custom node",
                action: (e: any) => console.log(">>> Custom action", e),
            },
        ],
        materials: [
            {
                label: "Add new Custom material",
                action: (e: any) => console.log(">>> Custom action", e),
            },
        ],
        particleSystems: [
            {
                label: "Add new Custom particle system",
                action: (e: any) => console.log(">>> Custom action", e),
            },
        ],
        spriteManagers: [
            {
                label: "Add new Custom sprite manager",
                action: (e: any) => console.log(">>> Custom action", e),
            },
        ],
    },
});
```

Or even override default items by this way:
```
scene.debugLayer.show({
    contextMenuOverride: ["pipeline", "node", "materials", "particleSystems", "spriteManagers"],
    contextMenu: {
```

Here we pass the list of menus that should be overwriten by custom items.