### PR TITLE
Fix an issue in the mesh parsing code

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -4008,7 +4008,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         mesh.checkCollisions = parsedMesh.checkCollisions;
-        mesh.overrideMaterialSideOrientation = parsedMesh.overrideMaterialSideOrientation;
+
+        if (parsedMesh.overrideMaterialSideOrientation !== undefined) {
+            mesh.overrideMaterialSideOrientation = parsedMesh.overrideMaterialSideOrientation;
+        }
 
         if (parsedMesh.isBlocker !== undefined) {
             mesh.isBlocker = parsedMesh.isBlocker;


### PR DESCRIPTION
Causes `overrideMaterialSideOrientation` to be `undefined`

Fixes #14445