### PR TITLE
Don't deduce stride size in rollback function of PrepareMeshForTrianglesAndVerticesMode

### DIFF
--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -603,7 +603,8 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
             rollback = function () {
                 mesh.setIndices(indices);
                 for (const kind of kinds) {
-                    mesh.setVerticesData(kind, data[kind]);
+                    const stride = mesh.getVertexBuffer(kind)!.getStrideSize();
+                    mesh.setVerticesData(kind, data[kind], undefined, stride);
                 }
                 mesh.removeVerticesData("dbg_initialPass");
             };


### PR DESCRIPTION
This will fix an issue with the vertex color buffer not being reset properly.