### PR TITLE
Particle Systems: Fix the pivot position for rotations

### DIFF
--- a/packages/dev/core/src/Shaders/gpuRenderParticles.vertex.fx
+++ b/packages/dev/core/src/Shaders/gpuRenderParticles.vertex.fx
@@ -110,7 +110,7 @@ void main() {
 	vColor = color * vec4(1.0 - ratio) + colorDead * vec4(ratio);
 #endif
 
-  vec2 cornerPos = (offset - translationPivot) * size.yz * size.x + translationPivot;
+  vec2 cornerPos = (offset - translationPivot) * size.yz * size.x;
 
 #ifdef BILLBOARD
 	vec4 rotatedCorner;
@@ -120,6 +120,7 @@ void main() {
 		rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 		rotatedCorner.z = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 		rotatedCorner.y = 0.;
+        rotatedCorner.xz += translationPivot;
 
 		vec3 yaxis = (position + worldOffset) - eyePosition;
 		yaxis.y = 0.;
@@ -130,6 +131,7 @@ void main() {
 		rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 		rotatedCorner.y = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 		rotatedCorner.z = 0.;
+        rotatedCorner.xy += translationPivot;
 
 		vec3 toCamera = (position + worldOffset) - eyePosition;
 		vPositionW = rotateAlign(toCamera, rotatedCorner.xyz);
@@ -140,6 +142,7 @@ void main() {
 		rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 		rotatedCorner.y = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 		rotatedCorner.z = 0.;
+        rotatedCorner.xy += translationPivot;
 
 		// Expand position
 		#ifdef LOCAL
@@ -157,6 +160,7 @@ void main() {
 	rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 	rotatedCorner.y = 0.;
 	rotatedCorner.z = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
+    rotatedCorner.xz += translationPivot;
 
 	vec3 yaxis = normalize(initialDirection);
 	vPositionW = rotate(yaxis, rotatedCorner);

--- a/packages/dev/core/src/Shaders/particles.vertex.fx
+++ b/packages/dev/core/src/Shaders/particles.vertex.fx
@@ -90,7 +90,7 @@ void main(void) {
 
 	vec2 cornerPos;
 
-	cornerPos = (vec2(offset.x - 0.5, offset.y  - 0.5) - translationPivot) * size + translationPivot;
+	cornerPos = (vec2(offset.x - 0.5, offset.y  - 0.5) - translationPivot) * size;
 
 #ifdef BILLBOARD
 	// Rotate
@@ -100,6 +100,7 @@ void main(void) {
 	rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 	rotatedCorner.z = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 	rotatedCorner.y = 0.;
+    rotatedCorner.xz += translationPivot;
 
 	vec3 yaxis = position - eyePosition;
 	yaxis.y = 0.;
@@ -111,6 +112,7 @@ void main(void) {
 	rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 	rotatedCorner.y = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 	rotatedCorner.z = 0.;
+    rotatedCorner.xy += translationPivot;
 
 	vec3 toCamera = position - eyePosition;
 	vPositionW = rotateAlign(toCamera, rotatedCorner);
@@ -120,6 +122,7 @@ void main(void) {
 	rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 	rotatedCorner.y = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 	rotatedCorner.z = 0.;
+    rotatedCorner.xy += translationPivot;
 
 	vec3 viewPos = (view * vec4(position, 1.0)).xyz + rotatedCorner;
 
@@ -138,6 +141,7 @@ void main(void) {
 	rotatedCorner.x = cornerPos.x * cos(angle) - cornerPos.y * sin(angle);
 	rotatedCorner.z = cornerPos.x * sin(angle) + cornerPos.y * cos(angle);
 	rotatedCorner.y = 0.;
+    rotatedCorner.xz += translationPivot;
 
 	vec3 yaxis = normalize(direction);
 	vPositionW = rotate(yaxis, rotatedCorner);


### PR DESCRIPTION
The fix applies the rotation before the pivot is added back, whereas the current code add the pivot back before applying the rotation.

Test PG: https://playground.babylonjs.com/#0K3AQ2#2628