### PR TITLE
[ACE] Add Backspace key to delete keyframe so it works on Mac

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/animationCurveEditorComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/animationCurveEditorComponent.tsx
@@ -61,6 +61,7 @@ export class AnimationCurveEditorComponent extends React.Component<IAnimationCur
     private _onKeyDown(evt: KeyboardEvent) {
         switch (evt.key) {
             case "Delete":
+            case "Backspace":
                 if (this.props.context.activeKeyPoints?.length && !this.props.context.focusedInput) {
                     this.props.context.onDeleteKeyActiveKeyPoints.notifyObservers();
                 }


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/how-does-one-remove-a-keyframe-in-the-ace-ux/38938/3