### PR TITLE
fix: missing export for public property type

### DIFF
--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -25,7 +25,10 @@ import type { TargetCamera } from "./targetCamera";
 import type { Ray } from "../Culling/ray";
 import type { ArcRotateCamera } from "./arcRotateCamera";
 
-interface IObliqueParams {
+/**
+ * Oblique projection values
+ */
+export interface IObliqueParams {
     /** The angle of the plane */
     angle: number;
     /** The length of the plane */


### PR DESCRIPTION
I'm unable to build my project with the missing type.
https://forum.babylonjs.com/t/public-property-type-not-exported/45169/5