### PR TITLE
Unification and allowedHosts in local dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2121,8 +2121,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "license": "MIT",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -4555,6 +4556,141 @@
         "nx": ">= 14.1 <= 16"
       }
     },
+    "node_modules/@nrwl/nx-darwin-arm64": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.3.tgz",
+      "integrity": "sha512-2htJzVa+S/uLg5tj4nbO/tRz2SRMQIpT6EeWMgDGuEKQdpuRLVj2ez9hMpkRn9tl1tBUwR05hbV28DnOLRESVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.3.tgz",
+      "integrity": "sha512-p+8UkfC6KTLOX4XRt7NSP8DoTzEgs73+SN0csoXT9VsNO35+F0Z5zMZxpEc7RVo5Wen/4PGh2OWA+8gtgntsJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.3.tgz",
+      "integrity": "sha512-xwW7bZtggrxhFbYvvWWArtcSWwoxWzi/4wNgP3wPbcZFNZiraahVQSpIyJXrS9aajGbdvuDBM8cbDsMj9v7mwg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.3.tgz",
+      "integrity": "sha512-KNxDL2OAHxhFqztEjv2mNwXD6xrzoUury7NsYZYqlxJUNc3YYBfRSLEatnw491crvMBndbxfGVTWEO9S4YmRuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.3.tgz",
+      "integrity": "sha512-AxoZzfsXH7ZqDE+WrQtRumufIcSIBw4U/LikiDLaWWoGtNpAfKLkD/PHirZiNxHIeGy1Toi4ccMUolXbafLVFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-x64-gnu": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.3.tgz",
+      "integrity": "sha512-P8AOPRufvV4a5cSczNsw84zFAI7NgAiEBTybYcyymdNJmo0iArJXEmvj/G4mB20O8VCsCkwqMYAu6nQEnES1Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-x64-musl": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.3.tgz",
+      "integrity": "sha512-4ZYDp7T319+xbw7Z7KVtRefzaXJipZfgrM49r+Y1FAfYDc8y18zvKz3slK26wfWz+EUZwKsa/DfA2KmyRG3DvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.3.tgz",
+      "integrity": "sha512-UhgxIPgTZBKN1oxlLPSklkSzVL3hA4lAiVc9A0Utumpbp0ob/Xx+2vHzg3cnmNH3jWkZ+9OsC2dKyeMB6gAbSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.3.tgz",
+      "integrity": "sha512-gdnvqURKnu0EQGOFJ6NUKq6wSB+viNb7Z8qtKhzSmFwVjT8akOnLWn7ZhL9v28TAjLM7/s1Mwvmz/IMj1PGlcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nrwl/tao": {
       "version": "15.9.7",
       "dev": true,
@@ -4572,6 +4708,150 @@
       "license": "MIT",
       "dependencies": {
         "nx": "15.9.7"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-darwin-arm64": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.7.tgz",
+      "integrity": "sha512-aBUgnhlkrgC0vu0fK6eb9Vob7eFnkuknrK+YzTjmLrrZwj7FGNAeyGXSlyo1dVokIzjVKjJg2saZZ0WQbfuCJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.7.tgz",
+      "integrity": "sha512-L+elVa34jhGf1cmn38Z0sotQatmLovxoASCIw5r1CBZZeJ5Tg7Y9nOwjRiDixZxNN56hPKXm6xl9EKlVHVeKlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.7.tgz",
+      "integrity": "sha512-pqmfqqEUGFu6PmmHKyXyUw1Al0Ki8PSaR0+ndgCAb1qrekVDGDfznJfaqxN0JSLeolPD6+PFtLyXNr9ZyPFlFg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.7.tgz",
+      "integrity": "sha512-NYOa/eRrqmM+In5g3M0rrPVIS9Z+q6fvwXJYf/KrjOHqqan/KL+2TOfroA30UhcBrwghZvib7O++7gZ2hzwOnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.7.tgz",
+      "integrity": "sha512-zyStqjEcmbvLbejdTOrLUSEdhnxNtdQXlmOuymznCzYUEGRv+4f7OAepD3yRoR0a/57SSORZmmGQB7XHZoYZJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-linux-x64-gnu": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.7.tgz",
+      "integrity": "sha512-saNK5i2A8pKO3Il+Ejk/KStTApUpWgCxjeUz9G+T8A+QHeDloZYH2c7pU/P3jA9QoNeKwjVO9wYQllPL9loeVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-linux-x64-musl": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.7.tgz",
+      "integrity": "sha512-extIUThYN94m4Vj4iZggt6hhMZWQSukBCo8pp91JHnDcryBg7SnYmnikwtY1ZAFyyRiNFBLCKNIDFGkKkSrZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.7.tgz",
+      "integrity": "sha512-GSQ54hJ5AAnKZb4KP4cmBnJ1oC4ILxnrG1mekxeM65c1RtWg9NpBwZ8E0gU3xNrTv8ZNsBeKi/9UhXBxhsIh8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/tao/node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.7.tgz",
+      "integrity": "sha512-x6URof79RPd8AlapVbPefUD3ynJZpmah3tYaYZ9xZRMXojVtEHV8Qh5vysKXQ1rNYJiiB8Ah6evSKWLbAH60tw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nrwl/tao/node_modules/@yarnpkg/parsers": {
@@ -4765,6 +5045,150 @@
       "license": "MIT",
       "dependencies": {
         "nx": "15.9.7"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-darwin-arm64": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.7.tgz",
+      "integrity": "sha512-aBUgnhlkrgC0vu0fK6eb9Vob7eFnkuknrK+YzTjmLrrZwj7FGNAeyGXSlyo1dVokIzjVKjJg2saZZ0WQbfuCJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.7.tgz",
+      "integrity": "sha512-L+elVa34jhGf1cmn38Z0sotQatmLovxoASCIw5r1CBZZeJ5Tg7Y9nOwjRiDixZxNN56hPKXm6xl9EKlVHVeKlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.7.tgz",
+      "integrity": "sha512-pqmfqqEUGFu6PmmHKyXyUw1Al0Ki8PSaR0+ndgCAb1qrekVDGDfznJfaqxN0JSLeolPD6+PFtLyXNr9ZyPFlFg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.7.tgz",
+      "integrity": "sha512-NYOa/eRrqmM+In5g3M0rrPVIS9Z+q6fvwXJYf/KrjOHqqan/KL+2TOfroA30UhcBrwghZvib7O++7gZ2hzwOnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.7.tgz",
+      "integrity": "sha512-zyStqjEcmbvLbejdTOrLUSEdhnxNtdQXlmOuymznCzYUEGRv+4f7OAepD3yRoR0a/57SSORZmmGQB7XHZoYZJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-linux-x64-gnu": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.7.tgz",
+      "integrity": "sha512-saNK5i2A8pKO3Il+Ejk/KStTApUpWgCxjeUz9G+T8A+QHeDloZYH2c7pU/P3jA9QoNeKwjVO9wYQllPL9loeVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-linux-x64-musl": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.7.tgz",
+      "integrity": "sha512-extIUThYN94m4Vj4iZggt6hhMZWQSukBCo8pp91JHnDcryBg7SnYmnikwtY1ZAFyyRiNFBLCKNIDFGkKkSrZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.7.tgz",
+      "integrity": "sha512-GSQ54hJ5AAnKZb4KP4cmBnJ1oC4ILxnrG1mekxeM65c1RtWg9NpBwZ8E0gU3xNrTv8ZNsBeKi/9UhXBxhsIh8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/workspace/node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.7.tgz",
+      "integrity": "sha512-x6URof79RPd8AlapVbPefUD3ynJZpmah3tYaYZ9xZRMXojVtEHV8Qh5vysKXQ1rNYJiiB8Ah6evSKWLbAH60tw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nrwl/workspace/node_modules/@yarnpkg/parsers": {
@@ -4974,6 +5398,156 @@
     "node_modules/@nx/devkit/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC"
+    },
+    "node_modules/@nx/nx-darwin-arm64": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.10.0.tgz",
+      "integrity": "sha512-YF+MIpeuwFkyvM5OwgY/rTNRpgVAI/YiR0yTYCZR+X3AAvP775IVlusNgQ3oedTBRUzyRnI4Tknj1WniENFsvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-darwin-x64": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.10.0.tgz",
+      "integrity": "sha512-ypi6YxwXgb0kg2ixKXE3pwf5myVNUgWf1CsV5OzVccCM8NzheMO51KDXTDmEpXdzUsfT0AkO1sk5GZeCjhVONg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-freebsd-x64": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.10.0.tgz",
+      "integrity": "sha512-UeEYFDmdbbDkTQamqvtU8ibgu5jQLgFF1ruNb/U4Ywvwutw2d4ruOMl2e0u9hiNja9NFFAnDbvzrDcMo7jYqYw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.10.0.tgz",
+      "integrity": "sha512-WV3XUC2DB6/+bz1sx+d1Ai9q2Cdr+kTZRN50SOkfmZUQyEBaF6DRYpx/a4ahhxH3ktpNfyY8Maa9OEYxGCBkQA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.10.0.tgz",
+      "integrity": "sha512-aWIkOUw995V3ItfpAi5FuxQ+1e9EWLS1cjWM1jmeuo+5WtaKToJn5itgQOkvSlPz+HSLgM3VfXMvOFALNk125g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.10.0.tgz",
+      "integrity": "sha512-uO6Gg+irqpVcCKMcEPIQcTFZ+tDI02AZkqkP7koQAjniLEappd8DnUBSQdcn53T086pHpdc264X/ZEpXFfrKWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
+      "integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-musl": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.10.0.tgz",
+      "integrity": "sha512-q8sINYLdIJxK/iUx9vRk5jWAWb/2O0PAbOJFwv4qkxBv4rLoN7y+otgCZ5v0xfx/zztFgk/oNY4lg5xYjIso2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.10.0.tgz",
+      "integrity": "sha512-moJkL9kcqxUdJSRpG7dET3UeLIciwrfP08mzBQ12ewo8K8FzxU8ZUsTIVVdNrwt01CXOdXoweGfdQLjJ4qTURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.10.0.tgz",
+      "integrity": "sha512-5iV2NKZnzxJwZZ4DM5JVbRG/nkhAbzEskKaLBB82PmYGKzaDHuMHP1lcPoD/rtYMlowZgNA/RQndfKvPBPwmXA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@octokit/auth-token": {
       "version": "3.0.4",

--- a/packages/public/babylonjs-viewer-assets/webpack.config.js
+++ b/packages/public/babylonjs-viewer-assets/webpack.config.js
@@ -4,9 +4,15 @@ const webpackTools = require("@dev/build-tools").webpackTools;
 module.exports = (env) => {
     const commonConfig = {
         entry: "./src/index.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                mode: env.mode,
+            },
+            {
+                post: 1339,
+                static: ["public"],
+            }
+        ),
         output: {
             path: path.resolve(__dirname, "dist"),
             filename: "babylon.viewer.assets.js",
@@ -49,23 +55,6 @@ module.exports = (env) => {
                     },
                 },
             ],
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            hot: false,
-            port: 1339,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };

--- a/packages/tools/babylonServer/webpack.config.js
+++ b/packages/tools/babylonServer/webpack.config.js
@@ -67,13 +67,22 @@ module.exports = (env) => {
         exclude: /node_modules/,
         sideEffects: true,
     });
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
-        ...buildTools.webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "[name].js",
-            dirName: __dirname,
-        }),
+        ...buildTools.webpackTools.commonDevWebpackConfiguration(
+            {
+                mode: env.mode,
+                outputFilename: "[name].js",
+                dirName: __dirname,
+                enableHotReload: env.enableHotReload,
+                enableHttps: env.enableHttps,
+                enableLiveReload: env.enableLiveReload,
+            },
+            {
+                port: env.cdnPort || env.CDN_PORT || 1337,
+                static: ["public", "declarations", "../playground/public"],
+                showBuildProcess: true,
+            }
+        ),
         entry: {
             sceneTs: "./src/sceneTs.ts",
             sceneJs: "./src/sceneJs.js",
@@ -107,7 +116,7 @@ module.exports = (env) => {
                 "node-editor": path.resolve(basePathForTools, "nodeEditor", outputDirectoryForAliases),
                 "node-geometry-editor": path.resolve(basePathForTools, "nodeGeometryEditor", outputDirectoryForAliases),
                 "gui-editor": path.resolve(basePathForTools, "guiEditor", outputDirectoryForAliases),
-                "accessibility": path.resolve(basePathForTools, "accessibility", outputDirectoryForAliases),
+                accessibility: path.resolve(basePathForTools, "accessibility", outputDirectoryForAliases),
             },
             symlinks: false,
             // modules: [path.resolve(__dirname, "../../dev/"), 'node_modules'],
@@ -136,26 +145,6 @@ module.exports = (env) => {
         },
         module: {
             rules,
-        },
-        devServer: {
-            static: ["public", "declarations", "../playground/public"],
-            webSocketServer: production ? false : "ws",
-            compress: production,
-            port: env.cdnPort || env.CDN_PORT || 1337,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-                logging: production ? "error" : "info",
-                progress: true,
-            },
         },
         plugins: [],
     };
