### PR TITLE
HDRFiltering: Fix final cube texture not having the right type

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Filtering/hdrFiltering.ts
+++ b/packages/dev/core/src/Materials/Textures/Filtering/hdrFiltering.ts
@@ -141,7 +141,13 @@ export class HDRFiltering {
         this._engine._releaseTexture(texture._texture!);
 
         // Internal Swap
+        const type = outputTexture.texture!.type;
+        const format = outputTexture.texture!.format;
+
         outputTexture._swapAndDie(texture._texture!);
+
+        texture._texture!.type = type;
+        texture._texture!.format = format;
 
         // New settings
         texture.gammaSpace = false;


### PR DESCRIPTION
[This PG](https://playground.babylonjs.com/#064AUB#71) generates some warnings:

![image](https://user-images.githubusercontent.com/4152247/231767335-648c3450-d7b4-4dfa-8493-b8e67a49278a.png)

and the spherical polynomials are not computed correctly because of the bug.