### PR TITLE
ArcRotateCamera: Modify mapPanning to account for upVector

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -948,7 +948,7 @@ export class ArcRotateCamera extends TargetCamera {
             // make sure we're not panning in the y direction
             if (this.mapPanning) {
                 const up = this.upVector;
-                const right = Vector3.Cross(this._transformedDirection, up);
+                const right = Vector3.CrossToRef(this._transformedDirection, up, this._transformedDirection);
                 Vector3.CrossToRef(up, right, this._transformedDirection);
             } else if (!this.panningAxis.y) {
                 this._transformedDirection.y = 0;

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -943,8 +943,14 @@ export class ArcRotateCamera extends TargetCamera {
             this._viewMatrix.invertToRef(this._cameraTransformMatrix);
             localDirection.multiplyInPlace(this.panningAxis);
             Vector3.TransformNormalToRef(localDirection, this._cameraTransformMatrix, this._transformedDirection);
-            // Eliminate y if mapPanning is enabled
-            if (this.mapPanning || !this.panningAxis.y) {
+
+            // If mapPanning is enabled, we need to take the upVector into account and
+            // make sure we're not panning in the y direction
+            if (this.mapPanning) {
+                const up = this.upVector;
+                const right = Vector3.Cross(this._transformedDirection, up);
+                Vector3.CrossToRef(up, right, this._transformedDirection);
+            } else if (!this.panningAxis.y) {
                 this._transformedDirection.y = 0;
             }
 


### PR DESCRIPTION
This PR contains a change to the logic for `mapPanning` so that the X/Z panning will happen with respect to whatever the current upVector is, rather than against the absolute X/Z axes.

Related forum link: https://forum.babylonjs.com/t/arcrotatecamera-mappanning-does-not-take-upvector-into-account/43820/3

Example PR to test in future: https://playground.babylonjs.com/#YSVLLN#1