### PR TITLE
Node Material Editor: Allow loading GLTF format files in preview window, add drag and drop, revert to cube when loading fails

### DIFF
--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -35,6 +35,7 @@ import { DataStorage } from "core/Misc/dataStorage";
 import type { NodeMaterialBlock } from "core/Materials/Node/nodeMaterialBlock";
 import { CreateTorus } from "core/Meshes/Builders/torusBuilder";
 import type { TextureBlock } from "core/Materials/Node/Blocks/Dual/textureBlock";
+import { FilesInput } from "core/Misc/filesInput";
 
 import "core/Rendering/depthRendererSceneComponent";
 
@@ -380,10 +381,28 @@ export class PreviewManager {
                         });
                         return;
                     case PreviewType.Custom:
-                        SceneLoader.AppendAsync("file:", this._globalState.previewFile, this._scene).then(() => {
-                            this._meshes.push(...this._scene.meshes);
-                            this._prepareScene();
-                        });
+                        const filesLoader = new FilesInput(
+                            this._scene.getEngine(),
+                            this._scene,
+                            (sceneFile, scene) => {
+                                console.log("loading done");
+                                this._meshes.push(...scene.meshes);
+                                this._prepareScene();
+                            },
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            true
+                        );
+                        console.log("start loading files");
+                        filesLoader.loadFiles({ target: { files: this._globalState.listOfCustomPreviewFiles } });
+                        // SceneLoader.AppendAsync("file:", this._globalState.previewFile, this._scene).then(() => {
+                        //     this._meshes.push(...this._scene.meshes);
+                        //     this._prepareScene();
+                        // });
                         return;
                 }
             } else if (this._globalState.mode === NodeMaterialModes.ProceduralTexture) {

--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -173,11 +173,7 @@ export class PreviewManager {
             null,
             null,
             () => {
-                this._globalState.previewType = PreviewType.Box;
-                this._globalState.listOfCustomPreviewFiles = [];
-                this._scene.meshes.forEach((m) => m.dispose());
-                this._globalState.onRefreshPreviewMeshControlComponentRequiredObservable.notifyObservers();
-                this._refreshPreviewMesh(true);
+                this._reset();
             },
             true
         );
@@ -230,6 +226,14 @@ export class PreviewManager {
             this._lightParent.rotation.y += rotateLighting;
             lastOffsetX = evt.event.offsetX;
         });
