### PR TITLE
Create snapshot of a scene not using the main canvas fails

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1790,7 +1790,8 @@ export class ThinEngine {
         }
 
         if (IsWindowObjectExist() && IsDocumentAvailable()) {
-            if (this._renderingCanvas && document.body.contains(this._renderingCanvas)) {
+            // make sure it is a Node object, and is a part of the document.
+            if (this._renderingCanvas && this._renderingCanvas.nodeType && document.body.contains(this._renderingCanvas)) {
                 const boundingRect = this._renderingCanvas.getBoundingClientRect
                     ? this._renderingCanvas.getBoundingClientRect()
                     : {
@@ -1800,7 +1801,7 @@ export class ThinEngine {
                       };
                 width = this._renderingCanvas.clientWidth || boundingRect.width;
                 height = this._renderingCanvas.clientHeight || boundingRect.height;
-            } else if (this._renderingCanvas && !document.body.contains(this._renderingCanvas)) {
+            } else if (this._renderingCanvas) {
                 width = this._renderingCanvas.width;
                 height = this._renderingCanvas.height;
             } else {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1781,7 +1781,7 @@ export class ThinEngine {
         let width: number;
         let height: number;
 
-        // Requery hardware scaling level to handle zoomed-in resizing.
+        // Re-query hardware scaling level to handle zoomed-in resizing.
         if (this.adaptToDeviceRatio) {
             const devicePixelRatio = IsWindowObjectExist() ? window.devicePixelRatio || 1.0 : 1.0;
             const changeRatio = this._lastDevicePixelRatio / devicePixelRatio;
@@ -1789,8 +1789,8 @@ export class ThinEngine {
             this._hardwareScalingLevel *= changeRatio;
         }
 
-        if (IsWindowObjectExist()) {
-            if (this._renderingCanvas) {
+        if (IsWindowObjectExist() && IsDocumentAvailable()) {
+            if (this._renderingCanvas && document.body.contains(this._renderingCanvas)) {
                 const boundingRect = this._renderingCanvas.getBoundingClientRect
                     ? this._renderingCanvas.getBoundingClientRect()
                     : {
@@ -1800,6 +1800,9 @@ export class ThinEngine {
                       };
                 width = this._renderingCanvas.clientWidth || boundingRect.width;
                 height = this._renderingCanvas.clientHeight || boundingRect.height;
+            } else if (this._renderingCanvas && !document.body.contains(this._renderingCanvas)) {
+                width = this._renderingCanvas.width;
+                height = this._renderingCanvas.height;
             } else {
                 width = window.innerWidth;
                 height = window.innerHeight;


### PR DESCRIPTION
Fixes #13924
If canvas is not part of the document use the canvas' width and height directly.