### PR TITLE
Update havokPlugin.ts

### DIFF
--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -413,7 +413,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
                 body._pluginDataInstances.push(pluginData);
                 this._hknp.HP_World_AddBody(this.world, hkbody, body.startAsleep);
                 pluginData.worldTransformOffset = this._hknp.HP_Body_GetWorldTransformOffset(hkbody)[1];
-                this._bodies.set(hkbody[0], { body: pluginData, index: i });
+                this._bodies.set(hkbody[0], { body: body, index: i });
             }
         }
     }

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -383,9 +383,6 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             return; // TODO: error handling
         }
         this._createOrUpdateBodyInstances(body, motionType, matrixData, 0, instancesCount, false);
-        body._pluginDataInstances.forEach((bodyId, index) => {
-            this._bodies.set(bodyId.hpBodyId[0], { body: body, index: index });
-        });
     }
 
     private _createOrUpdateBodyInstances(body: PhysicsBody, motionType: PhysicsMotionType, matrixData: Float32Array, startIndex: number, endIndex: number, update: boolean): void {
@@ -416,6 +413,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
                 body._pluginDataInstances.push(pluginData);
                 this._hknp.HP_World_AddBody(this.world, hkbody, body.startAsleep);
                 pluginData.worldTransformOffset = this._hknp.HP_Body_GetWorldTransformOffset(hkbody)[1];
+                this._bodies.set(hkbody[0], { body: pluginData, index: i });
             }
         }
     }
@@ -445,6 +443,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             const instancesToRemove = pluginInstancesCount - instancesCount;
             for (let i = 0; i < instancesToRemove; i++) {
                 const hkbody = body._pluginDataInstances.pop();
+                this._bodies.delete(hkbody.hpBodyId[0]);
                 this._hknp.HP_World_RemoveBody(this.world, hkbody.hpBodyId);
                 this._hknp.HP_Body_Release(hkbody.hpBodyId);
             }

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -383,6 +383,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             return; // TODO: error handling
         }
         this._createOrUpdateBodyInstances(body, motionType, matrixData, 0, instancesCount, false);
+        body._pluginDataInstances.forEach((bodyId, index) => {
+            this._bodies.set(bodyId.hpBodyId[0], { body: body, index: index });
+        });
     }
 
     private _createOrUpdateBodyInstances(body: PhysicsBody, motionType: PhysicsMotionType, matrixData: Float32Array, startIndex: number, endIndex: number, update: boolean): void {
@@ -413,7 +416,6 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
                 body._pluginDataInstances.push(pluginData);
                 this._hknp.HP_World_AddBody(this.world, hkbody, body.startAsleep);
                 pluginData.worldTransformOffset = this._hknp.HP_Body_GetWorldTransformOffset(hkbody)[1];
-                this._bodies.set(hkbody[0], { body: body, index: i });
             }
         }
     }
@@ -438,6 +440,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             for (let i = pluginInstancesCount; i < instancesCount; i++) {
                 this._hknp.HP_Body_SetShape(body._pluginDataInstances[i].hpBodyId, firstBodyShape);
                 this._internalUpdateMassProperties(body._pluginDataInstances[i]);
+                this._bodies.set(body._pluginDataInstances[i].hpBodyId[0], { body: body, index: i });
             }
         } else if (instancesCount < pluginInstancesCount) {
             const instancesToRemove = pluginInstancesCount - instancesCount;


### PR DESCRIPTION
Attempt to fix https://forum.babylonjs.com/t/havoc-thininstances-collisioncallback/40315
+ Add new thinInstances to `havokPlugin._bodies` map when `body.updateBodyInstances()` is called, not only when initiated.
+ Add removal of deleted thinInstances from `havokPlugin._bodies` map

Test (&stress) case for latest commit. console logs the _bodies map at the end.
https://playground.babylonjs.com/#LJX5R3
https://playground.babylonjs.com/?snapshot=refs/pull/13783/merge#LJX5R3
The PG spawns 2500 thinInstances of a sphere to test performance and memory, previous commit caused memory issues.
initially 100 spheres then + 25 per frame up to 2500 total.
