### PR TITLE
cylinder/capsule size computation fix

### DIFF
--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1,13 +1,19 @@
 import { Matrix, Quaternion, TmpVectors, Vector3 } from "../../../Maths/math.vector";
-import { PhysicsShapeType, PhysicsConstraintType, PhysicsMotionType , PhysicsConstraintMotorType, PhysicsConstraintAxis , PhysicsConstraintAxisLimitMode } from "../IPhysicsEnginePlugin";
+import {
+    PhysicsShapeType,
+    PhysicsConstraintType,
+    PhysicsMotionType,
+    PhysicsConstraintMotorType,
+    PhysicsConstraintAxis,
+    PhysicsConstraintAxisLimitMode,
+} from "../IPhysicsEnginePlugin";
 import type { PhysicsShapeParameters, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
 import { Logger } from "../../../Misc/logger";
 import type { PhysicsBody } from "../physicsBody";
-import type { PhysicsConstraint , Physics6DoFConstraint } from "../physicsConstraint";
+import type { PhysicsConstraint, Physics6DoFConstraint } from "../physicsConstraint";
 
 import type { PhysicsMaterial } from "../physicsMaterial";
 import { PhysicsMaterialCombineMode } from "../physicsMaterial";
-
 
 import { PhysicsShape } from "../physicsShape";
 import type { BoundingBox } from "../../../Culling/boundingBox";

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1,6 +1,6 @@
 import { Matrix, Quaternion, TmpVectors, Vector3 } from "../../../Maths/math.vector";
 import { PhysicsShapeType, PhysicsConstraintType, PhysicsMotionType } from "../IPhysicsEnginePlugin";
-import type { PhysicsShapeParameters, PhysicsConstraintMotorType, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
+import { PhysicsShapeParameters, PhysicsConstraintMotorType, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
 import { Logger } from "../../../Misc/logger";
 import type { PhysicsBody } from "../physicsBody";
 import type { PhysicsConstraint } from "../physicsConstraint";
@@ -1483,7 +1483,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, motorType: PhysicsConstraintMotorType): void {
-        this._hknp.HP_Constraint_SetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis), motorType);
+        this._hknp.HP_Constraint_SetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis), this._constraintMotorTypeToNative(motorType));
     }
 
     /**
@@ -1494,7 +1494,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public getAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): PhysicsConstraintMotorType {
-        return this._hknp.HP_Constraint_GetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+        return this._nativeToMotorType(this._hknp.HP_Constraint_GetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis))[1]);
     }
 
     /**
@@ -1693,6 +1693,26 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
 
     private _bQuatToV4(q: Quaternion): Array<number> {
         return [q._x, q._y, q._z, q._w];
+    }
+
+    private _constraintMotorTypeToNative(motorType: PhysicsConstraintMotorType): any {
+        switch (motorType) {
+            case PhysicsConstraintMotorType.POSITION:
+                return this._hknp.ConstraintMotorType.POSITION;
+            case PhysicsConstraintMotorType.VELOCITY:
+                return this._hknp.ConstraintMotorType.VELOCITY;
+        }
+        return this._hknp.ConstraintMotorType.NONE;
+    }
+
+    private _nativeToMotorType(motorType: any): PhysicsConstraintMotorType {
+        switch (motorType) {
+            case this._hknp.ConstraintMotorType.POSITION:
+                return PhysicsConstraintMotorType.POSITION;
+            case this._hknp.ConstraintMotorType.VELOCITY:
+                return PhysicsConstraintMotorType.VELOCITY;
+        }
+        return PhysicsConstraintMotorType.NONE;
     }
 
     private _materialCombineToNative(mat: PhysicsMaterialCombineMode): any {

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1,14 +1,14 @@
 import { Matrix, Quaternion, TmpVectors, Vector3 } from "../../../Maths/math.vector";
-import { PhysicsShapeType, PhysicsConstraintType, PhysicsMotionType } from "../IPhysicsEnginePlugin";
-import { PhysicsShapeParameters, PhysicsConstraintMotorType, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
+import { PhysicsShapeType, PhysicsConstraintType, PhysicsMotionType , PhysicsConstraintMotorType, PhysicsConstraintAxis , PhysicsConstraintAxisLimitMode } from "../IPhysicsEnginePlugin";
+import type { PhysicsShapeParameters, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
 import { Logger } from "../../../Misc/logger";
 import type { PhysicsBody } from "../physicsBody";
-import type { PhysicsConstraint } from "../physicsConstraint";
-import type { Physics6DoFConstraint } from "../physicsConstraint";
+import type { PhysicsConstraint , Physics6DoFConstraint } from "../physicsConstraint";
+
 import type { PhysicsMaterial } from "../physicsMaterial";
 import { PhysicsMaterialCombineMode } from "../physicsMaterial";
-import { PhysicsConstraintAxis } from "../IPhysicsEnginePlugin";
-import { PhysicsConstraintAxisLimitMode } from "../IPhysicsEnginePlugin";
+
+
 import { PhysicsShape } from "../physicsShape";
 import type { BoundingBox } from "../../../Culling/boundingBox";
 import type { TransformNode } from "../../../Meshes/transformNode";

--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -223,7 +223,6 @@ export class PhysicsAggregate {
 
         const min = TmpVectors.Vector3[1];
         min.copyFrom(bb.minimum);
-        min.scaleInPlace(2);
         min.multiplyInPlace(this.transformNode.scaling);
 
         if (!this._options.center) {


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/capsule-uncentered-physical-body/40321
fixes #13799 
fixes #13801
bbox minimum was scaled by a factor of 2.
fix the motortype conversion between wasm and ts