### PR TITLE
Flow graph pause animation node

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPauseAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPauseAnimationBlock.ts
@@ -1,0 +1,27 @@
+import type { FlowGraphContext } from "../../../flowGraphContext";
+import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
+import { FlowGraphWithOnDoneExecutionBlock } from "../../../flowGraphWithOnDoneExecutionBlock";
+import type { Animatable } from "../../../../Animations";
+import { RichTypeAny } from "../../../flowGraphRichTypes";
+
+/**
+ * @experimental
+ * Block that stops a running animation
+ */
+export class FlowGraphPauseAnimationBlock extends FlowGraphWithOnDoneExecutionBlock {
+    /**
+     *
+     */
+    public readonly animationToPause: FlowGraphDataConnection<Animatable>;
+
+    constructor() {
+        super();
+        this.animationToPause = this._registerDataInput("animationToPause", RichTypeAny);
+    }
+
+    public _execute(context: FlowGraphContext): void {
+        const animationToPauseValue = this.animationToPause.getValue(context);
+        animationToPauseValue.pause();
+        this.onDone._activateSignal(context);
+    }
+}

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
@@ -75,10 +75,10 @@ export class FlowGraphPlayAnimationBlock extends FlowGraphAsyncExecutionBlock {
 
         const contextAnimatables = (context._getExecutionVariable(this, "runningAnimatables") as Animatable[]) ?? [];
 
-        // was an animation started on this target already?
+        // was an animation started on this target already and was just paused? if so, we can unpause it.
         const existingAnimatable = this.runningAnimatable.getValue(context);
-        if (existingAnimatable) {
-            // todo: continue existing animation
+        if (existingAnimatable && existingAnimatable.paused) {
+            existingAnimatable.restart();
         } else {
             const scene = context.graphVariables.scene;
             const animatable = scene.beginDirectAnimation(

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
@@ -1,9 +1,9 @@
-import type { FlowGraphContext } from "../../flowGraphContext";
-import type { Animatable, Animation, IAnimatable } from "../../../Animations";
-import type { FlowGraphDataConnection } from "../../flowGraphDataConnection";
-import type { FlowGraphSignalConnection } from "../../flowGraphSignalConnection";
-import { FlowGraphAsyncExecutionBlock } from "../../flowGraphAsyncExecutionBlock";
-import { RichTypeAny, RichTypeNumber, RichTypeBoolean } from "../../flowGraphRichTypes";
+import type { FlowGraphContext } from "../../../flowGraphContext";
+import type { Animatable, Animation, IAnimatable } from "../../../../Animations";
+import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
+import type { FlowGraphSignalConnection } from "../../../flowGraphSignalConnection";
+import { FlowGraphAsyncExecutionBlock } from "../../../flowGraphAsyncExecutionBlock";
+import { RichTypeAny, RichTypeNumber, RichTypeBoolean } from "../../../flowGraphRichTypes";
 
 /**
  * @experimental
@@ -73,22 +73,28 @@ export class FlowGraphPlayAnimationBlock extends FlowGraphAsyncExecutionBlock {
             throw new Error("Cannot play animation without target or animation");
         }
 
-        const contextAnims = (context._getExecutionVariable(this, "runningAnimatables") as Animatable[]) ?? [];
+        const contextAnimatables = (context._getExecutionVariable(this, "runningAnimatables") as Animatable[]) ?? [];
 
-        const scene = context.graphVariables.scene;
-        const animatable = scene.beginDirectAnimation(
-            targetValue,
-            [animationValue],
-            this.from.getValue(context),
-            this.to.getValue(context),
-            this.loop.getValue(context),
-            this.speed.getValue(context),
-            () => this._onAnimationEnd(animatable, context)
-        );
-        this.runningAnimatable.value = animatable;
-        contextAnims.push(animatable);
+        // was an animation started on this target already?
+        const existingAnimatable = this.runningAnimatable.getValue(context);
+        if (existingAnimatable) {
+            // todo: continue existing animation
+        } else {
+            const scene = context.graphVariables.scene;
+            const animatable = scene.beginDirectAnimation(
+                targetValue,
+                [animationValue],
+                this.from.getValue(context),
+                this.to.getValue(context),
+                this.loop.getValue(context),
+                this.speed.getValue(context),
+                () => this._onAnimationEnd(animatable, context)
+            );
+            this.runningAnimatable.value = animatable;
+            contextAnimatables.push(animatable);
+        }
 
-        context._setExecutionVariable(this, "runningAnimatables", contextAnims);
+        context._setExecutionVariable(this, "runningAnimatables", contextAnimatables);
     }
 
     public _execute(context: FlowGraphContext): void {

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphStopAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphStopAnimationBlock.ts
@@ -1,8 +1,8 @@
-import type { FlowGraphContext } from "../../flowGraphContext";
-import type { FlowGraphDataConnection } from "../../flowGraphDataConnection";
-import { FlowGraphWithOnDoneExecutionBlock } from "../../flowGraphWithOnDoneExecutionBlock";
-import type { Animatable } from "../../../Animations";
-import { RichTypeAny } from "../../flowGraphRichTypes";
+import type { FlowGraphContext } from "../../../flowGraphContext";
+import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
+import { FlowGraphWithOnDoneExecutionBlock } from "../../../flowGraphWithOnDoneExecutionBlock";
+import type { Animatable } from "../../../../Animations";
+import { RichTypeAny } from "../../../flowGraphRichTypes";
 
 /**
  * @experimental

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/index.ts
@@ -1,0 +1,3 @@
+export * from "./flowGraphPlayAnimationBlock";
+export * from "./flowGraphStopAnimationBlock";
+export * from "./flowGraphPauseAnimationBlock";

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/index.ts
@@ -1,9 +1,9 @@
 export * from "./flowGraphForLoopBlock";
 export * from "./flowGraphLogBlock";
 export * from "./flowGraphConditionalBlock";
-export * from "./flowGraphPlayAnimationBlock";
 export * from "./flowGraphSetVariableBlock";
 export * from "./flowGraphSetPropertyBlock";
 export * from "./flowGraphTimerBlock";
 export * from "./flowGraphSendCustomEventBlock";
-export * from "./flowGraphStopAnimationBlock";
+// eslint-disable-next-line import/no-internal-modules
+export * from "./Animation/index";


### PR DESCRIPTION
# Changes
- Move Play/Stop Animation blocks to its own subfolder
- Add Pause Animation node
- Update Play Animation logic to account for possibly paused animations

# Example
Car semaphore example with pause (yellow button): #GPPEUA#7