### PR TITLE
Animation: Fix animation.runtimeAnimations array not cleaned up on stop

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -357,6 +357,12 @@ export class Animatable {
                 if (!useGlobalSplice) {
                     this._scene._activeAnimatables.splice(index, 1);
                 }
+                const runtimeAnimations = this._runtimeAnimations;
+
+                for (let index = 0; index < runtimeAnimations.length; index++) {
+                    runtimeAnimations[index].dispose();
+                }
+
                 this._runtimeAnimations.length = 0;
 
                 this._raiseOnAnimationEnd();

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -317,7 +317,6 @@ export class RuntimeAnimation {
 
     /**
      * Disposes of the runtime animation
-     * Note: No hard dispose should happen here as this method is skipped for performance reason (look at animatable.stop())
      */
     public dispose(): void {
         const index = this._animation.runtimeAnimations.indexOf(this);


### PR DESCRIPTION
Fixes #13762 

The code I added back was removed in https://github.com/BabylonJS/Babylon.js/commit/93d7ccc2f98435a455ece615f6e0a3561bcded9a but calling `runtimeAnimations[index].dispose();` is cleaning the `Animation._runtimeAnimations` array, which is different from the `Animatable._runtimeAnimations` array.