### PR TITLE
Animation groups: Add ClipKeys helper + update inspector

### DIFF
--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -1140,9 +1140,10 @@ export class Animation {
     /**
      * Sets the key frames of the animation
      * @param values The animation key frames to set
+     * @param dontClone Whether to clone the keys or not (default is false, so the array of keys is cloned)
      */
-    public setKeys(values: Array<IAnimationKey>): void {
-        this._keys = values.slice(0);
+    public setKeys(values: Array<IAnimationKey>, dontClone = false): void {
+        this._keys = !dontClone ? values.slice(0) : values;
     }
 
     /**

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -380,7 +380,7 @@ export class AnimationGroup implements IDisposable {
         weight = weight ?? animationGroups[0].weight;
 
         let beginFrame = Number.MAX_VALUE;
-        let endFrame = Number.MIN_VALUE;
+        let endFrame = -Number.MAX_VALUE;
 
         if (normalize) {
             for (const animationGroup of animationGroups) {

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -62,6 +62,8 @@ export class AnimationGroup implements IDisposable {
     private _isAdditive = false;
     private _weight = -1;
     private _playOrder = 0;
+    private _enableBlending: Nullable<boolean> = null;
+    private _blendingSpeed: Nullable<number> = null;
 
     /** @internal */
     public _parentContainer: Nullable<AbstractScene> = null;
@@ -320,22 +322,45 @@ export class AnimationGroup implements IDisposable {
 
     /**
      * Allows the animations of the animation group to blend with current running animations
-     * Note: this method should be called after all targeted animations have been added to the group
-     * @param blendingSpeed defines the blending speed to use
+     * Note that a null value means that each animation will use their own existing blending configuration (Animation.enableBlending)
      */
-    public enableBlending(blendingSpeed: number) {
-        for (let i = 0; i < this._targetedAnimations.length; ++i) {
-            this._targetedAnimations[i].animation.enableBlending = true;
-            this._targetedAnimations[i].animation.blendingSpeed = blendingSpeed;
+    public get enableBlending() {
+        return this._enableBlending;
+    }
+
+    public set enableBlending(value: Nullable<boolean>) {
+        if (this._enableBlending === value) {
+            return;
+        }
+
+        this._enableBlending = value;
+
+        if (value !== null) {
+            for (let i = 0; i < this._targetedAnimations.length; ++i) {
+                this._targetedAnimations[i].animation.enableBlending = value;
+            }
         }
     }
 
     /**
-     * Disable animation blending
+     * Gets or sets the animation blending speed
+     * Note that a null value means that each animation will use their own existing blending configuration (Animation.blendingSpeed)
      */
-    public disableBlending() {
-        for (let i = 0; i < this._targetedAnimations.length; ++i) {
-            this._targetedAnimations[i].animation.enableBlending = false;
+    public get blendingSpeed() {
+        return this._blendingSpeed;
+    }
+
+    public set blendingSpeed(value: Nullable<number>) {
+        if (this._blendingSpeed === value) {
+            return;
+        }
+
+        this._blendingSpeed = value;
+
+        if (value !== null) {
+            for (let i = 0; i < this._targetedAnimations.length; ++i) {
+                this._targetedAnimations[i].animation.blendingSpeed = value;
+            }
         }
     }
 
@@ -430,6 +455,14 @@ export class AnimationGroup implements IDisposable {
 
         if (this._to < keys[keys.length - 1].frame) {
             this._to = keys[keys.length - 1].frame;
+        }
+
+        if (this._enableBlending !== null) {
+            animation.enableBlending = this._enableBlending;
+        }
+
+        if (this._blendingSpeed !== null) {
+            animation.blendingSpeed = this._blendingSpeed;
         }
 
         this._targetedAnimations.push(targetedAnimation);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
@@ -15,6 +15,8 @@ import type { GlobalState } from "../../../../globalState";
 import { TextInputLineComponent } from "shared-ui-components/lines/textInputLineComponent";
 import { Context } from "./curveEditor/context";
 import { AnimationCurveEditorComponent } from "./curveEditor/animationCurveEditorComponent";
+import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import { CheckBoxLineComponent } from "shared-ui-components/lines/checkBoxLineComponent";
 
 interface IAnimationGroupGridComponentProps {
     globalState: GlobalState;
@@ -155,6 +157,7 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
                 </LineContainerComponent>
                 <LineContainerComponent title="CONTROLS">
                     <ButtonLineComponent label={playButtonText} onClick={() => this.playOrPause()} />
+                    <ButtonLineComponent label="Stop" onClick={() => this.props.animationGroup.stop()} />
                     <SliderLineComponent
                         lockObject={this.props.lockObject}
                         label="Speed ratio"
@@ -174,6 +177,33 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
                         step={(animationGroup.to - animationGroup.from) / 1000.0}
                         directValue={this.state.currentFrame}
                         onInput={(value) => this.onCurrentFrameChange(value)}
+                    />
+                    <CheckBoxLineComponent label="Blending" target={animationGroup} propertyName="enableBlending" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
+                    <SliderLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Blending speed"
+                        minimum={0}
+                        maximum={1}
+                        step={0.01}
+                        target={animationGroup}
+                        propertyName="blendingSpeed"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
+                    <CheckBoxLineComponent label="Is additive" target={animationGroup} propertyName="isAdditive" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Weight"
+                        target={animationGroup}
+                        propertyName="weight"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Play order"
+                        target={animationGroup}
+                        propertyName="playOrder"
+                        isInteger={true}
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
                 </LineContainerComponent>
                 <LineContainerComponent title="INFOS">

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationGroupPropertyGridComponent.tsx
@@ -178,7 +178,12 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
                         directValue={this.state.currentFrame}
                         onInput={(value) => this.onCurrentFrameChange(value)}
                     />
-                    <CheckBoxLineComponent label="Blending" target={animationGroup} propertyName="enableBlending" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
+                    <CheckBoxLineComponent
+                        label="Blending"
+                        target={animationGroup}
+                        propertyName="enableBlending"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                     <SliderLineComponent
                         lockObject={this.props.lockObject}
                         label="Blending speed"
@@ -189,7 +194,12 @@ export class AnimationGroupGridComponent extends React.Component<IAnimationGroup
                         propertyName="blendingSpeed"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
-                    <CheckBoxLineComponent label="Is additive" target={animationGroup} propertyName="isAdditive" onPropertyChangedObservable={this.props.onPropertyChangedObservable} />
+                    <CheckBoxLineComponent
+                        label="Is additive"
+                        target={animationGroup}
+                        propertyName="isAdditive"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                     <FloatLineComponent
                         lockObject={this.props.lockObject}
                         label="Weight"


### PR DESCRIPTION
I also modified the `enableBlending` method to make it a getter/setter instead + added `blendingSpeed` as a getter/setter.

Creating a method instead of a getter/setter was a bad decision I made a few weeks ago. As this is a new feature for version 7.0 and not yet used by any PGs, I thought it right to make a breaking change to keep the code clear.

I've added a "Stop" button to the inspector, as the "Is Additive" and "Enable blending" switches only work after an animation group has been stopped and restarted (simply pausing/playing again doesn't work).