### PR TITLE
[Inspector] When changing relevant properties on the Camera, Light an…

### DIFF
--- a/packages/dev/inspector/src/components/sceneExplorer/entities/cameraTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/cameraTreeItemComponent.tsx
@@ -34,8 +34,11 @@ export class CameraTreeItemComponent extends React.Component<ICameraTreeItemComp
         const camera = this.props.camera;
         const scene = camera.getScene();
 
+        const previousActiveCamera = scene.activeCamera;
         scene.activeCamera = camera;
         camera.attachControl(true);
+
+        this.props.globalState.onPropertyChangedObservable.notifyObservers({ object: scene, property: "activeCamera", value: camera, initialValue: previousActiveCamera });
 
         this.setState({ isActive: true });
     }

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/lightTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/lightTreeItemComponent.tsx
@@ -29,6 +29,7 @@ export class LightTreeItemComponent extends React.Component<ILightTreeItemCompon
         const light = this.props.light;
 
         light.setEnabled(!light.isEnabled());
+        this.props.globalState.onPropertyChangedObservable.notifyObservers({ object: light, property: "isEnabled", value: light.isEnabled(), initialValue: !light.isEnabled() });
 
         this.setState({ isEnabled: light.isEnabled() });
     }

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/meshTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/meshTreeItemComponent.tsx
@@ -30,6 +30,12 @@ export class MeshTreeItemComponent extends React.Component<IMeshTreeItemComponen
     showBoundingBox(): void {
         const mesh = this.props.mesh;
         mesh.showBoundingBox = !this.state.isBoundingBoxEnabled;
+        this.props.globalState.onPropertyChangedObservable.notifyObservers({
+            object: mesh,
+            property: "showBoundingBox",
+            value: mesh.showBoundingBox,
+            initialValue: !mesh.showBoundingBox,
+        });
         this.setState({ isBoundingBoxEnabled: !this.state.isBoundingBoxEnabled });
     }
 
@@ -37,6 +43,7 @@ export class MeshTreeItemComponent extends React.Component<IMeshTreeItemComponen
         const newState = !this.state.isVisible;
         this.setState({ isVisible: newState });
         this.props.mesh.isVisible = newState;
+        this.props.globalState.onPropertyChangedObservable.notifyObservers({ object: this.props.mesh, property: "isVisible", value: newState, initialValue: !newState });
     }
 
     // mesh.name can fail the type check when we're in javascript, so


### PR DESCRIPTION
…d Mesh tree items, call onPropertyChangedObservable

Related forum issue: https://forum.babylonjs.com/t/debuglayer-onpropertychangedobservable-not-firing-when-enabling-disabling-lights/42184