### PR TITLE
Fix invalidateRect of a Rectangle Control with thickness

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1605,12 +1605,12 @@ export class Control implements IAnimatable {
     }
 
     /** @internal */
-    protected _computeAdditionnalOffsetX() {
+    protected _computeAdditionalOffsetX() {
         return 0;
     }
 
     /** @internal */
-    protected _computeAdditionnalOffsetY() {
+    protected _computeAdditionalOffsetY() {
         return 0;
     }
 
@@ -1635,8 +1635,8 @@ export class Control implements IAnimatable {
             const topShadowOffset = Math.min(Math.min(shadowOffsetY, 0) - shadowBlur * 2, 0);
             const bottomShadowOffset = Math.max(Math.max(shadowOffsetY, 0) + shadowBlur * 2, 0);
 
-            const offsetX = this._computeAdditionnalOffsetX();
-            const offsetY = this._computeAdditionnalOffsetY();
+            const offsetX = this._computeAdditionalOffsetX();
+            const offsetY = this._computeAdditionalOffsetY();
 
             this.host.invalidateRect(
                 Math.floor(this._tmpMeasureA.left + leftShadowOffset - offsetX),

--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -109,21 +109,29 @@ export class Rectangle extends Container {
     }
 
     /** @internal */
-    protected _computeAdditionnalOffsetX() {
+    protected _computeAdditionalOffsetX() {
+        let additionalWidth = 0;
         if (this._cornerRadius[0] !== 0 || this._cornerRadius[1] !== 0 || this._cornerRadius[2] !== 0 || this._cornerRadius[3] !== 0) {
             // Take in account the aliasing
-            return 1;
+            additionalWidth += 1;
         }
-        return 0;
+        if (this.thickness) {
+            additionalWidth += this.thickness / 2;
+        }
+        return additionalWidth;
     }
 
     /** @internal */
-    protected _computeAdditionnalOffsetY() {
+    protected _computeAdditionalOffsetY() {
+        let additionalHeight = 0;
         if (this._cornerRadius[0] !== 0 || this._cornerRadius[1] !== 0 || this._cornerRadius[2] !== 0 || this._cornerRadius[3] !== 0) {
             // Take in account the aliasing
-            return 1;
+            additionalHeight += 1;
         }
-        return 0;
+        if (this.thickness) {
+            additionalHeight += this.thickness / 2;
+        }
+        return additionalHeight;
     }
 
     protected _getRectangleFill(context: ICanvasRenderingContext) {


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-btn-add-pointerupanimation-event/42500

Another example PG: https://playground.babylonjs.com/#JUG11I#7

