### PR TITLE
Material plugins: Add support for #include resolution

### DIFF
--- a/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
+++ b/packages/dev/core/src/Engines/Processors/shaderProcessor.ts
@@ -373,7 +373,8 @@ export class ShaderProcessor {
         return preparedSourceCode;
     }
 
-    private static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
+    /** @internal */
+    public static _ProcessIncludes(sourceCode: string, options: ProcessingOptions, callback: (data: any) => void): void {
         reusableMatches.length = 0;
         let match: RegExpMatchArray | null;
         // stay back-compat to the old matchAll syntax

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1465,6 +1465,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
         const uniformBuffers = ["Material", "Scene", "Mesh"];
 
+        const indexParameters = { maxSimultaneousLights: this._maxSimultaneousLights, maxSimultaneousMorphTargets: defines.NUM_MORPH_INFLUENCERS };
+
         this._eventInfo.fallbacks = fallbacks;
         this._eventInfo.fallbackRank = fallbackRank;
         this._eventInfo.defines = defines;
@@ -1474,6 +1476,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         this._eventInfo.uniformBuffersNames = uniformBuffers;
         this._eventInfo.customCode = undefined;
         this._eventInfo.mesh = mesh;
+        this._eventInfo.indexParameters = indexParameters;
         this._callbackPluginEventGeneric(MaterialPluginEvent.PrepareEffect, this._eventInfo);
 
         PrePassConfiguration.AddUniforms(uniforms);
@@ -1511,7 +1514,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 fallbacks: fallbacks,
                 onCompiled: onCompiled,
                 onError: onError,
-                indexParameters: { maxSimultaneousLights: this._maxSimultaneousLights, maxSimultaneousMorphTargets: defines.NUM_MORPH_INFLUENCERS },
+                indexParameters,
                 processFinalCode: csnrOptions.processFinalCode,
                 processCodeAfterIncludes: this._eventInfo.customCode,
                 multiTarget: defines.PREPASS,

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -34,6 +34,12 @@ export class MaterialPluginBase {
     public priority: number = 500;
 
     /**
+     * Indicates that any #include directive in the plugin code must be replaced by the corresponding code.
+     */
+    @serialize()
+    public resolveIncludes: boolean = false;
+
+    /**
      * Indicates that this plugin should be notified for the extra events (HasRenderTargetTextures / FillRenderTargetTextures / HardBindForSubMesh)
      */
     @serialize()
@@ -62,11 +68,13 @@ export class MaterialPluginBase {
      * @param defines list of defines used by the plugin. The value of the property is the default value for this property
      * @param addToPluginList true to add the plugin to the list of plugins managed by the material plugin manager of the material (default: true)
      * @param enable true to enable the plugin (it is handy if the plugin does not handle properties to switch its current activation)
+     * @param resolveIncludes Indicates that any #include directive in the plugin code must be replaced by the corresponding code (default: false)
      */
-    constructor(material: Material, name: string, priority: number, defines?: { [key: string]: any }, addToPluginList = true, enable = false) {
+    constructor(material: Material, name: string, priority: number, defines?: { [key: string]: any }, addToPluginList = true, enable = false, resolveIncludes = false) {
         this._material = material;
         this.name = name;
         this.priority = priority;
+        this.resolveIncludes = resolveIncludes;
 
         if (!material.pluginManager) {
             material.pluginManager = new MaterialPluginManager(material);
@@ -140,7 +148,7 @@ export class MaterialPluginBase {
     /**
      * Returns a list of custom shader code fragments to customize the shader.
      * @param shaderType "vertex" or "fragment"
-     * @returns null if no code to be added, or a list of pointName => code.
+     * @returns null if no code to be added, or a list of pointName =\> code.
      * Note that `pointName` can also be a regular expression if it starts with a `!`.
      * In that case, the string found by the regular expression (if any) will be
      * replaced by the code provided.

--- a/packages/dev/core/src/Materials/materialPluginEvent.ts
+++ b/packages/dev/core/src/Materials/materialPluginEvent.ts
@@ -47,6 +47,7 @@ export type MaterialPluginPrepareEffect = {
     samplers: string[];
     uniformBuffersNames: string[];
     mesh: AbstractMesh;
+    indexParameters: any;
 };
 
 /** @internal */

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1385,6 +1385,8 @@ export class StandardMaterial extends PushMaterial {
 
             const uniformBuffers = ["Material", "Scene", "Mesh"];
 
+            const indexParameters = { maxSimultaneousLights: this._maxSimultaneousLights, maxSimultaneousMorphTargets: defines.NUM_MORPH_INFLUENCERS };
+
             this._eventInfo.fallbacks = fallbacks;
             this._eventInfo.fallbackRank = 0;
             this._eventInfo.defines = defines;
@@ -1394,6 +1396,7 @@ export class StandardMaterial extends PushMaterial {
             this._eventInfo.uniformBuffersNames = uniformBuffers;
             this._eventInfo.customCode = undefined;
             this._eventInfo.mesh = mesh;
+            this._eventInfo.indexParameters = indexParameters;
             this._callbackPluginEventGeneric(MaterialPluginEvent.PrepareEffect, this._eventInfo);
 
             PrePassConfiguration.AddUniforms(uniforms);
@@ -1434,7 +1437,7 @@ export class StandardMaterial extends PushMaterial {
                     fallbacks: fallbacks,
                     onCompiled: this.onCompiled,
                     onError: this.onError,
-                    indexParameters: { maxSimultaneousLights: this._maxSimultaneousLights, maxSimultaneousMorphTargets: defines.NUM_MORPH_INFLUENCERS },
+                    indexParameters,
                     processFinalCode: csnrOptions.processFinalCode,
                     processCodeAfterIncludes: this._eventInfo.customCode,
                     multiTarget: defines.PREPASS,


### PR DESCRIPTION
This PR adds the possibility of replacing any #include directives that appear in the material plugin code with their corresponding code.

However, to avoid unnecessary code parsing when there are no inclusions, you must explicitly enable resolution of #include directives (7th parameter of the `MaterialPluginBase` constructor).