### PR TITLE
Effect layer stencil

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -65,6 +65,11 @@ export interface IEffectLayerOptions {
      * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
      */
     mainTextureType: number;
+
+    /**
+     * Whether or not to generate a stencil buffer. Default: false
+     */
+    generateStencilBuffer: boolean;
 }
 
 /**
@@ -332,6 +337,7 @@ export abstract class EffectLayer {
             camera: null,
             renderingGroupId: -1,
             mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            generateStencilBuffer: false,
             ...options,
         };
 
@@ -409,7 +415,11 @@ export abstract class EffectLayer {
             this._scene,
             false,
             true,
-            this._effectLayerOptions.mainTextureType
+            this._effectLayerOptions.mainTextureType,
+            false,
+            Texture.TRILINEAR_SAMPLINGMODE,
+            true,
+            this._effectLayerOptions.generateStencilBuffer
         );
         this._mainTexture.activeCamera = this._effectLayerOptions.camera;
         this._mainTexture.wrapU = Texture.CLAMP_ADDRESSMODE;

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -97,6 +97,11 @@ export interface IGlowLayerOptions {
      * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
      */
     mainTextureType: number;
+
+    /**
+     * Whether or not to generate a stencil buffer. Default: false
+     */
+    generateStencilBuffer: boolean;
 }
 
 /**
@@ -209,6 +214,7 @@ export class GlowLayer extends EffectLayer {
             ldrMerge: false,
             alphaBlendingMode: Constants.ALPHA_ADD,
             mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            generateStencilBuffer: false,
             ...options,
         };
 
@@ -220,6 +226,7 @@ export class GlowLayer extends EffectLayer {
             mainTextureRatio: this._options.mainTextureRatio,
             renderingGroupId: this._options.renderingGroupId,
             mainTextureType: this._options.mainTextureType,
+            generateStencilBuffer: this._options.generateStencilBuffer,
         });
     }
 

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -133,11 +133,6 @@ export interface IHighlightLayerOptions {
      * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
      */
     mainTextureType: number;
-
-    /**
-     * Whether or not to generate a stencil buffer. Default: false
-     */
-    generateStencilBuffer: boolean;
 }
 
 /**
@@ -310,7 +305,6 @@ export class HighlightLayer extends EffectLayer {
             camera: null,
             renderingGroupId: -1,
             mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
-            generateStencilBuffer: false,
             ...options,
         };
 
@@ -322,7 +316,6 @@ export class HighlightLayer extends EffectLayer {
             mainTextureRatio: this._options.mainTextureRatio,
             renderingGroupId: this._options.renderingGroupId,
             mainTextureType: this._options.mainTextureType,
-            generateStencilBuffer: this._options.generateStencilBuffer,
         });
 
         // Do not render as long as no meshes have been added

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -133,6 +133,11 @@ export interface IHighlightLayerOptions {
      * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
      */
     mainTextureType: number;
+
+    /**
+     * Whether or not to generate a stencil buffer. Default: false
+     */
+    generateStencilBuffer: boolean;
 }
 
 /**
@@ -305,6 +310,7 @@ export class HighlightLayer extends EffectLayer {
             camera: null,
             renderingGroupId: -1,
             mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            generateStencilBuffer: false,
             ...options,
         };
 
@@ -316,6 +322,7 @@ export class HighlightLayer extends EffectLayer {
             mainTextureRatio: this._options.mainTextureRatio,
             renderingGroupId: this._options.renderingGroupId,
             mainTextureType: this._options.mainTextureType,
+            generateStencilBuffer: this._options.generateStencilBuffer,
         });
 
         // Do not render as long as no meshes have been added


### PR DESCRIPTION
This change allows `GlowLayer` to be used with stenciling.

https://forum.babylonjs.com/t/42331