### PR TITLE
WebGPU/Compute: Added function that resolves when all compute effects are ready

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
@@ -79,6 +79,12 @@ declare module "../../Engines/thinEngine" {
         areAllComputeEffectsReady(): boolean;
 
         /**
+        * Returns a promise that resolves when all compute effects are ready
+        * @returns A promise that resolves when all compute effects are ready
+        */
+        whenAllComputeEffectsReadyAsync(): Promise<void>;
+
+        /**
          * Forces the engine to release all cached compute effects. This means that next effect compilation will have to be done completely even if a similar effect was already compiled
          */
         releaseComputeEffects(): void;
@@ -132,6 +138,10 @@ ThinEngine.prototype.computeDispatch = function (
 
 ThinEngine.prototype.areAllComputeEffectsReady = function (): boolean {
     return true;
+};
+
+ThinEngine.prototype.whenAllComputeEffectsReadyAsync = function (): Promise<void> {
+    return Promise.resolve();
 };
 
 ThinEngine.prototype.releaseComputeEffects = function (): void {};

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
@@ -54,6 +54,20 @@ WebGPUEngine.prototype.areAllComputeEffectsReady = function (): boolean {
     return true;
 };
 
+WebGPUEngine.prototype.whenAllComputeEffectsReadyAsync = async function () {
+    return new Promise((resolve) => {
+        const check = () => {
+            if (this.areAllComputeEffectsReady()) {
+                resolve();
+            }
+            else {
+                setTimeout(check, 100);
+            }
+        };
+        check();
+    });
+};
+
 WebGPUEngine.prototype.computeDispatch = function (
     effect: ComputeEffect,
     context: IComputeContext,


### PR DESCRIPTION
Not sure if this is the best way to do it, but thought it would be helpful to have a function like this to wait for all compute effects to be ready.

This should avoid the need to always use `dispatchWhenReady` on the first compute invocation.

Happy to try a different approach if preferred.