### PR TITLE
Allow `scene.audioListenerPositionProvider` to be set to null

### DIFF
--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -244,7 +244,7 @@ Object.defineProperty(Scene.prototype, "audioListenerRotationProvider", {
             this._addComponent(compo);
         }
 
-        if (typeof value !== "function") {
+        if (value && typeof value !== "function") {
             throw new Error("The value passed to [Scene.audioListenerRotationProvider] must be a function that returns a Vector3");
         } else {
             compo.audioListenerRotationProvider = value;

--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -217,7 +217,7 @@ Object.defineProperty(Scene.prototype, "audioListenerPositionProvider", {
             this._addComponent(compo);
         }
 
-        if (typeof value !== "function") {
+        if (value && typeof value !== "function") {
             throw new Error("The value passed to [Scene.audioListenerPositionProvider] must be a function that returns a Vector3");
         } else {
             compo.audioListenerPositionProvider = value;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/setting-scene-audiolistenerpositionprovider-to-null-throws-an-error/40820