### PR TITLE
Occlusion queries: Use the first camera in the case of multiple cameras

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2218,7 +2218,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this._internalAbstractMeshDataInfo._isActive = false;
         }
 
-        if (this._checkOcclusionQuery() && !this._occlusionDataStorage.forceRenderingWhenOccluded) {
+        const numActiveCameras = scene.activeCameras?.length ?? 0;
+        const canCheckOcclusionQuery = (numActiveCameras > 1 && scene.activeCamera === scene.activeCameras![0]) || numActiveCameras <= 1;
+
+        if (canCheckOcclusionQuery && this._checkOcclusionQuery() && !this._occlusionDataStorage.forceRenderingWhenOccluded) {
             return this;
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-occlusion-query-with-2-cameras/43840