### PR TITLE
Add extra conditions for outParams declarations in PBR block shaders

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAmbientOcclusion.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAmbientOcclusion.fx
@@ -1,8 +1,8 @@
 struct ambientOcclusionOutParams
 {
     vec3 ambientOcclusionColor;
-#if DEBUGMODE > 0
-    vec3 ambientOcclusionColorMap;
+#if DEBUGMODE > 0 && defined(AMBIENT)
+        vec3 ambientOcclusionColorMap;
 #endif
 };
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAmbientOcclusion.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAmbientOcclusion.fx
@@ -2,7 +2,7 @@ struct ambientOcclusionOutParams
 {
     vec3 ambientOcclusionColor;
 #if DEBUGMODE > 0 && defined(AMBIENT)
-        vec3 ambientOcclusionColorMap;
+    vec3 ambientOcclusionColorMap;
 #endif
 };
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAnisotropic.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockAnisotropic.fx
@@ -5,7 +5,7 @@
         vec3 anisotropicTangent;
         vec3 anisotropicBitangent;
         vec3 anisotropicNormal;
-    #if DEBUGMODE > 0
+    #if DEBUGMODE > 0 && defined(ANISOTROPIC_TEXTURE)
         vec3 anisotropyMapData;
     #endif
     };

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockClearcoat.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockClearcoat.fx
@@ -19,12 +19,20 @@ struct clearcoatOutParams
     vec3 energyConservationFactorClearCoat;
 #endif
 #if DEBUGMODE > 0
-    mat3 TBNClearCoat;
-    vec2 clearCoatMapData;
-    vec4 clearCoatTintMapData;
-    vec4 environmentClearCoatRadiance;
+    #ifdef CLEARCOAT_BUMP
+        mat3 TBNClearCoat;
+    #endif
+    #ifdef CLEARCOAT_TEXTURE
+        vec2 clearCoatMapData;
+    #endif
+    #if defined(CLEARCOAT_TINT) && defined(CLEARCOAT_TINT_TEXTURE)
+        vec4 clearCoatTintMapData;
+    #endif
+    #ifdef REFLECTION
+        vec4 environmentClearCoatRadiance;
+        vec3 clearCoatEnvironmentReflectance;
+    #endif
     float clearCoatNdotV;
-    vec3 clearCoatEnvironmentReflectance;
 #endif
 };
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
@@ -10,10 +10,19 @@ struct reflectivityOutParams
     vec3 ambientOcclusionColor;
 #endif
 #if DEBUGMODE > 0
-    vec4 surfaceMetallicColorMap;
-    vec4 surfaceReflectivityColorMap;
-    vec2 metallicRoughness;
-    vec3 metallicF0;
+    #ifdef METALLICWORKFLOW
+        vec2 metallicRoughness;
+        #ifdef REFLECTIVITY
+            vec4 surfaceMetallicColorMap;
+        #endif
+        #ifndef FROSTBITE_REFLECTANCE
+            vec3 metallicF0;
+        #endif
+    #else
+        #ifdef REFLECTIVITY
+            vec4 surfaceReflectivityColorMap;
+        #endif
+    #endif
 #endif
 };
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSheen.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSheen.fx
@@ -14,8 +14,12 @@
         vec3 finalSheenRadianceScaled;
     #endif
     #if DEBUGMODE > 0
-        vec4 sheenMapData;
-        vec3 sheenEnvironmentReflectance;
+        #ifdef SHEEN_TEXTURE
+            vec4 sheenMapData;
+        #endif
+        #if defined(REFLECTION) && defined(ENVIRONMENTBRDF)
+            vec3 sheenEnvironmentReflectance;
+        #endif
     #endif
     };
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -19,9 +19,13 @@ struct subSurfaceOutParams
     #endif
 #endif
 #if DEBUGMODE > 0
-    vec4 thicknessMap;
-    vec4 environmentRefraction;
-    vec3 refractionTransmittance;
+    #ifdef SS_THICKNESSANDMASK_TEXTURE
+        vec4 thicknessMap;
+    #endif
+    #ifdef SS_REFRACTION
+        vec4 environmentRefraction;
+        vec3 refractionTransmittance;
+    #endif
 #endif
 };
 


### PR DESCRIPTION
When using PBR debug modes in Babylon Native, these structs will be marked "not fully initialized" and error. These extra checks should ensure that any declared debug parameter will also be initialized.