### PR TITLE
Fix incorrect spelling of `wgslLanguageFeatures` (should be `WGSLLanguageFeatures`)

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webgpu.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webgpu.d.ts
@@ -68,7 +68,7 @@ declare class GPU {
     requestAdapter(options?: GPURequestAdapterOptions): Promise<GPUAdapter | undefined>;
     getPreferredCanvasFormat(): GPUTextureFormat;
 
-    readonly WGSLLanguageFeatures: wgslLanguageFeatures;
+    readonly WGSLLanguageFeatures: WGSLLanguageFeatures;
 }
 
 interface GPURequestAdapterOptions {

--- a/packages/dev/core/src/LibDeclarations/webgpu.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webgpu.d.ts
@@ -68,7 +68,7 @@ declare class GPU {
     requestAdapter(options?: GPURequestAdapterOptions): Promise<GPUAdapter | undefined>;
     getPreferredCanvasFormat(): GPUTextureFormat;
 
-    readonly WGSLLanguageFeatures: WGSLLanguageFeatures;
+    readonly wgslLanguageFeatures: WGSLLanguageFeatures;
 }
 
 interface GPURequestAdapterOptions {


### PR DESCRIPTION
Bug reproduction:

Install  `@babylonjs/core@6.23.0` and navigate to `node_modules/@babylonjs/core/Engines/engine.d.ts:1272`

Actual:
![image](https://github.com/BabylonJS/Babylon.js/assets/75621402/0a836870-948e-4d60-9049-71332f192fc8)

Error message:
![image](https://github.com/BabylonJS/Babylon.js/assets/75621402/608e3ca1-00f3-4225-ae98-6b2df9531bc4)

Expected:
![image](https://github.com/BabylonJS/Babylon.js/assets/75621402/44565548-2650-4e1d-aba8-3c40d084027b)

The erroneous code is defined in [`packages/dev/core/src/LibDeclarations/webgpu.d.ts:71`](https://github.com/BabylonJS/Babylon.js/blob/6.23.0/packages/dev/core/src/LibDeclarations/webgpu.d.ts#L71)


