### PR TITLE
Function to add element and all its children to AssetContainer

### DIFF
--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -18,8 +18,6 @@ import { InstancedMesh } from "./Meshes/instancedMesh";
 import { Light } from "./Lights/light";
 import { Camera } from "./Cameras/camera";
 import { Tools } from "./Misc/tools";
-import { PBRMaterial } from "./Materials/PBR/pbrMaterial";
-import { StandardMaterial } from "./Materials/standardMaterial";
 
 /**
  * Set of assets to keep when moving a scene into an asset container.
@@ -1053,18 +1051,6 @@ export class AssetContainer extends AbstractScene {
         });
     }
 
-    private _checkAndAddTextureStandardMaterial(material: StandardMaterial, textureName: keyof StandardMaterial) {
-        if (material[textureName]) {
-            this.textures.push(material[textureName]);
-        }
-    }
-
-    private _checkAndAddTexturePBRMaterial(material: PBRMaterial, textureName: keyof PBRMaterial) {
-        if (material[textureName]) {
-            this.textures.push(material[textureName]);
-        }
-    }
-
     /**
      * @since
      * Given a root asset, this method will traverse its hierarchy and add it, its children and any materials/skeletons/animation groups to the container.
@@ -1100,31 +1086,7 @@ export class AssetContainer extends AbstractScene {
             if (nodeToVisit instanceof AbstractMesh) {
                 if (nodeToVisit.material) {
                     this.materials.push(nodeToVisit.material);
-                    if (nodeToVisit.material instanceof StandardMaterial) {
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "diffuseTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "bumpTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "ambientTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "opacityTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "reflectionTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "emissiveTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "specularTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "lightmapTexture");
-                        this._checkAndAddTextureStandardMaterial(nodeToVisit.material, "refractionTexture");
-                    } else if (nodeToVisit.material instanceof PBRMaterial) {
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "albedoTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "ambientTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "opacityTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "reflectionTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "emissiveTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "metallicTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "reflectivityTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "bumpTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "lightmapTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "refractionTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "microSurfaceTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "metallicReflectanceTexture");
-                        this._checkAndAddTexturePBRMaterial(nodeToVisit.material, "reflectanceTexture");
-                    }
+                    this.textures.push(...nodeToVisit.material.getActiveTextures());
                 }
 
                 if (nodeToVisit.skeleton) {

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -1068,7 +1068,6 @@ export class AssetContainer extends AbstractScene {
 
         while (nodesToVisit.length > 0) {
             const nodeToVisit = nodesToVisit.pop()!;
-            visitedNodes.add(nodeToVisit);
 
             if (nodeToVisit instanceof Mesh) {
                 if (nodeToVisit.geometry) {
@@ -1103,6 +1102,8 @@ export class AssetContainer extends AbstractScene {
                     nodesToVisit.push(child);
                 }
             }
+
+            visitedNodes.add(nodeToVisit);
         }
 
         this.populateRootNodes();

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -1141,5 +1141,7 @@ export class AssetContainer extends AbstractScene {
                 }
             }
         }
+
+        this.populateRootNodes();
     }
 }

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -18,7 +18,8 @@ import { InstancedMesh } from "./Meshes/instancedMesh";
 import { Light } from "./Lights/light";
 import { Camera } from "./Cameras/camera";
 import { Tools } from "./Misc/tools";
-import { PBRMaterial, StandardMaterial } from "./Materials";
+import { PBRMaterial } from "./Materials/PBR/pbrMaterial";
+import { StandardMaterial } from "./Materials/standardMaterial";
 
 /**
  * Set of assets to keep when moving a scene into an asset container.

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -1070,7 +1070,7 @@ export class AssetContainer extends AbstractScene {
             const nodeToVisit = nodesToVisit.pop()!;
 
             if (nodeToVisit instanceof Mesh) {
-                if (nodeToVisit.geometry) {
+                if (nodeToVisit.geometry && this.geometries.indexOf(nodeToVisit.geometry) === -1) {
                     this.geometries.push(nodeToVisit.geometry);
                 }
                 this.meshes.push(nodeToVisit);
@@ -1083,16 +1083,20 @@ export class AssetContainer extends AbstractScene {
             }
 
             if (nodeToVisit instanceof AbstractMesh) {
-                if (nodeToVisit.material) {
+                if (nodeToVisit.material && this.materials.indexOf(nodeToVisit.material) === -1) {
                     this.materials.push(nodeToVisit.material);
-                    this.textures.push(...nodeToVisit.material.getActiveTextures());
+                    for (const texture of nodeToVisit.material.getActiveTextures()) {
+                        if (this.textures.indexOf(texture) === -1) {
+                            this.textures.push(texture);
+                        }
+                    }
                 }
 
-                if (nodeToVisit.skeleton) {
+                if (nodeToVisit.skeleton && this.skeletons.indexOf(nodeToVisit.skeleton) === -1) {
                     this.skeletons.push(nodeToVisit.skeleton);
                 }
 
-                if (nodeToVisit.morphTargetManager) {
+                if (nodeToVisit.morphTargetManager && this.morphTargetManagers.indexOf(nodeToVisit.morphTargetManager) === -1) {
                     this.morphTargetManagers.push(nodeToVisit.morphTargetManager);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/BabylonJS/ThePirateCove/issues/663

The function `addAllAssetsToContainer` receives a Node as argument and adds that node and all its children and derived elements (such as materials and skeletons) to an asset container. It is intended to work as a utility function used after loading a mesh with AssetsManager, for example. Usage example on: #TLFUIB#1