### PR TITLE
RuntimeAnimation: Fix original value used in the bone matrix case

### DIFF
--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -346,9 +346,9 @@ export class RuntimeAnimation {
         let originalValue: any;
         const target = this._activeTargets[targetIndex];
 
-        if (target.getRestPose && this._targetPath === "_matrix") {
+        if (target.getLocalMatrix && this._targetPath === "_matrix") {
             // For bones
-            originalValue = target.getRestPose();
+            originalValue = target.getLocalMatrix();
         } else {
             originalValue = target[this._targetPath];
         }


### PR DESCRIPTION
We want the original value to be the current (matrix) value at the time the `RuntimeAnimation` is started, which may be different than the rest matrix (which should not be used, anyway, as it's a matrix for user consumption only).