### PR TITLE
Fix a legacy issue with older ts versions

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -53,7 +53,7 @@ import type { RenderTargetTexture } from "../Materials/Textures/renderTargetText
 import type { WebRequest } from "../Misc/webRequest";
 import type { LoadFileError } from "../Misc/fileTools";
 import type { Texture } from "../Materials/Textures/texture";
-import { PrecisionDate } from "core/Misc/precisionDate";
+import { PrecisionDate } from "../Misc/precisionDate";
 
 /**
  * Defines the interface used by objects working like Scene

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
@@ -1,7 +1,8 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { Effect } from "../../../../Materials/effect";
-import { NodeMaterialConnectionPointDirection, type NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
+import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
+import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";


### PR DESCRIPTION
type in an import is 100% correct, but fails if used with an older version of typescript.

The thinEngine change is just for consistency.