### PR TITLE
CubeTexture: Fix parsing when name has been overwritten

### DIFF
--- a/packages/dev/core/src/Materials/Textures/cubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/cubeTexture.ts
@@ -448,7 +448,7 @@ export class CubeTexture extends BaseTexture {
                     prefiltered = parsedTexture.prefiltered;
                 }
                 return new CubeTexture(
-                    rootUrl + parsedTexture.name,
+                    rootUrl + parsedTexture.url,
                     scene,
                     parsedTexture.extensions,
                     false,

--- a/packages/dev/core/src/Materials/Textures/cubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/cubeTexture.ts
@@ -448,7 +448,7 @@ export class CubeTexture extends BaseTexture {
                     prefiltered = parsedTexture.prefiltered;
                 }
                 return new CubeTexture(
-                    rootUrl + parsedTexture.url,
+                    rootUrl + (parsedTexture.url ?? parsedTexture.name),
                     scene,
                     parsedTexture.extensions,
                     false,


### PR DESCRIPTION
See https://forum.babylonjs.com/t/pbrmaterial-clone-has-stopped-working-in-my-scene-just-now-or-a-few-hours-ago/41805/9
