### PR TITLE
Pre-pass renderer: Fix bloom and depth renderer

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1235,10 +1235,10 @@ export class Engine extends ThinEngine {
     public setTextureFromPostProcess(channel: number, postProcess: Nullable<PostProcess>, name: string): void {
         let postProcessInput = null;
         if (postProcess) {
-            if (postProcess._textures.data[postProcess._currentRenderTextureInd]) {
-                postProcessInput = postProcess._textures.data[postProcess._currentRenderTextureInd];
-            } else if (postProcess._forcedOutputTexture) {
+            if (postProcess._forcedOutputTexture) {
                 postProcessInput = postProcess._forcedOutputTexture;
+            } else if (postProcess._textures.data[postProcess._currentRenderTextureInd]) {
+                postProcessInput = postProcess._textures.data[postProcess._currentRenderTextureInd];
             }
         }
 

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
@@ -784,7 +784,6 @@ export class SSRRenderingPipeline extends PostProcessRenderPipeline {
                 this._depthRenderer = new DepthRenderer(this._scene, undefined, undefined, undefined, Constants.TEXTURE_NEAREST_SAMPLINGMODE, true, "SSRBackDepth");
                 this._depthRenderer.clearColor.r = 1e8; // "infinity": put a big value because we use the storeCameraSpaceZ mode
                 this._depthRenderer.reverseCulling = true; // we generate depth for the back faces
-                this._depthRenderer.getDepthMap().noPrePassRenderer = true; // we don't want the prepass renderer to attach to our depth buffer!
                 this._depthRenderer.forceDepthWriteTransparentMeshes = this._backfaceForceDepthWriteTransparentMeshes;
 
                 this._resizeDepthRenderer();

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -136,6 +136,7 @@ export class DepthRenderer {
         this._depthMap.refreshRate = 1;
         this._depthMap.renderParticles = false;
         this._depthMap.renderList = null;
+        this._depthMap.noPrePassRenderer = true;
 
         // Camera to get depth map from to support multiple concurrent cameras
         this._depthMap.activeCamera = this._camera;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/prepassrenderer-fails-with-rendertargettexture-whose-active-camera-is-not-scene-activecamera/41143 and https://forum.babylonjs.com/t/enable-ssao2-scene-render-notify-error/40962/8