### PR TITLE
bug: TypeError: Cannot read properties of undefined (reading 'boundingSphere')

### DIFF
--- a/packages/dev/core/src/Rendering/renderingGroup.ts
+++ b/packages/dev/core/src/Rendering/renderingGroup.ts
@@ -242,7 +242,9 @@ export class RenderingGroup {
             for (; subIndex < subMeshes.length; subIndex++) {
                 subMesh = subMeshes.data[subIndex];
                 subMesh._alphaIndex = subMesh.getMesh().alphaIndex;
-                subMesh._distanceToCamera = Vector3.Distance(subMesh.getBoundingInfo().boundingSphere.centerWorld, cameraPosition);
+                if(subMesh.getBoundingInfo()){
+                    subMesh._distanceToCamera = Vector3.Distance(subMesh.getBoundingInfo().boundingSphere.centerWorld, cameraPosition);
+                }
             }
         }
 


### PR DESCRIPTION
Does not automatically build a boundingSphere for arrows. Therefore, it is worth adding the condition "if".