### PR TITLE
Ability to not antialias GridMaterial

### DIFF
--- a/packages/dev/materials/src/grid/gridMaterial.ts
+++ b/packages/dev/materials/src/grid/gridMaterial.ts
@@ -20,6 +20,7 @@ import "./grid.vertex";
 
 class GridMaterialDefines extends MaterialDefines {
     public OPACITY = false;
+    public ANTIALIAS = false;
     public TRANSPARENT = false;
     public FOG = false;
     public PREMULTIPLYALPHA = false;
@@ -83,6 +84,12 @@ export class GridMaterial extends PushMaterial {
      */
     @serialize()
     public opacity = 1.0;
+
+    /**
+     * Whether to antialias the grid
+     */
+    @serialize()
+    public antialias = true;
 
     /**
      * Determine RBG output is premultiplied by alpha value.
@@ -153,6 +160,11 @@ export class GridMaterial extends PushMaterial {
 
         if (defines.MAX_LINE !== this.useMaxLine) {
             defines.MAX_LINE = !defines.MAX_LINE;
+            defines.markAsUnprocessed();
+        }
+
+        if (defines.ANTIALIAS !== this.antialias) {
+            defines.ANTIALIAS = !defines.ANTIALIAS;
             defines.markAsUnprocessed();
         }
 


### PR DESCRIPTION
Pretty simple, adds ability for the GridMaterial to not be antialiased using `gridMaterial.antialias = false`

This playground can be used for testing: `#2KKVBH#127`

![image](https://github.com/BabylonJS/Babylon.js/assets/540620/2cf935ff-ef5e-4159-b7ac-9f31f974e83c)

Note: maybe someone with better GLSL experience can figure out if it's possible to fix some of the diagnal lines:

![Screenshot from 2023-08-27 23-46-30](https://github.com/BabylonJS/Babylon.js/assets/540620/41b69008-61e2-45d1-a6cd-101e09ba3836)
