### PR TITLE
Correct description of Behavior.init

### DIFF
--- a/packages/dev/core/src/Behaviors/behavior.ts
+++ b/packages/dev/core/src/Behaviors/behavior.ts
@@ -8,7 +8,7 @@ export interface Behavior<T> {
     name: string;
 
     /**
-     * Function called when the behavior needs to be initialized (after attaching it to a target)
+     * Function called when the behavior needs to be initialized (before attaching it to a target)
      */
     init(): void;
     /**


### PR DESCRIPTION
There's discrepancy in the docs as to when `Behavior.init` is called in relation to `Behavior.attach`.

https://doc.babylonjs.com/features/featuresDeepDive/behaviors says:

>init(): This function will be called when a behavior needs to be initialized. This is **before** the attachment to a target.

The current typedoc says

>Function called when the behavior needs to be initialized (**after** attaching it to a target)

The [source](https://github.com/BabylonJS/Babylon.js/blob/48abfa6cef5555c8316428c4915f448ecfe365ab/packages/dev/core/src/node.ts#L390) says init is called before attach:

```
public addBehavior(behavior: Behavior<Node>, attachImmediately = false): Node {
        const index = this._behaviors.indexOf(behavior);

        if (index !== -1) {
            return this;
        }

        behavior.init();
        if (this._scene.isLoading && !attachImmediately) {
            // We defer the attach when the scene will be loaded
            this._scene.onDataLoadedObservable.addOnce(() => {
                behavior.attach(this);
            });
        } else {
            behavior.attach(this);
        }
        this._behaviors.push(behavior);

        return this;
    }
```
