### PR TITLE
GUI InputTextArea: Fix inserting character in long string (wrapped)

### DIFF
--- a/packages/dev/gui/src/2D/controls/inputTextArea.ts
+++ b/packages/dev/gui/src/2D/controls/inputTextArea.ts
@@ -545,7 +545,7 @@ export class InputTextArea extends InputText {
 
                 line.split("").map((char) => {
                     if (context.measureText(flushedLine + char).width > width) {
-                        lines.push({ text: flushedLine, width: context.measureText(flushedLine).width, lineEnding: "\n" });
+                        lines.push({ text: flushedLine, width: context.measureText(flushedLine).width, lineEnding: "" });
                         flushedLine = "";
                     }
                     flushedLine += char;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/incorrect-word-wrap-behavior-in-inputtextarea-component/43346