### PR TITLE
Fix sound distance not respecting Scene `audioListenerProvider` when set

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -719,7 +719,9 @@ export class Sound {
     /** @internal */
     public updateDistanceFromListener() {
         if (Engine.audioEngine?.canUseWebAudio && this._connectedTransformNode && this.useCustomAttenuation && this._soundGain && this._scene.activeCamera) {
-            const distance = this._connectedTransformNode.getDistanceToCamera(this._scene.activeCamera);
+            const distance = this._scene.audioListenerPositionProvider
+                ? this._connectedTransformNode.position.subtract(this._scene.audioListenerPositionProvider()).length()
+                : this._connectedTransformNode.getDistanceToCamera(this._scene.activeCamera);
             this._soundGain.gain.value = this._customAttenuationFunction(this._volume, distance, this.maxDistance, this.refDistance, this.rolloffFactor);
         }
     }


### PR DESCRIPTION
When the `Scene.audioListenerProvider` function is set, the Sound class's distance calculation continues to use the active camera instead of using the position returned by `scene.audioListenerProvider`. This change fixes the issue by calculating the sound's distance from the point returned by the scene's `audioListenerProvider` if it has been set; otherwise it uses the active camera, as before.

Tested on playground https://playground.babylonjs.com/#G4PMF3#1.

Reported on forum:
https://forum.babylonjs.com/t/sounds-custom-attenuation-function-is-not-provided-with-distance-from-scene-audiolistenerpositionprovider-position/41164