### PR TITLE
videoTexture serialization

### DIFF
--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -20,6 +20,7 @@ import type { CubeTexture } from "../../Materials/Textures/cubeTexture";
 import type { MirrorTexture } from "../../Materials/Textures/mirrorTexture";
 import type { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
 import type { Scene } from "../../scene";
+import type { VideoTexture, VideoTextureSettings } from "./videoTexture";
 
 /**
  * Defines the available options when creating a texture
@@ -110,6 +111,20 @@ export class Texture extends BaseTexture {
     public static _CreateRenderTargetTexture = (name: string, renderTargetSize: number, scene: Scene, generateMipMaps: boolean, creationFlags?: number): RenderTargetTexture => {
         throw _WarnImport("RenderTargetTexture");
     };
+
+    public static _CreateVideoTexture(
+        name: Nullable<string>,
+        src: string | string[] | HTMLVideoElement,
+        scene: Nullable<Scene>,
+        generateMipMaps = false,
+        invertY = false,
+        samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
+        settings: Partial<VideoTextureSettings> = {},
+        onError?: Nullable<(message?: string, exception?: any) => void>,
+        format: number = Constants.TEXTUREFORMAT_RGBA
+    ): VideoTexture {
+        throw _WarnImport("VideoTexture");
+    }
 
     /** nearest is mag = nearest and min = nearest and no mip */
     public static readonly NEAREST_SAMPLINGMODE = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
@@ -1029,6 +1044,18 @@ export class Texture extends BaseTexture {
                     }
                     onLoaded(renderTargetTexture);
                     return renderTargetTexture;
+                } else if (parsedTexture.isVideo) {
+                    const texture = Texture._CreateVideoTexture(
+                        rootUrl + (parsedTexture.url || parsedTexture.name),
+                        rootUrl + (parsedTexture.src || parsedTexture.url),
+                        scene,
+                        generateMipMaps,
+                        parsedTexture.invertY,
+                        parsedTexture.samplingMode,
+                        parsedTexture.settings || {}
+                    );
+                    onLoaded(texture);
+                    return texture;
                 } else {
                     let texture: Texture;
 

--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -9,7 +9,7 @@ import type { ExternalTexture } from "./externalTexture";
 
 import "../../Engines/Extensions/engine.videoTexture";
 import "../../Engines/Extensions/engine.dynamicTexture";
-import { SerializationHelper, serialize } from "core/Misc/decorators";
+import { serialize } from "core/Misc/decorators";
 import { RegisterClass } from "core/Misc/typeStore";
 
 function removeSource(video: HTMLVideoElement): void {

--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -10,6 +10,7 @@ import type { ExternalTexture } from "./externalTexture";
 import "../../Engines/Extensions/engine.videoTexture";
 import "../../Engines/Extensions/engine.dynamicTexture";
 import { SerializationHelper, serialize } from "core/Misc/decorators";
+import { RegisterClass } from "core/Misc/typeStore";
 
 function removeSource(video: HTMLVideoElement): void {
     // Remove any <source> elements, etc.
@@ -452,33 +453,6 @@ export class VideoTexture extends Texture {
     }
 
     /**
-     * Parses text to create a cube texture
-     * @param parsedTexture define the serialized text to read from
-     * @param scene defines the hosting scene
-     * @param rootUrl defines the root url of the cube texture
-     * @returns a cube texture
-     */
-    public static Parse(parsedTexture: any, scene: Scene, rootUrl: string): VideoTexture {
-        const texture = SerializationHelper.Parse(
-            () => {
-                return new VideoTexture(
-                    rootUrl + (parsedTexture.url || parsedTexture.name),
-                    rootUrl + (parsedTexture.src || parsedTexture.url),
-                    scene,
-                    !!parsedTexture.generateMipMaps,
-                    parsedTexture.invertY,
-                    parsedTexture.samplingMode,
-                    parsedTexture.settings || {}
-                );
-            },
-            parsedTexture,
-            scene
-        );
-
-        return texture;
-    }
-
-    /**
      * Creates a video texture straight from a stream.
      * @param scene Define the scene the texture should be created in
      * @param stream Define the stream the texture should be created from
@@ -610,3 +584,19 @@ export class VideoTexture extends Texture {
             });
     }
 }
+
+Texture._CreateVideoTexture = (
+    name: Nullable<string>,
+    src: string | string[] | HTMLVideoElement,
+    scene: Nullable<Scene>,
+    generateMipMaps = false,
+    invertY = false,
+    samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
+    settings: Partial<VideoTextureSettings> = {},
+    onError?: Nullable<(message?: string, exception?: any) => void>,
+    format: number = Constants.TEXTUREFORMAT_RGBA
+) => {
+    return new VideoTexture(name, src, scene, generateMipMaps, invertY, samplingMode, settings, onError, format);
+};
+// Some exporters relies on Tools.Instantiate
+RegisterClass("BABYLON.VideoTexture", VideoTexture);


### PR DESCRIPTION
this adds the needed functionality to serialize and parse a video texture.

src, isVideo and settings were missing. Until now VideoTexture was parsed as a regular source-less texture.