### PR TITLE
[Inspector] Prevent crashing when a mesh's name is of the wrong type.

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2358,10 +2358,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             return;
         }
 
-        if (typeof newMesh.name !== "string") {
-            Tools.Warn("Mesh's name is not of string type.");
-        }
-
         this.meshes.push(newMesh);
 
         newMesh._resyncLightSources();

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2358,6 +2358,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             return;
         }
 
+        if (typeof newMesh.name !== "string") {
+            Tools.Warn("Mesh's name is not of string type.");
+        }
+
         this.meshes.push(newMesh);
 
         newMesh._resyncLightSources();

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
@@ -34,9 +34,8 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
         const sortedNodes = scene
             .getNodes()
             .filter((n) => n !== node)
+            .map((n) => this._getNameForSorting).
             .sort((a, b) => {
-                const aName = this._getNameForSorting(a);
-                const bName = this._getNameForSorting(b);
                 return aName.localeCompare(bName);
             });
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
@@ -34,8 +34,8 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
         const sortedNodes = scene
             .getNodes()
             .filter((n) => n !== node)
-            .map((n) => this._getNameForSorting).
-            .sort((a, b) => {
+            .map((n) => this._getNameForSorting(n))
+            .sort((aName, bName) => {
                 return aName.localeCompare(bName);
             });
 
@@ -65,7 +65,7 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
                     noDirectUpdate={true}
                     onSelect={(value) => {
                         const nodeAsTransform = node as TransformNode;
-                        if (typeof value === "number" && value < 0) {
+                        if (typeof value !== "number" || value < 0) {
                             if (nodeAsTransform.setParent) {
                                 nodeAsTransform.setParent(null);
                             } else {

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
@@ -22,6 +22,11 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
         super(props);
     }
 
+    private _getNameForSorting(node: any) {
+        const isNameAString = node.name && typeof node.name === "string";
+        return isNameAString ? node.name : "no name";
+    }
+
     render() {
         const node = this.props.node;
         const scene = node.getScene();
@@ -29,7 +34,11 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
         const sortedNodes = scene
             .getNodes()
             .filter((n) => n !== node)
-            .sort((a, b) => (a.name || "no name").localeCompare(b.name || "no name"));
+            .sort((a, b) => {
+                const aName = this._getNameForSorting(a);
+                const bName = this._getNameForSorting(b);
+                return aName.localeCompare(bName);
+            });
 
         const nodeOptions = sortedNodes.map((m, i) => {
             return {
@@ -57,7 +66,7 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
                     noDirectUpdate={true}
                     onSelect={(value) => {
                         const nodeAsTransform = node as TransformNode;
-                        if (value < 0) {
+                        if (typeof value === "number" && value < 0) {
                             if (nodeAsTransform.setParent) {
                                 nodeAsTransform.setParent(null);
                             } else {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/meshTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/meshTreeItemComponent.tsx
@@ -39,6 +39,12 @@ export class MeshTreeItemComponent extends React.Component<IMeshTreeItemComponen
         this.props.mesh.isVisible = newState;
     }
 
+    // mesh.name can fail the type check when we're in javascript, so
+    // we can check to avoid crashing
+    private _getNameForLabel(): string {
+        return typeof this.props.mesh.name === "string" ? this.props.mesh.name : "no name";
+    }
+
     render() {
         const mesh = this.props.mesh;
 
@@ -46,7 +52,7 @@ export class MeshTreeItemComponent extends React.Component<IMeshTreeItemComponen
 
         return (
             <div className="meshTools">
-                <TreeItemLabelComponent label={mesh.name} onClick={() => this.props.onClick()} icon={faCube} color="dodgerblue" />
+                <TreeItemLabelComponent label={this._getNameForLabel()} onClick={() => this.props.onClick()} icon={faCube} color="dodgerblue" />
                 <div
                     className={this.state.isBoundingBoxEnabled ? "bounding-box selected icon" : "bounding-box icon"}
                     onClick={() => this.showBoundingBox()}


### PR DESCRIPTION
A user can mistakenly set a mesh's name with the wrong type (not string), like this example: https://playground.babylonjs.com/#XT7L5S, where trying to open the Inspector makes it crash. This PR just adds some extra type checking to avoid it crashing, and also adds a quick check to warn the user when adding to a scene.