@@ -220,7 +209,7 @@ module.exports = (env) => {
         {
             from: "/nodeGeometryEditor/babylon.nodeGeometryEditor.d.ts",
             to: "/node-geometry-editor.d.ts",
-        },        
+        },
         {
             from: "/guiEditor/babylon.guiEditor.js",
             to: "/guiEditor/babylon.guiEditor.min.js",

--- a/packages/tools/babylonServer/webpack.config.snapshot.js
+++ b/packages/tools/babylonServer/webpack.config.snapshot.js
@@ -82,7 +82,5 @@ module.exports = (env) => {
         },
     };
 
-    console.log(commonConfig);
-
     return commonConfig;
 };

--- a/packages/tools/devHost/webpack.config.js
+++ b/packages/tools/devHost/webpack.config.js
@@ -4,14 +4,19 @@ const webpackTools = require("@dev/build-tools").webpackTools;
 
 module.exports = (env) => {
     const source = env.source || process.env.SOURCE || "dev";
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/index.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "main.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "main.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.TOOLS_PORT || 1338,
+            }
+        ),
         resolve: {
             extensions: [".ts", ".js"],
             alias: {
@@ -31,37 +36,8 @@ module.exports = (env) => {
         experiments: {
             outputModule: true,
         },
-        // externalsType: "module",
-        // externals: [
-        //     function ({ context, request }, callback) {
-        //         if (/^core\//.test(request)) {
-        //             // Externalize to a commonjs module using the request path
-        //             const changed = request.replace(/^core\//, "core/dist/");
-        //             return callback(null, "../../dev/" + changed + ".js");
-        //         }
-
-        //         // Continue without externalizing the import
-        //         callback();
-        //     },
-        // ],
         module: {
             rules: webpackTools.getRules(),
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-            },
-            static: ["public"],
-            port: process.env.TOOLS_PORT || 1338,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [
             new HtmlWebpackPlugin({

--- a/packages/tools/guiEditor/webpack.config.js
+++ b/packages/tools/guiEditor/webpack.config.js
@@ -2,14 +2,19 @@ const path = require("path");
 const webpackTools = require("@dev/build-tools").webpackTools;
 
 module.exports = (env) => {
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.guiEditor.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.guiEditor.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.GUIEDITOR_PORT || 1341,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx", ".svg", "*.scss"],
             alias: {
@@ -42,28 +47,6 @@ module.exports = (env) => {
                     },
                 },
             }),
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY
-                    ? false
-                    : {
-                          warnings: false,
-                          errors: true,
-                      },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: env.GUIEDITOR_PORT || 1341,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };

--- a/packages/tools/nodeEditor/webpack.config.js
+++ b/packages/tools/nodeEditor/webpack.config.js
@@ -5,11 +5,17 @@ module.exports = (env) => {
     const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.nodeEditor.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.nodeEditor.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.NME_PORT || 1340,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx", ".scss", "*.svg"],
             alias: {
@@ -41,26 +47,6 @@ module.exports = (env) => {
                 },
                 mode: production ? "production" : "development",
             }),
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: process.env.NME_PORT || 1340,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };

--- a/packages/tools/nodeGeometryEditor/webpack.config.js
+++ b/packages/tools/nodeGeometryEditor/webpack.config.js
@@ -5,11 +5,17 @@ module.exports = (env) => {
     const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.nodeGeometryEditor.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.nodeGeometryEditor.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.NGE_PORT || 1340,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx", ".scss", "*.svg"],
             alias: {
@@ -42,20 +48,6 @@ module.exports = (env) => {
                 },
                 mode: production ? "production" : "development",
             }),
-        },
-        devServer: {
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: process.env.NME_PORT || 1340,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -1,16 +1,20 @@
-const path = require("path");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const webpackTools = require("@dev/build-tools").webpackTools;
 
 module.exports = (env) => {
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.playground.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.playground.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.PLAYGROUND_PORT || 1338,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx"],
         },
@@ -32,97 +36,8 @@ module.exports = (env) => {
                     },
                 ],
             }),
