### PR TITLE
Make core pass strict lib check

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -1063,8 +1063,8 @@ interface XRFrame {
     // Anchors
     trackedAnchors?: XRAnchorSet;
     // World geometries. DEPRECATED
-    worldInformation?: XRWorldInformation;
-    detectedPlanes?: XRPlaneSet;
+    worldInformation?: XRWorldInformation | undefined;
+    detectedPlanes?: XRPlaneSet | undefined;
     // Hand tracking
     getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose;
     fillJointRadii?(jointSpaces: XRJointSpace[], radii: Float32Array): boolean;

--- a/packages/dev/core/src/LibDeclarations/webxr.nativeextensions.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.nativeextensions.d.ts
@@ -65,7 +65,7 @@ interface XRSession {
 }
 
 interface XRFrame {
-    featurePointCloud?: Array<number>;
+    featurePointCloud?: Array<number> | undefined;
 }
 
 type XRMeshSet = Set<XRMesh>;

--- a/packages/dev/core/src/Meshes/meshSimplification.ts
+++ b/packages/dev/core/src/Meshes/meshSimplification.ts
@@ -37,7 +37,7 @@ export interface ISimplificationSettings {
     /**
      * Gets an already optimized mesh
      */
-    optimizeMesh?: boolean;
+    optimizeMesh?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
Specifically `exactOptionalPropertyTypes: true`. Context: https://forum.babylonjs.com/t/support-typescript-tsconfig-flag-exactoptionalpropertytypes-true/33824