### PR TITLE
Better fix for recent Draco changes

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -848,7 +848,7 @@ export class VertexBuffer {
 
         if (type !== VertexBuffer.FLOAT || byteStride !== tightlyPackedByteStride) {
             const copy = new Float32Array(count);
-            VertexBuffer.ForEach(data, byteOffset, byteStride, size, type, count, normalized, (value, index) => copy[index] = value);
+            VertexBuffer.ForEach(data, byteOffset, byteStride, size, type, count, normalized, (value, index) => (copy[index] = value));
             return copy;
         }
 

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -499,8 +499,19 @@
             "referenceImage": "customRTT.png"
         },
         {
-            "title": "Draco Mesh Compression",
+            "title": "Draco Mesh Compression (decodeMeshAsync, numWorkers = 1)",
             "playgroundId": "#22MFU2#4",
+            "referenceImage": "draco.png"
+        },
+        {
+            "title": "Draco Mesh Compression (decodeMeshToGeometryAsync, numWorkers = 0)",
+            "playgroundId": "#22MFU2#65",
+            "referenceImage": "draco.png"
+        },
+        {
+            "title": "Draco Mesh Compression (decodeMeshToGeometryAsync, numWorkers = 1)",
+            "playgroundId": "#22MFU2#65",
+            "replace": "numWorkers = 0, numWorkers = 1",
             "referenceImage": "draco.png"
         },
         {


### PR DESCRIPTION
See forum: https://forum.babylonjs.com/t/setting-the-value-0-to-the-defaultnumworkers-from-dracocompression-throw-an-engine-error-since-6-21-1-version/44323

- Undo changes to vertex buffer so that engine is no longer nullable.
- Factor out GetFloatData function so that it can be used in DracoCompression.
- Update DracoCompression code to use VertexBuffer only when it's necessary.
