### PR TITLE
switch all dependencies to CDN Serve and Watch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -370,7 +370,7 @@
             "port": 9229,
             // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
             // "envFile": "${workspaceRoot}/.env",
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*
@@ -386,7 +386,7 @@
             "port": 9229,
             // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
             // "envFile": "${workspaceRoot}/.env",
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*
@@ -402,7 +402,7 @@
             "port": 9229,
             // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
             // "envFile": "${workspaceRoot}/.env",
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*
@@ -418,7 +418,7 @@
             "port": 9229,
             // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
             // "envFile": "${workspaceRoot}/.env",
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*
@@ -437,7 +437,7 @@
             },
             // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
             // "envFile": "${workspaceRoot}/.env",
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*
@@ -451,7 +451,7 @@
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
-            "preLaunchTask": "CDN Serve (Dev)"
+            "preLaunchTask": "CDN Serve and watch (Dev)"
         },
         {
             /*

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
         },
         {
             "label": "Run visualization tests (Dev)",
-            "dependsOn": ["CDN Serve (Dev)"],
+            "dependsOn": ["CDN Serve and watch (Dev)"],
             "type": "shell",
             "command": "npm",
             "runOptions": {
@@ -91,7 +91,7 @@
         },
         {
             "label": "Run visualization tests headless (Dev)",
-            "dependsOn": ["CDN Serve (Dev)"],
+            "dependsOn": ["CDN Serve and watch (Dev)"],
             "type": "shell",
             "command": "npm",
             "runOptions": {
@@ -235,7 +235,7 @@
             "label": "Playground Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -253,7 +253,7 @@
             "label": "Playground Serve (LTS)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (LTS)",
+            "dependsOn": "CDN Serve and watch (LTS)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -289,7 +289,7 @@
             "label": "Sandbox Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -325,7 +325,7 @@
             "label": "GUI Editor Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -361,7 +361,7 @@
             "label": "Node Editor Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -397,7 +397,7 @@
             "label": "Node Geometry Editor Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -433,7 +433,7 @@
             "label": "VSM Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve (Dev)",
+            "dependsOn": "CDN Serve and watch (Dev)",
             "runOptions": {
                 "instanceLimit": 1
             },


### PR DESCRIPTION
This way tasks can be reused when running more than one server (sandbox + playground, or vis-tests)