### PR TITLE
Change script loading architecture

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -222,7 +222,7 @@ export class DebugLayer {
      * By default it uses the babylonjs CDN.
      * @ignoreNaming
      */
-    public static InspectorURL = `https://unpkg.com/babylonjs-inspector@${Engine.Version}/babylon.inspector.bundle.js`;
+    public static InspectorURL = `inspector/v${Engine.Version}/babylon.inspector.bundle.js`;
 
     private _scene: Scene;
 

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -391,7 +391,7 @@ export class DebugLayer {
                 const inspectorUrl = config && config.inspectorURL ? config.inspectorURL : DebugLayer.InspectorURL;
 
                 // Load inspector and add it to the DOM
-                Tools.LoadScript(inspectorUrl, () => {
+                Tools.LoadBabylonScript(inspectorUrl, () => {
                     this._createInspector(config);
                     resolve(this);
                 });

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
@@ -49,7 +49,7 @@ export class WebGPUTintWASM {
         }
 
         if (twgslOptions.jsPath && twgslOptions.wasmPath) {
-            await Tools.LoadScriptAsync(twgslOptions.jsPath);
+            await Tools.LoadBabylonScriptAsync(twgslOptions.jsPath);
         }
 
         if ((self as any).twgsl) {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
@@ -1,7 +1,4 @@
-import { IsWindowObjectExist } from "../../Misc/domManagement";
 import { Tools } from "../../Misc/tools";
-
-declare function importScripts(...urls: string[]): void;
 
 /**
  * Options to load the associated Twgsl library
@@ -25,8 +22,8 @@ export interface TwgslOptions {
 export class WebGPUTintWASM {
     // Default twgsl options.
     private static readonly _TWgslDefaultOptions: TwgslOptions = {
-        jsPath: "https://preview.babylonjs.com/twgsl/twgsl.js",
-        wasmPath: "https://preview.babylonjs.com/twgsl/twgsl.wasm",
+        jsPath: "twgsl/twgsl.js",
+        wasmPath: "twgsl/twgsl.wasm",
     };
 
     public static ShowWGSLShaderCode = false;
@@ -52,15 +49,11 @@ export class WebGPUTintWASM {
         }
 
         if (twgslOptions.jsPath && twgslOptions.wasmPath) {
-            if (IsWindowObjectExist()) {
-                await Tools.LoadScriptAsync(twgslOptions.jsPath);
-            } else {
-                importScripts(twgslOptions.jsPath);
-            }
+            await Tools.LoadScriptAsync(twgslOptions.jsPath);
         }
 
         if ((self as any).twgsl) {
-            WebGPUTintWASM._twgsl = await (self as any).twgsl(twgslOptions!.wasmPath);
+            WebGPUTintWASM._twgsl = await (self as any).twgsl(Tools.GetScriptUrl(twgslOptions!.wasmPath!));
             return Promise.resolve();
         }
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
@@ -53,7 +53,7 @@ export class WebGPUTintWASM {
         }
 
         if ((self as any).twgsl) {
-            WebGPUTintWASM._twgsl = await (self as any).twgsl(Tools.GetScriptUrl(twgslOptions!.wasmPath!));
+            WebGPUTintWASM._twgsl = await (self as any).twgsl(Tools.GetBabylonScriptURL(twgslOptions!.wasmPath!));
             return Promise.resolve();
         }
 

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -741,7 +741,7 @@ export class WebGPUEngine extends Engine {
         }
 
         if (glslangOptions.jsPath && glslangOptions.wasmPath) {
-            return Tools.LoadScriptAsync(glslangOptions.jsPath).then(() => {
+            return Tools.LoadBabylonScriptAsync(glslangOptions.jsPath).then(() => {
                 return (self as any).glslang(Tools.GetScriptUrl(glslangOptions!.wasmPath!));
             });
         }

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -1,5 +1,4 @@
 import { Logger } from "../Misc/logger";
-import { IsWindowObjectExist } from "../Misc/domManagement";
 import type { Nullable, DataArray, IndicesArray, Immutable } from "../types";
 import { Color4 } from "../Maths/math";
 import { Engine } from "../Engines/engine";
@@ -166,8 +165,8 @@ export interface WebGPUEngineOptions extends ThinEngineOptions, GPURequestAdapte
 export class WebGPUEngine extends Engine {
     // Default glslang options.
     private static readonly _GLSLslangDefaultOptions: GlslangOptions = {
-        jsPath: "https://preview.babylonjs.com/glslang/glslang.js",
-        wasmPath: "https://preview.babylonjs.com/glslang/glslang.wasm",
+        jsPath: "glslang/glslang.js",
+        wasmPath: "glslang/glslang.wasm",
     };
 
     /** true to enable using TintWASM to convert Spir-V to WGSL */
@@ -742,14 +741,9 @@ export class WebGPUEngine extends Engine {
         }
 
         if (glslangOptions.jsPath && glslangOptions.wasmPath) {
-            if (IsWindowObjectExist()) {
-                return Tools.LoadScriptAsync(glslangOptions.jsPath).then(() => {
-                    return (self as any).glslang(glslangOptions!.wasmPath);
-                });
-            } else {
-                importScripts(glslangOptions.jsPath);
-                return (self as any).glslang(glslangOptions!.wasmPath);
-            }
+            return Tools.LoadScriptAsync(glslangOptions.jsPath).then(() => {
+                return (self as any).glslang(Tools.GetScriptUrl(glslangOptions!.wasmPath!));
+            });
         }
 
         return Promise.reject("gslang is not available.");

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -742,7 +742,7 @@ export class WebGPUEngine extends Engine {
 
         if (glslangOptions.jsPath && glslangOptions.wasmPath) {
             return Tools.LoadBabylonScriptAsync(glslangOptions.jsPath).then(() => {
-                return (self as any).glslang(Tools.GetScriptUrl(glslangOptions!.wasmPath!));
+                return (self as any).glslang(Tools.GetBabylonScriptURL(glslangOptions!.wasmPath!));
             });
         }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1743,7 +1743,7 @@ export class NodeMaterial extends PushMaterial {
                 const editorUrl = config && config.editorURL ? config.editorURL : NodeMaterial.EditorURL;
 
                 // Load editor and add it to the DOM
-                Tools.LoadScript(editorUrl, () => {
+                Tools.LoadBabylonScript(editorUrl, () => {
                     this.BJSNODEMATERIALEDITOR = this.BJSNODEMATERIALEDITOR || this._getGlobalNodeMaterialEditor();
                     this._createNodeEditor(config?.nodeEditorConfig);
                     resolve();

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -201,7 +201,7 @@ export class NodeMaterial extends PushMaterial {
     private _animationFrame = -1;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `https://unpkg.com/babylonjs-node-editor@${Engine.Version}/babylon.nodeEditor.js`;
+    public static EditorURL = `nodeEditor/v${Engine.Version}/babylon.nodeEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -308,9 +308,9 @@ export class DracoCompression implements IDisposable {
      */
     public static Configuration: IDracoCompressionConfiguration = {
         decoder: {
-            wasmUrl: "https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js",
-            wasmBinaryUrl: "https://preview.babylonjs.com/draco_decoder_gltf.wasm",
-            fallbackUrl: "https://preview.babylonjs.com/draco_decoder_gltf.js",
+            wasmUrl: "draco_wasm_wrapper_gltf.js",
+            wasmBinaryUrl: "draco_decoder_gltf.wasm",
+            fallbackUrl: "draco_decoder_gltf.js",
         },
     };
 
@@ -359,11 +359,11 @@ export class DracoCompression implements IDisposable {
         const decoderInfo: { url: string | undefined; wasmBinaryPromise: Promise<ArrayBuffer | string | undefined> } =
             decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object"
                 ? {
-                      url: Tools.GetAbsoluteUrl(decoder.wasmUrl),
-                      wasmBinaryPromise: Tools.LoadFileAsync(Tools.GetAbsoluteUrl(decoder.wasmBinaryUrl)),
+                      url: Tools.GetScriptUrl(decoder.wasmUrl, true),
+                      wasmBinaryPromise: Tools.LoadFileAsync(Tools.GetScriptUrl(decoder.wasmBinaryUrl, true)),
                   }
                 : {
-                      url: Tools.GetAbsoluteUrl(decoder.fallbackUrl!),
+                      url: Tools.GetScriptUrl(decoder.fallbackUrl!),
                       wasmBinaryPromise: Promise.resolve(undefined),
                   };
 

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -408,7 +408,7 @@ export class DracoCompression implements IDisposable {
                     throw new Error("Draco decoder module is not available");
                 }
 
-                return Tools.LoadScriptAsync(decoderInfo.url).then(() => {
+                return Tools.LoadBabylonScriptAsync(decoderInfo.url).then(() => {
                     return createDecoderAsync(decoderWasmBinary as ArrayBuffer);
                 });
             });

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -359,11 +359,11 @@ export class DracoCompression implements IDisposable {
         const decoderInfo: { url: string | undefined; wasmBinaryPromise: Promise<ArrayBuffer | string | undefined> } =
             decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object"
                 ? {
-                      url: Tools.GetScriptUrl(decoder.wasmUrl, true),
-                      wasmBinaryPromise: Tools.LoadFileAsync(Tools.GetScriptUrl(decoder.wasmBinaryUrl, true)),
+                      url: Tools.GetBabylonScriptURL(decoder.wasmUrl, true),
+                      wasmBinaryPromise: Tools.LoadFileAsync(Tools.GetBabylonScriptURL(decoder.wasmBinaryUrl, true)),
                   }
                 : {
-                      url: Tools.GetScriptUrl(decoder.fallbackUrl!),
+                      url: Tools.GetBabylonScriptURL(decoder.fallbackUrl!),
                       wasmBinaryPromise: Promise.resolve(undefined),
                   };
 

--- a/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
@@ -55,7 +55,7 @@ export class MeshoptCompression implements IDisposable {
      */
     public static Configuration: IMeshoptCompressionConfiguration = {
         decoder: {
-            url: "https://preview.babylonjs.com/meshopt_decoder.js",
+            url: "meshopt_decoder.js",
         },
     };
 
@@ -78,7 +78,7 @@ export class MeshoptCompression implements IDisposable {
     constructor() {
         const decoder = MeshoptCompression.Configuration.decoder;
 
-        this._decoderModulePromise = Tools.LoadScriptAsync(Tools.GetAbsoluteUrl(decoder.url)).then(() => {
+        this._decoderModulePromise = Tools.LoadScriptAsync(Tools.GetScriptUrl(decoder.url, true)).then(() => {
             // Wait for WebAssembly compilation before resolving promise
             return MeshoptDecoder.ready;
         });

--- a/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
@@ -78,7 +78,7 @@ export class MeshoptCompression implements IDisposable {
     constructor() {
         const decoder = MeshoptCompression.Configuration.decoder;
 
-        this._decoderModulePromise = Tools.LoadScriptAsync(Tools.GetScriptUrl(decoder.url, true)).then(() => {
+        this._decoderModulePromise = Tools.LoadBabylonScriptAsync(decoder.url).then(() => {
             // Wait for WebAssembly compilation before resolving promise
             return MeshoptDecoder.ready;
         });

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -194,7 +194,7 @@ export class NodeGeometry {
                 const editorUrl = config && config.editorURL ? config.editorURL : NodeGeometry.EditorURL;
 
                 // Load editor and add it to the DOM
-                Tools.LoadScript(editorUrl, () => {
+                Tools.LoadBabylonScript(editorUrl, () => {
                     this.BJSNODEGEOMETRYEDITOR = this.BJSNODEGEOMETRYEDITOR || this._getGlobalNodeGeometryEditor();
                     this._createNodeEditor(config?.nodeGeometryEditorConfig);
                     resolve();

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -49,7 +49,7 @@ export class NodeGeometry {
     private _buildExecutionTime: number = 0;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `https://unpkg.com/babylonjs-node-geometry-editor@${Engine.Version}/babylon.nodeGeometryEditor.js`;
+    public static EditorURL = `nodeGeometryEditor/v${Engine.Version}/babylon.nodeGeometryEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Misc/basis.ts
+++ b/packages/dev/core/src/Misc/basis.ts
@@ -168,7 +168,7 @@ const _CreateWorkerAsync = () => {
             if (_Worker) {
                 res(_Worker);
             } else {
-                Tools.LoadFileAsync(Tools.GetScriptUrl(BasisToolsOptions.WasmModuleURL))
+                Tools.LoadFileAsync(Tools.GetBabylonScriptURL(BasisToolsOptions.WasmModuleURL))
                     .then((wasmBinary) => {
                         if (typeof URL !== "function") {
                             return reject("Basis transcoder requires an environment with a URL constructor");
@@ -185,7 +185,7 @@ const _CreateWorkerAsync = () => {
                             }
                         };
                         _Worker.addEventListener("message", initHandler);
-                        _Worker.postMessage({ action: "init", url: Tools.GetScriptUrl(BasisToolsOptions.JSModuleURL), wasmBinary: wasmBinary });
+                        _Worker.postMessage({ action: "init", url: Tools.GetBabylonScriptURL(BasisToolsOptions.JSModuleURL), wasmBinary: wasmBinary });
                     })
                     .catch(reject);
             }

--- a/packages/dev/core/src/Misc/basis.ts
+++ b/packages/dev/core/src/Misc/basis.ts
@@ -114,11 +114,11 @@ export const BasisToolsOptions = {
     /**
      * URL to use when loading the basis transcoder
      */
-    JSModuleURL: "https://cdn.babylonjs.com/basisTranscoder/1/basis_transcoder.js",
+    JSModuleURL: "basisTranscoder/1/basis_transcoder.js",
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    WasmModuleURL: "https://cdn.babylonjs.com/basisTranscoder/1/basis_transcoder.wasm",
+    WasmModuleURL: "basisTranscoder/1/basis_transcoder.wasm",
 };
 
 /**
@@ -168,7 +168,7 @@ const _CreateWorkerAsync = () => {
             if (_Worker) {
                 res(_Worker);
             } else {
-                Tools.LoadFileAsync(BasisToolsOptions.WasmModuleURL)
+                Tools.LoadFileAsync(Tools.GetScriptUrl(BasisToolsOptions.WasmModuleURL))
                     .then((wasmBinary) => {
                         if (typeof URL !== "function") {
                             return reject("Basis transcoder requires an environment with a URL constructor");
@@ -185,7 +185,7 @@ const _CreateWorkerAsync = () => {
                             }
                         };
                         _Worker.addEventListener("message", initHandler);
-                        _Worker.postMessage({ action: "init", url: BasisToolsOptions.JSModuleURL, wasmBinary: wasmBinary });
+                        _Worker.postMessage({ action: "init", url: Tools.GetScriptUrl(BasisToolsOptions.JSModuleURL), wasmBinary: wasmBinary });
                     })
                     .catch(reject);
             }

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -76,6 +76,8 @@ export const FileToolsOptions: {
     BaseUrl: string;
     CorsBehavior: string | ((url: string | string[]) => string);
     PreprocessUrl: (url: string) => string;
+    ScriptBaseUrl: string;
+    ScriptPreprocessUrl: (url: string) => string;
 } = {
     /**
      * Gets or sets the retry strategy to apply when an error happens while loading an asset.
@@ -100,9 +102,19 @@ export const FileToolsOptions: {
      * Gets or sets a function used to pre-process url before using them to load assets
      * @param url
      */
-    PreprocessUrl: (url: string) => {
-        return url;
-    },
+    PreprocessUrl: (url: string) => url,
+
+    /**
+     * Gets or sets the base URL to use to load scripts
+     * Used for both JS and WASM
+     */
+    ScriptBaseUrl: "https://cdn.babylonjs.com/",
+    /**
+     * Gets or sets a function used to pre-process script url before using them to load.
+     * Used for both JS and WASM
+     * @param url defines the url to process
+     */
+    ScriptPreprocessUrl: (url: string) => url,
 };
 
 /**

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -330,7 +330,7 @@ export class KhronosTextureContainer2 {
                 );
             });
         } else if (typeof KTX2DECODER === "undefined") {
-            KhronosTextureContainer2._DecoderModulePromise = Tools.LoadScriptAsync(urls.jsDecoderModule).then(() => {
+            KhronosTextureContainer2._DecoderModulePromise = Tools.LoadBabylonScriptAsync(urls.jsDecoderModule).then(() => {
                 KTX2DECODER.MSCTranscoder.UseFromWorkerThread = false;
                 KTX2DECODER.WASMMemoryManager.LoadBinariesFromCurrentThread = true;
                 applyConfig(urls);

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -281,16 +281,16 @@ export class KhronosTextureContainer2 {
         }
 
         const urls = {
-            jsDecoderModule: Tools.GetScriptUrl(this.URLConfig.jsDecoderModule, true),
-            wasmUASTCToASTC: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToASTC, true),
-            wasmUASTCToBC7: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToBC7, true),
-            wasmUASTCToRGBA_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRGBA_UNORM, true),
-            wasmUASTCToRGBA_SRGB: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRGBA_SRGB, true),
-            wasmUASTCToR8_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToR8_UNORM, true),
-            wasmUASTCToRG8_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRG8_UNORM, true),
-            jsMSCTranscoder: Tools.GetScriptUrl(this.URLConfig.jsMSCTranscoder, true),
-            wasmMSCTranscoder: Tools.GetScriptUrl(this.URLConfig.wasmMSCTranscoder, true),
-            wasmZSTDDecoder: Tools.GetScriptUrl(this.URLConfig.wasmZSTDDecoder, true),
+            jsDecoderModule: Tools.GetBabylonScriptURL(this.URLConfig.jsDecoderModule, true),
+            wasmUASTCToASTC: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToASTC, true),
+            wasmUASTCToBC7: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToBC7, true),
+            wasmUASTCToRGBA_UNORM: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToRGBA_UNORM, true),
+            wasmUASTCToRGBA_SRGB: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToRGBA_SRGB, true),
+            wasmUASTCToR8_UNORM: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToR8_UNORM, true),
+            wasmUASTCToRG8_UNORM: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToRG8_UNORM, true),
+            jsMSCTranscoder: Tools.GetBabylonScriptURL(this.URLConfig.jsMSCTranscoder, true),
+            wasmMSCTranscoder: Tools.GetBabylonScriptURL(this.URLConfig.wasmMSCTranscoder, true),
+            wasmZSTDDecoder: Tools.GetBabylonScriptURL(this.URLConfig.wasmZSTDDecoder, true),
         };
 
         if (numWorkers && typeof Worker === "function" && typeof URL !== "undefined") {

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -10,44 +10,40 @@ import { EngineFormat, TranscodeTarget } from "core/Materials/Textures/ktx2decod
 
 declare let KTX2DECODER: any;
 
-function getAbsoluteUrlOrNull(url: Nullable<string>): Nullable<string> {
-    return url ? Tools.GetAbsoluteUrl(url) : null;
-}
-
 function applyConfig(urls: typeof KhronosTextureContainer2.URLConfig): void {
-    if (urls.wasmUASTCToASTC !== null) {
+    if (urls.wasmUASTCToASTC) {
         KTX2DECODER.LiteTranscoder_UASTC_ASTC.WasmModuleURL = urls.wasmUASTCToASTC;
     }
 
-    if (urls.wasmUASTCToBC7 !== null) {
+    if (urls.wasmUASTCToBC7) {
         KTX2DECODER.LiteTranscoder_UASTC_BC7.WasmModuleURL = urls.wasmUASTCToBC7;
     }
 
-    if (urls.wasmUASTCToRGBA_UNORM !== null) {
+    if (urls.wasmUASTCToRGBA_UNORM) {
         KTX2DECODER.LiteTranscoder_UASTC_RGBA_UNORM.WasmModuleURL = urls.wasmUASTCToRGBA_UNORM;
     }
 
-    if (urls.wasmUASTCToRGBA_SRGB !== null) {
+    if (urls.wasmUASTCToRGBA_SRGB) {
         KTX2DECODER.LiteTranscoder_UASTC_RGBA_SRGB.WasmModuleURL = urls.wasmUASTCToRGBA_SRGB;
     }
 
-    if (urls.wasmUASTCToR8_UNORM !== null) {
+    if (urls.wasmUASTCToR8_UNORM) {
         KTX2DECODER.LiteTranscoder_UASTC_R8_UNORM.WasmModuleURL = urls.wasmUASTCToR8_UNORM;
     }
 
-    if (urls.wasmUASTCToRG8_UNORM !== null) {
+    if (urls.wasmUASTCToRG8_UNORM) {
         KTX2DECODER.LiteTranscoder_UASTC_RG8_UNORM.WasmModuleURL = urls.wasmUASTCToRG8_UNORM;
     }
 
-    if (urls.jsMSCTranscoder !== null) {
+    if (urls.jsMSCTranscoder) {
         KTX2DECODER.MSCTranscoder.JSModuleURL = urls.jsMSCTranscoder;
     }
 
-    if (urls.wasmMSCTranscoder !== null) {
+    if (urls.wasmMSCTranscoder) {
         KTX2DECODER.MSCTranscoder.WasmModuleURL = urls.wasmMSCTranscoder;
     }
 
-    if (urls.wasmZSTDDecoder !== null) {
+    if (urls.wasmZSTDDecoder) {
         KTX2DECODER.ZSTDDecoder.WasmModuleURL = urls.wasmZSTDDecoder;
     }
 }
@@ -245,7 +241,7 @@ export class KhronosTextureContainer2 {
         wasmMSCTranscoder: Nullable<string>;
         wasmZSTDDecoder: Nullable<string>;
     } = {
-        jsDecoderModule: "https://preview.babylonjs.com/babylon.ktx2Decoder.js",
+        jsDecoderModule: "babylon.ktx2Decoder.js",
         wasmUASTCToASTC: null,
         wasmUASTCToBC7: null,
         wasmUASTCToRGBA_UNORM: null,
@@ -285,16 +281,16 @@ export class KhronosTextureContainer2 {
         }
 
         const urls = {
-            jsDecoderModule: Tools.GetAbsoluteUrl(this.URLConfig.jsDecoderModule),
-            wasmUASTCToASTC: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToASTC),
-            wasmUASTCToBC7: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToBC7),
-            wasmUASTCToRGBA_UNORM: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToRGBA_UNORM),
-            wasmUASTCToRGBA_SRGB: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToRGBA_SRGB),
-            wasmUASTCToR8_UNORM: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToR8_UNORM),
-            wasmUASTCToRG8_UNORM: getAbsoluteUrlOrNull(this.URLConfig.wasmUASTCToRG8_UNORM),
-            jsMSCTranscoder: getAbsoluteUrlOrNull(this.URLConfig.jsMSCTranscoder),
-            wasmMSCTranscoder: getAbsoluteUrlOrNull(this.URLConfig.wasmMSCTranscoder),
-            wasmZSTDDecoder: getAbsoluteUrlOrNull(this.URLConfig.wasmZSTDDecoder),
+            jsDecoderModule: Tools.GetScriptUrl(this.URLConfig.jsDecoderModule, true),
+            wasmUASTCToASTC: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToASTC, true),
+            wasmUASTCToBC7: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToBC7, true),
+            wasmUASTCToRGBA_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRGBA_UNORM, true),
+            wasmUASTCToRGBA_SRGB: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRGBA_SRGB, true),
+            wasmUASTCToR8_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToR8_UNORM, true),
+            wasmUASTCToRG8_UNORM: Tools.GetScriptUrl(this.URLConfig.wasmUASTCToRG8_UNORM, true),
+            jsMSCTranscoder: Tools.GetScriptUrl(this.URLConfig.jsMSCTranscoder, true),
+            wasmMSCTranscoder: Tools.GetScriptUrl(this.URLConfig.wasmMSCTranscoder, true),
+            wasmZSTDDecoder: Tools.GetScriptUrl(this.URLConfig.wasmZSTDDecoder, true),
         };
 
         if (numWorkers && typeof Worker === "function" && typeof URL !== "undefined") {

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -52,7 +52,43 @@ export class Tools {
      * @returns is the url absolute or relative
      */
     public static IsAbsoluteUrl(url: string): boolean {
-        return url.indexOf("://") !== -1 || url.indexOf("//") === 0 || url.indexOf("data:") === 0 || url.indexOf("blob:") === 0;
+        // See https://stackoverflow.com/a/38979205.
+
+        // URL is protocol-relative (= absolute)
+        if (url.indexOf("//") === 0) {
+            return true;
+        }
+
+        // URL has no protocol (= relative)
+        if (url.indexOf("://") === -1) {
+            return false;
+        }
+
+        // URL does not contain a dot, i.e. no TLD (= relative, possibly REST)
+        if (url.indexOf(".") === -1) {
+            return false;
+        }
+
+        // URL does not contain a single slash (= relative)
+        if (url.indexOf("/") === -1) {
+            return false;
+        }
+
+        // The first colon comes after the first slash (= relative)
+        if (url.indexOf(":") > url.indexOf("/")) {
+            return false;
+        }
+
+        // Protocol is defined before first dot (= absolute)
+        if (url.indexOf("://") < url.indexOf(".")) {
+            return true;
+        }
+        if (url.indexOf("data:") === 0 || url.indexOf("blob:") === 0) {
+            return true;
+        }
+
+        // Anything else must be relative
+        return false;
     }
 
     /**

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -47,11 +47,12 @@ export class Tools {
 
     /**
      * This function checks whether a URL is absolute or not.
+     * It will also detect data and blob URLs
      * @param url the url to check
      * @returns is the url absolute or relative
      */
     public static IsAbsoluteUrl(url: string): boolean {
-        return url.indexOf("://") !== -1 || url.indexOf("//") === 0;
+        return url.indexOf("://") !== -1 || url.indexOf("//") === 0 || url.indexOf("data:") === 0 || url.indexOf("blob:") === 0;
     }
 
     /**

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -506,8 +506,6 @@ export class Tools {
      * @param scriptId defines the id of the script element
      */
     public static LoadScript(scriptUrl: string, onSuccess: () => void, onError?: (message?: string, exception?: any) => void, scriptId?: string) {
-        
-
         if (typeof importScripts === "function") {
             try {
                 importScripts(scriptUrl);

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -454,13 +454,14 @@ export class Tools {
      * @param scriptUrl the script Url to process
      * @returns a modified URL to use
      */
-    public static GetScriptUrl(scriptUrl: Nullable<string>, forceAbsoluteUrl?: boolean): string {
+    public static GetBabylonScriptURL(scriptUrl: Nullable<string>, forceAbsoluteUrl?: boolean): string {
         if (!scriptUrl) {
             return "";
         }
         // check if the URL is absolute or relative. Otherwise, append the base URL
         if (!Tools.IsAbsoluteUrl(scriptUrl)) {
-            scriptUrl = Tools.ScriptBaseUrl + (scriptUrl[0] === "/" ? scriptUrl.substring(1) : scriptUrl);
+            const baseUrl = Tools.ScriptBaseUrl[Tools.ScriptBaseUrl.length - 1] === "/" ? Tools.ScriptBaseUrl : Tools.ScriptBaseUrl + "/";
+            scriptUrl = baseUrl + (scriptUrl[0] === "/" ? scriptUrl.substring(1) : scriptUrl);
         }
 
         // run the preprocessor
@@ -482,7 +483,7 @@ export class Tools {
      * @param scriptId defines the id of the script element
      */
     public static LoadBabylonScript(scriptUrl: string, onSuccess: () => void, onError?: (message?: string, exception?: any) => void, scriptId?: string) {
-        scriptUrl = Tools.GetScriptUrl(scriptUrl);
+        scriptUrl = Tools.GetBabylonScriptURL(scriptUrl);
         Tools.LoadScript(scriptUrl, onSuccess, onError);
     }
 
@@ -493,7 +494,7 @@ export class Tools {
      * @returns a promise request object
      */
     public static LoadBabylonScriptAsync(scriptUrl: string): Promise<void> {
-        scriptUrl = Tools.GetScriptUrl(scriptUrl);
+        scriptUrl = Tools.GetBabylonScriptURL(scriptUrl);
         return Tools.LoadScriptAsync(scriptUrl);
     }
 

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -474,7 +474,31 @@ export class Tools {
     }
 
     /**
-     * Load a script (identified by an url). When the url returns, the
+     * This function is used internally by babylon components to load a script (identified by an url). When the url returns, the
+     * content of this file is added into a new script element, attached to the DOM (body element)
+     * @param scriptUrl defines the url of the script to load
+     * @param onSuccess defines the callback called when the script is loaded
+     * @param onError defines the callback to call if an error occurs
+     * @param scriptId defines the id of the script element
+     */
+    public static LoadBabylonScript(scriptUrl: string, onSuccess: () => void, onError?: (message?: string, exception?: any) => void, scriptId?: string) {
+        scriptUrl = Tools.GetScriptUrl(scriptUrl);
+        Tools.LoadScript(scriptUrl, onSuccess, onError);
+    }
+
+    /**
+     * Load an asynchronous script (identified by an url). When the url returns, the
+     * content of this file is added into a new script element, attached to the DOM (body element)
+     * @param scriptUrl defines the url of the script to laod
+     * @returns a promise request object
+     */
+    public static LoadBabylonScriptAsync(scriptUrl: string): Promise<void> {
+        scriptUrl = Tools.GetScriptUrl(scriptUrl);
+        return Tools.LoadScriptAsync(scriptUrl);
+    }
+
+    /**
+     * This function is used internally by babylon components to load a script (identified by an url). When the url returns, the
      * content of this file is added into a new script element, attached to the DOM (body element)
      * @param scriptUrl defines the url of the script to load
      * @param onSuccess defines the callback called when the script is loaded
@@ -482,7 +506,7 @@ export class Tools {
      * @param scriptId defines the id of the script element
      */
     public static LoadScript(scriptUrl: string, onSuccess: () => void, onError?: (message?: string, exception?: any) => void, scriptId?: string) {
-        scriptUrl = Tools.GetScriptUrl(scriptUrl);
+        
 
         if (typeof importScripts === "function") {
             try {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -5,7 +5,7 @@ import { GUIEditor } from "gui-editor/guiEditor";
 
 declare let BABYLON: any;
 
-let editorUrl = `https://unpkg.com/babylonjs-gui-editor@${Engine.Version}/babylon.guiEditor.js`;
+let editorUrl = `guiEditor/v${Engine.Version}/babylon.guiEditor.js`;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 let guiEditorContainer: { GUIEditor: typeof GUIEditor };
 /** Get the inspector from bundle or global */

--- a/packages/dev/loaders/src/glTF/glTFValidation.ts
+++ b/packages/dev/loaders/src/glTF/glTFValidation.ts
@@ -89,7 +89,7 @@ export class GLTFValidation {
      * The configuration. Defaults to `{ url: "https://preview.babylonjs.com/gltf_validator.js" }`.
      */
     public static Configuration: IGLTFValidationConfiguration = {
-        url: "https://preview.babylonjs.com/gltf_validator.js",
+        url: "gltf_validator.js",
     };
 
     private static _LoadScriptPromise: Promise<void>;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder.ts
@@ -36,7 +36,7 @@ export class LiteTranscoder extends Transcoder {
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     protected setModulePath(modulePath: string): void {
-        this._modulePath = modulePath;
+        this._modulePath = Transcoder.GetWasmUrl(modulePath);
     }
 
     public initialize(): void {

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
@@ -10,7 +10,7 @@ export class LiteTranscoder_UASTC_ASTC extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_astc.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_astc.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
@@ -10,7 +10,7 @@ export class LiteTranscoder_UASTC_BC7 extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_bc7.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_bc7.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_R8_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_r8_unorm.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_r8_unorm.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.R8;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RG8_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rg8_unorm.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rg8_unorm.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RG8;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RGBA_SRGB extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (srgb)
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && isInGammaSpace;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RGBA_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && !isInGammaSpace;

--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -15,11 +15,11 @@ export class MSCTranscoder extends Transcoder {
     /**
      * URL to use when loading the MSC transcoder
      */
-    public static JSModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/msc_basis_transcoder.js";
+    public static JSModuleURL = "ktx2Transcoders/1/msc_basis_transcoder.js";
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "https://preview.babylonjs.com/ktx2Transcoders/1/msc_basis_transcoder.wasm";
+    public static WasmModuleURL = "ktx2Transcoders/1/msc_basis_transcoder.wasm";
 
     public static UseFromWorkerThread = true;
 
@@ -37,9 +37,9 @@ export class MSCTranscoder extends Transcoder {
             return this._mscBasisTranscoderPromise;
         }
 
-        this._mscBasisTranscoderPromise = WASMMemoryManager.LoadWASM(MSCTranscoder.WasmModuleURL).then((wasmBinary) => {
+        this._mscBasisTranscoderPromise = WASMMemoryManager.LoadWASM(Transcoder.GetWasmUrl(MSCTranscoder.WasmModuleURL)).then((wasmBinary) => {
             if (MSCTranscoder.UseFromWorkerThread) {
-                importScripts(MSCTranscoder.JSModuleURL);
+                importScripts(Transcoder.GetWasmUrl(MSCTranscoder.JSModuleURL));
             }
             // Worker Number = 0 and MSC_TRANSCODER has not been loaded yet.
             else if (typeof MSC_TRANSCODER === "undefined") {
@@ -47,7 +47,7 @@ export class MSCTranscoder extends Transcoder {
                     const head = document.getElementsByTagName("head")[0];
                     const script = document.createElement("script");
                     script.setAttribute("type", "text/javascript");
-                    script.setAttribute("src", MSCTranscoder.JSModuleURL);
+                    script.setAttribute("src", Transcoder.GetWasmUrl(MSCTranscoder.JSModuleURL));
 
                     script.onload = () => {
                         MSC_TRANSCODER({ wasmBinary }).then((basisModule: any) => {

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -15,6 +15,12 @@ export class Transcoder {
 
     public static Name = "Transcoder";
 
+    public static WasmBaseUrl = "https://preview.babylonjs.com/";
+
+    public static GetWasmUrl(wasmUrl: string) {
+        return `${Transcoder.WasmBaseUrl}${wasmUrl}`;
+    }
+
     public getName(): string {
         return Transcoder.Name;
     }

--- a/packages/tools/ktx2Decoder/src/zstddec.ts
+++ b/packages/tools/ktx2Decoder/src/zstddec.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+
+import { Transcoder } from "./transcoder";
+
 /**
  * From https://github.com/donmccurdy/zstddec by Don McCurdy
  */
@@ -27,7 +30,7 @@ const IMPORT_OBJECT = {
  * ZSTD (Zstandard) decoder.
  */
 export class ZSTDDecoder {
-    public static WasmModuleURL = "https://preview.babylonjs.com/zstddec.wasm";
+    public static WasmModuleURL = "zstddec.wasm";
 
     init(): Promise<void> {
         if (init) {
@@ -37,7 +40,7 @@ export class ZSTDDecoder {
         if (typeof fetch !== "undefined") {
             // Web.
 
-            init = fetch(ZSTDDecoder.WasmModuleURL)
+            init = fetch(Transcoder.GetWasmUrl(ZSTDDecoder.WasmModuleURL))
                 .then((response) => {
                     if (response.ok) {
                         return response.arrayBuffer();

--- a/packages/tools/testTools/src/utils.ts
+++ b/packages/tools/testTools/src/utils.ts
@@ -62,36 +62,12 @@ export const evaluateInitEngine = async (engineName: string, baseUrl: string, pa
     window.gc && window.gc();
     engineName = engineName ? engineName.toLowerCase() : "webgl2";
 
-    if (BABYLON.DracoCompression) {
-        BABYLON.DracoCompression.Configuration.decoder = {
-            wasmUrl: baseUrl + "/draco_wasm_wrapper_gltf.js",
-            wasmBinaryUrl: baseUrl + "/draco_decoder_gltf.wasm",
-            fallbackUrl: baseUrl + "/draco_decoder_gltf.js",
-        };
-    }
-    if (BABYLON.MeshoptCompression) {
-        BABYLON.MeshoptCompression.Configuration.decoder = {
-            url: baseUrl + "/meshopt_decoder.js",
-        };
-    }
-
-    BABYLON.BasisToolsOptions.JSModuleURL = baseUrl + "/basisTranscoder/1/basis_transcoder.js";
-    BABYLON.BasisToolsOptions.WasmModuleURL = baseUrl + "/basisTranscoder/1/basis_transcoder.wasm";
+    BABYLON.Tools.ScriptBaseUrl = baseUrl;
 
     const canvas = document.getElementById("babylon-canvas") as HTMLCanvasElement;
     if (!canvas) return;
     window.canvas = canvas;
     if (engineName === "webgpu") {
-        const glslangOptions = {
-            jsPath: baseUrl + "/glslang/glslang.js",
-            wasmPath: baseUrl + "/glslang/glslang.wasm",
-        };
-
-        const twgslOptions = {
-            jsPath: baseUrl + "/twgsl/twgsl.js",
-            wasmPath: baseUrl + "/twgsl/twgsl.wasm",
-        };
-
         const options = {
             antialias: false,
         };
@@ -99,7 +75,7 @@ export const evaluateInitEngine = async (engineName: string, baseUrl: string, pa
         const engine = new BABYLON.WebGPUEngine(canvas, options);
         engine.enableOfflineSupport = false;
         window.engine = engine;
-        await engine.initAsync(glslangOptions, twgslOptions);
+        await engine.initAsync();
     } else {
         const engine = new BABYLON.Engine(canvas, true, {
             disableWebGL2Support: engineName === "webgl1" ? true : false,

--- a/packages/tools/testTools/src/visualizationUtils.ts
+++ b/packages/tools/testTools/src/visualizationUtils.ts
@@ -14,47 +14,13 @@ export const evaluateInitEngineForVisualization = async (engineName: string, use
     BABYLON.SceneLoader.ShowLoadingScreen = false;
     BABYLON.SceneLoader.ForceFullSceneLoadingForIncremental = true;
 
-    BABYLON.DracoCompression.Configuration.decoder = {
-        wasmUrl: baseUrl + "/draco_wasm_wrapper_gltf.js",
-        wasmBinaryUrl: baseUrl + "/draco_decoder_gltf.wasm",
-        fallbackUrl: baseUrl + "/draco_decoder_gltf.js",
-    };
-    BABYLON.MeshoptCompression.Configuration.decoder = {
-        url: baseUrl + "/meshopt_decoder.js",
-    };
-    (BABYLON as any).GLTFValidation.Configuration = {
-        url: baseUrl + "/gltf_validator.js",
-    };
-
-    (BABYLON.KhronosTextureContainer2.URLConfig as any) = {
-        jsDecoderModule: baseUrl + "/babylon.ktx2Decoder.js",
-        wasmUASTCToASTC: baseUrl + "/ktx2Transcoders/uastc_astc.wasm",
-        wasmUASTCToBC7: baseUrl + "/ktx2Transcoders/uastc_bc7.wasm",
-        wasmUASTCToRGBA_UNORM: baseUrl + "/ktx2Transcoders/uastc_rgba32_unorm.wasm",
-        wasmUASTCToRGBA_SRGB: baseUrl + "/ktx2Transcoders/uastc_rgba32_srgb.wasm",
-        jsMSCTranscoder: baseUrl + "/ktx2Transcoders/msc_basis_transcoder.js",
-        wasmMSCTranscoder: baseUrl + "/ktx2Transcoders/msc_basis_transcoder.wasm",
-        wasmZSTDDecoder: baseUrl + "/zstddec.wasm",
-    };
-
-    BABYLON.BasisToolsOptions.JSModuleURL = baseUrl + "/basisTranscoder/1/basis_transcoder.js";
-    BABYLON.BasisToolsOptions.WasmModuleURL = baseUrl + "/basisTranscoder/1/basis_transcoder.wasm";
+    BABYLON.Tools.ScriptBaseUrl = baseUrl;
 
     window.forceUseReverseDepthBuffer = useReverseDepthBuffer === 1 || useReverseDepthBuffer === "true";
     window.forceUseNonCompatibilityMode = useNonCompatibilityMode === 1 || useNonCompatibilityMode === "true";
 
     window.canvas = document.getElementById("babylon-canvas") as HTMLCanvasElement;
     if (engineName === "webgpu") {
-        const glslangOptions = {
-            jsPath: baseUrl + "/glslang/glslang.js",
-            wasmPath: baseUrl + "/glslang/glslang.wasm",
-        };
-
-        const twgslOptions = {
-            jsPath: baseUrl + "/twgsl/twgsl.js",
-            wasmPath: baseUrl + "/twgsl/twgsl.wasm",
-        };
-
         const options = {
             enableAllFeatures: true,
             setMaximumLimits: true,
@@ -67,7 +33,7 @@ export const evaluateInitEngineForVisualization = async (engineName: string, use
         engine.compatibilityMode = !window.forceUseNonCompatibilityMode;
         window.engine = engine;
 
-        await engine.initAsync(glslangOptions, twgslOptions);
+        await engine.initAsync();
     } else {
         const engine = new BABYLON.Engine(window.canvas, false, {
             useHighPrecisionFloats: true,


### PR DESCRIPTION
Scripts (js and wasm) should now be loaded using the Tools'  GetScriptUrl function.

This function will check if the URL is absolute or relative. if relative it will append the BaseScriptUrl defined in Tools to the URL. Otherwise it will run a preprocessor and will make sure, if requested, that the URL is absolute.

This one you can either define a new URL per module OR a new global base URL for the scripts and thus replace the babylon's CDN in one call.

The preprocessor can be defined by the devs themselves to modify the URL to whatever it needs to be. Checking if the URL is absolute (GetAbsoluteUrl) was kept for back-compat reasons.

Notes

* Tools.LoadScript will automatically use GetScriptUrl
* It is possible to define a blob or data URL instead of a (relative) URL.
* KTXDecoder has a different, simpler mechanism to change the base URL