### PR TITLE
WebGL engine: Add a loseContextOnDispose option

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -191,6 +191,12 @@ export interface EngineOptions extends ThinEngineOptions, WebGLContextAttributes
      * This will not influence NativeEngine and WebGPUEngine which set the behavior to true during construction.
      */
     forceSRGBBufferSupportState?: boolean;
+
+    /**
+     * Defines if the gl context should be released.
+     * It's false by default for backward compatibility, but you should probably pass true (see https://registry.khronos.org/webgl/extensions/WEBGL_lose_context/)
+     */
+    loseContextOnDispose?: boolean;
 }
 
 /**
@@ -5520,6 +5526,10 @@ export class ThinEngine {
 
         this.onDisposeObservable.notifyObservers(this);
         this.onDisposeObservable.clear();
+
+        if (this._creationOptions.loseContextOnDispose) {
+            this._gl.getExtension("WEBGL_lose_context")?.loseContext();
+        }
     }
 
     /**


### PR DESCRIPTION
EAFP, so here's a tentative PR to allow the user to free WebGL resources when disposing the engine.

See https://forum.babylonjs.com/t/request-for-adding-canvas-webgl-context-cleanup-method/44749/11 for context and why I chose to add an option instead of a parameter to the `dispose` function.

I can change it, but at least we got the ball rolling!