### PR TITLE
Distinguish sounds with no soundTrackId from those in soundTrack 0.

### DIFF
--- a/packages/dev/core/src/Audio/soundTrack.ts
+++ b/packages/dev/core/src/Audio/soundTrack.ts
@@ -106,7 +106,7 @@ export class SoundTrack {
         if (Engine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
             sound.connectToSoundTrackAudioNode(this._outputAudioNode);
         }
-        if (sound.soundTrackId) {
+        if (sound.soundTrackId !== undefined) {
             if (sound.soundTrackId === -1) {
                 this._scene.mainSoundTrack.removeSound(sound);
             } else if (this._scene.soundTracks) {


### PR DESCRIPTION
Add a sound to sound track #0 and then put into a different track did not unregister it from sound track #0. This resulted in an infinite loop when the tracks were eventually disposed (since this.soundCollection.length never dropped to 0).

There are no existing SoundTrack unit tests. I can add `soundTrack.test.ts` and add a regression test just for this case if you feel like it's worthwhile.