### PR TITLE
fix: correct the comment for resizeToFit

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -76,7 +76,7 @@ export class TextBlock extends Control {
     }
 
     /**
-     * Gets or sets an boolean indicating that the TextBlock will be resized to fit container
+     * Gets or sets an boolean indicating that the TextBlock will be resized to fit it's content
      */
     @serialize()
     public get resizeToFit(): boolean {
@@ -84,7 +84,7 @@ export class TextBlock extends Control {
     }
 
     /**
-     * Gets or sets an boolean indicating that the TextBlock will be resized to fit container
+     * Gets or sets an boolean indicating that the TextBlock will be resized to fit it's content
      */
     public set resizeToFit(value: boolean) {
         if (this._resizeToFit === value) {

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -76,7 +76,8 @@ export class TextBlock extends Control {
     }
 
     /**
-     * Gets or sets an boolean indicating that the TextBlock will be resized to fit it's content
+     * Gets or sets an boolean indicating that the TextBlock will be resized to fit its content
+
      */
     @serialize()
     public get resizeToFit(): boolean {

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -85,7 +85,8 @@ export class TextBlock extends Control {
     }
 
     /**
-     * Gets or sets an boolean indicating that the TextBlock will be resized to fit it's content
+     * Gets or sets an boolean indicating that the TextBlock will be resized to fit its content
+
      */
     public set resizeToFit(value: boolean) {
         if (this._resizeToFit === value) {


### PR DESCRIPTION
According to the actual effect of `resizeToFit()`, I think it would be better to change the comment to `to fit it's content` rather `to fit container`.

The `TextBlock` will always be resized to fit it's content whether the text is too long or too large. Any excess beyond the container, like a plane attached the texture with one `TextBlock`,  will not be displayed.

In the meanwhile, when I set the `fontSize`, `width` and `resizeToFit` simultaneously, it's `width` to fit `fontSize`, rather `fontSize` to fit `width`.

```
let text = new BABYLON.GUI.TextBlock();
text.text = "Hello world";
text.fontSize = 50;
text.width = 0.5
text.resizeToFit = true
```

**It's all about the content.** There's nothing about the `container` or `to fit container`.

As far as I'm concerned, the original version is kind of ambiguous to understand. And I think it might be better to make this modification for better clarity.

Thanks.
