### PR TITLE
Physics: Fix aggregate size calculation and allow passing box rotatio…

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -4,7 +4,7 @@ import { PhysicsShape } from "./physicsShape";
 import { Logger } from "../../Misc/logger";
 import type { Scene } from "../../scene";
 import type { TransformNode } from "../../Meshes/transformNode";
-import { TmpVectors, Vector3 } from "../../Maths/math.vector";
+import { Quaternion, TmpVectors, Vector3 } from "../../Maths/math.vector";
 import { Scalar } from "../../Maths/math.scalar";
 import { PhysicsMotionType, PhysicsShapeType } from "./IPhysicsEnginePlugin";
 import type { Mesh } from "../../Meshes/mesh";
@@ -100,6 +100,11 @@ export interface PhysicsAggregateParameters {
      * Extents for box
      */
     extents?: Vector3;
+
+    /**
+     * Orientation for box
+     */
+    rotation?: Quaternion;
 
     /**
      * mesh local center
@@ -212,7 +217,7 @@ export class PhysicsAggregate {
         this.transformNode.computeWorldMatrix(true);
         const bb = this._getObjectBoundingBox();
         const extents = TmpVectors.Vector3[0];
-        extents.copyFrom(bb.extendSizeWorld);
+        extents.copyFrom(bb.extendSize);
         extents.scaleInPlace(2);
         extents.multiplyInPlace(this.transformNode.scaling);
 
@@ -269,6 +274,7 @@ export class PhysicsAggregate {
                 break;
             case PhysicsShapeType.BOX:
                 this._options.extents = this._options.extents ?? new Vector3(extents.x, extents.y, extents.z);
+                this._options.rotation = this._options.rotation ?? Quaternion.Identity();
                 break;
         }
     }

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -57,7 +57,11 @@ export class PhysicsBody {
     /**
      * Constructs a new physics body for the given node.
      * @param transformNode - The Transform Node to construct the physics body for.
-     * @param motionType - The motion type of the physics body.
+     * @param motionType - The motion type of the physics body. The options are:
+     *  - PhysicsMotionType.STATIC - Static bodies are not moving and unaffected by forces or collisions. They are good for level boundaries or terrain.
+     *  - PhysicsMotionType.DYNAMIC - Dynamic bodies are fully simulated. They can move and collide with other objects.
+     *  - PhysicsMotionType.ANIMATED - They behave like dynamic bodies, but they won't be affected by other bodies, but still push other bodies out of the way.
+     * @param startsAsleep - Whether the physics body should start in a sleeping state (not a guarantee). Defaults to false.
      * @param scene - The scene containing the physics engine.
      *
      * This code is useful for creating a physics body for a given Transform Node in a scene.


### PR DESCRIPTION
…n as an aggregate option. Also add a basic explanation of motion types on PhysicsBody constructor.

Related forum issue: https://forum.babylonjs.com/t/physical-body-dont-rotate-with-its-mesh/40207