### PR TITLE
Performance tests preparations to run on the server

### DIFF
--- a/packages/tools/tests/test/performance/playgrounds.test.ts
+++ b/packages/tools/tests/test/performance/playgrounds.test.ts
@@ -1,46 +1,22 @@
 import { evaluatePrepareScene, getGlobalConfig, checkPerformanceOfScene } from "@tools/test-tools";
 
-const framesToRender = 2500;
+const framesToRender = 2000;
 const numberOfPasses = 10;
-const acceptedThreshold = 0.075; // 7.5% compensation
+const acceptedThreshold = 0.05; // 5% compensation
 
-const playgrounds = [
-    "#WIR77Z",
-    "#2AH4YH",
-    "#YEZPVT",
-    // "#SRZRWV#6",
-    "#XCPP9Y#1",
-    "#XZ0TH6",
-    "#JU1DZP",
-    "#7V0Y1I#1523",
-    "#6FBD14#2004",
-    "#KQV9SA",
-    "#7CBW04",
-];
+const playgrounds = ["#WIR77Z", "#2AH4YH", "#YEZPVT", "#6HWS9M#28", "#XCPP9Y#1", "#XZ0TH6", "#JU1DZP", "#7V0Y1I#1523", "#6FBD14#2004", "#KQV9SA", "#7CBW04"];
 
 // IN TESTS
 // declare const BABYLON: typeof import("core/index");
 
 describe("Playground Memory Leaks", () => {
-    jest.setTimeout(30000);
+    jest.setTimeout(40000);
 
     // eslint-disable-next-line jest/expect-expect
     test.each(playgrounds)(
         "Performance for playground %s",
         async (playgroundId) => {
             const globalConfig = getGlobalConfig();
-            const preview = await checkPerformanceOfScene(
-                page,
-                getGlobalConfig().baseUrl,
-                "preview",
-                evaluatePrepareScene,
-                numberOfPasses,
-                framesToRender,
-                {
-                    playgroundId,
-                },
-                globalConfig
-            );
             const stable = await checkPerformanceOfScene(
                 page,
                 getGlobalConfig().baseUrl,
@@ -65,8 +41,7 @@ describe("Playground Memory Leaks", () => {
                 },
                 globalConfig
             );
-            console.log(`Performance - scene: preview: ${preview}ms, stable: ${stable}ms, dev: ${dev}ms`);
-            expect(dev / preview, `Dev: ${dev}ms, Preview: ${preview}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
+            console.log(`Performance - scene: stable: ${stable}ms, dev: ${dev}ms`);
             expect(dev / stable, `Dev: ${dev}ms, Stable: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
         },
         40000

--- a/packages/tools/tests/test/performance/scene.test.ts
+++ b/packages/tools/tests/test/performance/scene.test.ts
@@ -5,25 +5,23 @@ declare const BABYLON: typeof import("core/index");
 
 // Performance tests require the PROD version of the CDN (babylon-server)
 
-const framesToRender = 5000;
+const framesToRender = 2500;
 const numberOfPasses = 8;
-const acceptedThreshold = 0.075; // 7.5% compensation
+const acceptedThreshold = 0.05; // 5% compensation
 
 describe("Performance - scene", () => {
-    jest.setTimeout(60000);
+    jest.setTimeout(40000);
 
     it("Should have same or better performance with default scene", async () => {
-        const preview = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "preview", evaluateDefaultScene, numberOfPasses, framesToRender);
         const stable = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "stable", evaluateDefaultScene, numberOfPasses, framesToRender);
         const dev = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "dev", evaluateDefaultScene, numberOfPasses, framesToRender);
-        console.log(`Performance - scene: preview: ${preview}ms, stable: ${stable}ms, dev: ${dev}ms`);
-        expect(dev / preview, `Dev: ${dev}ms, Preview: ${preview}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
-        expect(dev / stable, `Dev: ${dev}ms, Preview: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
-    }, 30000);
+        console.log(`Performance - scene: stable: ${stable}ms, dev: ${dev}ms`);
+        expect(dev / stable, `Dev: ${dev}ms, Stable: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
+    }, 40000);
 
     it("Should have same or better performance with particle system", async () => {
         // this code will run in the browser
-        const createScene = async () => {
+        const createScene = () => {
             if (!window.scene) {
                 window.scene = new BABYLON.Scene(window.engine!);
             }
@@ -37,25 +35,21 @@ describe("Performance - scene", () => {
 
             particleSystem.start();
 
-            await new Promise<void>((resolve) => {
+            return new Promise<void>((resolve) => {
                 window.scene?.executeWhenReady(() => {
                     resolve();
                 });
             });
         };
 
-        // await page.waitForFunction(`window.scene.isReady()`);
-
-        const preview = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "preview", createScene, numberOfPasses, framesToRender);
         const stable = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "stable", createScene, numberOfPasses, framesToRender);
         const dev = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "dev", createScene, numberOfPasses, framesToRender);
-        expect(dev / preview, `Dev: ${dev}ms, Preview: ${preview}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
-        expect(dev / stable, `Dev: ${dev}ms, Preview: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
+        expect(dev / stable, `Dev: ${dev}ms, Stable: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
     }, 40000);
 
     it("Should have same or better performance with follow camera", async () => {
         // this code will run in the browser
-        const createScene = async () => {
+        const createScene = () => {
             const scene = new BABYLON.Scene(window.engine!);
             const camera = new BABYLON.FollowCamera("FollowCam", new BABYLON.Vector3(0, 10, -10), scene);
             camera.radius = 30;
@@ -102,17 +96,15 @@ describe("Performance - scene", () => {
 
             window.scene = scene;
 
-            await new Promise<void>((resolve) => {
+            return new Promise<void>((resolve) => {
                 window.scene?.executeWhenReady(() => {
                     resolve();
                 });
             });
         };
 
-        const preview = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "preview", createScene, numberOfPasses, framesToRender);
         const stable = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "stable", createScene, numberOfPasses, framesToRender);
         const dev = await checkPerformanceOfScene(page, getGlobalConfig().baseUrl, "dev", createScene, numberOfPasses, framesToRender);
-        expect(dev / preview, `Dev: ${dev}ms, Preview: ${preview}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
-        expect(dev / stable, `Dev: ${dev}ms, Preview: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
+        expect(dev / stable, `Dev: ${dev}ms, Stable: ${stable}ms`).toBeLessThanOrEqual(1 + acceptedThreshold);
     }, 40000);
 });


### PR DESCRIPTION
I ran a few tests on the new server instance. performance tests seem to be running quite stable. 
This changes the perf-tests to support the dev version and the latest stable version. Current threshold is 5% but it will be configurable in the future. 

These tests should only run on the new GPU instance, otherwise they are not stable (even locally). 

Once merged I will run a few tests with the CI and will turn these tests on as optional until we decide they are stable enough.