### PR TITLE
WebGPU: Fix morphTargetTextureIndices overwritting morphTargetTextureInfo

### DIFF
--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -340,6 +340,10 @@ export class MorphTargetManager implements IDisposable {
             }
         }
 
+        if (this._morphTargetTextureIndices.length !== influenceCount) {
+            this._morphTargetTextureIndices = this._morphTargetTextureIndices.slice(0, influenceCount);
+        }
+
         if (!this._influences || this._influences.length !== influenceCount) {
             this._influences = new Float32Array(influenceCount);
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-inactive-morph-target-shrinks-mesh-to-vertex-0/40864