### PR TITLE
Material plugin: Fix cleaning when engine is disposed

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1928,7 +1928,6 @@ export class Engine extends ThinEngine {
         // no more engines left in the engine store? Notify!
         if (!Engine.Instances.length) {
             EngineStore.OnEnginesDisposedObservable.notifyObservers(this);
-            EngineStore.OnEnginesDisposedObservable.clear();
         }
 
         // Observables

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -203,12 +203,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     public static OnEventObservable = new Observable<Material>();
 
-    static {
-        EngineStore.OnEnginesDisposedObservable.addOnce(() => {
-            Material.OnEventObservable.clear();
-        });
-    }
-
     /**
      * Custom callback helping to override the default shader used in the material.
      */

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -18,6 +18,7 @@ import type {
 } from "./materialPluginEvent";
 import { MaterialPluginEvent } from "./materialPluginEvent";
 import type { Observer } from "core/Misc/observable";
+import { EngineStore } from "../Engines/engineStore";
 
 declare type Scene = import("../scene").Scene;
 declare type Engine = import("../Engines/engine").Engine;
@@ -57,6 +58,12 @@ export class MaterialPluginManager {
     protected _uniformList: string[];
     protected _samplerList: string[];
     protected _uboList: string[];
+
+    static {
+        EngineStore.OnEnginesDisposedObservable.add(() => {
+            UnregisterAllMaterialPlugins();
+        });
+    }
 
     /**
      * Creates a new instance of the plugin manager
@@ -448,4 +455,5 @@ export function UnregisterAllMaterialPlugins(): void {
     plugins.length = 0;
     inited = false;
     Material.OnEventObservable.remove(observer);
+    observer = null;
 }

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -3,7 +3,7 @@ import type { GlobalState } from "../globalState";
 import { RuntimeMode } from "../globalState";
 import { Utilities } from "../tools/utilities";
 import { DownloadManager } from "../tools/downloadManager";
-import { Engine, WebGPUEngine, UnregisterAllMaterialPlugins } from "@dev/core";
+import { Engine, WebGPUEngine } from "@dev/core";
 
 declare type Nullable<T> = import("@dev/core").Nullable<T>;
 declare type Scene = import("@dev/core").Scene;
@@ -98,11 +98,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
     private async _compileAndRunAsync() {
         this.props.globalState.onDisplayWaitRingObservable.notifyObservers(false);
         this.props.globalState.onErrorObservable.notifyObservers(null);
-
-        // Check to make sure this function exists before calling as this function doesn't exist with older versions.
-        if (UnregisterAllMaterialPlugins) {
-            UnregisterAllMaterialPlugins();
-        }
 
         const displayInspector = this._scene?.debugLayer.isVisible();
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/material-oneventobservable-clear-cause-material-plugins-not-work/40838/3

