### PR TITLE
Move GetTextureDataAsync from inspector to core

### DIFF
--- a/packages/dev/core/src/Maths/math.path.ts
+++ b/packages/dev/core/src/Maths/math.path.ts
@@ -427,7 +427,7 @@ export class Path2 {
     }
 
     /**
-     * Retreives the point at the distance aways from the starting point
+     * Retrieves the point at the distance aways from the starting point
      * @param normalizedLengthPosition the length along the path to retrieve the point from
      * @returns a new Vector2 located at a percentage of the Path2 total length on this path.
      */

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -252,12 +252,11 @@ const ProcessAsync = async (
         lodPostProcess = new PostProcess("lodCube", "lodCube", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine, false, faceDefines[face]);
     }
 
-    let isPostProcessReady = lodPostProcess.getEffect().isReady();
-    while (!isPostProcessReady) {
-        isPostProcessReady = await new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(lodPostProcess.getEffect().isReady());
-            }, 250);
+    if (!lodPostProcess.getEffect().isReady()) {
+        await new Promise((resolve) => {
+            lodPostProcess.getEffect().onCompileObservable.addOnce(() => {
+                resolve(0);
+            });
         });
     }
 

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -307,14 +307,18 @@ const ProcessAsync = async (
  * @returns the 8-bit texture data
  */
 export async function GetTextureDataAsync(texture: BaseTexture, width: number, height: number, face: number = 0, lod: number = 0): Promise<Uint8Array> {
-    return new Promise((resolve, reject) => {
-        if (!texture.isReady() && texture._texture) {
+    if (!texture.isReady() && texture._texture) {
+        await new Promise((resolve, reject) => {
+            if (texture._texture === null) {
+                reject(0);
+                return;
+            }
             texture._texture.onLoadedObservable.addOnce(() => {
-                ProcessAsync(texture, width, height, face, lod, resolve, reject);
+                resolve(0);
             });
-            return;
-        }
-
+        });
+    }
+    return await new Promise((resolve, reject) => {
         ProcessAsync(texture, width, height, face, lod, resolve, reject);
     });
 }

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -252,13 +252,11 @@ const ProcessAsync = async (
         lodPostProcess = new PostProcess("lodCube", "lodCube", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine, false, faceDefines[face]);
     }
 
-    if (!lodPostProcess.getEffect().isReady()) {
-        await new Promise((resolve) => {
-            lodPostProcess.getEffect().onCompileObservable.addOnce(() => {
-                resolve(0);
-            });
+    await new Promise((resolve) => {
+        lodPostProcess.getEffect().executeWhenCompiled(() => {
+            resolve(0);
         });
-    }
+    });
 
     const rtt = new RenderTargetTexture("temp", { width: width, height: height }, scene, false);
 

--- a/packages/dev/inspector/src/textureHelper.ts
+++ b/packages/dev/inspector/src/textureHelper.ts
@@ -1,174 +1,48 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { PostProcess } from "core/PostProcesses/postProcess";
-import { Texture } from "core/Materials/Textures/texture";
-import type { GlobalState } from "./components/globalState";
-import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";
-import type { Nullable } from "core/types";
-
+import type { GlobalState } from "./components/globalState";
+import { TextureTools } from "core/Misc/textureTools";
 import "./lod";
 import "./lodCube";
 
+/**
+ * Defines which channels of the texture to retrieve with {@link TextureHelper.GetTextureDataAsync}.
+ */
 export interface TextureChannelsToDisplay {
+    /**
+     * True if the red channel should be included.
+     */
     R: boolean;
+    /**
+     * True if the green channel should be included.
+     */
     G: boolean;
+    /**
+     * True if the blue channel should be included.
+     */
     B: boolean;
+    /**
+     * True if the alpha channel should be included.
+     */
     A: boolean;
 }
 
+/**
+ * Helper class for retrieving texture data.
+ */
 export class TextureHelper {
-    private static async _ProcessAsync(
-        texture: BaseTexture,
-        width: number,
-        height: number,
-        face: number,
-        channels: TextureChannelsToDisplay,
-        lod: number,
-        globalState: Nullable<GlobalState>,
-        resolve: (result: Uint8Array) => void,
-        reject: () => void
-    ) {
-        const scene = texture.getScene()!;
-        const engine = scene.getEngine();
-
-        let lodPostProcess: PostProcess;
-
-        if (!texture.isCube) {
-            lodPostProcess = new PostProcess("lod", "lod", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine);
-        } else {
-            const faceDefines = ["#define POSITIVEX", "#define NEGATIVEX", "#define POSITIVEY", "#define NEGATIVEY", "#define POSITIVEZ", "#define NEGATIVEZ"];
-            lodPostProcess = new PostProcess("lodCube", "lodCube", ["lod", "gamma"], null, 1.0, null, Texture.NEAREST_NEAREST_MIPNEAREST, engine, false, faceDefines[face]);
-        }
-
-        if (!lodPostProcess.getEffect().isReady()) {
-            // Try again later
-            lodPostProcess.dispose();
-
-            setTimeout(() => {
-                this._ProcessAsync(texture, width, height, face, channels, lod, globalState, resolve, reject);
-            }, 250);
-
-            return;
-        }
-
-        if (globalState) {
-            globalState.blockMutationUpdates = true;
-        }
-
-        const rtt = new RenderTargetTexture("temp", { width: width, height: height }, scene, false);
-
-        lodPostProcess.onApply = function (effect) {
-            effect.setTexture("textureSampler", texture);
-            effect.setFloat("lod", lod);
-            effect.setBool("gamma", texture.gammaSpace);
-        };
-
-        const internalTexture = texture.getInternalTexture();
-
-        if (rtt.renderTarget && internalTexture) {
-            const samplingMode = internalTexture.samplingMode;
-            if (lod !== 0) {
-                texture.updateSamplingMode(Texture.NEAREST_NEAREST_MIPNEAREST);
-            } else {
-                texture.updateSamplingMode(Texture.NEAREST_NEAREST);
-            }
-
-            scene.postProcessManager.directRender([lodPostProcess], rtt.renderTarget, true);
-            texture.updateSamplingMode(samplingMode);
-
-            // Read the contents of the framebuffer
-            const numberOfChannelsByLine = width * 4;
-            const halfHeight = height / 2;
-
-            //Reading datas from WebGL
-            const bufferView = await engine.readPixels(0, 0, width, height);
-            const data = new Uint8Array(bufferView.buffer, 0, bufferView.byteLength);
-
-            if (!channels.R || !channels.G || !channels.B || !channels.A) {
-                for (let i = 0; i < width * height * 4; i += 4) {
-                    // If alpha is the only channel, just display alpha across all channels
-                    if (channels.A && !channels.R && !channels.G && !channels.B) {
-                        data[i] = data[i + 3];
-                        data[i + 1] = data[i + 3];
-                        data[i + 2] = data[i + 3];
-                        data[i + 3] = 255;
-                        continue;
-                    }
-                    let r = data[i],
-                        g = data[i + 1],
-                        b = data[i + 2],
-                        a = data[i + 3];
-                    // If alpha is not visible, make everything 100% alpha
-                    if (!channels.A) {
-                        a = 255;
-                    }
-                    // If only one color channel is selected, map both colors to it. If two are selected, the unused one gets set to 0
-                    if (!channels.R) {
-                        if (channels.G && !channels.B) {
-                            r = g;
-                        } else if (channels.B && !channels.G) {
-                            r = b;
-                        } else {
-                            r = 0;
-                        }
-                    }
-                    if (!channels.G) {
-                        if (channels.R && !channels.B) {
-                            g = r;
-                        } else if (channels.B && !channels.R) {
-                            g = b;
-                        } else {
-                            g = 0;
-                        }
-                    }
-                    if (!channels.B) {
-                        if (channels.R && !channels.G) {
-                            b = r;
-                        } else if (channels.G && !channels.R) {
-                            b = g;
-                        } else {
-                            b = 0;
-                        }
-                    }
-                    data[i] = r;
-                    data[i + 1] = g;
-                    data[i + 2] = b;
-                    data[i + 3] = a;
-                }
-            }
-
-            //To flip image on Y axis.
-            if ((texture as Texture).invertY || texture.isCube) {
-                for (let i = 0; i < halfHeight; i++) {
-                    for (let j = 0; j < numberOfChannelsByLine; j++) {
-                        const currentCell = j + i * numberOfChannelsByLine;
-                        const targetLine = height - i - 1;
-                        const targetCell = j + targetLine * numberOfChannelsByLine;
-
-                        const temp = data[currentCell];
-                        data[currentCell] = data[targetCell];
-                        data[targetCell] = temp;
-                    }
-                }
-            }
-
-            resolve(data);
-
-            // Unbind
-            engine.unBindFramebuffer(rtt.renderTarget);
-        } else {
-            reject();
-        }
-
-        rtt.dispose();
-        lodPostProcess.dispose();
-
-        if (globalState) {
-            globalState.blockMutationUpdates = false;
-        }
-    }
-
-    public static GetTextureDataAsync(
+    /**
+     * Gets the data of the specified texture by rendering it to an intermediate RGBA texture and retreiving the bytes from it.
+     * This is convienent to get 8-bit RGBA values for a texture in a GPU compressed format.
+     * @param texture the source texture
+     * @param width the width of the result, which does not have to match the source texture width
+     * @param height the height of the result, which does not have to match the source texture height
+     * @param face if the texture has multiple faces, the face index to use for the source
+     * @param channels a filter for which of the RGBA channels to return in the result
+     * @param lod if the texture has multiple LODs, the lod index to use for the source
+     * @returns the 8-bit texture data
+     */
+    public static async GetTextureDataAsync(
         texture: BaseTexture,
         width: number,
         height: number,
@@ -177,15 +51,16 @@ export class TextureHelper {
         globalState?: GlobalState,
         lod: number = 0
     ): Promise<Uint8Array> {
-        return new Promise((resolve, reject) => {
-            if (!texture.isReady() && texture._texture) {
-                texture._texture.onLoadedObservable.addOnce(() => {
-                    this._ProcessAsync(texture, width, height, face, channels, lod, globalState || null, resolve, reject);
-                });
-                return;
+        if (globalState) {
+            globalState.blockMutationUpdates = true;
+        }
+        try {
+            const result = await TextureTools.GetTextureDataAsync(texture, width, height, face, channels, lod);
+            return result;
+        } finally {
+            if (globalState) {
+                globalState.blockMutationUpdates = true;
             }
-
-            this._ProcessAsync(texture, width, height, face, channels, lod, globalState || null, resolve, reject);
-        });
+        }
     }
 }

--- a/packages/dev/inspector/src/textureHelper.ts
+++ b/packages/dev/inspector/src/textureHelper.ts
@@ -56,7 +56,7 @@ export class TextureHelper {
             globalState.blockMutationUpdates = true;
         }
         try {
-            const data = await TextureTools.GetTextureDataAsync(texture, width, height, face, channels, lod);
+            const data = await TextureTools.GetTextureDataAsync(texture, width, height, face, lod);
             if (!channels.R || !channels.G || !channels.B || !channels.A) {
                 for (let i = 0; i < width * height * 4; i += 4) {
                     // If alpha is the only channel, just display alpha across all channels

--- a/packages/dev/inspector/src/textureHelper.ts
+++ b/packages/dev/inspector/src/textureHelper.ts
@@ -33,7 +33,7 @@ export interface TextureChannelsToDisplay {
  */
 export class TextureHelper {
     /**
-     * Gets the data of the specified texture by rendering it to an intermediate RGBA texture and retreiving the bytes from it.
+     * Gets the data of the specified texture by rendering it to an intermediate RGBA texture and retrieving the bytes from it.
      * This is convienent to get 8-bit RGBA values for a texture in a GPU compressed format.
      * @param texture the source texture
      * @param width the width of the result, which does not have to match the source texture width

--- a/packages/dev/inspector/src/textureHelper.ts
+++ b/packages/dev/inspector/src/textureHelper.ts
@@ -59,7 +59,7 @@ export class TextureHelper {
             return result;
         } finally {
             if (globalState) {
-                globalState.blockMutationUpdates = true;
+                globalState.blockMutationUpdates = false;
             }
         }
     }

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -57,7 +57,7 @@ export class EXT_mesh_gpu_instancing implements IGLTFExporterExtensionV2 {
                     const noRotation = Quaternion.Identity();
                     const noScale = Vector3.One();
 
-                    // retreive all the instance world matrix
+                    // retrieve all the instance world matrix
                     const matrix = babylonNode.thinInstanceGetWorldMatrices();
 
                     const iwt = TmpVectors.Vector3[2];


### PR DESCRIPTION
This is a refactor that will eventually enable a serializer like GLTFExporter to use the now core-based `GetTextureDataAsync` in order to serialize textures that are not directly retrievable as RGBA e.g., GPU-compressed formats.

For more discussion on that point, see #12257. The part that is missing to ultimately solve this is some sort of function or BaseTexture-property that can tell whether the texture uses a GPU compressed format. Once that exists, then it should be easy to do something like this... from `glTFMaterialExporter.ts`:

![image](https://github.com/BabylonJS/Babylon.js/assets/20366429/21df00fc-a5b4-4ed5-a735-5f9d984bb54a)

