### PR TITLE
Fix mute button getting stuck on iOS

### DIFF
--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -163,8 +163,7 @@ export class AudioEngine implements IAudioEngine {
                 this._tryToRun = false;
                 this._triggerRunningState();
             });
-        }
-        else {
+        } else {
             this._triggerRunningState();
         }
     }

--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -150,7 +150,23 @@ export class AudioEngine implements IAudioEngine {
      * This is helpful to resume play once browser policies have been satisfied.
      */
     public unlock() {
-        this._triggerRunningState();
+        if (this._audioContext?.state === "running") {
+            this._hideMuteButton();
+            return;
+        }
+
+        // On iOS, if the audio context resume request was sent from an event other than a `click` event, then
+        // the resume promise will never resolve and the only way to get the audio context unstuck is to
+        // suspend it and make another resume request.
+        if (this._tryToRun) {
+            this._audioContext?.suspend().then(() => {
+                this._tryToRun = false;
+                this._triggerRunningState();
+            });
+        }
+        else {
+            this._triggerRunningState();
+        }
     }
 
     private _resumeAudioContext(): Promise<void> {
@@ -251,7 +267,7 @@ export class AudioEngine implements IAudioEngine {
         this._muteButton.addEventListener(
             "click",
             () => {
-                this._triggerRunningState();
+                this.unlock();
             },
             true
         );

--- a/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
@@ -125,6 +125,10 @@ export class MockedAudioObjects {
                 resume: jest.fn().mockName("resume").mockImplementation(() => {
                     this.audioContext.state = "running";
                     return Promise.resolve();
+                }),
+                suspend: jest.fn().mockName("suspend").mockImplementation(() => {
+                    this.audioContext.state = "suspended";
+                    return Promise.resolve();
                 })
             };
         }) as any;


### PR DESCRIPTION
On iOS, if `AudioEngine.unlock()` is called from any other event handler than a `click` event handler, then the promise returned by `audioContext.resume` never resolves and the audio engine `_tryToRun` flag never gets set back to `false`. This causes all subsequent calls to `AudioEngine._triggerRunningState()` to early out making it impossible to resume the audio context again.

This change fixes the issue by checking the `_tryToRun` flag. If it is `true` then the audio context is suspended and the `_tryToRun` flag is reset to `false` before attempting to resume the audio context.

Reported on forum: https://forum.babylonjs.com/t/unmute-icon-remove/257/25

Tested on iOS using playground https://playground.babylonjs.com/#35VF39#3