### PR TITLE
WebDeviceInputSystem: Added workaround for MacOS Chromium based Browsers

### DIFF
--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -51,6 +51,8 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
     private _pointerWheelEvent = (evt: any) => {};
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private _pointerBlurEvent = (evt: any) => {};
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    private _pointerMacOSChromeOutEvent = (evt: any) => {};
     private _wheelEventName: string;
     private _eventsAttached: boolean = false;
 
@@ -70,6 +72,13 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
     private _eventPrefix: string;
 
+    /**
+     * Constructor for the WebDeviceInputSystem
+     * @param engine Engine to reference
+     * @param onDeviceConnected Callback to execute when device is connected
+     * @param onDeviceDisconnected Callback to execute when device is disconnected
+     * @param onInputChanged Callback to execute when input changes on device
+     */
     constructor(
         engine: Engine,
         onDeviceConnected: (deviceType: DeviceType, deviceSlot: number) => void,
@@ -765,11 +774,19 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             }
         };
 
+        // Workaround for MacOS Chromium Browsers for lost pointer capture bug
+        this._pointerMacOSChromeOutEvent = (evt) => {
+            if (this._usingMacOS && !this._usingSafari && evt.buttons > 1) {
+                this._pointerCancelEvent(evt);
+            }
+        };
+
         this._elementToAttachTo.addEventListener(this._eventPrefix + "move", this._pointerMoveEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "down", this._pointerDownEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "up", this._pointerUpEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
         this._elementToAttachTo.addEventListener("blur", this._pointerBlurEvent);
+        this._elementToAttachTo.addEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
         this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: false } : false);
 
         // Since there's no up or down event for mouse wheel or delta x/y, clear mouse values at end of frame

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -58,6 +58,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
     private _mouseId = -1;
     private readonly _isUsingFirefox = IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Firefox") !== -1;
+    private readonly _isUsingChromium = IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Chrome") !== -1;
 
     // Array to store active Pointer ID values; prevents issues with negative pointerIds
     private _activeTouchIds: Array<number>;
@@ -777,7 +778,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
         // Workaround for MacOS Chromium Browsers for lost pointer capture bug
         this._pointerMacOSChromeOutEvent = (evt) => {
-            if (this._usingMacOS && !this._usingSafari && evt.buttons > 1) {
+            if (this._usingMacOS && this._isUsingChromium  && evt.buttons > 1) {
                 this._pointerCancelEvent(evt);
             }
         };

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -223,7 +223,9 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             this._elementToAttachTo.removeEventListener(this._eventPrefix + "up", this._pointerUpEvent);
             this._elementToAttachTo.removeEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
             this._elementToAttachTo.removeEventListener(this._wheelEventName, this._pointerWheelEvent);
-            this._elementToAttachTo.removeEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
+            if (this._usingMacOS && this._isUsingChromium) {
+                this._elementToAttachTo.removeEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
+            }
 
             // Gamepad Events
             window.removeEventListener("gamepadconnected", this._gamepadConnectedEvent);
@@ -777,18 +779,20 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         };
 
         // Workaround for MacOS Chromium Browsers for lost pointer capture bug
-        this._pointerMacOSChromeOutEvent = (evt) => {
-            if (this._usingMacOS && this._isUsingChromium  && evt.buttons > 1) {
-                this._pointerCancelEvent(evt);
-            }
-        };
+        if (this._usingMacOS && this._isUsingChromium) {
+            this._pointerMacOSChromeOutEvent = (evt) => {
+                if (evt.buttons > 1) {
+                    this._pointerCancelEvent(evt);
+                }
+            };
+            this._elementToAttachTo.addEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
+        }
 
         this._elementToAttachTo.addEventListener(this._eventPrefix + "move", this._pointerMoveEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "down", this._pointerDownEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "up", this._pointerUpEvent);
         this._elementToAttachTo.addEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
         this._elementToAttachTo.addEventListener("blur", this._pointerBlurEvent);
-        this._elementToAttachTo.addEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
         this._elementToAttachTo.addEventListener(this._wheelEventName, this._pointerWheelEvent, passiveSupported ? { passive: false } : false);
 
         // Since there's no up or down event for mouse wheel or delta x/y, clear mouse values at end of frame

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -222,6 +222,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             this._elementToAttachTo.removeEventListener(this._eventPrefix + "up", this._pointerUpEvent);
             this._elementToAttachTo.removeEventListener(this._eventPrefix + "cancel", this._pointerCancelEvent);
             this._elementToAttachTo.removeEventListener(this._wheelEventName, this._pointerWheelEvent);
+            this._elementToAttachTo.removeEventListener("lostpointercapture", this._pointerMacOSChromeOutEvent);
 
             // Gamepad Events
             window.removeEventListener("gamepadconnected", this._gamepadConnectedEvent);


### PR DESCRIPTION
There was an issue found with Chromium based browsers on MacOS where if the cursor left the browser window after clicking on the canvas with a mouse button other than left click, pointer capture will be lost and the canvas will still think that there's a button down.  Because this is a Chromium issue, the only thing that we can do is to create a workaround until it's fixed.  This workaround will catch the `lostpointercapture` event generated and release the button, if necessary.