### PR TITLE
[Ray] Add same parameters from AbstractMesh.intersects to Ray.intersectsMesh

### DIFF
--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -296,9 +296,20 @@ export class Ray {
      * Checks if ray intersects a mesh. The ray is defined in WORLD space.
      * @param mesh the mesh to check
      * @param fastCheck defines if the first intersection will be used (and not the closest)
+     * @param trianglePredicate defines an optional predicate used to select faces when a mesh intersection is detected
+     * @param onlyBoundingInfo defines a boolean indicating if picking should only happen using bounding info (false by default)
+     * @param worldToUse defines the world matrix to use to get the world coordinate of the intersection point
+     * @param skipBoundingInfo a boolean indicating if we should skip the bounding info check
      * @returns picking info of the intersection
      */
-    public intersectsMesh(mesh: DeepImmutable<AbstractMesh>, fastCheck?: boolean): PickingInfo {
+    public intersectsMesh(
+        mesh: DeepImmutable<AbstractMesh>,
+        fastCheck?: boolean,
+        trianglePredicate?: TrianglePickingPredicate,
+        onlyBoundingInfo = false,
+        worldToUse?: Matrix,
+        skipBoundingInfo = false
+    ): PickingInfo {
         const tm = TmpVectors.Matrix[0];
 
         mesh.getWorldMatrix().invertToRef(tm);
@@ -309,7 +320,7 @@ export class Ray {
             this._tmpRay = Ray.Transform(this, tm);
         }
 
-        return mesh.intersects(this._tmpRay, fastCheck);
+        return mesh.intersects(this._tmpRay, fastCheck, trianglePredicate, onlyBoundingInfo, worldToUse, skipBoundingInfo);
     }
 
     /**


### PR DESCRIPTION
This makes it easier for a user to chose which function suits them best
Related forum issue: https://forum.babylonjs.com/t/ray-intersection-from-the-invisible-culled-side/41545/6