### PR TITLE
Prevent previous element props to be selected

### DIFF
--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -242,7 +242,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
         } else if (keyEvent.keyCode === 46) {
             // delete
             this.state.selectedEntity.dispose();
-            this.setState({ selectedEntity: null });
+            this.props.globalState.onSelectionChangedObservable.notifyObservers(scene);
         }
 
         if (!search) {


### PR DESCRIPTION
https://forum.babylonjs.com/t/inspector-broken-if-add-sprite-and-remove-it/39824/3