### PR TITLE
Bone IK controller: Make sure the absolute matrices are up to date

### DIFF
--- a/packages/dev/core/src/Bones/boneIKController.ts
+++ b/packages/dev/core/src/Bones/boneIKController.ts
@@ -136,6 +136,8 @@ export class BoneIKController {
 
         this.mesh = mesh;
 
+        bone.getSkeleton().computeAbsoluteMatrices();
+
         const bonePos = bone.getPosition();
 
         if (bone.getAbsoluteMatrix().determinant() > 0) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/boneikcontroller-demo-broken/43211

This bug appeared after my changes to the bone class because `BoneIKController` relied on a bug in the old `Bone` class, where the absolute transformation matrix had a value, but a wrong one - it contained the absolute bind matrix instead of the absolute matrix! To make sure we get up-to-date absolute matrices, we need to call `skeleton.computeAbsoluteMatrices()`.