### PR TITLE
Use addFunction to add MultiMaterial to a scene

### DIFF
--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -49,7 +49,7 @@ export class MultiMaterial extends Material {
     constructor(name: string, scene?: Scene) {
         super(name, scene, true);
 
-        this.getScene().multiMaterials.push(this);
+        this.getScene().addMultiMaterial(this);
 
         this.subMaterials = new Array<Material>();
 


### PR DESCRIPTION
The function `addMultiMaterial` is affected by the observer or the _blockEntityCollection variable. This needs to be taken into account.

You can see a similar case with the Material class.
https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Materials/material.ts#L922


And this is the problematic code. Even if _blockEntityCollection is set, MultiMaterial will still be added to the scene.
https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/loaders/src/glTF/1.0/glTFLoader.ts#L786