### PR TITLE
Add missing collision and trigger events to IPhysicsEnginePluginV2 in…

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -346,6 +346,14 @@ export interface IPhysicsEnginePluginV2 {
      * Collision observable
      */
     onCollisionObservable: Observable<IPhysicsCollisionEvent>;
+    /**
+     * Collision ended observable
+     */
+    onCollisionEndedObservable: Observable<IBasePhysicsCollisionEvent>;
+    /**
+     * Trigger observable
+     */
+    onTriggerCollisionObservable: Observable<IBasePhysicsCollisionEvent>;
 
     setGravity(gravity: Vector3): void;
     setTimeStep(timeStep: number): void;


### PR DESCRIPTION
…terface

I noticed these were in the HavokPlugin class but not on the general interface, so I added them.