### PR TITLE
When reusing the same PhysicsConstraint JS object for more than one p…

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -407,19 +407,19 @@ export interface IPhysicsEnginePluginV2 {
     setCollisionsEnabled(constraint: PhysicsConstraint, isEnabled: boolean): void;
     getCollisionsEnabled(constraint: PhysicsConstraint): boolean;
     setAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, friction: number): void;
-    getAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number;
+    getAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     setAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, limitMode: PhysicsConstraintAxisLimitMode): void;
-    getAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): PhysicsConstraintAxisLimitMode;
+    getAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintAxisLimitMode>;
     setAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, minLimit: number): void;
-    getAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number;
+    getAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     setAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, limit: number): void;
-    getAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number;
+    getAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     setAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, motorType: PhysicsConstraintMotorType): void;
-    getAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): PhysicsConstraintMotorType;
+    getAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintMotorType>;
     setAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, target: number): void;
-    getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number;
+    getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     setAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, maxForce: number): void;
-    getAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number;
+    getAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     disposeConstraint(constraint: PhysicsConstraint): void;
 
     // raycast

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1389,8 +1389,10 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
             return;
         }
 
+        const pluginDataArray = constraint._pluginData ?? [];
         const jointId = this._hknp.HP_Constraint_Create()[1];
-        constraint._pluginData = jointId;
+        pluginDataArray.push(jointId);
+        constraint._pluginData = pluginDataArray;
 
         // body parenting
         const bodyA = this._getPluginReference(body, instanceIndex).hpBodyId;
@@ -1506,7 +1508,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setEnabled(constraint: PhysicsConstraint, isEnabled: boolean): void {
-        this._hknp.HP_Constraint_SetEnabled(constraint._pluginData, isEnabled);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetEnabled(jointId, isEnabled);
+        }
     }
 
     /**
@@ -1516,7 +1520,11 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public getEnabled(constraint: PhysicsConstraint): boolean {
-        return this._hknp.HP_Constraint_GetEnabled(constraint._pluginData)[1];
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetEnabled(firstId)[1];
+        }
+        return false;
     }
 
     /**
@@ -1526,7 +1534,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setCollisionsEnabled(constraint: PhysicsConstraint, isEnabled: boolean): void {
-        this._hknp.HP_Constraint_SetCollisionsEnabled(constraint._pluginData, isEnabled);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetCollisionsEnabled(jointId, isEnabled);
+        }
     }
 
     /**
@@ -1536,7 +1546,11 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public getCollisionsEnabled(constraint: PhysicsConstraint): boolean {
-        return this._hknp.HP_Constraint_GetCollisionsEnabled(constraint._pluginData)[1];
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetCollisionsEnabled(firstId)[1];
+        }
+        return false;
     }
 
     /**
@@ -1549,7 +1563,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, friction: number): void {
-        this._hknp.HP_Constraint_SetAxisFriction(constraint._pluginData, this._constraintAxisToNative(axis), friction);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisFriction(jointId, this._constraintAxisToNative(axis), friction);
+        }
     }
 
     /**
@@ -1560,8 +1576,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The friction value of the specified axis.
      *
      */
-    public getAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number {
-        return this._hknp.HP_Constraint_GetAxisFriction(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+    public getAxisFriction(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisFriction(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
     }
 
     /**
@@ -1571,7 +1591,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @param limitMode - The limit mode to set.
      */
     public setAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, limitMode: PhysicsConstraintAxisLimitMode): void {
-        this._hknp.HP_Constraint_SetAxisMode(constraint._pluginData, this._constraintAxisToNative(axis), this._limitModeToNative(limitMode));
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMode(jointId, this._constraintAxisToNative(axis), this._limitModeToNative(limitMode));
+        }
     }
 
     /**
@@ -1582,9 +1604,13 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The axis limit mode of the given constraint.
      *
      */
-    public getAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): PhysicsConstraintAxisLimitMode {
-        const mode = this._hknp.HP_Constraint_GetAxisMode(constraint._pluginData, this._constraintAxisToNative(axis))[1];
-        return this._nativeToLimitMode(mode);
+    public getAxisMode(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintAxisLimitMode> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            const mode = this._hknp.HP_Constraint_GetAxisMode(firstId, this._constraintAxisToNative(axis))[1];
+            return this._nativeToLimitMode(mode);
+        }
+        return null;
     }
 
     /**
@@ -1595,7 +1621,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, limit: number): void {
-        this._hknp.HP_Constraint_SetAxisMinLimit(constraint._pluginData, this._constraintAxisToNative(axis), limit);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMinLimit(jointId, this._constraintAxisToNative(axis), limit);
+        }
     }
 
     /**
@@ -1605,8 +1633,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The minimum limit of the specified axis of the given constraint.
      *
      */
