### PR TITLE
Narrow numbers to const enums

### DIFF
--- a/packages/dev/core/src/Misc/sceneSerializer.ts
+++ b/packages/dev/core/src/Misc/sceneSerializer.ts
@@ -155,7 +155,7 @@ export class SceneSerializer {
         serializationObject.useRightHandedSystem = scene.useRightHandedSystem;
 
         // Fog
-        if (scene.fogMode && scene.fogMode !== 0) {
+        if (scene.fogMode !== 0) {
             serializationObject.fogMode = scene.fogMode;
             serializationObject.fogColor = scene.fogColor.asArray();
             serializationObject.fogStart = scene.fogStart;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -137,19 +137,30 @@ export enum ScenePerformancePriority {
     Aggressive,
 }
 
+export const enum FogMode {
+    /** The fog is deactivated */
+    None = 0,
+    /** The fog density is following an exponential function */
+    Exp = 1,
+    /** The fog density is following an exponential function faster than FogMode.Exp */
+    Exp2 = 2,
+    /** The fog density is following a linear function. */
+    Linear = 3,
+}
+
 /**
  * Represents a scene to be rendered by the engine.
  * @see https://doc.babylonjs.com/features/featuresDeepDive/scene
  */
 export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHolder {
     /** The fog is deactivated */
-    public static readonly FOGMODE_NONE = 0;
+    public static readonly FOGMODE_NONE = FogMode.None;
     /** The fog density is following an exponential function */
-    public static readonly FOGMODE_EXP = 1;
+    public static readonly FOGMODE_EXP = FogMode.Exp;
     /** The fog density is following an exponential function faster than FOGMODE_EXP */
-    public static readonly FOGMODE_EXP2 = 2;
+    public static readonly FOGMODE_EXP2 = FogMode.Exp2;
     /** The fog density is following a linear function. */
-    public static readonly FOGMODE_LINEAR = 3;
+    public static readonly FOGMODE_LINEAR = FogMode.Linear;
 
     /**
      * Gets or sets the minimum deltatime when deterministic lock step is enabled
@@ -1063,14 +1074,14 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * | FOGMODE_EXP2 | 2 |
      * | FOGMODE_LINEAR | 3 |
      */
-    public set fogMode(value: number) {
+    public set fogMode(value: FogMode) {
         if (this._fogMode === value) {
             return;
         }
         this._fogMode = value;
         this.markAllMaterialsAsDirty(Constants.MATERIAL_MiscDirtyFlag);
     }
-    public get fogMode(): number {
+    public get fogMode(): FogMode {
         return this._fogMode;
     }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -137,6 +137,9 @@ export enum ScenePerformancePriority {
     Aggressive,
 }
 
+/**
+ * Define how the scene should display fog
+ */
 export const enum FogMode {
     /** The fog is deactivated */
     None = 0,
@@ -1069,10 +1072,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @see https://doc.babylonjs.com/features/featuresDeepDive/environment/environment_introduction#fog
      * | mode | value |
      * | --- | --- |
-     * | FOGMODE_NONE | 0 |
-     * | FOGMODE_EXP | 1 |
-     * | FOGMODE_EXP2 | 2 |
-     * | FOGMODE_LINEAR | 3 |
+     * | FogMode.None | 0 |
+     * | FogMode.Exp | 1 |
+     * | FogMode.Exp2 | 2 |
+     * | FogMode.Linear | 3 |
      */
     public set fogMode(value: FogMode) {
         if (this._fogMode === value) {


### PR DESCRIPTION
Babylon has a lot of APIs where a property or variable type is just `number`, and you typically set the value based on a static property of a class (though I've seen plenty of code where it was just set to a number directly). For example:

```ts
scene.fogMode = Scene.FOGMODE_EXP;
```

Since the type of `fogMode` is just `number`, it can be hard to know what value it should be set to (especially for folks who are new to the Babylon API and not aware of this repeated pattern), and is also error prone in that you can easily assign it to an invalid numeric value and not know until runtime.

It seems like one simple fix for this could be do to define light weight `const enum`s, something like:

```ts
// Newly introduced const enum for fog modes,
// with values matching the existing values
const enum FogMode { 
  None = 0,
  Exp = 1,
  Exp2 = 2,
  Linear = 3,
};

class Scene {
  public static readonly FOGMODE_NONE = FogMode.None;
  public static readonly FOGMODE_EXP = FogMode.Exp;
  ...

  public set fogMode(value: FogMode) {
  ...
  }
}

// New standard way of setting fogMode - immediately discoverable
scene.fogMode = FogMode.Exp; 

// Existing code using the old pattern still works
scene.fogMode = Scene.FOGMODE_EXP;

// Same existing code that was using numeric values directly
scene.fogMode = 1;

// But trying to assign an invalid value is also a compile time error
scene.fogMode = 5; // ERROR
```

It seems like this approach has several benefits:
1. It's backward compatible
2. It's much more discoverable
3. It's less error prone
4. It has no performance overhead (since const enums compile down to just constant values)

I see a few open questions with this approach as well though:
1. If the const enums are not preserved in the built JavaScript, then JavaScript source must be written like it is today (with "legacy" static readonly properties) and the doc comments would be correct for TypeScript but not for JavaScript.
2. If the const enums are preserved in the built JavaScript, the built JavaScript size will increase. The change in this PR showing the pattern with fog mode **increases the dev build of babylon.js by 880 bytes**. I'm not sure how to build the fully minified JavaScript though (@RaananW? 🙏), so maybe it would be less in that case.
3. There can be interesting cases where the change can result in a TypeScript error in existing (incorrect but functional) code. One example can be seen in this PR, where there was a condition like this: `if (scene.fogMode && scene.fogMode !== 0)`. This code is technically incorrect, or at least redundant as it is essentially checking if fogMode is zero twice. With the proposed change, this line becomes a compile time error. If the first part of the condition is false, then fogMode is not zero, and so fogMode is narrowed to 1|2|3, which results in the second check producing an error (since 0 is not part of the 1|2|3 union). I would say technically this is actually catching a programming error in the code which is good, but it does mean existing code that does not produce TypeScript errors could produce TypeScrpit errors with this change.

I made this a draft PR to get feedback on the proposal. If folks think the pros outweigh the cons, then I would apply this pattern to many more cases. Thoughts?