### PR TITLE
Mesh: Add a helper method to draw a mesh given a render pass id

### DIFF
--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -713,7 +713,7 @@ export class UniformBuffer {
             for (let i = 0; i < size; i++) {
                 // We are checking the matrix cache before calling updateUniform so we do not need to check it here
                 // Hence the test for size === 16 to simply commit the matrix values
-                if ((size === 16 && !this._engine._features.uniformBufferHardCheckMatrix) || this._bufferData[location + i] !== Tools.FloatRound(data[i])) {
+                if ((size === 16 && !this._engine._features.uniformBufferHardCheckMatrix) || this._bufferData[location + i] !== Math.fround(data[i])) {
                     changed = true;
                     if (this._createBufferOnWrite) {
                         this._createNewBuffer();

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2203,6 +2203,43 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     }
 
     /**
+     * Triggers the draw call for the mesh (or a submesh), for a specific render pass id
+     * @param renderPassId defines the render pass id to use to draw the mesh / submesh. If not provided, use the current renderPassId of the engine.
+     * @param enableAlphaMode defines if alpha mode can be changed (default: false)
+     * @param effectiveMeshReplacement defines an optional mesh used to provide info for the rendering (default: undefined)
+     * @param subMesh defines the subMesh to render. If not provided, draw all mesh submeshes (default: undefined)
+     * @param checkFrustumCulling defines if frustum culling must be checked (default: true). If you know the mesh is in the frustum (or if you don't care!), you can pass false to optimize.
+     * @returns the current mesh
+     */
+    public renderWithRenderPassId(renderPassId?: number, enableAlphaMode?: boolean, effectiveMeshReplacement?: AbstractMesh, subMesh?: SubMesh, checkFrustumCulling = true) {
+        const engine = this._scene.getEngine();
+        const currentRenderPassId = engine.currentRenderPassId;
+
+        if (renderPassId !== undefined) {
+            engine.currentRenderPassId = renderPassId;
+        }
+
+        if (subMesh) {
+            if (!checkFrustumCulling || (checkFrustumCulling && subMesh.isInFrustum(this._scene._frustumPlanes))) {
+                this.render(subMesh, !!enableAlphaMode, effectiveMeshReplacement);
+            }
+        } else {
+            for (let s = 0; s < this.subMeshes.length; s++) {
+                const subMesh = this.subMeshes[s];
+                if (!checkFrustumCulling || (checkFrustumCulling && subMesh.isInFrustum(this._scene._frustumPlanes))) {
+                    this.render(subMesh, !!enableAlphaMode, effectiveMeshReplacement);
+                }
+            }
+        }
+
+        if (renderPassId !== undefined) {
+            engine.currentRenderPassId = currentRenderPassId;
+        }
+
+        return this;
+    }
+
+    /**
      * Triggers the draw call for the mesh. Usually, you don't need to call this method by your own because the mesh rendering is handled by the scene rendering manager
      * @param subMesh defines the subMesh to render
      * @param enableAlphaMode defines if alpha mode can be changed

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -183,8 +183,6 @@ export class Tools {
         return count === value;
     }
 
-    private static _TmpFloatArray = new Float32Array(1);
-
     /**
      * Returns the nearest 32-bit single precision float representation of a Number
      * @param value A Number.  If the parameter is of a different type, it will get converted
@@ -192,11 +190,7 @@ export class Tools {
      * @returns number
      */
     public static FloatRound(value: number): number {
-        if (Math.fround) {
-            return Math.fround(value);
-        }
-
-        return (Tools._TmpFloatArray[0] = value), Tools._TmpFloatArray[0];
+        return Math.fround(value);
     }
 
     /**


### PR DESCRIPTION
I've added `Mesh.renderWithRenderPassId` to make it easier to render an entire mesh without having to loop through sub-meshes by hand. If you provide a render pass ID, this is a useful method for rendering a mesh multiple times in a frame.

In the past, I used to reply to forum posts, when a specific rendering effect required a mesh to be rendered multiple times per frame, that the mesh needed to be cloned. In fact, using render pass IDs solves the problem neatly: simply create a new render pass ID and use it to assign the material you want to use to render your mesh a second time! The helper method simplifies this scheme by allowing you to perform the additional rendering in a single call.

For example
* Mesh cloning: https://playground.babylonjs.com/#QDAZ80#207
* Use of a render pass id + helper method: https://playground.babylonjs.com/#QDAZ80#506

I'd have preferred to call it `render`, but this method already exists (and draws a sub-mesh)...

This PR also makes a small change to `Tools.FloatRound`. I've checked that `Math.fround` is supported by all the browsers we're targeting (it wasn't supported by IE11 only, for which we dropped support some time ago), so it's a small performance improvement to remove the `if` condition.