### PR TITLE
Add NativeEngine enableScissor and disableScissor

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -230,6 +230,7 @@ interface INativeEngineConstructor {
     readonly COMMAND_CLEAR: NativeData;
     readonly COMMAND_SETSTENCIL: NativeData;
     readonly COMMAND_SETVIEWPORT: NativeData;
+    readonly COMMAND_SETSCISSOR: NativeData;
 }
 
 /** @internal */

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -803,6 +803,24 @@ export class NativeEngine extends Engine {
         this._commandBufferEncoder.finishEncodingCommand();
     }
 
+    public enableScissor(x: number, y: number, width: number, height: number): void {
+        this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_SETSCISSOR);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(x);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(y);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(width);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(height);
+        this._commandBufferEncoder.finishEncodingCommand();
+    }
+
+    public disableScissor() {
+        this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_SETSCISSOR);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(0);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(0);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(0);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(0);
+        this._commandBufferEncoder.finishEncodingCommand();
+    }
+
     public setState(culling: boolean, zOffset: number = 0, force?: boolean, reverseSide = false, cullBackFaces?: boolean, stencil?: IStencilState, zOffsetUnits: number = 0): void {
         this._zOffset = zOffset;
         this._zOffsetUnits = zOffsetUnits;


### PR DESCRIPTION
Adds `enableScissor` and `disableScissor` functions to the `NativeEngine` class so they can be implemented in BabylonNative. See PR https://github.com/BabylonJS/BabylonNative/pull/1243.

This change was tested against the current BabylonNative master branch to make sure it doesn't break when scissors are not being used. It was also tested against the BabylonNative PR implementing scissors https://github.com/BabylonJS/BabylonNative/pull/1243 to make sure all tests pass.

BabylonNative was crashing before this change when scissors are being used, and with this change it still crashes but for a different reason. Because BabylonNative master was crashing before this PR and after it, no protocol version change is needed in `nativeEngine.ts`. Scissor behavior for the end user is the same as before.