### PR TITLE
DomManagement avoid unneeded object imports

### DIFF
--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -1,6 +1,6 @@
 import type { Engine } from "../Engines/engine";
 import type { IPointerEvent, IUIEvent } from "../Events/deviceInputEvents";
-import { DomManagement, IsNavigatorAvailable } from "../Misc/domManagement";
+import { IsNavigatorAvailable } from "../Misc/domManagement";
 import type { Observer } from "../Misc/observable";
 import { Tools } from "../Misc/tools";
 import type { Nullable } from "../types";
@@ -55,7 +55,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     private _eventsAttached: boolean = false;
 
     private _mouseId = -1;
-    private readonly _isUsingFirefox = DomManagement.IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Firefox") !== -1;
+    private readonly _isUsingFirefox = IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Firefox") !== -1;
 
     // Array to store active Pointer ID values; prevents issues with negative pointerIds
     private _activeTouchIds: Array<number>;
@@ -400,7 +400,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
      */
     private _handlePointerActions(): void {
         // If maxTouchPoints is defined, use that value.  Otherwise, allow for a minimum for supported gestures like pinch
-        this._maxTouchPoints = (DomManagement.IsNavigatorAvailable() && navigator.maxTouchPoints) || 2;
+        this._maxTouchPoints = (IsNavigatorAvailable() && navigator.maxTouchPoints) || 2;
         if (!this._activeTouchIds) {
             this._activeTouchIds = new Array<number>(this._maxTouchPoints);
         }

--- a/packages/dev/core/src/Misc/precisionDate.ts
+++ b/packages/dev/core/src/Misc/precisionDate.ts
@@ -1,4 +1,4 @@
-import { DomManagement } from "./domManagement";
+import { IsWindowObjectExist } from "./domManagement";
 
 /**
  * Class containing a set of static utilities functions for precision date
@@ -8,7 +8,7 @@ export class PrecisionDate {
      * Gets either window.performance.now() if supported or Date.now() else
      */
     public static get Now(): number {
-        if (DomManagement.IsWindowObjectExist() && window.performance && window.performance.now) {
+        if (IsWindowObjectExist() && window.performance && window.performance.now) {
             return window.performance.now();
         }
 

--- a/packages/dev/gui/src/3D/controls/MRTK3/touchHolographicButton.ts
+++ b/packages/dev/gui/src/3D/controls/MRTK3/touchHolographicButton.ts
@@ -13,7 +13,7 @@ import { Color3, Color4 } from "core/Maths/math.color";
 import { Control } from "../../../2D/controls/control";
 import { CreatePlane } from "core/Meshes/Builders/planeBuilder";
 import { CreateBox } from "core/Meshes/Builders/boxBuilder";
-import { DomManagement } from "core/Misc/domManagement";
+import { IsDocumentAvailable } from "core/Misc/domManagement";
 import { FadeInOutBehavior } from "core/Behaviors/Meshes/fadeInOutBehavior";
 import { Grid } from "../../../2D/controls/grid";
 import { Image } from "../../../2D/controls/image";
@@ -475,7 +475,7 @@ export class TouchHolographicButton extends TouchButton3D {
         const panel = new StackPanel();
         panel.isVertical = true;
 
-        if (DomManagement.IsDocumentAvailable() && !!document.createElement) {
+        if (IsDocumentAvailable() && !!document.createElement) {
             if (this._imageUrl) {
                 const image = new Image();
                 image.source = this._imageUrl;
@@ -514,7 +514,7 @@ export class TouchHolographicButton extends TouchButton3D {
         panel.isVertical = false;
         panel.scaleY = this._getAspectRatio();
 
-        if (DomManagement.IsDocumentAvailable() && !!document.createElement) {
+        if (IsDocumentAvailable() && !!document.createElement) {
             if (this._imageUrl) {
                 const imageContainer = new Rectangle(`${this.name}_image`);
                 imageContainer.widthInPixels = this.imageSizeInPixels;

--- a/packages/dev/gui/src/3D/controls/holographicButton.ts
+++ b/packages/dev/gui/src/3D/controls/holographicButton.ts
@@ -18,7 +18,7 @@ import { TextBlock } from "../../2D/controls/textBlock";
 import { AdvancedDynamicTexture } from "../../2D/advancedDynamicTexture";
 import type { Control3D } from "./control3D";
 import { Color3 } from "core/Maths/math.color";
-import { DomManagement } from "core/Misc/domManagement";
+import { IsDocumentAvailable } from "core/Misc/domManagement";
 
 /**
  * Class used to create a holographic button in 3D
@@ -229,7 +229,7 @@ export class HolographicButton extends Button3D {
         const panel = new StackPanel();
         panel.isVertical = true;
 
-        if (DomManagement.IsDocumentAvailable() && !!document.createElement) {
+        if (IsDocumentAvailable() && !!document.createElement) {
             if (this._imageUrl) {
                 const image = new Image();
                 image.source = this._imageUrl;

--- a/packages/dev/gui/src/3D/controls/touchHolographicButton.ts
+++ b/packages/dev/gui/src/3D/controls/touchHolographicButton.ts
@@ -19,7 +19,7 @@ import { Color3 } from "core/Maths/math.color";
 import { TouchButton3D } from "./touchButton3D";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { SceneLoader } from "core/Loading/sceneLoader";
-import { DomManagement } from "core/Misc/domManagement";
+import { IsDocumentAvailable } from "core/Misc/domManagement";
 import { Scalar } from "core/Maths/math.scalar";
 
 /**
@@ -297,7 +297,7 @@ export class TouchHolographicButton extends TouchButton3D {
         const panel = new StackPanel();
         panel.isVertical = true;
 
-        if (DomManagement.IsDocumentAvailable() && !!document.createElement) {
+        if (IsDocumentAvailable() && !!document.createElement) {
             if (this._imageUrl) {
                 const image = new Image();
                 image.source = this._imageUrl;


### PR DESCRIPTION
discovered here - https://forum.babylonjs.com/t/iswindowobjectexist-is-not-a-function-es6-support-with-tree-shaking-bug/42583

Still working on understanding why parcel totally tree-shake the entire object, but the module export itself exists.