### PR TITLE
Shaders: Fix shader parsing

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -68,7 +68,6 @@ export class ShaderCodeCursor {
                     }
 
                     this._lines.push(subLine + (index !== split.length - 1 ? ";" : ""));
-                    console.log(subLine + (index !== split.length - 1 ? ";" : ""));
                 }
             }
         }

--- a/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderCodeCursor.ts
@@ -45,8 +45,11 @@ export class ShaderCodeCursor {
                 // No semicolon in the line
                 this._lines.push(trimmedLine);
             } else if (semicolonIndex === trimmedLine.length - 1) {
-                // Semicolon at the end of the line
-                this._lines.push(trimmedLine);
+                // Single semicolon at the end of the line
+                // If trimmedLine == ";", we must not push, to be backward compatible with the old code!
+                if (trimmedLine.length > 1) {
+                    this._lines.push(trimmedLine);
+                }
             } else {
                 // Semicolon in the middle of the line
                 const split = line.split(";");
@@ -65,6 +68,7 @@ export class ShaderCodeCursor {
                     }
 
                     this._lines.push(subLine + (index !== split.length - 1 ? ";" : ""));
+                    console.log(subLine + (index !== split.length - 1 ? ";" : ""));
                 }
             }
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -263,7 +263,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         state._emitExtension("derivatives", "#extension GL_OES_standard_derivatives : enable");
 
         const tangentReplaceString = { search: /defined\(TANGENT\)/g, replace: worldTangent.isConnected ? "defined(TANGENT)" : "defined(IGNORE)" };
-        const tbnVarying = { search: /varying mat3 vTBN/g, replace: "" };
+        const tbnVarying = { search: /varying mat3 vTBN;/g, replace: "" };
         const normalMatrixReplaceString = { search: /uniform mat4 normalMatrix;/g, replace: "" };
 
         const TBN = this.TBN;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/app-that-worked-for-months-using-nme-materials-suddenly-hangs-with-shader-errors/42441/8

The problem is a bug in `PerturbNormal` (that does not remove a ";" in some injected shader code), but which was hidden by the way we parsed the shader code before #13935.