### PR TITLE
Refraction: Fix refraction coordinates in right handed system

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
@@ -204,7 +204,7 @@ export class RefractionBlock extends NodeMaterialBlock {
         defines.setValue(this._define3DName, refractionTexture!.isCube, true);
         defines.setValue(this._defineLODRefractionAlpha, refractionTexture!.lodLevelInAlpha, true);
         defines.setValue(this._defineLinearSpecularRefraction, refractionTexture!.linearSpecularLOD, true);
-        defines.setValue(this._defineOppositeZ, this._scene.useRightHandedSystem ? !refractionTexture!.invertZ : refractionTexture!.invertZ, true);
+        defines.setValue(this._defineOppositeZ, this._scene.useRightHandedSystem && refractionTexture.isCube ? !refractionTexture!.invertZ : refractionTexture!.invertZ, true);
 
         defines.setValue("SS_LINKREFRACTIONTOTRANSPARENCY", this.linkRefractionWithTransparency, true);
         defines.setValue("SS_GAMMAREFRACTION", refractionTexture!.gammaSpace, true);

--- a/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
@@ -457,7 +457,7 @@ export class PBRSubSurfaceConfiguration extends MaterialPluginBase {
                         defines.SS_GAMMAREFRACTION = refractionTexture.gammaSpace;
                         defines.SS_RGBDREFRACTION = refractionTexture.isRGBD;
                         defines.SS_LINEARSPECULARREFRACTION = refractionTexture.linearSpecularLOD;
-                        defines.SS_REFRACTIONMAP_OPPOSITEZ = this._scene.useRightHandedSystem ? !refractionTexture.invertZ : refractionTexture.invertZ;
+                        defines.SS_REFRACTIONMAP_OPPOSITEZ = this._scene.useRightHandedSystem && refractionTexture.isCube ? !refractionTexture.invertZ : refractionTexture.invertZ;
                         defines.SS_LODINREFRACTIONALPHA = refractionTexture.lodLevelInAlpha;
                         defines.SS_LINKREFRACTIONTOTRANSPARENCY = this._linkRefractionWithTransparency;
                         defines.SS_ALBEDOFORREFRACTIONTINT = this.useAlbedoToTintRefraction;

--- a/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.modules.scss
+++ b/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.modules.scss
@@ -13,3 +13,7 @@
 .triplanar-texture-block {
     margin-top: 155px;
 }
+
+.refraction-texture-block {
+    margin-top: 80px;
+}

--- a/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/display/textureDisplayManager.ts
@@ -1,6 +1,6 @@
 import type { NodeMaterialBlock } from "core/Materials/Node/nodeMaterialBlock";
 import { TextureBlock } from "core/Materials/Node/Blocks/Dual/textureBlock";
-import type { RefractionBlock } from "core/Materials/Node/Blocks/PBR/refractionBlock";
+import { RefractionBlock } from "core/Materials/Node/Blocks/PBR/refractionBlock";
 import { ReflectionTextureBlock } from "core/Materials/Node/Blocks/Dual/reflectionTextureBlock";
 import { TextureLineComponent } from "../../sharedComponents/textureLineComponent";
 import { CurrentScreenBlock } from "core/Materials/Node/Blocks/Dual/currentScreenBlock";
@@ -50,6 +50,9 @@ export class TextureDisplayManager implements IDisplayManager {
             }
             if (block instanceof TriPlanarBlock) {
                 contentArea.classList.add(localStyles["triplanar-texture-block"]);
+            }
+            if (block instanceof RefractionBlock) {
+                contentArea.classList.add(localStyles["refraction-texture-block"]);
             }
 
             this._previewCanvas = contentArea.ownerDocument!.createElement("canvas");


### PR DESCRIPTION
See https://forum.babylonjs.com/t/nodematerial-refraction-of-rendertargettexture/40617/3.

Follow up to #13818, the correction must be done only for cube textures.

This PG, which is using a 2D texture for refraction, fails without the fix: https://playground.babylonjs.com/#FIWZP6#5
