### PR TITLE
DeviceEventFactory: Modified event factory to provide correct value for buttons property (part deux)

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -76,6 +76,15 @@ export class DeviceEventFactory {
             evt.pointerType = "touch";
         }
 
+        let buttons = 0;
+
+        // Populate buttons property with current state of all mouse buttons
+        // Uses values found on: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.LeftClick);
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.RightClick) * 2;
+        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MiddleClick) * 4;
+        evt.buttons = buttons;
+
         if (inputIndex === PointerInput.Move) {
             evt.type = "pointermove";
         } else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -848,20 +848,15 @@ export class InputManager {
             this._startingPointerTime = Date.now();
 
             // PreObservable support
-            /*if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
+            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
                 return;
-            }*/
+            }
 
             if (!scene.cameraToUseForPointers && !scene.activeCamera) {
                 return;
             }
 
             this._pointerCaptures[evt.pointerId] = true;
-
-            // PreObservable support
-            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
-                return;
-            }
 
             if (!scene.pointerDownPredicate) {
                 scene.pointerDownPredicate = (mesh: AbstractMesh): boolean => {

--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -848,15 +848,20 @@ export class InputManager {
             this._startingPointerTime = Date.now();
 
             // PreObservable support
-            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
+            /*if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
                 return;
-            }
+            }*/
 
             if (!scene.cameraToUseForPointers && !scene.activeCamera) {
                 return;
             }
 
             this._pointerCaptures[evt.pointerId] = true;
+
+            // PreObservable support
+            if (this._checkPrePointerObservable(null, evt, PointerEventTypes.POINTERDOWN)) {
+                return;
+            }
 
             if (!scene.pointerDownPredicate) {
                 scene.pointerDownPredicate = (mesh: AbstractMesh): boolean => {
@@ -916,6 +921,12 @@ export class InputManager {
                                 this._isSwiping = false;
                                 this._swipeButtonPressed = -1;
                             }
+
+                            // If we're going to skip the POINTERUP, we need to reset the pointer capture
+                            if (evt.buttons === 0) {
+                                this._pointerCaptures[evt.pointerId] = false;
+                            }
+
                             return;
                         }
                         if (!clickInfo.hasSwiped) {

--- a/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
@@ -8,6 +8,7 @@ import type { IPointerEvent, IUIEvent } from "core/Events";
 import type { Nullable } from "core/types";
 import type { ITestDeviceInputSystem} from "./testDeviceInputSystem";
 import { TestDeviceInputSystem } from "./testDeviceInputSystem";
+import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
 
 jest.mock("core/DeviceInput/webDeviceInputSystem", () => {
     return {
@@ -221,5 +222,48 @@ describe("DeviceSourceManager", () => {
         deviceSourceManager3.dispose();
         expect(unregisterSpy).toBeCalledTimes(3);
         expect(disposeSpy).toBeCalledTimes(1);
+    });
+
+    it ("DeviceEventFactory can create proper pointer events", () => {
+        const deviceInputSystem = new TestDeviceInputSystem(
+            engine!,
+            () => {},
+            () => {},
+            () => {}
+        );
+    
+        // Connect device and grab DeviceSource
+        deviceInputSystem.connectDevice(DeviceType.Mouse, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+    
+        // Click down the three main mouse buttons
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 1);
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
+    
+        // Create a pointer event
+        const threeButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
+    
+        // Verify that the three buttons are pressed down
+        expect(threeButtonsEvent.buttons).toBe(7);
+    
+        // Release middle button and verify that it's no longer pressed
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0);
+    
+        // Create a pointer event
+        const twoButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0, deviceInputSystem) as IPointerEvent;
+    
+        // Verify that two buttons are pressed down and the middle is released
+        expect(twoButtonsEvent.buttons).toBe(3);
+        expect(twoButtonsEvent.button).toBe(1);
+    
+        // Release the rest of the buttons
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
+        deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
+    
+        // Create a pointer event
+        const noButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
+    
+        // Verify that no buttons are pressed down
+        expect(noButtonsEvent.buttons).toBe(0);
     });
 });

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -364,7 +364,7 @@ describe("InputManager", () => {
                 eventData.skipOnPointerObservable = true;
             }, PointerEventTypes.POINTERDOWN);
 
-            // Expect to get just an UP
+            // Expect nothing because we skipped the DOWN and no capture was made
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
             deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
 
@@ -419,10 +419,10 @@ describe("InputManager", () => {
         }
 
         expect(downCt).toBe(12);
-        expect(upCt).toBe(11);
+        expect(upCt).toBe(10);
         expect(moveCt).toBe(5);
         expect(pickCt).toBe(1);
-        expect(tapCt).toBe(4);
+        expect(tapCt).toBe(3);
         expect(dblTapCt).toBe(3);
     });
 

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1490,7 +1490,7 @@
         {
             "title": "GUI Input Test",
             "renderCount": 2,
-            "playgroundId": "#UB4F3B#7",
+            "playgroundId": "#UB4F3B#8",
             "referenceImage": "guiInputTest.png"
         },
         {


### PR DESCRIPTION
This PR is a fix to https://github.com/BabylonJS/Babylon.js/pull/13927.  It addresses some of the logic changes but also re-adds support for buttons in Native pointer events.