### PR TITLE
Cancel any pending animation frames on stopRenderLoop

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -1281,6 +1281,18 @@ export class Engine extends ThinEngine {
         }
     }
 
+    protected _cancelFrame() {
+        if (this._renderingQueueLaunched && this.customAnimationFrameRequester) {
+            this._renderingQueueLaunched = false;
+            const { cancelAnimationFrame } = this.customAnimationFrameRequester;
+            if (cancelAnimationFrame) {
+                cancelAnimationFrame(this.customAnimationFrameRequester.requestID);
+            }
+        } else {
+            super._cancelFrame();
+        }
+    }
+
     public _renderLoop(): void {
         if (!this._contextWasLost) {
             let shouldRender = true;

--- a/packages/dev/core/src/Misc/customAnimationFrameRequester.ts
+++ b/packages/dev/core/src/Misc/customAnimationFrameRequester.ts
@@ -16,4 +16,8 @@ export interface ICustomAnimationFrameRequester {
      * @see https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#Return_value
      */
     requestID?: number;
+    /**
+     * Called to cancel the next frame request
+     */
+    cancelAnimationFrame?: Function;
 }


### PR DESCRIPTION
When calling stopRenderLoop, we weren't canceling any animation frames requested, this was causing a problem in the multiview scenario: https://forum.babylonjs.com/t/stop-render-loop-and-keep-last-frame-rendered-multiview/42847/3

Test PG: #LYSEQ9#2 (starts and stops a render loop and prints on begin/end frame), in the current version there's a log even after the stopRenderLoop:
<img width="208" alt="image" src="https://github.com/BabylonJS/Babylon.js/assets/6002144/112ebb72-20ac-48ba-8265-9796ec6a7771">

