### PR TITLE
Scene dispose: Fix endless loop when stopping animations

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4765,6 +4765,11 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this.importedMeshesFiles = new Array<string>();
 
         if (this.stopAllAnimations) {
+            // Ensures that no animatable notifies a callback that could start a new animation group, constantly adding new animatables to the active list...
+            this._activeAnimatables.forEach((animatable) => {
+                animatable.onAnimationEndObservable.clear();
+                animatable.onAnimationEnd = null;
+            });
             this.stopAllAnimations();
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/looping-in-color-animations-is-not-possible/43125/8