### PR TITLE
[XR] getMeshUnderPointer can now receive a WebXRInputSource instead of the controller id

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -319,15 +319,13 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
     /**
      * Will get the mesh under a specific pointer.
      * `scene.meshUnderPointer` will only return one mesh - either left or right.
-     * @param controllerId the controllerId to check
+     * @param controllerOrId the input source or controller id string to check
      * @returns The mesh under pointer or null if no mesh is under the pointer
      */
-    public getMeshUnderPointer(controllerId: string): Nullable<AbstractMesh> {
-        if (typeof controllerId !== "string") {
-            Tools.Warn("[getMeshUnderPointer] controllerId is not of string type");
-        }
-        if (this._controllers[controllerId]) {
-            return this._controllers[controllerId].meshUnderPointer;
+    public getMeshUnderPointer(controllerOrId: string | WebXRInputSource): Nullable<AbstractMesh> {
+        const id = typeof controllerOrId === "string" ? controllerOrId : controllerOrId.uniqueId;
+        if (this._controllers[id]) {
+            return this._controllers[id].meshUnderPointer;
         } else {
             return null;
         }

--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -323,6 +323,9 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
      * @returns The mesh under pointer or null if no mesh is under the pointer
      */
     public getMeshUnderPointer(controllerId: string): Nullable<AbstractMesh> {
+        if (typeof controllerId !== "string") {
+            Tools.Warn("[getMeshUnderPointer] controllerId is not of string type");
+        }
         if (this._controllers[controllerId]) {
             return this._controllers[controllerId].meshUnderPointer;
         } else {


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/xr-pointerselection-getmeshunderpointer-silently-fails-when-uniqueid-isnt-provided/41702