### PR TITLE
Add GLTF Anisotropy extension.

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -49,6 +49,7 @@ export class AnisotropyBlock extends NodeMaterialBlock {
             NodeMaterialBlockTargets.VertexAndFragment,
             new NodeMaterialConnectionPointCustomObject("TBN", this, NodeMaterialConnectionPointDirection.Input, TBNBlock, "TBNBlock")
         );
+        this.registerInput("roughness", NodeMaterialBlockConnectionPointTypes.Float, true, NodeMaterialBlockTargets.Fragment);
 
         this.registerOutput(
             "anisotropy",
@@ -109,6 +110,13 @@ export class AnisotropyBlock extends NodeMaterialBlock {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public get TBN(): NodeMaterialConnectionPoint {
         return this._inputs[4];
+    }
+
+    /**
+     * Gets the roughness input component
+     */
+    public get roughness(): NodeMaterialConnectionPoint {
+        return this._inputs[5];
     }
 
     /**
@@ -183,10 +191,12 @@ export class AnisotropyBlock extends NodeMaterialBlock {
 
         const intensity = this.intensity.isConnected ? this.intensity.associatedVariableName : "1.0";
         const direction = this.direction.isConnected ? this.direction.associatedVariableName : "vec2(1., 0.)";
+        const roughness = this.roughness.isConnected ? this.roughness.associatedVariableName : "0.";
 
         code += `anisotropicOutParams anisotropicOut;
             anisotropicBlock(
                 vec3(${direction}, ${intensity}),
+                ${roughness},
             #ifdef ANISOTROPIC_TEXTURE
                 vec3(0.),
             #endif
@@ -204,6 +214,7 @@ export class AnisotropyBlock extends NodeMaterialBlock {
 
         defines.setValue("ANISOTROPIC", true);
         defines.setValue("ANISOTROPIC_TEXTURE", false, true);
+        defines.setValue("ANISOTROPIC_LEGACY", !this.roughness.isConnected);
     }
 
     public bind(effect: Effect, nodeMaterial: NodeMaterial, mesh?: Mesh) {

--- a/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrAnisotropicConfiguration.ts
@@ -24,6 +24,7 @@ export class MaterialAnisotropicDefines extends MaterialDefines {
     public ANISOTROPIC = false;
     public ANISOTROPIC_TEXTURE = false;
     public ANISOTROPIC_TEXTUREDIRECTUV = 0;
+    public ANISOTROPIC_LEGACY = false;
     public MAINUV1 = false;
 }
 
@@ -52,6 +53,22 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
     @serializeAsVector2()
     public direction = new Vector2(1, 0);
 
+    /**
+     * Sets the anisotropy direction as an angle.
+     */
+    public set angle(value: number) {
+        this.direction.x = Math.cos(value);
+        this.direction.y = Math.sin(value);
+    }
+
+    /**
+     * Gets the anisotropy angle value in radians.
+     * @returns the anisotropy angle value in radians.
+     */
+    public get angle(): number {
+        return Math.atan2(this.direction.y, this.direction.x);
+    }
+
     private _texture: Nullable<BaseTexture> = null;
     /**
      * Stores the anisotropy values in a texture.
@@ -62,6 +79,14 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
     public texture: Nullable<BaseTexture> = null;
 
+    private _legacy = false;
+    /**
+     * Defines if the anisotropy is in legacy mode for backwards compatibility before 6.4.0.
+     */
+    @serialize()
+    @expandToProperty("_markAllSubMeshesAsMiscDirty")
+    public legacy: boolean = false;
+
     /** @internal */
     private _internalMarkAllSubMeshesAsTexturesDirty: () => void;
 
@@ -71,10 +96,20 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
         this._internalMarkAllSubMeshesAsTexturesDirty();
     }
 
+    /** @internal */
+    private _internalMarkAllSubMeshesAsMiscDirty: () => void;
+
+    /** @internal */
+    public _markAllSubMeshesAsMiscDirty(): void {
+        this._enable(this._isEnabled);
+        this._internalMarkAllSubMeshesAsMiscDirty();
+    }
+
     constructor(material: PBRBaseMaterial, addToPluginList = true) {
         super(material, "PBRAnisotropic", 110, new MaterialAnisotropicDefines(), addToPluginList);
 
         this._internalMarkAllSubMeshesAsTexturesDirty = material._dirtyCallbacks[Constants.MATERIAL_TextureDirtyFlag];
+        this._internalMarkAllSubMeshesAsMiscDirty = material._dirtyCallbacks[Constants.MATERIAL_MiscDirtyFlag];
     }
 
     public isReadyForSubMesh(defines: MaterialAnisotropicDefines, scene: Scene): boolean {
@@ -112,10 +147,15 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
                     }
                 }
             }
