### PR TITLE
WebGPU: Fix bug introduced by #14378

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -288,9 +288,10 @@ export const renderableTextureFormatToIndex: { [name: string]: number } = {
     stencil8: 33,
     depth16unorm: 34,
     depth24plus: 35,
-    depth32float: 36,
+    "depth24plus-stencil8": 36,
+    depth32float: 37,
 
-    "depth32float-stencil8": 37,
+    "depth32float-stencil8": 38,
 };
 
 /** @internal */


### PR DESCRIPTION
A render target format has been removed by mistake in #14378, making the highlight layer (and probably other things!) fail.