### PR TITLE
[GUI Editor] Add isVisible property on the common control properties …

### DIFF
--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -40,6 +40,7 @@ import shadowOffsetXIcon from "shared-ui-components/imgs/shadowOffsetXIcon.svg";
 import colorIcon from "shared-ui-components/imgs/colorIcon.svg";
 import fillColorIcon from "shared-ui-components/imgs/fillColorIcon.svg";
 import linkedMeshOffsetIcon from "shared-ui-components/imgs/linkedMeshOffsetIcon.svg";
+import visibleIcon from "../../../../imgs/visibilityActiveIcon.svg";
 
 import hAlignCenterIcon from "shared-ui-components/imgs/hAlignCenterIcon.svg";
 import hAlignLeftIcon from "shared-ui-components/imgs/hAlignLeftIcon.svg";
@@ -73,6 +74,7 @@ type ControlProperty = keyof Control | "_paddingLeft" | "_paddingRight" | "_padd
 export class CommonControlPropertyGridComponent extends React.Component<ICommonControlPropertyGridComponentProps, ICommonControlPropertyGridComponentState> {
     private _onPropertyChangedObserver: Nullable<Observer<PropertyChangedEvent>> | undefined;
     private _onFontsParsedObserver: Nullable<Observer<void>> | undefined;
+    private _onControlVisibilityChangedObservers: Array<Nullable<Observer<boolean>>> = [];
 
     constructor(props: ICommonControlPropertyGridComponentProps) {
         super(props);
@@ -97,6 +99,10 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                 control.metadata = {};
             }
             control.metadata._previousCenter = transformed;
+            const visibilityObserver = control.onIsVisibleChangedObservable.add(() => {
+                this.forceUpdate();
+            });
+            this._onControlVisibilityChangedObservers.push(visibilityObserver);
         }
         this._onFontsParsedObserver = this.props.onFontsParsedObservable?.add(() => {
             this._checkFontsInLayout();
@@ -228,6 +234,9 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
         }
         if (this._onFontsParsedObserver) {
             this.props.onFontsParsedObservable?.remove(this._onFontsParsedObserver);
+        }
+        for (let i = 0; i < this._onControlVisibilityChangedObservers.length; i++) {
+            this.props.controls[i].onIsVisibleChangedObservable.remove(this._onControlVisibilityChangedObservers[i]);
         }
     }
 
@@ -590,6 +599,11 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         <hr className="ge" />
                     </>
                 )}
+                <TextLineComponent tooltip="" label="VISIBILITY" value=" " color="grey"></TextLineComponent>
+                <div className="ge-divider">
+                    <IconComponent icon={visibleIcon} label={"Visible"} />
+                    <CheckBoxLineComponent label="ISVISIBLE" target={proxy} propertyName="isVisible" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
+                </div>
                 <TextLineComponent tooltip="" label="TRANSFORMATION" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider double">
                     <IconComponent icon={scaleIcon} label={"Scale"} />

--- a/packages/tools/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
+++ b/packages/tools/guiEditor/src/components/sceneExplorer/entities/gui/controlTreeItemComponent.tsx
@@ -13,6 +13,8 @@ import visibilityNotActiveIcon from "../../../../imgs/visibilityNotActiveIcon.sv
 import visibilityActiveIcon from "../../../../imgs/visibilityActiveIcon.svg";
 import makeComponentIcon from "../../../../imgs/makeComponentIcon.svg";
 import makeChildOfContainerIcon from "../../../../imgs/makeChildOfContainerIcon.svg";
+import type { Observer } from "core/Misc/observable";
+import type { Nullable } from "core/types";
 
 interface IControlTreeItemComponentProps {
     control: Control;
@@ -26,12 +28,23 @@ interface IControlTreeItemComponentProps {
 }
 
 export class ControlTreeItemComponent extends React.Component<IControlTreeItemComponentProps, { isActive: boolean; isVisible: boolean; isRenaming: boolean }> {
+    private _onIsVisibleChangedObserver: Nullable<Observer<boolean>>;
     constructor(props: IControlTreeItemComponentProps) {
         super(props);
 
         const control = this.props.control;
 
         this.state = { isActive: control.isHighlighted, isVisible: control.isVisible, isRenaming: false };
+
+        this._onIsVisibleChangedObserver = control.onIsVisibleChangedObservable.add((isVisible) => {
+            this.setState({ isVisible });
+        });
+    }
+
+    componentWillUnmount() {
+        if (this._onIsVisibleChangedObserver) {
+            this.props.control.onIsVisibleChangedObservable.remove(this._onIsVisibleChangedObserver);
+        }
     }
 
     highlight() {
@@ -91,7 +104,7 @@ export class ControlTreeItemComponent extends React.Component<IControlTreeItemCo
                         <div className="addComponent icon" onClick={() => this.highlight()} title="Add component (Not Implemented)">
                             <img src={makeComponentIcon} />
                         </div>
-                        <div className="visibility icon" onClick={() => this.switchVisibility()} title="Show/Hide control">
+                        <div className="visibility icon" onClick={() => this.switchVisibility()} title="Set isVisible">
                             <img src={this.state.isVisible ? visibilityActiveIcon : visibilityNotActiveIcon} />
                         </div>
                     </>


### PR DESCRIPTION
…menu

Related forum issue: https://forum.babylonjs.com/t/gui-editor-text-not-displaying/41395/7

Adds a isVisible property on the common control property menu, which has the same function as the one on the tree view:
![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/ebd15da5-b439-4a49-b97b-72224b0534ea)


