### PR TITLE
Add possibility to apply supersampling when generating HDRCubeTexture()

### DIFF
--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -22,8 +22,8 @@ export class EquiRectangularCubeTexture extends BaseTexture {
     /** The size of the cubemap. */
     private _size: number;
 
-    /** Number of samples per cube map texel */
-    private _samples: number;
+    /** Whether to supersample the input image */
+    private _supersample: boolean;
 
     /** The buffer of the image. */
     private _buffer: ArrayBuffer;
@@ -56,7 +56,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         gammaSpace: boolean = true,
         onLoad: Nullable<() => void> = null,
         onError: Nullable<(message?: string, exception?: any) => void> = null,
-        samples = 1
+        supersample = false
     ) {
         super(scene);
 
@@ -68,7 +68,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         this.name = url;
         this.url = url;
         this._size = size;
-        this._samples = samples;
+        this._supersample = supersample;
         this._noMipmap = noMipmap;
         this.gammaSpace = gammaSpace;
         this._onLoad = onLoad;
@@ -136,7 +136,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
             const imageData = this._getFloat32ArrayFromArrayBuffer(this._buffer);
 
             // Extract the raw linear data.
-            const data = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(imageData, this._width, this._height, this._size, this._samples);
+            const data = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(imageData, this._width, this._height, this._size, this._supersample);
 
             const results = [];
 

--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -22,6 +22,9 @@ export class EquiRectangularCubeTexture extends BaseTexture {
     /** The size of the cubemap. */
     private _size: number;
 
+    /** Number of samples per cube map texel */
+    private _samples: number;
+
     /** The buffer of the image. */
     private _buffer: ArrayBuffer;
 
@@ -52,7 +55,8 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         noMipmap: boolean = false,
         gammaSpace: boolean = true,
         onLoad: Nullable<() => void> = null,
-        onError: Nullable<(message?: string, exception?: any) => void> = null
+        onError: Nullable<(message?: string, exception?: any) => void> = null,
+        samples = 1
     ) {
         super(scene);
 
@@ -64,6 +68,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         this.name = url;
         this.url = url;
         this._size = size;
+        this._samples = samples;
         this._noMipmap = noMipmap;
         this.gammaSpace = gammaSpace;
         this._onLoad = onLoad;
@@ -131,7 +136,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
             const imageData = this._getFloat32ArrayFromArrayBuffer(this._buffer);
 
             // Extract the raw linear data.
-            const data = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(imageData, this._width, this._height, this._size);
+            const data = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(imageData, this._width, this._height, this._size, this._samples);
 
             const results = [];
 

--- a/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
@@ -30,6 +30,7 @@ export class HDRCubeTexture extends BaseTexture {
     private _prefilterOnLoad: boolean;
     private _textureMatrix: Matrix;
     private _size: number;
+    private _samples: number;
     private _onLoad: () => void;
     private _onError: Nullable<() => void> = null;
 
@@ -122,7 +123,8 @@ export class HDRCubeTexture extends BaseTexture {
         gammaSpace = false,
         prefilterOnLoad = false,
         onLoad: Nullable<() => void> = null,
-        onError: Nullable<(message?: string, exception?: any) => void> = null
+        onError: Nullable<(message?: string, exception?: any) => void> = null,
+        samples = 1
     ) {
         super(sceneOrEngine);
 
@@ -149,6 +151,7 @@ export class HDRCubeTexture extends BaseTexture {
 
         this._noMipmap = noMipmap;
         this._size = size;
+        this._samples = samples;
         this._generateHarmonics = generateHarmonics;
 
         this._texture = this._getFromCache(url, this._noMipmap, undefined, undefined, undefined, this.isCube);
@@ -195,7 +198,7 @@ export class HDRCubeTexture extends BaseTexture {
             this.lodGenerationScale = 0.8;
 
             // Extract the raw linear data.
-            const data = HDRTools.GetCubeMapTextureData(buffer, this._size);
+            const data = HDRTools.GetCubeMapTextureData(buffer, this._size, this._samples);
 
             // Generate harmonics if needed.
             if (this._generateHarmonics) {

--- a/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
@@ -30,7 +30,7 @@ export class HDRCubeTexture extends BaseTexture {
     private _prefilterOnLoad: boolean;
     private _textureMatrix: Matrix;
     private _size: number;
-    private _samples: number;
+    private _supersample: boolean;
     private _onLoad: () => void;
     private _onError: Nullable<() => void> = null;
 
@@ -124,7 +124,7 @@ export class HDRCubeTexture extends BaseTexture {
         prefilterOnLoad = false,
         onLoad: Nullable<() => void> = null,
         onError: Nullable<(message?: string, exception?: any) => void> = null,
-        samples = 1
+        supersample = false
     ) {
         super(sceneOrEngine);
 
@@ -151,7 +151,7 @@ export class HDRCubeTexture extends BaseTexture {
 
         this._noMipmap = noMipmap;
         this._size = size;
-        this._samples = samples;
+        this._supersample = supersample;
         this._generateHarmonics = generateHarmonics;
 
         this._texture = this._getFromCache(url, this._noMipmap, undefined, undefined, undefined, this.isCube);
@@ -198,7 +198,7 @@ export class HDRCubeTexture extends BaseTexture {
             this.lodGenerationScale = 0.8;
 
             // Extract the raw linear data.
-            const data = HDRTools.GetCubeMapTextureData(buffer, this._size, this._samples);
+            const data = HDRTools.GetCubeMapTextureData(buffer, this._size, this._supersample);
 
             // Generate harmonics if needed.
             if (this._generateHarmonics) {

--- a/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
@@ -143,12 +143,12 @@ export class HDRTools {
      * @param size The expected size of the extracted cubemap.
      * @returns The Cube Map information.
      */
-    public static GetCubeMapTextureData(buffer: ArrayBuffer, size: number, samples = 1): CubeMapInfo {
+    public static GetCubeMapTextureData(buffer: ArrayBuffer, size: number, supersample = false): CubeMapInfo {
         const uint8array = new Uint8Array(buffer);
         const hdrInfo = this.RGBE_ReadHeader(uint8array);
         const data = this.RGBE_ReadPixels(uint8array, hdrInfo);
 
-        const cubeMapData = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(data, hdrInfo.width, hdrInfo.height, size, samples);
+        const cubeMapData = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(data, hdrInfo.width, hdrInfo.height, size, supersample);
 
         return cubeMapData;
     }

--- a/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
@@ -143,12 +143,12 @@ export class HDRTools {
      * @param size The expected size of the extracted cubemap.
      * @returns The Cube Map information.
      */
-    public static GetCubeMapTextureData(buffer: ArrayBuffer, size: number): CubeMapInfo {
+    public static GetCubeMapTextureData(buffer: ArrayBuffer, size: number, samples = 1): CubeMapInfo {
         const uint8array = new Uint8Array(buffer);
         const hdrInfo = this.RGBE_ReadHeader(uint8array);
         const data = this.RGBE_ReadPixels(uint8array, hdrInfo);
 
-        const cubeMapData = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(data, hdrInfo.width, hdrInfo.height, size);
+        const cubeMapData = PanoramaToCubeMapTools.ConvertPanoramaToCubemap(data, hdrInfo.width, hdrInfo.height, size, samples);
 
         return cubeMapData;
     }

--- a/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
@@ -90,7 +90,7 @@ export class PanoramaToCubeMapTools {
      * @param size The willing size of the generated cubemap (each faces will be size * size pixels)
      * @returns The cubemap data
      */
-    public static ConvertPanoramaToCubemap(float32Array: Float32Array, inputWidth: number, inputHeight: number, size: number): CubeMapInfo {
+    public static ConvertPanoramaToCubemap(float32Array: Float32Array, inputWidth: number, inputHeight: number, size: number, samples = 1): CubeMapInfo {
         if (!float32Array) {
             throw "ConvertPanoramaToCubemap: input cannot be null";
         }
@@ -99,12 +99,12 @@ export class PanoramaToCubeMapTools {
             throw "ConvertPanoramaToCubemap: input size is wrong";
         }
 
-        const textureFront = this.CreateCubemapTexture(size, this.FACE_FRONT, float32Array, inputWidth, inputHeight);
-        const textureBack = this.CreateCubemapTexture(size, this.FACE_BACK, float32Array, inputWidth, inputHeight);
-        const textureLeft = this.CreateCubemapTexture(size, this.FACE_LEFT, float32Array, inputWidth, inputHeight);
-        const textureRight = this.CreateCubemapTexture(size, this.FACE_RIGHT, float32Array, inputWidth, inputHeight);
-        const textureUp = this.CreateCubemapTexture(size, this.FACE_UP, float32Array, inputWidth, inputHeight);
-        const textureDown = this.CreateCubemapTexture(size, this.FACE_DOWN, float32Array, inputWidth, inputHeight);
+        const textureFront = this.CreateCubemapTexture(size, this.FACE_FRONT, float32Array, inputWidth, inputHeight, samples);
+        const textureBack = this.CreateCubemapTexture(size, this.FACE_BACK, float32Array, inputWidth, inputHeight, samples);
+        const textureLeft = this.CreateCubemapTexture(size, this.FACE_LEFT, float32Array, inputWidth, inputHeight, samples);
+        const textureRight = this.CreateCubemapTexture(size, this.FACE_RIGHT, float32Array, inputWidth, inputHeight, samples);
+        const textureUp = this.CreateCubemapTexture(size, this.FACE_UP, float32Array, inputWidth, inputHeight, samples);
+        const textureDown = this.CreateCubemapTexture(size, this.FACE_DOWN, float32Array, inputWidth, inputHeight, samples);
 
         return {
             front: textureFront,
@@ -120,36 +120,43 @@ export class PanoramaToCubeMapTools {
         };
     }
 
-    private static CreateCubemapTexture(texSize: number, faceData: Vector3[], float32Array: Float32Array, inputWidth: number, inputHeight: number) {
+    private static CreateCubemapTexture(texSize: number, faceData: Vector3[], float32Array: Float32Array, inputWidth: number, inputHeight: number, samples = 1) {
         const buffer = new ArrayBuffer(texSize * texSize * 4 * 3);
         const textureArray = new Float32Array(buffer);
 
-        const rotDX1 = faceData[1].subtract(faceData[0]).scale(1 / texSize);
-        const rotDX2 = faceData[3].subtract(faceData[2]).scale(1 / texSize);
+        const sampleFactor = 1 / samples;
+        const sampleFactorSqr = sampleFactor * sampleFactor;
+
+        const rotDX1 = faceData[1].subtract(faceData[0]).scale(sampleFactor / texSize);
+        const rotDX2 = faceData[3].subtract(faceData[2]).scale(sampleFactor / texSize);
 
         const dy = 1 / texSize;
         let fy = 0;
 
         for (let y = 0; y < texSize; y++) {
-            let xv1 = faceData[0];
-            let xv2 = faceData[2];
+            for (let sy = 0; sy < samples; sy++) {
+                let xv1 = faceData[0];
+                let xv2 = faceData[2];
 
-            for (let x = 0; x < texSize; x++) {
-                const v = xv2.subtract(xv1).scale(fy).add(xv1);
-                v.normalize();
+                for (let x = 0; x < texSize; x++) {
+                    for (let sx = 0; sx < samples; sx++) {
+                        const v = xv2.subtract(xv1).scale(fy).add(xv1);
+                        v.normalize();
 
-                const color = this.CalcProjectionSpherical(v, float32Array, inputWidth, inputHeight);
+                        const color = this.CalcProjectionSpherical(v, float32Array, inputWidth, inputHeight);
 
-                // 3 channels per pixels
-                textureArray[y * texSize * 3 + x * 3 + 0] = color.r;
-                textureArray[y * texSize * 3 + x * 3 + 1] = color.g;
-                textureArray[y * texSize * 3 + x * 3 + 2] = color.b;
+                        // 3 channels per pixels
+                        textureArray[y * texSize * 3 + x * 3 + 0] += color.r * sampleFactorSqr;
+                        textureArray[y * texSize * 3 + x * 3 + 1] += color.g * sampleFactorSqr;
+                        textureArray[y * texSize * 3 + x * 3 + 2] += color.b * sampleFactorSqr;
 
-                xv1 = xv1.add(rotDX1);
-                xv2 = xv2.add(rotDX2);
+                        xv1 = xv1.add(rotDX1);
+                        xv2 = xv2.add(rotDX2);
+                    }
+                }
+
+                fy += dy * sampleFactor;
             }
-
-            fy += dy;
         }
 
         return textureArray;

--- a/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
@@ -90,7 +90,7 @@ export class PanoramaToCubeMapTools {
      * @param size The willing size of the generated cubemap (each faces will be size * size pixels)
      * @returns The cubemap data
      */
-    public static ConvertPanoramaToCubemap(float32Array: Float32Array, inputWidth: number, inputHeight: number, size: number, samples = 1): CubeMapInfo {
+    public static ConvertPanoramaToCubemap(float32Array: Float32Array, inputWidth: number, inputHeight: number, size: number, supersample = false): CubeMapInfo {
         if (!float32Array) {
             throw "ConvertPanoramaToCubemap: input cannot be null";
         }
@@ -99,12 +99,12 @@ export class PanoramaToCubeMapTools {
             throw "ConvertPanoramaToCubemap: input size is wrong";
         }
 
-        const textureFront = this.CreateCubemapTexture(size, this.FACE_FRONT, float32Array, inputWidth, inputHeight, samples);
-        const textureBack = this.CreateCubemapTexture(size, this.FACE_BACK, float32Array, inputWidth, inputHeight, samples);
-        const textureLeft = this.CreateCubemapTexture(size, this.FACE_LEFT, float32Array, inputWidth, inputHeight, samples);
-        const textureRight = this.CreateCubemapTexture(size, this.FACE_RIGHT, float32Array, inputWidth, inputHeight, samples);
-        const textureUp = this.CreateCubemapTexture(size, this.FACE_UP, float32Array, inputWidth, inputHeight, samples);
-        const textureDown = this.CreateCubemapTexture(size, this.FACE_DOWN, float32Array, inputWidth, inputHeight, samples);
+        const textureFront = this.CreateCubemapTexture(size, this.FACE_FRONT, float32Array, inputWidth, inputHeight, supersample);
+        const textureBack = this.CreateCubemapTexture(size, this.FACE_BACK, float32Array, inputWidth, inputHeight, supersample);
+        const textureLeft = this.CreateCubemapTexture(size, this.FACE_LEFT, float32Array, inputWidth, inputHeight, supersample);
+        const textureRight = this.CreateCubemapTexture(size, this.FACE_RIGHT, float32Array, inputWidth, inputHeight, supersample);
+        const textureUp = this.CreateCubemapTexture(size, this.FACE_UP, float32Array, inputWidth, inputHeight, supersample);
+        const textureDown = this.CreateCubemapTexture(size, this.FACE_DOWN, float32Array, inputWidth, inputHeight, supersample);
 
         return {
             front: textureFront,
@@ -120,10 +120,12 @@ export class PanoramaToCubeMapTools {
         };
     }
 
-    private static CreateCubemapTexture(texSize: number, faceData: Vector3[], float32Array: Float32Array, inputWidth: number, inputHeight: number, samples = 1) {
+    private static CreateCubemapTexture(texSize: number, faceData: Vector3[], float32Array: Float32Array, inputWidth: number, inputHeight: number, supersample = false) {
         const buffer = new ArrayBuffer(texSize * texSize * 4 * 3);
         const textureArray = new Float32Array(buffer);
 
+        // If supersampling, determine number of samples needed when source texture width is divided for 4 cube faces
+        const samples = supersample ? Math.max(1, Math.round(inputWidth / 4 / texSize)) : 1;
         const sampleFactor = 1 / samples;
         const sampleFactorSqr = sampleFactor * sampleFactor;
 


### PR DESCRIPTION
I decided a take a quick attempt at adding number of samples option to `HDRCubeTexture()` in order to allow generating more accurate lower resolution HDRCubeTextures.

Original discussion about the issue here: https://forum.babylonjs.com/t/is-ibl-texture-tool-hdr-to-env-conversion-code-part-of-babylon-js/40031

Here is a Playground example using the proposed samples argument with 4 samples to match 512 -> 128 downsample: https://www.babylonjs-playground.com/#NWNUIH#2

The result is EXACTLY same as the comparison .env file that is generated with https://www.babylonjs.com/tools/ibl/, but this time possible to create within Babylon.js without added custom code.

Let me know if option like this makes sense? Performance should be exactly same than before unless additional samples are used.