### PR TITLE
[GUI] Fix fixedRatioMasterIsWidth not being preserved on the GUI Editor

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -588,6 +588,16 @@ export class Control implements IAnimatable {
         this._markAsDirty();
     }
 
+    private _fixedRatio = 0;
+    public set fixedRatio(value: number) {
+        if (this._fixedRatio === value) {
+            return;
+        }
+
+        this._fixedRatio = value;
+        this._markAsDirty();
+    }
+
     /**
      * Gets or sets a fixed ratio for this control.
      * When different from 0, the ratio is used to compute the "second" dimension.
@@ -595,9 +605,27 @@ export class Control implements IAnimatable {
      * second dimension is computed as first dimension * fixedRatio
      */
     @serialize()
-    public fixedRatio = 0;
+    public get fixedRatio(): number {
+        return this._fixedRatio;
+    }
 
     protected _fixedRatioMasterIsWidth = true;
+    set fixedRatioMasterIsWidth(value: boolean) {
+        if (this._fixedRatioMasterIsWidth === value) {
+            return;
+        }
+        this._fixedRatioMasterIsWidth = value;
+        this._markAsDirty();
+    }
+
+    /**
+     * Gets or sets a boolean indicating that the fixed ratio is set on the width instead of the height. True by default.
+     * When the height of a control is set, this property is changed to false.
+     */
+    @serialize()
+    get fixedRatioMasterIsWidth(): boolean {
+        return this._fixedRatioMasterIsWidth;
+    }
 
     /**
      * Gets or sets control width
@@ -1882,11 +1910,11 @@ export class Control implements IAnimatable {
             this._currentMeasure.height *= this._height.getValue(this._host);
         }
 
-        if (this.fixedRatio !== 0) {
+        if (this._fixedRatio !== 0) {
             if (this._fixedRatioMasterIsWidth) {
-                this._currentMeasure.height = this._currentMeasure.width * this.fixedRatio;
+                this._currentMeasure.height = this._currentMeasure.width * this._fixedRatio;
             } else {
-                this._currentMeasure.width = this._currentMeasure.height * this.fixedRatio;
+                this._currentMeasure.width = this._currentMeasure.height * this._fixedRatio;
             }
         }
     }
@@ -2474,6 +2502,8 @@ export class Control implements IAnimatable {
                     );
             }
         }
+
+        this.fixedRatioMasterIsWidth = serializedObject.fixedRatioMasterIsWidth ?? this.fixedRatioMasterIsWidth;
     }
 
     /** Releases associated resources */

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -609,7 +609,7 @@ export class Control implements IAnimatable {
         return this._fixedRatio;
     }
 
-    protected _fixedRatioMasterIsWidth = true;
+    private _fixedRatioMasterIsWidth = true;
     set fixedRatioMasterIsWidth(value: boolean) {
         if (this._fixedRatioMasterIsWidth === value) {
             return;

--- a/packages/dev/gui/src/2D/controls/inputTextArea.ts
+++ b/packages/dev/gui/src/2D/controls/inputTextArea.ts
@@ -103,7 +103,7 @@ export class InputTextArea extends InputText {
     }
 
     public set height(value: string | number) {
-        this._fixedRatioMasterIsWidth = false;
+        this.fixedRatioMasterIsWidth = false;
 
         if (this._height.toString(this._host) === value) {
             return;


### PR DESCRIPTION
Example PG: [#KEZ57F#1](https://playground.babylonjs.com/#KEZ57F#1)
When opened:
![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/7bce726c-03d5-47d9-84da-3de4dad0de8b)
If you open the GUI Editor, it switches from fixed width ratio to fixed height:
![image](https://github.com/BabylonJS/Babylon.js/assets/6002144/576d9595-78dd-4abe-aafe-21c4efb9456b)

This also exposes the property fixedRatioMasterIsWidth so the user can set it to their preference.