### PR TITLE
GPU Particle systems: Fix BILLBOARDMODE_STRETCHED

### DIFF
--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -1276,7 +1276,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
             attributeNamesOrOptions.push("initialDirection");
         }
 
-        if (!isBillboardStretched) {
+        if (isBillboardStretched) {
             attributeNamesOrOptions.push("direction");
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/gpu-particles-disappeared-with-billboardmode-stretched/42199