### PR TITLE
Move type out of import clause

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector2MathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector2MathBlocks.ts
@@ -2,7 +2,8 @@ import { RichTypeNumber, RichTypeVector2 } from "core/FlowGraph/flowGraphRichTyp
 import { Vector2 } from "../../../../Maths/math.vector";
 import { FlowGraphBinaryOperationBlock } from "../flowGraphBinaryOperationBlock";
 import { FlowGraphUnaryOperationBlock } from "../flowGraphUnaryOperationBlock";
-import { FlowGraphBlock, type IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import type { IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import { FlowGraphBlock } from "../../../flowGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
 import type { FlowGraphContext } from "../../../flowGraphContext";

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector3MathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector3MathBlocks.ts
@@ -3,7 +3,8 @@ import { FlowGraphBinaryOperationBlock } from "../flowGraphBinaryOperationBlock"
 import type { Matrix } from "../../../../Maths/math.vector";
 import { Quaternion, Vector3 } from "../../../../Maths/math.vector";
 import { FlowGraphUnaryOperationBlock } from "../flowGraphUnaryOperationBlock";
-import { FlowGraphBlock, type IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import type { IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import { FlowGraphBlock } from "../../../flowGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { FlowGraphContext } from "../../../flowGraphContext";
 import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector4MathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVector4MathBlocks.ts
@@ -2,7 +2,8 @@ import { RichTypeNumber, RichTypeVector4 } from "core/FlowGraph/flowGraphRichTyp
 import { FlowGraphBinaryOperationBlock } from "../flowGraphBinaryOperationBlock";
 import { Vector4 } from "../../../../Maths/math.vector";
 import { FlowGraphUnaryOperationBlock } from "../flowGraphUnaryOperationBlock";
-import { FlowGraphBlock, type IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import type { IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
+import { FlowGraphBlock } from "../../../flowGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { FlowGraphContext } from "../../../flowGraphContext";
 import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";

--- a/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
@@ -10,7 +10,8 @@ import { GreasedLineTools } from "../../Misc/greasedLineTools";
 import type { GreasedLineMeshOptions } from "../GreasedLine/greasedLineBaseMesh";
 import { GreasedLineRibbonAutoDirectionMode, GreasedLineRibbonFacesMode, GreasedLineRibbonPointsMode } from "../GreasedLine/greasedLineBaseMesh";
 import { GreasedLineRibbonMesh } from "../GreasedLine/greasedLineRibbonMesh";
-import { GreasedLineMeshMaterialType, type GreasedLineMaterialOptions } from "../../Materials/GreasedLine/greasedLineMaterialInterfaces";
+import type { GreasedLineMaterialOptions } from "../../Materials/GreasedLine/greasedLineMaterialInterfaces";
+import { GreasedLineMeshMaterialType } from "../../Materials/GreasedLine/greasedLineMaterialInterfaces";
 import { GreasedLinePluginMaterial } from "../../Materials/GreasedLine/greasedLinePluginMaterial";
 import { GreasedLineMaterialDefaults } from "../../Materials/GreasedLine/greasedLineMaterialDefaults";
 

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -9,7 +9,8 @@ import type { Nullable } from "../../types";
 import type { Node } from "../../node";
 import { DeepCopier } from "../../Misc/deepCopier";
 import { GreasedLineTools } from "../../Misc/greasedLineTools";
-import { GreasedLineBaseMesh, type GreasedLineMeshOptions } from "./greasedLineBaseMesh";
+import type { GreasedLineMeshOptions } from "./greasedLineBaseMesh";
+import { GreasedLineBaseMesh } from "./greasedLineBaseMesh";
 
 Mesh._GreasedLineMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
     return GreasedLineMesh.Parse(parsedMesh, scene);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateRadialBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateRadialBlock.ts
@@ -2,7 +2,7 @@ import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnect
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { Matrix, Quaternion, Vector3 } from "../../../../Maths/math.vector";
-import { type NodeGeometryBuildState } from "../../nodeGeometryBuildState";
+import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { VertexData } from "core/Meshes/mesh.vertexData";
 import { InstantiateBaseBlock } from "./instantiateBaseBlock";
 


### PR DESCRIPTION
TypeScript 4.5 introduces inline type imports. But for anyone who uses typescript < 4.5 the build will fail.

There is no lint rule to disallow that, as it is a perfectly correct syntax. I will keep on checking for that.