### PR TITLE
EquiRectangularCubeTexture: fix load

### DIFF
--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -121,6 +121,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
         texture.url = this.url;
         texture.isReady = false;
         scene.getEngine()._internalTexturesCache.push(texture);
+        this._texture = texture;
 
         const canvas = document.createElement("canvas");
         LoadImage(


### PR DESCRIPTION
Missing from https://github.com/BabylonJS/Babylon.js/pull/14330
Example: <https://playground.babylonjs.com/?snapshot=refs/pull/14345/merge#RY8LDL#32>