### PR TITLE
Shaders: Don't inject fragment output declaration if already existing

### DIFF
--- a/packages/dev/core/src/Engines/WebGL/webGL2ShaderProcessors.ts
+++ b/packages/dev/core/src/Engines/WebGL/webGL2ShaderProcessors.ts
@@ -29,13 +29,15 @@ export class WebGL2ShaderProcessor implements IShaderProcessor {
         // Replace instructions
         code = code.replace(/texture2D\s*\(/g, "texture(");
         if (isFragment) {
+            const hasOutput = code.search(/layout *\(location *= *0\) *out/g) !== -1;
+
             code = code.replace(/texture2DLodEXT\s*\(/g, "textureLod(");
             code = code.replace(/textureCubeLodEXT\s*\(/g, "textureLod(");
             code = code.replace(/textureCube\s*\(/g, "texture(");
             code = code.replace(/gl_FragDepthEXT/g, "gl_FragDepth");
             code = code.replace(/gl_FragColor/g, "glFragColor");
             code = code.replace(/gl_FragData/g, "glFragData");
-            code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension ? "" : "layout(location = 0) out vec4 glFragColor;\n") + "void main(");
+            code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension || hasOutput ? "" : "layout(location = 0) out vec4 glFragColor;\n") + "void main(");
         } else {
             const hasMultiviewExtension = defines.indexOf("#define MULTIVIEW") !== -1;
             if (hasMultiviewExtension) {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
@@ -283,6 +283,7 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
             `;
 
             const injectCode = hasFragCoord ? "vec4 glFragCoord_;\n" : "";
+            const hasOutput = code.search(/layout *\(location *= *0\) *out/g) !== -1;
 
             code = code.replace(/texture2DLodEXT\s*\(/g, "textureLod(");
             code = code.replace(/textureCubeLodEXT\s*\(/g, "textureLod(");
@@ -292,7 +293,7 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
             code = code.replace(/gl_FragData/g, "glFragData");
             code = code.replace(/gl_FragCoord/g, "glFragCoord_");
             if (!this._fragmentIsGLES3) {
-                code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension ? "" : "layout(location = 0) out vec4 glFragColor;\n") + "void main(");
+                code = code.replace(/void\s+?main\s*\(/g, (hasDrawBuffersExtension || hasOutput ? "" : "layout(location = 0) out vec4 glFragColor;\n") + "void main(");
             } else {
                 const match = /^\s*out\s+\S+\s+\S+\s*;/gm.exec(code);
                 if (match !== null) {


### PR DESCRIPTION
With this PR, you no longer need to have `#extension GL_EXT_draw_buffers require` in your shader if you want to provide your own fragment output declaration.

Simply declare your output (something like `layout(location = 0) out vec4 myOutput;`) and it will take precedence over the default `glFragColor` output.

Create the PR in draft mode, to make sure @sebavan sees it when he gets back from vacation.