### PR TITLE
[Inspector] Avoid crashes with bad name/id assignments

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -344,6 +344,13 @@ export class MeshPropertyGridComponent extends React.Component<
         return "Unknown";
     }
 
+    private _getIdForDisplay(id: any) {
+        if (typeof id === "string") {
+            return id;
+        }
+        return "[INVALID ID]";
+    }
+
     render() {
         const mesh = this.props.mesh;
         const scene = mesh.getScene();
@@ -409,7 +416,7 @@ export class MeshPropertyGridComponent extends React.Component<
                     onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                 />
                 <LineContainerComponent title="GENERAL" selection={this.props.globalState}>
-                    <TextLineComponent label="ID" value={mesh.id} />
+                    <TextLineComponent label="ID" value={this._getIdForDisplay(mesh.id)} />
                     <TextInputLineComponent
                         lockObject={this.props.lockObject}
                         label="Name"

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/parentPropertyGridComponent.tsx
@@ -22,7 +22,7 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
         super(props);
     }
 
-    private _getNameForSorting(node: any) {
+    private _getNameForSortingAndDisplay(node: any) {
         return typeof node.name === "string" ? node.name : "no name";
     }
 
@@ -34,12 +34,12 @@ export class ParentPropertyGridComponent extends React.Component<IParentProperty
             .getNodes()
             .filter((n) => n !== node)
             .sort((a, b) => {
-                return this._getNameForSorting(a).localeCompare(this._getNameForSorting(b));
+                return this._getNameForSortingAndDisplay(a).localeCompare(this._getNameForSortingAndDisplay(b));
             });
 
         const nodeOptions = sortedNodes.map((m, i) => {
             return {
-                label: m.name || "no name",
+                label: this._getNameForSortingAndDisplay(m),
                 value: i,
             };
         });


### PR DESCRIPTION
Example PG: https://playground.babylonjs.com/#XMIQ95#2
If you try to open the Inspector in it, it crashes. This happens because an Object is assigned as a mesh's name/id, which wouldn't be valid in TS, but it can happen in JS. This PR adds some measures on the Inspector to avoid this crash.