### PR TITLE
Video: Fix video not played when using multiple videos in a shader

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5211,6 +5211,10 @@ export class ThinEngine {
         // Video
         if ((<VideoTexture>texture).video) {
             this._activeChannel = channel;
+            const videoInternalTexture = (<VideoTexture>texture).getInternalTexture();
+            if (videoInternalTexture) {
+                videoInternalTexture._associatedChannel = channel;
+            }
             (<VideoTexture>texture).update();
         } else if (texture.delayLoadState === Constants.DELAYLOADSTATE_NOTLOADED) {
             // Delay loading


### PR DESCRIPTION
See https://forum.babylonjs.com/t/video-texture-lost-with-plugins-on-multi-materials/40479/5

This PG will be fixed by the PR: https://playground.babylonjs.com/#4R4FMK#19