### PR TITLE
[PG] make sure PG load correctly on safari

### DIFF
--- a/packages/tools/playground/src/tools/loadManager.ts
+++ b/packages/tools/playground/src/tools/loadManager.ts
@@ -88,7 +88,7 @@ export class LoadManager {
                 parent.location.hash = pgHash;
             }
             this._previousHash = pgHash;
-            this._loadPlayground(pgHash.substr(1));
+            this._loadPlayground(pgHash.substring(1));
         }
     }
 
@@ -151,13 +151,16 @@ export class LoadManager {
             };
 
             if (id[0] === "#") {
-                id = id.substr(1);
+                id = id.substring(1);
             }
 
             this.globalState.currentSnippetToken = id.split("#")[0];
             if (!id.split("#")[1]) {
                 id += "#0";
             }
+
+            // defensive-handling a safari issue
+            id.replace(/%23/g, "#");
 
             xmlHttp.open("GET", this.globalState.SnippetServerUrl + "/" + id.replace(/#/g, "/"));
             xmlHttp.send();


### PR DESCRIPTION
Safari changes the second hash to %23. Since we are not URI-decoding the hash string we need to be sure that no matter what, %23 is being replaced with # before processing the request.
