### PR TITLE
Inspector tweaks for CSM and removing an implicit varying from shadowsFragmentFunctions.fx

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -213,19 +213,19 @@
             }
         #elif defined(SHADOWCLOSEESM{X})
             #if defined(SHADOWCUBE{X})
-                shadow = computeShadowWithCloseESMCube(light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.depthValues);
+                shadow = computeShadowWithCloseESMCube(vPositionW, light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.depthValues);
             #else
                 shadow = computeShadowWithCloseESM(vPositionFromLight{X}, vDepthMetric{X}, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.shadowsInfo.w);
             #endif
         #elif defined(SHADOWESM{X})
             #if defined(SHADOWCUBE{X})
-                shadow = computeShadowWithESMCube(light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.depthValues);
+                shadow = computeShadowWithESMCube(vPositionW, light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.depthValues);
             #else
                 shadow = computeShadowWithESM(vPositionFromLight{X}, vDepthMetric{X}, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.z, light{X}.shadowsInfo.w);
             #endif
         #elif defined(SHADOWPOISSON{X})
             #if defined(SHADOWCUBE{X})
-                shadow = computeShadowWithPoissonSamplingCube(light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.y, light{X}.shadowsInfo.x, light{X}.depthValues);
+                shadow = computeShadowWithPoissonSamplingCube(vPositionW, light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.y, light{X}.shadowsInfo.x, light{X}.depthValues);
             #else
                 shadow = computeShadowWithPoissonSampling(vPositionFromLight{X}, vDepthMetric{X}, shadowSampler{X}, light{X}.shadowsInfo.y, light{X}.shadowsInfo.x, light{X}.shadowsInfo.w);
             #endif
@@ -247,7 +247,7 @@
             #endif
         #else
             #if defined(SHADOWCUBE{X})
-                shadow = computeShadowCube(light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.depthValues);
+                shadow = computeShadowCube(vPositionW, light{X}.vLightData.xyz, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.depthValues);
             #else
                 shadow = computeShadow(vPositionFromLight{X}, vDepthMetric{X}, shadowSampler{X}, light{X}.shadowsInfo.x, light{X}.shadowsInfo.w);
             #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
@@ -21,9 +21,9 @@
     }
 
     #define inline
-    float computeShadowCube(vec3 lightPosition, samplerCube shadowSampler, float darkness, vec2 depthValues)
+    float computeShadowCube(vec3 worldPos, vec3 lightPosition, samplerCube shadowSampler, float darkness, vec2 depthValues)
     {
-        vec3 directionToLight = vPositionW - lightPosition;
+        vec3 directionToLight = worldPos - lightPosition;
         float depth = length(directionToLight);
         depth = (depth + depthValues.x) / (depthValues.y);
         depth = clamp(depth, 0., 1.0);
@@ -41,9 +41,9 @@
     }
 
     #define inline
-    float computeShadowWithPoissonSamplingCube(vec3 lightPosition, samplerCube shadowSampler, float mapSize, float darkness, vec2 depthValues)
+    float computeShadowWithPoissonSamplingCube(vec3 worldPos, vec3 lightPosition, samplerCube shadowSampler, float mapSize, float darkness, vec2 depthValues)
     {
-        vec3 directionToLight = vPositionW - lightPosition;
+        vec3 directionToLight = worldPos - lightPosition;
         float depth = length(directionToLight);
         depth = (depth + depthValues.x) / (depthValues.y);
         depth = clamp(depth, 0., 1.0);
@@ -77,9 +77,9 @@
     }
 
     #define inline
