### PR TITLE
[Physics] Fix warning on copying a mesh with physics body

### DIFF
--- a/packages/dev/core/src/Misc/deepCopier.ts
+++ b/packages/dev/core/src/Misc/deepCopier.ts
@@ -9,7 +9,7 @@ const CloneValue = (source: any, destinationObject: any) => {
         return null;
     }
 
-    if (source.getClassName && source.getClassName() === "SubMesh") {
+    if (source.getClassName && (source.getClassName() === "SubMesh" || source.getClassName() === "PhysicsBody")) {
         return source.clone(destinationObject);
     } else if (source.clone) {
         return source.clone();


### PR DESCRIPTION
We need to pass the transform node of the body when cloning it.
Related forum issue: https://forum.babylonjs.com/t/havoc-problems-with-parented-meshes/40584/18?u=carolhmj
Test PG: https://playground.babylonjs.com/#Z8HTUN#396
In master, it displays these warnings:
![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/0e0688d0-d4da-40ed-9cf5-cee819c919eb)
