### PR TITLE
GamepadManager: Fixed issue where providing scene object to constructor would prevent status updates

### DIFF
--- a/packages/dev/core/src/Gamepads/gamepadManager.ts
+++ b/packages/dev/core/src/Gamepads/gamepadManager.ts
@@ -196,9 +196,7 @@ export class GamepadManager {
         if (!this._isMonitoring) {
             this._isMonitoring = true;
             //back-comp
-            if (!this._scene) {
-                this._checkGamepadsStatus();
-            }
+            this._checkGamepadsStatus();
         }
     }
 
@@ -228,7 +226,7 @@ export class GamepadManager {
             }
         }
 
-        if (this._isMonitoring && !this._scene) {
+        if (this._isMonitoring) {
             Engine.QueueNewFrame(() => {
                 this._checkGamepadsStatus();
             });


### PR DESCRIPTION
A user on the forum found an issue where the GamepadManager wouldn't update its gamepad statuses when `this._scene` was defined.  The fix was to remove these checks.  Thanks to user CiderPunk for finding this issue.

Forum Link: https://forum.babylonjs.com/t/gamepad-events-not-triggering/40362