### PR TITLE
Material: Adds a property to define the relative order in which decals and detailed maps are rendered

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -247,6 +247,8 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
 
     public UNLIT = false;
 
+    public DECAL_AFTER_DETAIL = false;
+
     public DEBUGMODE = 0;
 
     /**
@@ -820,6 +822,11 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      * If set to true, no lighting calculations will be applied.
      */
     private _unlit = false;
+
+    /**
+     * If sets to true, the decal map will be applied after the detail map. Else, it is applied before (default: false)
+     */
+    private _applyDecalMapAfterDetailMap = false;
 
     private _debugMode = 0;
     /**
@@ -1846,7 +1853,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 this.pointsCloud,
                 this.fogEnabled,
                 this._shouldTurnAlphaTestOn(mesh) || this._forceAlphaTest,
-                defines
+                defines,
+                this._applyDecalMapAfterDetailMap
             );
             defines.UNLIT = this._unlit || ((this.pointsCloud || this.wireframe) && !mesh.isVerticesDataPresent(VertexBuffer.NormalKind));
             defines.DEBUGMODE = this._debugMode;

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -621,6 +621,13 @@ export class PBRMaterial extends PBRBaseMaterial {
     public unlit = false;
 
     /**
+     * If sets to true, the decal map will be applied after the detail map. Else, it is applied before (default: false)
+     */
+    @serialize()
+    @expandToProperty("_markAllSubMeshesAsMiscDirty")
+    public applyDecalMapAfterDetailMap = false;
+
+    /**
      * Gets the image processing configuration used either in this material.
      */
     public get imageProcessingConfiguration(): ImageProcessingConfiguration {

--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -87,6 +87,7 @@ export class MaterialHelper {
      * @param fogEnabled defines if fog has to be turned on
      * @param alphaTest defines if alpha testing has to be turned on
      * @param defines defines the current list of defines
+     * @param applyDecalAfterDetail Defines if the decal is applied after or before the detail
      */
     public static PrepareDefinesForMisc(
         mesh: AbstractMesh,
@@ -95,7 +96,8 @@ export class MaterialHelper {
         pointsCloud: boolean,
         fogEnabled: boolean,
         alphaTest: boolean,
-        defines: any
+        defines: any,
+        applyDecalAfterDetail: boolean = false
     ): void {
         if (defines._areMiscDirty) {
             defines["LOGARITHMICDEPTH"] = useLogarithmicDepth;
@@ -103,6 +105,7 @@ export class MaterialHelper {
             defines["FOG"] = fogEnabled && this.GetFogState(mesh, scene);
             defines["NONUNIFORMSCALING"] = mesh.nonUniformScaling;
             defines["ALPHATEST"] = alphaTest;
+            defines["DECAL_AFTER_DETAIL"] = applyDecalAfterDetail;
         }
     }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -197,6 +197,8 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public IS_REFRACTION_LINEAR = false;
     public EXPOSURE = false;
 
+    public DECAL_AFTER_DETAIL = false;
+
     /**
      * Initializes the Standard Material defines.
      * @param externalProperties The external properties
@@ -563,6 +565,14 @@ export class StandardMaterial extends PushMaterial {
      */
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
     public twoSidedLighting: boolean;
+
+    @serialize("applyDecalMapAfterDetailMap")
+    private _applyDecalMapAfterDetailMap = false;
+    /**
+     * If sets to true, the decal map will be applied after the detail map. Else, it is applied before (default: false)
+     */
+    @expandToProperty("_markAllSubMeshesAsMiscDirty")
+    public applyDecalMapAfterDetailMap: boolean;
 
     /**
      * Default configuration related to image processing available in the standard Material.
@@ -1179,7 +1189,8 @@ export class StandardMaterial extends PushMaterial {
             this.pointsCloud,
             this.fogEnabled,
             this._shouldTurnAlphaTestOn(mesh) || this._forceAlphaTest,
-            defines
+            defines,
+            this._applyDecalMapAfterDetailMap
         );
 
         // Values that need to be evaluated on every frame

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAlbedoOpacity.fx
@@ -44,7 +44,9 @@ void albedoOpacityBlock(
         surfaceAlbedo *= albedoInfos.y;
     #endif
 
-    #include<decalFragment>
+    #ifndef DECAL_AFTER_DETAIL
+        #include<decalFragment>
+    #endif
 
     #if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
         surfaceAlbedo *= vColor.rgb;
@@ -53,6 +55,10 @@ void albedoOpacityBlock(
     #ifdef DETAIL
         float detailAlbedo = 2.0 * mix(0.5, detailColor.r, vDetailInfos.y);
         surfaceAlbedo.rgb = surfaceAlbedo.rgb * detailAlbedo * detailAlbedo; // should be pow(detailAlbedo, 2.2) but detailAlbedo² is close enough and cheaper to compute
+    #endif
+
+    #ifdef DECAL_AFTER_DETAIL
+        #include<decalFragment>
     #endif
 
     #define CUSTOM_FRAGMENT_UPDATE_ALBEDO

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -145,7 +145,7 @@ void main(void) {
 	baseColor.rgb *= vDiffuseInfos.y;
 #endif
 
-#ifdef DECAL
+#if defined(DECAL) && !defined(DECAL_AFTER_DETAIL)
 	vec4 decalColor = texture2D(decalSampler, vDecalUV + uvOffset);
 	#include<decalFragment>(surfaceAlbedo, baseColor, GAMMADECAL, _GAMMADECAL_NOTUSED_)
 #endif
@@ -158,6 +158,11 @@ void main(void) {
 
 #ifdef DETAIL
     baseColor.rgb = baseColor.rgb * 2.0 * mix(0.5, detailColor.r, vDetailInfos.y);
+#endif
+
+#if defined(DECAL) && defined(DECAL_AFTER_DETAIL)
+	vec4 decalColor = texture2D(decalSampler, vDecalUV + uvOffset);
+	#include<decalFragment>(surfaceAlbedo, baseColor, GAMMADECAL, _GAMMADECAL_NOTUSED_)
 #endif
 
 #define CUSTOM_FRAGMENT_UPDATE_DIFFUSE


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-to-render-decal-map-on-top-of-detail-map-or-control-the-render-order-on-a-material-and-its-various-map-properties/42165

Fixes #14024 