### PR TITLE
Add an ugly flag to glTF draco loader extension

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -453,7 +453,9 @@ export class DracoCompression implements IDisposable {
         const applyGltfNormalizedOverride = (kind: string, normalized: boolean): boolean => {
             if (gltfNormalizedOverride && gltfNormalizedOverride[kind] !== undefined) {
                 if (normalized !== gltfNormalizedOverride[kind]) {
-                    Logger.Warn(`Normalized flag from Draco data (${normalized}) does not match normalized flag from glTF accessor (${gltfNormalizedOverride[kind]}). Using flag from glTF accessor.`);
+                    Logger.Warn(
+                        `Normalized flag from Draco data (${normalized}) does not match normalized flag from glTF accessor (${gltfNormalizedOverride[kind]}). Using flag from glTF accessor.`
+                    );
                 }
 
                 return gltfNormalizedOverride[kind];

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -89,8 +89,10 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
                 attributes[kind] = uniqueId;
 
                 if (this.useNormalizedFlagFromAccessor) {
-                    const accessor = ArrayItem.Get(`${context}/attributes/${name}`, this._loader.gltf.accessors, primitive.attributes[name]);
-                    normalized[kind] = accessor.normalized || false;
+                    const accessor = ArrayItem.TryGet(this._loader.gltf.accessors, primitive.attributes[name]);
+                    if (accessor) {
+                        normalized[kind] = accessor.normalized || false;
+                    }
                 }
             };
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -36,6 +36,11 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
      */
     public enabled: boolean;
 
+    /**
+     * Defines whether to use the normalized flag from the glTF accessor instead of the Draco data. Defaults to true.
+     */
+    public useNormalizedFlagFromAccessor = true;
+
     private _loader: GLTFLoader;
 
     /**
@@ -69,6 +74,7 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
             }
 
             const attributes: { [kind: string]: number } = {};
+            const normalized: { [kind: string]: boolean } = {};
             const loadAttribute = (name: string, kind: string) => {
                 const uniqueId = extension.attributes[name];
                 if (uniqueId == undefined) {
@@ -81,6 +87,11 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
                 }
 
                 attributes[kind] = uniqueId;
+
+                if (this.useNormalizedFlagFromAccessor) {
+                    const accessor = ArrayItem.Get(`${context}/attributes/${name}`, this._loader.gltf.accessors, primitive.attributes[name]);
+                    normalized[kind] = accessor.normalized || false;
+                }
             };
 
             loadAttribute("POSITION", VertexBuffer.PositionKind);
@@ -100,7 +111,7 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
             if (!bufferView._dracoBabylonGeometry) {
                 bufferView._dracoBabylonGeometry = this._loader.loadBufferViewAsync(`/bufferViews/${bufferView.index}`, bufferView).then((data) => {
                     const dracoCompression = this.dracoCompression || DracoCompression.Default;
-                    return dracoCompression.decodeMeshToGeometryAsync(babylonMesh.name, this._loader.babylonScene, data, attributes).catch((error) => {
+                    return dracoCompression._decodeMeshToGeometryForGltfAsync(babylonMesh.name, this._loader.babylonScene, data, attributes, normalized).catch((error) => {
                         throw new Error(`${context}: ${error.message}`);
                     });
                 });

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1050,8 +1050,8 @@ export class GLTFLoader implements IGLTFLoader {
             );
         }
 
-        const loadAttribute = (attribute: string, kind: string, callback?: (accessor: IAccessor) => void) => {
-            if (attributes[attribute] == undefined) {
+        const loadAttribute = (name: string, kind: string, callback?: (accessor: IAccessor) => void) => {
+            if (attributes[name] == undefined) {
                 return;
             }
 
@@ -1060,7 +1060,7 @@ export class GLTFLoader implements IGLTFLoader {
                 babylonMesh._delayInfo.push(kind);
             }
 
-            const accessor = ArrayItem.Get(`${context}/attributes/${attribute}`, this._gltf.accessors, attributes[attribute]);
+            const accessor = ArrayItem.Get(`${context}/attributes/${name}`, this._gltf.accessors, attributes[name]);
             promises.push(
                 this._loadVertexAccessorAsync(`/accessors/${accessor.index}`, accessor, kind).then((babylonVertexBuffer) => {
                     if (babylonVertexBuffer.getKind() === VertexBuffer.PositionKind && !this.parent.alwaysComputeBoundingBox && !babylonMesh.skeleton) {

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -143,6 +143,20 @@ export class ArrayItem {
     }
 
     /**
+     * Gets an item from the given array or returns null if not available.
+     * @param array The array to get the item from
+     * @param index The index to the array
+     * @returns The array item or null
+     */
+    public static TryGet<T>(array: ArrayLike<T> | undefined, index: number | undefined): Nullable<T> {
+        if (!array || index == undefined || !array[index]) {
+            return null;
+        }
+
+        return array[index];
+    }
+
+    /**
      * Assign an `index` field to each item of the given array.
      * @param array The array of items
      */


### PR DESCRIPTION
There appears to be lots of files out there with invalid Draco data where the `normalized` flag in the data is marked `false` when it should be `true`. The glTF accessor info is correct. Draco data is supposed to be self-contained, so this is troubling. For now, adding this flag to read from the glTF accessor instead and log a warning when there is a mismatch.