### PR TITLE
Add _postMeasure method to GUI Control

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1817,6 +1817,10 @@ export class Control implements IAnimatable {
         this._preMeasure(this._tempPaddingMeasure, context);
 
         this._measure();
+
+        // Let children take some post-measurement actions
+        this._postMeasure(this._tempPaddingMeasure, context);
+
         this._computeAlignment(this._tempPaddingMeasure, context);
 
         // Convert to int values
@@ -1979,6 +1983,13 @@ export class Control implements IAnimatable {
      * @internal
      */
     protected _preMeasure(parentMeasure: Measure, context: ICanvasRenderingContext): void {
+        // Do nothing
+    }
+
+    /**
+     * @internal
+     */
+    protected _postMeasure(parentMeasure: Measure, context: ICanvasRenderingContext): void {
         // Do nothing
     }
 


### PR DESCRIPTION
Adding `_postMeasure` method to GUI.Control to allow derived classes take some post-measurement actions. This is necessary if we want to change a property such top, after the `_measure()` action but before the `_computeAlignment() `call.
Same should be obtained by overriding `_measure()` or `_computeAlignment()` into the derived class  

```
 public _measure(): void {
      super._measure();
      this.top = this._i * this._currentMeasure.height ;
 }
```
but this will not prevent regression later (as it is defined as prefixed _ private method) while the intend of `_postMeasure `is clear and should be maintened to serve child purposes

so the above code may be replaced with
```
protected _postMeasure(parentMeasure: Measure, context: ICanvasRenderingContext): void {
     this.top = this._i * this._currentMeasure.height ;
}
```