### PR TITLE
fix `Bone.returnToRest()`, `Bone.updateMatrix()` does not work properly

### DIFF
--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -68,12 +68,13 @@ export class Bone extends Node {
 
     /** @internal */
     set _matrix(value: Matrix) {
-        this._needToCompose = false; // in case there was a pending compose
-
         // skip if the matrices are the same
-        if (value.updateFlag === this._localMatrix.updateFlag) {
+        if (value.updateFlag === this._localMatrix.updateFlag && !this._needToCompose) {
+            this._needToCompose = false; // in case there was a pending compose
             return;
         }
+
+        this._needToCompose = false; // in case there was a pending compose
 
         this._localMatrix.copyFrom(value);
         this._markAsDirtyAndDecompose();

--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -70,7 +70,6 @@ export class Bone extends Node {
     set _matrix(value: Matrix) {
         // skip if the matrices are the same
         if (value.updateFlag === this._localMatrix.updateFlag && !this._needToCompose) {
-            this._needToCompose = false; // in case there was a pending compose
             return;
         }
 


### PR DESCRIPTION
Hello first let me explain the bug I found.

- The `Bone.returnToRest()` method performs `this._matrix = this._restMatrix;` when there is no `_linkedTransformNode`.
https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Bones/bone.ts#L322

- And the 'rest matrix' is compared to the 'local matrix', and if the two are the same, the matrix update is canceled.
https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Bones/bone.ts#L70-L80

However, if the local matrix needs to be composed (which means the local matrix is out of date), comparing the local matrix with the pose matrix is problematic.

Here's the specific code that causes the bug.
```typescript
// First, call returnToRest to make the localMatrix and restMetrix the same.
bone.returnToRest();

// then executes code that can replace the values of _localPosition, _localRotation, or _localScaling.
// The local matrix is now out of date and requires a compose.
bone.setPosition(new Vector3(1, 2, 3), Space.LOCAL);

// Then the _localPosition_ has changed, but the localMatrix and restMatrix are still the same,
// so this code does not work properly.
bone.returnToRest();
```

To solve this problem, you can check the equality comparison with _needToCompose. (May not be the best way)
So this is what the modified code looks like this:
```typescript
set _matrix(value: Matrix) {
    // skip if the matrices are the same
    if (value.updateFlag === this._localMatrix.updateFlag && !this._needToCompose) {
        this._needToCompose = false; // in case there was a pending compose
        return;
    }

    this._needToCompose = false; // in case there was a pending compose

    this._localMatrix.copyFrom(value);
    this._markAsDirtyAndDecompose();
}
```

The method `Bone.updateMatrix` also has the same problem because it uses the `_matrix` property.

I would like to mention someone who I think would be knowledgeable about this issue. If I mention someone incorrectly, I apologize in advance.
@Popov72 