### PR TITLE
Optimized mesh.subdivide function by delaying the BB refresh to once …

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1485,12 +1485,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 break;
             }
 
-            SubMesh.CreateFromIndices(0, offset, index === count - 1 ? totalIndices - offset : subdivisionSize, this);
+            SubMesh.CreateFromIndices(0, offset, index === count - 1 ? totalIndices - offset : subdivisionSize, this, undefined, false);
 
             offset += subdivisionSize;
         }
 
         this.synchronizeInstances();
+        this.refreshBoundingInfo();
     }
 
     /**

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1490,8 +1490,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             offset += subdivisionSize;
         }
 
-        this.synchronizeInstances();
         this.refreshBoundingInfo();
+        this.synchronizeInstances();
     }
 
     /**


### PR DESCRIPTION
Optimized mesh.subdivide function by delaying the BB refresh to once the subdivision is finished. 
Previously, copying entire mesh data inside the loop made the algorithm time scale with the number of subdivisions. 
This is no longer the case. 100+ times faster on a multi-million vertex mesh. 