### PR TITLE
Add clarification to expected coordinate spaces when using Ray.inters…

### DIFF
--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -293,7 +293,7 @@ export class Ray {
     }
 
     /**
-     * Checks if ray intersects a mesh
+     * Checks if ray intersects a mesh. The ray is defined in WORLD space.
      * @param mesh the mesh to check
      * @param fastCheck defines if the first intersection will be used (and not the closest)
      * @returns picking info of the intersection

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1871,7 +1871,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
 
     /**
      * Checks if the passed Ray intersects with the mesh
-     * @param ray defines the ray to use
+     * @param ray defines the ray to use. It should be in the mesh's LOCAL coordinate space.
      * @param fastCheck defines if fast mode (but less precise) must be used (false by default)
      * @param trianglePredicate defines an optional predicate used to select faces when a mesh intersection is detected
      * @param onlyBoundingInfo defines a boolean indicating if picking should only happen using bounding info (false by default)


### PR DESCRIPTION
…ectsMesh and AbstractMesh.intersects.

Related forum issue: https://forum.babylonjs.com/t/moved-extruded-polygons-dont-intersect-with-rays/40694