### PR TITLE
Fix transform node world space rotation when parent has negative world matrix determinant

### DIFF
--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -906,9 +906,14 @@ export class TransformNode extends Node {
             this.rotationQuaternion.multiplyToRef(rotationQuaternion, this.rotationQuaternion);
         } else {
             if (this.parent) {
+                const parentWorldMatrix = this.parent.getWorldMatrix();
                 const invertParentWorldMatrix = TmpVectors.Matrix[0];
-                this.parent.getWorldMatrix().invertToRef(invertParentWorldMatrix);
+                parentWorldMatrix.invertToRef(invertParentWorldMatrix);
                 axis = Vector3.TransformNormal(axis, invertParentWorldMatrix);
+
+                if (parentWorldMatrix.determinant() < 0) {
+                    amount *= -1;
+                }
             }
             rotationQuaternion = Quaternion.RotationAxisToRef(axis, amount, TransformNode._RotationAxisCache);
             rotationQuaternion.multiplyToRef(this.rotationQuaternion, this.rotationQuaternion);


### PR DESCRIPTION
https://forum.babylonjs.com/t/unexpected-behaviour-when-rotating-a-mesh-in-world-space/43298/8

Playground to try out: https://playground.babylonjs.com/#2GVE4L#40 (both buttons should rotate in the same direction)