### PR TITLE
Parsing of GLSL shaders in WebGPU: Fix detection of varyings

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
@@ -68,9 +68,9 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
     }
 
     public varyingCheck(varying: string, isFragment: boolean) {
-        const outRegex = /(flat\s)?\s*out/;
-        const inRegex = /(flat\s)?\s*in/;
-        const varyingRegex = /(flat\s)?\s*varying/;
+        const outRegex = /(flat\s)?\s*out /;
+        const inRegex = /(flat\s)?\s*in /;
+        const varyingRegex = /(flat\s)?\s*varying /;
 
         const regex = isFragment && this._fragmentIsGLES3 ? inRegex : !isFragment && this._vertexIsGLES3 ? outRegex : varyingRegex;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-use-glsl-bug-non-opaque-uniforms-outside-a-block/42972