### PR TITLE
DefaultRenderingPipeline: Fix pipeline reconstruction

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -510,6 +510,8 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
             true
         );
 
+        let avoidReentrancyAtConstructionTime = true;
+
         this._imageProcessingConfigurationObserver = this._scene.imageProcessingConfiguration.onUpdateParameters.add(() => {
             this.bloom._downscale._exposure = this._scene.imageProcessingConfiguration.exposure;
 
@@ -519,13 +521,19 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
                 // at the end of the constructor could end up triggering imageProcessingConfiguration.onUpdateParameters!
                 // Note that the pipeline could have been disposed before the deferred call was executed, but in that case
                 // _buildAllowed will have been set to false, preventing _buildPipeline from being executed.
-                Tools.SetImmediate(() => {
+                if (avoidReentrancyAtConstructionTime) {
+                    Tools.SetImmediate(() => {
+                        this._buildPipeline();
+                    });
+                } else {
                     this._buildPipeline();
-                });
+                }
             }
         });
 
         this._buildPipeline();
+
+        avoidReentrancyAtConstructionTime = false;
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/msaaframebuffer-undefined/44897

It seems my fix in #13535 was too broad, so I added code to only perform the deferred call during the construction of the `DefaultRenderingPipeline` object.

Here's the PG that #13535 fixed: https://playground.babylonjs.com/#5CX9XL

Here's a PG that fails with the fix from #13535 (look at the console) but works with the current PR: https://playground.babylonjs.com/#C43LFR#6
