### PR TITLE
Fix setting spatial sound option to false

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -123,7 +123,7 @@ export class Sound {
     public get spatialSound(): boolean {
         return this._spatialSound;
     }
-    
+
     /**
      * Does this sound enables spatial sound.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic#creating-a-spatial-3d-sound
@@ -139,8 +139,7 @@ export class Sound {
         if (newValue) {
             this._spatialSound = newValue;
             this._updateSpatialParameters();
-        }
-        else {
+        } else {
             this._disableSpatialSound();
         }
 
@@ -597,8 +596,7 @@ export class Sound {
                 this._soundPanner.rolloffFactor = this.rolloffFactor;
                 this._soundPanner.panningModel = this._panningModel as any;
             }
-        }
-        else {
+        } else {
             this._createSpatialParameters();
         }
     }

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -510,6 +510,7 @@ export class Sound {
             this.distanceModel = options.distanceModel ?? this.distanceModel;
             this._playbackRate = options.playbackRate ?? this._playbackRate;
             this._length = options.length ?? undefined;
+            this._spatialSound = options.spatialSound ?? this._spatialSound;
             this._setOffset(options.offset ?? undefined);
             this.setVolume(options.volume ?? this._volume);
             this._updateSpatialParameters();
@@ -552,20 +553,25 @@ export class Sound {
     }
 
     private _updateSpatialParameters() {
-        if (this._spatialSound && this._soundPanner) {
-            if (this.useCustomAttenuation) {
-                // Tricks to disable in a way embedded Web Audio attenuation
-                this._soundPanner.distanceModel = "linear";
-                this._soundPanner.maxDistance = Number.MAX_VALUE;
-                this._soundPanner.refDistance = 1;
-                this._soundPanner.rolloffFactor = 1;
-                this._soundPanner.panningModel = this._panningModel as any;
-            } else {
-                this._soundPanner.distanceModel = this.distanceModel as any;
-                this._soundPanner.maxDistance = this.maxDistance;
-                this._soundPanner.refDistance = this.refDistance;
-                this._soundPanner.rolloffFactor = this.rolloffFactor;
-                this._soundPanner.panningModel = this._panningModel as any;
+        if (this._spatialSound) {
+            if (this._soundPanner) {
+                if (this.useCustomAttenuation) {
+                    // Tricks to disable in a way embedded Web Audio attenuation
+                    this._soundPanner.distanceModel = "linear";
+                    this._soundPanner.maxDistance = Number.MAX_VALUE;
+                    this._soundPanner.refDistance = 1;
+                    this._soundPanner.rolloffFactor = 1;
+                    this._soundPanner.panningModel = this._panningModel as any;
+                } else {
+                    this._soundPanner.distanceModel = this.distanceModel as any;
+                    this._soundPanner.maxDistance = this.maxDistance;
+                    this._soundPanner.refDistance = this.refDistance;
+                    this._soundPanner.rolloffFactor = this.rolloffFactor;
+                    this._soundPanner.panningModel = this._panningModel as any;
+                }
+            }
+            else {
+                this._createSpatialParameters();
             }
         }
     }

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -133,12 +133,19 @@ export class Sound {
             return;
         }
 
+        const wasPlaying = this.isPlaying;
+        this.pause();
+
         if (newValue) {
             this._spatialSound = newValue;
             this._updateSpatialParameters();
         }
         else {
             this._disableSpatialSound();
+        }
+
+        if (wasPlaying) {
+            this.play();
         }
     }
 
@@ -565,17 +572,10 @@ export class Sound {
         if (!this._spatialSound) {
             return;
         }
-
-        const wasPlaying = this.isPlaying;
-        this.pause();
-
-        this._soundPanner?.disconnect();
         this._inputAudioNode = this._soundGain;
+        this._soundPanner?.disconnect();
+        this._soundPanner = null;
         this._spatialSound = false;
-
-        if (wasPlaying) {
-            this.play();
-        }
     }
 
     private _updateSpatialParameters() {

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -567,7 +567,7 @@ export class Sound {
         }
 
         const wasPlaying = this.isPlaying;
-        this.stop();
+        this.pause();
 
         this._soundPanner?.disconnect();
         this._inputAudioNode = this._soundGain;

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -64,6 +64,34 @@ class AudioSample {
 
 AudioSample.Add("silence, 1 second, 1 channel, 48000 kHz", 1, 48000, new Float32Array(48000));
 
+class AudioNodeMock {
+    public connect(destination: any) {
+        this._destination = destination;
+    }
+
+    public disconnect() {
+        this._destination = null;
+    }
+
+    public get destination() {
+        return this._destination;
+    }
+
+    private _destination: any = null;
+}
+
+class GainNodeMock extends AudioNodeMock {
+    get gain() {
+        return {
+            value: 1.0
+        }
+    }
+}
+
+class PannerNodeMock extends AudioNodeMock {
+
+}
+
 let mockedAudioContext: any = null;
 let mockedBufferSource: any = null;
 
@@ -109,19 +137,10 @@ window.AudioContext = jest.fn().mockName("AudioContext").mockImplementation(() =
             // 1) from AudioEngine._initializeAudioContext() to create the master gain.
             // 2) from Sound constructor.
             // 3) from main SoundTrack._initializeSoundTrackAudioGraph().
-            return {
-                connect: jest.fn().mockName("connect"),
-                disconnect: jest.fn().mockName("disconnect"),
-                gain: {
-                    value: 1
-                }
-            };
+            return new GainNodeMock;
         }),
         createPanner: jest.fn().mockName("createPanner").mockImplementation(() => {
-            return {
-                connect: jest.fn().mockName("connect"),
-                disconnect: jest.fn().mockName("disconnect")
-            }
+            return new PannerNodeMock;
         }),
         decodeAudioData: jest.fn().mockName("decodeAudioData").mockImplementation((data: ArrayBuffer, success: (buffer: AudioBuffer) => void) => {
             success(AudioSample.GetAudioBuffer(data));

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -151,7 +151,7 @@ window.AudioContext = jest.fn().mockName("AudioContext").mockImplementation(() =
         })
     };
     return mockedAudioContext;
-});
+}) as any;
 
 const waitForAudioContextSuspendedDoubleCheck = () => {
     jest.advanceTimersByTime(500);
@@ -171,7 +171,7 @@ jest.useFakeTimers();
 describe("Sound with no scene", () => {
     it("constructor does not set scene if no scene is given", () => {
         const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
-        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
+        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound._scene).toBeUndefined();
     });
@@ -211,7 +211,7 @@ describe("Sound", () => {
 
     it("constructor sets up a linear custom attenuation function by default", () => {
         const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
-        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
+        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound._customAttenuationFunction(1, 0, 100, 0, 0)).toBeCloseTo(1);
         expect(sound._customAttenuationFunction(1, 10, 100, 0, 0)).toBeCloseTo(0.9);
@@ -228,7 +228,7 @@ describe("Sound", () => {
 
     it("constructor sets state correctly when given no options", () => {
         const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
-        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
+        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound.autoplay).toBe(false);
         expect(sound.currentTime).toBe(0);
@@ -262,7 +262,7 @@ describe("Sound", () => {
             spatialSound: false,
             streaming: false,
             useCustomAttenuation: false
-        });
+        }) as any;
 
         expect(sound.autoplay).toBe(false);
         expect(sound.loop).toBe(false);
@@ -279,7 +279,7 @@ describe("Sound", () => {
             spatialSound: true,
             streaming: true,
             useCustomAttenuation: true
-        });
+        }) as any;
 
         expect(sound.autoplay).toBe(true);
         expect(sound.loop).toBe(true);
@@ -298,7 +298,7 @@ describe("Sound", () => {
             refDistance: 5,
             rolloffFactor: 6,
             volume: 7
-        });
+        }) as any;
 
         expect(sound._length).toBe(1);
         expect(sound.maxDistance).toBe(2);
@@ -322,130 +322,141 @@ describe("Sound", () => {
 
     it("constructor does codec check when no options are given", () => {
         expect(Engine.audioEngine?.isMP3supported).toBe(false);
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = jest.fn().mockName("scene._loadFile");
 
         new Sound(expect.getState().currentTestName, "test.mp3");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(0);
+        expect(scene!._loadFile).toHaveBeenCalledTimes(0);
     });
 
     it("constructor does codec check when skipCodecCheck option is false", () => {
         expect(Engine.audioEngine?.isMP3supported).toBe(false);
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = jest.fn().mockName("scene._loadFile");
 
         new Sound(expect.getState().currentTestName, "test.mp3", null, null, { skipCodecCheck: false });
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(0);
+        expect(scene!._loadFile).toHaveBeenCalledTimes(0);
     });
 
     it("constructor skips codec check when skipCodecCheck option is true", () => {
         expect(Engine.audioEngine?.isMP3supported).toBe(false);
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.mp3", null, null, { skipCodecCheck: true });
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.mp3");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.mp3");
     });
 
     it("constructor loads given .mp3 when supported", () => {
-        Engine.audioEngine!.isMP3supported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isMP3supported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.mp3");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.mp3");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.mp3");
     });
 
     it("constructor loads given .ogg when supported", () => {
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.ogg");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.ogg");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.ogg");
     });
 
     it("constructor loads given .wav", () => {
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.wav");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.wav");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.wav");
     });
 
     it("constructor loads given .m4a", () => {
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.m4a");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.m4a");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.m4a");
     });
 
     it("constructor loads given .mp4", () => {
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "test.mp4");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.mp4");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.mp4");
     });
 
     it("constructor loads given blob", () => {
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, "blob:test");
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("blob:test");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("blob:test");
     });
 
     it("constructor skips given .ogg when not supported", () => {
-        Engine.audioEngine!.isMP3supported = true;
-        Engine.audioEngine!.isOGGsupported = false;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isMP3supported = true;
+        (Engine.audioEngine as any).isOGGsupported = false;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, [ "test.ogg", "test.mp3" ]);
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.mp3");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.mp3");
     });
 
     it("constructor skips given .mp3 when not supported", () => {
-        Engine.audioEngine!.isMP3supported = false;
-        Engine.audioEngine!.isOGGsupported = true;
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        (Engine.audioEngine as any).isMP3supported = false;
+        (Engine.audioEngine as any).isOGGsupported = true;
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, [ "test.mp3", "test.ogg" ]);
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.ogg");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.ogg");
     });
 
     it("constructor first supported file", () => {
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, [ "test.jpg", "test.png", "test.wav" ]);
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.wav");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.wav");
     });
 
     it("constructor loads only the first supported file when given multiple supported files", () => {
-        scene._loadFile = jest.fn().mockName("scene._loadFile");
+        const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
+        scene!._loadFile = sceneLoadFileMock;
 
         new Sound(expect.getState().currentTestName, [ "test.mp4", "test.m4a" ]);
 
-        expect(scene._loadFile).toHaveBeenCalledTimes(1);
-        expect(scene._loadFile.mock.calls[0][0]).toBe("test.mp4");
+        expect(sceneLoadFileMock).toHaveBeenCalledTimes(1);
+        expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.mp4");
     });
 
     it("sets isPlaying to true when play is called", () => {

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -763,7 +763,7 @@ describe("Sound", () => {
         expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
     });
 
-    it("connects to panner node when spatialSound property is set to false before being set to true while playing", () => {
+    it("connects to panner node when playing and spatialSound property is set to false before being set to true", () => {
         const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
         
         sound.play();

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -744,4 +744,22 @@ describe("Sound", () => {
 
         expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
     });
+
+    it("connects to gain node when unspatialized via property", () => {
+        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        sound.spatialSound = false;
+
+        sound.play();
+
+        expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
+    });
+
+    it("connects to gain node when unspatialized via updateOptions", () => {
+        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        sound.updateOptions({ spatialSound: false });
+
+        sound.play();
+
+        expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
+    });
 });

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -736,7 +736,7 @@ describe("Sound", () => {
         expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
     });
 
-    it("connects to panner node when spatialized via options", () => {
+    it("connects to panner node when spatialized via updateOptions", () => {
         const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
         sound.updateOptions({ spatialSound: true });
 

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -762,4 +762,14 @@ describe("Sound", () => {
 
         expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
     });
+
+    it("connects to panner node when spatialSound property is set to false before being set to true while playing", () => {
+        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        
+        sound.play();
+        sound.spatialSound = false;
+        sound.spatialSound = true;
+
+        expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
+    });
 });


### PR DESCRIPTION
When sounds have the `spatialSound` option set to `true`, setting it to `false` does not disable spatial sound. This change fixes the issue. This change also gets setting the `spatialSound` option working when using the `Sound.updateOptions` function.

Reported on forum: https://forum.babylonjs.com/t/what-is-the-expected-behavior-when-i-detach-sound-from-a-mesh/42315

Tested on Chrome browser with playground https://playground.babylonjs.com/#2AH4YH#81.