### PR TITLE
Revert changes from PR 13927

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -76,15 +76,6 @@ export class DeviceEventFactory {
             evt.pointerType = "touch";
         }
 
-        let buttons = 0;
-
-        // Populate buttons property with current state of all mouse buttons
-        // Uses values found on: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.LeftClick);
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.RightClick) * 2;
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MiddleClick) * 4;
-        evt.buttons = buttons;
-
         if (inputIndex === PointerInput.Move) {
             evt.type = "pointermove";
         } else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -844,16 +844,16 @@ export class InputManager {
             this._startingPointerPosition.y = this._pointerY;
             this._startingPointerTime = Date.now();
 
+            // PreObservable support
+            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
+                return;
+            }
+
             if (!scene.cameraToUseForPointers && !scene.activeCamera) {
                 return;
             }
 
             this._pointerCaptures[evt.pointerId] = true;
-
-            // PreObservable support
-            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
-                return;
-            }
 
             if (!scene.pointerDownPredicate) {
                 scene.pointerDownPredicate = (mesh: AbstractMesh): boolean => {
@@ -907,12 +907,6 @@ export class InputManager {
                                 this._isSwiping = false;
                                 this._swipeButtonPressed = -1;
                             }
-
-                            // If we're going to skip the POINTERUP, we need to reset the pointer capture
-                            if (evt.buttons === 0) {
-                                this._pointerCaptures[evt.pointerId] = false;
-                            }
-
                             return;
                         }
                         if (!clickInfo.hasSwiped) {

--- a/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
@@ -8,7 +8,6 @@ import type { IPointerEvent, IUIEvent } from "core/Events";
 import type { Nullable } from "core/types";
 import type { ITestDeviceInputSystem} from "./testDeviceInputSystem";
 import { TestDeviceInputSystem } from "./testDeviceInputSystem";
-import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
 
 jest.mock("core/DeviceInput/webDeviceInputSystem", () => {
     return {
@@ -222,48 +221,5 @@ describe("DeviceSourceManager", () => {
         deviceSourceManager3.dispose();
         expect(unregisterSpy).toBeCalledTimes(3);
         expect(disposeSpy).toBeCalledTimes(1);
-    });
-
-    it ("DeviceEventFactory can create proper pointer events", () => {
-        const deviceInputSystem = new TestDeviceInputSystem(
-            engine!,
-            () => {},
-            () => {},
-            () => {}
-        );
-
-        // Connect device and grab DeviceSource
-        deviceInputSystem.connectDevice(DeviceType.Mouse, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
-
-        // Click down the three main mouse buttons
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 1);
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
-
-        // Create a pointer event
-        const threeButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
-
-        // Verify that the three buttons are pressed down
-        expect(threeButtonsEvent.buttons).toBe(7);
-
-        // Release middle button and verify that it's no longer pressed
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0);
-
-        // Create a pointer event
-        const twoButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0, deviceInputSystem) as IPointerEvent;
-
-        // Verify that two buttons are pressed down and the middle is released
-        expect(twoButtonsEvent.buttons).toBe(3);
-        expect(twoButtonsEvent.button).toBe(1);
-
-        // Release the rest of the buttons
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
-        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
-
-        // Create a pointer event
-        const noButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
-
-        // Verify that no buttons are pressed down
-        expect(noButtonsEvent.buttons).toBe(0);
     });
 });

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1465,7 +1465,7 @@
         {
             "title": "GUI Input Test",
             "renderCount": 2,
-            "playgroundId": "#UB4F3B#8",
+            "playgroundId": "#UB4F3B#7",
             "referenceImage": "guiInputTest.png"
         },
         {


### PR DESCRIPTION
PR https://github.com/BabylonJS/Babylon.js/pull/13927 breaks interaction with utility layer and makes gizmo unusable.
revert changes until a fix is found.