### PR TITLE
Fix planeRotationGizmo's behavior when updateGizmoRotationToMatchAttachedMesh is set to false.

### DIFF
--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -343,7 +343,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                     const translation = this.attachedNode.getWorldMatrix().getTranslation();
                     this.attachedNode.getWorldMatrix().multiplyToRef(TmpVectors.Matrix[0], this.attachedNode.getWorldMatrix());
                     this.attachedNode.getWorldMatrix().setTranslation(translation);
-                };
+                }
                 lastDragPosition.copyFrom(event.dragPlanePoint);
                 if (snapped) {
                     tmpSnapEvent.snapDistance = angle;


### PR DESCRIPTION
Hello dear Babylon maintainers,

This PR fixes seemingly incorrect behavior of plane rotation gizmos' when it is not set to be aligned with mesh's rotation.

To see an issue please run this code in Playground 6.6.1:

```ts
var createScene = function () {
    var scene = new BABYLON.Scene(engine);

    var camera = new BABYLON.FreeCamera("camera1", new BABYLON.Vector3(0, 5, -10), scene);
    camera.setTarget(BABYLON.Vector3.Zero());
    camera.attachControl(canvas, true);

    var light = new BABYLON.HemisphericLight("light", new BABYLON.Vector3(0, 1, 0), scene);
    light.intensity = 0.7;

    var box = BABYLON.MeshBuilder.CreateBox("box", {size: 1, height: 5}, scene);
    box.position.y = 1;
    box.rotation = new BABYLON.Vector3(0, 0, Math.PI / 6)

    const utilLayer = new BABYLON.UtilityLayerRenderer(scene);
    const gizmo = new BABYLON.PlaneRotationGizmo(new BABYLON.Vector3(0, 1, 0), BABYLON.Color3.FromHexString("#00b894"), utilLayer);
    gizmo.updateGizmoRotationToMatchAttachedMesh = false;
    gizmo.attachedMesh = box;

    return scene;
};
```

While gizmo is set to not align with mesh rotation's, it rotates a mesh as if it was aligned, i.e. rotation happens about mesh's local axes instead of gizmo's axes.

The fix boils down to simply changing an order of matrix multiplication in one place.