### PR TITLE
NME Triplanar block: Add a switch to better project the textures in the case of a cube

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
@@ -17,6 +17,7 @@ import "../../../Shaders/ShadersInclude/helperFunctions";
 import { ImageSourceBlock } from "./Dual/imageSourceBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../nodeMaterialConnectionPointCustomObject";
 import { EngineStore } from "../../../Engines/engineStore";
+import { editableInPropertyPage, PropertyTypeForEdition } from "../nodeMaterialDecorator";
 
 /**
  * Block used to read a texture with triplanar mapping (see "boxmap" in https://iquilezles.org/articles/biplanar/)
@@ -28,6 +29,12 @@ export class TriPlanarBlock extends NodeMaterialBlock {
     private _samplerName: string;
     private _textureInfoName: string;
     private _imageSource: Nullable<ImageSourceBlock>;
+
+    /**
+     * Project the texture(s) for a better fit to a cube
+     */
+    @editableInPropertyPage("Project as cube", PropertyTypeForEdition.Boolean, "ADVANCED", { notifiers: { update: true } })
+    public projectAsCube: boolean = false;
 
     protected _texture: Nullable<Texture>;
     /**
@@ -358,15 +365,39 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         const x = state._getFreeVariableName("x");
         const y = state._getFreeVariableName("y");
         const z = state._getFreeVariableName("z");
-        const w = state._getFreeVariableName("z");
+        const w = state._getFreeVariableName("w");
 
         state.compilationString += `
-            vec4 ${x} = texture2D(${samplerName}, ${this.position.associatedVariableName}.yz);
-            vec4 ${y} = texture2D(${samplerYName}, ${this.position.associatedVariableName}.zx);
-            vec4 ${z} = texture2D(${samplerZName}, ${this.position.associatedVariableName}.xy);
-            
+            vec3 n = ${this.normal.associatedVariableName}.xyz;
+
+            vec2 uvx = ${this.position.associatedVariableName}.yz;
+            vec2 uvy = ${this.position.associatedVariableName}.zx;
+            vec2 uvz = ${this.position.associatedVariableName}.xy;
+        `;
+
+        if (this.projectAsCube) {
+            state.compilationString += `
+                uvx.xy = uvx.yx;
+
+                if (n.x >= 0.0) {
+                    uvx.x = -uvx.x;
+                }
+                if (n.y < 0.0) {
+                    uvy.y = -uvy.y;
+                }
+                if (n.z < 0.0) {
+                    uvz.x = -uvz.x;
+                }
+            `;
+        }
+
+        state.compilationString += `
+            vec4 ${x} = texture2D(${samplerName}, uvx);
+            vec4 ${y} = texture2D(${samplerYName}, uvy);
+            vec4 ${z} = texture2D(${samplerZName}, uvz);
+           
             // blend weights
-            vec3 ${w} = pow(abs(${this.normal.associatedVariableName}.xyz), vec3(${sharpness}));
+            vec3 ${w} = pow(abs(n), vec3(${sharpness}));
 
             // blend and return
             vec4 ${this._tempTextureRead} = (${x}*${w}.x + ${y}*${w}.y + ${z}*${w}.z) / (${w}.x + ${w}.y + ${w}.z);        
@@ -452,6 +483,7 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         codeString += `${this._codeVariableName}.convertToGammaSpace = ${this.convertToGammaSpace};\r\n`;
         codeString += `${this._codeVariableName}.convertToLinearSpace = ${this.convertToLinearSpace};\r\n`;
         codeString += `${this._codeVariableName}.disableLevelMultiplication = ${this.disableLevelMultiplication};\r\n`;
+        codeString += `${this._codeVariableName}.projectAsCube = ${this.projectAsCube};\r\n`;
 
         if (!this.texture) {
             return codeString;
@@ -478,6 +510,7 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         serializationObject.convertToGammaSpace = this.convertToGammaSpace;
         serializationObject.convertToLinearSpace = this.convertToLinearSpace;
         serializationObject.disableLevelMultiplication = this.disableLevelMultiplication;
+        serializationObject.projectAsCube = this.projectAsCube;
         if (!this.hasImageSource && this.texture && !this.texture.isRenderTarget && this.texture.getClassName() !== "VideoTexture") {
             serializationObject.texture = this.texture.serialize();
         }
@@ -491,6 +524,7 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         this.convertToGammaSpace = serializationObject.convertToGammaSpace;
         this.convertToLinearSpace = !!serializationObject.convertToLinearSpace;
         this.disableLevelMultiplication = !!serializationObject.disableLevelMultiplication;
+        this.projectAsCube = !!serializationObject.projectAsCube;
 
         if (serializationObject.texture && !NodeMaterial.IgnoreTexturesAtLoadTime && serializationObject.texture.url !== undefined) {
             rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/orientation-of-textures-with-triplanar-node-material/40528

The switch also helps for more rounded shapes:

