### PR TITLE
PostProcess: Fix crash when detaching and reattaching a camera from/to a render pipeline

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderEffect.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderEffect.ts
@@ -167,6 +167,8 @@ export class PostProcessRenderEffect {
             if (this._cameras[cameraName]) {
                 this._cameras[cameraName] = null;
             }
+
+            delete this._indicesForCamera[cameraName];
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/bugs-when-managing-postprocess-pipeline/43184