### PR TITLE
Add option to keep context menu entries open, but close them by default.

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -23,6 +23,10 @@ export interface IExplorerExtensibilityOption {
      * Defines the action to execute on click
      */
     action: (entity: any) => void;
+    /**
+     * Keep popup open after click
+     */
+    keepOpenAfterClick?: boolean;
 }
 
 /**

--- a/packages/dev/inspector/src/components/sceneExplorer/extensionsComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/extensionsComponent.tsx
@@ -56,8 +56,8 @@ export class ExtensionsComponent extends React.Component<IExtensionsComponentPro
         }
 
         return (
-            <div ref={this._extensionRef} className="extensions" onClick={() => this.showPopup()}>
-                <div title="Additional options" className="icon">
+            <div ref={this._extensionRef} className="extensions">
+                <div title="Additional options" className="icon" onClick={() => this.showPopup()}>
                     <FontAwesomeIcon icon={faEllipsisH} />
                 </div>
                 <div
@@ -70,7 +70,16 @@ export class ExtensionsComponent extends React.Component<IExtensionsComponentPro
                 >
                     {options.map((extensibility) => {
                         return (
-                            <div key={extensibility.label} className="popupMenu" onClick={() => extensibility.action(this.props.target)}>
+                            <div
+                                key={extensibility.label}
+                                className="popupMenu"
+                                onClick={() => {
+                                    extensibility.action(this.props.target);
+                                    if (!extensibility.keepOpenAfterClick) {
+                                        this.setState({ popupVisible: false });
+                                    }
+                                }}
+                            >
                                 {extensibility.label}
                             </div>
                         );


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/inspector-close-the-context-menu-after-click-by-item/39668