### PR TITLE
Mesh: Fix subMesh bounding info when mesh has thin instances

### DIFF
--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -240,7 +240,7 @@ export class SubMesh implements ICullable {
      * @returns current bounding info (or mesh's one if the submesh is global)
      */
     public getBoundingInfo(): BoundingInfo {
-        if (this.IsGlobal) {
+        if (this.IsGlobal || this._mesh.hasThinInstances) {
             return this._mesh.getBoundingInfo();
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/creating-thininstance-after-merging-mesh-using-mergedmesh-causes-the-origin-to-exceed-frustum/44145/5

As we can't maintain a bounding info per submesh when thin instances are defined, just take the main mesh bounding info when a submesh bounding info is requested (because the bounding info of the main mesh does take into account all the thin instances).