### PR TITLE
DeviceEventFactory: Modified event factory to provide correct value for buttons property

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -76,6 +76,15 @@ export class DeviceEventFactory {
             evt.pointerType = "touch";
         }
 
+        let buttons = 0;
+
+        // Populate buttons property with current state of all mouse buttons
+        // Uses values found on: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.LeftClick);
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.RightClick) * 2;
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MiddleClick) * 4;
+        evt.buttons = buttons;
+
         if (inputIndex === PointerInput.Move) {
             evt.type = "pointermove";
         } else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -844,16 +844,16 @@ export class InputManager {
             this._startingPointerPosition.y = this._pointerY;
             this._startingPointerTime = Date.now();
 
-            // PreObservable support
-            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
-                return;
-            }
-
             if (!scene.cameraToUseForPointers && !scene.activeCamera) {
                 return;
             }
 
             this._pointerCaptures[evt.pointerId] = true;
+
+            // PreObservable support
+            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
+                return;
+            }
 
             if (!scene.pointerDownPredicate) {
                 scene.pointerDownPredicate = (mesh: AbstractMesh): boolean => {
@@ -907,6 +907,12 @@ export class InputManager {
                                 this._isSwiping = false;
                                 this._swipeButtonPressed = -1;
                             }
+
+                            // If we're going to skip the POINTERUP, we need to reset the pointer capture
+                            if (evt.buttons === 0) {
+                                this._pointerCaptures[evt.pointerId] = false;
+                            }
+
                             return;
                         }
                         if (!clickInfo.hasSwiped) {

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1465,7 +1465,7 @@
         {
             "title": "GUI Input Test",
             "renderCount": 2,
-            "playgroundId": "#UB4F3B#7",
+            "playgroundId": "#UB4F3B#8",
             "referenceImage": "guiInputTest.png"
         },
         {


### PR DESCRIPTION
There was an [issue](https://github.com/BabylonJS/Babylon.js/issues/13920) brought up where drag controls where not "letting go" when the mouse button was released.  This PR will now properly propagate this value based off of the MouseEvent standard.

Edit: This also contains a little change to out pointer capture is being handled.  Basically, if the POINTERDOWN is skipped, the pointer capture bool is still set to true and if the POINTERUP is skipped and there are no buttons pressed, it should be released.