### PR TITLE
Pre-Pass renderer: Fix scene.isReady when using the prepass renderer

### DIFF
--- a/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -799,6 +799,7 @@ export class CascadedShadowGenerator extends ShadowGenerator {
             undefined /*, Constants.TEXTUREFORMAT_RED*/
         );
         this._shadowMap.createDepthStencilTexture(engine.useReverseDepthBuffer ? Constants.GREATER : Constants.LESS, true);
+        this._shadowMap.noPrePassRenderer = true;
     }
 
     protected _initializeShadowMap(): void {

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -928,6 +928,7 @@ export class ShadowGenerator implements IShadowGenerator {
         } else {
             this._shadowMap = new RenderTargetTexture(this._light.name + "_shadowMap", this._mapSize, this._scene, false, true, this._textureType, this._light.needCube());
         }
+        this._shadowMap.noPrePassRenderer = true;
     }
 
     protected _initializeShadowMap(): void {

--- a/packages/dev/core/src/Materials/materialDefines.ts
+++ b/packages/dev/core/src/Materials/materialDefines.ts
@@ -94,6 +94,7 @@ export class MaterialDefines {
         this._areLightsDirty = true;
         this._areFresnelDirty = true;
         this._areMiscDirty = true;
+        this._arePrePassDirty = false;
         this._areImageProcessingDirty = true;
         this._isDirty = true;
     }

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1274,13 +1274,15 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             for (let key = iterator.next(); key.done !== true; key = iterator.next()) {
                 const generator = key.value;
                 if (generator && (!generator.getShadowMap()?.renderList || (generator.getShadowMap()?.renderList && generator.getShadowMap()?.renderList?.indexOf(this) !== -1))) {
-                    if (generator.getShadowMap()) {
-                        engine.currentRenderPassId = generator.getShadowMap()!.renderPassId;
-                    }
-                    for (const subMesh of this.subMeshes) {
-                        if (!generator.isReady(subMesh, hardwareInstancedRendering, subMesh.getMaterial()?.needAlphaBlendingForMesh(this) ?? false)) {
-                            engine.currentRenderPassId = currentRenderPassId;
-                            return false;
+                    const shadowMap = generator.getShadowMap()!;
+                    const renderPassIds = shadowMap.renderPassIds ?? [engine.currentRenderPassId];
+                    for (let p = 0; p < renderPassIds.length; ++p) {
+                        engine.currentRenderPassId = renderPassIds[p];
+                        for (const subMesh of this.subMeshes) {
+                            if (!generator.isReady(subMesh, hardwareInstancedRendering, subMesh.getMaterial()?.needAlphaBlendingForMesh(this) ?? false)) {
+                                engine.currentRenderPassId = currentRenderPassId;
+                                return false;
+                            }
                         }
                     }
                     engine.currentRenderPassId = currentRenderPassId;

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -299,6 +299,11 @@ export class PrePassRenderer {
 
         this.renderTargets.push(rt);
 
+        if (this._enabled) {
+            // The pre-pass renderer is already enabled, so make sure we create the render target with the correct number of textures
+            this._update();
+        }
+
         return rt;
     }
 

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -184,7 +184,7 @@ export class PrePassRenderer {
             this._currentTarget = prePassRenderTarget;
         } else {
             this._currentTarget = this.defaultRT;
-            this._engine.currentRenderPassId = this._currentTarget.renderPassId;
+            this._engine.currentRenderPassId = this._scene.activeCamera?.renderPassId ?? this._currentTarget.renderPassId;
         }
     }
 
@@ -782,6 +782,15 @@ export class PrePassRenderer {
             if (type === Constants.PREPASS_VELOCITY_TEXTURE_TYPE) {
                 this._scene.needsPreviousWorldMatrices = true;
             }
+        }
+    }
+
+    /**
+     * Makes sure that the prepass renderer is up to date if it has been dirtified.
+     */
+    public update() {
+        if (this._isDirty) {
+            this._update();
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-to-detect-the-completion-of-initialization/40952/7 and https://forum.babylonjs.com/t/model-load-much-slower-with-cascadedshadow-and-prepassrenderer/40893/6.
