### PR TITLE
Scene: Make sure the layers are ready in scene.isReady

### DIFF
--- a/packages/dev/core/src/Layers/layer.ts
+++ b/packages/dev/core/src/Layers/layer.ts
@@ -230,13 +230,10 @@ export class Layer {
     }
 
     /**
-     * Renders the layer in the scene.
+     * Checks if the layer is ready to be rendered
+     * @returns true if the layer is ready. False otherwise.
      */
-    public render(): void {
-        if (!this.isEnabled) {
-            return;
-        }
-
+    public isReady() {
         const engine = this._scene.getEngine();
 
         let defines = "";
@@ -253,12 +250,28 @@ export class Layer {
             this._previousDefines = defines;
             this._drawWrapper.effect = engine.createEffect("layer", [VertexBuffer.PositionKind], ["textureMatrix", "color", "scale", "offset"], ["textureSampler"], defines);
         }
+
         const currentEffect = this._drawWrapper.effect;
 
-        // Check
-        if (!currentEffect || !currentEffect.isReady() || !this.texture || !this.texture.isReady()) {
+        return currentEffect?.isReady() && this.texture?.isReady();
+    }
+
+    /**
+     * Renders the layer in the scene.
+     */
+    public render(): void {
+        if (!this.isEnabled) {
             return;
         }
+
+        const engine = this._scene.getEngine();
+
+        // Check
+        if (!this.isReady()) {
+            return;
+        }
+
+        const currentEffect = this._drawWrapper.effect!;
 
         this.onBeforeRenderObservable.notifyObservers(this);
 
@@ -268,7 +281,7 @@ export class Layer {
 
         // Texture
         currentEffect.setTexture("textureSampler", this.texture);
-        currentEffect.setMatrix("textureMatrix", this.texture.getTextureMatrix());
+        currentEffect.setMatrix("textureMatrix", this.texture!.getTextureMatrix());
 
         // Color
         currentEffect.setFloat4("color", this.color.r, this.color.g, this.color.b, this.color.a);

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2005,24 +2005,12 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             }
         }
 
-        if (!isReady) {
-            engine.currentRenderPassId = currentRenderPassId;
-            return false;
-        }
-
-        // Effects
-        if (!engine.areAllEffectsReady()) {
-            engine.currentRenderPassId = currentRenderPassId;
-            return false;
-        }
-
         // Render targets
         if (checkRenderTargets) {
             for (index = 0; index < this._materialsRenderTargets.length; ++index) {
                 const rtt = this._materialsRenderTargets.data[index];
                 if (!rtt.isReadyForRendering()) {
-                    engine.currentRenderPassId = currentRenderPassId;
-                    return false;
+                    isReady = false;
                 }
             }
         }
@@ -2032,8 +2020,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             const geometry = this.geometries[index];
 
             if (geometry.delayLoadState === Constants.DELAYLOADSTATE_LOADING) {
-                engine.currentRenderPassId = currentRenderPassId;
-                return false;
+                isReady = false;
             }
         }
 
@@ -2041,28 +2028,39 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         if (this.activeCameras && this.activeCameras.length > 0) {
             for (const camera of this.activeCameras) {
                 if (!camera.isReady(true)) {
-                    engine.currentRenderPassId = currentRenderPassId;
-                    return false;
+                    isReady = false;
                 }
             }
         } else if (this.activeCamera) {
             if (!this.activeCamera.isReady(true)) {
-                engine.currentRenderPassId = currentRenderPassId;
-                return false;
+                isReady = false;
             }
         }
 
         // Particles
         for (const particleSystem of this.particleSystems) {
             if (!particleSystem.isReady()) {
-                engine.currentRenderPassId = currentRenderPassId;
-                return false;
+                isReady = false;
             }
+        }
+
+        // Layers
+        if (this.layers) {
+            for (const layer of this.layers) {
+                if (!layer.isReady()) {
+                    isReady = false;
+                }
+            }
+        }
+
+        // Effects
+        if (!engine.areAllEffectsReady()) {
+            isReady = false;
         }
 
         engine.currentRenderPassId = currentRenderPassId;
 
-        return true;
+        return isReady;
     }
 
     /** Resets all cached information relative to material (including effect and visibility) */


### PR DESCRIPTION
See https://forum.babylonjs.com/t/problems-rendering-a-single-frame-when-using-multiple-cameras-and-layermasks/41112

Note that I made a change in `isReady` so as not to return prematurely if some things are not ready: it is better to let all the code go through to make sure everything is checked, because some resources can be created during these checks, and we don't want to delay these creations.