### PR TITLE
[Perf improvement] move bind to Arrow functions

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -232,7 +232,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
             this.onLostFocus();
         };
 
-        this._contextMenuBind = this.onContextMenu.bind(this);
+        this._contextMenuBind = (evt: Event) => this.onContextMenu(evt as PointerEvent);
 
         element && element.addEventListener("contextmenu", this._contextMenuBind, false);
 

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraVRDeviceOrientationInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraVRDeviceOrientationInput.ts
@@ -48,13 +48,13 @@ export class ArcRotateCameraVRDeviceOrientationInput implements ICameraInput<Arc
     private _gamma = 0;
     private _dirty = false;
 
-    private _deviceOrientationHandler: () => void;
+    private _deviceOrientationHandler: (evt: DeviceOrientationEvent) => void;
 
     /**
      * Instantiate a new ArcRotateCameraVRDeviceOrientationInput.
      */
     constructor() {
-        this._deviceOrientationHandler = this._onOrientationEvent.bind(this);
+        this._deviceOrientationHandler = (evt: DeviceOrientationEvent) => this._onOrientationEvent(evt);
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -48,7 +48,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
 
     private _currentActiveButton: number = -1;
     private _activePointerId: number = -1;
-    private _contextMenuBind: () => void;
+    private _contextMenuBind: (evt: MouseEvent) => void;
 
     /**
      * Manage the mouse inputs to control the movement of a free camera.
@@ -197,7 +197,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
             ._inputManager._addCameraPointerObserver(this._pointerInput, PointerEventTypes.POINTERDOWN | PointerEventTypes.POINTERUP | PointerEventTypes.POINTERMOVE);
 
         if (element) {
-            this._contextMenuBind = this.onContextMenu.bind(this);
+            this._contextMenuBind = (evt: MouseEvent) => this.onContextMenu(evt as PointerEvent);
             element.addEventListener("contextmenu", this._contextMenuBind, false); // TODO: We need to figure out how to handle this for Native
         }
     }

--- a/packages/dev/core/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/anaglyphArcRotateCamera.ts
@@ -38,5 +38,5 @@ export class AnaglyphArcRotateCamera extends ArcRotateCamera {
         return "AnaglyphArcRotateCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicAnaglyphRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/anaglyphFreeCamera.ts
@@ -35,5 +35,5 @@ export class AnaglyphFreeCamera extends FreeCamera {
         return "AnaglyphFreeCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicAnaglyphRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/anaglyphGamepadCamera.ts
@@ -35,5 +35,5 @@ export class AnaglyphGamepadCamera extends GamepadCamera {
         return "AnaglyphGamepadCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicAnaglyphRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/anaglyphUniversalCamera.ts
@@ -36,5 +36,5 @@ export class AnaglyphUniversalCamera extends UniversalCamera {
         return "AnaglyphUniversalCamera";
     }
 
-    protected _setRigMode = setStereoscopicAnaglyphRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicAnaglyphRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicArcRotateCamera.ts
@@ -42,5 +42,5 @@ export class StereoscopicArcRotateCamera extends ArcRotateCamera {
         return "StereoscopicArcRotateCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicFreeCamera.ts
@@ -39,5 +39,5 @@ export class StereoscopicFreeCamera extends FreeCamera {
         return "StereoscopicFreeCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicGamepadCamera.ts
@@ -39,5 +39,5 @@ export class StereoscopicGamepadCamera extends GamepadCamera {
         return "StereoscopicGamepadCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
+++ b/packages/dev/core/src/Cameras/Stereoscopic/stereoscopicUniversalCamera.ts
@@ -38,5 +38,5 @@ export class StereoscopicUniversalCamera extends UniversalCamera {
         return "StereoscopicUniversalCamera";
     }
 
-    protected _setRigMode = setStereoscopicRigMode.bind(null, this);
+    protected _setRigMode = () => setStereoscopicRigMode(this);
 }

--- a/packages/dev/core/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/VR/vrDeviceOrientationArcRotateCamera.ts
@@ -54,5 +54,5 @@ export class VRDeviceOrientationArcRotateCamera extends ArcRotateCamera {
         return "VRDeviceOrientationArcRotateCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(null, this);
+    protected _setRigMode = (rigParams: any) => setVRRigMode(this, rigParams);
 }

--- a/packages/dev/core/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
+++ b/packages/dev/core/src/Cameras/VR/vrDeviceOrientationFreeCamera.ts
@@ -38,5 +38,5 @@ export class VRDeviceOrientationFreeCamera extends DeviceOrientationCamera {
         return "VRDeviceOrientationFreeCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(null, this);
+    protected _setRigMode = (rigParams: any) => setVRRigMode(this, rigParams);
 }

--- a/packages/dev/core/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
+++ b/packages/dev/core/src/Cameras/VR/vrDeviceOrientationGamepadCamera.ts
@@ -38,5 +38,5 @@ export class VRDeviceOrientationGamepadCamera extends VRDeviceOrientationFreeCam
         return "VRDeviceOrientationGamepadCamera";
     }
 
-    protected _setRigMode = setVRRigMode.bind(null, this);
+    protected _setRigMode = (rigParams: any) => setVRRigMode(this, rigParams);
 }

--- a/packages/dev/core/src/Culling/Octrees/octreeSceneComponent.ts
+++ b/packages/dev/core/src/Culling/Octrees/octreeSceneComponent.ts
@@ -147,11 +147,10 @@ export class OctreeSceneComponent {
         }
         this.scene = scene;
 
-        this.scene.getActiveMeshCandidates = this.getActiveMeshCandidates.bind(this);
-
-        this.scene.getActiveSubMeshCandidates = this.getActiveSubMeshCandidates.bind(this);
-        this.scene.getCollidingSubMeshCandidates = this.getCollidingSubMeshCandidates.bind(this);
-        this.scene.getIntersectingSubMeshCandidates = this.getIntersectingSubMeshCandidates.bind(this);
+        this.scene.getActiveMeshCandidates = () => this.getActiveMeshCandidates();
+        this.scene.getActiveSubMeshCandidates = (mesh: AbstractMesh) => this.getActiveSubMeshCandidates(mesh);
+        this.scene.getCollidingSubMeshCandidates = (mesh: AbstractMesh, collider: Collider) => this.getCollidingSubMeshCandidates(mesh, collider);
+        this.scene.getIntersectingSubMeshCandidates = (mesh: AbstractMesh, localRay: Ray) => this.getIntersectingSubMeshCandidates(mesh, localRay);
     }
 
     /**

--- a/packages/dev/core/src/Debug/physicsViewer.ts
+++ b/packages/dev/core/src/Debug/physicsViewer.ts
@@ -297,7 +297,7 @@ export class PhysicsViewer {
             this._meshes[this._numMeshes] = debugMesh;
 
             if (this._numMeshes === 0) {
-                this._renderFunction = this._updateDebugMeshes.bind(this);
+                this._renderFunction = () => this._updateDebugMeshes();
                 this._scene.registerBeforeRender(this._renderFunction);
             }
 
@@ -334,7 +334,7 @@ export class PhysicsViewer {
             this._bodyMeshes[this._numBodies] = debugMesh;
 
             if (this._numBodies === 0) {
-                this._renderFunction = this._updateDebugMeshes.bind(this);
+                this._renderFunction = () => this._updateDebugMeshes();
                 this._scene.registerBeforeRender(this._renderFunction);
             }
 
@@ -365,7 +365,7 @@ export class PhysicsViewer {
             this._inertiaMeshes[this._numInertiaBodies] = debugMesh;
 
             if (this._numInertiaBodies === 0) {
-                this._inertiaRenderFunction = this._updateInertiaMeshes.bind(this);
+                this._inertiaRenderFunction = () => this._updateInertiaMeshes();
                 this._scene.registerBeforeRender(this._inertiaRenderFunction);
             }
 
@@ -397,7 +397,7 @@ export class PhysicsViewer {
             this._constraintMeshes[this._numConstraints] = debugMesh;
 
             if (this._numConstraints === 0) {
-                this._constraintRenderFunction = this._updateDebugConstraints.bind(this);
+                this._constraintRenderFunction = () => this._updateDebugConstraints();
                 this._scene.registerBeforeRender(this._constraintRenderFunction);
             }
 

--- a/packages/dev/core/src/Debug/rayHelper.ts
+++ b/packages/dev/core/src/Debug/rayHelper.ts
@@ -66,7 +66,7 @@ export class RayHelper {
         if (!this._renderFunction && this.ray) {
             const ray = this.ray;
 
-            this._renderFunction = this._render.bind(this);
+            this._renderFunction = () => this._render();
             this._scene = scene;
             this._renderPoints = [ray.origin, ray.origin.add(ray.direction.scale(ray.length))];
             this._renderLine = CreateLines("ray", { points: this._renderPoints, updatable: true }, scene);

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -908,7 +908,7 @@ export class ThinEngine {
                 };
 
                 this._onContextRestored = () => {
-                    this._restoreEngineAfterContextLost(this._initGLContext.bind(this));
+                    this._restoreEngineAfterContextLost(() => this._initGLContext());
                 };
 
                 canvas.addEventListener("webglcontextlost", this._onContextLost, false);
@@ -1708,7 +1708,7 @@ export class ThinEngine {
 
         if (!this._renderingQueueLaunched) {
             this._renderingQueueLaunched = true;
-            this._boundRenderFunction = this._renderLoop.bind(this);
+            this._boundRenderFunction = () => this._renderLoop();
             this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
         }
     }

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -647,7 +647,7 @@ export class WebGPUEngine extends Engine {
                             this._contextWasLost = true;
                             Logger.Warn("WebGPU context lost. " + info);
                             this.onContextLostObservable.notifyObservers(this);
-                            this._restoreEngineAfterContextLost(this.initAsync.bind(this));
+                            this._restoreEngineAfterContextLost(() => this.initAsync());
                         });
                     }
                 },

--- a/packages/dev/core/src/FlowGraph/flowGraph.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraph.ts
@@ -65,7 +65,7 @@ export class FlowGraph {
     public constructor(params: FlowGraphParams) {
         this._scene = params.scene;
         this._eventCoordinator = params.eventCoordinator;
-        this._sceneDisposeObserver = this._scene.onDisposeObservable.add(this.dispose.bind(this));
+        this._sceneDisposeObserver = this._scene.onDisposeObservable.add(() => this.dispose());
     }
 
     /**

--- a/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -134,7 +134,7 @@ export class CascadedShadowGenerator extends ShadowGenerator {
         }
 
         if (!this._freezeShadowCastersBoundingInfoObservable && !freeze) {
-            this._freezeShadowCastersBoundingInfoObservable = this._scene.onBeforeRenderObservable.add(this._computeShadowCastersBoundingInfo.bind(this));
+            this._freezeShadowCastersBoundingInfoObservable = this._scene.onBeforeRenderObservable.add(() => this._computeShadowCastersBoundingInfo());
         }
 
         this._freezeShadowCastersBoundingInfo = freeze;

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -954,7 +954,12 @@ export class ShadowGenerator implements IShadowGenerator {
         }
 
         // Custom render function.
-        this._shadowMap.customRenderFunction = this._renderForShadowMap.bind(this);
+        this._shadowMap.customRenderFunction = (
+            opaqueSubMeshes: SmartArray<SubMesh>,
+            alphaTestSubMeshes: SmartArray<SubMesh>,
+            transparentSubMeshes: SmartArray<SubMesh>,
+            depthOnlySubMeshes: SmartArray<SubMesh>
+        ) => this._renderForShadowMap(opaqueSubMeshes, alphaTestSubMeshes, transparentSubMeshes, depthOnlySubMeshes);
 
         // Force the mesh is ready function to true as we are double checking it
         // in the custom render function. Also it prevents side effects and useless

--- a/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/equiRectangularCubeTexture.ts
@@ -81,7 +81,7 @@ export class EquiRectangularCubeTexture extends BaseTexture {
 
         if (!this._texture) {
             if (!scene.useDelayedTextureLoading) {
-                this._loadImage(this._loadTexture.bind(this), this._onError);
+                this._loadImage(() => this._loadTexture(), this._onError);
             } else {
                 this.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
             }

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -751,7 +751,12 @@ export class Effect implements IDisposable {
             this._pipelineContext = engine.createPipelineContext(this._processingContext);
             this._pipelineContext._name = this._key;
 
-            const rebuildRebind = this._rebuildProgram.bind(this);
+            const rebuildRebind = (
+                vertexSourceCode: string,
+                fragmentSourceCode: string,
+                onCompiled: (pipelineContext: IPipelineContext) => void,
+                onError: (message: string) => void
+            ) => this._rebuildProgram(vertexSourceCode, fragmentSourceCode, onCompiled, onError);
             if (this._vertexSourceCodeOverride && this._fragmentSourceCodeOverride) {
                 engine._preparePipelineContext(
                     this._pipelineContext,

--- a/packages/dev/core/src/Misc/videoRecorder.ts
+++ b/packages/dev/core/src/Misc/videoRecorder.ts
@@ -133,9 +133,9 @@ export class VideoRecorder {
         }
 
         this._mediaRecorder = new MediaRecorder(stream, { mimeType: this._options.mimeType });
-        this._mediaRecorder.ondataavailable = this._handleDataAvailable.bind(this);
-        this._mediaRecorder.onerror = this._handleError.bind(this);
-        this._mediaRecorder.onstop = this._handleStop.bind(this);
+        this._mediaRecorder.ondataavailable = (evt: Event) => this._handleDataAvailable(evt);
+        this._mediaRecorder.onerror = (evt: ErrorEvent) => this._handleError(evt);
+        this._mediaRecorder.onstop = () => this._handleStop();
     }
 
     /**

--- a/packages/dev/core/src/Physics/physicsHelper.ts
+++ b/packages/dev/core/src/Physics/physicsHelper.ts
@@ -565,7 +565,7 @@ class PhysicsGravitationalFieldEvent {
     constructor(private _physicsHelper: PhysicsHelper, private _scene: Scene, private _origin: Vector3, private _options: PhysicsRadialExplosionEventOptions) {
         this._options = { ...new PhysicsRadialExplosionEventOptions(), ...this._options };
 
-        this._tickCallback = this._tick.bind(this);
+        this._tickCallback = () => this._tick();
 
         this._options.strength = this._options.strength * -1;
     }
@@ -658,7 +658,7 @@ class PhysicsUpdraftEvent {
             this._originDirection = this._origin.subtract(this._originTop).normalize();
         }
 
-        this._tickCallback = this._tick.bind(this);
+        this._tickCallback = () => this._tick();
 
         if (this._physicsEngine.getPluginVersion() === 1) {
             this._prepareCylinder();
@@ -838,7 +838,7 @@ class PhysicsVortexEvent {
         this._origin.addToRef(new Vector3(0, this._options.height / 2, 0), this._cylinderPosition);
         this._origin.addToRef(new Vector3(0, this._options.height, 0), this._originTop);
 
-        this._tickCallback = this._tick.bind(this);
+        this._tickCallback = () => this._tick();
 
         if (this._physicsEngine.getPluginVersion() === 1) {
             this._prepareCylinder();

--- a/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.ts
+++ b/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.ts
@@ -230,7 +230,7 @@ export class FluidRenderer {
     public addParticleSystem(ps: IParticleSystem, generateDiffuseTexture?: boolean, targetRenderer?: FluidRenderingTargetRenderer, camera?: Camera): IFluidRenderingRenderObject {
         const object = new FluidRenderingObjectParticleSystem(this._scene, ps);
 
-        object.onParticleSizeChanged.add(this._setParticleSizeForRenderTargets.bind(this));
+        object.onParticleSizeChanged.add(() => this._setParticleSizeForRenderTargets());
 
         if (!targetRenderer) {
             targetRenderer = new FluidRenderingTargetRenderer(this._scene, camera);
@@ -238,7 +238,7 @@ export class FluidRenderer {
         }
 
         if (!targetRenderer._onUseVelocityChanged.hasObservers()) {
-            targetRenderer._onUseVelocityChanged.add(this._setUseVelocityForRenderObject.bind(this));
+            targetRenderer._onUseVelocityChanged.add(() => this._setUseVelocityForRenderObject());
         }
 
         if (generateDiffuseTexture !== undefined) {
@@ -274,7 +274,7 @@ export class FluidRenderer {
     ): IFluidRenderingRenderObject {
         const object = new FluidRenderingObjectCustomParticles(this._scene, buffers, numParticles);
 
-        object.onParticleSizeChanged.add(this._setParticleSizeForRenderTargets.bind(this));
+        object.onParticleSizeChanged.add(() => this._setParticleSizeForRenderTargets());
 
         if (!targetRenderer) {
             targetRenderer = new FluidRenderingTargetRenderer(this._scene, camera);
@@ -282,7 +282,7 @@ export class FluidRenderer {
         }
 
         if (!targetRenderer._onUseVelocityChanged.hasObservers()) {
-            targetRenderer._onUseVelocityChanged.add(this._setUseVelocityForRenderObject.bind(this));
+            targetRenderer._onUseVelocityChanged.add(() => this._setUseVelocityForRenderObject());
         }
 
         if (generateDiffuseTexture !== undefined) {

--- a/packages/dev/core/src/XR/features/WebXRSpaceWarp.ts
+++ b/packages/dev/core/src/XR/features/WebXRSpaceWarp.ts
@@ -16,6 +16,7 @@ import type { Material } from "../../Materials/material";
 
 import "../../Shaders/velocity.fragment";
 import "../../Shaders/velocity.vertex";
+import type { Observer } from "core/Misc/observable";
 
 /**
  * Used for Space Warp render process
@@ -286,6 +287,7 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
     private _glContext: WebGLRenderingContext | WebGL2RenderingContext;
     private _xrWebGLBinding: XRWebGLBinding;
     private _renderTargetTexture: Nullable<RenderTargetTexture>;
+    private _onAfterRenderObserver: Nullable<Observer<Scene>> = null;
 
     /**
      * constructor for the space warp feature
@@ -314,9 +316,14 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
 
         this.spaceWarpRTTProvider = new WebXRSpaceWarpRenderTargetTextureProvider(this._xrSessionManager.scene, this._xrSessionManager, this._xrWebGLBinding);
 
-        this._xrSessionManager.scene.onAfterRenderObservable.add(this._onAfterRender.bind(this));
+        this._onAfterRenderObserver = this._xrSessionManager.scene.onAfterRenderObservable.add(() => this._onAfterRender());
 
         return true;
+    }
+
+    public detach(): boolean {
+        this._xrSessionManager.scene.onAfterRenderObservable.remove(this._onAfterRenderObserver);
+        return super.detach();
     }
 
     private _onAfterRender(): void {

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -282,7 +282,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
 
         // Tell the engine's render loop to be driven by the xr session's refresh rate and provide xr pose information
         this._engine.customAnimationFrameRequester = {
-            requestAnimationFrame: this.session.requestAnimationFrame.bind(this.session),
+            requestAnimationFrame: this.session.requestAnimationFrame,
             renderFunction: (timestamp: number, xrFrame: Nullable<XRFrame>) => {
                 if (!this.inXRSession || !this._engine) {
                     return;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1742,11 +1742,10 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * and getCollidingSubMeshCandidates to their default function
      */
     public setDefaultCandidateProviders(): void {
-        this.getActiveMeshCandidates = this._getDefaultMeshCandidates.bind(this);
-
-        this.getActiveSubMeshCandidates = this._getDefaultSubMeshCandidates.bind(this);
-        this.getIntersectingSubMeshCandidates = this._getDefaultSubMeshCandidates.bind(this);
-        this.getCollidingSubMeshCandidates = this._getDefaultSubMeshCandidates.bind(this);
+        this.getActiveMeshCandidates = () => this._getDefaultMeshCandidates();
+        this.getActiveSubMeshCandidates = (mesh: AbstractMesh) => this._getDefaultSubMeshCandidates(mesh);
+        this.getIntersectingSubMeshCandidates = (mesh: AbstractMesh, localRay: Ray) => this._getDefaultSubMeshCandidates(mesh);
+        this.getCollidingSubMeshCandidates = (mesh: AbstractMesh, collider: Collider) => this._getDefaultSubMeshCandidates(mesh);
     }
 
     /**


### PR DESCRIPTION
This is a suggestion to move every bind(this) call to use arrow functions, as they are much faster.

I especially want to move the render function binding in the engine to use arrow function.

This is just a suggestion, and of course can be discussed.

