### PR TITLE
Fix aggregate extent calculation when scaling is negative

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -188,6 +188,10 @@ export class PhysicsAggregate {
         extents.copyFrom(bb.extendSize);
         extents.scaleInPlace(2);
         extents.multiplyInPlace(this.transformNode.scaling);
+        // In case we had any negative scaling, we need to take the absolute value of the extents.
+        extents.x = Math.abs(extents.x);
+        extents.y = Math.abs(extents.y);
+        extents.z = Math.abs(extents.z);
 
         const min = TmpVectors.Vector3[1];
         min.copyFrom(bb.minimum);


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/what-are-the-best-practices-for-physics-gltf-models/43660

If the scaling of the node used for the aggregate was negative, we were getting negative extents, which would create the wrong physics shape.