### PR TITLE
Fix initial audio engine unlock state

### DIFF
--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -57,7 +57,7 @@ export class AudioEngine implements IAudioEngine {
 
     /**
      * Gets whether audio has been unlocked on the device.
-     * Some Browsers have strong restrictions about Audio and won t autoplay unless
+     * Some Browsers have strong restrictions about Audio and won't autoplay unless
      * a user interaction has happened.
      */
     public unlocked: boolean = true;

--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -60,7 +60,7 @@ export class AudioEngine implements IAudioEngine {
      * Some Browsers have strong restrictions about Audio and won't autoplay unless
      * a user interaction has happened.
      */
-    public unlocked: boolean = true;
+    public unlocked: boolean = false;
 
     /**
      * Defines if the audio engine relies on a custom unlocked button.
@@ -84,10 +84,6 @@ export class AudioEngine implements IAudioEngine {
     public get audioContext(): Nullable<AudioContext> {
         if (!this._audioContextInitialized) {
             this._initializeAudioContext();
-        } else {
-            if (!this.unlocked && !this._muteButton) {
-                this._displayMuteButton();
-            }
         }
         return this._audioContext;
     }

--- a/packages/dev/core/test/unit/Audio/audioEngine.test.ts
+++ b/packages/dev/core/test/unit/Audio/audioEngine.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AudioEngine } from "core/Audio";
+import { Engine, NullEngine } from "core/Engines";
+import { Scene } from "core/scene";
+import { Sound } from "core/Audio/sound";
+
+import { MockedAudioObjects } from "./helpers/mockedAudioObjects";
+import { AudioTestSamples } from "./helpers/audioTestSamples";
+import { AudioTestHelper } from "./helpers/audioTestHelper";
+
+// Required for timers (eg. setTimeout) to work.
+jest.useFakeTimers();
+
+describe("AudioEngine", () => {
+    AudioTestSamples.Initialize();
+
+    let audioEngine: AudioEngine;
+    let engine: NullEngine;
+    let mock: MockedAudioObjects;
+    let scene: Scene;
+
+    beforeEach(() => {
+        mock = new MockedAudioObjects;
+        engine = new NullEngine;
+        scene = new Scene(engine);
+        audioEngine = Engine.audioEngine = new AudioEngine(null, new AudioContext, null);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        (scene as any) = null;
+
+        engine.dispose();
+        (engine as any) = null;
+        (audioEngine as any) = null;
+
+        mock.dispose();
+        (mock as any) = null;
+    });
+
+    it("unlocked is initialized to false when browser requires user interaction", () => {
+        mock.audioContext.state = "suspended";
+
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
+
+        expect(audioEngine.unlocked).toBe(false);
+    });
+
+    it("unlocked is initialized to true when browser does not require user interaction", () => {
+        mock.audioContext.state = "running";
+
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
+
+        return AudioTestHelper.WhenAudioContextResumes(() => {
+            expect(audioEngine.unlocked).toBe(true);
+        });
+    });
+
+    it("should not show mute button until a sound plays when browser requires user interaction", () => {
+        mock.audioContext.state = "suspended";
+        const arrayBuffer = AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz");
+        const sound = new Sound(expect.getState().currentTestName, arrayBuffer);
+
+        expect((audioEngine as any)._muteButton).toBe(null);
+
+        sound.play();
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
+
+        expect((audioEngine as any)._muteButton).not.toBe(null);
+    });
+
+    it("should not show mute button when sound plays and browser does not require user interaction", () => {
+        mock.audioContext.state = "running";
+        const arrayBuffer = AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz");
+        const sound = new Sound(expect.getState().currentTestName, arrayBuffer);
+
+        expect((audioEngine as any)._muteButton).toBe(null);
+
+        sound.play();
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
+
+        expect((audioEngine as any)._muteButton).toBe(null);
+    });
+});

--- a/packages/dev/core/test/unit/Audio/helpers/audioTestHelper.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/audioTestHelper.ts
@@ -1,0 +1,22 @@
+import { MockedAudioObjects } from "./mockedAudioObjects";
+
+export class AudioTestHelper {
+    static SoundWasStarted() {
+        // When a Sound object actually starts playing, it creates an audio buffer source. We use this here to know
+        // if a sound started playing or not.
+        return MockedAudioObjects.Instance.audioBufferSourceWasCreated;
+    }
+
+    /**
+     * Advance timers by 500ms to trigger the Sound class's timeout used for double-checking the audio context state.
+     *
+     * https://github.com/BabylonJS/Babylon.js/blob/7e6ad554/packages/dev/core/src/Audio/sound.ts#L888-L891
+     */
+    static WaitForAudioContextSuspendedDoubleCheck() {
+        jest.advanceTimersByTime(500);
+    };
+
+    static WhenAudioContextResumes(callback: () => void) {
+        return Promise.resolve().then(callback);
+    }
+}

--- a/packages/dev/core/test/unit/Audio/helpers/audioTestSamples.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/audioTestSamples.ts
@@ -1,0 +1,59 @@
+
+export class AudioTestSamples {
+    static Initialize() {
+        if (AudioTestSamples._Initialized) {
+            return;
+        }
+        AudioTestSamples.Add("silence, 1 second, 1 channel, 48000 kHz", 1, 48000, new Float32Array(48000));
+        AudioTestSamples._Initialized = true;
+    }
+
+    static Add(name: string, channelCount: number, sampleRate: number, channelData: Float32Array) {
+        const sample = new AudioSample(channelCount, sampleRate, channelData);
+        AudioTestSamples._Array.push(sample);
+        AudioTestSamples._Map.set(name, sample);
+    }
+
+    static Get(name: string): AudioSample {
+        return AudioTestSamples._Map.get(name)!;
+    }
+
+    static GetArrayBuffer(name: string): ArrayBuffer {
+        return AudioTestSamples._Map.get(name)!.arrayBuffer;
+    }
+
+    static GetAudioBuffer(arrayBuffer: ArrayBuffer): AudioBuffer {
+        const indexView = new Uint32Array(arrayBuffer);
+        const index = indexView[0];
+        return AudioTestSamples._Array[index].audioBuffer;
+    }
+
+    private static _Initialized = false;
+    private static _Array = new Array<AudioSample>();
+    private static _Map = new Map<string, AudioSample>();
+}
+
+class AudioSample {
+    constructor(channelCount: number, sampleRate: number, channelData: Float32Array) {
+        this.arrayBuffer = AudioSample._CreateArrayBuffer();
+        this.audioBuffer = {
+            channels: channelCount,
+            duration: (channelData.length / channelCount) / sampleRate,
+            length: channelData.length / channelCount,
+            sampleRate: sampleRate,
+            getChannelData: () => channelData
+        } as unknown as AudioBuffer;
+    }
+
+    arrayBuffer: ArrayBuffer;
+    audioBuffer: AudioBuffer;
+
+    private static _CurrentArrayBufferIndex = 0;
+
+    private static _CreateArrayBuffer = () => {
+        const arrayBuffer = new ArrayBuffer(4);
+        const arrayBufferView = new Uint32Array(arrayBuffer);
+        arrayBufferView[0] = AudioSample._CurrentArrayBufferIndex++;
+        return arrayBuffer;
+    }
+}

--- a/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
@@ -1,0 +1,170 @@
+
+import { Engine } from "core/Engines";
+
+import { AudioTestSamples } from "./audioTestSamples";
+
+class AudioParamMock {
+    public cancelScheduledValues = jest.fn().mockName("cancelScheduledValues");
+    public exponentialRampToValueAtTime = jest.fn().mockName("exponentialRampToValueAtTime");
+    public linearRampToValueAtTime = jest.fn().mockName("linearRampToValueAtTime");
+    public setTargetAtTime = jest.fn().mockName("setTargetAtTime");
+    public setValueAtTime = jest.fn().mockName("setValueAtTime");
+    public setValueCurveAtTime = jest.fn().mockName("setValueCurveAtTime");
+    public value = 0;
+}
+
+class AudioNodeMock {
+    public connect(destination: any) {
+        this._destination = destination;
+    }
+
+    public disconnect() {
+        this._destination = null;
+    }
+
+    public get destination() {
+        return this._destination;
+    }
+
+    private _destination: any = null;
+}
+
+class AudioBufferSourceNodeMock extends AudioNodeMock {
+    onended = () => void 0;
+
+    start = jest.fn().mockName("start").mockImplementation(() => {
+        this.startTime = MockedAudioObjects.Instance.audioContext.currentTime;
+    });
+
+    stop = jest.fn().mockName("stop").mockImplementation(() => {
+        this.onended();
+    });
+
+    buffer = {
+        duration: 0
+    };
+    loop = false;
+    loopEnd = 0;
+    loopStart = 0;
+    playbackRate = {
+        value: 1
+    };
+
+    startTime = 0
+}
+
+class GainNodeMock extends AudioNodeMock {
+    gain = new AudioParamMock;
+}
+
+class MediaElementAudioSourceNodeMock extends AudioNodeMock {
+}
+
+class PannerNodeMock extends AudioNodeMock {
+    positionX = new AudioParamMock;
+    positionY = new AudioParamMock;
+    positionZ = new AudioParamMock;
+    coneInnerAngle = new AudioParamMock;
+    coneOuterAngle = new AudioParamMock;
+    coneOuterGain = new AudioParamMock;
+
+    setOrientation = jest.fn().mockName("setOrientation");
+}
+
+export class MockedAudioObjects {
+    static Instance: MockedAudioObjects;
+
+    constructor() {
+        MockedAudioObjects.Instance = this;
+
+        document.body.appendChild = jest.fn().mockName("appendChild");
+        document.body.removeChild = jest.fn().mockName("removeChild");
+
+        global.Audio = jest.fn().mockName("Audio").mockImplementation(() => {
+            return {
+                addEventListener: jest.fn().mockName("addEventListener"),
+                controls: true,
+                crossOrigin: null,
+                loop: false,
+                load: jest.fn().mockName("load"),
+                pause: jest.fn().mockName("pause"),
+                preload: "none",
+            }
+        });
+        global.AudioBuffer = jest.fn().mockName("AudioBuffer");
+        global.MediaStream = jest.fn().mockName("MediaStream");
+
+        // AudioContext mock.
+        this._previousAudioContext = window.AudioContext;
+        window.AudioContext = jest.fn().mockName("AudioContext").mockImplementation(() => {
+            return {
+                currentTime: 0,
+                state: "running",
+                createBufferSource: jest.fn().mockName("createBufferSource").mockImplementation(() => {
+                    const bufferSource = new AudioBufferSourceNodeMock;
+                    this._audioBufferSources.push(bufferSource);
+                    return bufferSource;
+                }),
+                createGain: jest.fn().mockName("createGain").mockImplementation(() => {
+                    // Note that when creating a single Sound object, createGain() is called three times:
+                    // 1) from AudioEngine._initializeAudioContext() to create the master gain.
+                    // 2) from Sound constructor.
+                    // 3) from main SoundTrack._initializeSoundTrackAudioGraph().
+                    return new GainNodeMock;
+                }),
+                createMediaElementSource: jest.fn().mockName("createMediaElementSource").mockImplementation((mediaElement: HTMLMediaElement) => {
+                    // Streaming sounds need to be able to create a media element source node.
+                    return new MediaElementAudioSourceNodeMock;
+                }),
+                createPanner: jest.fn().mockName("createPanner").mockImplementation(() => {
+                    return new PannerNodeMock;
+                }),
+                decodeAudioData: jest.fn().mockName("decodeAudioData").mockImplementation((data: ArrayBuffer, success: (buffer: AudioBuffer) => void) => {
+                    success(AudioTestSamples.GetAudioBuffer(data));
+                }),
+                resume: jest.fn().mockName("resume").mockImplementation(() => {
+                    this.audioContext.state = "running";
+                    return Promise.resolve();
+                })
+            };
+        }) as any;
+    }
+
+    get audioBufferSource() {
+        return this._audioBufferSources[this._audioBufferSources.length - 1];
+    }
+
+    get audioBufferSourceWasCreated() {
+        return 0 < this._audioBufferSources.length;
+    }
+
+    get audioContext() {
+        // Return the audio context as `any` so its `state` property can be set.
+        return Engine.audioEngine!.audioContext! as any;
+    }
+
+    dispose() {
+        this._audioBufferSources.length = 0;
+        window.AudioContext = this._previousAudioContext;
+    }
+
+    incrementCurrentTime(seconds: number) {
+        this.audioContext.currentTime += seconds;
+        this._audioBufferSources.forEach(audioBufferSource => {
+            if (audioBufferSource.startTime + audioBufferSource.buffer.duration <= this.audioContext.currentTime) {
+                audioBufferSource.stop();
+            }
+        })
+    }
+
+    nodeIsGainNode(node: AudioNode) {
+        return node instanceof GainNodeMock;
+    }
+
+    nodeIsPannerNode(node: AudioNode) {
+        return node instanceof PannerNodeMock;
+    }
+
+    private _previousAudioContext: any;
+    private _audioBufferSources = new Array<AudioBufferSourceNodeMock>();
+}

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -5,188 +5,17 @@
 import { AudioEngine, Sound } from "core/Audio";
 import { Engine, NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
-import type { Nullable } from "core/types";
 
-class AudioSample {
-    public static Add(name: string, channelCount: number, sampleRate: number, channelData: Float32Array) {
-        const sample = new AudioSample(channelCount, sampleRate, channelData);
-        AudioSample._Array.push(sample);
-        AudioSample._Map.set(name, sample);
-    }
+import { AudioTestHelper } from "./helpers/audioTestHelper";
+import { AudioTestSamples } from "./helpers/audioTestSamples";
+import { MockedAudioObjects } from "./helpers/mockedAudioObjects";
 
-    public static Get(name: string): AudioSample {
-        return AudioSample._Map.get(name)!;
-    }
-
-    public static GetArrayBuffer(name: string): ArrayBuffer {
-        return AudioSample._Map.get(name)!.arrayBuffer;
-    }
-
-    public static GetAudioBuffer(arrayBuffer: ArrayBuffer): AudioBuffer {
-        const indexView = new Uint32Array(arrayBuffer);
-        const index = indexView[0];
-        return AudioSample._Array[index].audioBuffer;
-    }
-
-    public get arrayBuffer() {
-        return this._arrayBuffer;
-    }
-
-    public get audioBuffer() {
-        return this._audioBuffer;
-    }
-
-    private static _Array = new Array<AudioSample>();
-    private static _Map = new Map<string, AudioSample>();
-    private static _CurrentArrayBufferIndex = 0;
-
-    private static _CreateArrayBuffer = () => {
-        const arrayBuffer = new ArrayBuffer(4);
-        const arrayBufferView = new Uint32Array(arrayBuffer);
-        arrayBufferView[0] = AudioSample._CurrentArrayBufferIndex++;
-        return arrayBuffer;
-    }
-
-    private constructor(channelCount: number, sampleRate: number, channelData: Float32Array) {
-        this._arrayBuffer = AudioSample._CreateArrayBuffer();
-        this._audioBuffer = {
-            channels: channelCount,
-            duration: (channelData.length / channelCount) / sampleRate,
-            length: channelData.length / channelCount,
-            sampleRate: sampleRate,
-            getChannelData: () => channelData
-        } as unknown as AudioBuffer;
-    }
-
-    private _arrayBuffer: ArrayBuffer;
-    private _audioBuffer: AudioBuffer;
-}
-
-AudioSample.Add("silence, 1 second, 1 channel, 48000 kHz", 1, 48000, new Float32Array(48000));
-
-class AudioParamMock {
-    public cancelScheduledValues = jest.fn().mockName("cancelScheduledValues");
-    public exponentialRampToValueAtTime = jest.fn().mockName("exponentialRampToValueAtTime");
-    public linearRampToValueAtTime = jest.fn().mockName("linearRampToValueAtTime");
-    public setTargetAtTime = jest.fn().mockName("setTargetAtTime");
-    public setValueAtTime = jest.fn().mockName("setValueAtTime");
-    public setValueCurveAtTime = jest.fn().mockName("setValueCurveAtTime");
-    public value = 0;
-}
-
-class AudioNodeMock {
-    public connect(destination: any) {
-        this._destination = destination;
-    }
-
-    public disconnect() {
-        this._destination = null;
-    }
-
-    public get destination() {
-        return this._destination;
-    }
-
-    private _destination: any = null;
-}
-
-class AudioBufferSourceNodeMock extends AudioNodeMock {
-    onended = () => void 0;
-
-    start = jest.fn().mockName("start").mockImplementation(() => {
-        mockedBufferSource.startTime = mockedAudioContext.currentTime;
-    });
-
-    stop = jest.fn().mockName("stop").mockImplementation(() => {
-        mockedBufferSource?.onended();
-    });
-
-    buffer = {};
-    loop = false;
-    loopEnd = 0;
-    loopStart = 0;
-    playbackRate = {
-        value: 1
-    };
-
-    startTime = 0
-}
-
-class GainNodeMock extends AudioNodeMock {
-    gain = new AudioParamMock;
-}
-
-class PannerNodeMock extends AudioNodeMock {
-    positionX = new AudioParamMock;
-    positionY = new AudioParamMock;
-    positionZ = new AudioParamMock;
-    coneInnerAngle = new AudioParamMock;
-    coneOuterAngle = new AudioParamMock;
-    coneOuterGain = new AudioParamMock;
-
-    setOrientation = jest.fn().mockName("setOrientation");
-}
-
-let mockedAudioContext: any = null;
-let mockedBufferSource: any = null;
-
-const incrementCurrentTime = (seconds: number) => {
-    mockedAudioContext.currentTime += seconds;
-    if (mockedBufferSource.startTime + mockedBufferSource.buffer.duration <= mockedAudioContext.currentTime) {
-        mockedBufferSource.stop();
-    }
-}
-
-global.AudioBuffer = jest.fn().mockName("AudioBuffer");
-global.MediaStream = jest.fn().mockName("MediaStream");
-
-window.AudioContext = jest.fn().mockName("AudioContext").mockImplementation(() => {
-    mockedAudioContext = {
-        currentTime: 0,
-        state: "running",
-        createBufferSource: jest.fn().mockName("createBufferSource").mockImplementation(() => {
-            mockedBufferSource = new AudioBufferSourceNodeMock;
-            return mockedBufferSource;
-        }),
-        createGain: jest.fn().mockName("createGain").mockImplementation(() => {
-            // When creating a single Sound object, createGain() is called three times:
-            // 1) from AudioEngine._initializeAudioContext() to create the master gain.
-            // 2) from Sound constructor.
-            // 3) from main SoundTrack._initializeSoundTrackAudioGraph().
-            return new GainNodeMock;
-        }),
-        createPanner: jest.fn().mockName("createPanner").mockImplementation(() => {
-            return new PannerNodeMock;
-        }),
-        decodeAudioData: jest.fn().mockName("decodeAudioData").mockImplementation((data: ArrayBuffer, success: (buffer: AudioBuffer) => void) => {
-            success(AudioSample.GetAudioBuffer(data));
-        }),
-        resume: jest.fn().mockName("resume").mockImplementation(() => {
-            mockedAudioContext.state = "running";
-            return Promise.resolve();
-        })
-    };
-    return mockedAudioContext;
-}) as any;
-
-const waitForAudioContextSuspendedDoubleCheck = () => {
-    jest.advanceTimersByTime(500);
-};
-
-const soundWasStarted = () => {
-    return mockedBufferSource !== null;
-};
-
-const whenAudioContextResumes = (callback: () => void) => {
-    return Promise.resolve().then(callback);
-};
-
-// Required for timers (eg. setTimeout) to work
+// Required for timers (eg. setTimeout) to work.
 jest.useFakeTimers();
 
 describe("Sound with no scene", () => {
     it("constructor does not set scene if no scene is given", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound._scene).toBeUndefined();
@@ -194,31 +23,41 @@ describe("Sound with no scene", () => {
 });
 
 describe("Sound", () => {
-    let engine: Nullable<NullEngine> = null;
-    let scene: Nullable<Scene> = null;
+    AudioTestSamples.Initialize();
+
+    let audioEngine: AudioEngine;
+    let engine: NullEngine;
+    let mock: MockedAudioObjects;
+    let scene: Scene;
 
     beforeEach(() => {
+        mock = new MockedAudioObjects;
         engine = new NullEngine;
         scene = new Scene(engine);
-        Engine.audioEngine = new AudioEngine(null, new AudioContext, null);
+        audioEngine = Engine.audioEngine = new AudioEngine(null, new AudioContext, null);
     });
 
     afterEach(() => {
-        mockedAudioContext = null;
-        mockedBufferSource = null;
-        scene?.dispose();
-        engine?.dispose();
+        scene.dispose();
+        (scene as any) = null;
+
+        engine.dispose();
+        (engine as any) = null;
+        (audioEngine as any) = null;
+
+        mock.dispose();
+        (mock as any) = null;
     });
 
     it("constructor initializes AudioSceneComponent", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
 
         expect(scene!._getComponent("Audio")).not.toBeNull();
     });
 
     it("constructor sets given readyToPlayCallback", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const readyToPlayCallback = jest.fn();
         new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, scene, readyToPlayCallback);
 
@@ -226,7 +65,7 @@ describe("Sound", () => {
     });
 
     it("constructor sets up a linear custom attenuation function by default", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound._customAttenuationFunction(1, 0, 100, 0, 0)).toBeCloseTo(1);
@@ -243,7 +82,7 @@ describe("Sound", () => {
     });
 
     it("constructor sets state correctly when given no options", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer) as any;
 
         expect(sound.autoplay).toBe(false);
@@ -264,14 +103,14 @@ describe("Sound", () => {
         expect(sound.useCustomAttenuation).toBe(false);
         expect(sound.getAudioBuffer()).toBe(audioSample.audioBuffer);
         expect(sound.getPlaybackRate()).toBe(1);
-        expect(sound.getSoundGain()).toBe(mockedAudioContext.createGain.mock.results[1].value);
+        expect(sound.getSoundGain()).toBe(mock.audioContext.createGain.mock.results[1].value);
         expect(sound.getVolume()).toBe(1);
 
         expect(sound._scene).toBe(scene);
     });
 
     it("constructor sets boolean options correctly when given false", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, {
             autoplay: false,
             loop: false,
@@ -288,10 +127,10 @@ describe("Sound", () => {
     });
 
     it("constructor sets boolean options correctly when given true", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
-        const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, {
+        const sound = new Sound(expect.getState().currentTestName, "https://example.com/any.mp3", null, null, {
             autoplay: true,
             loop: true,
+            skipCodecCheck: true,
             spatialSound: true,
             streaming: true,
             useCustomAttenuation: true
@@ -305,7 +144,7 @@ describe("Sound", () => {
     });
 
     it("constructor sets number options correctly", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, {
             length: 1,
             maxDistance: 2,
@@ -326,7 +165,7 @@ describe("Sound", () => {
     });
 
     it("constructor sets string options correctly", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound1 = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, { distanceModel: "linear" });
         const sound2 = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, { distanceModel: "inverse" });
         const sound3 = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, { distanceModel: "exponential" });
@@ -337,7 +176,7 @@ describe("Sound", () => {
     });
 
     it("constructor does codec check when no options are given", () => {
-        expect(Engine.audioEngine?.isMP3supported).toBe(false);
+        expect(audioEngine.isMP3supported).toBe(false);
         scene!._loadFile = jest.fn().mockName("scene._loadFile");
 
         new Sound(expect.getState().currentTestName, "test.mp3");
@@ -346,7 +185,7 @@ describe("Sound", () => {
     });
 
     it("constructor does codec check when skipCodecCheck option is false", () => {
-        expect(Engine.audioEngine?.isMP3supported).toBe(false);
+        expect(audioEngine.isMP3supported).toBe(false);
         scene!._loadFile = jest.fn().mockName("scene._loadFile");
 
         new Sound(expect.getState().currentTestName, "test.mp3", null, null, { skipCodecCheck: false });
@@ -355,7 +194,7 @@ describe("Sound", () => {
     });
 
     it("constructor skips codec check when skipCodecCheck option is true", () => {
-        expect(Engine.audioEngine?.isMP3supported).toBe(false);
+        expect(audioEngine.isMP3supported).toBe(false);
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -455,7 +294,7 @@ describe("Sound", () => {
         expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.ogg");
     });
 
-    it("constructor first supported file", () => {
+    it("constructor loads first supported file", () => {
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -465,7 +304,7 @@ describe("Sound", () => {
         expect(sceneLoadFileMock.mock.calls[0][0]).toBe("test.wav");
     });
 
-    it("constructor loads only the first supported file when given multiple supported files", () => {
+    it("constructor loads only first supported file when given multiple supported files", () => {
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -476,126 +315,126 @@ describe("Sound", () => {
     });
 
     it("sets isPlaying to true when play is called", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"));
-        
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"));
+
         sound.play();
-        
+
         expect(sound.isPlaying).toBe(true);
     });
 
     it("updates currentTime when play is called and audio context time advances", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"));
-        mockedAudioContext.currentTime = 0.1
-        
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"));
+        mock.audioContext.currentTime = 0.1
+
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
 
         expect(sound.currentTime).toBeCloseTo(0.2);
     });
 
     it("starts the buffer source at the constructor's given offset when play is called", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const options = {
             offset: 0.1
         };
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, options);
-        
+
         sound.play();
-        
-        expect(mockedBufferSource.start).toBeCalledWith(0, 0.1, undefined);
+
+        expect(mock.audioBufferSource.start).toBeCalledWith(0, 0.1, undefined);
     });
 
     it("resumes the buffer source node at the time it was paused at after playing from the constructor's given offset", () => {
         const pausedAtTime = 0.2;
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const options = {
             offset: 0.1
         };
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, options);
-        mockedAudioContext.currentTime = 0.1;
+        mock.audioContext.currentTime = 0.1;
 
         sound.play();
-        mockedAudioContext.currentTime += pausedAtTime;
+        mock.audioContext.currentTime += pausedAtTime;
         sound.pause();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.play();
 
-        const args = mockedBufferSource.start.mock.calls[0];
+        const args = mock.audioBufferSource.start.mock.calls[0];
         expect(args[1]).toBeCloseTo(options.offset + pausedAtTime);
     });
 
     it("restarts the buffer source at the given positive offset when play, stop, play, pause, and play are called", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1;
+        mock.audioContext.currentTime = 0.1;
 
         sound.play();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.stop();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.play(0.9);
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.pause();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.play(0, 0.9);
 
-        expect(mockedBufferSource.start).toBeCalledWith(mockedAudioContext.currentTime, 0.9, undefined);
+        expect(mock.audioBufferSource.start).toBeCalledWith(mock.audioContext.currentTime, 0.9, undefined);
     });
 
     it("restarts the buffer source at the given zero offset when play, stop, play, pause, and play are called", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1;
+        mock.audioContext.currentTime = 0.1;
 
         sound.play();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.stop();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.play(0.9);
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.pause();
-        incrementCurrentTime(0.1);
+        mock.incrementCurrentTime(0.1);
         sound.play(0, 0);
 
-        expect(mockedBufferSource.start).toBeCalledWith(mockedAudioContext.currentTime, 0, undefined);
+        expect(mock.audioBufferSource.start).toBeCalledWith(mock.audioContext.currentTime, 0, undefined);
     });
 
     it("restarts the buffer source at the given offset when play, pause, updateOptions, and play are called", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const options = {
             offset: 0.1
         };
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer, null, null, options);
-        mockedAudioContext.currentTime = 0.1
-        
+        mock.audioContext.currentTime = 0.1
+
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.pause();
         sound.updateOptions({ offset: 0.4 });
         sound.play();
-        
-        expect(mockedBufferSource.start).toBeCalledWith(mockedAudioContext.currentTime, 0.4, undefined);
+
+        expect(mock.audioBufferSource.start).toBeCalledWith(mock.audioContext.currentTime, 0.4, undefined);
     });
 
     it("resets current time to zero when stopped while playing", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
 
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.stop();
 
         expect(sound.currentTime).toBe(0);
     });
 
     it("resets current time to zero when stopped while paused", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
 
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.pause();
         sound.stop();
 
@@ -603,53 +442,53 @@ describe("Sound", () => {
     });
 
     it("sets current time to time it was paused at", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
 
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.pause();
 
         expect(sound.currentTime).toBeCloseTo(0.2);
     });
 
     it("calls onended when stopped", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
         const onended = jest.fn().mockName("onended");
         sound.onended = onended;
 
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.stop();
 
         expect(onended.mock.calls.length).toBe(1);
     });
 
     it("calls onended when sound buffer reaches end", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
         const onended = jest.fn().mockName("onended");
         sound.onended = onended;
 
         sound.play();
-        incrementCurrentTime(1);
+        mock.incrementCurrentTime(1);
 
         expect(onended.mock.calls.length).toBe(1);
     });
 
     it("does not call onended when paused", () => {
-        const audioSample = AudioSample.Get("silence, 1 second, 1 channel, 48000 kHz");
+        const audioSample = AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz");
         const sound = new Sound(expect.getState().currentTestName, audioSample.arrayBuffer);
-        mockedAudioContext.currentTime = 0.1
+        mock.audioContext.currentTime = 0.1
         const onended = jest.fn().mockName("onended");
         sound.onended = onended;
 
         sound.play();
-        incrementCurrentTime(0.2);
+        mock.incrementCurrentTime(0.2);
         sound.pause();
 
         expect(onended.mock.calls.length).toBe(0);
@@ -658,15 +497,15 @@ describe("Sound", () => {
     // For historical reasons, a sound's `isPlaying` property is set to `true` when it is constructed with the autoplay
     // option set, even if the audio context state is suspended.
     it("sets isPlaying to true when constructed with autoplay option set while audio context is suspended", () => {
-        mockedAudioContext.state = "suspended";
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
+        mock.audioContext.state = "suspended";
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
 
         expect(sound.isPlaying).toBe(true);
     });
 
     it("sets isPlaying to false when stopped while audio context is suspended", () => {
-        mockedAudioContext.state = "suspended";
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
+        mock.audioContext.state = "suspended";
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
 
         sound.stop();
 
@@ -674,102 +513,102 @@ describe("Sound", () => {
     });
 
     it("does not autoplay after 500 ms when stopped before audio context is resumed", () => {
-        mockedAudioContext.state = "suspended";
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
+        mock.audioContext.state = "suspended";
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
 
         sound.stop();
-        mockedAudioContext.state = "running";
+        mock.audioContext.state = "running";
         jest.advanceTimersByTime(500);
 
-        expect(soundWasStarted()).toBe(false);
+        expect(AudioTestHelper.SoundWasStarted()).toBe(false);
     });
 
     it("does not autoplay when stopped before audio engine is unlocked", () => {
-        mockedAudioContext.state = "suspended";
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
-        
-        waitForAudioContextSuspendedDoubleCheck();
+        mock.audioContext.state = "suspended";
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
+
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
         sound.stop();
         Engine.audioEngine!.unlock();
 
-        return whenAudioContextResumes(() => {
-            expect(soundWasStarted()).toBe(false);
+        return AudioTestHelper.WhenAudioContextResumes(() => {
+            expect(AudioTestHelper.SoundWasStarted()).toBe(false);
         });
     });
 
     it("does not autoplay when played and stopped before audio engine is unlocked", () => {
-        mockedAudioContext.state = "suspended";
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
-    
+        mock.audioContext.state = "suspended";
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { autoplay: true });
+
         sound.play();
-        waitForAudioContextSuspendedDoubleCheck();
+        AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
         sound.stop();
         Engine.audioEngine!.unlock();
 
-        return whenAudioContextResumes(() => {
-            expect(soundWasStarted()).toBe(false);
+        return AudioTestHelper.WhenAudioContextResumes(() => {
+            expect(AudioTestHelper.SoundWasStarted()).toBe(false);
         });
     });
 
     it("connects to gain node when not spatialized via constructor", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
+        expect(mock.nodeIsGainNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to panner node when spatialized via constructor", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
+        expect(mock.nodeIsPannerNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to panner node when spatialized via property", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
         sound.spatialSound = true;
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
+        expect(mock.nodeIsPannerNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to panner node when spatialized via updateOptions", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: false });
         sound.updateOptions({ spatialSound: true });
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
+        expect(mock.nodeIsPannerNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to gain node when unspatialized via property", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
         sound.spatialSound = false;
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
+        expect(mock.nodeIsGainNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to gain node when unspatialized via updateOptions", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
         sound.updateOptions({ spatialSound: false });
 
         sound.play();
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(GainNodeMock);
+        expect(mock.nodeIsGainNode(mock.audioBufferSource.destination)).toBe(true);
     });
 
     it("connects to panner node when playing and spatialSound property is set to false before being set to true", () => {
-        const sound = new Sound(expect.getState().currentTestName, AudioSample.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
-        
+        const sound = new Sound(expect.getState().currentTestName, AudioTestSamples.GetArrayBuffer("silence, 1 second, 1 channel, 48000 kHz"), null, null, { spatialSound: true });
+
         sound.play();
         sound.spatialSound = false;
         sound.spatialSound = true;
 
-        expect(mockedBufferSource.destination).toBeInstanceOf(PannerNodeMock);
+        expect(mock.nodeIsPannerNode(mock.audioBufferSource.destination)).toBe(true);
     });
 });


### PR DESCRIPTION
Changes the audio engine's initial `unlock` value to `false` so it is correct if the browser prevents audio before a user interaction.

Reported on forum: https://forum.babylonjs.com/t/remove-unmute-button/27577/30

Tested on Windows Edge, Chrome, and Firefox, macOS Safari, and iOS Safari.