### PR TITLE
ArcRotateCamera: Account for offset when using zoom to mouse location

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -114,7 +114,14 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
             }
 
             if (delta) {
-                if (this.zoomToMouseLocation && this._hitPlane) {
+                if (this.zoomToMouseLocation) {
+                    // If we are zooming to the mouse location, then we need to get the hit plane at the start of the zoom gesture if it doesn't exist
+                    // The hit plane is normally calculated after the first motion and each time there's motion so if we don't do this first,
+                    // the first zoom will be to the center of the screen
+                    if (!this._hitPlane) {
+                        this._updateHitPlane();
+                    }
+
                     this._zoomToMouse(delta);
                 } else {
                     this.camera.inertialRadiusOffset += delta;
@@ -202,6 +209,8 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
         // we don't have to worry about this ray shooting off to infinity. This ray creates
         // a vector defining where we want to zoom to.
         const ray = scene.createPickingRay(scene.pointerX, scene.pointerY, Matrix.Identity(), camera, false);
+        // Since the camera is the origin of the picking ray, we need to offset it by the camera's offset manually
+        ray.origin.subtractInPlace(new Vector3(camera.targetScreenOffset.x, camera.targetScreenOffset.y, 0));
         let distance = 0;
         if (this._hitPlane) {
             distance = ray.intersectsPlane(this._hitPlane) ?? 0;

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraMouseWheelInput.ts
@@ -210,7 +210,8 @@ export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCam
         // a vector defining where we want to zoom to.
         const ray = scene.createPickingRay(scene.pointerX, scene.pointerY, Matrix.Identity(), camera, false);
         // Since the camera is the origin of the picking ray, we need to offset it by the camera's offset manually
-        ray.origin.subtractInPlace(new Vector3(camera.targetScreenOffset.x, camera.targetScreenOffset.y, 0));
+        ray.origin.x -= camera.targetScreenOffset.x;
+        ray.origin.y -= camera.targetScreenOffset.y;
         let distance = 0;
         if (this._hitPlane) {
             distance = ray.intersectsPlane(this._hitPlane) ?? 0;


### PR DESCRIPTION
A user brought up an issue in the forum where the camera will zoom to a location but not account for any defined `targetScreenOffset` values.  This PR will now apply the offset to the zoom ray so that it's origin will come from the correct location.

Forum Link: https://forum.babylonjs.com/t/arcrotatecamera-zoomtomouselocation-does-not-take-targetscreenoffset-into-account/40743