+    }
+
+    private _reset() {
+        this._globalState.previewType = PreviewType.Box;
+        this._globalState.listOfCustomPreviewFiles = [];
+        this._scene.meshes.forEach((m) => m.dispose());
+        this._globalState.onRefreshPreviewMeshControlComponentRequiredObservable.notifyObservers();
+        this._refreshPreviewMesh(true);
     }
 
     private _handleAnimations() {

--- a/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
@@ -22,6 +22,8 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
     private _colorInputRef: React.RefObject<HTMLInputElement>;
     private _filePickerRef: React.RefObject<HTMLInputElement>;
     private _onResetRequiredObserver: Nullable<Observer<boolean>>;
+    private _onDropEventObserver: Nullable<Observer<DragEvent>>;
+    private _onRefreshPreviewMeshControlComponentRequiredObserver: Nullable<Observer<void>>;
 
     constructor(props: IPreviewMeshControlComponent) {
         super(props);
@@ -31,10 +33,20 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
         this._onResetRequiredObserver = this.props.globalState.onResetRequiredObservable.add(() => {
             this.forceUpdate();
         });
+
+        this._onDropEventObserver = this.props.globalState.onDropEventReceivedObservable.add((event) => {
+            this.useCustomMesh(event);
+        });
+
+        this._onRefreshPreviewMeshControlComponentRequiredObserver = this.props.globalState.onRefreshPreviewMeshControlComponentRequiredObservable.add(() => {
+            this.forceUpdate();
+        });
     }
 
     componentWillUnmount() {
         this.props.globalState.onResetRequiredObservable.remove(this._onResetRequiredObserver);
+        this.props.globalState.onDropEventReceivedObservable.remove(this._onDropEventObserver);
+        this.props.globalState.onRefreshPreviewMeshControlComponentRequiredObservable.remove(this._onRefreshPreviewMeshControlComponentRequiredObserver);
     }
 
     changeMeshType(newOne: PreviewType) {
@@ -51,7 +63,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
     }
 
     useCustomMesh(evt: any) {
-        const files: File[] = evt.target.files;
+        const files: File[] = evt.target?.files || evt.dataTransfer?.files;
         if (files && files.length) {
             const file = files[0];
 
@@ -59,7 +71,6 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
             this.props.globalState.previewType = PreviewType.Custom;
             this.props.globalState.listOfCustomPreviewFiles = [...files];
             this.props.globalState.onPreviewCommandActivated.notifyObservers(false);
-            // this.props.globalState.listOfCustomPreviewFiles = [file];
             this.forceUpdate();
         }
         if (this._filePickerRef.current) {
@@ -112,7 +123,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
             { label: "Smoke", value: PreviewType.Smoke },
             { label: "Load...", value: PreviewType.Custom + 1 },
         ];
-        console.log("list of custom previewFiles length", this.props.globalState.listOfCustomPreviewFiles.length);
+
         if (this.props.globalState.listOfCustomPreviewFiles.length > 0) {
             meshTypeOptions.splice(0, 0, {
                 label: "Custom",

--- a/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/preview/previewMeshControlComponent.tsx
@@ -57,8 +57,9 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
 
             this.props.globalState.previewFile = file;
             this.props.globalState.previewType = PreviewType.Custom;
+            this.props.globalState.listOfCustomPreviewFiles = [...files];
             this.props.globalState.onPreviewCommandActivated.notifyObservers(false);
-            this.props.globalState.listOfCustomPreviewFiles = [file];
+            // this.props.globalState.listOfCustomPreviewFiles = [file];
             this.forceUpdate();
         }
         if (this._filePickerRef.current) {
@@ -111,7 +112,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
             { label: "Smoke", value: PreviewType.Smoke },
             { label: "Load...", value: PreviewType.Custom + 1 },
         ];
-
+        console.log("list of custom previewFiles length", this.props.globalState.listOfCustomPreviewFiles.length);
         if (this.props.globalState.listOfCustomPreviewFiles.length > 0) {
             meshTypeOptions.splice(0, 0, {
                 label: "Custom",
@@ -125,7 +126,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
         }
 
         const options = this.props.globalState.mode === NodeMaterialModes.Particle ? particleTypeOptions : meshTypeOptions;
-        const accept = this.props.globalState.mode === NodeMaterialModes.Particle ? ".json" : ".glb, .babylon, .obj";
+        const accept = this.props.globalState.mode === NodeMaterialModes.Particle ? ".json" : ".*";
 
         return (
             <div id="preview-mesh-bar">
@@ -151,7 +152,7 @@ export class PreviewMeshControlComponent extends React.Component<IPreviewMeshCon
                             }}
                             title="Preview with a custom mesh"
                         >
-                            <input ref={this._filePickerRef} id="file-picker" type="file" onChange={(evt) => this.useCustomMesh(evt)} accept={accept} />
+                            <input ref={this._filePickerRef} multiple id="file-picker" type="file" onChange={(evt) => this.useCustomMesh(evt)} accept={accept} />
                         </div>
                     </>
                 )}

--- a/packages/tools/nodeEditor/src/globalState.ts
+++ b/packages/tools/nodeEditor/src/globalState.ts
@@ -16,6 +16,7 @@ import { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
 import { StateManager } from "shared-ui-components/nodeGraphSystem/stateManager";
 import { RegisterDefaultInput } from "./graphSystem/registerDefaultInput";
 import { RegisterExportData } from "./graphSystem/registerExportData";
+import type { FilesInput } from "core/Misc/filesInput";
 
 export class GlobalState {
     nodeMaterial: NodeMaterial;
@@ -37,6 +38,7 @@ export class GlobalState {
     onAnimationCommandActivated = new Observable<void>();
     onImportFrameObservable = new Observable<any>();
     onPopupClosedObservable = new Observable<void>();
+    onDropEventReceivedObservable = new Observable<DragEvent>();
     onGetNodeFromBlock: (block: NodeMaterialBlock) => GraphNode;
     previewType: PreviewType;
     previewFile: File;
@@ -53,6 +55,8 @@ export class GlobalState {
     controlCamera: boolean;
     _mode: NodeMaterialModes;
     pointerOverCanvas: boolean = false;
+    filesInput: FilesInput;
+    onRefreshPreviewMeshControlComponentRequiredObservable = new Observable<void>();
 
     /** Gets the mode */
     public get mode(): NodeMaterialModes {


### PR DESCRIPTION
Close #12752

To load a GLTF, you have to select all of its files in the file input/drag and drop all the files.