### PR TITLE
Clear transform node's physicsBody attribute when that is disposed

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -557,6 +557,7 @@ export class PhysicsBody {
         this._physicsEngine.removeBody(this);
         this._physicsPlugin.removeBody(this);
         this._physicsPlugin.disposeBody(this);
+        this.transformNode.physicsBody = null;
         this._pluginData = null;
         this._pluginDataInstances.length = 0;
     }


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/exception-in-inspector-when-physics-body-disposed/43044