### PR TITLE
Document parameter ranges of HSVtoRGBToRef()

### DIFF
--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -451,9 +451,9 @@ export class Color3 {
 
     /**
      * Converts Hue, saturation and value to a Color3 (RGB)
-     * @param hue defines the hue
-     * @param saturation defines the saturation
-     * @param value defines the value
+     * @param hue defines the hue (value between 0 and 360)
+     * @param saturation defines the saturation (value between 0 and 1)
+     * @param value defines the value (value between 0 and 1)
      * @param result defines the Color3 where to store the RGB values
      */
     public static HSVtoRGBToRef(hue: number, saturation: number, value: number, result: Color3) {


### PR DESCRIPTION
HSVtoRGBToRef() of Color3 was missing ranges of hue, saturation, and value parameters:

Forum: https://forum.babylonjs.com/t/hsv-colorspace-hue-in-degrees/42796