### PR TITLE
Use getBoundingClientRect instead of width

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1790,7 +1790,7 @@ export class ThinEngine {
         }
 
         if (IsWindowObjectExist()) {
-            if(this._renderingCanvas) {
+            if (this._renderingCanvas) {
                 const boundingRect = this._renderingCanvas.getBoundingClientRect();
                 width = this._renderingCanvas.clientWidth || boundingRect.width;
                 height = this._renderingCanvas.clientHeight || boundingRect.height;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1790,8 +1790,14 @@ export class ThinEngine {
         }
 
         if (IsWindowObjectExist()) {
-            width = this._renderingCanvas ? this._renderingCanvas.clientWidth || this._renderingCanvas.width : window.innerWidth;
-            height = this._renderingCanvas ? this._renderingCanvas.clientHeight || this._renderingCanvas.height : window.innerHeight;
+            if(this._renderingCanvas) {
+                const boundingRect = this._renderingCanvas.getBoundingClientRect();
+                width = this._renderingCanvas.clientWidth || boundingRect.width;
+                height = this._renderingCanvas.clientHeight || boundingRect.height;
+            } else {
+                width = window.innerWidth;
+                height = window.innerHeight;
+            }
         } else {
             width = this._renderingCanvas ? this._renderingCanvas.width : 100;
             height = this._renderingCanvas ? this._renderingCanvas.height : 100;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1791,7 +1791,13 @@ export class ThinEngine {
 
         if (IsWindowObjectExist()) {
             if (this._renderingCanvas) {
-                const boundingRect = this._renderingCanvas.getBoundingClientRect();
+                const boundingRect = this._renderingCanvas.getBoundingClientRect
+                    ? this._renderingCanvas.getBoundingClientRect()
+                    : {
+                          // fallback to last solution in case the function doesn't exist
+                          width: this._renderingCanvas.width * this._hardwareScalingLevel,
+                          height: this._renderingCanvas.height * this._hardwareScalingLevel,
+                      };
                 width = this._renderingCanvas.clientWidth || boundingRect.width;
                 height = this._renderingCanvas.clientHeight || boundingRect.height;
             } else {


### PR DESCRIPTION
Following up on https://forum.babylonjs.com/t/engine-resize-issue-with-adapttodeviceratio-when-canvas-clientwidth-clientheight-are-0/40363

In certain cases clientWidth and height are undefined (or 0) - for example when the canvas is inlined. In this case, the defined width and height will be taken as the new width and height. The problem is that these values are already taking the hardware scaling into account, so it is then applied twice.

This approach uses the boundingClientRect, which will return the correct width and height, irrelevant of the width and height defined on the canvas itself.