### PR TITLE
[Physics] Fix type checking for mesh parameter in aggregate

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -168,6 +168,10 @@ export class PhysicsAggregate {
         }
     }
 
+    private _isOfMeshType(node: TransformNode): boolean {
+        return node.getClassName() === "Mesh" || node.getClassName() === "InstancedMesh" || node.getClassName() === "GroundMesh";
+    }
+
     private _addSizeOptions(): void {
         this.transformNode.computeWorldMatrix(true);
         const bb = this._getObjectBoundingBox();
@@ -214,15 +218,9 @@ export class PhysicsAggregate {
                 break;
             case PhysicsShapeType.MESH:
             case PhysicsShapeType.CONVEX_HULL:
-                if (!this._options.mesh && (this.transformNode.getClassName() === "Mesh" || this.transformNode.getClassName() === "InstancedMesh")) {
+                if (!this._options.mesh && this._isOfMeshType(this.transformNode)) {
                     this._options.mesh = this.transformNode as Mesh;
-                } else if (
-                    !(
-                        this._options.mesh &&
-                        this._options.mesh.getClassName &&
-                        (this._options.mesh.getClassName() === "Mesh" || this._options.mesh.getClassName() === "InstancedMesh")
-                    )
-                ) {
+                } else if (!this._options.mesh || !this._isOfMeshType(this._options.mesh)) {
                     throw new Error("No valid mesh was provided for mesh or convex hull shape parameter.");
                 }
                 break;

--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -168,8 +168,8 @@ export class PhysicsAggregate {
         }
     }
 
-    private _isOfMeshType(node: TransformNode): boolean {
-        return node.getClassName() === "Mesh" || node.getClassName() === "InstancedMesh" || node.getClassName() === "GroundMesh";
+    private _hasVertices(node: TransformNode): boolean {
+        return (node as any)?.getTotalVertices() > 0;
     }
 
     private _addSizeOptions(): void {
@@ -218,10 +218,12 @@ export class PhysicsAggregate {
                 break;
             case PhysicsShapeType.MESH:
             case PhysicsShapeType.CONVEX_HULL:
-                if (!this._options.mesh && this._isOfMeshType(this.transformNode)) {
+                if (!this._options.mesh && this._hasVertices(this.transformNode)) {
                     this._options.mesh = this.transformNode as Mesh;
-                } else if (!this._options.mesh || !this._isOfMeshType(this._options.mesh)) {
-                    throw new Error("No valid mesh was provided for mesh or convex hull shape parameter.");
+                } else if (!this._options.mesh || !this._hasVertices(this._options.mesh)) {
+                    throw new Error(
+                        "No valid mesh was provided for mesh or convex hull shape parameter. Please provide a mesh with valid geometry (number of vertices greater than 0)."
+                    );
                 }
                 break;
             case PhysicsShapeType.BOX:


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/physics-v2-replacement-for-ammojs-mesh-impostor/41232
Related playground: https://playground.babylonjs.com/#C0ILX9#3 (doesn't work in current version, will work with the fix)
Also changed the handling of this case: https://playground.babylonjs.com/#G7GU7W#2, which currently doesn't throw an error, but also doesn't display anything because the root node IS a mesh but doesn't have vertices. 