### PR TITLE
* Change the Custom Frame name formatting.

### DIFF
--- a/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -579,7 +579,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 if (blocks.length) {
                     for (const block of blocks) {
                         if (!ledger.includes(block)) {
-                            ledger.push(...blocks);
+                            ledger.push(block);
                         }
                     }
                 }

--- a/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -252,6 +252,10 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
     removeItem(value: string): void {
         const frameJson = localStorage.getItem("Custom-Frame-List");
         if (frameJson) {
+            const registeredIdx = NodeLedger.RegisteredNodeNames.indexOf(value);
+            if (registeredIdx !== -1) {
+                NodeLedger.RegisteredNodeNames.splice(registeredIdx, 1);
+            }
             const frameList = JSON.parse(frameJson);
             delete frameList[value];
             localStorage.removeItem(value);
@@ -573,11 +577,24 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
             for (const key in allBlocks) {
                 const blocks = allBlocks[key] as string[];
                 if (blocks.length) {
-                    ledger.push(...blocks);
+                    for (const block of blocks) {
+                        if (!ledger.includes(block)) {
+                            ledger.push(...blocks);
+                        }
+                    }
                 }
             }
             NodeLedger.NameFormatter = (name) => {
-                return name.replace("Block", "");
+                let finalName = name;
+                // custom frame
+                if (name.endsWith("Custom")) {
+                    const nameIndex = name.lastIndexOf("Custom");
+                    finalName = name.substring(0, nameIndex);
+                    finalName += " [custom]";
+                } else {
+                    finalName = name.replace("Block", "");
+                }
+                return finalName;
             };
         }
 

--- a/packages/tools/nodeGeometryEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/components/nodeList/nodeListComponent.tsx
@@ -181,6 +181,10 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
     removeItem(value: string): void {
         const frameJson = localStorage.getItem("Custom-Frame-List");
         if (frameJson) {
+            const registeredIdx = NodeLedger.RegisteredNodeNames.indexOf(value);
+            if (registeredIdx !== -1) {
+                NodeLedger.RegisteredNodeNames.splice(registeredIdx, 1);
+            }
             const frameList = JSON.parse(frameJson);
             delete frameList[value];
             localStorage.removeItem(value);
@@ -322,11 +326,24 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
             for (const key in allBlocks) {
                 const blocks = allBlocks[key] as string[];
                 if (blocks.length) {
-                    ledger.push(...blocks);
+                    for (const block of blocks) {
+                        if (!ledger.includes(block)) {
+                            ledger.push(...blocks);
+                        }
+                    }
                 }
             }
             NodeLedger.NameFormatter = (name) => {
-                return name.replace("Block", "");
+                let finalName = name;
+                // custom frame
+                if (name.endsWith("Custom")) {
+                    const nameIndex = name.lastIndexOf("Custom");
+                    finalName = name.substring(0, nameIndex);
+                    finalName += " [custom]";
+                } else {
+                    finalName = name.replace("Block", "");
+                }
+                return finalName;
             };
         }
 

--- a/packages/tools/nodeGeometryEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/components/nodeList/nodeListComponent.tsx
@@ -328,7 +328,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 if (blocks.length) {
                     for (const block of blocks) {
                         if (!ledger.includes(block)) {
-                            ledger.push(...blocks);
+                            ledger.push(block);
                         }
                     }
                 }


### PR DESCRIPTION
* Fix bug when deleting a custom frame from the list, its name would still appear on the space search menu.

Here's how the custom frame name looks with the new formatting:
<img width="251" alt="image" src="https://github.com/BabylonJS/Babylon.js/assets/6002144/1dcc010c-8de9-48e5-8a19-67bc475f1d21">


Fixes #14208