-    float computeShadowWithESMCube(vec3 lightPosition, samplerCube shadowSampler, float darkness, float depthScale, vec2 depthValues)
+    float computeShadowWithESMCube(vec3 worldPos, vec3 lightPosition, samplerCube shadowSampler, float darkness, float depthScale, vec2 depthValues)
     {
-        vec3 directionToLight = vPositionW - lightPosition;
+        vec3 directionToLight = worldPos - lightPosition;
         float depth = length(directionToLight);
         depth = (depth + depthValues.x) / (depthValues.y);
         float shadowPixelDepth = clamp(depth, 0., 1.0);
@@ -93,21 +93,21 @@
             float shadowMapSample = textureCube(shadowSampler, directionToLight).x;
         #endif
 
-        float esm = 1.0 - clamp(exp(min(87., depthScale * shadowPixelDepth)) * shadowMapSample, 0., 1. - darkness);	
+        float esm = 1.0 - clamp(exp(min(87., depthScale * shadowPixelDepth)) * shadowMapSample, 0., 1. - darkness);
         return esm;
     }
 
     #define inline
-    float computeShadowWithCloseESMCube(vec3 lightPosition, samplerCube shadowSampler, float darkness, float depthScale, vec2 depthValues)
+    float computeShadowWithCloseESMCube(vec3 worldPos, vec3 lightPosition, samplerCube shadowSampler, float darkness, float depthScale, vec2 depthValues)
     {
-        vec3 directionToLight = vPositionW - lightPosition;
+        vec3 directionToLight = worldPos - lightPosition;
         float depth = length(directionToLight);
         depth = (depth + depthValues.x) / (depthValues.y);
         float shadowPixelDepth = clamp(depth, 0., 1.0);
 
         directionToLight = normalize(directionToLight);
         directionToLight.y = -directionToLight.y;
-        
+
         #ifndef SHADOWFLOAT
             float shadowMapSample = unpack(textureCube(shadowSampler, directionToLight));
         #else
@@ -299,7 +299,7 @@
 
             // Equation resolved to fit in a 3*3 distribution like 
             // 1 2 1
-            // 2 4 2 
+            // 2 4 2
             // 1 2 1
             vec2 uvw0 = 3. - 2. * st;
             vec2 uvw1 = 1. + 2. * st;
@@ -421,7 +421,7 @@
                 return computeFallOff(shadow, clipSpace.xy, frustumEdgeFalloff);
             }
         }
-        
+
         // Shadow PCF kernel 5*5 in only 9 taps (high quality)
         // This uses a well distributed taps to allow a gaussian distribution covering a 5*5 kernel
         // https://mynameismjp.wordpress.com/2013/09/10/shadow-maps/
@@ -504,38 +504,38 @@
             vec3(-0.04661255, 0.7995201, 0.),
             vec3(0.4402924, 0.3640312, 0.),
 
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.),
-            vec3(0., 0., 0.)
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.),
+            vec3(0.)
         );
 
         const vec3 PoissonSamplers64[64] = vec3[64](

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/commonShadowLightPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/commonShadowLightPropertyGridComponent.tsx
@@ -74,6 +74,7 @@ export class CommonShadowLightPropertyGridComponent extends React.Component<ICom
         }
 
         const mapSizeOptions = [
+            { label: "4096x4096", value: 4096 },
             { label: "2048x2048", value: 2048 },
             { label: "1024x1024", value: 1024 },
             { label: "512x512", value: 512 },
@@ -114,7 +115,7 @@ export class CommonShadowLightPropertyGridComponent extends React.Component<ICom
         ];
 
         const near = camera ? camera.minZ : 0,
-            far = camera ? camera.maxZ : 0;
+            far = camera ? (camera.maxZ ? camera.maxZ : 500000) : 0;
 
         const filter = generator ? generator.filter : 0;
 


### PR DESCRIPTION
* Allow for editing shadow max Z in CSM inspector when camera is using an infinite far plane (i.e. camera.maxZ = 0)
* Add 4K shadow map option to CSM inspector
* Replace implicit usages vPositionW with a function parameter (worldPos) which allows shadowsFragmentFunctions.fx to be included in shaders that don't have a vPositionW varying.
* Other minor cleanup in shadowsFragmentFunctions.fx