### PR TITLE
Expose options of MeshDebugPluginMaterial

### DIFF
--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -340,24 +340,6 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
    @expandToProperty("_markAllDefinesAsDirty")
    public options: Required<MeshDebugOptions>;
 
-    private _mode: MeshDebugMode;
-    /**
-     * Current mesh debug visualization.
-     * Defaults to NONE in constructor.
-     */
-    @serialize()
-    @expandToProperty("_markAllDefinesAsDirty")
-    public mode: MeshDebugMode;
-
-    private _multiply: boolean;
-    /**
-     * Whether the mesh debug visualization multiplies with colors underneath.
-     * Defaults to true in constructor.
-     */
-    @serialize()
-    @expandToProperty("_markAllDefinesAsDirty")
-    public multiply: boolean;
-
     /** @internal */
     protected _markAllDefinesAsDirty(): void {
         this._enable(this._isEnabled);
@@ -393,8 +375,6 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
             uvSecondaryColor: new Color3(0.5, 0.5, 0.5),
         };
 
-        this._mode = defines.DBG_MODE;
-        this._multiply = defines.DBG_MULTIPLY;
         this._options = { ...defaults, ...options };
         this._materialColor = MeshDebugPluginMaterial.MaterialColors[MeshDebugPluginMaterial._PluginCount++ % MeshDebugPluginMaterial.MaterialColors.length];
         this.isEnabled = true;
@@ -439,7 +419,7 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
      */
     public prepareDefines(defines: MeshDebugDefines, scene: Scene, mesh: AbstractMesh) {
         if (
-            (this._mode == MeshDebugMode.VERTICES || this._mode == MeshDebugMode.TRIANGLES || this._mode == MeshDebugMode.TRIANGLES_VERTICES) &&
+            (this._options.mode == MeshDebugMode.VERTICES || this._options.mode == MeshDebugMode.TRIANGLES || this._options.mode == MeshDebugMode.TRIANGLES_VERTICES) &&
             !mesh.isVerticesDataPresent("dbg_initialPass")
         ) {
             Logger.Warn(
@@ -448,8 +428,8 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
             );
         }
 
-        defines.DBG_MODE = this._mode;
-        defines.DBG_MULTIPLY = this._multiply;
+        defines.DBG_MODE = this._options.mode;
+        defines.DBG_MULTIPLY = this._options.multiply;
         defines.DBG_ENABLED = this._isEnabled;
     }
 
@@ -531,6 +511,8 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
     public serialize(): any {
         const serializationObject = super.serialize();
 
+        serializationObject.mode = this._options.mode;
+        serializationObject.multiply = this._options.multiply;
         serializationObject.shadedDiffuseColor = this._options.shadedDiffuseColor.asArray();
         serializationObject.shadedSpecularColor = this._options.shadedSpecularColor.asArray();
         serializationObject.shadedSpecularPower = this._options.shadedSpecularPower;

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -328,17 +328,17 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
     /**
      * Whether the mesh debug plugin is enabled in the material.
      * Defaults to true in constructor.
-    */
-   @serialize()
-   private _isEnabled: boolean;
+     */
+    @serialize()
+    private _isEnabled: boolean;
 
-   private _options: Required<MeshDebugOptions>;
-   /**
-    * Options for the plugin.
-    * See MeshDebugOptions interface for defaults.
-    */
-   @expandToProperty("_markAllDefinesAsDirty")
-   public options: Required<MeshDebugOptions>;
+    private _options: Required<MeshDebugOptions>;
+    /**
+     * Options for the plugin.
+     * See MeshDebugOptions interface for defaults.
+     */
+    @expandToProperty("_markAllDefinesAsDirty")
+    public options: Required<MeshDebugOptions>;
 
     /** @internal */
     protected _markAllDefinesAsDirty(): void {

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -319,42 +319,44 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
     public static MaterialColors: Color3[] = defaultMaterialColors;
 
     /**
-     * Options for the plugin.
-     * See MeshDebugOptions interface for defaults.
-     */
-    private _options: Required<MeshDebugOptions>;
-
-    /**
      * Material ID color of this plugin instance.
      * Taken from index `_PluginCount` of `MaterialColors` at time of instantiation.
      */
     @serializeAsColor3()
     private _materialColor: Color3;
-
+    
     /**
      * Whether the mesh debug plugin is enabled in the material.
      * Defaults to true in constructor.
-     */
-    @serialize()
-    private _isEnabled = false;
+    */
+   @serialize()
+   private _isEnabled: boolean;
 
-    private _mode: MeshDebugMode = MeshDebugMode.NONE;
+   private _options: Required<MeshDebugOptions>;
+   /**
+    * Options for the plugin.
+    * See MeshDebugOptions interface for defaults.
+    */
+   @expandToProperty("_markAllDefinesAsDirty")
+   public options: Required<MeshDebugOptions>;
+
+    private _mode: MeshDebugMode;
     /**
      * Current mesh debug visualization.
-     * Defaults to NONE.
+     * Defaults to NONE in constructor.
      */
     @serialize()
     @expandToProperty("_markAllDefinesAsDirty")
-    public mode: MeshDebugMode = MeshDebugMode.NONE;
+    public mode: MeshDebugMode;
 
-    private _multiply: boolean = true;
+    private _multiply: boolean;
     /**
      * Whether the mesh debug visualization multiplies with colors underneath.
-     * Defaults to true.
+     * Defaults to true in constructor.
      */
     @serialize()
     @expandToProperty("_markAllDefinesAsDirty")
-    public multiply: boolean = true;
+    public multiply: boolean;
 
     /** @internal */
     protected _markAllDefinesAsDirty(): void {

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -324,7 +324,7 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
      */
     @serializeAsColor3()
     private _materialColor: Color3;
-    
+
     /**
      * Whether the mesh debug plugin is enabled in the material.
      * Defaults to true in constructor.

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1684,7 +1684,7 @@
         },
         {
             "title": "MeshDebugPluginMaterial",
-            "playgroundId": "#TFDNZI#2",
+            "playgroundId": "#TFDNZI#5",
             "excludedEngines": ["webgl1"]
         },
         {


### PR DESCRIPTION
Exposing all options of MeshDebugPluginMaterial for users to modify after initialization.

Would it be ok if I remove the class members `mode` and `multiply`, and instead rely on `options.mode` and `options.multiply`? It'd make things consistent.