### PR TITLE
STL export multiple meshes

### DIFF
--- a/packages/dev/serializers/src/stl/stlSerializer.ts
+++ b/packages/dev/serializers/src/stl/stlSerializer.ts
@@ -16,6 +16,7 @@ export class STLExport {
      * @param isLittleEndian toggle for binary type exporter.
      * @param doNotBakeTransform toggle if meshes transforms should be baked or not.
      * @param supportInstancedMeshes toggle to export instanced Meshes. Enabling support for instanced meshes will override doNoBakeTransform as true
+     * @param mergeMeshes toggle to export each mesh as an independent mesh. By default, all the meshes are combined into one mesh. This property has no effect when exporting in binary format
      * @returns the STL as UTF8 string
      */
     public static CreateSTL(
@@ -25,7 +26,8 @@ export class STLExport {
         binary: boolean = false,
         isLittleEndian: boolean = true,
         doNotBakeTransform: boolean = false,
-        supportInstancedMeshes: boolean = false
+        supportInstancedMeshes: boolean = false,
+        mergeMeshes: boolean = true
     ): any {
         //Binary support adapted from https://gist.github.com/paulkaplan/6d5f0ab2c7e8fdc68a61
 
@@ -77,7 +79,7 @@ export class STLExport {
             doNotBakeTransform = true;
         }
 
-        let data;
+        let data: DataView | string = "";
 
         let faceCount = 0;
         let offset = 0;
@@ -97,11 +99,16 @@ export class STLExport {
             data.setUint32(offset, faceCount, isLittleEndian);
             offset += 4;
         } else {
-            data = "solid stlmesh\r\n";
+            if (mergeMeshes) {
+                data = "solid stlmesh\r\n";
+            }
         }
 
         for (let i = 0; i < meshes.length; i++) {
             const mesh = meshes[i];
+            if (!binary && !mergeMeshes) {
+                data += "solid " + mesh.name + "\r\n";
+            }
             if (!doNotBakeTransform && mesh instanceof Mesh) {
                 mesh.bakeCurrentTransformIntoVertices();
             }
@@ -118,18 +125,21 @@ export class STLExport {
                     offset = writeVector(data, offset, fd.v[2], isLittleEndian);
                     offset += 2;
                 } else {
-                    data += "facet normal " + fd.n.x + " " + fd.n.y + " " + fd.n.z + "\r\n";
-                    data += "\touter loop\r\n";
-                    data += "\t\tvertex " + fd.v[0].x + " " + fd.v[0].y + " " + fd.v[0].z + "\r\n";
-                    data += "\t\tvertex " + fd.v[1].x + " " + fd.v[1].y + " " + fd.v[1].z + "\r\n";
-                    data += "\t\tvertex " + fd.v[2].x + " " + fd.v[2].y + " " + fd.v[2].z + "\r\n";
-                    data += "\tendloop\r\n";
-                    data += "endfacet\r\n";
+                    data += "\tfacet normal " + fd.n.x + " " + fd.n.y + " " + fd.n.z + "\r\n";
+                    data += "\t\touter loop\r\n";
+                    data += "\t\t\tvertex " + fd.v[0].x + " " + fd.v[0].y + " " + fd.v[0].z + "\r\n";
+                    data += "\t\t\tvertex " + fd.v[1].x + " " + fd.v[1].y + " " + fd.v[1].z + "\r\n";
+                    data += "\t\t\tvertex " + fd.v[2].x + " " + fd.v[2].y + " " + fd.v[2].z + "\r\n";
+                    data += "\t\tendloop\r\n";
+                    data += "\tendfacet\r\n";
                 }
+            }
+            if (!binary && !mergeMeshes) {
+                data += "endsolid " + name + "\r\n";
             }
         }
 
-        if (!binary) {
+        if (!binary && mergeMeshes) {
             data += "endsolid stlmesh";
         }
 


### PR DESCRIPTION
Add the option to not combine the meshes on export as STL
Based on this discussion
https://forum.babylonjs.com/t/stlexport-could-use-mesh-name-s-instead-than-the-generic-stlmesh-as-solid-label-s/40120