### PR TITLE
Fix createTexture for R and RG format textures

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4444,8 +4444,20 @@ export class ThinEngine {
             babylonFormat = fileExtension === ".jpg" && !useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA;
         }
 
-        const format = this._getInternalFormat(babylonFormat, false);
-        const internalFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, babylonFormat, useSRGBBuffer);
+        let format: number, internalFormat: number;
+        if (this.webGLVersion === 1) {
+            // In WebGL 1, format and internalFormat must be the same and taken from a limited set of values, see https://docs.gl/es2/glTexImage2D.
+            // The SRGB extension (https://developer.mozilla.org/en-US/docs/Web/API/EXT_sRGB) adds some extra values, hence passing useSRGBBuffer
+            // to getInternalFormat.
+            format = this._getInternalFormat(babylonFormat, useSRGBBuffer);
+            internalFormat = format;
+        } else {
+            // In WebGL 2, format has a wider range of values and internal format can be one of the sized formats, see
+            // https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml.
+            // SRGB is included in the sized format and should not be passed in "format", hence always passing useSRGBBuffer as false.
+            format = this._getInternalFormat(babylonFormat, false);
+            internalFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, babylonFormat, useSRGBBuffer);
+        }
 
         return {
             internalFormat,

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4381,7 +4381,7 @@ export class ThinEngine {
 
                 const tip = this._getTexImageParametersForCreateTexture(format, extension, texture._useSRGBBuffer);
                 if (isPot) {
-                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.sizedFormat, tip.internalFormat, tip.type, img as any);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.internalFormat, tip.format, tip.type, img as any);
                     return false;
                 }
 
@@ -4397,7 +4397,7 @@ export class ThinEngine {
                     this._workingCanvas.height = potHeight;
 
                     this._workingContext.drawImage(img as any, 0, 0, img.width, img.height, 0, 0, potWidth, potHeight);
-                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.sizedFormat, tip.internalFormat, tip.type, this._workingCanvas as TexImageSource);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.internalFormat, tip.format, tip.type, this._workingCanvas as TexImageSource);
 
                     texture.width = potWidth;
                     texture.height = potHeight;
@@ -4407,9 +4407,9 @@ export class ThinEngine {
                     // Using shaders when possible to rescale because canvas.drawImage is lossy
                     const source = new InternalTexture(this, InternalTextureSource.Temp);
                     this._bindTextureDirectly(gl.TEXTURE_2D, source, true);
-                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.sizedFormat, tip.internalFormat, tip.type, img as any);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, tip.internalFormat, tip.format, tip.type, img as any);
 
