### PR TITLE
 Implement word boundary checks in regular expressions

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
@@ -68,9 +68,9 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
     }
 
     public varyingCheck(varying: string, isFragment: boolean) {
-        const outRegex = /(flat\s)?\s*out /;
-        const inRegex = /(flat\s)?\s*in /;
-        const varyingRegex = /(flat\s)?\s*varying /;
+        const outRegex = /(flat\s)?\s*\bout\b /;
+        const inRegex = /(flat\s)?\s*\bin\b /;
+        const varyingRegex = /(flat\s)?\s*\bvarying\b /;
 
         const regex = isFragment && this._fragmentIsGLES3 ? inRegex : !isFragment && this._vertexIsGLES3 ? outRegex : varyingRegex;
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
@@ -68,9 +68,9 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
     }
 
     public varyingCheck(varying: string, isFragment: boolean) {
-        const outRegex = /(flat\s)?\s*\bout\b /;
-        const inRegex = /(flat\s)?\s*\bin\b /;
-        const varyingRegex = /(flat\s)?\s*\bvarying\b /;
+        const outRegex = /(flat\s)?\s*\bout\b/;
+        const inRegex = /(flat\s)?\s*\bin\b/;
+        const varyingRegex = /(flat\s)?\s*\bvarying\b/;
 
         const regex = isFragment && this._fragmentIsGLES3 ? inRegex : !isFragment && this._vertexIsGLES3 ? outRegex : varyingRegex;
 


### PR DESCRIPTION
See [WebGPU use glsl bug ： non-opaque uniforms outside a block - Bugs - Babylon.js](https://forum.babylonjs.com/t/webgpu-use-glsl-bug-non-opaque-uniforms-outside-a-block/42972/7)

In the current implementation of regular expressions intended to match the GLSL keywords "in", "out", and "varying", it has been found that the patterns may match parts of variable names or within comments that contain these keywords, leading to inaccurate results.
Example
````
vec3 origin = vec3(0.0);
````

To improve accuracy, word boundaries (\b) have been applied around each keyword in the regular expressions. This ensures that the engine would only match complete words, not substrings within longer words or comments.

The regular expressions have been updated as follows: 
````
const outRegex = /(flat\s)?\s*\bout\b /;
const inRegex = /(flat\s)?\s*\bin\b /;
const varyingRegex = /(flat\s)?\s*\bvarying\b/ ;
````

