### PR TITLE
[Screen Reader Support] Option for twin renderer to not render all GUI controls by default

### DIFF
--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinHostComponent.tsx
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinHostComponent.tsx
@@ -13,9 +13,11 @@ import { Container } from "gui/2D/controls/container";
 import type { Control } from "gui/2D/controls/control";
 import type { Node } from "core/node";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";
+import type { IHTMLTwinRendererOptions } from "./htmlTwinRenderer";
 
 interface IHTMLTwinHostComponentProps {
     scene: Scene;
+    options?: IHTMLTwinRendererOptions;
 }
 interface IHTMLTwinHostComponentState {
     a11yTreeItems: HTMLTwinItem[];
@@ -23,9 +25,13 @@ interface IHTMLTwinHostComponentState {
 
 export class HTMLTwinHostComponent extends React.Component<IHTMLTwinHostComponentProps, IHTMLTwinHostComponentState> {
     private _observersMap = new Map<Observable<any>, Nullable<Observer<any>>>();
+    private _options: IHTMLTwinRendererOptions;
 
     constructor(props: IHTMLTwinHostComponentProps) {
         super(props);
+        this._options = props.options ?? {
+            addAllControls: true,
+        };
         this.state = { a11yTreeItems: [] };
     }
 
@@ -267,7 +273,7 @@ export class HTMLTwinHostComponent extends React.Component<IHTMLTwinHostComponen
         const queue: Control[] = [...rootItems];
         for (let i: number = 0; i < queue.length; i++) {
             const curNode = queue[i];
-            if (!curNode.isVisible) {
+            if (!curNode.isVisible || (!this._options.addAllControls && curNode.name !== "root" && !curNode.accessibilityTag?.description)) {
                 continue;
             }
             if (curNode instanceof Container && curNode.children.length !== 0 && !(curNode instanceof Button)) {

--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinRenderer.ts
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinRenderer.ts
@@ -3,10 +3,32 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { HTMLTwinHostComponent } from "./htmlTwinHostComponent";
 
+/**
+ * Options for the HTMLTwinRenderer.
+ */
+export interface IHTMLTwinRendererOptions {
+    /**
+     * If this is true, all GUI controls will be added to the twin tree, regardless if they have
+     * a defined accessibility tag or not. If it's false, only controls with an accessibility tag
+     * will be added. True by default.
+     */
+    addAllControls: boolean;
+}
+
+/**
+ * This class is the main entry point for the HTML twin renderer. To render a twin for a scene,
+ * simply call HTMLTwinRenderer.Render(scene).
+ */
 export class HTMLTwinRenderer {
-    public static Render(scene: Scene) {
+    /**
+     * Render the HTML twin for the given scene.
+     * @param scene the scene to render the twin for
+     * @param options options for the renderer
+     */
+    public static Render(scene: Scene, options?: IHTMLTwinRendererOptions) {
         const htmlTwinHost = React.createElement(HTMLTwinHostComponent, {
             scene,
+            options,
         });
         ReactDOM.render(htmlTwinHost, scene.getEngine().getRenderingCanvas());
     }


### PR DESCRIPTION
Closes #13865

Adds a new option for HTMLTwinRenderer.Render, addAllControls, which is true by default and when false, only processes controls that have an explicit accessibilityTag set
Example PG: #XCPP9Y#18673

@gabrieljbaker please take a look and see what you think! 