### PR TITLE
Allow customizing vis-tests further

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -10,30 +10,16 @@
 
 const headless = process.env.HEADLESS === "true";
 const browser = process.env.BROWSER || "chrome";
-const engineType = process.env.TEST_ENGINE || "webgl2";
 const gpuType = process.env.TEST_GPU || ""; // egl, desktop or nothing
-const costumeFlags = engineType === "webgpu" ? ["--enable-unsafe-webgpu"] : [];
+const customFlags = process.env.CUSTOM_FLAGS ? process.env.CUSTOM_FLAGS.split(" ") : [];
 const browserPath = process.env.BROWSER_PATH || "";
-
-// console.log(process.env, headless, gpuType);
+// for linux and WebGPU make sure to enable the following flags:
+// --enable-unsafe-webgpu --enable-features=Vulkan,UseSkiaRenderer
 
 const chromeFlags = [
     "--js-flags=--expose-gc",
     "--enable-unsafe-webgpu",
-    // "--no-sandbox",
-    // "--disable-setuid-sandbox",
-    // // "--gpu",
-    // "--enable-webgl2-compute-context",
-    // "--enable-webgl-image-chromium",
-    // // "--ignore-gpu-blocklist",
-    // // "--enable-gpu-rasterization",
-    // "--enable-zero-copy",
-    // // "--disable-gpu-driver-bug-workarounds",
-    // "--enable-gpu-compositing",
-    // "--use-gl=egl",
-    // "--use-gl=desktop",
-    /*"--window-size=600x400",*/
-    ...costumeFlags,
+    ...customFlags,
 ];
 
 if(gpuType) {
@@ -58,5 +44,5 @@ module.exports = {
         args: browser === "chrome" ? chromeFlags : firefoxFlags, // additional arguments for Chrome
         executablePath: browserPath,
     },
-    browserContext: "default",
+    browserContext: process.env.BROWSER_CONTEXT || "default", // "incognito" or "default"
 };


### PR DESCRIPTION
Visualization tests for WebGPU on Linux require a few new configuration flags, otherwise they sometimes fail.

This PR adds the following:

* Set custom flags as an environment variable
* set the browser context as env variable
* ask to reset the entire browser PER TEST. This is important to make sure the entire context changes per test (avoiding any leaks or state errors)
