### PR TITLE
EquiRectangularCubeTexture: load from url only once

### DIFF
--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -153,23 +153,25 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         if (!scene) {
             return;
         }
+        const faceDataArrays = callback();
+
         const texture = scene
             .getEngine()
             .createRawCubeTexture(
-                this._buffer,
-                scene,
+                faceDataArrays,
                 this._size,
                 Constants.TEXTUREFORMAT_RGB,
                 scene.getEngine().getCaps().textureFloat ? Constants.TEXTURETYPE_FLOAT : Constants.TEXTURETYPE_UNSIGNED_INTEGER,
                 this._noMipmap,
-                callback,
-                null,
-                this._onLoad,
-                this._onError
+                false,
+                Constants.TEXTURE_TRILINEAR_SAMPLINGMODE
             );
-        texture.url = url;
+        texture.url = this.url;
         scene.getEngine()._internalTexturesCache.push(texture);
         this._texture = texture;
+        if (this._onLoad) {
+            this._onLoad();
+        }
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -175,17 +175,10 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         if (!scene) {
             return;
         }
-
         const faceDataArrays = callback();
 
         const texture = this._texture!;
-        scene.getEngine().updateRawCubeTexture(
-            texture,
-            faceDataArrays,
-            texture.format,
-            texture.type,
-            texture.invertY
-        );
+        scene.getEngine().updateRawCubeTexture(texture, faceDataArrays, texture.format, texture.type, texture.invertY);
         texture.isReady = true;
         scene.removePendingData(texture);
 

--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -101,6 +101,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
      */
     private _loadImage(loadTextureCallback: () => void, onError: Nullable<(message?: string, exception?: any) => void>): void {
         const canvas = document.createElement("canvas");
+        const scene = this.getScene();
         LoadImage(
             this.url,
             (image) => {
@@ -123,7 +124,8 @@ export class EquiRectangularCubeTexture extends BaseTexture {
                     onError(`${this.getClassName()} could not be loaded`, e);
                 }
             },
-            null
+            // From ThinEngine#createTexture
+            scene ? scene.offlineProvider : undefined
         );
     }
 
@@ -152,10 +154,11 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         if (!scene) {
             return;
         }
-        this._texture = scene
+        // createRawCubeTextureFromUrl loads from url again
+        const texture = scene
             .getEngine()
-            .createRawCubeTextureFromUrl(
-                this.url,
+            .createRawCubeTexture(
+                this._buffer,
                 scene,
                 this._size,
                 Constants.TEXTUREFORMAT_RGB,
@@ -166,6 +169,10 @@ export class EquiRectangularCubeTexture extends BaseTexture {
                 this._onLoad,
                 this._onError
             );
+        // Code from ThinEngine#createRawCubeTextureFromUrl
+        texture.url = url;
+        scene.getEngine()._internalTexturesCache.push(texture);
+        this._texture = texture;
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -124,8 +124,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
                     onError(`${this.getClassName()} could not be loaded`, e);
                 }
             },
-            // From ThinEngine#createTexture
-            scene ? scene.offlineProvider : undefined
+            scene ? scene.offlineProvider : null
         );
     }
 
@@ -154,7 +153,6 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         if (!scene) {
             return;
         }
-        // createRawCubeTextureFromUrl loads from url again
         const texture = scene
             .getEngine()
             .createRawCubeTexture(
@@ -169,7 +167,6 @@ export class EquiRectangularCubeTexture extends BaseTexture {
                 this._onLoad,
                 this._onError
             );
-        // Code from ThinEngine#createRawCubeTextureFromUrl
         texture.url = url;
         scene.getEngine()._internalTexturesCache.push(texture);
         this._texture = texture;


### PR DESCRIPTION
https://forum.babylonjs.com/t/equirectangularcubetexture-loads-the-texture-twice/44319/1

Playground example:
<https://playground.babylonjs.com/?snapshot=refs/pull/14330/merge#RY8LDL#53>
![Playground screenshot](https://github.com/BabylonJS/Babylon.js/assets/120431159/b4414b2a-bf32-4dc6-b663-d03473b3cfde)