-            // [
-            //     {
-            //         test: /\.tsx?$/,
-            //         loader: "ts-loader",
-            //         exclude: /node_modules/,
-            //         sideEffects: true,
-            //         options: {
-            //             configFile: "tsconfig.build.json",
-            //         },
-            //     },
-            //     {
-            //         sideEffects: true,
-            //         test: /\.js$/,
-            //         enforce: "pre",
-            //         use: ["source-map-loader"],
-            //     },
-            //     {
-            //         test: /\.scss$/,
-            //         use: [
-            //             // Fallback to style-loader in development
-            //             process.env.NODE_ENV !== "production" ? "style-loader" : MiniCssExtractPlugin.loader,
-            //             "css-loader",
-            //             "sass-loader",
-            //         ],
-            //     },
-            //     {
-            //         test: /\.css$/,
-            //         use: ["style-loader", "css-loader"],
-            //     },
-            //     {
-            //         test: /\.svg$/,
-            //         use: ["@svgr/webpack"],
-            //     },
-            //     {
-            //         test: /\.ttf$/,
-            //         type: "asset/resource",
-            //     },
-            // ],
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: process.env.PLAYGROUND_PORT || 1338,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [
-            // new HtmlWebpackPlugin({
-            //     inject: true,
-            //     template: path.resolve(__dirname, "public/index.html"),
-            // }),
-            // new HtmlWebpackPlugin({
-            //     inject: true,
-            //     filename: "frame.html",
-            //     template: path.resolve(__dirname, "public/frame.html"),
-            // }),
-            // new HtmlWebpackPlugin({
-            //     inject: true,
-            //     filename: "landmarkeditor.html",
-            //     template: path.resolve(__dirname, "public/landmarkeditor.html"),
-            // }),
-            // new CopyPlugin({
-            //     patterns: [
-            //         {
-            //             from: "**/*.!(html)",
-            //             to() {
-            //                 return "[path]/[name][ext]";
-            //             },
-            //             context: "public/",
-            //         },
-            //     ],
-            // }),
-            // new MiniCssExtractPlugin({
-            //     // Options similar to the same options in webpackOptions.output
-            //     // Both options are optional
-            //     filename: "[name].css",
-            //     chunkFilename: "[id].css",
-            // }),
             new MonacoWebpackPlugin({
                 // publicPath: "public/",
                 languages: ["typescript", "javascript"],

--- a/packages/tools/sandbox/webpack.config.js
+++ b/packages/tools/sandbox/webpack.config.js
@@ -2,14 +2,19 @@ const path = require("path");
 const webpackTools = require("@dev/build-tools").webpackTools;
 
 module.exports = (env) => {
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.sandbox.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.sandbox.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.SANDBOX_PORT || 1339,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx"],
             alias: {
@@ -43,26 +48,6 @@ module.exports = (env) => {
         ],
         module: {
             rules: webpackTools.getRules(),
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY ? false : {
-                    warnings: false,
-                    errors: true,
-                },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: process.env.SANDBOX_PORT || 1339,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };

--- a/packages/tools/viewer/webpack.config.js
+++ b/packages/tools/viewer/webpack.config.js
@@ -14,9 +14,15 @@ module.exports = (env) => {
             viewer: "./src/index.ts",
             renderOnlyViewer: "./src/renderOnlyIndex.ts",
         },
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+            },
+            {
+                static: ["public"],
+                port: process.env.VIEWER_PORT || 1338,
+            }
+        ),
         output: {
             path: path.resolve(__dirname, "dist"),
             filename: "[name].js",
@@ -43,27 +49,5 @@ module.exports = (env) => {
             }),
         },
         ignoreWarnings: [/Failed to parse source map/],
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY
-                    ? false
-                    : {
-                          warnings: false,
-                          errors: true,
-                      },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-            },
-            compress: false,
-            //open: true,
-            port: 1338,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
-        },
     };
 };

