### PR TITLE
Add flag on ADT to skip blocking certain events

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -365,6 +365,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     }
 
     /**
+     * If this is set, even when a control is pointer blocker, some events can still be passed through to the scene.
+     */
+    public skipBlockEvents = 0;
+
+    /**
      * If set to true, every scene render will trigger a pointer event for the GUI
      * if it is linked to a mesh or has controls linked to a mesh. This will allow
      * you to catch the pointer moving around the GUI due to camera or mesh movements,
@@ -924,7 +929,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             const pointerId = (pi.event as IPointerEvent).pointerId || this._defaultMousePointerId;
             this._doPicking(transformedX, transformedY, pi, pi.type, pointerId, pi.event.button, (<IWheelEvent>pi.event).deltaX, (<IWheelEvent>pi.event).deltaY);
             // Avoid overwriting a true skipOnPointerObservable to false
-            if (this._shouldBlockPointer || this._capturingControl[pointerId]) {
+            if ((this._shouldBlockPointer && !(pi.type & this.skipBlockEvents)) || this._capturingControl[pointerId]) {
                 pi.skipOnPointerObservable = true;
             }
         } else {

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -366,6 +366,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
 
     /**
      * If this is set, even when a control is pointer blocker, some events can still be passed through to the scene.
+     * Options from values are PointerEventTypes
+     * POINTERDOWN, POINTERUP, POINTERMOVE, POINTERWHEEL, POINTERPICK, POINTERTAP, POINTERDOUBLETAP
      */
     public skipBlockEvents = 0;
 


### PR DESCRIPTION
This PR adds a new flag to the ADT, skipBlockEvents, defined as 0 by default, to which can be added events that will NOT be blocked even if the control is defined as a pointer blocker. This allows, for example, for a pointer blocker button to still allow wheel events to pass through.

Example PG: #XCPP9Y#19861