### PR TITLE
Allows colour changes from bboxrenderer observers

### DIFF
--- a/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
+++ b/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
@@ -296,8 +296,6 @@ export class BoundingBoxRenderer implements ISceneComponent {
         const engine = this.scene.getEngine();
         engine.setDepthWrite(false);
 
-        const frontColor = this.frontColor.toColor4();
-        const backColor = this.backColor.toColor4();
         const transformMatrix = this.scene.getTransformMatrix();
 
         for (let boundingBoxIndex = 0; boundingBoxIndex < this.renderList.length; boundingBoxIndex++) {
@@ -332,7 +330,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
                     engine.setDepthFunctionToGreaterOrEqual();
                 }
                 this._uniformBufferBack.bindToEffect(drawWrapperBack.effect!, "BoundingBoxRenderer");
-                this._uniformBufferBack.updateDirectColor4("color", backColor);
+                this._uniformBufferBack.updateDirectColor4("color", this.backColor.toColor4());
                 this._uniformBufferBack.updateMatrix("world", worldMatrix);
                 this._uniformBufferBack.updateMatrix("viewProjection", transformMatrix);
                 this._uniformBufferBack.update();
@@ -354,7 +352,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
                 engine.setDepthFunctionToLess();
             }
             this._uniformBufferFront.bindToEffect(drawWrapperFront.effect!, "BoundingBoxRenderer");
-            this._uniformBufferFront.updateDirectColor4("color", frontColor);
+            this._uniformBufferFront.updateDirectColor4("color", this.frontColor.toColor4());
             this._uniformBufferFront.updateMatrix("world", worldMatrix);
             this._uniformBufferFront.updateMatrix("viewProjection", transformMatrix);
             this._uniformBufferFront.update();

--- a/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
+++ b/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
@@ -330,7 +330,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
                     engine.setDepthFunctionToGreaterOrEqual();
                 }
                 this._uniformBufferBack.bindToEffect(drawWrapperBack.effect!, "BoundingBoxRenderer");
-                this._uniformBufferBack.updateDirectColor4("color", this.backColor.toColor4());
+                this._uniformBufferBack.updateColor4("color", this.backColor, 1);
                 this._uniformBufferBack.updateMatrix("world", worldMatrix);
                 this._uniformBufferBack.updateMatrix("viewProjection", transformMatrix);
                 this._uniformBufferBack.update();
@@ -352,7 +352,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
                 engine.setDepthFunctionToLess();
             }
             this._uniformBufferFront.bindToEffect(drawWrapperFront.effect!, "BoundingBoxRenderer");
-            this._uniformBufferFront.updateDirectColor4("color", this.frontColor.toColor4());
+            this._uniformBufferFront.updateColor4("color", this.frontColor, 1);
             this._uniformBufferFront.updateMatrix("world", worldMatrix);
             this._uniformBufferFront.updateMatrix("viewProjection", transformMatrix);
             this._uniformBufferFront.update();


### PR DESCRIPTION
Uses the this.frontColor and this.backColor properties directly when drawing the bounding boxes to allow colour changes from onBeforeBoxRenderingObservable observers.

