### PR TITLE
GRL - resolution added

### DIFF
--- a/packages/dev/core/src/Materials/greasedLinePluginMaterial.ts
+++ b/packages/dev/core/src/Materials/greasedLinePluginMaterial.ts
@@ -329,7 +329,7 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
         const ubo = [
             { name: "grl_projection", size: 16, type: "mat4" },
             { name: "grl_singleColor", size: 3, type: "vec3" },
-            { name: "grl_aspect_lineWidth", size: 3, type: "vec3" },
+            { name: "grl_aspect_resolution_lineWidth", size: 4, type: "vec4" },
             { name: "grl_dashOptions", size: 4, type: "vec4" },
             { name: "grl_colorMode_visibility_colorsWidth_useColors", size: 4, type: "vec4" },
         ];
@@ -337,7 +337,7 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
         return {
             ubo,
             vertex: `
-                uniform vec3 grl_aspect_lineWidth;
+                uniform vec4 grl_aspect_resolution_lineWidth;
                 uniform mat4 grl_projection;
                 `,
             fragment: `
@@ -368,11 +368,12 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
             throw Error("GreasedLinePluginMaterial requires an active camera.");
         }
 
-        const resolutionLineWidth = TmpVectors.Vector3[0];
+        const resolutionLineWidth = TmpVectors.Vector4[0];
         resolutionLineWidth.x = this._aspect;
-        // TODO: y free
-        resolutionLineWidth.z = this.width;
-        uniformBuffer.updateVector3("grl_aspect_lineWidth", resolutionLineWidth);
+        resolutionLineWidth.y = this._resolution.x
+        resolutionLineWidth.z = this._resolution.y
+        resolutionLineWidth.w = this.width;
+        uniformBuffer.updateVector4("grl_aspect_resolution_lineWidth", resolutionLineWidth);
 
         const dashOptions = TmpVectors.Vector4[0];
         dashOptions.x = GreasedLinePluginMaterial._BooleanToNumber(this.useDash);
@@ -448,8 +449,8 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 CUSTOM_VERTEX_MAIN_END: `
 
-                    float grlAspect = grl_aspect_lineWidth.x;
-                    float grlBaseWidth = grl_aspect_lineWidth.z;
+                    float grlAspect = grl_aspect_resolution_lineWidth.x;
+                    float grlBaseWidth = grl_aspect_resolution_lineWidth.w;
 
                     grlColorPointer = grl_colorPointers;
 
@@ -484,7 +485,7 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
                     grlNormal *= grl_projection;
                     #ifdef GREASED_LINE_SIZE_ATTENUATION
                         grlNormal.xy *= grlFinalPosition.w;
-                        grlNormal.xy /= ( vec4( grlResolution, 0., 1. ) * grl_projection ).xy;
+                        grlNormal.xy /= ( vec4( grl_aspect_resolution_lineWidth.yz, 0., 1. ) * grl_projection ).xy;
                     #endif
                     grlFinalPosition.xy += grlNormal.xy * grlSide;
                     gl_Position = grlFinalPosition;

--- a/packages/dev/core/src/Materials/greasedLinePluginMaterial.ts
+++ b/packages/dev/core/src/Materials/greasedLinePluginMaterial.ts
@@ -370,8 +370,8 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase {
 
         const resolutionLineWidth = TmpVectors.Vector4[0];
         resolutionLineWidth.x = this._aspect;
-        resolutionLineWidth.y = this._resolution.x
-        resolutionLineWidth.z = this._resolution.y
+        resolutionLineWidth.y = this._resolution.x;
+        resolutionLineWidth.z = this._resolution.y;
         resolutionLineWidth.w = this.width;
         uniformBuffer.updateVector4("grl_aspect_resolution_lineWidth", resolutionLineWidth);
 


### PR DESCRIPTION
resolution was removed and aspect was introduced to save one divide operation in the shader, however when GREASED_LINE_SIZE_ATTENUATION is true, the vec2 resolution is needed. float aspect, vec2 resolution and float width are now packed into one vec4 attribute.