### PR TITLE
WebGPU: Fix anisotropy usage when mipmap filtering is nearest

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheSampler.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheSampler.ts
@@ -197,7 +197,7 @@ export class WebGPUCacheSampler {
                 break;
         }
 
-        if (anisotropy > 1 && (lodMinClamp !== 0 || lodMaxClamp !== 0)) {
+        if (anisotropy > 1 && (lodMinClamp !== 0 || lodMaxClamp !== 0) && mipmapFilter !== WebGPUConstants.FilterMode.Nearest) {
             return {
                 magFilter: WebGPUConstants.FilterMode.Linear,
                 minFilter: WebGPUConstants.FilterMode.Linear,


### PR DESCRIPTION
Linear filtering was forced for min/mag/mip when anisotropy was enabled, even if mip filtering was nearest.