### PR TITLE
[Physics] Reset body and body index on PhysicsRaycastResult

### DIFF
--- a/packages/dev/core/src/Physics/physicsRaycastResult.ts
+++ b/packages/dev/core/src/Physics/physicsRaycastResult.ts
@@ -126,6 +126,9 @@ export class PhysicsRaycastResult {
         this._hitNormalWorld.setAll(0);
         this._hitPointWorld.setAll(0);
         this._triangleIndex = -1;
+
+        this.body = undefined;
+        this.bodyIndex = undefined;
     }
 }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/physicsraycastresult-reset-does-not-reset-body-property/42135/