### PR TITLE
Bump mapping: Fix parallax mapping in right handed mode

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -180,6 +180,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
 
         defines.setValue("BUMP", true);
         defines.setValue("PARALLAX", useParallax, true);
+        defines.setValue("PARALLAX_RHS", nodeMaterial.getScene().useRightHandedSystem, true);
         defines.setValue("PARALLAXOCCLUSION", this.useParallaxOcclusion, true);
         defines.setValue("OBJECTSPACE_NORMALMAP", this.useObjectSpaceNormalMap, true);
     }

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -137,6 +137,7 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public BUMPDIRECTUV = 0;
     public OBJECTSPACE_NORMALMAP = false;
     public PARALLAX = false;
+    public PARALLAX_RHS = false;
     public PARALLAXOCCLUSION = false;
     public NORMALXYSCALE = true;
 
@@ -1281,6 +1282,9 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         if (defines.PARALLAX) {
             fallbacks.addFallback(fallbackRank, "PARALLAX");
         }
+        if (defines.PARALLAX_RHS) {
+            fallbacks.addFallback(fallbackRank, "PARALLAX_RHS");
+        }
         if (defines.PARALLAXOCCLUSION) {
             fallbacks.addFallback(fallbackRank++, "PARALLAXOCCLUSION");
         }
@@ -1778,6 +1782,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
                     if (this._useParallax && this._albedoTexture && MaterialFlags.DiffuseTextureEnabled) {
                         defines.PARALLAX = true;
+                        defines.PARALLAX_RHS = scene.useRightHandedSystem;
                         defines.PARALLAXOCCLUSION = !!this._useParallaxOcclusion;
                     } else {
                         defines.PARALLAX = false;
@@ -1787,6 +1792,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 } else {
                     defines.BUMP = false;
                     defines.PARALLAX = false;
+                    defines.PARALLAX_RHS = false;
                     defines.PARALLAXOCCLUSION = false;
                     defines.OBJECTSPACE_NORMALMAP = false;
                 }

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -66,6 +66,7 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public BUMP = false;
     public BUMPDIRECTUV = 0;
     public PARALLAX = false;
+    public PARALLAX_RHS = false;
     public PARALLAXOCCLUSION = false;
     public SPECULAROVERALPHA = false;
     public CLIPPLANE = false;
@@ -1080,6 +1081,7 @@ export class StandardMaterial extends PushMaterial {
                         MaterialHelper.PrepareDefinesForMergedUV(this._bumpTexture, defines, "BUMP");
 
                         defines.PARALLAX = this._useParallax;
+                        defines.PARALLAX_RHS = scene.useRightHandedSystem;
                         defines.PARALLAXOCCLUSION = this._useParallaxOcclusion;
                     }
 
@@ -1087,6 +1089,7 @@ export class StandardMaterial extends PushMaterial {
                 } else {
                     defines.BUMP = false;
                     defines.PARALLAX = false;
+                    defines.PARALLAX_RHS = false;
                     defines.PARALLAXOCCLUSION = false;
                 }
 
@@ -1231,6 +1234,10 @@ export class StandardMaterial extends PushMaterial {
 
             if (defines.PARALLAX) {
                 fallbacks.addFallback(1, "PARALLAX");
+            }
+
+            if (defines.PARALLAX_RHS) {
+                fallbacks.addFallback(1, "PARALLAX_RHS");
             }
 
             if (defines.PARALLAXOCCLUSION) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -52,7 +52,11 @@
 			{
 				currRayHeight -= stepSize;
 				vLastOffset = vCurrOffset;
+			#ifdef PARALLAX_RHS
+				vCurrOffset -= stepSize * vMaxOffset;
+			#else
 				vCurrOffset += stepSize * vMaxOffset;
+			#endif
 
 				lastSampledHeight = currSampledHeight;
 			}
@@ -66,6 +70,10 @@
 		// calculate amount of offset for Parallax Mapping With Offset Limiting
 		float height = texture2D(bumpSampler, vBumpUV).w;
 		vec2 texCoordOffset = heightScale * viewDir.xy * height;
+	#ifdef PARALLAX_RHS
+		return texCoordOffset;
+	#else
 		return -texCoordOffset;
+	#endif
 	}
 #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/using-an-right-coordinate-system-results-in-parallax-occlusion-mapping-rendering-errors/44101