### PR TITLE
Water material: Fix support for mesh instances

### DIFF
--- a/packages/dev/materials/src/water/water.fragment.fx
+++ b/packages/dev/materials/src/water/water.fragment.fx
@@ -66,7 +66,6 @@ uniform float time;
 // Water varyings
 varying vec3 vRefractionMapTexCoord;
 varying vec3 vReflectionMapTexCoord;
-varying vec3 vPosition;
 
 #include<clipPlaneFragmentDeclaration>
 #include<logDepthDeclaration>

--- a/packages/dev/materials/src/water/water.vertex.fx
+++ b/packages/dev/materials/src/water/water.vertex.fx
@@ -55,7 +55,7 @@ varying vec4 vColor;
 #include<logDepthDeclaration>
 
 // Water uniforms
-uniform mat4 worldReflectionViewProjection;
+uniform mat4 reflectionViewProjection;
 uniform vec2 windDirection;
 uniform float waveLength;
 uniform float time;
@@ -65,7 +65,6 @@ uniform float waveSpeed;
 uniform float waveCount;
 
 // Water varyings
-varying vec3 vPosition;
 varying vec3 vRefractionMapTexCoord;
 varying vec3 vReflectionMapTexCoord;
 
@@ -133,24 +132,29 @@ void main(void) {
 
 	float finalWaveCount = 1.0 / (waveCount * 0.5);
 
+#ifdef USE_WORLD_COORDINATES
+	vec3 p = worldPos.xyz;
+#else
 	vec3 p = position;
+#endif
 	float newY = (sin(((p.x / finalWaveCount) + time * waveSpeed)) * waveHeight * windDirection.x * 5.0)
 			   + (cos(((p.z / finalWaveCount) +  time * waveSpeed)) * waveHeight * windDirection.y * 5.0);
 	p.y += abs(newY);
 	
+#ifdef USE_WORLD_COORDINATES
+	gl_Position = viewProjection * vec4(p, 1.0);
+#else
 	gl_Position = viewProjection * finalWorld * vec4(p, 1.0);
+#endif
 
 #ifdef REFLECTION
-	worldPos = viewProjection * finalWorld * vec4(p, 1.0);
-	
 	// Water
-	vPosition = position;
 	
-	vRefractionMapTexCoord.x = 0.5 * (worldPos.w + worldPos.x);
-	vRefractionMapTexCoord.y = 0.5 * (worldPos.w + worldPos.y);
-	vRefractionMapTexCoord.z = worldPos.w;
+	vRefractionMapTexCoord.x = 0.5 * (gl_Position.w + gl_Position.x);
+	vRefractionMapTexCoord.y = 0.5 * (gl_Position.w + gl_Position.y);
+	vRefractionMapTexCoord.z = gl_Position.w;
 	
-	worldPos = worldReflectionViewProjection * vec4(position, 1.0);
+	worldPos = reflectionViewProjection * finalWorld * vec4(position, 1.0);
 	vReflectionMapTexCoord.x = 0.5 * (worldPos.w + worldPos.x);
 	vReflectionMapTexCoord.y = 0.5 * (worldPos.w + worldPos.y);
 	vReflectionMapTexCoord.z = worldPos.w;

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -59,6 +59,7 @@ class WaterMaterialDefines extends MaterialDefines implements IImageProcessingCo
     public FRESNELSEPARATE = false;
     public BUMPSUPERIMPOSE = false;
     public BUMPAFFECTSREFLECTION = false;
+    public USE_WORLD_COORDINATES = false;
 
     public IMAGEPROCESSING = false;
     public VIGNETTE = false;
@@ -198,6 +199,16 @@ export class WaterMaterial extends PushMaterial {
      */
     @serialize()
     public disableClipPlane: boolean = false;
+
+    /**
+     * Defines whether or not to use world coordinates for wave deformations.
+     * The default value is false, meaning that the deformation is applied in object (local) space.
+     * You will probably need to set it to true if you are using instances or thin instances for your water objects.
+     */
+    @serialize("useWorldCoordinatesForWaveDeformation")
+    private _useWorldCoordinatesForWaveDeformation = false;
+    @expandToProperty("_markAllSubMeshesAsMiscDirty")
+    public useWorldCoordinatesForWaveDeformation: boolean;
 
     protected _renderTargets = new SmartArray<RenderTargetTexture>(16);
 
@@ -361,17 +372,10 @@ export class WaterMaterial extends PushMaterial {
         MaterialHelper.PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
 
         if (defines._areMiscDirty) {
-            if (this._fresnelSeparate) {
-                defines.FRESNELSEPARATE = true;
-            }
-
-            if (this._bumpSuperimpose) {
-                defines.BUMPSUPERIMPOSE = true;
-            }
-
-            if (this._bumpAffectsReflection) {
-                defines.BUMPAFFECTSREFLECTION = true;
-            }
+            defines.FRESNELSEPARATE = this._fresnelSeparate;
+            defines.BUMPSUPERIMPOSE = this._bumpSuperimpose;
+            defines.BUMPAFFECTSREFLECTION = this._bumpAffectsReflection;
+            defines.USE_WORLD_COORDINATES = this._useWorldCoordinatesForWaveDeformation;
         }
 
         // Lights
@@ -466,7 +470,7 @@ export class WaterMaterial extends PushMaterial {
                 "logarithmicDepthConstant",
 
                 // Water
-                "worldReflectionViewProjection",
+                "reflectionViewProjection",
                 "windDirection",
                 "waveLength",
                 "time",
@@ -601,7 +605,7 @@ export class WaterMaterial extends PushMaterial {
             this._activeEffect.setTexture("reflectionSampler", this._reflectionRTT);
         }
 
-        const wrvp = this._mesh.getWorldMatrix().multiply(this._reflectionTransform).multiply(scene.getProjectionMatrix());
+        const wrvp = this._reflectionTransform.multiply(scene.getProjectionMatrix());
 
         // Add delta time. Prevent adding delta time if it hasn't changed.
         const deltaTime = scene.getEngine().getDeltaTime();
@@ -610,7 +614,7 @@ export class WaterMaterial extends PushMaterial {
             this._lastTime += this._lastDeltaTime;
         }
 
-        this._activeEffect.setMatrix("worldReflectionViewProjection", wrvp);
+        this._activeEffect.setMatrix("reflectionViewProjection", wrvp);
         this._activeEffect.setVector2("windDirection", this.windDirection);
         this._activeEffect.setFloat("waveLength", this.waveLength);
         this._activeEffect.setFloat("time", this._lastTime / 100000);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/water-material-fix/41609/5

It also fixes use of `bumpSuperimpose`, `fresnelSeparate` and `bumpAffectsReflection`, which were not reset when switching their state from `true` to `false`.