### PR TITLE
Fix an issue with NME canvas resizing

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1791,7 +1791,7 @@ export class ThinEngine {
 
         if (IsWindowObjectExist() && IsDocumentAvailable()) {
             // make sure it is a Node object, and is a part of the document.
-            if (this._renderingCanvas && this._renderingCanvas.nodeType && document.body.contains(this._renderingCanvas)) {
+            if (this._renderingCanvas) {
                 const boundingRect = this._renderingCanvas.getBoundingClientRect
                     ? this._renderingCanvas.getBoundingClientRect()
                     : {
@@ -1799,11 +1799,8 @@ export class ThinEngine {
                           width: this._renderingCanvas.width * this._hardwareScalingLevel,
                           height: this._renderingCanvas.height * this._hardwareScalingLevel,
                       };
-                width = this._renderingCanvas.clientWidth || boundingRect.width;
-                height = this._renderingCanvas.clientHeight || boundingRect.height;
-            } else if (this._renderingCanvas) {
-                width = this._renderingCanvas.width;
-                height = this._renderingCanvas.height;
+                width = this._renderingCanvas.clientWidth || boundingRect.width || this._renderingCanvas.width;
+                height = this._renderingCanvas.clientHeight || boundingRect.height || this._renderingCanvas.height;
             } else {
                 width = window.innerWidth;
                 height = window.innerHeight;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1799,8 +1799,8 @@ export class ThinEngine {
                           width: this._renderingCanvas.width * this._hardwareScalingLevel,
                           height: this._renderingCanvas.height * this._hardwareScalingLevel,
                       };
-                width = this._renderingCanvas.clientWidth || boundingRect.width || this._renderingCanvas.width;
-                height = this._renderingCanvas.clientHeight || boundingRect.height || this._renderingCanvas.height;
+                width = this._renderingCanvas.clientWidth || boundingRect.width || this._renderingCanvas.width || 100;
+                height = this._renderingCanvas.clientHeight || boundingRect.height || this._renderingCanvas.height || 100;
             } else {
                 width = window.innerWidth;
                 height = window.innerHeight;


### PR DESCRIPTION
There is an issue with NME canvas resizing because the canvas belongs to a different document.

The following fix makes a few assumptions (that were fully tested in different scenarios):

1) When a canvas is not attached to a document its width and height are 0,0
2) when a canvas is not attached the user must define width and height OR use the default values
3) An element doesn't have to belong to the document in which the js context is running. (NME case)

This playground can be used for testing, along with all NME playgrounds:
#NZZAUD#7