### PR TITLE
Screenshot tools: Fallback on regular canvas if offscreen canvas not supported

### DIFF
--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -26,16 +26,32 @@ export class DumpTools {
 
     private static _CreateDumpRenderer(): DumpToolsEngine {
         if (!DumpTools._DumpToolsEngine) {
-            const canvas = new OffscreenCanvas(100, 100); // will be resized later
-            const engine = new ThinEngine(canvas, false, {
-                preserveDrawingBuffer: true,
-                depth: false,
-                stencil: false,
-                alpha: true,
-                premultipliedAlpha: false,
-                antialias: false,
-                failIfMajorPerformanceCaveat: false,
-            });
+            let canvas: HTMLCanvasElement | OffscreenCanvas = new OffscreenCanvas(100, 100); // will be resized later
+            let engine: Nullable<ThinEngine> = null;
+            try {
+                engine = new ThinEngine(canvas, false, {
+                    preserveDrawingBuffer: true,
+                    depth: false,
+                    stencil: false,
+                    alpha: true,
+                    premultipliedAlpha: false,
+                    antialias: false,
+                    failIfMajorPerformanceCaveat: false,
+                });
+            } catch (e) {}
+            if (!engine) {
+                // The browser does not support WebGL context in OffscreenCanvas, fallback on a regular canvas
+                canvas = document.createElement("canvas");
+                engine = new ThinEngine(canvas, false, {
+                    preserveDrawingBuffer: true,
+                    depth: false,
+                    stencil: false,
+                    alpha: true,
+                    premultipliedAlpha: false,
+                    antialias: false,
+                    failIfMajorPerformanceCaveat: false,
+                });
+            }
             engine.getCaps().parallelShaderCompile = undefined;
             const renderer = new EffectRenderer(engine);
             const wrapper = new EffectWrapper({

--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -28,29 +28,21 @@ export class DumpTools {
         if (!DumpTools._DumpToolsEngine) {
             let canvas: HTMLCanvasElement | OffscreenCanvas = new OffscreenCanvas(100, 100); // will be resized later
             let engine: Nullable<ThinEngine> = null;
+            const options = {
+                preserveDrawingBuffer: true,
+                depth: false,
+                stencil: false,
+                alpha: true,
+                premultipliedAlpha: false,
+                antialias: false,
+                failIfMajorPerformanceCaveat: false,
+            };
             try {
-                engine = new ThinEngine(canvas, false, {
-                    preserveDrawingBuffer: true,
-                    depth: false,
-                    stencil: false,
-                    alpha: true,
-                    premultipliedAlpha: false,
-                    antialias: false,
-                    failIfMajorPerformanceCaveat: false,
-                });
-            } catch (e) {}
-            if (!engine) {
+                engine = new ThinEngine(canvas, false, options);
+            } catch (e) {
                 // The browser does not support WebGL context in OffscreenCanvas, fallback on a regular canvas
                 canvas = document.createElement("canvas");
-                engine = new ThinEngine(canvas, false, {
-                    preserveDrawingBuffer: true,
-                    depth: false,
-                    stencil: false,
-                    alpha: true,
-                    premultipliedAlpha: false,
-                    antialias: false,
-                    failIfMajorPerformanceCaveat: false,
-                });
+                engine = new ThinEngine(canvas, false, options);
             }
             engine.getCaps().parallelShaderCompile = undefined;
             const renderer = new EffectRenderer(engine);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/safari-create-screenshot-using-render-target-broken/42512/8

~~Please wait for comments from the author of the thread to make sure the fix works before merging it!~~ Can be merged!