### PR TITLE
Reset raycast result when no hit

### DIFF
--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1591,6 +1591,8 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             const hitBody = this._bodies.get(hitData[1][0][0]);
             result.body = hitBody?.body;
             result.bodyIndex = hitBody?.index;
+        } else {
+            result.reset();
         }
     }
 


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/havok-plugin-raycast-doesnt-update-the-result-if-theres-no-hit/40500/2
reset raycast result when no hit