### PR TITLE
STL loader: Fix out of memory when loading big stl files

### DIFF
--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -71,12 +71,7 @@ export class STLFileLoader implements ISceneLoaderPlugin {
             // ASCII .stl
 
             // convert to string
-            const array_buffer = new Uint8Array(data);
-            let str = "";
-            for (let i = 0; i < data.byteLength; i++) {
-                str += String.fromCharCode(array_buffer[i]); // implicitly assumes little-endian
-            }
-            data = str;
+            data = new TextDecoder().decode(new Uint8Array(data));
         }
 
         //if arrived here, data is a string, containing the STLA data.


### PR DESCRIPTION
See https://forum.babylonjs.com/t/higher-file-size-model-load-issue/44214/6

[...]

I forgot to mention that the use of `TextDecoder` is ok because it is supported by all browsers except IE11, which we no longer support.