### PR TITLE
Expose collisionEndedObservable to PhysicsBody

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -378,8 +378,10 @@ export interface IPhysicsEnginePluginV2 {
     getBodyGeometry(body: PhysicsBody): {};
     disposeBody(body: PhysicsBody): void;
     setCollisionCallbackEnabled(body: PhysicsBody, enabled: boolean, instanceIndex?: number): void;
+    setCollisionEndedCallbackEnabled(body: PhysicsBody, enabled: boolean, instanceIndex?: number): void;
     addConstraint(body: PhysicsBody, childBody: PhysicsBody, constraint: PhysicsConstraint, instanceIndex?: number, childInstanceIndex?: number): void;
     getCollisionObservable(body: PhysicsBody, instanceIndex?: number): Observable<IPhysicsCollisionEvent>;
+    getCollisionEndedObservable(body: PhysicsBody, instanceIndex?: number): Observable<IBasePhysicsCollisionEvent>;
     setGravityFactor(body: PhysicsBody, factor: number, instanceIndex?: number): void;
     getGravityFactor(body: PhysicsBody, instanceIndex?: number): number;
     setTargetTransform(body: PhysicsBody, position: Vector3, rotation: Quaternion, instanceIndex?: number): void;

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -40,6 +40,10 @@ export class PhysicsBody {
      */
     private _collisionCBEnabled: boolean = false;
     /**
+     * If the collision ended callback is enabled
+     */
+    private _collisionEndedCBEnabled: boolean = false;
+    /**
      * The transform node associated with this Physics Body
      */
     transformNode: TransformNode;
@@ -419,11 +423,19 @@ export class PhysicsBody {
     }
 
     /**
-     * Returns an observable that will be notified for all collisions happening for event-enabled bodies
+     * Returns an observable that will be notified for when a collision starts or continues for this PhysicsBody
      * @returns Observable
      */
     public getCollisionObservable(): Observable<IPhysicsCollisionEvent> {
         return this._physicsPlugin.getCollisionObservable(this);
+    }
+
+    /**
+     * Returns an observable that will be notified when the body has finished colliding with another body
+     * @returns
+     */
+    public getCollisionEndedObservable(): Observable<IPhysicsCollisionEvent> {
+        return this._physicsPlugin.getCollisionEndedObservable(this);
     }
 
     /**
@@ -433,6 +445,11 @@ export class PhysicsBody {
     public setCollisionCallbackEnabled(enabled: boolean): void {
         this._collisionCBEnabled = enabled;
         this._physicsPlugin.setCollisionCallbackEnabled(this, enabled);
+    }
+
+    public setCollisionEndedCallbackEnabled(enabled: boolean): void {
+        this._collisionEndedCBEnabled = enabled;
+        this._physicsPlugin.setCollisionEndedCallbackEnabled(this, enabled);
     }
 
     /*
@@ -576,6 +593,9 @@ export class PhysicsBody {
         // Disable collisions CB so it doesn't fire when the body is disposed
         if (this._collisionCBEnabled) {
             this.setCollisionCallbackEnabled(false);
+        }
+        if (this._collisionEndedCBEnabled) {
+            this.setCollisionEndedCallbackEnabled(false);
         }
         if (this._nodeDisposeObserver) {
             this.transformNode.onDisposeObservable.remove(this._nodeDisposeObserver);

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -1,4 +1,4 @@
-import type { IPhysicsCollisionEvent, IPhysicsEnginePluginV2, PhysicsMassProperties, PhysicsMotionType } from "./IPhysicsEnginePlugin";
+import type { IBasePhysicsCollisionEvent, IPhysicsCollisionEvent, IPhysicsEnginePluginV2, PhysicsMassProperties, PhysicsMotionType } from "./IPhysicsEnginePlugin";
 import type { PhysicsShape } from "./physicsShape";
 import { Vector3, Quaternion, TmpVectors } from "../../Maths/math.vector";
 import type { Scene } from "../../scene";
@@ -434,7 +434,7 @@ export class PhysicsBody {
      * Returns an observable that will be notified when the body has finished colliding with another body
      * @returns
      */
-    public getCollisionEndedObservable(): Observable<IPhysicsCollisionEvent> {
+    public getCollisionEndedObservable(): Observable<IBasePhysicsCollisionEvent> {
         return this._physicsPlugin.getCollisionEndedObservable(this);
     }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/how-to-detect-when-two-physics-bodies-stop-colliding/42309/15?u=carolhmj

This PR just exposes a getCollisionEndedObservable on the same way as the getCollisionObservable.

Example PG: #Z8HTUN#678