### PR TITLE
OIT: Fix wrong prepass state when material transparency changes

### DIFF
--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -321,7 +321,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
 
         // Only call dirty when there is a state change (no alpha / alpha)
         if (oldValue === 1 || value === 1) {
-            this.markAsDirty(Material.MiscDirtyFlag);
+            this.markAsDirty(Material.MiscDirtyFlag + Material.PrePassDirtyFlag);
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/shader-crash-with-oit/40332/15