### PR TITLE
Fix GLTF export of ambient texture with texture transforms

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -1014,6 +1014,7 @@ export class _GLTFMaterialExporter {
                             const occlusionTexture: IMaterialOcclusionTextureInfo = {
                                 index: glTFTexture.index,
                                 texCoord: glTFTexture.texCoord,
+                                extensions: glTFTexture.extensions,
                             };
 
                             glTFMaterial.occlusionTexture = occlusionTexture;


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gltf2export-glbasync-missing-uv-scale-on-ambienttexture/39900