### PR TITLE
Fix Required dependency in HTMLElementTexture

### DIFF
--- a/packages/dev/core/src/Materials/Textures/htmlElementTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/htmlElementTexture.ts
@@ -7,6 +7,7 @@ import type { ExternalTexture } from "./externalTexture";
 
 import "../../Engines/Extensions/engine.dynamicTexture";
 import "../../Engines/Extensions/engine.videoTexture";
+import "../../Engines/Extensions/engine.externalTexture";
 
 declare type ThinEngine = import("../../Engines/thinEngine").ThinEngine;
 declare type Scene = import("../../scene").Scene;


### PR DESCRIPTION
Ensures the ES6 version of the HTMLElementTexture contains all its mandatory dependencies.