### PR TITLE
Shader define expression optimization

### DIFF
--- a/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /** @internal */
 export class ShaderDefineExpression {
+    static _InfixToPostfixCache = new Map();
+    static infixToPostfixCacheLimitSize = 50000;
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public isTrue(preprocessors: { [key: string]: string }): boolean {
         return true;
@@ -34,6 +37,12 @@ export class ShaderDefineExpression {
     }
 
     public static infixToPostfix(infix: string): string[] {
+        // Is infix already in cache
+        const existedResult = this._InfixToPostfixCache.get(infix);
+        if (existedResult) {
+            return existedResult;
+        }
+
         // Is infix contain any operator
         if (!infix.includes(")") && !infix.includes("(") && !infix.includes("||") && !infix.includes("&&")) {
             return [infix];
@@ -98,6 +107,10 @@ export class ShaderDefineExpression {
             } else {
                 result.push(pop());
             }
+        }
+
+        if (this._InfixToPostfixCache.size < this.infixToPostfixCacheLimitSize) {
+            this._InfixToPostfixCache.set(infix, result);
         }
 
         return result;

--- a/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
@@ -34,6 +34,11 @@ export class ShaderDefineExpression {
     }
 
     public static infixToPostfix(infix: string): string[] {
+        // Is infix contain any operator
+        if (!infix.includes(")") && !infix.includes("(") && !infix.includes("||") && !infix.includes("&&")) {
+            return [infix];
+        }
+
         const result: string[] = [];
 
         let stackIdx = -1;


### PR DESCRIPTION
In my scene with 50+ shaders the ShaderDefineExpression.infixToPostfix was called 15 000–35 000 times while scene is loading. In average for one loading it takes 54.28ms for all calls and 34.39ms for first 15 000 calls.
After optimized from this PR I achieve next result: 9.68ms for all calls and 7.02ms for first 15 000 calls.

I made to simple changes:
1. If `infix` does not contain operators, then it will not be modified, so we can return it as is.
2. As I mention above this function called thousands times while scene loading. But the input string are not unique every time, in fact, in my case, it was only 168 unique infixes. So there is a reason to use memoization, because the result of this function deterministic and has no side effects as I can see.
For safety work with memory I add a limit for memoize cache as 50000 entries. In my case the 100 entries takes 6504 chars of memory, so with the basic interpolation it might be around 640 KB. As all we know, 640K ought to be enough for anybody :)

So, just with this two changes  performance of the function was boosted 5.6x times and for my middle (as I think now) scene it saves 45ms (or almost 3 frames) for loading.