### PR TITLE
WIP: initial EXT_materials_bump support for glTF importer.

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_materials_bump.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_materials_bump.ts
@@ -1,0 +1,82 @@
+import type { Nullable } from "core/types";
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import type { Material } from "core/Materials/material";
+
+import type { IMaterial, ITextureInfo } from "../glTFLoaderInterfaces";
+import type { IGLTFLoaderExtension } from "../glTFLoaderExtension";
+import { GLTFLoader } from "../glTFLoader";
+import { Color3 } from "core/Maths/math.color";
+import type { IKHRMaterialsBump } from "babylonjs-gltf2interface";
+
+const NAME = "KHR_materials_bump";
+
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_bump/README.md)
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_materials_bump implements IGLTFLoaderExtension {
+    /**
+     * The name of this extension.
+     */
+    public readonly name = NAME;
+
+    /**
+     * Defines whether this extension is enabled.
+     */
+    public enabled: boolean;
+
+    /**
+     * Defines a number that determines the order the extensions are applied.
+     */
+    public order = 190;
+
+    private _loader: GLTFLoader;
+
+    /**
+     * @internal
+     */
+    constructor(loader: GLTFLoader) {
+        this._loader = loader;
+        this.enabled = this._loader.isExtensionUsed(NAME);
+    }
+
+    /** @internal */
+    public dispose() {
+        (this._loader as any) = null;
+    }
+
+    /**
+     * @internal
+     */
+    public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
+        return GLTFLoader.LoadExtensionAsync<IKHRMaterialsBump>(context, material, this.name, (extensionContext, extension) => {
+            const promises = new Array<Promise<any>>();
+            promises.push(this._loader.loadMaterialPropertiesAsync(context, material, babylonMaterial));
+            promises.push(this._loadSpecularPropertiesAsync(extensionContext, extension, babylonMaterial));
+            return Promise.all(promises).then(() => {});
+        });
+    }
+
+    private _loadSpecularPropertiesAsync(context: string, properties: IKHRMaterialsBump, babylonMaterial: Material): Promise<void> {
+        if (!(babylonMaterial instanceof PBRMaterial)) {
+            throw new Error(`${context}: Material type not supported`);
+        }
+
+        const promises = new Array<Promise<any>>();
+
+        // only apply bump map if bumpFactor is 1.0 as BabylonJS doesn't support scaling the bump map.
+        if (properties.bumpFactor === 1.0 && properties.bumpTexture) {
+            (properties.bumpTexture as ITextureInfo).nonColorData = true;
+            promises.push(
+                this._loader.loadTextureInfoAsync(`${context}/bumpTexture`, properties.bumpTexture, (texture) => {
+                    texture.name = `${babylonMaterial.name} (Bump)`;
+                    babylonMaterial.bumpTexture = texture;
+                })
+            );
+        }
+
+        return Promise.all(promises).then(() => {});
+    }
+}
+
+GLTFLoader.RegisterExtension(NAME, (loader) => new KHR_materials_bump(loader));

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -1101,6 +1101,16 @@ declare module BABYLON.GLTF2 {
     }
 
     /**
+     * Interfaces from the KHR_materials_bump extension
+     */
+
+    /** @internal */
+    interface IKHRMaterialsBump extends IMaterialExtension {
+        bumpFactor?: number;
+        bumpTexture?: ITextureInfo;
+    }
+
+    /**
      * Interfaces from the KHR_materials_transmission extension
      */
 


### PR DESCRIPTION
WIP (Work-in-progress)

This is an initial attempt at an implementation of the proposed EXT_materials_bump glTF extension.  It proposes adding a traditional bump map along with bump scale to the standard PBR material representation.

I tried implementing it in a straight forward fashion using the pre-existing bumpTexture on material.  But I couldn't find an appropriate bumpScale/bumpFactor for the extension's bumpFactor.