### PR TITLE
Fix instance rendering issue in Babylon Native

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -325,7 +325,9 @@ interface INativeEngineConstructor {
     readonly COMMAND_UNBINDFRAMEBUFFER: NativeData;
     readonly COMMAND_DELETEFRAMEBUFFER: NativeData;
     readonly COMMAND_DRAWINDEXED: NativeData;
+    readonly COMMAND_DRAWINDEXEDINSTANCED?: NativeData;
     readonly COMMAND_DRAW: NativeData;
+    readonly COMMAND_DRAWINSTANCED?: NativeData;
     readonly COMMAND_CLEAR: NativeData;
     readonly COMMAND_SETSTENCIL: NativeData;
     readonly COMMAND_SETVIEWPORT: NativeData;

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -631,7 +631,7 @@ export class NativeEngine extends Engine {
         //     this._gl.drawArraysInstanced(drawMode, verticesStart, verticesCount, instancesCount);
         // } else {
 
-        if (instancesCount === undefined || _native.Engine.COMMAND_DRAWINSTANCED === undefined) {
+        if (instancesCount && _native.Engine.COMMAND_DRAWINDEXEDINSTANCED) {
             this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAW);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -190,7 +190,7 @@ class CommandBufferEncoder {
 /** @internal */
 export class NativeEngine extends Engine {
     // This must match the protocol version in NativeEngine.cpp
-    private static readonly PROTOCOL_VERSION = 8;
+    private static readonly PROTOCOL_VERSION = 9;
 
     private readonly _engine: INativeEngine = new _native.Engine();
     private readonly _camera: Nullable<INativeCamera> = _native.Camera ? new _native.Camera() : null;
@@ -599,6 +599,7 @@ export class NativeEngine extends Engine {
         this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount ? instancesCount : 0);
         this._commandBufferEncoder.finishEncodingCommand();
         // }
     }
@@ -623,6 +624,7 @@ export class NativeEngine extends Engine {
         this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount ? instancesCount : 0);
         this._commandBufferEncoder.finishEncodingCommand();
         // }
     }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -586,16 +586,6 @@ export class NativeEngine extends Engine {
         // Apply states
         this._drawCalls.addCount(1, false);
 
-        // TODO: Make this implementation more robust like core Engine version.
-
-        // Render
-        //var indexFormat = this._uintIndicesCurrentlySet ? this._gl.UNSIGNED_INT : this._gl.UNSIGNED_SHORT;
-
-        //var mult = this._uintIndicesCurrentlySet ? 4 : 2;
-        // if (instancesCount) {
-        //     this._gl.drawElementsInstanced(drawMode, indexCount, indexFormat, indexStart * mult, instancesCount);
-        // } else {
-
         if (instancesCount && _native.Engine.COMMAND_DRAWINDEXEDINSTANCED) {
             this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXEDINSTANCED);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
@@ -624,12 +614,6 @@ export class NativeEngine extends Engine {
     public drawArraysType(fillMode: number, verticesStart: number, verticesCount: number, instancesCount?: number): void {
         // Apply states
         this._drawCalls.addCount(1, false);
-
-        // TODO: Make this implementation more robust like core Engine version.
-
-        // if (instancesCount) {
-        //     this._gl.drawArraysInstanced(drawMode, verticesStart, verticesCount, instancesCount);
-        // } else {
 
         if (instancesCount && _native.Engine.COMMAND_DRAWINSTANCED) {
             this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINSTANCED);

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -596,20 +596,20 @@ export class NativeEngine extends Engine {
         //     this._gl.drawElementsInstanced(drawMode, indexCount, indexFormat, indexStart * mult, instancesCount);
         // } else {
 
-        if (instancesCount === undefined || _native.Engine.COMMAND_DRAWINDEXEDINSTANCED === undefined) {
-            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXED);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
-            this._commandBufferEncoder.finishEncodingCommand();
-        } else {
+        if (instancesCount && _native.Engine.COMMAND_DRAWINDEXEDINSTANCED) {
             this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXEDINSTANCED);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount);
-            this._commandBufferEncoder.finishEncodingCommand();
+        } else {
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXED);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
         }
+
+        this._commandBufferEncoder.finishEncodingCommand();
 
         // }
     }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -190,7 +190,7 @@ class CommandBufferEncoder {
 /** @internal */
 export class NativeEngine extends Engine {
     // This must match the protocol version in NativeEngine.cpp
-    private static readonly PROTOCOL_VERSION = 9;
+    private static readonly PROTOCOL_VERSION = 8;
 
     private readonly _engine: INativeEngine = new _native.Engine();
     private readonly _camera: Nullable<INativeCamera> = _native.Camera ? new _native.Camera() : null;
@@ -595,12 +595,22 @@ export class NativeEngine extends Engine {
         // if (instancesCount) {
         //     this._gl.drawElementsInstanced(drawMode, indexCount, indexFormat, indexStart * mult, instancesCount);
         // } else {
-        this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXED);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount ? instancesCount : 0);
-        this._commandBufferEncoder.finishEncodingCommand();
+
+        if (instancesCount === undefined || _native.Engine.COMMAND_DRAWINDEXEDINSTANCED === undefined) {
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXED);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
+            this._commandBufferEncoder.finishEncodingCommand();
+        } else {
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINDEXEDINSTANCED);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(indexCount);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount);
+            this._commandBufferEncoder.finishEncodingCommand();
+        }
+
         // }
     }
 
@@ -620,12 +630,22 @@ export class NativeEngine extends Engine {
         // if (instancesCount) {
         //     this._gl.drawArraysInstanced(drawMode, verticesStart, verticesCount, instancesCount);
         // } else {
-        this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAW);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
-        this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount ? instancesCount : 0);
-        this._commandBufferEncoder.finishEncodingCommand();
+
+        if (instancesCount === undefined || _native.Engine.COMMAND_DRAWINSTANCED === undefined) {
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAW);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
+            this._commandBufferEncoder.finishEncodingCommand();
+        }
+        else{
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINSTANCED);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount);
+            this._commandBufferEncoder.finishEncodingCommand();
+        }
         // }
     }
 

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -631,19 +631,19 @@ export class NativeEngine extends Engine {
         //     this._gl.drawArraysInstanced(drawMode, verticesStart, verticesCount, instancesCount);
         // } else {
 
-        if (instancesCount && _native.Engine.COMMAND_DRAWINDEXEDINSTANCED) {
-            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAW);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
-            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
-            this._commandBufferEncoder.finishEncodingCommand();
-        }
-        else{
+        if (instancesCount && _native.Engine.COMMAND_DRAWINSTANCED) {
             this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAWINSTANCED);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
             this._commandBufferEncoder.encodeCommandArgAsUInt32(instancesCount);
+            this._commandBufferEncoder.finishEncodingCommand();
+        }
+        else{
+            this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_DRAW);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(fillMode);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesStart);
+            this._commandBufferEncoder.encodeCommandArgAsUInt32(verticesCount);
             this._commandBufferEncoder.finishEncodingCommand();
         }
         // }


### PR DESCRIPTION
Babylon Native is currently not using the instanceCount information when performing instance rendering. This PR sends that information so Babylon Native can properly handle it. 

Babylon Native PR: https://github.com/BabylonJS/BabylonNative/pull/1290

Since this changes Protocol version, this PR must be merged first and Babylon Native must than be updated to the latest version of Babylon.js otherwise it will fail validation test. 

Forum issue: https://forum.babylonjs.com/t/react-native-unexpected-behaviour-of-instance-mesh-on-its-parent-movement/37001/2