### PR TITLE
Bones: Fix wrong world matrix for meshes attached to bone

### DIFF
--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -48,6 +48,7 @@ export class Skeleton implements IAnimatable {
     private _animatables: IAnimatable[];
     private _identity = Matrix.Identity();
     private _synchronizedWithMesh: AbstractMesh;
+    private _currentRenderId = -1;
 
     private _ranges: { [name: string]: Nullable<AnimationRange> } = {};
 
@@ -503,7 +504,15 @@ export class Skeleton implements IAnimatable {
     /**
      * Build all resources required to render a skeleton
      */
-    public prepare(): void {
+    public prepare(dontCheckFrameId = false): void {
+        if (!dontCheckFrameId) {
+            const currentRenderId = this.getScene().getRenderId();
+            if (this._currentRenderId === currentRenderId) {
+                return;
+            }
+            this._currentRenderId = currentRenderId;
+        }
+
         // Update the local matrix of bones with linked transform nodes.
         if (this._numBonesWithLinkedTransformNode > 0) {
             for (const bone of this.bones) {
@@ -669,7 +678,7 @@ export class Skeleton implements IAnimatable {
 
         this._isDirty = true;
 
-        result.prepare();
+        result.prepare(true);
 
         return result;
     }

--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -503,6 +503,7 @@ export class Skeleton implements IAnimatable {
 
     /**
      * Build all resources required to render a skeleton
+     * @param dontCheckFrameId defines a boolean indicating if prepare should be run without checking first the current frame id (default: false)
      */
     public prepare(dontCheckFrameId = false): void {
         if (!dontCheckFrameId) {

--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -850,7 +850,7 @@ export class TransformNode extends Node {
         this._transformToBoneReferal = affectedTransformNode;
         this.parent = bone;
 
-        bone.getSkeleton().prepare(); // make sure bone.getFinalMatrix() is up to date
+        bone.getSkeleton().prepare(true); // make sure bone.getFinalMatrix() is up to date
 
         if (bone.getFinalMatrix().determinant() < 0) {
             this.scalingDeterminant *= -1;
@@ -1128,7 +1128,9 @@ export class TransformNode extends Node {
             }
             if (cache.useBillboardPath) {
                 if (this._transformToBoneReferal) {
-                    parent.getWorldMatrix().multiplyToRef(this._transformToBoneReferal.getWorldMatrix(), TmpVectors.Matrix[7]);
+                    const bone = this.parent as Bone;
+                    bone.getSkeleton().prepare();
+                    bone.getFinalMatrix().multiplyToRef(this._transformToBoneReferal.getWorldMatrix(), TmpVectors.Matrix[7]);
                 } else {
                     TmpVectors.Matrix[7].copyFrom(parent.getWorldMatrix());
                 }
@@ -1150,7 +1152,9 @@ export class TransformNode extends Node {
                 this._localMatrix.multiplyToRef(TmpVectors.Matrix[7], this._worldMatrix);
             } else {
                 if (this._transformToBoneReferal) {
-                    this._localMatrix.multiplyToRef(parent.getWorldMatrix(), TmpVectors.Matrix[6]);
+                    const bone = this.parent as Bone;
+                    bone.getSkeleton().prepare();
+                    this._localMatrix.multiplyToRef(bone.getFinalMatrix(), TmpVectors.Matrix[6]);
                     TmpVectors.Matrix[6].multiplyToRef(this._transformToBoneReferal.getWorldMatrix(), this._worldMatrix);
                 } else {
                     this._localMatrix.multiplyToRef(parent.getWorldMatrix(), this._worldMatrix);


### PR DESCRIPTION
Let's say mesh M1 is attached to bone B, and bone B is part of a skeleton used by mesh M2.

If M1 comes before M2 in `scene.meshes`, then M1 will use a world matrix from B that is lagging one frame behind compared to M2, because it's when M2 is processed that the world matrices of the bones are being recomputed (in `Skeleton.prepare`).

Repro: https://playground.babylonjs.com/#317BIH#37

If you click on "Slash 01", the sword is moved and a screenshot of the next frame is taken and displayed in the bottom right corner. You will see that the particle system (attached to the sword) is displayed at the previous location of the sword.