### PR TITLE
Allow removing an observer without knowing its observable

### DIFF
--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -75,6 +75,13 @@ export class Observer<T> {
     public unregisterOnNextCall = false;
 
     /**
+     * this function can be used to remove the observer from the observable.
+     * It will be set by the observable that the observer belongs to.
+     * @internal
+     */
+    public _remove: Nullable<() => void> = null;
+
+    /**
      * Creates a new observer
      * @param callback defines the callback to call when the observer is notified
      * @param mask defines the mask of the observer (used to filter notifications)
@@ -94,6 +101,16 @@ export class Observer<T> {
          */
         public scope: any = null
     ) {}
+
+    /**
+     * Remove the observer from its observable
+     * This can be used instead of using the observable's remove function.
+     */
+    public remove() {
+        if (this._remove) {
+            this._remove();
+        }
+    }
 }
 
 /**
@@ -208,6 +225,10 @@ export class Observable<T> {
                 this.notifyObserver(observer, this._lastNotifiedValue);
             }
         }
+        // attach the remove function to the observer
+        observer._remove = () => {
+            this.remove(observer);
+        };
 
         return observer;
     }
@@ -231,6 +252,7 @@ export class Observable<T> {
             return false;
         }
 
+        observer._remove = null;
         const index = this._observers.indexOf(observer);
 
         if (index !== -1) {
@@ -405,7 +427,12 @@ export class Observable<T> {
      * Clear the list of observers
      */
     public clear(): void {
-        this._observers.length = 0;
+        while(this._observers.length) {
+            const o = this._observers.pop();
+            if(o) {
+                o._remove = null;
+            }
+        }
         this._onObserverAdded = null;
         this._numObserversMarkedAsDeleted = 0;
         this.cleanLastNotifiedState();

--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -427,9 +427,9 @@ export class Observable<T> {
      * Clear the list of observers
      */
     public clear(): void {
-        while(this._observers.length) {
+        while (this._observers.length) {
             const o = this._observers.pop();
-            if(o) {
+            if (o) {
                 o._remove = null;
             }
         }


### PR DESCRIPTION
Suggestion to add a remove function to the observer.

This implementation maintains back-compat, allows using either one of the functions to remove the observer. calling both functions would be a no-op for the 2nd call.