### PR TITLE
Fix for RTT rendering in an XR session

### DIFF
--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -936,7 +936,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                 scene.setTransformMatrix(camera.getViewMatrix(), camera.getProjectionMatrix(true));
                 scene.activeCamera = camera;
             }
-            engine.setViewport(camera.viewport, this.getRenderWidth(), this.getRenderHeight());
+            engine.setViewport(camera.rigParent ? camera.rigParent.viewport : camera.viewport, this.getRenderWidth(), this.getRenderHeight());
         }
 
         this._defaultRenderListPrepared = false;


### PR DESCRIPTION
When rendered in an XR session, the camera's viewport was applied on the full size of the RTT). This made the RTT render on a quarter of the screen (instead of half of the screen, as expected in XR with two eyes).
This changes RTT rendering in Rigged cameras (which ATM is mainly WebXR). It is expected that tha parent's camera will be the full viewport to render both eyes (which is 100% viewport in case of XR).

It is a small breaking change, but is actually more a bug fix.