### PR TITLE
[GUI Editor] Fix conversion from % to px throwing error

### DIFF
--- a/packages/tools/guiEditor/src/diagram/coordinateHelper.tsx
+++ b/packages/tools/guiEditor/src/diagram/coordinateHelper.tsx
@@ -313,7 +313,7 @@ export class CoordinateHelper {
     ) {
         // make sure we are using the latest measures for the control
         const parentMeasure = CoordinateHelper.GetParentSizes(guiControl);
-        (guiControl as any)._processMeasures(parentMeasure, guiControl.host);
+        (guiControl as any)._processMeasures(parentMeasure, guiControl.host.getContext());
         for (const property of properties) {
             const initialValue = guiControl[property];
             guiControl[`_${property}`] = new ValueAndUnit(this.Round(guiControl[`${property}InPixels`]), ValueAndUnit.UNITMODE_PIXEL);


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-editor-gives-error-when-trying-to-switch-from-to-px-in-position-of-textblock/41304