### PR TITLE
Gizmo+inspector world/local coordinates switch

### DIFF
--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -50,9 +50,9 @@ export enum GizmoAnchorPoint {
 }
 
 /**
- * Coordinate system mode: Local or World. Defines how axis is aligned: either on world axis or transform local axis
+ * Coordinates mode: Local or World. Defines how axis is aligned: either on world axis or transform local axis
  */
-export enum GizmoCoordinates {
+export enum GizmoCoordinatesMode {
     World,
     Local,
 }
@@ -94,9 +94,9 @@ export interface IGizmo extends IDisposable {
     anchorPoint: GizmoAnchorPoint;
 
     /**
-     * Set the coordinate system to use. By default it's local.
+     * Set the coordinate mode to use. By default it's local.
      */
-    coordinates: GizmoCoordinates;
+    coordinatesMode: GizmoCoordinatesMode;
 
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
@@ -207,7 +207,7 @@ export class Gizmo implements IGizmo {
     protected _updateGizmoPositionToMatchAttachedMesh = true;
     protected _anchorPoint = GizmoAnchorPoint.Origin;
     protected _updateScale = true;
-    protected _coordinates = GizmoCoordinates.Local;
+    protected _coordinatesMode = GizmoCoordinatesMode.Local;
 
     /**
      * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
@@ -245,15 +245,15 @@ export class Gizmo implements IGizmo {
      * But it's possible for a user to tweak so its local for translation and world for rotation.
      * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
      */
-    public set coordinates(coordinates: GizmoCoordinates) {
-        this._coordinates = coordinates;
-        const local = coordinates == GizmoCoordinates.Local;
+    public set coordinatesMode(coordinatesMode: GizmoCoordinatesMode) {
+        this._coordinatesMode = coordinatesMode;
+        const local = coordinatesMode == GizmoCoordinatesMode.Local;
         this.updateGizmoRotationToMatchAttachedMesh = local;
         this.updateGizmoPositionToMatchAttachedMesh = local;
     }
 
-    public get coordinates() {
-        return this._coordinates;
+    public get coordinatesMode() {
+        return this._coordinatesMode;
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -50,6 +50,14 @@ export enum GizmoAnchorPoint {
 }
 
 /**
+ * Coordinate system mode: Local or World. Defines how axis is aligned: either on world axis or transform local axis
+ */
+export enum GizmoCoordinates {
+    World,
+    Local,
+}
+
+/**
  * Interface for basic gizmo
  */
 export interface IGizmo extends IDisposable {
@@ -84,6 +92,12 @@ export interface IGizmo extends IDisposable {
      * (Default: GizmoAnchorPoint.Origin)
      */
     anchorPoint: GizmoAnchorPoint;
+
+    /**
+     * Set the coordinate system to use. By default it's local.
+     */
+    coordinates: GizmoCoordinates;
+
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
      */
@@ -193,6 +207,7 @@ export class Gizmo implements IGizmo {
     protected _updateGizmoPositionToMatchAttachedMesh = true;
     protected _anchorPoint = GizmoAnchorPoint.Origin;
     protected _updateScale = true;
+    protected _coordinates = GizmoCoordinates.Local;
 
     /**
      * If set the gizmo's rotation will be updated to match the attached mesh each frame (Default: true)
@@ -224,6 +239,23 @@ export class Gizmo implements IGizmo {
     public get anchorPoint() {
         return this._anchorPoint;
     }
+
+    /**
+     * Set the coordinate system to use. By default it's local.
+     * But it's possible for a user to tweak so its local for translation and world for rotation.
+     * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
+     */
+    public set coordinates(coordinates: GizmoCoordinates) {
+        this._coordinates = coordinates;
+        const local = coordinates == GizmoCoordinates.Local;
+        this.updateGizmoRotationToMatchAttachedMesh = local;
+        this.updateGizmoPositionToMatchAttachedMesh = local;
+    }
+
+    public get coordinates() {
+        return this._coordinates;
+    }
+
     /**
      * When set, the gizmo will always appear the same size no matter where the camera is (default: true)
      */

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -11,7 +11,7 @@ import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
 import { Color3 } from "../Maths/math.color";
 import { SixDofDragBehavior } from "../Behaviors/Meshes/sixDofDragBehavior";
 import type { GizmoAxisCache, IGizmo } from "./gizmo";
-import { Gizmo, GizmoCoordinates } from "./gizmo";
+import { Gizmo, GizmoCoordinatesMode } from "./gizmo";
 import type { IRotationGizmo } from "./rotationGizmo";
 import { RotationGizmo } from "./rotationGizmo";
 import type { IPositionGizmo } from "./positionGizmo";
@@ -56,7 +56,7 @@ export class GizmoManager implements IDisposable {
     protected _defaultKeepDepthUtilityLayer: UtilityLayerRenderer;
     protected _thickness: number = 1;
     protected _scaleRatio: number = 1;
-    protected _coordinates = GizmoCoordinates.Local;
+    protected _coordinatesMode = GizmoCoordinatesMode.Local;
 
     /** Node Caching for quick lookup */
     private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
@@ -121,17 +121,22 @@ export class GizmoManager implements IDisposable {
         return this._scaleRatio;
     }
 
-    public set coordinates(coordinates: GizmoCoordinates) {
-        this._coordinates = coordinates;
+    /**
+     * Set the coordinate system to use. By default it's local.
+     * But it's possible for a user to tweak so its local for translation and world for rotation.
+     * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
+     */
+    public set coordinatesMode(coordinatesMode: GizmoCoordinatesMode) {
+        this._coordinatesMode = coordinatesMode;
         [this.gizmos.positionGizmo, this.gizmos.rotationGizmo, this.gizmos.scaleGizmo].forEach((gizmo) => {
             if (gizmo) {
-                gizmo.coordinates = coordinates;
+                gizmo.coordinatesMode = coordinatesMode;
             }
         });
     }
 
-    public get coordinates(): GizmoCoordinates {
-        return this._coordinates;
+    public get coordinatesMode(): GizmoCoordinatesMode {
+        return this._coordinatesMode;
     }
     /**
      * Instantiates a gizmo manager

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -11,7 +11,7 @@ import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
 import { Color3 } from "../Maths/math.color";
 import { SixDofDragBehavior } from "../Behaviors/Meshes/sixDofDragBehavior";
 import type { GizmoAxisCache, IGizmo } from "./gizmo";
-import { Gizmo } from "./gizmo";
+import { Gizmo, GizmoCoordinates } from "./gizmo";
 import type { IRotationGizmo } from "./rotationGizmo";
 import { RotationGizmo } from "./rotationGizmo";
 import type { IPositionGizmo } from "./positionGizmo";
@@ -56,6 +56,7 @@ export class GizmoManager implements IDisposable {
     protected _defaultKeepDepthUtilityLayer: UtilityLayerRenderer;
     protected _thickness: number = 1;
     protected _scaleRatio: number = 1;
+    protected _coordinates = GizmoCoordinates.Local;
 
     /** Node Caching for quick lookup */
     private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
@@ -120,6 +121,18 @@ export class GizmoManager implements IDisposable {
         return this._scaleRatio;
     }
 
+    public set coordinates(coordinates: GizmoCoordinates) {
+        this._coordinates = coordinates;
+        [this.gizmos.positionGizmo, this.gizmos.rotationGizmo, this.gizmos.scaleGizmo].forEach((gizmo) => {
+            if (gizmo) {
+                gizmo.coordinates = coordinates;
+            }
+        });
+    }
+
+    public get coordinates(): GizmoCoordinates {
+        return this._coordinates;
+    }
     /**
      * Instantiates a gizmo manager
      * @param _scene the scene to overlay the gizmos on top of

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -340,7 +340,9 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 } else {
                     // Rotate selected mesh quaternion over rotated axis
                     amountToRotate.toRotationMatrix(TmpVectors.Matrix[0]);
-                    TmpVectors.Matrix[0].multiplyToRef(this.attachedNode.getWorldMatrix(), this.attachedNode.getWorldMatrix());
+                    const translation = this.attachedNode.getWorldMatrix().getTranslation();
+                    this.attachedNode.getWorldMatrix().multiplyToRef(TmpVectors.Matrix[0], this.attachedNode.getWorldMatrix());
+                    this.attachedNode.getWorldMatrix().setTranslation(translation);
                 }
 
                 lastDragPosition.copyFrom(event.dragPlanePoint);

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -7,7 +7,7 @@ import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Node } from "../node";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisDragGizmo } from "./axisDragGizmo";
 import { AxisDragGizmo } from "./axisDragGizmo";
@@ -237,6 +237,12 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
     }
     public get anchorPoint() {
         return this._anchorPoint;
+    }
+
+    public set coordinates(coordinates: GizmoCoordinates) {
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
+            gizmo.coordinates = coordinates;
+        });
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -7,7 +7,7 @@ import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Node } from "../node";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinatesMode, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisDragGizmo } from "./axisDragGizmo";
 import { AxisDragGizmo } from "./axisDragGizmo";
@@ -239,9 +239,14 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         return this._anchorPoint;
     }
 
-    public set coordinates(coordinates: GizmoCoordinates) {
+    /**
+     * Set the coordinate system to use. By default it's local.
+     * But it's possible for a user to tweak so its local for translation and world for rotation.
+     * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
+     */
+    public set coordinatesMode(coordinatesMode: GizmoCoordinatesMode) {
         [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
-            gizmo.coordinates = coordinates;
+            gizmo.coordinatesMode = coordinatesMode;
         });
     }
 

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IPlaneRotationGizmo } from "./planeRotationGizmo";
 import { PlaneRotationGizmo } from "./planeRotationGizmo";
@@ -238,6 +238,12 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
     }
     public get anchorPoint() {
         return this._anchorPoint;
+    }
+
+    public set coordinates(coordinates: GizmoCoordinates) {
+        [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
+            gizmo.coordinates = coordinates;
+        });
     }
 
     public set updateScale(value: boolean) {

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Mesh } from "../Meshes/mesh";
-import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinatesMode, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IPlaneRotationGizmo } from "./planeRotationGizmo";
 import { PlaneRotationGizmo } from "./planeRotationGizmo";
@@ -240,9 +240,14 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         return this._anchorPoint;
     }
 
-    public set coordinates(coordinates: GizmoCoordinates) {
+    /**
+     * Set the coordinate system to use. By default it's local.
+     * But it's possible for a user to tweak so its local for translation and world for rotation.
+     * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
+     */
+    public set coordinatesMode(coordinatesMode: GizmoCoordinatesMode) {
         [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
-            gizmo.coordinates = coordinates;
+            gizmo.coordinatesMode = coordinatesMode;
         });
     }
 

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { CreatePolyhedron } from "../Meshes/Builders/polyhedronBuilder";
-import type { GizmoAnchorPoint, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisScaleGizmo } from "./axisScaleGizmo";
 import { AxisScaleGizmo } from "./axisScaleGizmo";
@@ -258,6 +258,12 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
     }
     public get anchorPoint() {
         return this._anchorPoint;
+    }
+
+    public set coordinates(coordinates: GizmoCoordinates) {
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {
+            gizmo.coordinates = coordinates;
+        });
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -6,7 +6,7 @@ import { Vector3 } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { CreatePolyhedron } from "../Meshes/Builders/polyhedronBuilder";
-import type { GizmoAnchorPoint, GizmoCoordinates, GizmoAxisCache, IGizmo } from "./gizmo";
+import type { GizmoAnchorPoint, GizmoCoordinatesMode, GizmoAxisCache, IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
 import type { IAxisScaleGizmo } from "./axisScaleGizmo";
 import { AxisScaleGizmo } from "./axisScaleGizmo";
@@ -260,9 +260,14 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
         return this._anchorPoint;
     }
 
-    public set coordinates(coordinates: GizmoCoordinates) {
+    /**
+     * Set the coordinate system to use. By default it's local.
+     * But it's possible for a user to tweak so its local for translation and world for rotation.
+     * In that case, setting the coordinate system will change `updateGizmoRotationToMatchAttachedMesh` and `updateGizmoPositionToMatchAttachedMesh`
+     */
+    public set coordinatesMode(coordinatesMode: GizmoCoordinatesMode) {
         [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {
-            gizmo.coordinates = coordinates;
+            gizmo.coordinatesMode = coordinatesMode;
         });
     }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -18,7 +18,7 @@ import type { LightGizmo } from "core/Gizmos/lightGizmo";
 import type { CameraGizmo } from "core/Gizmos/cameraGizmo";
 import type { Camera } from "core/Cameras/camera";
 import { TmpVectors, Vector3 } from "core/Maths/math";
-import { GizmoCoordinates } from "core/Gizmos/gizmo";
+import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
 
 interface ISceneTreeItemComponentProps {
     scene: Scene;
@@ -153,7 +153,7 @@ export class SceneTreeItemComponent extends React.Component<
         const scene = this.props.scene;
         const manager: GizmoManager = scene.reservedDataStore.gizmoManager;
         // flip coordinate system
-        manager.coordinates = this.state.isInWorldCoodinatesMode ? GizmoCoordinates.Local : GizmoCoordinates.World;
+        manager.coordinatesMode = this.state.isInWorldCoodinatesMode ? GizmoCoordinatesMode.Local : GizmoCoordinatesMode.World;
         this.setState({ isInWorldCoodinatesMode: !this.state.isInWorldCoodinatesMode });
     }
     onPickingMode() {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -7,7 +7,7 @@ import { GizmoManager } from "core/Gizmos/gizmoManager";
 import type { Scene } from "core/scene";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSyncAlt, faImage, faCrosshairs, faArrowsAlt, faCompress, faRedoAlt, faVectorSquare } from "@fortawesome/free-solid-svg-icons";
+import { faSyncAlt, faImage, faCrosshairs, faArrowsAlt, faCompress, faRedoAlt, faVectorSquare, faLocationDot } from "@fortawesome/free-solid-svg-icons";
 import { ExtensionsComponent } from "../extensionsComponent";
 import * as React from "react";
 
@@ -18,6 +18,7 @@ import type { LightGizmo } from "core/Gizmos/lightGizmo";
 import type { CameraGizmo } from "core/Gizmos/cameraGizmo";
 import type { Camera } from "core/Cameras/camera";
 import { TmpVectors, Vector3 } from "core/Maths/math";
+import { GizmoCoordinates } from "core/Gizmos/gizmo";
 
 interface ISceneTreeItemComponentProps {
     scene: Scene;
@@ -29,7 +30,10 @@ interface ISceneTreeItemComponentProps {
     globalState: GlobalState;
 }
 
-export class SceneTreeItemComponent extends React.Component<ISceneTreeItemComponentProps, { isSelected: boolean; isInPickingMode: boolean; gizmoMode: number }> {
+export class SceneTreeItemComponent extends React.Component<
+    ISceneTreeItemComponentProps,
+    { isSelected: boolean; isInPickingMode: boolean; gizmoMode: number; isInWorldCoodinatesMode: boolean }
+> {
     private _gizmoLayerOnPointerObserver: Nullable<Observer<PointerInfo>>;
     private _onPointerObserver: Nullable<Observer<PointerInfo>>;
     private _onSelectionChangeObserver: Nullable<Observer<any>>;
@@ -59,7 +63,7 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
             manager.enableAutoPicking = false;
         }
 
-        this.state = { isSelected: false, isInPickingMode: false, gizmoMode: gizmoMode };
+        this.state = { isSelected: false, isInPickingMode: false, gizmoMode: gizmoMode, isInWorldCoodinatesMode: false };
     }
 
     shouldComponentUpdate(nextProps: ISceneTreeItemComponentProps, nextState: { isSelected: boolean; isInPickingMode: boolean }) {
@@ -145,6 +149,13 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
         this.props.onSelectionChangedObservable.notifyObservers(scene);
     }
 
+    onCoordinatesMode() {
+        const scene = this.props.scene;
+        const manager: GizmoManager = scene.reservedDataStore.gizmoManager;
+        // flip coordinate system
+        manager.coordinates = this.state.isInWorldCoodinatesMode ? GizmoCoordinates.Local : GizmoCoordinates.World;
+        this.setState({ isInWorldCoodinatesMode: !this.state.isInWorldCoodinatesMode });
+    }
     onPickingMode() {
         const scene = this.props.scene;
 
@@ -454,6 +465,13 @@ export class SceneTreeItemComponent extends React.Component<ISceneTreeItemCompon
                         title="Turn picking mode on/off"
                     >
                         <FontAwesomeIcon icon={faCrosshairs} />
+                    </div>
+                    <div
+                        className={this.state.isInWorldCoodinatesMode ? "coordinates selected icon" : "coordinates icon"}
+                        onClick={() => this.onCoordinatesMode()}
+                        title="Switch between world and local coordinates"
+                    >
+                        <FontAwesomeIcon icon={faLocationDot} />
                     </div>
                     <div className="refresh icon" onClick={() => this.props.onRefresh()} title="Refresh the explorer">
                         <FontAwesomeIcon icon={faSyncAlt} />

--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorer.scss
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorer.scss
@@ -331,13 +331,22 @@
                 }
             }
 
-            .refresh {
+            .coordinates {
                 grid-column: 8;
+                opacity: 0.6;
+
+                &.selected {
+                    opacity: 1;
+                }
+            }
+
+            .refresh {
+                grid-column: 9;
             }
 
             .extensions {
                 width: 20px;
-                grid-column: 9;
+                grid-column: 10;
             }
         }
 


### PR DESCRIPTION
related to https://github.com/BabylonJS/Babylon.js/pull/13939
Add the ability to change coordinate system world/local for gizmos.
Also add that switch to the inspector 
@PatrickRyanMS Let me know if you have a more suitable icon that this one:
![image](https://github.com/BabylonJS/Babylon.js/assets/1312968/548364db-5c5a-4126-ba76-53d1d72f50ee)