+
+            if (defines._areMiscDirty) {
+                defines.ANISOTROPIC_LEGACY = this._legacy;
+            }
         } else {
             defines.ANISOTROPIC = false;
             defines.ANISOTROPIC_TEXTURE = false;
             defines.ANISOTROPIC_TEXTUREDIRECTUV = 0;
+            defines.ANISOTROPIC_LEGACY = false;
         }
     }
 
@@ -195,5 +235,20 @@ export class PBRAnisotropicConfiguration extends MaterialPluginBase {
                 { name: "anisotropyMatrix", size: 16, type: "mat4" },
             ],
         };
+    }
+
+    /**
+     * Parses a anisotropy Configuration from a serialized object.
+     * @param source - Serialized object.
+     * @param scene Defines the scene we are parsing for
+     * @param rootUrl Defines the rootUrl to load from
+     */
+    public parse(source: any, scene: Scene, rootUrl: string): void {
+        super.parse(source, scene, rootUrl);
+
+        // Backward compatibility
+        if (source.legacy === undefined) {
+            this.legacy = true;
+        }
     }
 }

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAnisotropic.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAnisotropic.fx
@@ -13,6 +13,7 @@
     #define pbr_inline
     void anisotropicBlock(
         in vec3 vAnisotropy,
+        in float roughness,
     #ifdef ANISOTROPIC_TEXTURE
         in vec3 anisotropyMapData,
     #endif
@@ -27,7 +28,14 @@
 
         #ifdef ANISOTROPIC_TEXTURE
             anisotropy *= anisotropyMapData.b;
-            anisotropyDirection.rg *= anisotropyMapData.rg * 2.0 - 1.0;
+            anisotropyMapData.rg = anisotropyMapData.rg * 2.0 - 1.0;
+
+            #ifdef ANISOTROPIC_LEGACY
+                anisotropyDirection.rg *= anisotropyMapData.rg;
+            #else
+                anisotropyDirection.xy = mat2(anisotropyDirection.x, anisotropyDirection.y, -anisotropyDirection.y, anisotropyDirection.x) * normalize(anisotropyMapData.rg);
+            #endif
+
             #if DEBUGMODE > 0
                 outParams.anisotropyMapData = anisotropyMapData;
             #endif
@@ -40,6 +48,6 @@
         outParams.anisotropy = anisotropy;
         outParams.anisotropicTangent = anisotropicTangent;
         outParams.anisotropicBitangent = anisotropicBitangent;
-        outParams.anisotropicNormal = getAnisotropicBentNormals(anisotropicTangent, anisotropicBitangent, normalW, viewDirectionW, anisotropy);
+        outParams.anisotropicNormal = getAnisotropicBentNormals(anisotropicTangent, anisotropicBitangent, normalW, viewDirectionW, anisotropy, roughness);
     }
 #endif

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -253,6 +253,7 @@ void main(void) {
 
         anisotropicBlock(
             vAnisotropy,
+            roughness,
         #ifdef ANISOTROPIC_TEXTURE
             anisotropyMapData,
         #endif

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/pbrMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/pbrMaterialPropertyGridComponent.tsx
@@ -604,6 +604,13 @@ export class PBRMaterialPropertyGridComponent extends React.Component<IPBRMateri
                     />
                     {material.anisotropy.isEnabled && (
                         <div className="fragment">
+                            <CheckBoxLineComponent
+                                label="Legacy Mode"
+                                target={material.anisotropy}
+                                propertyName="legacy"
+                                onValueChanged={() => this.forceUpdate()}
+                                onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                            />
                             <SliderLineComponent
                                 lockObject={this.props.lockObject}
                                 label="Intensity"

--- a/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
@@ -169,6 +169,11 @@ export class GLTFComponent extends React.Component<IGLTFComponentProps> {
                         onSelect={(value) => (extensionStates["KHR_materials_iridescence"].enabled = value)}
                     />
                     <CheckBoxLineComponent
+                        label="KHR_materials_anisotropy"
+                        isSelected={() => extensionStates["KHR_materials_anisotropy"].enabled}
+                        onSelect={(value) => (extensionStates["KHR_materials_anisotropy"].enabled = value)}
+                    />
+                    <CheckBoxLineComponent
                         label="KHR_materials_emissive_strength"
                         isSelected={() => extensionStates["KHR_materials_emissive_strength"].enabled}
                         onSelect={(value) => (extensionStates["KHR_materials_emissive_strength"].enabled = value)}

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -44,6 +44,7 @@ export class GlobalState {
         KHR_materials_pbrSpecularGlossiness: { enabled: true },
         KHR_materials_clearcoat: { enabled: true },
         KHR_materials_iridescence: { enabled: true },
+        KHR_materials_anisotropy: { enabled: true },
         KHR_materials_emissive_strength: { enabled: true },
         KHR_materials_ior: { enabled: true },
         KHR_materials_sheen: { enabled: true },

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.data.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.data.ts
@@ -167,6 +167,10 @@ const materialsTree = {
                 iridescenceThicknessMinimum: [new MaterialAnimationPropertyInfo(Animation.ANIMATIONTYPE_FLOAT, "iridescence.minimumThickness", getFloat, () => 1)],
                 iridescenceThicknessMaximum: [new MaterialAnimationPropertyInfo(Animation.ANIMATIONTYPE_FLOAT, "iridescence.maximumThickness", getFloat, () => 1)],
             },
+            KHR_materials_anisotropy: {
+                anisotropyStrength: [new MaterialAnimationPropertyInfo(Animation.ANIMATIONTYPE_FLOAT, "anisotropy.intensity", getFloat, () => 1)],
+                anisotropyRotation: [new MaterialAnimationPropertyInfo(Animation.ANIMATIONTYPE_FLOAT, "anisotropy.angle", getFloat, () => 1)],
+            },
         },
     },
 };

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
@@ -1,0 +1,84 @@
+import type { Nullable } from "core/types";
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import type { Material } from "core/Materials/material";
+
+import type { IMaterial } from "../glTFLoaderInterfaces";
+import type { IGLTFLoaderExtension } from "../glTFLoaderExtension";
+import { GLTFLoader } from "../glTFLoader";
+import type { IKHRMaterialsAnisotropy } from "babylonjs-gltf2interface";
+
+const NAME = "KHR_materials_anisotropy";
+
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy)
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_materials_anisotropy implements IGLTFLoaderExtension {
+    /**
+     * The name of this extension.
+     */
+    public readonly name = NAME;
+
+    /**
+     * Defines whether this extension is enabled.
+     */
+    public enabled: boolean;
+
+    /**
+     * Defines a number that determines the order the extensions are applied.
+     */
+    public order = 195;
+
+    private _loader: GLTFLoader;
+
+    /**
+     * @internal
+     */
+    constructor(loader: GLTFLoader) {
+        this._loader = loader;
+        this.enabled = this._loader.isExtensionUsed(NAME);
+    }
+
+    /** @internal */
+    public dispose() {
+        (this._loader as any) = null;
+    }
+
+    /**
+     * @internal
+     */
+    public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        return GLTFLoader.LoadExtensionAsync<IKHRMaterialsAnisotropy>(context, material, this.name, (extensionContext, extension) => {
+            const promises = new Array<Promise<any>>();
+            promises.push(this._loader.loadMaterialPropertiesAsync(context, material, babylonMaterial));
+            promises.push(this._loadIridescencePropertiesAsync(extensionContext, extension, babylonMaterial));
+            return Promise.all(promises).then(() => {});
+        });
+    }
+
+    private _loadIridescencePropertiesAsync(context: string, properties: IKHRMaterialsAnisotropy, babylonMaterial: Material): Promise<void> {
+        if (!(babylonMaterial instanceof PBRMaterial)) {
+            throw new Error(`${context}: Material type not supported`);
+        }
+
+        const promises = new Array<Promise<any>>();
+
+        babylonMaterial.anisotropy.isEnabled = true;
+
+        babylonMaterial.anisotropy.intensity = properties.anisotropyStrength ?? 0;
+        babylonMaterial.anisotropy.angle = properties.anisotropyRotation ?? 0;
+
+        if (properties.anisotropyTexture) {
+            promises.push(
+                this._loader.loadTextureInfoAsync(`${context}/anisotropyTexture`, properties.anisotropyTexture, (texture) => {
+                    texture.name = `${babylonMaterial.name} (Anisotropy Intensity)`;
+                    babylonMaterial.anisotropy.texture = texture;
+                })
+            );
+        }
+
+        return Promise.all(promises).then(() => {});
+    }
+}
+
+GLTFLoader.RegisterExtension(NAME, (loader) => new KHR_materials_anisotropy(loader));

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
@@ -8,6 +8,7 @@ export * from "./KHR_materials_pbrSpecularGlossiness";
 export * from "./KHR_materials_unlit";
 export * from "./KHR_materials_clearcoat";
 export * from "./KHR_materials_iridescence";
+export * from "./KHR_materials_anisotropy";
 export * from "./KHR_materials_emissive_strength";
 export * from "./KHR_materials_sheen";
 export * from "./KHR_materials_specular";

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
@@ -1,0 +1,83 @@
+import type { IMaterial, IKHRMaterialsAnisotropy } from "babylonjs-gltf2interface";
+import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
+import { _Exporter } from "../glTFExporter";
+import type { Material } from "core/Materials/material";
+import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
+import type { BaseTexture } from "core/Materials/Textures/baseTexture";
+
+const NAME = "KHR_materials_anisotropy";
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_materials_anisotropy implements IGLTFExporterExtensionV2 {
+    /** Name of this extension */
+    public readonly name = NAME;
+
+    /** Defines whether this extension is enabled */
+    public enabled = true;
+
+    /** Defines whether this extension is required */
+    public required = false;
+
+    private _exporter: _Exporter;
+
+    private _wasUsed = false;
+
+    constructor(exporter: _Exporter) {
+        this._exporter = exporter;
+    }
+
+    public dispose() {}
+
+    /** @internal */
+    public get wasUsed() {
+        return this._wasUsed;
+    }
+
+    public postExportMaterialAdditionalTextures?(context: string, node: IMaterial, babylonMaterial: Material): BaseTexture[] {
+        const additionalTextures: BaseTexture[] = [];
+        if (babylonMaterial instanceof PBRBaseMaterial) {
+            if (babylonMaterial.anisotropy.isEnabled && !babylonMaterial.anisotropy.legacy) {
+                if (babylonMaterial.anisotropy.texture) {
+                    additionalTextures.push(babylonMaterial.anisotropy.texture);
+                }
+                return additionalTextures;
+            }
+        }
+
+        return [];
+    }
+
+    public postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
+        return new Promise((resolve) => {
+            if (babylonMaterial instanceof PBRBaseMaterial) {
+                if (!babylonMaterial.anisotropy.isEnabled || babylonMaterial.anisotropy.legacy) {
+                    resolve(node);
+                    return;
+                }
+
+                this._wasUsed = true;
+
+                node.extensions = node.extensions || {};
+
+                const anisotropyTextureInfo = this._exporter._glTFMaterialExporter._getTextureInfo(babylonMaterial.anisotropy.texture);
+
+                const anisotropyInfo: IKHRMaterialsAnisotropy = {
+                    anisotropyStrength: babylonMaterial.anisotropy.intensity,
+                    anisotropyRotation: babylonMaterial.anisotropy.angle,
+                    anisotropyTexture: anisotropyTextureInfo ?? undefined,
+                    hasTextures: () => {
+                        return anisotropyInfo.anisotropyTexture !== null;
+                    },
+                };
+
+                node.extensions[NAME] = anisotropyInfo;
+            }
+            resolve(node);
+        });
+    }
+}
+
+_Exporter.RegisterExtension(NAME, (exporter) => new KHR_materials_anisotropy(exporter));

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/index.ts
@@ -2,6 +2,7 @@ export * from "./KHR_texture_transform";
 export * from "./KHR_lights_punctual";
 export * from "./KHR_materials_clearcoat";
 export * from "./KHR_materials_iridescence";
