### PR TITLE
WebGPU: Allow to pass to a compute shader the gpu buffer used in a bundle to render instances

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
@@ -49,7 +49,10 @@ export class WebGPUDrawContext implements IDrawContext {
             this.indirectDrawBuffer = undefined;
             this._indirectDrawData = undefined;
         } else {
-            this.indirectDrawBuffer = this._bufferManager.createRawBuffer(40, WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Indirect);
+            this.indirectDrawBuffer = this._bufferManager.createRawBuffer(
+                20,
+                WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Indirect | WebGPUConstants.BufferUsage.Storage
+            );
             this._indirectDrawData = new Uint32Array(5);
             this._indirectDrawData[3] = 0;
             this._indirectDrawData[4] = 0;

--- a/packages/dev/core/src/Meshes/WebGPU/webgpuDataBuffer.ts
+++ b/packages/dev/core/src/Meshes/WebGPU/webgpuDataBuffer.ts
@@ -5,8 +5,9 @@ import type { Nullable } from "../../types";
 export class WebGPUDataBuffer extends DataBuffer {
     private _buffer: Nullable<GPUBuffer>;
 
-    public constructor(resource: GPUBuffer) {
+    public constructor(resource: GPUBuffer, capacity = 0) {
         super();
+        this.capacity = capacity;
         this._buffer = resource;
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/dynamic-size-of-instance-count/40839/9

This change allows you to pass the buffer used by the "draw indirect" call made in a render bundle to a compute shader.

It is useful to update the number of instances visible directly from a compute shader, when doing your own culling on the GPU, for example.