### PR TITLE
Shader processor optimization

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -24,7 +24,7 @@ const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
 
 /** @internal */
 export class ShaderProcessor {
-    private static _moveCursorRegex = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
+    private static _MoveCursorRegex = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
 
     public static Initialize(options: ProcessingOptions): void {
         if (options.processor && options.processor.initializeShaders) {
@@ -208,7 +208,7 @@ export class ShaderProcessor {
             const line = cursor.currentLine;
 
             if (line.indexOf("#") >= 0) {
-                const matches = ShaderProcessor._moveCursorRegex.exec(line);
+                const matches = ShaderProcessor._MoveCursorRegex.exec(line);
 
                 if (matches && matches.length) {
                     const keyword = matches[0];

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -24,6 +24,8 @@ const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
 
 /** @internal */
 export class ShaderProcessor {
+    private static moveCursorRegex = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
+
     public static Initialize(options: ProcessingOptions): void {
         if (options.processor && options.processor.initializeShaders) {
             options.processor.initializeShaders(options.processingContext);
@@ -204,8 +206,7 @@ export class ShaderProcessor {
         while (cursor.canRead) {
             cursor.lineIndex++;
             const line = cursor.currentLine;
-            const keywords = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
-            const matches = keywords.exec(line);
+            const matches = ShaderProcessor.moveCursorRegex.exec(line);
 
             if (matches && matches.length) {
                 const keyword = matches[0];

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -206,58 +206,62 @@ export class ShaderProcessor {
         while (cursor.canRead) {
             cursor.lineIndex++;
             const line = cursor.currentLine;
-            const matches = ShaderProcessor.moveCursorRegex.exec(line);
 
-            if (matches && matches.length) {
-                const keyword = matches[0];
+            if (line.indexOf("#") >= 0) {
+                const matches = ShaderProcessor.moveCursorRegex.exec(line);
 
-                switch (keyword) {
-                    case "#ifdef": {
-                        const newRootNode = new ShaderCodeConditionNode();
-                        rootNode.children.push(newRootNode);
+                if (matches && matches.length) {
+                    const keyword = matches[0];
 
-                        const ifNode = this._BuildExpression(line, 6);
-                        newRootNode.children.push(ifNode);
-                        this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
-                        break;
+                    switch (keyword) {
+                        case "#ifdef": {
+                            const newRootNode = new ShaderCodeConditionNode();
+                            rootNode.children.push(newRootNode);
+
+                            const ifNode = this._BuildExpression(line, 6);
+                            newRootNode.children.push(ifNode);
+                            this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
+                            break;
+                        }
+                        case "#else":
+                        case "#elif":
+                            return true;
+                        case "#endif":
+                            return false;
+                        case "#ifndef": {
+                            const newRootNode = new ShaderCodeConditionNode();
+                            rootNode.children.push(newRootNode);
+
+                            const ifNode = this._BuildExpression(line, 7);
+                            newRootNode.children.push(ifNode);
+                            this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
+                            break;
+                        }
+                        case "#if": {
+                            const newRootNode = new ShaderCodeConditionNode();
+                            const ifNode = this._BuildExpression(line, 3);
+                            rootNode.children.push(newRootNode);
+
+                            newRootNode.children.push(ifNode);
+                            this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
+                            break;
+                        }
                     }
-                    case "#else":
-                    case "#elif":
-                        return true;
-                    case "#endif":
-                        return false;
-                    case "#ifndef": {
-                        const newRootNode = new ShaderCodeConditionNode();
-                        rootNode.children.push(newRootNode);
-
-                        const ifNode = this._BuildExpression(line, 7);
-                        newRootNode.children.push(ifNode);
-                        this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
-                        break;
-                    }
-                    case "#if": {
-                        const newRootNode = new ShaderCodeConditionNode();
-                        const ifNode = this._BuildExpression(line, 3);
-                        rootNode.children.push(newRootNode);
-
-                        newRootNode.children.push(ifNode);
-                        this._MoveCursorWithinIf(cursor, newRootNode, ifNode);
-                        break;
-                    }
+                    continue;
                 }
-            } else {
-                const newNode = new ShaderCodeNode();
-                newNode.line = line;
-                rootNode.children.push(newNode);
+            }
 
-                // Detect additional defines
-                if (line[0] === "#" && line[1] === "d") {
-                    const split = line.replace(";", "").split(" ");
-                    newNode.additionalDefineKey = split[1];
+            const newNode = new ShaderCodeNode();
+            newNode.line = line;
+            rootNode.children.push(newNode);
 
-                    if (split.length === 3) {
-                        newNode.additionalDefineValue = split[2];
-                    }
+            // Detect additional defines
+            if (line[0] === "#" && line[1] === "d") {
+                const split = line.replace(";", "").split(" ");
+                newNode.additionalDefineKey = split[1];
+
+                if (split.length === 3) {
+                    newNode.additionalDefineValue = split[2];
                 }
             }
         }

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -24,7 +24,7 @@ const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
 
 /** @internal */
 export class ShaderProcessor {
-    private static moveCursorRegex = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
+    private static _moveCursorRegex = /(#ifdef)|(#else)|(#elif)|(#endif)|(#ifndef)|(#if)/;
 
     public static Initialize(options: ProcessingOptions): void {
         if (options.processor && options.processor.initializeShaders) {
@@ -208,7 +208,7 @@ export class ShaderProcessor {
             const line = cursor.currentLine;
 
             if (line.indexOf("#") >= 0) {
-                const matches = ShaderProcessor.moveCursorRegex.exec(line);
+                const matches = ShaderProcessor._moveCursorRegex.exec(line);
 
                 if (matches && matches.length) {
                     const keyword = matches[0];


### PR DESCRIPTION
Hi, I made two little optimization:
1. Make regex as a static field, insted of building this regex in the while loop.
2. Avoid regex test, when it need with simple condition with `indexOf("#")`.

Why I made it. I has a pretty big scene, where by my performance tracker to the `_MoveCursor` was detected 51475 call times.
I had 16 measurements and it takes from 31 to 58 ms for my scene for all calls, and 44.73ms for all measurements in average.

Then I tried to move regex into static field, then I had 13 runs of my measurement tool and now `_MoveCursor` takes 40.74ms in average for same 51475 calls.

Then I add condition with `indexOf("#")` and for 18 runs the `_MoveCursor` takes 28.67ms in average.

One improtant moment: I don't now how to test this changes. I see that ShaderProcessor does not have own test file. Maybe it possible to test with screenshot tests, but how it runs now?

P. S. Here is statistic of all measurements, if you want too see it:
```
default:

{count: 51475, avg: 0.0010043710270455997, max: 0.20000004768371582, allTime: 51.69999861717224}
{count: 51475, avg: 0.0009927149221930706, max: 0.20000004768371582, allTime: 51.10000061988831}
{count: 51475, avg: 0.0005322972196233452, max: 0.20000004768371582, allTime: 27.39999938011169}
{count: 51475, avg: 0.0010607092423367233, max: 0.20000004768371582, allTime: 54.60000824928284}
{count: 51475, avg: 0.0006877125438525296, max: 0.2999999523162842, allTime: 35.40000319480896}
{count: 51475, avg: 0.0009480331220807469, max: 0.20000004768371582, allTime: 48.800004959106445}
{count: 51475, avg: 0.0009791161841475424, max: 0.20000004768371582, allTime: 50.400005578994744}
{count: 51475, avg: 0.0006158329804815558, max: 1.2999999523162842, allTime: 31.700002670288086}
{count: 51475, avg: 0.0006566294447318508, max: 1.4000000953674316, allTime: 33.80000066757202}
{count: 51475, avg: 0.0010101990702083934, max: 0.2999999523162842, allTime: 51.99999713897705}
{count: 51475, avg: 0.000617775604411084, max: 0.20000004768371582, allTime: 31.799999237060547}
{count: 51475, avg: 0.0010140845033368652, max: 0.20000004768371582, allTime: 52.19999980926514}
{count: 51475, avg: 0.0009402622743507448, max: 0.20000004768371582, allTime: 48.40000057220459}
{count: 51475, avg: 0.0011403593801653112, max: 1.2000000476837158, allTime: 58.69999909400939}
{count: 51475, avg: 0.0006041767320452297, max: 0.20000004768371582, allTime: 31.0999972820282}
{count: 51475, avg: 0.0010995628788611333, max: 0.2999999523162842, allTime: 56.59999918937684}

avg allTime is 44.73ms (from 16 runs)

-------------------------------------------------------------------------------
regex to static field:

{count: 51475, avg: 0.000592520631824436, max: 0.20000004768371582, allTime: 30.499999523162842}
{count: 51475, avg: 0.0010373968566257206, max: 0.3000001907348633, allTime: 53.40000319480897}
{count: 51475, avg: 0.0006158328322660234, max: 0.19999980926513672, allTime: 31.699995040893555}
{count: 51475, avg: 0.0010801359448055436, max: 0.20000004768371582, allTime: 55.599997758865356}
{count: 51475, avg: 0.0006119475983021733, max: 0.20000004768371582, allTime: 31.50000262260437}
{count: 51475, avg: 0.0005672656685012588, max: 0.20000004768371582, allTime: 29.200000286102295}
{count: 51475, avg: 0.0010859640481808974, max: 0.20000004768371582, allTime: 55.899999380111694}
{count: 51475, avg: 0.0009402622604555386, max: 0.20000004768371582, allTime: 48.39999985694885}
{count: 51475, avg: 0.0010451675746671316, max: 0.20000004768371582, allTime: 53.8000009059906}
{count: 51475, avg: 0.0009616319388657765, max: 0.40000009536743164, allTime: 49.500004053115845}
{count: 51475, avg: 0.0005322972196233452, max: 0.20000004768371582, allTime: 27.39999938011169}
{count: 51475, avg: 0.0005828072991169674, max: 0.20000004768371582, allTime: 30.000005722045895}
{count: 51475, avg: 0.0006352598126389669, max: 0.20000004768371582, allTime: 32.69999885559082}

avg allTime is 40.74ms (from 13 runs)

-------------------------------------------------------------------------------
add indexOf statement:

{count: 51475, avg: 0.0005186983796796387, max: 0.2999999523162842, allTime: 26.699999094009403}
{count: 51475, avg: 0.000491500681265284, max: 0.20000004768371582, allTime: 25.299997568130493}
{count: 51475, avg: 0.000693540475853674, max: 0.20000004768371582, allTime: 35.69999599456787}
{count: 51475, avg: 0.000575036423596553, max: 0.2999999523162842, allTime: 29.59999990463257}
{count: 51475, avg: 0.0006566294030462323, max: 0.9000000953674316, allTime: 33.79999852180481}
{count: 51475, avg: 0.0005536669119287892, max: 0.20000004768371582, allTime: 28.500004291534424}
{count: 51475, avg: 0.000573093716295788, max: 0.20000004768371582, allTime: 29.499999046325687}
{count: 51475, avg: 0.0005614375836528465, max: 0.7999999523162842, allTime: 28.89999961853027}
{count: 51475, avg: 0.0005050995443676674, max: 0.20000004768371582, allTime: 25.99999904632568}
{count: 51475, avg: 0.0005322972196233452, max: 0.9000000953674316, allTime: 27.39999938011169}
{count: 51475, avg: 0.0006488586850048212, max: 1.3999998569488525, allTime: 33.40000081062317}
{count: 51475, avg: 0.0006002914286053488, max: 0.10000014305114746, allTime: 30.900001287460327}
{count: 51475, avg: 0.000433220031945783, max: 0.20000004768371582, allTime: 22.30000114440918}
{count: 51475, avg: 0.00048567270757852104, max: 0.20000004768371582, allTime: 25.00000262260437}
{count: 51475, avg: 0.0005070422053510787, max: 0.3000001907348633, allTime: 26.099997520446774}
{count: 51475, avg: 0.0006119475658800256, max: 0.2999999523162842, allTime: 31.50000095367432}
{count: 51475, avg: 0.0005128702716725495, max: 0.2999999523162842, allTime: 26.399997234344486}
{count: 51475, avg: 0.0005672656823964649, max: 0.20000004768371582, allTime: 29.200001001358032}

avg allTime is 28.67ms (from 18 runs)
```