### PR TITLE
[Physics] Add raycast filtering to physics engine interface

### DIFF
--- a/packages/dev/core/src/Physics/IPhysicsEngine.ts
+++ b/packages/dev/core/src/Physics/IPhysicsEngine.ts
@@ -1,5 +1,5 @@
 import type { Vector3 } from "../Maths/math.vector";
-import type { PhysicsRaycastResult } from "./physicsRaycastResult";
+import type { PhysicsRaycastResult, IRaycastQuery } from "./physicsRaycastResult";
 import type { IPhysicsEnginePlugin as IPhysicsEnginePluginV1 } from "./v1/IPhysicsEnginePlugin";
 import type { IPhysicsEnginePluginV2 } from "./v2/IPhysicsEnginePlugin";
 
@@ -75,7 +75,7 @@ export interface IPhysicsEngine {
      * @param to when should the ray end?
      * @returns PhysicsRaycastResult
      */
-    raycast(from: Vector3, to: Vector3): PhysicsRaycastResult;
+    raycast(from: Vector3, to: Vector3, query?: IRaycastQuery): PhysicsRaycastResult;
 
     /**
      * Called by the scene. No need to call it.

--- a/packages/dev/core/src/Physics/physicsRaycastResult.ts
+++ b/packages/dev/core/src/Physics/physicsRaycastResult.ts
@@ -2,6 +2,17 @@ import { Vector3 } from "../Maths/math.vector";
 import type { PhysicsBody } from "./v2/physicsBody";
 
 /**
+ * Interface for query parameters in the raycast function.
+ * @see the "Collision Filtering" section in https://github.com/eoineoineoin/glTF/tree/MSFT_RigidBodies/extensions/2.0/Vendor/MSFT_collision_primitives
+ */
+export interface IRaycastQuery {
+    /** Membership mask */
+    membership?: number;
+    /** CollideWith mask */
+    collideWith?: number;
+}
+
+/**
  * Holds the data for the raycast result
  * @see https://doc.babylonjs.com/features/featuresDeepDive/physics/usingPhysicsEngine
  */

--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -1,5 +1,5 @@
 import type { Vector3, Quaternion } from "../../Maths/math.vector";
-import type { PhysicsRaycastResult } from "../physicsRaycastResult";
+import type { IRaycastQuery, PhysicsRaycastResult } from "../physicsRaycastResult";
 import type { PhysicsBody } from "./physicsBody";
 import type { PhysicsShape } from "./physicsShape";
 import type { PhysicsConstraint } from "./physicsConstraint";
@@ -308,17 +308,6 @@ export enum PhysicsMotionType {
     DYNAMIC,
 }
 
-/**
- * Interface for query parameters in the raycast function.
- * @see the "Collision Filtering" section in https://github.com/eoineoineoin/glTF/tree/MSFT_RigidBodies/extensions/2.0/Vendor/MSFT_collision_primitives
- */
-export interface IRaycastQuery {
-    /** Membership mask */
-    membership?: number;
-    /** CollideWith mask */
-    collideWith?: number;
-}
-
 /** @internal */
 export interface IPhysicsEnginePluginV2 {
     /**
@@ -414,7 +403,7 @@ export interface IPhysicsEnginePluginV2 {
     disposeConstraint(constraint: PhysicsConstraint): void;
 
     // raycast
-    raycast(from: Vector3, to: Vector3, result: PhysicsRaycastResult): void;
+    raycast(from: Vector3, to: Vector3, result: PhysicsRaycastResult, query?: IRaycastQuery): void;
 
     dispose(): void;
 }

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -7,7 +7,8 @@ import {
     PhysicsConstraintAxis,
     PhysicsConstraintAxisLimitMode,
 } from "../IPhysicsEnginePlugin";
-import type { PhysicsShapeParameters, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent, IRaycastQuery } from "../IPhysicsEnginePlugin";
+import type { PhysicsShapeParameters, IPhysicsEnginePluginV2, PhysicsMassProperties, IPhysicsCollisionEvent } from "../IPhysicsEnginePlugin";
+import type { IRaycastQuery, PhysicsRaycastResult } from "../../physicsRaycastResult";
 import { Logger } from "../../../Misc/logger";
 import type { PhysicsBody } from "../physicsBody";
 import type { PhysicsConstraint, Physics6DoFConstraint } from "../physicsConstraint";
@@ -16,7 +17,6 @@ import { PhysicsMaterialCombineMode } from "../physicsMaterial";
 import { PhysicsShape } from "../physicsShape";
 import type { BoundingBox } from "../../../Culling/boundingBox";
 import type { TransformNode } from "../../../Meshes/transformNode";
-import type { PhysicsRaycastResult } from "../../physicsRaycastResult";
 import { Mesh } from "../../../Meshes/mesh";
 import type { Scene } from "../../../scene";
 import { VertexBuffer } from "../../../Buffers/buffer";

--- a/packages/dev/core/src/Physics/v2/physicsEngine.ts
+++ b/packages/dev/core/src/Physics/v2/physicsEngine.ts
@@ -2,6 +2,7 @@ import type { Nullable } from "../../types";
 import { Vector3 } from "../../Maths/math.vector";
 import type { IPhysicsEngine } from "../IPhysicsEngine";
 import type { IPhysicsEnginePluginV2 } from "./IPhysicsEnginePlugin";
+import type { IRaycastQuery } from "../physicsRaycastResult";
 import { PhysicsRaycastResult } from "../physicsRaycastResult";
 import { _WarnImport } from "../../Misc/devTools";
 import type { PhysicsBody } from "./physicsBody";
@@ -165,8 +166,8 @@ export class PhysicsEngine implements IPhysicsEngine {
      * @param to when should the ray end?
      * @param result resulting PhysicsRaycastResult
      */
-    public raycastToRef(from: Vector3, to: Vector3, result: PhysicsRaycastResult): void {
-        this._physicsPlugin.raycast(from, to, result);
+    public raycastToRef(from: Vector3, to: Vector3, result: PhysicsRaycastResult, query?: IRaycastQuery): void {
+        this._physicsPlugin.raycast(from, to, result, query);
     }
 
     /**
@@ -175,9 +176,9 @@ export class PhysicsEngine implements IPhysicsEngine {
      * @param to when should the ray end?
      * @returns PhysicsRaycastResult
      */
-    public raycast(from: Vector3, to: Vector3): PhysicsRaycastResult {
+    public raycast(from: Vector3, to: Vector3, query?: IRaycastQuery): PhysicsRaycastResult {
         const result = new PhysicsRaycastResult();
-        this._physicsPlugin.raycast(from, to, result);
+        this._physicsPlugin.raycast(from, to, result, query);
         return result;
     }
 }


### PR DESCRIPTION
So you can do: 
```javascript
physicsEngine.raycastToRef(from, to, result, query);
```

Instead of having to access the Havok Plugin.