--- a/packages/tools/vsm/webpack.config.js
+++ b/packages/tools/vsm/webpack.config.js
@@ -2,14 +2,19 @@ const path = require("path");
 const webpackTools = require("@dev/build-tools").webpackTools;
 
 module.exports = (env) => {
-    const production = env.mode === "production" || process.env.NODE_ENV === "production";
     const commonConfig = {
         entry: "./src/legacy/legacy.ts",
-        ...webpackTools.commonDevWebpackConfiguration({
-            mode: env.mode,
-            outputFilename: "babylon.vsm.js",
-            dirName: __dirname,
-        }),
+        ...webpackTools.commonDevWebpackConfiguration(
+            {
+                ...env,
+                outputFilename: "babylon.vsm.js",
+                dirName: __dirname,
+            },
+            {
+                static: ["public"],
+                port: process.env.VSM_PORT || 1342,
+            }
+        ),
         resolve: {
             extensions: [".js", ".ts", ".tsx", ".svg", "*.scss"],
             alias: {
@@ -42,28 +47,6 @@ module.exports = (env) => {
                     },
                 },
             }),
-        },
-        devServer: {
-            client: {
-                overlay: process.env.DISABLE_DEV_OVERLAY
-                    ? false
-                    : {
-                          warnings: false,
-                          errors: true,
-                      },
-            },
-            static: {
-                directory: path.join(__dirname, "public"),
-                watch: false,
-            },
-            // hot: true,
-            port: env.VSM_PORT || 1342,
-            server: env.enableHttps !== undefined || process.env.ENABLE_HTTPS === "true" ? "https" : "http",
-            hot: (env.enableHotReload !== undefined || process.env.ENABLE_HOT_RELOAD === "true") && !production ? true : false,
-            liveReload: (env.enableLiveReload !== undefined || process.env.ENABLE_LIVE_RELOAD === "true") && !production ? true : false,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
         },
         plugins: [],
     };


### PR DESCRIPTION
I got a request to add allowedHosts to our dev server as an extra measure of security.

This PR unifies dev-server generation in all of our webpack configurations, and, of course, add allowedHosts as an optional environment variable.

After this is merged you will need to run `npm install` to get everything to work correctly.