### PR TITLE
ShaderCodeCursor. Optimization of lines parsing

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -39,14 +39,14 @@ export class ShaderCodeCursor {
             }
 
             // Work with semicolon in the line
-            const semicolonIndex = line.indexOf(";");
+            const semicolonIndex = trimmedLine.indexOf(";");
 
             if (semicolonIndex === -1) {
                 // No semicolon in the line
                 this._lines.push(trimmedLine);
-            } else if (semicolonIndex === line.length - 1 || semicolonIndex === trimmedLine.length - 1) {
+            } else if (semicolonIndex === trimmedLine.length - 1) {
                 // Semicolon at the end of the line
-                this._lines.push(line);
+                this._lines.push(trimmedLine);
             } else {
                 // Semicolon in the middle of the line
                 const split = line.split(";");

--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -15,6 +15,11 @@ export class ShaderCodeCursor {
         this._lines.length = 0;
 
         for (const line of value) {
+            // Skip empty lines
+            if (!line || line === "\r") {
+                continue;
+            }
+
             // Prevent removing line break in macros.
             if (line[0] === "#") {
                 this._lines.push(line);
@@ -22,22 +27,45 @@ export class ShaderCodeCursor {
             }
 
             // Do not split single line comments
-            if (line.trim().startsWith("//")) {
+            const trimmedLine = line.trim();
+
+            if (!trimmedLine) {
+                continue;
+            }
+
+            if (trimmedLine.startsWith("//")) {
                 this._lines.push(line);
                 continue;
             }
 
-            const split = line.split(";");
+            // Work with semicolon in the line
+            const semicolonIndex = line.indexOf(";");
 
-            for (let index = 0; index < split.length; index++) {
-                let subLine = split[index];
-                subLine = subLine.trim();
+            if (semicolonIndex === -1) {
+                // No semicolon in the line
+                this._lines.push(trimmedLine);
+            } else if (semicolonIndex === line.length - 1 || semicolonIndex === trimmedLine.length - 1) {
+                // Semicolon at the end of the line
+                this._lines.push(line);
+            } else {
+                // Semicolon in the middle of the line
+                const split = line.split(";");
 
-                if (!subLine) {
-                    continue;
+                for (let index = 0; index < split.length; index++) {
+                    let subLine = split[index];
+
+                    if (!subLine) {
+                        continue;
+                    }
+
+                    subLine = subLine.trim();
+
+                    if (!subLine) {
+                        continue;
+                    }
+
+                    this._lines.push(subLine + (index !== split.length - 1 ? ";" : ""));
                 }
-
-                this._lines.push(subLine + (index !== split.length - 1 ? ";" : ""));
             }
         }
     }


### PR DESCRIPTION
I notices that `set lines` takes 19.29ms for 68 calls while my scene initializaion, so I add some checks to avoid process heavy operations like `trim` and `split` on the string. As a result, in my case this function take 9.45ms for same 68 calls. And it still works as before, of course, but faster :)

P.S. Results of my measurements:
```
default:

{count: 68, avg: 0.342647, max: 1.500000, allTime: 23.299999}
{count: 68, avg: 0.267647, max: 1.300000, allTime: 18.199999}
{count: 68, avg: 0.282352, max: 1.299999, allTime: 19.200000}
{count: 68, avg: 0.294117, max: 1.200000, allTime: 19.999999}
{count: 68, avg: 0.330882, max: 1.700000, allTime: 22.500000}
{count: 68, avg: 0.326470, max: 4.500000, allTime: 22.199999}
{count: 68, avg: 0.276470, max: 1.100000, allTime: 18.799998}
{count: 68, avg: 0.255882, max: 0.799999, allTime: 17.400000}
{count: 68, avg: 0.263235, max: 1.200000, allTime: 17.900000}
{count: 68, avg: 0.260294, max: 0.899999, allTime: 17.699999}
{count: 68, avg: 0.269117, max: 1.000000, allTime: 18.299999}
{count: 68, avg: 0.280882, max: 1.099999, allTime: 19.099999}
{count: 68, avg: 0.260294, max: 0.900000, allTime: 17.700000}
{count: 68, avg: 0.263235, max: 0.900000, allTime: 17.899999}

avg allTime: 19.29ms

-------------------------------------------------------------

after optimization:

{count: 68, avg: 0.195588, max: 3.000000, allTime: 13.299999}
{count: 68, avg: 0.138235, max: 1.000000, allTime:  9.399999}
{count: 68, avg: 0.180882, max: 2.000000, allTime: 12.300000}
{count: 68, avg: 0.155882, max: 1.400000, allTime: 10.600000}
{count: 68, avg: 0.151470, max: 0.900000, allTime: 10.299999}
{count: 68, avg: 0.145588, max: 1.599999, allTime:  9.899999}
{count: 68, avg: 0.120588, max: 0.699999, allTime:  8.199999}
{count: 68, avg: 0.122058, max: 0.700000, allTime:  8.299999}
{count: 68, avg: 0.117647, max: 0.700000, allTime:  8.000000}
{count: 68, avg: 0.123529, max: 0.799999, allTime:  8.400000}
{count: 68, avg: 0.135294, max: 0.800000, allTime:  9.200000}
{count: 68, avg: 0.141176, max: 0.700000, allTime:  9.600000}
{count: 68, avg: 0.138235, max: 1.000000, allTime:  9.400000}
{count: 68, avg: 0.133823, max: 0.799999, allTime:  9.099999}
{count: 68, avg: 0.117647, max: 0.600000, allTime:  8.000000}
{count: 68, avg: 0.150000, max: 1.899999, allTime: 10.200000}
{count: 68, avg: 0.114705, max: 0.900000, allTime:  7.799999}
{count: 68, avg: 0.135294, max: 0.700000, allTime:  9.199999}
{count: 68, avg: 0.123529, max: 0.700000, allTime:  8.399999}
{count: 68, avg: 0.138235, max: 0.699999, allTime:  9.400000}

avg allTime: 9.45ms
```