### PR TITLE
FreeCameraMouseInput: Reset Active pointerId when detaching controls

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -242,6 +242,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
             this._previousPosition = null;
         }
 
+        this._activePointerId = -1;
         this._currentActiveButton = -1;
     }
 

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -815,4 +815,58 @@ describe("InputManager", () => {
 
         expect(pickedTestMesh).not.toBe(null);
     });
+
+    it("can reset touch inputs on detachControl", () => {
+        let deltaX1 = 0;
+        let deltaY1 = 0;
+        let deltaX2 = 0;
+        let deltaY2 = 0;
+
+        if (deviceInputSystem && camera && scene) {
+            camera.attachControl();
+
+            // Connect the first touch and move down and right
+            deviceInputSystem.connectDevice(DeviceType.Touch, 1, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Move, 1);
+
+            // Both should be positive values based on movement
+            deltaX1 = camera.cameraRotation.x;
+            deltaY1 = camera.cameraRotation.y;
+
+            // Detach and reattach the camera
+            // Note: Detaching the controls will zero out the camera rotation
+            camera.detachControl();
+
+            // We need to trigger the up after the controls are detached
+            // This enables us to check if the inputs are reset properly on detach
+            // because the up code normally will reset things when controls are attached
+            deviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0);
+
+            camera.attachControl();
+
+            // Connect the second touch and move down and right
+            deviceInputSystem.connectDevice(DeviceType.Touch, 2, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 0, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Move, 1);
+            deviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0);
+
+            // Both should be positive values based on movement
+            deltaX2 = camera.cameraRotation.x;
+            deltaY2 = camera.cameraRotation.y;
+        }
+
+        expect(deltaX1).toBeGreaterThan(0);
+        expect(deltaY1).toBeGreaterThan(0);
+        expect(deltaX2).toBeGreaterThan(0);
+        expect(deltaY2).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
A user in the forum found an issue where the camera controls stopped working after an animation started.  It was determined the issue was caused by the controls being detached before the `pointerup` event was handled.  A line was added to make sure the the tracked active pointerid was being reset when the controls were no longer active so that input could begin to be received again.

A test has also been added to check for this scenario

Forum Link: https://forum.babylonjs.com/t/mesh-actionmanager-camera-control-bug/42292