### PR TITLE
HDRCubeTexture: Fix texture being ready too soon

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
@@ -576,6 +576,7 @@ ThinEngine.prototype.createRawCubeTextureFromUrl = function (
     const texture = this.createRawCubeTexture(null, size, format, type, !noMipmap, invertY, samplingMode, null);
     scene?.addPendingData(texture);
     texture.url = url;
+    texture.isReady = false;
     this._internalTexturesCache.push(texture);
 
     const onerror = (request?: IWebRequest, exception?: any) => {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/hdrcubetexture-reports-isready-before-it-has-loaded/40458