+export * from "./KHR_materials_anisotropy";
 export * from "./KHR_materials_sheen";
 export * from "./KHR_materials_unlit";
 export * from "./KHR_materials_ior";

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -1060,6 +1060,13 @@ declare module BABYLON.GLTF2 {
         iridescenceThicknessTexture?: ITextureInfo;
     }
 
+    /** @internal */
+    interface IKHRMaterialsAnisotropy extends IMaterialExtension {
+        anisotropyStrength?: number;
+        anisotropyRotation?: number;
+        anisotropyTexture?: ITextureInfo;
+    }
+
     /**
      * Interfaces from the KHR_materials_ior extension
      */
@@ -1215,7 +1222,6 @@ declare module BABYLON.GLTF2 {
     interface IKHRXmpJsonLd_Node {
         packet: number;
     }
-
 
     /**
      * Interfaces from the KHR_animation_pointer extension


### PR DESCRIPTION
Implements https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy

Can be tested with:
* https://github.com/DrX3D/glTF-Sample-Assets/tree/main/Models/AnisotropyStrengthTest
* https://github.com/DrX3D/glTF-Sample-Assets/tree/main/Models/AnisotropyRotationTest
* https://github.com/DrX3D/glTF-Sample-Assets/tree/main/Models/AnisotropyBarnLamp

This also fix a broken implementation of the aniso texture and implements the GLTF remapping of intensity by default.