### PR TITLE
[GUI] Fix the underline/strike-through line to use the color of the text when there is no outline.

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -405,22 +405,29 @@ export class TextBlock extends Control {
         context.fillText(text, this._currentMeasure.left + x, y);
 
         if (this._underline) {
-            context.beginPath();
-            context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
-            context.moveTo(this._currentMeasure.left + x, y + 3);
-            context.lineTo(this._currentMeasure.left + x + textWidth, y + 3);
-            context.stroke();
-            context.closePath();
+            this._drawLine(this._currentMeasure.left + x, y + 3, this._currentMeasure.left + x + textWidth, y + 3, context);
         }
 
         if (this._lineThrough) {
-            context.beginPath();
-            context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
-            context.moveTo(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3);
-            context.lineTo(this._currentMeasure.left + x + textWidth, y - this.fontSizeInPixels / 3);
-            context.stroke();
-            context.closePath();
+            this._drawLine(this._currentMeasure.left + x, y - this.fontSizeInPixels / 3, this._currentMeasure.left + x + textWidth, y - this.fontSizeInPixels / 3, context);
         }
+    }
+
+    private _drawLine(xFrom: number, yFrom: number, xTo: number, yTo: number, context: ICanvasRenderingContext): void {
+        context.beginPath();
+        context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
+        context.moveTo(xFrom, yFrom);
+        context.lineTo(xTo, yTo);
+        if (this.outlineWidth) {
+            context.stroke();
+            context.fill();
+        } else {
+            const currentStroke = context.strokeStyle;
+            context.strokeStyle = context.fillStyle;
+            context.stroke();
+            context.strokeStyle = currentStroke;
+        }
+        context.closePath();
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -51,6 +51,8 @@ export class TextBlock extends Control {
     private _lineThrough: boolean = false;
     private _wordDivider: string = " ";
     private _forceResizeWidth: boolean = false;
+    private _applyOutlineToUnderline: boolean = false;
+
     /**
      * An event triggered after the text is changed
      */
@@ -253,6 +255,22 @@ export class TextBlock extends Control {
     }
 
     /**
+     * If the outline should be applied to the underline/strike-through too. Has different behavior in Edge/Chrome vs Firefox.
+     */
+    @serialize()
+    public get applyOutlineToUnderline(): boolean {
+        return this._applyOutlineToUnderline;
+    }
+
+    public set applyOutlineToUnderline(value: boolean) {
+        if (this._applyOutlineToUnderline === value) {
+            return;
+        }
+        this._applyOutlineToUnderline = value;
+        this._markAsDirty();
+    }
+
+    /**
      * Gets or sets outlineColor of the text to display
      */
     @serialize()
@@ -418,7 +436,7 @@ export class TextBlock extends Control {
         context.lineWidth = Math.round(this.fontSizeInPixels * 0.05);
         context.moveTo(xFrom, yFrom);
         context.lineTo(xTo, yTo);
-        if (this.outlineWidth) {
+        if (this.outlineWidth && this.applyOutlineToUnderline) {
             context.stroke();
             context.fill();
         } else {


### PR DESCRIPTION
Please not that, due to a bug in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1834594), it's not possible to have both the text and the outline color on that browser. So I added an option to use or not the behavior in case consistent behavior is needed:
Example PG: #CMMCCJ#6

In Edge/Chrome:

![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/262194fd-e931-47e6-b6ae-81db3d6b7d23)

In FF:
![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/fec96b5e-d9f3-44cf-a3a8-b5e4a7bc892b)