-                    this._rescaleTexture(source, texture, scene, tip.internalFormat, () => {
+                    this._rescaleTexture(source, texture, scene, tip.format, () => {
                         this._releaseTexture(source);
                         this._bindTextureDirectly(gl.TEXTURE_2D, texture, true);
 
@@ -4431,24 +4431,25 @@ export class ThinEngine {
 
     /**
      * Calls to the GL texImage2D and texImage3D functions require three arguments describing the pixel format of the texture.
-     * createTexture derives these from the format and useSRGBBuffer arguments and also the file extension of the URL it's working with.
+     * createTexture derives these from the babylonFormat and useSRGBBuffer arguments and also the file extension of the URL it's working with.
      * This function encapsulates that derivation for easy unit testing.
-     * @param format Babylon's format enum, as specified in ITextureCreationOptions.
+     * @param babylonFormat Babylon's format enum, as specified in ITextureCreationOptions.
      * @param fileExtension The file extension including the dot, e.g. .jpg.
      * @param useSRGBBuffer Use SRGB not linear.
      * @returns The options to pass to texImage2D or texImage3D calls.
+     * @internal
      */
-    public _getTexImageParametersForCreateTexture(format: Nullable<number>, fileExtension: string, useSRGBBuffer: boolean): TexImageParameters {
-        if (format === undefined || format === null) {
-            format = fileExtension === ".jpg" && !useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA;
+    public _getTexImageParametersForCreateTexture(babylonFormat: Nullable<number>, fileExtension: string, useSRGBBuffer: boolean): TexImageParameters {
+        if (babylonFormat === undefined || babylonFormat === null) {
+            babylonFormat = fileExtension === ".jpg" && !useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA;
         }
 
-        const internalFormat = this._getInternalFormat(format, useSRGBBuffer);
-        const sizedFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, format, useSRGBBuffer);
+        const format = this._getInternalFormat(babylonFormat, useSRGBBuffer);
+        const internalFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, babylonFormat, useSRGBBuffer);
 
         return {
-            sizedFormat,
             internalFormat,
+            format,
             type: this._gl.UNSIGNED_BYTE,
         };
     }
@@ -6163,7 +6164,7 @@ export class ThinEngine {
 }
 
 interface TexImageParameters {
-    sizedFormat: number;
     internalFormat: number;
+    format: number;
     type: number;
 }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4444,7 +4444,7 @@ export class ThinEngine {
             babylonFormat = fileExtension === ".jpg" && !useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA;
         }
 
-        const format = this._getInternalFormat(babylonFormat, useSRGBBuffer);
+        const format = this._getInternalFormat(babylonFormat, false);
         const internalFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, babylonFormat, useSRGBBuffer);
 
         return {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4379,7 +4379,7 @@ export class ThinEngine {
                 const gl = this._gl;
                 const isPot = img.width === potWidth && img.height === potHeight;
 
-                const tip = this._getTexImageParametersForCreateTexture(format, extension, texture._useSRGBBuffer); 
+                const tip = this._getTexImageParametersForCreateTexture(format, extension, texture._useSRGBBuffer);
                 if (isPot) {
                     gl.texImage2D(gl.TEXTURE_2D, 0, tip.sizedFormat, tip.internalFormat, tip.type, img as any);
                     return false;
@@ -4440,18 +4440,16 @@ export class ThinEngine {
      */
     public _getTexImageParametersForCreateTexture(format: Nullable<number>, fileExtension: string, useSRGBBuffer: boolean): TexImageParameters {
         if (format === undefined || format === null) {
-            format = (fileExtension === ".jpg" && !useSRGBBuffer)
-            ? Constants.TEXTUREFORMAT_RGB
-            : Constants.TEXTUREFORMAT_RGBA;
+            format = fileExtension === ".jpg" && !useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA;
         }
 
         const internalFormat = this._getInternalFormat(format, useSRGBBuffer);
         const sizedFormat = this._getRGBABufferInternalSizedFormat(Constants.TEXTURETYPE_UNSIGNED_BYTE, format, useSRGBBuffer);
-        
+
         return {
             sizedFormat,
             internalFormat,
-            type: this._gl.UNSIGNED_BYTE
+            type: this._gl.UNSIGNED_BYTE,
         };
     }
 

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -27,9 +27,9 @@ describe("ThinEngine", () => {
 Babylon format                Ext. SRGB  Int. format     Format          Type
 ==============                ==== ====  ===========     ======          ====
 <undefined>                   .jpg false RGB             RGB             UNSIGNED_BYTE
-<undefined>                   .jpg true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .jpg true  RGBA            RGBA            UNSIGNED_BYTE
 <undefined>                   .png false RGBA            RGBA            UNSIGNED_BYTE
-<undefined>                   .png true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .png true  RGBA            RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
@@ -43,13 +43,13 @@ TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNE
 TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
 TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .jpg false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg true  SRGB            SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg true  SRGB            RGB             UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .png false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png true  SRGB            SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png true  SRGB            RGB             UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .jpg false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg true  RGBA            RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .png false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE`.trimStart());
+TEXTUREFORMAT_RGBA            .png true  RGBA            RGBA            UNSIGNED_BYTE`.trimStart());
         });
 
         it("gets tex image parameters for WebGL 2", () => {
@@ -73,9 +73,9 @@ TEXTUREFORMAT_RGBA            .png true  RGBA            SRGB8_ALPHA8    UNSIGNE
 Babylon format                Ext. SRGB  Int. format     Format          Type
 ==============                ==== ====  ===========     ======          ====
 <undefined>                   .jpg false RGB8            RGB             UNSIGNED_BYTE
-<undefined>                   .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .jpg true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
 <undefined>                   .png false RGBA8           RGBA            UNSIGNED_BYTE
-<undefined>                   .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .png true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
@@ -101,13 +101,13 @@ TEXTUREFORMAT_RG              .jpg true  RG8             RG              UNSIGNE
 TEXTUREFORMAT_RG              .png false RG8             RG              UNSIGNED_BYTE
 TEXTUREFORMAT_RG              .png true  RG8             RG              UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .jpg false RGB8            RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg true  SRGB8           SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg true  SRGB8           RGB             UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .png false RGB8            RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png true  SRGB8           SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png true  SRGB8           RGB             UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .jpg false RGBA8           RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .png false RGBA8           RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_R_INTEGER       .jpg false R8UI            RED_INTEGER     UNSIGNED_BYTE
 TEXTUREFORMAT_R_INTEGER       .jpg true  R8UI            RED_INTEGER     UNSIGNED_BYTE
 TEXTUREFORMAT_R_INTEGER       .png false R8UI            RED_INTEGER     UNSIGNED_BYTE

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -1,0 +1,157 @@
+import { Engine, ThinEngine } from "core/Engines";
+
+describe("ThinEngine", () => {
+    describe("getTexImageParametersForCreateTexture", () => {
+        let thinEngine: ThinEngine;
+        
+        beforeEach(() => {
+            const fakeConstProvider: any = new Proxy({}, {
+                get: (_, propertyName) => {
+                    return propertyName;
+                }
+            });
+            thinEngine = new ThinEngine(null);
+            thinEngine._gl = fakeConstProvider;
+            thinEngine._glSRGBExtensionValues = fakeConstProvider;
+        });
+        
+        it("gets tex image parameters for WebGL 1", () => {
+            test([
+                "<undefined>",
+                "TEXTUREFORMAT_ALPHA",
+                "TEXTUREFORMAT_LUMINANCE",
+                "TEXTUREFORMAT_LUMINANCE_ALPHA",
+                "TEXTUREFORMAT_RGB",
+                "TEXTUREFORMAT_RGBA"
+            ], `
+Babylon format                Ext. SRGB  Sized format    Int. format     Type
+==============                ==== ====  ============    ===========     ====
+<undefined>                   .jpg false RGB             RGB             UNSIGNED_BYTE
+<undefined>                   .jpg true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .png false RGBA            RGBA            UNSIGNED_BYTE
+<undefined>                   .png true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .png true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .jpg false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .jpg true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .png false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .png true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .jpg false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg false RGB             RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg true  SRGB            SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png false RGB             RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png true  SRGB            SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg false RGBA            RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .png false RGBA            RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .png true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE`.trimStart());
+        });
+
+        it("gets tex image parameters for WebGL 2", () => {
+            thinEngine._webGLVersion = 2;
+            test([
+                "<undefined>",
+                "TEXTUREFORMAT_ALPHA",
+                "TEXTUREFORMAT_LUMINANCE",
+                "TEXTUREFORMAT_LUMINANCE_ALPHA",
+                "TEXTUREFORMAT_R",
+                "TEXTUREFORMAT_RED",
+                "TEXTUREFORMAT_RG",
+                "TEXTUREFORMAT_RGB",
+                "TEXTUREFORMAT_RGBA",
+                "TEXTUREFORMAT_R_INTEGER",
+                "TEXTUREFORMAT_RG_INTEGER",
+                "TEXTUREFORMAT_RED_INTEGER",
+                "TEXTUREFORMAT_RGB_INTEGER",
+                "TEXTUREFORMAT_RGBA_INTEGER"
+            ], `
+Babylon format                Ext. SRGB  Sized format    Int. format     Type
+==============                ==== ====  ============    ===========     ====
+<undefined>                   .jpg false RGB8            RGB             UNSIGNED_BYTE
+<undefined>                   .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+<undefined>                   .png false RGBA8           RGBA            UNSIGNED_BYTE
+<undefined>                   .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           .png true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .jpg false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .jpg true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .png false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       .png true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .jpg false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_R               .jpg false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_R               .jpg true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_R               .png false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_R               .png true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             .jpg false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             .jpg true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             .png false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             .png true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RG              .jpg false RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RG              .jpg true  RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RG              .png false RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RG              .png true  RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg false RGB8            RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg true  SRGB8           SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png false RGB8            RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png true  SRGB8           SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg false RGBA8           RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .png false RGBA8           RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       .jpg false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       .jpg true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       .png false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       .png true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      .jpg false RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      .jpg true  RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      .png false RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      .png true  RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     .jpg false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     .jpg true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     .png false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     .png true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     .jpg false RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     .jpg true  RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     .png false RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     .png true  RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    .jpg false RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    .jpg true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    .png false RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    .png true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE`.trimStart());
+        });
+
+        function test(formatStrs: string[], expected: string) {
+            const results = [
+                "Babylon format                Ext. SRGB  Sized format    Int. format     Type",
+                "==============                ==== ====  ============    ===========     ===="
+            ];
+            for (const formatStr of formatStrs) {
+                const format = formatStr === "<undefined>" ? undefined : (Engine as any)[formatStr];
+                for (const fileExtension of [".jpg", ".png"]) {
+                    for (const useSRGBBuffer of [false, true]) {
+                        const texImageParams = thinEngine._getTexImageParametersForCreateTexture(format, fileExtension, useSRGBBuffer);
+                        results.push(
+                            formatStr.padEnd(30) +
+                            fileExtension.padEnd(5) +
+                            useSRGBBuffer.toString().padEnd(6) +
+                            (texImageParams.sizedFormat as any).padEnd(16) +
+                            (texImageParams.internalFormat as any).padEnd(16) +
+                            texImageParams.type
+                        );
+                    }
+                }
+            }
+            expect(results.join("\n")).toEqual(expected);
+        }
+    });
+});

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -24,8 +24,8 @@ describe("ThinEngine", () => {
                 "TEXTUREFORMAT_RGB",
                 "TEXTUREFORMAT_RGBA"
             ], `
-Babylon format                Ext. SRGB  Sized format    Int. format     Type
-==============                ==== ====  ============    ===========     ====
+Babylon format                Ext. SRGB  Int. format     Format          Type
+==============                ==== ====  ===========     ======          ====
 <undefined>                   .jpg false RGB             RGB             UNSIGNED_BYTE
 <undefined>                   .jpg true  RGBA            SRGB8_ALPHA8    UNSIGNED_BYTE
 <undefined>                   .png false RGBA            RGBA            UNSIGNED_BYTE
@@ -70,8 +70,8 @@ TEXTUREFORMAT_RGBA            .png true  RGBA            SRGB8_ALPHA8    UNSIGNE
                 "TEXTUREFORMAT_RGB_INTEGER",
                 "TEXTUREFORMAT_RGBA_INTEGER"
             ], `
-Babylon format                Ext. SRGB  Sized format    Int. format     Type
-==============                ==== ====  ============    ===========     ====
+Babylon format                Ext. SRGB  Int. format     Format          Type
+==============                ==== ====  ===========     ======          ====
 <undefined>                   .jpg false RGB8            RGB             UNSIGNED_BYTE
 <undefined>                   .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
 <undefined>                   .png false RGBA8           RGBA            UNSIGNED_BYTE
@@ -132,8 +132,8 @@ TEXTUREFORMAT_RGBA_INTEGER    .png true  RGBA8UI         RGBA_INTEGER    UNSIGNE
 
         function test(formatStrs: string[], expected: string) {
             const results = [
-                "Babylon format                Ext. SRGB  Sized format    Int. format     Type",
-                "==============                ==== ====  ============    ===========     ===="
+                "Babylon format                Ext. SRGB  Int. format     Format          Type",
+                "==============                ==== ====  ===========     ======          ===="
             ];
             for (const formatStr of formatStrs) {
                 const format = formatStr === "<undefined>" ? undefined : (Engine as any)[formatStr];
@@ -144,8 +144,8 @@ TEXTUREFORMAT_RGBA_INTEGER    .png true  RGBA8UI         RGBA_INTEGER    UNSIGNE
                             formatStr.padEnd(30) +
                             fileExtension.padEnd(5) +
                             useSRGBBuffer.toString().padEnd(6) +
-                            (texImageParams.sizedFormat as any).padEnd(16) +
                             (texImageParams.internalFormat as any).padEnd(16) +
+                            (texImageParams.format as any).padEnd(16) +
                             texImageParams.type
                         );
                     }

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -27,9 +27,9 @@ describe("ThinEngine", () => {
 Babylon format                Ext. SRGB  Int. format     Format          Type
 ==============                ==== ====  ===========     ======          ====
 <undefined>                   .jpg false RGB             RGB             UNSIGNED_BYTE
-<undefined>                   .jpg true  RGBA            RGBA            UNSIGNED_BYTE
+<undefined>                   .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
 <undefined>                   .png false RGBA            RGBA            UNSIGNED_BYTE
-<undefined>                   .png true  RGBA            RGBA            UNSIGNED_BYTE
+<undefined>                   .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
@@ -43,13 +43,13 @@ TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNE
 TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
 TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .jpg false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg true  SRGB            RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .jpg true  SRGB            SRGB            UNSIGNED_BYTE
 TEXTUREFORMAT_RGB             .png false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png true  SRGB            RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             .png true  SRGB            SRGB            UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .jpg false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg true  RGBA            RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
 TEXTUREFORMAT_RGBA            .png false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png true  RGBA            RGBA            UNSIGNED_BYTE`.trimStart());
+TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE`.trimStart());
         });
 
         it("gets tex image parameters for WebGL 2", () => {


### PR DESCRIPTION
I think I've found a bug in createTexture when the texture creation options pass format: Engine.TEXTUREFORMAT_R or _RG. Repro is in this playground https://playground.babylonjs.com/#YCY2IL#1861, I've also [posted to the forum](https://forum.babylonjs.com/t/bug-and-proposed-fix-createtexture-does-not-work-with-textureformat-r-or-rg-on-webgl2/44763) with some extra information.

This PR is my attempt to fix it by using _getRGBABufferInternalSizedFormat to get the sized format, similar to other forms of texture creation in thinEngine.ts.