### PR TITLE
WebGPU: Add labels to buffers + support non float vertex buffers

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -1007,7 +1007,7 @@ export class AnimationGroup implements IDisposable {
     /**
      * Convert the keyframes for all animations belonging to the group to be relative to a given reference frame.
      * @param sourceAnimationGroup defines the AnimationGroup containing animations to convert
-     * @param options defines the options to use when converting ey keyframes
+     * @param options defines the options to use when converting keyframes
      * @returns a new AnimationGroup if options.cloneOriginalAnimationGroup is true or the original AnimationGroup if options.cloneOriginalAnimationGroup is false
      */
     public static MakeAnimationAdditive(sourceAnimationGroup: AnimationGroup, options?: IMakeAnimationGroupAdditiveOptions): AnimationGroup;

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -174,7 +174,7 @@ export class Buffer {
                 this._buffer = this._engine.createDynamicVertexBuffer(data, this._label);
                 this._data = data;
             } else {
-                this._buffer = this._engine.createVertexBuffer(data, this._label);
+                this._buffer = this._engine.createVertexBuffer(data, undefined, this._label);
             }
         } else if (this._updatable) {
             // update buffer

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -838,27 +838,6 @@ export class VertexBuffer {
     }
 
     /**
-     * Returns true if the type is a signed type, false otherwise.
-     * @param type the type
-     * @returns true or false depending on whether the type is signed or not
-     */
-    public static IsSignedType(type: number): boolean {
-        switch (type) {
-            case VertexBuffer.BYTE:
-            case VertexBuffer.SHORT:
-            case VertexBuffer.INT:
-            case VertexBuffer.FLOAT:
-                return true;
-            case VertexBuffer.UNSIGNED_BYTE:
-            case VertexBuffer.UNSIGNED_SHORT:
-            case VertexBuffer.UNSIGNED_INT:
-                return false;
-            default:
-                throw new Error(`Invalid type '${type}'`);
-        }
-    }
-
-    /**
      * Enumerates each value of the given parameters as numbers.
      * @param data the data to enumerate
      * @param byteOffset the byte offset of the data

--- a/packages/dev/core/src/Buffers/storageBuffer.ts
+++ b/packages/dev/core/src/Buffers/storageBuffer.ts
@@ -11,15 +11,18 @@ export class StorageBuffer {
     private _buffer: DataBuffer;
     private _bufferSize: number;
     private _creationFlags: number;
+    private _label?: string;
 
     /**
      * Creates a new storage buffer instance
      * @param engine The engine the buffer will be created inside
      * @param size The size of the buffer in bytes
      * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE flag will be automatically added.
+     * @param label defines the label of the buffer (for debug purpose)
      */
-    constructor(engine: ThinEngine, size: number, creationFlags = Constants.BUFFER_CREATIONFLAG_READWRITE) {
+    constructor(engine: ThinEngine, size: number, creationFlags = Constants.BUFFER_CREATIONFLAG_READWRITE, label?: string) {
         this._engine = engine;
+        this._label = label;
         this._engine._storageBuffers.push(this);
         this._create(size, creationFlags);
     }
@@ -27,7 +30,7 @@ export class StorageBuffer {
     private _create(size: number, creationFlags: number): void {
         this._bufferSize = size;
         this._creationFlags = creationFlags;
-        this._buffer = this._engine.createStorageBuffer(size, creationFlags);
+        this._buffer = this._engine.createStorageBuffer(size, creationFlags, this._label);
     }
 
     /** @internal */

--- a/packages/dev/core/src/Engines/Extensions/engine.storageBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.storageBuffer.ts
@@ -10,9 +10,10 @@ declare module "../../Engines/thinEngine" {
          * Creates a storage buffer
          * @param data the data for the storage buffer or the size of the buffer
          * @param creationFlags flags to use when creating the buffer (see Constants.BUFFER_CREATIONFLAG_XXX). The BUFFER_CREATIONFLAG_STORAGE flag will be automatically added
+         * @param label defines the label of the buffer (for debug purpose)
          * @returns the new buffer
          */
-        createStorageBuffer(data: DataArray | number, creationFlags: number): DataBuffer;
+        createStorageBuffer(data: DataArray | number, creationFlags: number, label?: string): DataBuffer;
 
         /**
          * Updates a storage buffer

--- a/packages/dev/core/src/Engines/Extensions/engine.uniformBuffer.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.uniformBuffer.ts
@@ -11,17 +11,19 @@ declare module "../../Engines/thinEngine" {
          * Create an uniform buffer
          * @see https://doc.babylonjs.com/setup/support/webGL2#uniform-buffer-objets
          * @param elements defines the content of the uniform buffer
+         * @param label defines a name for the buffer (for debugging purpose)
          * @returns the webGL uniform buffer
          */
-        createUniformBuffer(elements: FloatArray): DataBuffer;
+        createUniformBuffer(elements: FloatArray, label?: string): DataBuffer;
 
         /**
          * Create a dynamic uniform buffer
          * @see https://doc.babylonjs.com/setup/support/webGL2#uniform-buffer-objets
          * @param elements defines the content of the uniform buffer
+         * @param label defines a name for the buffer (for debugging purpose)
          * @returns the webGL uniform buffer
          */
-        createDynamicUniformBuffer(elements: FloatArray): DataBuffer;
+        createDynamicUniformBuffer(elements: FloatArray, label?: string): DataBuffer;
 
         /**
          * Update an existing uniform buffer
@@ -57,7 +59,7 @@ declare module "../../Engines/thinEngine" {
     }
 }
 
-ThinEngine.prototype.createUniformBuffer = function (elements: FloatArray): DataBuffer {
+ThinEngine.prototype.createUniformBuffer = function (elements: FloatArray, _label?: string): DataBuffer {
     const ubo = this._gl.createBuffer();
 
     if (!ubo) {
@@ -79,7 +81,7 @@ ThinEngine.prototype.createUniformBuffer = function (elements: FloatArray): Data
     return result;
 };
 
-ThinEngine.prototype.createDynamicUniformBuffer = function (elements: FloatArray): DataBuffer {
+ThinEngine.prototype.createDynamicUniformBuffer = function (elements: FloatArray, _label?: string): DataBuffer {
     const ubo = this._gl.createBuffer();
 
     if (!ubo) {

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.storageBuffer.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.storageBuffer.ts
@@ -14,8 +14,9 @@ declare module "../../../Materials/effect" {
          * Sets a storage buffer on the engine to be used in the shader.
          * @param name Name of the storage buffer variable.
          * @param buffer Storage buffer to set.
+         * @param label defines the label of the buffer (for debug purpose)
          */
-        setStorageBuffer(name: string, buffer: Nullable<StorageBuffer>): void;
+        setStorageBuffer(name: string, buffer: Nullable<StorageBuffer>, label?: string): void;
     }
 }
 
@@ -23,8 +24,8 @@ Effect.prototype.setStorageBuffer = function (name: string, buffer: Nullable<Sto
     this._engine.setStorageBuffer(name, buffer);
 };
 
-WebGPUEngine.prototype.createStorageBuffer = function (data: DataArray | number, creationFlags: number): DataBuffer {
-    return this._createBuffer(data, creationFlags | Constants.BUFFER_CREATIONFLAG_STORAGE);
+WebGPUEngine.prototype.createStorageBuffer = function (data: DataArray | number, creationFlags: number, label?: string): DataBuffer {
+    return this._createBuffer(data, creationFlags | Constants.BUFFER_CREATIONFLAG_STORAGE, label);
 };
 
 WebGPUEngine.prototype.updateStorageBuffer = function (buffer: DataBuffer, data: DataArray, byteOffset?: number, byteLength?: number): void {
@@ -59,7 +60,7 @@ WebGPUEngine.prototype.updateStorageBuffer = function (buffer: DataBuffer, data:
 WebGPUEngine.prototype.readFromStorageBuffer = function (storageBuffer: DataBuffer, offset?: number, size?: number, buffer?: ArrayBufferView): Promise<ArrayBufferView> {
     size = size || storageBuffer.capacity;
 
-    const gpuBuffer = this._bufferManager.createRawBuffer(size, WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst);
+    const gpuBuffer = this._bufferManager.createRawBuffer(size, WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst, undefined, "TempReadFromStorageBuffer");
 
     this._renderTargetEncoder.copyBufferToBuffer(storageBuffer.underlyingResource, offset ?? 0, gpuBuffer, 0, size);
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.uniformBuffer.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.uniformBuffer.ts
@@ -4,7 +4,7 @@ import type { FloatArray } from "../../../types";
 import { WebGPUEngine } from "../../webgpuEngine";
 import * as WebGPUConstants from "../webgpuConstants";
 
-WebGPUEngine.prototype.createUniformBuffer = function (elements: FloatArray): DataBuffer {
+WebGPUEngine.prototype.createUniformBuffer = function (elements: FloatArray, label?: string): DataBuffer {
     let view: Float32Array;
     if (elements instanceof Array) {
         view = new Float32Array(elements);
@@ -12,12 +12,12 @@ WebGPUEngine.prototype.createUniformBuffer = function (elements: FloatArray): Da
         view = elements;
     }
 
-    const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst);
+    const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst, label);
     return dataBuffer;
 };
 
-WebGPUEngine.prototype.createDynamicUniformBuffer = function (elements: FloatArray): DataBuffer {
-    return this.createUniformBuffer(elements);
+WebGPUEngine.prototype.createDynamicUniformBuffer = function (elements: FloatArray, label?: string): DataBuffer {
+    return this.createUniformBuffer(elements, label);
 };
 
 WebGPUEngine.prototype.updateUniformBuffer = function (uniformBuffer: DataBuffer, elements: FloatArray, offset?: number, count?: number): void {
@@ -45,7 +45,7 @@ WebGPUEngine.prototype.updateUniformBuffer = function (uniformBuffer: DataBuffer
     this._bufferManager.setSubData(dataBuffer, offset, view, 0, count);
 };
 
-WebGPUEngine.prototype.bindUniformBufferBase = function (buffer: DataBuffer, location: number, name: string): void {
+WebGPUEngine.prototype.bindUniformBufferBase = function (buffer: DataBuffer, _location: number, name: string): void {
     this._currentDrawContext.setBuffer(name, buffer as WebGPUDataBuffer);
 };
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -140,6 +140,22 @@ export abstract class WebGPUCacheRenderPipeline {
     private _textureState: number;
     private _useTextureStage: boolean;
 
+    private static _IsSignedType(type: number): boolean {
+        switch (type) {
+            case VertexBuffer.BYTE:
+            case VertexBuffer.SHORT:
+            case VertexBuffer.INT:
+            case VertexBuffer.FLOAT:
+                return true;
+            case VertexBuffer.UNSIGNED_BYTE:
+            case VertexBuffer.UNSIGNED_SHORT:
+            case VertexBuffer.UNSIGNED_INT:
+                return false;
+            default:
+                throw new Error(`Invalid type '${type}'`);
+        }
+    }
+
     constructor(device: GPUDevice, emptyVertexBuffer: VertexBuffer, useTextureStage: boolean) {
         this._device = device;
         this._useTextureStage = useTextureStage;
@@ -989,7 +1005,7 @@ export abstract class WebGPUCacheRenderPipeline {
                 webgpuPipelineContext.vertexBufferKindToType[kind] = currentVertexBufferType;
                 if (currentVertexBufferType !== VertexBuffer.FLOAT) {
                     webgpuShaderProcessor.vertexBufferKindToNumberOfComponents[kind] = VertexBuffer.DeduceStride(kind);
-                    if (VertexBuffer.IsSignedType(currentVertexBufferType)) {
+                    if (WebGPUCacheRenderPipeline._IsSignedType(currentVertexBufferType)) {
                         webgpuShaderProcessor.vertexBufferKindToNumberOfComponents[kind] *= -1;
                     }
                 }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable babylonjs/available */
+/* eslint-disable jsdoc/require-jsdoc */
 import { Constants } from "../constants";
 import * as WebGPUConstants from "./webgpuConstants";
 import type { Effect } from "../../Materials/effect";
@@ -56,6 +58,24 @@ const stencilOpToIndex: { [name: number]: number } = {
     0x150a: 5, // INVERT
     0x8507: 6, // INCR_WRAP
     0x8508: 7, // DECR_WRAP
+};
+
+const vertexBufferKindForNonFloatProcessing: { [kind: string]: boolean } = {
+    [VertexBuffer.PositionKind]: true,
+    [VertexBuffer.NormalKind]: true,
+    [VertexBuffer.TangentKind]: true,
+    [VertexBuffer.UVKind]: true,
+    [VertexBuffer.UV2Kind]: true,
+    [VertexBuffer.UV3Kind]: true,
+    [VertexBuffer.UV4Kind]: true,
+    [VertexBuffer.UV5Kind]: true,
+    [VertexBuffer.UV6Kind]: true,
+    [VertexBuffer.ColorKind]: true,
+    [VertexBuffer.ColorInstanceKind]: true,
+    [VertexBuffer.MatricesIndicesKind]: true,
+    [VertexBuffer.MatricesWeightsKind]: true,
+    [VertexBuffer.MatricesIndicesExtraKind]: true,
+    [VertexBuffer.MatricesWeightsExtraKind]: true,
 };
 
 /** @internal */
@@ -946,6 +966,41 @@ export abstract class WebGPUCacheRenderPipeline {
         return descriptors;
     }
 
+    private _processNonFloatVertexBuffers(webgpuPipelineContext: WebGPUPipelineContext, effect: Effect) {
+        const webgpuShaderProcessor = webgpuPipelineContext.engine._getShaderProcessor(webgpuPipelineContext.shaderProcessingContext.shaderLanguage) as WebGPUShaderProcessor;
+
+        let reprocessShaders = false;
+
+        for (const kind in this._vertexBuffers) {
+            const currentVertexBuffer = this._vertexBuffers[kind];
+
+            if (!currentVertexBuffer || !vertexBufferKindForNonFloatProcessing[kind]) {
+                continue;
+            }
+
+            const currentVertexBufferType = currentVertexBuffer.normalized ? VertexBuffer.FLOAT : currentVertexBuffer.type;
+            const vertexBufferType = webgpuPipelineContext.vertexBufferKindToType[kind];
+
+            if (
+                (currentVertexBufferType !== VertexBuffer.FLOAT && vertexBufferType === undefined) ||
+                (vertexBufferType !== undefined && vertexBufferType !== currentVertexBufferType)
+            ) {
+                reprocessShaders = true;
+                webgpuPipelineContext.vertexBufferKindToType[kind] = currentVertexBufferType;
+                if (currentVertexBufferType !== VertexBuffer.FLOAT) {
+                    webgpuShaderProcessor.vertexBufferKindToNumberOfComponents[kind] = VertexBuffer.DeduceStride(kind);
+                    if (VertexBuffer.IsSignedType(currentVertexBufferType)) {
+                        webgpuShaderProcessor.vertexBufferKindToNumberOfComponents[kind] *= -1;
+                    }
+                }
+            }
+        }
+
+        if (reprocessShaders) {
+            effect._processShaderCode(webgpuShaderProcessor, true);
+        }
+    }
+
     private _createRenderPipeline(effect: Effect, topology: GPUPrimitiveTopology, sampleCount: number): GPURenderPipeline {
         const webgpuPipelineContext = effect._pipelineContext as WebGPUPipelineContext;
         const inputStateDescriptor = this._getVertexInputDescriptor(effect);
@@ -954,6 +1009,8 @@ export abstract class WebGPUCacheRenderPipeline {
         const colorStates: Array<GPUColorTargetState | null> = [];
         const alphaBlend = this._getAphaBlendState();
         const colorBlend = this._getColorBlendState();
+
+        this._processNonFloatVertexBuffers(webgpuPipelineContext, effect);
 
         if (this._mrtAttachments1 > 0) {
             for (let i = 0; i < this._mrtFormats.length; ++i) {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
@@ -51,7 +51,9 @@ export class WebGPUDrawContext implements IDrawContext {
         } else {
             this.indirectDrawBuffer = this._bufferManager.createRawBuffer(
                 20,
-                WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Indirect | WebGPUConstants.BufferUsage.Storage
+                WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Indirect | WebGPUConstants.BufferUsage.Storage,
+                undefined,
+                "IndirectDrawBuffer"
             );
             this._indirectDrawData = new Uint32Array(5);
             this._indirectDrawData[3] = 0;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
@@ -1,3 +1,5 @@
+/* eslint-disable babylonjs/available */
+/* eslint-disable jsdoc/require-jsdoc */
 import type { IPipelineContext } from "../IPipelineContext";
 import type { Nullable } from "../../types";
 import type { WebGPUEngine } from "../webgpuEngine";
@@ -20,6 +22,9 @@ export class WebGPUPipelineContext implements IPipelineContext {
     public shaderProcessingContext: WebGPUShaderProcessingContext;
 
     protected _leftOverUniformsByName: { [name: string]: string };
+
+    // Property used to handle vertex buffers with int values when the shader code expect float values.
+    public vertexBufferKindToType: { [kind: string]: number };
 
     public sources: {
         vertex: string;
@@ -61,6 +66,7 @@ export class WebGPUPipelineContext implements IPipelineContext {
         this.shaderProcessingContext = shaderProcessingContext;
         this._leftOverUniformsByName = {};
         this.engine = engine;
+        this.vertexBufferKindToType = {};
     }
 
     public _handlesSpectorRebuildCallback(): void {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuQuerySet.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuQuerySet.ts
@@ -29,10 +29,17 @@ export class WebGPUQuerySet {
             count,
         });
 
-        this._queryBuffer = bufferManager.createRawBuffer(8 * count, WebGPUConstants.BufferUsage.QueryResolve | WebGPUConstants.BufferUsage.CopySrc);
+        this._queryBuffer = bufferManager.createRawBuffer(8 * count, WebGPUConstants.BufferUsage.QueryResolve | WebGPUConstants.BufferUsage.CopySrc, undefined, "QueryBuffer");
 
         if (!canUseMultipleBuffers) {
-            this._dstBuffers.push(this._bufferManager.createRawBuffer(8 * this._count, WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst));
+            this._dstBuffers.push(
+                this._bufferManager.createRawBuffer(
+                    8 * this._count,
+                    WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst,
+                    undefined,
+                    "QueryBufferNoMultipleBuffers"
+                )
+            );
         }
     }
 
@@ -45,7 +52,12 @@ export class WebGPUQuerySet {
 
         let buffer: GPUBuffer;
         if (this._dstBuffers.length === 0) {
-            buffer = this._bufferManager.createRawBuffer(8 * this._count, WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst);
+            buffer = this._bufferManager.createRawBuffer(
+                8 * this._count,
+                WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst,
+                undefined,
+                "QueryBufferAdditionalBuffer"
+            );
         } else {
             buffer = this._dstBuffers[this._dstBuffers.length - 1];
             this._dstBuffers.length--;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessingContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessingContext.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable babylonjs/available */
+/* eslint-disable jsdoc/require-jsdoc */
 import type { ShaderLanguage } from "../../Materials/shaderLanguage";
 import type { ShaderProcessingContext } from "../Processors/shaderProcessingOptions";
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessor.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessor.ts
@@ -1,3 +1,5 @@
+/* eslint-disable babylonjs/available */
+/* eslint-disable jsdoc/require-jsdoc */
 import { ShaderLanguage } from "../../Materials/shaderLanguage";
 import type { Nullable } from "../../types";
 import type { IShaderProcessor } from "../Processors/iShaderProcessor";
@@ -82,6 +84,10 @@ export abstract class WebGPUShaderProcessor implements IShaderProcessor {
     };
 
     public shaderLanguage = ShaderLanguage.GLSL;
+
+    // this object is populated only with vertex kinds known by the engine (position, uv, ...) and only if the type of the corresponding vertex buffer is an integer type)
+    // if the type is a signed type, the value is negated
+    public vertexBufferKindToNumberOfComponents: { [kind: string]: number } = {};
 
     protected _webgpuProcessingContext: WebGPUShaderProcessingContext;
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable babylonjs/available */
+/* eslint-disable jsdoc/require-jsdoc */
 // License for the mipmap generation code:
 //
 // Copyright 2020 Brandon Jones
@@ -331,7 +333,11 @@ export class WebGPUTextureHelper {
 
         this._mipmapSampler = device.createSampler({ minFilter: WebGPUConstants.FilterMode.Linear });
         this._videoSampler = device.createSampler({ minFilter: WebGPUConstants.FilterMode.Linear });
-        this._ubCopyWithOfst = this._bufferManager.createBuffer(4 * 4, WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst).underlyingResource;
+        this._ubCopyWithOfst = this._bufferManager.createBuffer(
+            4 * 4,
+            WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst,
+            "UBCopyWithOffset"
+        ).underlyingResource;
 
         this._getPipeline(WebGPUConstants.TextureFormat.RGBA8Unorm);
         this._getVideoPipeline(WebGPUConstants.TextureFormat.RGBA8Unorm);
@@ -1870,7 +1876,12 @@ export class WebGPUTextureHelper {
             if (aligned) {
                 const commandEncoder = this._device.createCommandEncoder({});
 
-                const buffer = this._bufferManager.createRawBuffer(imageBitmap.byteLength, WebGPUConstants.BufferUsage.MapWrite | WebGPUConstants.BufferUsage.CopySrc, true);
+                const buffer = this._bufferManager.createRawBuffer(
+                    imageBitmap.byteLength,
+                    WebGPUConstants.BufferUsage.MapWrite | WebGPUConstants.BufferUsage.CopySrc,
+                    true,
+                    "TempBufferForUpdateTexture" + (gpuTexture ? "_" + gpuTexture.label : "")
+                );
 
                 const arrayBuffer = buffer.getMappedRange();
 
@@ -2036,7 +2047,12 @@ export class WebGPUTextureHelper {
 
         const size = bytesPerRowAligned * height;
 
-        const gpuBuffer = this._bufferManager.createRawBuffer(size, WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst);
+        const gpuBuffer = this._bufferManager.createRawBuffer(
+            size,
+            WebGPUConstants.BufferUsage.MapRead | WebGPUConstants.BufferUsage.CopyDst,
+            undefined,
+            "TempBufferForReadPixels" + (texture.label ? "_" + texture.label : "")
+        );
 
         const commandEncoder = this._device.createCommandEncoder({});
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
@@ -68,11 +68,11 @@ export class WebGPUTintWASM {
     }
 
     public convertSpirV2WGSL(code: Uint32Array, disableUniformityAnalysis = false): string {
-        const ccode = WebGPUTintWASM._twgsl.convertSpirV2WGSL(code);
+        const ccode = WebGPUTintWASM._twgsl.convertSpirV2WGSL(code, WebGPUTintWASM.DisableUniformityAnalysis || disableUniformityAnalysis);
         if (WebGPUTintWASM.ShowWGSLShaderCode) {
             console.log(ccode);
             console.log("***********************************************");
         }
-        return WebGPUTintWASM.DisableUniformityAnalysis || disableUniformityAnalysis ? "diagnostic(off, derivative_uniformity);\n" + ccode : ccode;
+        return ccode;
     }
 }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -468,7 +468,7 @@ export class NativeEngine extends Engine {
         this._commandBufferEncoder.finishEncodingCommand();
     }
 
-    public createIndexBuffer(indices: IndicesArray, updateable?: boolean): NativeDataBuffer {
+    public createIndexBuffer(indices: IndicesArray, updateable?: boolean, _label?: string): NativeDataBuffer {
         const data = this._normalizeIndexData(indices);
         const buffer = new NativeDataBuffer();
         buffer.references = 1;
@@ -479,7 +479,7 @@ export class NativeEngine extends Engine {
         return buffer;
     }
 
-    public createVertexBuffer(vertices: DataArray, updateable?: boolean): NativeDataBuffer {
+    public createVertexBuffer(vertices: DataArray, updateable?: boolean, _label?: string): NativeDataBuffer {
         const data = ArrayBuffer.isView(vertices) ? vertices : new Float32Array(vertices);
         const buffer = new NativeDataBuffer();
         buffer.references = 1;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -2153,10 +2153,11 @@ export class ThinEngine {
     /**
      * Creates a vertex buffer
      * @param data the data for the vertex buffer
+     * @param _updatable whether the buffer should be created as updatable
      * @param _label defines the label of the buffer (for debug purpose)
      * @returns the new WebGL static buffer
      */
-    public createVertexBuffer(data: DataArray, _label?: string): DataBuffer {
+    public createVertexBuffer(data: DataArray, _updatable?: boolean, _label?: string): DataBuffer {
         return this._createVertexBuffer(data, this._gl.STATIC_DRAW);
     }
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -2153,9 +2153,10 @@ export class ThinEngine {
     /**
      * Creates a vertex buffer
      * @param data the data for the vertex buffer
+     * @param _label defines the label of the buffer (for debug purpose)
      * @returns the new WebGL static buffer
      */
-    public createVertexBuffer(data: DataArray): DataBuffer {
+    public createVertexBuffer(data: DataArray, _label?: string): DataBuffer {
         return this._createVertexBuffer(data, this._gl.STATIC_DRAW);
     }
 
@@ -2184,9 +2185,10 @@ export class ThinEngine {
     /**
      * Creates a dynamic vertex buffer
      * @param data the data for the dynamic vertex buffer
+     * @param _label defines the label of the buffer (for debug purpose)
      * @returns the new WebGL dynamic buffer
      */
-    public createDynamicVertexBuffer(data: DataArray): DataBuffer {
+    public createDynamicVertexBuffer(data: DataArray, _label?: string): DataBuffer {
         return this._createVertexBuffer(data, this._gl.DYNAMIC_DRAW);
     }
 
@@ -2199,9 +2201,10 @@ export class ThinEngine {
      * Creates a new index buffer
      * @param indices defines the content of the index buffer
      * @param updatable defines if the index buffer must be updatable
+     * @param _label defines the label of the buffer (for debug purpose)
      * @returns a new webGL buffer
      */
-    public createIndexBuffer(indices: IndicesArray, updatable?: boolean): DataBuffer {
+    public createIndexBuffer(indices: IndicesArray, updatable?: boolean, _label?: string): DataBuffer {
         const vbo = this._gl.createBuffer();
         const dataBuffer = new WebGLDataBuffer(vbo!);
 

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -1390,10 +1390,11 @@ export class WebGPUEngine extends Engine {
     /**
      * Creates a vertex buffer
      * @param data the data for the vertex buffer
+     * @param _updatable whether the buffer should be created as updatable
      * @param label defines the label of the buffer (for debug purpose)
      * @returns the new buffer
      */
-    public createVertexBuffer(data: DataArray, label?: string): DataBuffer {
+    public createVertexBuffer(data: DataArray, _updatable?: boolean, label?: string): DataBuffer {
         let view: ArrayBufferView;
 
         if (data instanceof Array) {
@@ -1415,7 +1416,7 @@ export class WebGPUEngine extends Engine {
      * @returns the new buffer
      */
     public createDynamicVertexBuffer(data: DataArray, label?: string): DataBuffer {
-        return this.createVertexBuffer(data, label);
+        return this.createVertexBuffer(data, undefined, label);
     }
 
     /**

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -667,8 +667,16 @@ export class WebGPUEngine extends Engine {
                 this._bundleListRenderTarget = new WebGPUBundleList(this._device);
                 this._snapshotRendering = new WebGPUSnapshotRendering(this, this._snapshotRenderingMode, this._bundleList, this._bundleListRenderTarget);
 
-                this._ubInvertY = this._bufferManager.createBuffer(new Float32Array([-1, 0]), WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst);
-                this._ubDontInvertY = this._bufferManager.createBuffer(new Float32Array([1, 0]), WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst);
+                this._ubInvertY = this._bufferManager.createBuffer(
+                    new Float32Array([-1, 0]),
+                    WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst,
+                    "UBInvertY"
+                );
+                this._ubDontInvertY = this._bufferManager.createBuffer(
+                    new Float32Array([1, 0]),
+                    WebGPUConstants.BufferUsage.Uniform | WebGPUConstants.BufferUsage.CopyDst,
+                    "UBDontInvertY"
+                );
 
                 if (this.dbgVerboseLogsForFirstFrames) {
                     if ((this as any)._count === undefined) {
@@ -1382,9 +1390,10 @@ export class WebGPUEngine extends Engine {
     /**
      * Creates a vertex buffer
      * @param data the data for the vertex buffer
+     * @param label defines the label of the buffer (for debug purpose)
      * @returns the new buffer
      */
-    public createVertexBuffer(data: DataArray): DataBuffer {
+    public createVertexBuffer(data: DataArray, label?: string): DataBuffer {
         let view: ArrayBufferView;
 
         if (data instanceof Array) {
@@ -1395,25 +1404,28 @@ export class WebGPUEngine extends Engine {
             view = data;
         }
 
-        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Vertex | WebGPUConstants.BufferUsage.CopyDst);
+        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Vertex | WebGPUConstants.BufferUsage.CopyDst, label);
         return dataBuffer;
     }
 
     /**
      * Creates a vertex buffer
      * @param data the data for the dynamic vertex buffer
+     * @param label defines the label of the buffer (for debug purpose)
      * @returns the new buffer
      */
-    public createDynamicVertexBuffer(data: DataArray): DataBuffer {
-        return this.createVertexBuffer(data);
+    public createDynamicVertexBuffer(data: DataArray, label?: string): DataBuffer {
+        return this.createVertexBuffer(data, label);
     }
 
     /**
      * Creates a new index buffer
      * @param indices defines the content of the index buffer
+     * @param updatable defines if the index buffer must be updatable
+     * @param label defines the label of the buffer (for debug purpose)
      * @returns a new buffer
      */
-    public createIndexBuffer(indices: IndicesArray): DataBuffer {
+    public createIndexBuffer(indices: IndicesArray, _updatable?: boolean, label?: string): DataBuffer {
         let is32Bits = true;
         let view: ArrayBufferView;
 
@@ -1431,7 +1443,7 @@ export class WebGPUEngine extends Engine {
             }
         }
 
-        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Index | WebGPUConstants.BufferUsage.CopyDst);
+        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Index | WebGPUConstants.BufferUsage.CopyDst, label);
         dataBuffer.is32Bits = is32Bits;
         return dataBuffer;
     }
@@ -1439,7 +1451,7 @@ export class WebGPUEngine extends Engine {
     /**
      * @internal
      */
-    public _createBuffer(data: DataArray | number, creationFlags: number): DataBuffer {
+    public _createBuffer(data: DataArray | number, creationFlags: number, label?: string): DataBuffer {
         let view: ArrayBufferView | number;
 
         if (data instanceof Array) {
@@ -1470,7 +1482,7 @@ export class WebGPUEngine extends Engine {
             flags |= WebGPUConstants.BufferUsage.Storage;
         }
 
-        return this._bufferManager.createBuffer(view, flags);
+        return this._bufferManager.createBuffer(view, flags, label);
     }
 
     /**

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -7,6 +7,7 @@ import type { IDisposable } from "../scene";
 import type { IPipelineContext } from "../Engines/IPipelineContext";
 import type { DataBuffer } from "../Buffers/dataBuffer";
 import { ShaderProcessor } from "../Engines/Processors/shaderProcessor";
+import type { IShaderProcessor } from "../Engines/Processors/iShaderProcessor";
 import type { ProcessingOptions, ShaderCustomProcessingFunction, ShaderProcessingContext } from "../Engines/Processors/shaderProcessingOptions";
 import type { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like, IColor4Like, IQuaternionLike } from "../Maths/math.like";
 import type { ThinEngine } from "../Engines/thinEngine";
@@ -57,7 +58,7 @@ export interface IEffectCreationOptions {
      */
     onError: Nullable<(effect: Effect, errors: string) => void>;
     /**
-     * Parameters to be used with Babylons include syntax to iterate over an array (eg. {lights: 10})
+     * Parameters to be used with Babylons include syntax to iterate over an array (eg. \{lights: 10\})
      */
     indexParameters?: any;
     /**
@@ -228,6 +229,9 @@ export class Effect implements IDisposable {
     private static _BaseCache: { [key: number]: DataBuffer } = {};
     private _processingContext: Nullable<ShaderProcessingContext>;
 
+    private _processCodeAfterIncludes: ShaderCustomProcessingFunction | undefined = undefined;
+    private _processFinalCode: Nullable<ShaderCustomProcessingFunction> = null;
+
     /**
      * Instantiates an effect.
      * An effect can be used to create/manage/execute vertex and fragment shaders.
@@ -240,7 +244,7 @@ export class Effect implements IDisposable {
      * @param fallbacks Possible fallbacks for this effect to improve performance when needed.
      * @param onCompiled Callback that will be called when the shader is compiled.
      * @param onError Callback that will be called if an error occurs during shader compilation.
-     * @param indexParameters Parameters to be used with Babylons include syntax to iterate over an array (eg. {lights: 10})
+     * @param indexParameters Parameters to be used with Babylons include syntax to iterate over an array (eg. \{lights: 10\})
      * @param key Effect Key identifying uniquely compiled shader variants
      * @param shaderLanguage the language the shader is written in (default: GLSL)
      */
@@ -260,9 +264,6 @@ export class Effect implements IDisposable {
     ) {
         this.name = baseName;
         this._key = key;
-
-        let processCodeAfterIncludes: ShaderCustomProcessingFunction | undefined = undefined;
-        let processFinalCode: Nullable<ShaderCustomProcessingFunction> = null;
 
         if ((<IEffectCreationOptions>attributesNamesOrOptions).attributes) {
             const options = <IEffectCreationOptions>attributesNamesOrOptions;
@@ -287,8 +288,8 @@ export class Effect implements IDisposable {
                 }
             }
 
-            processFinalCode = options.processFinalCode ?? null;
-            processCodeAfterIncludes = options.processCodeAfterIncludes ?? undefined;
+            this._processFinalCode = options.processFinalCode ?? null;
+            this._processCodeAfterIncludes = options.processCodeAfterIncludes ?? undefined;
         } else {
             this._engine = <Engine>engine;
             this.defines = defines == null ? "" : defines;
@@ -309,9 +310,15 @@ export class Effect implements IDisposable {
 
         this.uniqueId = Effect._UniqueIdSeed++;
 
+        this._processShaderCode();
+    }
+
+    /** @internal */
+    public _processShaderCode(shaderProcessor: Nullable<IShaderProcessor> = null, keepExistingPipelineContext = false) {
         let vertexSource: any;
         let fragmentSource: any;
 
+        const baseName = this.name;
         const hostDocument = IsWindowObjectExist() ? this._engine.getHostDocument() : null;
 
         if (baseName.vertexSource) {
@@ -345,7 +352,7 @@ export class Effect implements IDisposable {
             indexParameters: this._indexParameters,
             isFragment: false,
             shouldUseHighPrecisionShader: this._engine._shouldUseHighPrecisionShader,
-            processor: this._engine._getShaderProcessor(this._shaderLanguage),
+            processor: shaderProcessor ?? this._engine._getShaderProcessor(this._shaderLanguage),
             supportsUniformBuffers: this._engine.supportsUniformBuffers,
             shadersRepository: EngineShaderStore.GetShadersRepository(this._shaderLanguage),
             includesShadersStore: EngineShaderStore.GetIncludesShadersStore(this._shaderLanguage),
@@ -354,7 +361,7 @@ export class Effect implements IDisposable {
             processingContext: this._processingContext,
             isNDCHalfZRange: this._engine.isNDCHalfZRange,
             useReverseDepthBuffer: this._engine.useReverseDepthBuffer,
-            processCodeAfterIncludes,
+            processCodeAfterIncludes: this._processCodeAfterIncludes,
         };
 
         const shaderCodes: [string | undefined, string | undefined] = [undefined, undefined];
@@ -367,12 +374,12 @@ export class Effect implements IDisposable {
                     processorOptions,
                     (migratedFragmentCode, codeBeforeMigration) => {
                         this._fragmentSourceCodeBeforeMigration = codeBeforeMigration;
-                        if (processFinalCode) {
-                            migratedFragmentCode = processFinalCode("fragment", migratedFragmentCode);
+                        if (this._processFinalCode) {
+                            migratedFragmentCode = this._processFinalCode("fragment", migratedFragmentCode);
                         }
                         const finalShaders = ShaderProcessor.Finalize(migratedVertexCode, migratedFragmentCode, processorOptions);
                         processorOptions = null as any;
-                        this._useFinalCode(finalShaders.vertexCode, finalShaders.fragmentCode, baseName);
+                        this._useFinalCode(finalShaders.vertexCode, finalShaders.fragmentCode, baseName, keepExistingPipelineContext);
                     },
                     this._engine
                 );
@@ -386,8 +393,8 @@ export class Effect implements IDisposable {
                 (migratedVertexCode, codeBeforeMigration) => {
                     this._rawVertexSourceCode = vertexCode;
                     this._vertexSourceCodeBeforeMigration = codeBeforeMigration;
-                    if (processFinalCode) {
-                        migratedVertexCode = processFinalCode("vertex", migratedVertexCode);
+                    if (this._processFinalCode) {
+                        migratedVertexCode = this._processFinalCode("vertex", migratedVertexCode);
                     }
                     shaderCodes[0] = migratedVertexCode;
                     shadersLoaded();
@@ -402,7 +409,7 @@ export class Effect implements IDisposable {
         });
     }
 
-    private _useFinalCode(migratedVertexCode: string, migratedFragmentCode: string, baseName: any) {
+    private _useFinalCode(migratedVertexCode: string, migratedFragmentCode: string, baseName: any, keepExistingPipelineContext = false) {
         if (baseName) {
             const vertex = baseName.vertexElement || baseName.vertex || baseName.spectorName || baseName;
             const fragment = baseName.fragmentElement || baseName.fragment || baseName.spectorName || baseName;
@@ -413,7 +420,7 @@ export class Effect implements IDisposable {
             this._vertexSourceCode = migratedVertexCode;
             this._fragmentSourceCode = migratedFragmentCode;
         }
-        this._prepareEffect();
+        this._prepareEffect(keepExistingPipelineContext);
     }
 
     /**
@@ -737,7 +744,7 @@ export class Effect implements IDisposable {
      * Prepares the effect
      * @internal
      */
-    public _prepareEffect() {
+    public _prepareEffect(keepExistingPipelineContext = false) {
         const attributesNames = this._attributesNames;
         const defines = this.defines;
 
@@ -748,8 +755,8 @@ export class Effect implements IDisposable {
         try {
             const engine = this._engine;
 
-            this._pipelineContext = engine.createPipelineContext(this._processingContext);
-            this._pipelineContext._name = this._key;
+            this._pipelineContext = (keepExistingPipelineContext ? previousPipelineContext : undefined) ?? engine.createPipelineContext(this._processingContext);
+            this._pipelineContext._name = this._key.replace(/\r/g, "").replace(/\n/g, "|");
 
             const rebuildRebind = this._rebuildProgram.bind(this);
             if (this._vertexSourceCodeOverride && this._fragmentSourceCodeOverride) {
@@ -816,7 +823,7 @@ export class Effect implements IDisposable {
                     this._fallbacks.unBindMesh();
                 }
 
-                if (previousPipelineContext) {
+                if (previousPipelineContext && !keepExistingPipelineContext) {
                     this.getEngine()._deletePipelineContext(previousPipelineContext);
                 }
             });

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -484,7 +484,7 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
         if (this._isEnabled === value) {
             return;
         }
-        if (this._material.getScene().getEngine().webGLVersion == 1) {
+        if (!this._material.getScene().getEngine().isWebGPU && this._material.getScene().getEngine().webGLVersion == 1) {
             Logger.Error("MeshDebugPluginMaterial is not supported on WebGL 1.0.");
             this._isEnabled = false;
             return;

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -558,6 +558,14 @@ export class UniformBuffer {
         this._needSync = true;
     }
 
+    private _getNames() {
+        const names = [];
+        for (const name in this._uniformLocations) {
+            names.push(name);
+        }
+        return names.join(",");
+    }
+
     /** @internal */
     public _rebuild(): void {
         if (this._noUBO || !this._bufferData) {
@@ -565,9 +573,9 @@ export class UniformBuffer {
         }
 
         if (this._dynamic) {
-            this._buffer = this._engine.createDynamicUniformBuffer(this._bufferData);
+            this._buffer = this._engine.createDynamicUniformBuffer(this._bufferData, this._name + "_UniformList:" + this._getNames());
         } else {
-            this._buffer = this._engine.createUniformBuffer(this._bufferData);
+            this._buffer = this._engine.createUniformBuffer(this._bufferData, this._name + "_UniformList:" + this._getNames());
         }
 
         if (this._engine._features.trackUbosInFrame) {

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -252,23 +252,12 @@ export class Geometry implements IGetSetVerticesData {
             // to avoid converting to Float32Array at each draw call in engine.updateDynamicVertexBuffer, we make the conversion a single time here
             data = new Float32Array(data);
         }
-        const buffer = new VertexBuffer(
-            this._engine,
-            data,
-            kind,
+        const buffer = new VertexBuffer(this._engine, data, kind, {
             updatable,
-            this._meshes.length === 0,
+            postponeInternalCreation: this._meshes.length === 0,
             stride,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            "Geometry_" + this.id + "_" + kind
-        );
+            label: "Geometry_" + this.id + "_" + kind,
+        });
         this.setVerticesBuffer(buffer);
     }
 

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -252,7 +252,23 @@ export class Geometry implements IGetSetVerticesData {
             // to avoid converting to Float32Array at each draw call in engine.updateDynamicVertexBuffer, we make the conversion a single time here
             data = new Float32Array(data);
         }
-        const buffer = new VertexBuffer(this._engine, data, kind, updatable, this._meshes.length === 0, stride);
+        const buffer = new VertexBuffer(
+            this._engine,
+            data,
+            kind,
+            updatable,
+            this._meshes.length === 0,
+            stride,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            "Geometry_" + this.id + "_" + kind
+        );
         this.setVerticesBuffer(buffer);
     }
 
@@ -297,7 +313,8 @@ export class Geometry implements IGetSetVerticesData {
                 this._totalVertices = totalVertices;
             } else {
                 if (data != null) {
-                    this._totalVertices = data.length / (buffer.type === VertexBuffer.BYTE ? buffer.byteStride : buffer.byteStride / 4);
+                    this._totalVertices =
+                        data.length / (buffer.type === VertexBuffer.BYTE || buffer.type === VertexBuffer.UNSIGNED_BYTE ? buffer.byteStride : buffer.byteStride / 4);
                 }
             }
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/shadowsFragmentFunctions.fx
@@ -264,6 +264,11 @@
     #if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE)
         #define GREATEST_LESS_THAN_ONE 0.99999994
 
+        // We need to disable uniformity analysis when using CSM, as there's no textureLod overload that takes a sampler2DArrayShadow.
+        // And the workaround that uses textureGrad (which does work with sampler2DArrayShadow) is not supported by the SpirV to WGSL conversion (from Tint)
+
+        /* disable_uniformity_analysis */
+
         // Shadow PCF kernel size 1 with a single tap (lowest quality)
         #define inline
         float computeShadowWithCSMPCF1(float layer, vec4 vPositionFromLight, float depthMetric, highp sampler2DArrayShadow shadowSampler, float darkness, float frustumEdgeFalloff)

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -270,7 +270,8 @@
         {
             "title": "ShadowOnlyMaterial",
             "playgroundId": "#1KF7V1#18",
-            "referenceImage": "shadowOnlyMaterial.png"
+            "referenceImage": "shadowOnlyMaterial.png",
+            "excludedEngines": ["webgpu"]
         },
         {
             "title": "Gizmos",
@@ -414,11 +415,8 @@
         {
             "title": "Highlights",
             "renderCount": 5,
-            "scriptToRun": "/Demos/Highlights/highlights.js",
-            "functionToCall": "CreateHighlightsScene",
-            "referenceImage": "highlights.png",
-            "rootPath": "/Demos/Highlights/",
-            "replaceUrl": "room.hdr, reflectivity.png, albedo.png"
+            "playgroundId": "#P7N8YW#1",
+            "referenceImage": "highlights.png"
         },
         {
             "title": "Lines",
@@ -784,8 +782,7 @@
         {
             "title": "GLTF Buggy with Meshopt Compression",
             "playgroundId": "#CIYTF6#0",
-            "referenceImage": "gltfBuggyMeshopt.png",
-            "excludedEngines": ["webgpu"]
+            "referenceImage": "gltfBuggyMeshopt.png"
         },
         {
             "title": "GLTF BoomBox with Unlit Material",
@@ -1254,7 +1251,7 @@
             "title": "Prepass SSAO + shadow only",
             "renderCount": 10,
             "playgroundId": "#1KF7V1#55",
-            "excludedEngines": ["webgl1"],
+            "excludedEngines": ["webgl1","webgpu"],
             "referenceImage": "prepass-ssao-shadow-only.png"
         },
         {
@@ -1349,12 +1346,14 @@
         {
             "title": "Scissor test with negative x and y",
             "playgroundId": "#3L5BCD#2",
-            "referenceImage": "scissorTestNegativeXandY.png"
+            "referenceImage": "scissorTestNegativeXandY.png",
+            "excludedEngines": ["webgpu"]
         },
         {
             "title": "Scissor test with out of bounds width and height",
             "playgroundId": "#3L5BCD#3",
-            "referenceImage": "scissorTestOobWidthAndHeight.png"
+            "referenceImage": "scissorTestOobWidthAndHeight.png",
+            "excludedEngines": ["webgpu"]
         },
         {
             "title": "Refraction local cube map STD",


### PR DESCRIPTION
There are several updates in this PR:
* add labels to buffers to help debugging
* add support for non float buffers for the standard vertex buffer types (position, normal, uv, etc)
* fix a bug in `Geometry.setVerticesBuffer` when computing the number of vertices when the type is UNSIGNED_BYTE
* re-enable the "GLTF Buggy with Meshopt Compression" visualization test, now that non float vertex buffers are supported

After the PR is merged, these PGs, which are using non float vertex buffers for position/normal/uv, will work:
* Simple face: https://playground.babylonjs.com/?webgpu#U1CZV3#16
* glTF Draco compression: https://playground.babylonjs.com/?webgpu#3RWEGG#7
* WGSL custom shader: https://playground.babylonjs.com/?webgpu#6GFJNR#209

Regarding TintWASM, I did not include the latest package in the PR because it went from 1.6Mb to 2.6Mb...