### PR TITLE
Shader processor include optimization

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -385,8 +385,7 @@ export class ShaderProcessor {
             if (includeFile.indexOf("__decl__") !== -1) {
                 includeFile = includeFile.replace(regexShaderDecl, "");
                 if (options.supportsUniformBuffers) {
-                    includeFile = includeFile.replace(/Vertex/, "Ubo");
-                    includeFile = includeFile.replace(/Fragment/, "Ubo");
+                    includeFile = includeFile.replace("Vertex", "Ubo").replace("Fragment", "Ubo");
                 }
                 includeFile = includeFile + "Declaration";
             }

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -375,7 +375,7 @@ export class ShaderProcessor {
     private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
         const matches = sourceCode.matchAll(regexShaderInclude);
 
-        let returnValue = new String(sourceCode);
+        let returnValue = String(sourceCode);
         let parts = [sourceCode];
 
         let keepProcessing = false;

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -373,12 +373,12 @@ export class ShaderProcessor {
     }
 
     private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
-        let match = regexShaderInclude.exec(sourceCode);
+        const matches = sourceCode.matchAll(regexShaderInclude);
 
         let returnValue = new String(sourceCode);
         let keepProcessing = false;
 
-        while (match != null) {
+        for (const match of matches) {
             let includeFile = match[1];
 
             // Uniform declaration
@@ -451,8 +451,6 @@ export class ShaderProcessor {
                 });
                 return;
             }
-
-            match = regexShaderInclude.exec(sourceCode);
         }
 
         if (keepProcessing) {

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -376,6 +376,8 @@ export class ShaderProcessor {
         const matches = sourceCode.matchAll(regexShaderInclude);
 
         let returnValue = new String(sourceCode);
+        let parts = [sourceCode];
+
         let keepProcessing = false;
 
         for (const match of matches) {
@@ -439,7 +441,17 @@ export class ShaderProcessor {
                 }
 
                 // Replace
-                returnValue = returnValue.replace(match[0], includeContent);
+                // Split all parts on match[0] and intersperse the parts with the include content
+                const newParts = [];
+                for (const part of parts) {
+                    const splitPart = part.split(match[0]);
+                    for (let i = 0; i < splitPart.length - 1; i++) {
+                        newParts.push(splitPart[i]);
+                        newParts.push(includeContent);
+                    }
+                    newParts.push(splitPart[splitPart.length - 1]);
+                }
+                parts = newParts;
 
                 keepProcessing = keepProcessing || includeContent.indexOf("#include<") >= 0 || includeContent.indexOf("#include <") >= 0;
             } else {
@@ -452,6 +464,8 @@ export class ShaderProcessor {
                 return;
             }
         }
+
+        returnValue = parts.join("");
 
         if (keepProcessing) {
             this._ProcessIncludes(returnValue.toString(), options, callback);

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -373,7 +373,7 @@ export class ShaderProcessor {
     }
 
     private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
-        const matches = sourceCode.matchAll(regexShaderInclude);
+        const matches = Array.from(sourceCode.matchAll(regexShaderInclude));
 
         let returnValue = String(sourceCode);
         let parts = [sourceCode];

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -21,6 +21,9 @@ declare type ThinEngine = import("../thinEngine").ThinEngine;
 const regexSE = /defined\s*?\((.+?)\)/g;
 const regexSERevert = /defined\s*?\[(.+?)\]/g;
 const regexShaderInclude = /#include\s?<(.+)>(\((.*)\))*(\[(.*)\])*/g;
+const regexShaderDecl = /__decl__/;
+const regexLightX = /light\{X\}.(\w*)/g;
+const regexX = /\{X\}/g;
 
 /** @internal */
 export class ShaderProcessor {
@@ -380,7 +383,7 @@ export class ShaderProcessor {
 
             // Uniform declaration
             if (includeFile.indexOf("__decl__") !== -1) {
-                includeFile = includeFile.replace(/__decl__/, "");
+                includeFile = includeFile.replace(regexShaderDecl, "");
                 if (options.supportsUniformBuffers) {
                     includeFile = includeFile.replace(/Vertex/, "Ubo");
                     includeFile = includeFile.replace(/Fragment/, "Ubo");
@@ -419,20 +422,20 @@ export class ShaderProcessor {
                         for (let i = minIndex; i < maxIndex; i++) {
                             if (!options.supportsUniformBuffers) {
                                 // Ubo replacement
-                                sourceIncludeContent = sourceIncludeContent.replace(/light\{X\}.(\w*)/g, (str: string, p1: string) => {
+                                sourceIncludeContent = sourceIncludeContent.replace(regexLightX, (str: string, p1: string) => {
                                     return p1 + "{X}";
                                 });
                             }
-                            includeContent += sourceIncludeContent.replace(/\{X\}/g, i.toString()) + "\n";
+                            includeContent += sourceIncludeContent.replace(regexX, i.toString()) + "\n";
                         }
                     } else {
                         if (!options.supportsUniformBuffers) {
                             // Ubo replacement
-                            includeContent = includeContent.replace(/light\{X\}.(\w*)/g, (str: string, p1: string) => {
+                            includeContent = includeContent.replace(regexLightX, (str: string, p1: string) => {
                                 return p1 + "{X}";
                             });
                         }
-                        includeContent = includeContent.replace(/\{X\}/g, indexString);
+                        includeContent = includeContent.replace(regexX, indexString);
                     }
                 }
 

--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -459,7 +459,7 @@ export class ShaderProcessor {
 
                 ShaderProcessor._FileToolsLoadFile(includeShaderUrl, (fileContent) => {
                     options.includesShadersStore[includeFile] = fileContent as string;
-                    this._ProcessIncludes(<string>returnValue, options, callback);
+                    this._ProcessIncludes(parts.join(""), options, callback);
                 });
                 return;
             }


### PR DESCRIPTION
I have a pretty big scene (100+ meshed, 50+ shaders) in glb format, when it loaded the loop in the `ShaderProcessor._ProcessIncludes()` was called 4927 times, and takes 200.57 ms and each loop take 0.0407ms. This values bases on 30 runs.
After performance optimzations I got next result — the loop calls 3955 times, takes 70.82ms for all calls and 0.0179ms per one loop.

1. I make regex as a static fields to avoid builing it in runtime.
2. Change string replaces from regex to regular string where it possible.
3. Replace while loop to for-of to avoid uneccessary `.exec()` at end of while-loop.
4. Replace very heavy string replace opertation to `parts.join("")` (more then 2x boost here)
5. Fix warning from `new String()`.

Every change puts in a single commit.

For future discussing - we also can change this part:
```ts
for (let index = 0; index < splits.length; index += 2) {
    const source = new RegExp(splits[index], "g");
    const dest = splits[index + 1];
    includeContent = includeContent.replace(source, dest);
}
```

with `.replaceAll` and save 5-7ms for all loading time (it would be 65ms for all calls in my case). But now I can't use it because `TS2550: Property 'replaceAll' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.`