### PR TITLE
Interaction Test: Update first test to remove inertia

### DIFF
--- a/packages/tools/tests/test/interactions/safari.test.ts
+++ b/packages/tools/tests/test/interactions/safari.test.ts
@@ -17,9 +17,9 @@ describe("safari", () => {
     });
 
     // Check if allowMouse logic for camera touch input is validating correctly
-    // PG: https://playground.babylonjs.com/#ITQ2NZ#9
+    // PG: https://playground.babylonjs.com/#ITQ2NZ#10
     it("check isMouseEvent", async () => {
-        await LoadPlayground(driver, "#ITQ2NZ#9", getGlobalConfig(), 1000);
+        await LoadPlayground(driver, "#ITQ2NZ#10", getGlobalConfig(), 1000);
         const el = await driver.findElement(By.id("babylon-canvas"));
 
         // With allowMouse = true, touch controls should move camera forward if isMouseEvent is true


### PR DESCRIPTION
For this PR, it just makes a minor change to the interaction test to remove inertia (`camera.inertia = 0`) from the camera movement.  This will remove any chance that the camera will move (due to left over momentum) when it's not supposed to.