-    public getAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number {
-        return this._hknp.HP_Constraint_GetAxisMinLimit(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+    public getAxisMinLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMinLimit(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
     }
 
     /**
@@ -1617,7 +1649,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, limit: number): void {
-        this._hknp.HP_Constraint_SetAxisMaxLimit(constraint._pluginData, this._constraintAxisToNative(axis), limit);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMaxLimit(jointId, this._constraintAxisToNative(axis), limit);
+        }
     }
 
     /**
@@ -1628,8 +1662,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The maximum limit of the given axis of the given constraint.
      *
      */
-    public getAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number {
-        return this._hknp.HP_Constraint_GetAxisMaxLimit(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+    public getAxisMaxLimit(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMaxLimit(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
     }
 
     /**
@@ -1641,7 +1679,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, motorType: PhysicsConstraintMotorType): void {
-        this._hknp.HP_Constraint_SetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis), this._constraintMotorTypeToNative(motorType));
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMotorType(jointId, this._constraintAxisToNative(axis), this._constraintMotorTypeToNative(motorType));
+        }
     }
 
     /**
@@ -1651,8 +1691,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The motor type of the specified axis of the given constraint.
      *
      */
-    public getAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): PhysicsConstraintMotorType {
-        return this._nativeToMotorType(this._hknp.HP_Constraint_GetAxisMotorType(constraint._pluginData, this._constraintAxisToNative(axis))[1]);
+    public getAxisMotorType(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintMotorType> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._nativeToMotorType(this._hknp.HP_Constraint_GetAxisMotorType(firstId, this._constraintAxisToNative(axis))[1]);
+        }
+        return null;
     }
 
     /**
@@ -1664,7 +1708,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, target: number): void {
-        this._hknp.HP_Constraint_SetAxisMotorTarget(constraint._pluginData, this._constraintAxisToNative(axis), target);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMotorTarget(jointId, this._constraintAxisToNative(axis), target);
+        }
     }
 
     /**
@@ -1675,8 +1721,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The target of the motor of the given axis of the given constraint.
      *
      */
-    public getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number {
-        return this._hknp.HP_Constraint_GetAxisMotorTarget(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+    public getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMotorTarget(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
     }
 
     /**
@@ -1687,7 +1737,9 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      *
      */
     public setAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, maxForce: number): void {
-        this._hknp.HP_Constraint_SetAxisMotorMaxForce(constraint._pluginData, this._constraintAxisToNative(axis), maxForce);
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMotorMaxForce(jointId, this._constraintAxisToNative(axis), maxForce);
+        }
     }
 
     /**
@@ -1698,8 +1750,12 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns The maximum force of the motor of the given constraint axis.
      *
      */
-    public getAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): number {
-        return this._hknp.HP_Constraint_GetAxisMotorMaxForce(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+    public getAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMotorMaxForce(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
     }
 
     /**
@@ -1711,10 +1767,11 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * the Havok constraint, when it is no longer needed. This is important for avoiding memory leaks.
      */
     public disposeConstraint(constraint: PhysicsConstraint): void {
-        const jointId = constraint._pluginData;
-        this._hknp.HP_Constraint_SetEnabled(jointId, false);
-        this._hknp.HP_Constraint_Release(jointId);
-        constraint._pluginData = undefined;
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetEnabled(jointId, false);
+            this._hknp.HP_Constraint_Release(jointId);
+        }
+        constraint._pluginData.length = 0;
     }
 
     /**

--- a/packages/dev/core/src/Physics/v2/physicsConstraint.ts
+++ b/packages/dev/core/src/Physics/v2/physicsConstraint.ts
@@ -1,5 +1,6 @@
 import type { Scene } from "../../scene";
 import type { Vector3 } from "../../Maths/math.vector";
+import type { Nullable } from "../../types";
 import type { IPhysicsEnginePluginV2, PhysicsConstraintParameters, PhysicsConstraintAxisLimitMode, PhysicsConstraintMotorType } from "./IPhysicsEnginePlugin";
 import { PhysicsConstraintAxis, PhysicsConstraintType } from "./IPhysicsEnginePlugin";
 
@@ -174,10 +175,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     /**
      * Gets the friction of the given axis of the physics engine.
      * @param axis - The axis of the physics engine.
-     * @returns The friction of the given axis.
+     * @returns The friction of the given axis, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisFriction(axis: PhysicsConstraintAxis): number {
+    public getAxisFriction(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisFriction(this, axis);
     }
 
@@ -199,10 +200,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
      * Gets the limit mode of the given axis of the constraint.
      *
      * @param axis - The axis of the constraint.
-     * @returns The limit mode of the given axis.
+     * @returns The limit mode of the given axis, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMode(axis: PhysicsConstraintAxis): PhysicsConstraintAxisLimitMode {
+    public getAxisMode(axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintAxisLimitMode> {
         return this._physicsPlugin.getAxisMode(this, axis);
     }
 
@@ -219,10 +220,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     /**
      * Gets the minimum limit of the given axis of the physics engine.
      * @param axis - The axis of the physics engine.
-     * @returns The minimum limit of the given axis.
+     * @returns The minimum limit of the given axis, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMinLimit(axis: PhysicsConstraintAxis): number {
+    public getAxisMinLimit(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisMinLimit(this, axis);
     }
 
@@ -242,10 +243,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     /**
      * Gets the maximum limit of the given axis of the physics engine.
      * @param axis - The axis of the physics engine.
-     * @returns The maximum limit of the given axis.
+     * @returns The maximum limit of the given axis, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMaxLimit(axis: PhysicsConstraintAxis): number {
+    public getAxisMaxLimit(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisMaxLimit(this, axis);
     }
 
@@ -264,10 +265,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
      * Gets the motor type of the specified axis of the constraint.
      *
      * @param axis - The axis of the constraint.
-     * @returns The motor type of the specified axis.
+     * @returns The motor type of the specified axis, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMotorType(axis: PhysicsConstraintAxis): PhysicsConstraintMotorType {
+    public getAxisMotorType(axis: PhysicsConstraintAxis): Nullable<PhysicsConstraintMotorType> {
         return this._physicsPlugin.getAxisMotorType(this, axis);
     }
 
@@ -285,10 +286,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     /**
      * Gets the target velocity of the motor associated to the given constraint axis.
      * @param axis - The constraint axis associated to the motor.
-     * @returns The target velocity of the motor.
+     * @returns The target velocity of the motor, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMotorTarget(axis: PhysicsConstraintAxis): number {
+    public getAxisMotorTarget(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisMotorTarget(this, axis);
     }
 
@@ -305,10 +306,10 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     /**
      * Gets the maximum force of the motor of the given axis of the constraint.
      * @param axis - The axis of the constraint.
-     * @returns The maximum force of the motor.
+     * @returns The maximum force of the motor, or null if the constraint hasn't been initialized yet.
      *
      */
-    public getAxisMotorMaxForce(axis: PhysicsConstraintAxis): number {
+    public getAxisMotorMaxForce(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisMotorMaxForce(this, axis);
     }
 }


### PR DESCRIPTION
…air of bodies, store the information of all created Havok objects for proper get/set of properties and disposal.

Currently, if you create a PhysicsConstraint and use it on more than one `addConstraint` call, one Havok object will be created for each call, but only the most recent object is stored in JS side, which means it wasn't possible to set properties or dispose of the previously created ones. This can be observed in this PG: https://playground.babylonjs.com/#7DMWP8#574, where the same constraint is used for the two pairs of bodies and disposed of after 2s.

This PR changes the `_pluginData` object on the PhysicsConstraint to be an array, where each created joint reference is pushed, and updates the plugin methods accordingly. 