### PR TITLE
Shadow generators: Add support for red channel only for the shadow map texture

### DIFF
--- a/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -759,14 +759,15 @@ export class CascadedShadowGenerator extends ShadowGenerator {
      * @param light The directional light object generating the shadows.
      * @param usefulFloatFirst By default the generator will try to use half float textures but if you need precision (for self shadowing for instance), you can use this option to enforce full float texture.
      * @param camera Camera associated with this shadow generator (default: null). If null, takes the scene active camera at the time we need to access it
+     * @param useRedTextureType Forces the generator to use a Red instead of a RGBA type for the shadow map texture format (default: true)
      */
-    constructor(mapSize: number, light: DirectionalLight, usefulFloatFirst?: boolean, camera?: Nullable<Camera>) {
+    constructor(mapSize: number, light: DirectionalLight, usefulFloatFirst?: boolean, camera?: Nullable<Camera>, useRedTextureType = true) {
         if (!CascadedShadowGenerator.IsSupported) {
             Logger.Error("CascadedShadowMap is not supported by the current engine.");
             return;
         }
 
-        super(mapSize, light, usefulFloatFirst, camera);
+        super(mapSize, light, usefulFloatFirst, camera, useRedTextureType);
 
         this.usePercentageCloserFiltering = true;
     }
@@ -810,7 +811,8 @@ export class CascadedShadowGenerator extends ShadowGenerator {
             undefined,
             false,
             false,
-            undefined /*, Constants.TEXTUREFORMAT_RED*/
+            undefined,
+            this._useRedTextureType ? Constants.TEXTUREFORMAT_RED : Constants.TEXTUREFORMAT_RGBA
         );
         this._shadowMap.createDepthStencilTexture(engine.useReverseDepthBuffer ? Constants.GREATER : Constants.LESS, true);
         this._shadowMap.noPrePassRenderer = true;

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -804,6 +804,7 @@ export class ShadowGenerator implements IShadowGenerator {
     }
 
     protected _scene: Scene;
+    protected _useRedTextureType: boolean;
     protected _lightDirection = Vector3.Zero();
 
     protected _viewMatrix = Matrix.Zero();
@@ -857,12 +858,14 @@ export class ShadowGenerator implements IShadowGenerator {
      * @param light The light object generating the shadows.
      * @param usefullFloatFirst By default the generator will try to use half float textures but if you need precision (for self shadowing for instance), you can use this option to enforce full float texture.
      * @param camera Camera associated with this shadow generator (default: null). If null, takes the scene active camera at the time we need to access it
+     * @param useRedTextureType Forces the generator to use a Red instead of a RGBA type for the shadow map texture format (default: false)
      */
-    constructor(mapSize: number, light: IShadowLight, usefullFloatFirst?: boolean, camera?: Nullable<Camera>) {
+    constructor(mapSize: number, light: IShadowLight, usefullFloatFirst?: boolean, camera?: Nullable<Camera>, useRedTextureType?: boolean) {
         this._mapSize = mapSize;
         this._light = light;
         this._scene = light.getScene();
         this._camera = camera ?? null;
+        this._useRedTextureType = !!useRedTextureType;
 
         let shadowGenerators = light._shadowGenerators;
         if (!shadowGenerators) {
@@ -922,7 +925,9 @@ export class ShadowGenerator implements IShadowGenerator {
                 this._light.needCube(),
                 undefined,
                 false,
-                false
+                false,
+                undefined,
+                this._useRedTextureType ? Constants.TEXTUREFORMAT_RED : Constants.TEXTUREFORMAT_RGBA
             );
             this._shadowMap.createDepthStencilTexture(engine.useReverseDepthBuffer ? Constants.GREATER : Constants.LESS, true);
         } else {


### PR DESCRIPTION
For CSM, this is now the default setting, as all engines that support CSM also support red textures only.

For the regular shadow generator, the default setting is to use an RGBA texture due to WebGL1 backward compatibility.