### PR TITLE
Add max value clamping and preserve colors options to CubeMapToSphericalPolynomialTools

### DIFF
--- a/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
@@ -36,6 +36,11 @@ export class CubeMapToSphericalPolynomialTools {
         new FileFaceOrientation("back", new Vector3(0, 0, -1), new Vector3(-1, 0, 0), new Vector3(0, -1, 0)), // -Z bottom
     ];
 
+    /** @internal */
+    public static MAX_HDRI_VALUE = 4096;
+    /** @internal */
+    public static PRESERVE_CLAMPED_COLORS = false;
+
     /**
      * Converts a texture to the according Spherical Polynomial data.
      * This extracts the first 3 orders only as they are the only one used in the lighting.
@@ -180,10 +185,20 @@ export class CubeMapToSphericalPolynomialTools {
 
                     // Prevent to explode in case of really high dynamic ranges.
                     // sh 3 would not be enough to accurately represent it.
-                    const max = 16777216;
-                    r = Scalar.Clamp(r, 0, max);
-                    g = Scalar.Clamp(g, 0, max);
-                    b = Scalar.Clamp(b, 0, max);
+                    const max = this.MAX_HDRI_VALUE;
+                    if (this.PRESERVE_CLAMPED_COLORS) {
+                        const currentMax = Math.max(r, g, b);
+                        if (currentMax > max) {
+                            const factor = max / currentMax;
+                            r *= factor;
+                            g *= factor;
+                            b *= factor;
+                        }
+                    } else {
+                        r = Scalar.Clamp(r, 0, max);
+                        g = Scalar.Clamp(g, 0, max);
+                        b = Scalar.Clamp(b, 0, max);
+                    }
 
                     const color = new Color3(r, g, b);
 

--- a/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
@@ -180,7 +180,7 @@ export class CubeMapToSphericalPolynomialTools {
 
                     // Prevent to explode in case of really high dynamic ranges.
                     // sh 3 would not be enough to accurately represent it.
-                    const max = 4096;
+                    const max = 16777216;
                     r = Scalar.Clamp(r, 0, max);
                     g = Scalar.Clamp(g, 0, max);
                     b = Scalar.Clamp(b, 0, max);


### PR DESCRIPTION
Is there any reason to have the 4096 limit for `ConvertCubeMapToSphericalPolynomial`? Can it be removed, adjusted higher or an additional option added to ignore it?

With the current 4096 max value limit in place it is impossible to use any proper "out door" unclipped HDRI images without having incorrect lighting.

For example an extremely bright outdoor HDRI here (https://polyhaven.com/a/rustig_koppie) has peak brightness of over 300.000 for pixels directly in the center of the sun.

A Playground example shows how the current limit incorrectly produces extremely dim lighting: https://www.babylonjs-playground.com/#6CJSXS#2

With 4096 limit in place:
![bright-hdr-sh-with-limit](https://user-images.githubusercontent.com/1881360/235967809-4f45bc7f-74d5-47c3-82ce-77c38bda668e.jpg)

This PR proposes removing the limit, in which case the calculated spherical harmonics produces correctly bright lighting even for bright outdoor HDRIs:
![bright-hdr-sh-no-limit](https://user-images.githubusercontent.com/1881360/235968047-f42d609a-8712-4e99-b12a-8379b792f6a7.jpg)
