### PR TITLE
docs: fix typo (2x "the")

### DIFF
--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -26,7 +26,7 @@ export interface IAxisDragGizmo extends IGizmo {
     snapDistance: number;
     /**
      * Event that fires each time the gizmo snaps to a new location.
-     * * snapDistance is the the change in distance
+     * * snapDistance is the change in distance
      */
     onSnapObservable: Observable<{ snapDistance: number }>;
     /** If the gizmo is enabled */


### PR DESCRIPTION
Nit-pick 🤓🔎: remove one `the` :innocent:.