### PR TITLE
[PG] allow ts playground in full and frame

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -69,13 +69,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             this._engine?.switchFullscreen(false);
         });
 
-        if (this.props.globalState.runtimeMode !== RuntimeMode.Editor) {
-            this.props.globalState.onCodeLoaded.add((code) => {
-                this.props.globalState.currentCode = code;
-                this.props.globalState.onRunRequiredObservable.notifyObservers();
-            });
-        }
-
         window.addEventListener("resize", () => {
             if (!this._engine) {
                 return;

--- a/packages/tools/playground/src/playground.tsx
+++ b/packages/tools/playground/src/playground.tsx
@@ -114,22 +114,28 @@ export class Playground extends React.Component<IPlaygroundProps, { errorMessage
     public render() {
         if (this._globalState.runtimeMode === RuntimeMode.Full) {
             return (
-                <div className="canvasZone" id="pg-root-full">
-                    <RenderingComponent globalState={this._globalState} />
-                    <ErrorDisplayComponent globalState={this._globalState} />
-                    <WaitRingComponent globalState={this._globalState} />
-                </div>
+                <>
+                    <MonacoComponent globalState={this._globalState} className="pg-split-part hidden" refObject={this._monacoRef} />
+                    <div className="canvasZone" id="pg-root-full">
+                        <RenderingComponent globalState={this._globalState} />
+                        <ErrorDisplayComponent globalState={this._globalState} />
+                        <WaitRingComponent globalState={this._globalState} />
+                    </div>
+                </>
             );
         }
 
         if (this._globalState.runtimeMode === RuntimeMode.Frame) {
             return (
-                <div className="canvasZone" id="pg-root-frame">
-                    <RenderingComponent globalState={this._globalState} />
-                    <FooterComponent globalState={this._globalState} />
-                    <ErrorDisplayComponent globalState={this._globalState} />
-                    <WaitRingComponent globalState={this._globalState} />
-                </div>
+                <>
+                    <MonacoComponent globalState={this._globalState} className="pg-split-part hidden" refObject={this._monacoRef} />
+                    <div className="canvasZone" id="pg-root-frame">
+                        <RenderingComponent globalState={this._globalState} />
+                        <FooterComponent globalState={this._globalState} />
+                        <ErrorDisplayComponent globalState={this._globalState} />
+                        <WaitRingComponent globalState={this._globalState} />
+                    </div>
+                </>
             );
         }
 


### PR DESCRIPTION
The editor is resposible of parsing ts and converting it to js. I am adding a hidden instance of the editor that will load the code and send it to the PG.

there is a very small load time reduction (20-30ms), but typescript playground will now load correctly.

As part of playground improvements we will need to deal with this issue as well.