### PR TITLE
FreeCameraTouchInput: Add check for Handedness

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraMouseInput.ts
@@ -244,15 +244,9 @@ export class FlyCameraMouseInput implements ICameraInput<FlyCamera> {
      */
     private _rotateCamera(offsetX: number, offsetY: number): void {
         const camera = this.camera;
-        const scene = this.camera.getScene();
+        const handednessMultiplier = camera._calculateHandednessMultiplier();
 
-        if (scene.useRightHandedSystem) {
-            offsetX *= -1;
-        }
-
-        if (camera.parent && camera.parent._getWorldMatrixDeterminant() < 0) {
-            offsetX *= -1;
-        }
+        offsetX *= handednessMultiplier;
 
         const x = offsetX / this.angularSensibility;
         const y = offsetY / this.angularSensibility;

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
@@ -250,13 +250,9 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
     }
 
     private _getLocalRotation(): number {
-        let rotation = (this.rotationSpeed * this._engine.getDeltaTime()) / 1000;
-        if (this.camera.getScene().useRightHandedSystem) {
-            rotation *= -1;
-        }
-        if (this.camera.parent && this.camera.parent._getWorldMatrixDeterminant() < 0) {
-            rotation *= -1;
-        }
+        const handednessMultiplier = this.camera._calculateHandednessMultiplier();
+        const rotation = ((this.rotationSpeed * this._engine.getDeltaTime()) / 1000) * handednessMultiplier;
+
         return rotation;
     }
 }

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -145,14 +145,9 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                     if (engine.isPointerLock && this._onMouseMove) {
                         this._onMouseMove(p.event);
                     } else if (this._previousPosition) {
-                        let offsetX = evt.clientX - this._previousPosition.x;
+                        const handednessMultiplier = this.camera._calculateHandednessMultiplier();
+                        const offsetX = (evt.clientX - this._previousPosition.x) * handednessMultiplier;
                         const offsetY = evt.clientY - this._previousPosition.y;
-                        if (this.camera.getScene().useRightHandedSystem) {
-                            offsetX *= -1;
-                        }
-                        if (this.camera.parent && this.camera.parent._getWorldMatrixDeterminant() < 0) {
-                            offsetX *= -1;
-                        }
 
                         if (this._allowCameraRotation) {
                             this.camera.cameraRotation.y += offsetX / this.angularSensibility;
@@ -182,13 +177,9 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
                 return;
             }
 
-            let offsetX = evt.movementX;
-            if (this.camera.getScene().useRightHandedSystem) {
-                offsetX *= -1;
-            }
-            if (this.camera.parent && this.camera.parent._getWorldMatrixDeterminant() < 0) {
-                offsetX *= -1;
-            }
+            const handednessMultiplier = this.camera._calculateHandednessMultiplier();
+            const offsetX = evt.movementX * handednessMultiplier;
+
             this.camera.cameraRotation.y += offsetX / this.angularSensibility;
 
             const offsetY = evt.movementY;

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -185,7 +185,11 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         }
 
         const camera = this.camera;
-        camera.cameraRotation.y = this._offsetX / this.touchAngularSensibility;
+        let handednessMultiplier = camera.getScene().useRightHandedSystem ? -1 : 1;
+        if (camera.parent && camera.parent._getWorldMatrixDeterminant() < 0) {
+            handednessMultiplier *= -1;
+        }
+        camera.cameraRotation.y = handednessMultiplier * this._offsetX / this.touchAngularSensibility;
 
         const rotateCamera = (this.singleFingerRotate && this._pointerPressed.length === 1) || (!this.singleFingerRotate && this._pointerPressed.length > 1);
 

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -185,11 +185,8 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         }
 
         const camera = this.camera;
-        let handednessMultiplier = camera.getScene().useRightHandedSystem ? -1 : 1;
-        if (camera.parent && camera.parent._getWorldMatrixDeterminant() < 0) {
-            handednessMultiplier *= -1;
-        }
-        camera.cameraRotation.y = handednessMultiplier * this._offsetX / this.touchAngularSensibility;
+        const handednessMultiplier = camera._calculateHandednessMultiplier();
+        camera.cameraRotation.y = (handednessMultiplier * this._offsetX) / this.touchAngularSensibility;
 
         const rotateCamera = (this.singleFingerRotate && this._pointerPressed.length === 1) || (!this.singleFingerRotate && this._pointerPressed.length > 1);
 

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -911,18 +911,14 @@ export class ArcRotateCamera extends TargetCamera {
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
             const directionModifier = this.invertRotation ? -1 : 1;
-            let inertialAlphaOffset = this.inertialAlphaOffset;
+            const handednessMultiplier = this._calculateHandednessMultiplier();
+            let inertialAlphaOffset = this.inertialAlphaOffset * handednessMultiplier;
+
             if (this.beta <= 0) {
                 inertialAlphaOffset *= -1;
             }
-            if (this.getScene().useRightHandedSystem) {
-                inertialAlphaOffset *= -1;
-            }
-            if (this.parent && this.parent._getWorldMatrixDeterminant() < 0) {
-                inertialAlphaOffset *= -1;
-            }
-            this.alpha += inertialAlphaOffset * directionModifier;
 
+            this.alpha += inertialAlphaOffset * directionModifier;
             this.beta += this.inertialBetaOffset * directionModifier;
 
             this.radius -= this.inertialRadiusOffset;

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -1495,4 +1495,14 @@ export class Camera extends Node {
 
         return camera;
     }
+
+    /** @internal */
+    public _calculateHandednessMultiplier(): number {
+        let handednessMultiplier = this.getScene().useRightHandedSystem ? -1 : 1;
+        if (this.parent && this.parent._getWorldMatrixDeterminant() < 0) {
+            handednessMultiplier *= -1;
+        }
+
+        return handednessMultiplier;
+    }
 }


### PR DESCRIPTION
Recently, on the forum, a user found an issue where the UniversalCamera's touch controls weren't accounting for a right-handed system.  Upon investigating, it was found that this check was missing.  This PR adds that check to the touch controls.

Edit: Moved logic to Camera function and modified calls to use said function.

Forum Link: https://forum.babylonjs.com/t/how-to-make-the-touch-rotation-on-the-y-axis-of-universalcamera-consistent-in-different-coordinate-system/43716