### PR TITLE
InputManager: Move-based Picking not working with SpriteManager and specific flag

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -227,6 +227,9 @@ export class InputManager {
         this._setCursorAndPointerOverMesh(pickResult, evt, scene);
 
         for (const step of scene._pointerMoveStage) {
+            // If _pointerMoveState is defined, we have an active spriteManager and can't use Lazy Picking
+            // Therefore, we need to force a pick to update the pickResult
+            pickResult = pickResult || this._pickMove(evt);
             const isMeshPicked = pickResult?.pickedMesh ? true : false;
             pickResult = step.action(this._unTranslatedPointerX, this._unTranslatedPointerY, pickResult, isMeshPicked, canvas);
         }
@@ -791,7 +794,7 @@ export class InputManager {
                     (!scene.cameraToUseForPointers || (scene.cameraToUseForPointers.layerMask & mesh.layerMask) !== 0);
             }
 
-            const pickResult = scene._registeredActions > 0 ? this._pickMove(evt as IPointerEvent) : null;
+            const pickResult = scene._registeredActions > 0 || scene.constantlyUpdateMeshUnderPointer ? this._pickMove(evt as IPointerEvent) : null;
             this._processPointerMove(pickResult, evt as IPointerEvent);
         };
 


### PR DESCRIPTION
A user in the forum found an issue where having an active SpriteManager was interfering with picking being done when `scene.constantlyUpdateMeshUnderPointer` is set to true.  This PR makes two small changes.  First, because of how the SpriteManager works, lazy picking cannot be applied so if there's an active SpriteManager, lazy picking isn't used.  Second, if the `scene.constantlyUpdateMeshUnderPointer` is set to true, lazy picking will also be disabled as the mesh under the pointer will not be updated normally until the property is accessed.

A test has also been added to verify that picking is done before the picking info is referenced under these specific circumstances.