### PR TITLE
Add anchor options for gizmos

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -83,7 +83,7 @@ export interface IGizmo extends IDisposable {
      * Defines where the gizmo will be positioned if `updateGizmoPositionToMatchAttachedMesh` is enabled.
      * (Default: GizmoAnchorPoint.Origin)
      */
-    targetAnchorPoint: GizmoAnchorPoint;
+    anchorPoint: GizmoAnchorPoint;
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
      */
@@ -191,7 +191,7 @@ export class Gizmo implements IGizmo {
 
     protected _updateGizmoRotationToMatchAttachedMesh = true;
     protected _updateGizmoPositionToMatchAttachedMesh = true;
-    protected _targetAnchorPoint = GizmoAnchorPoint.Origin;
+    protected _anchorPoint = GizmoAnchorPoint.Origin;
     protected _updateScale = true;
 
     /**
@@ -218,11 +218,11 @@ export class Gizmo implements IGizmo {
      * Defines where the gizmo will be positioned if `updateGizmoPositionToMatchAttachedMesh` is enabled.
      * (Default: GizmoAnchorPoint.Origin)
      */
-    public set targetAnchorPoint(value: GizmoAnchorPoint) {
-        this._targetAnchorPoint = value;
+    public set anchorPoint(value: GizmoAnchorPoint) {
+        this._anchorPoint = value;
     }
-    public get targetAnchorPoint() {
-        return this._targetAnchorPoint;
+    public get anchorPoint() {
+        return this._anchorPoint;
     }
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
@@ -281,7 +281,7 @@ export class Gizmo implements IGizmo {
 
             // Position
             if (this.updateGizmoPositionToMatchAttachedMesh) {
-                if (this.targetAnchorPoint == GizmoAnchorPoint.Pivot && effectiveNode instanceof TransformNode) {
+                if (this.anchorPoint == GizmoAnchorPoint.Pivot && effectiveNode instanceof TransformNode) {
                     const position = effectiveNode.getAbsolutePivotPoint();
                     this._rootMesh.position.copyFrom(position);
                 } else {

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -10,7 +10,7 @@ import type { TargetCamera } from "../Cameras/targetCamera";
 import type { Node } from "../node";
 import type { Bone } from "../Bones/bone";
 import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
-import { TransformNode } from "../Meshes/transformNode";
+import type { TransformNode } from "../Meshes/transformNode";
 import type { StandardMaterial } from "../Materials/standardMaterial";
 import type { PointerInfo } from "../Events/pointerEvents";
 import { PointerEventTypes } from "../Events/pointerEvents";
@@ -281,8 +281,8 @@ export class Gizmo implements IGizmo {
 
             // Position
             if (this.updateGizmoPositionToMatchAttachedMesh) {
-                if (this.anchorPoint == GizmoAnchorPoint.Pivot && effectiveNode instanceof TransformNode) {
-                    const position = effectiveNode.getAbsolutePivotPoint();
+                if (this.anchorPoint == GizmoAnchorPoint.Pivot && (<TransformNode>effectiveNode).getAbsolutePivotPoint) {
+                    const position = (<TransformNode>effectiveNode).getAbsolutePivotPoint();
                     this._rootMesh.position.copyFrom(position);
                 } else {
                     const row = effectiveNode.getWorldMatrix().getRow(3);

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -285,7 +285,7 @@ export class Gizmo implements IGizmo {
                     const position = effectiveNode.getAbsolutePivotPoint();
                     this._rootMesh.position.copyFrom(position);
                 } else {
-                    let row = effectiveNode.getWorldMatrix().getRow(3);
+                    const row = effectiveNode.getWorldMatrix().getRow(3);
                     const position = row ? row.toVector3() : new Vector3(0, 0, 0);
                     this._rootMesh.position.copyFrom(position);
                 }

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -7,7 +7,7 @@ import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Node } from "../node";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisDragGizmo } from "./axisDragGizmo";
 import { AxisDragGizmo } from "./axisDragGizmo";
@@ -227,6 +227,16 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
     }
     public get updateGizmoPositionToMatchAttachedMesh() {
         return this._updateGizmoPositionToMatchAttachedMesh;
+    }
+
+    public set targetAnchorPoint(value: GizmoAnchorPoint) {
+        this._targetAnchorPoint = value;
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
+            gizmo.targetAnchorPoint = value;
+        });
+    }
+    public get targetAnchorPoint() {
+        return this._targetAnchorPoint;
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -229,14 +229,14 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         return this._updateGizmoPositionToMatchAttachedMesh;
     }
 
-    public set targetAnchorPoint(value: GizmoAnchorPoint) {
-        this._targetAnchorPoint = value;
+    public set anchorPoint(value: GizmoAnchorPoint) {
+        this._anchorPoint = value;
         [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
-            gizmo.targetAnchorPoint = value;
+            gizmo.anchorPoint = value;
         });
     }
-    public get targetAnchorPoint() {
-        return this._targetAnchorPoint;
+    public get anchorPoint() {
+        return this._anchorPoint;
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -230,14 +230,14 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         return this.xGizmo.updateGizmoPositionToMatchAttachedMesh;
     }
 
-    public set targetAnchorPoint(value: GizmoAnchorPoint) {
-        this._targetAnchorPoint = value;
+    public set anchorPoint(value: GizmoAnchorPoint) {
+        this._anchorPoint = value;
         [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
-            gizmo.targetAnchorPoint = value;
+            gizmo.anchorPoint = value;
         });
     }
-    public get targetAnchorPoint() {
-        return this._targetAnchorPoint;
+    public get anchorPoint() {
+        return this._anchorPoint;
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IPlaneRotationGizmo } from "./planeRotationGizmo";
 import { PlaneRotationGizmo } from "./planeRotationGizmo";
@@ -228,6 +228,16 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
     }
     public get updateGizmoPositionToMatchAttachedMesh() {
         return this.xGizmo.updateGizmoPositionToMatchAttachedMesh;
+    }
+
+    public set targetAnchorPoint(value: GizmoAnchorPoint) {
+        this._targetAnchorPoint = value;
+        [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
+            gizmo.targetAnchorPoint = value;
+        });
+    }
+    public get targetAnchorPoint() {
+        return this._targetAnchorPoint;
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -248,16 +248,16 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
         return this._updateGizmoRotationToMatchAttachedMesh;
     }
 
-    public set targetAnchorPoint(value: GizmoAnchorPoint) {
-        this._targetAnchorPoint = value;
+    public set anchorPoint(value: GizmoAnchorPoint) {
+        this._anchorPoint = value;
         [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {
             if (gizmo) {
-                gizmo.targetAnchorPoint = value;
+                gizmo.anchorPoint = value;
             }
         });
     }
-    public get targetAnchorPoint() {
-        return this._targetAnchorPoint;
+    public get anchorPoint() {
+        return this._anchorPoint;
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { CreatePolyhedron } from "../Meshes/Builders/polyhedronBuilder";
-import type { GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisScaleGizmo } from "./axisScaleGizmo";
 import { AxisScaleGizmo } from "./axisScaleGizmo";
@@ -246,6 +246,18 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
     }
     public get updateGizmoRotationToMatchAttachedMesh() {
         return this._updateGizmoRotationToMatchAttachedMesh;
+    }
+
+    public set targetAnchorPoint(value: GizmoAnchorPoint) {
+        this._targetAnchorPoint = value;
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {
+            if (gizmo) {
+                gizmo.targetAnchorPoint = value;
+            }
+        });
+    }
+    public get targetAnchorPoint() {
+        return this._targetAnchorPoint;
     }
 
     /**


### PR DESCRIPTION
By default the gizmos are anchored at the origin of the attached node. This PR allows that the target position can also be set to the pivot point of the attached node (If it is an instance of `TransformNode`). This mainly increases the usability of the `RotationGizmo` since it will stay in place during the rotation if a custom pivot point was defined.

**Tests:**
I tested it for all Gizmos (position, rotation, scale, boundingBox) with different settings (`updateScale`, `updateGizmoPositionToMatchAttachedMesh`, custom mesh pivot). The only thing I noticed is that `BoundingBoxGizmo` does not work probably with a custom pivot point. However this is not related to this PR and I`ll create another bug report / PR for that.

**Related Discussion:**
https://forum.babylonjs.com/t/gizmo-location-with-setpivotpoint/41271/3