### PR TITLE
WebGPU: Fix viewport reset too often

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -1080,13 +1080,6 @@ export class WebGPUEngine extends Engine {
         this._viewportsCurrent[index].y = 0;
         this._viewportsCurrent[index].w = 0;
         this._viewportsCurrent[index].h = 0;
-
-        if (index === 1) {
-            this._viewportCached.x = 0;
-            this._viewportCached.y = 0;
-            this._viewportCached.z = 0;
-            this._viewportCached.w = 0;
-        }
     }
 
     private _mustUpdateViewport(renderPass: GPURenderPassEncoder): boolean {
@@ -2840,6 +2833,7 @@ export class WebGPUEngine extends Engine {
             }
             this._debugPopGroup?.(1);
             this._resetCurrentViewport(1);
+            this._viewport(0, 0, 0, 0);
             this._resetCurrentScissor(1);
             this._resetCurrentStencilRef(1);
             this._resetCurrentColorBlend(1);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-rendertargettexture-take-the-last-cameras-active/40473