### PR TITLE
Prevent possible `Material.dispose()` uncaught exception

### DIFF
--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -8,7 +8,6 @@ import type { Nullable } from "../types";
 import type { Matrix } from "../Maths/math.vector";
 import { EngineStore } from "../Engines/engineStore";
 import { SubMesh } from "../Meshes/subMesh";
-import type { Geometry } from "../Meshes/geometry";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { UniformBuffer } from "./uniformBuffer";
 import type { Effect } from "./effect";

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1828,7 +1828,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private releaseVertexArrayObject(mesh: AbstractMesh, forceDisposeEffect?: boolean) {
-        const geometry = <Geometry>(<Mesh>mesh).geometry;
+        const geometry = (<Mesh>mesh).geometry;
         if (geometry) {
             if (this._storeEffectOnSubMeshes) {
                 if (mesh.subMeshes) {

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1828,13 +1828,15 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private releaseVertexArrayObject(mesh: AbstractMesh, forceDisposeEffect?: boolean) {
-        if ((<Mesh>mesh).geometry) {
-            const geometry = <Geometry>(<Mesh>mesh).geometry;
+        const geometry = <Geometry>(<Mesh>mesh).geometry;
+        if (geometry) {
             if (this._storeEffectOnSubMeshes) {
-                for (const subMesh of mesh.subMeshes) {
-                    geometry._releaseVertexArrayObject(subMesh.effect);
-                    if (forceDisposeEffect && subMesh.effect) {
-                        subMesh.effect.dispose();
+                if (mesh.subMeshes) {
+                    for (const subMesh of mesh.subMeshes) {
+                        geometry._releaseVertexArrayObject(subMesh.effect);
+                        if (forceDisposeEffect && subMesh.effect) {
+                            subMesh.effect.dispose();
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Hi babylon folks,

This small PR is about preventing an exception when `Material.dispos()` is called while beeing assigned to a `Mesh` that has no subMesh  (in the function `Material.releaseVertexArrayObject` called within `Material.dispose()`).

Context ; If a mesh is never assigned some valid `VertexData`, the `subMeshes` array is never created and remains to its default value, which is `undefined` for some reasons.

The third parameter of `Material.dispos()`, namely `notBoundToMesh`, could be is used to prevent the exception BUT it would require to track whether a mesh has subMeshes and it would not work is the case of a Material shared by several Meshes.


Here is a simple playground that shows the error : https://playground.babylonjs.com/#43L9NF

