### PR TITLE
WebGPU: Fix warnings when using occlusion queries

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.query.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.query.ts
@@ -508,7 +508,7 @@ AbstractMesh.prototype._checkOcclusionQuery = function () {
         return false;
     }
 
-    if (this.isOcclusionQueryInProgress && this._occlusionQuery) {
+    if (this.isOcclusionQueryInProgress && this._occlusionQuery !== null && this._occlusionQuery !== undefined) {
         const isOcclusionQueryAvailable = engine.isQueryResultAvailable(this._occlusionQuery);
         if (isOcclusionQueryAvailable) {
             const occlusionQueryResult = engine.getQueryResult(this._occlusionQuery);

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTarget.ts
@@ -37,6 +37,7 @@ WebGPUEngine.prototype.createRenderTargetTexture = function (size: TextureSize, 
 
     const texture = fullOptions.noColorAttachment ? null : this._createInternalTexture(size, options, true, InternalTextureSource.RenderTarget);
 
+    rtWrapper.label = fullOptions.label ?? "RenderTargetWrapper";
     rtWrapper._samples = fullOptions.samples ?? 1;
     rtWrapper._generateDepthBuffer = fullOptions.generateDepthBuffer;
     rtWrapper._generateStencilBuffer = fullOptions.generateStencilBuffer ? true : false;

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTargetCube.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTargetCube.ts
@@ -19,6 +19,7 @@ WebGPUEngine.prototype.createRenderTargetCubeTexture = function (size: number, o
     };
     fullOptions.generateStencilBuffer = fullOptions.generateDepthBuffer && fullOptions.generateStencilBuffer;
 
+    rtWrapper.label = fullOptions.label ?? "RenderTargetWrapper";
     rtWrapper._generateDepthBuffer = fullOptions.generateDepthBuffer;
     rtWrapper._generateStencilBuffer = fullOptions.generateStencilBuffer;
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuQuerySet.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuQuerySet.ts
@@ -17,13 +17,14 @@ export class WebGPUQuerySet {
         return this._querySet;
     }
 
-    constructor(count: number, type: QueryType, device: GPUDevice, bufferManager: WebGPUBufferManager, canUseMultipleBuffers = true) {
+    constructor(count: number, type: QueryType, device: GPUDevice, bufferManager: WebGPUBufferManager, canUseMultipleBuffers = true, label?: string) {
         this._device = device;
         this._bufferManager = bufferManager;
         this._count = count;
         this._canUseMultipleBuffers = canUseMultipleBuffers;
 
         this._querySet = device.createQuerySet({
+            label,
             type,
             count,
         });

--- a/packages/dev/core/src/Engines/renderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/renderTargetWrapper.ts
@@ -43,6 +43,11 @@ export class RenderTargetWrapper {
     public _depthStencilTextureWithStencil: boolean = false;
 
     /**
+     * Gets or sets the label of the render target wrapper (optional, for debugging purpose)
+     */
+    public label?: string;
+
+    /**
      * Gets the depth/stencil texture (if created by a createDepthStencilTexture() call)
      */
     public get depthStencilTexture() {
@@ -165,13 +170,15 @@ export class RenderTargetWrapper {
      * @param isCube true if the wrapper should render to a cube texture
      * @param size size of the render target (width/height/layers)
      * @param engine engine used to create the render target
+     * @param label defines the label to use for the wrapper (for debugging purpose only)
      */
-    constructor(isMulti: boolean, isCube: boolean, size: TextureSize, engine: ThinEngine) {
+    constructor(isMulti: boolean, isCube: boolean, size: TextureSize, engine: ThinEngine, label?: string) {
         this._isMulti = isMulti;
         this._isCube = isCube;
         this._size = size;
         this._engine = engine;
         this._depthStencilTexture = null;
+        this.label = label;
     }
 
     /**

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -941,6 +941,7 @@ export class WebGPUEngine extends Engine {
         };
 
         this._mainRenderPassWrapper.renderPassDescriptor = {
+            label: "MainRenderPass",
             colorAttachments: mainColorAttachments,
             depthStencilAttachment: mainDepthAttachment,
         };
@@ -2775,6 +2776,7 @@ export class WebGPUEngine extends Engine {
         this._debugPushGroup?.("render target pass", 1);
 
         this._rttRenderPassWrapper.renderPassDescriptor = {
+            label: (renderTargetWrapper.label ?? "RTT") + "RenderPass",
             colorAttachments,
             depthStencilAttachment:
                 depthStencilTexture && gpuDepthStencilTexture


### PR DESCRIPTION
I also added some labels for some objects for debugging purpose in WebGPU.

(my PG so that it does not get lost: http://localhost:1338/?webgpu#QDAZ80#457)