### PR TITLE
Fix breaking issue with ScriptBaseUrl

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -222,7 +222,7 @@ export class DebugLayer {
      * By default it uses the babylonjs CDN.
      * @ignoreNaming
      */
-    public static InspectorURL = `v${Engine.Version}/inspector/babylon.inspector.bundle.js`;
+    public static InspectorURL = `https://cdn.babylonjs.com/v${Engine.Version}/inspector/babylon.inspector.bundle.js`;
 
     private _scene: Scene;
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTintWASM.ts
@@ -22,8 +22,8 @@ export interface TwgslOptions {
 export class WebGPUTintWASM {
     // Default twgsl options.
     private static readonly _TWgslDefaultOptions: TwgslOptions = {
-        jsPath: "twgsl/twgsl.js",
-        wasmPath: "twgsl/twgsl.wasm",
+        jsPath: "https://cdn.babylonjs.com/twgsl/twgsl.js",
+        wasmPath: "https://cdn.babylonjs.com/twgsl/twgsl.wasm",
     };
 
     public static ShowWGSLShaderCode = false;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -165,8 +165,8 @@ export interface WebGPUEngineOptions extends ThinEngineOptions, GPURequestAdapte
 export class WebGPUEngine extends Engine {
     // Default glslang options.
     private static readonly _GLSLslangDefaultOptions: GlslangOptions = {
-        jsPath: "glslang/glslang.js",
-        wasmPath: "glslang/glslang.wasm",
+        jsPath: "https://cdn.babylonjs.com/glslang/glslang.js",
+        wasmPath: "https://cdn.babylonjs.com/glslang/glslang.wasm",
     };
 
     /** true to enable using TintWASM to convert Spir-V to WGSL */

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -201,7 +201,7 @@ export class NodeMaterial extends PushMaterial {
     private _animationFrame = -1;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `v${Engine.Version}/nodeEditor/babylon.nodeEditor.js`;
+    public static EditorURL = `https://cdn.babylonjs.com/v${Engine.Version}/nodeEditor/babylon.nodeEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -302,15 +302,15 @@ export class DracoCompression implements IDisposable {
 
     /**
      * The configuration. Defaults to the following urls:
-     * - wasmUrl: "https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js"
-     * - wasmBinaryUrl: "https://preview.babylonjs.com/draco_decoder_gltf.wasm"
-     * - fallbackUrl: "https://preview.babylonjs.com/draco_decoder_gltf.js"
+     * - wasmUrl: "https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"
+     * - wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm"
+     * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
      */
     public static Configuration: IDracoCompressionConfiguration = {
         decoder: {
-            wasmUrl: "draco_wasm_wrapper_gltf.js",
-            wasmBinaryUrl: "draco_decoder_gltf.wasm",
-            fallbackUrl: "draco_decoder_gltf.js",
+            wasmUrl: "https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js",
+            wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm",
+            fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js",
         },
     };
 

--- a/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
@@ -49,13 +49,13 @@ export class MeshoptCompression implements IDisposable {
      * The configuration. Defaults to the following:
      * ```javascript
      * decoder: {
-     *   url: "https://preview.babylonjs.com/meshopt_decoder.js"
+     *   url: "https://cdn.babylonjs.com/meshopt_decoder.js"
      * }
      * ```
      */
     public static Configuration: IMeshoptCompressionConfiguration = {
         decoder: {
-            url: "meshopt_decoder.js",
+            url: "https://cdn.babylonjs.com/meshopt_decoder.js",
         },
     };
 

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -49,7 +49,7 @@ export class NodeGeometry {
     private _buildExecutionTime: number = 0;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `v${Engine.Version}/nodeGeometryEditor/babylon.nodeGeometryEditor.js`;
+    public static EditorURL = `https://cdn.babylonjs.com/v${Engine.Version}/nodeGeometryEditor/babylon.nodeGeometryEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Misc/basis.ts
+++ b/packages/dev/core/src/Misc/basis.ts
@@ -114,11 +114,11 @@ export const BasisToolsOptions = {
     /**
      * URL to use when loading the basis transcoder
      */
-    JSModuleURL: "basisTranscoder/1/basis_transcoder.js",
+    JSModuleURL: "https://cdn.babylonjs.com/basisTranscoder/1/basis_transcoder.js",
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    WasmModuleURL: "basisTranscoder/1/basis_transcoder.wasm",
+    WasmModuleURL: "https://cdn.babylonjs.com/basisTranscoder/1/basis_transcoder.wasm",
 };
 
 /**

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -114,7 +114,7 @@ export const FileToolsOptions: {
      * Gets or sets the base URL to use to load scripts
      * Used for both JS and WASM
      */
-    ScriptBaseUrl: "https://cdn.babylonjs.com/",
+    ScriptBaseUrl: "",
     /**
      * Gets or sets a function used to pre-process script url before using them to load.
      * Used for both JS and WASM

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -241,7 +241,7 @@ export class KhronosTextureContainer2 {
         wasmMSCTranscoder: Nullable<string>;
         wasmZSTDDecoder: Nullable<string>;
     } = {
-        jsDecoderModule: "babylon.ktx2Decoder.js",
+        jsDecoderModule: "https://cdn.babylonjs.com/babylon.ktx2Decoder.js",
         wasmUASTCToASTC: null,
         wasmUASTCToBC7: null,
         wasmUASTCToRGBA_UNORM: null,

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -486,6 +486,11 @@ export class Tools {
     }
 
     /**
+     * @internal
+     */
+    public static _DefaultCdnUrl = "https://cdn.babylonjs.com/";
+
+    /**
      * Get a script URL including preprocessing
      * @param scriptUrl the script Url to process
      * @returns a modified URL to use
@@ -494,10 +499,11 @@ export class Tools {
         if (!scriptUrl) {
             return "";
         }
-        // check if the URL is absolute or relative. Otherwise, append the base URL
-        if (!Tools.IsAbsoluteUrl(scriptUrl)) {
+        // if the base URL was set, and the script Url is an absolute path change the default path
+        if(Tools.ScriptBaseUrl && scriptUrl.startsWith(Tools._DefaultCdnUrl)) {
+            // change the default host, which is https://cdn.babylonjs.com with the one defined
             const baseUrl = Tools.ScriptBaseUrl[Tools.ScriptBaseUrl.length - 1] === "/" ? Tools.ScriptBaseUrl : Tools.ScriptBaseUrl + "/";
-            scriptUrl = baseUrl + (scriptUrl[0] === "/" ? scriptUrl.substring(1) : scriptUrl);
+            scriptUrl = scriptUrl.replace(Tools._DefaultCdnUrl, baseUrl);
         }
 
         // run the preprocessor

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -500,7 +500,7 @@ export class Tools {
             return "";
         }
         // if the base URL was set, and the script Url is an absolute path change the default path
-        if(Tools.ScriptBaseUrl && scriptUrl.startsWith(Tools._DefaultCdnUrl)) {
+        if (Tools.ScriptBaseUrl && scriptUrl.startsWith(Tools._DefaultCdnUrl)) {
             // change the default host, which is https://cdn.babylonjs.com with the one defined
             const baseUrl = Tools.ScriptBaseUrl[Tools.ScriptBaseUrl.length - 1] === "/" ? Tools.ScriptBaseUrl : Tools.ScriptBaseUrl + "/";
             scriptUrl = scriptUrl.replace(Tools._DefaultCdnUrl, baseUrl);

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -5,7 +5,7 @@ import { GUIEditor } from "gui-editor/guiEditor";
 
 declare let BABYLON: any;
 
-let editorUrl = `v${Engine.Version}/guiEditor/babylon.guiEditor.js`;
+let editorUrl = `https://cdn.babylonjs.com/v${Engine.Version}/guiEditor/babylon.guiEditor.js`;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 let guiEditorContainer: { GUIEditor: typeof GUIEditor };
 /** Get the inspector from bundle or global */

--- a/packages/dev/loaders/src/glTF/glTFValidation.ts
+++ b/packages/dev/loaders/src/glTF/glTFValidation.ts
@@ -86,10 +86,10 @@ export interface IGLTFValidationConfiguration {
  */
 export class GLTFValidation {
     /**
-     * The configuration. Defaults to `{ url: "https://preview.babylonjs.com/gltf_validator.js" }`.
+     * The configuration. Defaults to `{ url: "https://cdn.babylonjs.com/gltf_validator.js" }`.
      */
     public static Configuration: IGLTFValidationConfiguration = {
-        url: "gltf_validator.js",
+        url: "https://cdn.babylonjs.com/gltf_validator.js",
     };
 
     private static _LoadScriptPromise: Promise<void>;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_ASTC.ts
@@ -10,7 +10,7 @@ export class LiteTranscoder_UASTC_ASTC extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_astc.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_astc.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_BC7.ts
@@ -10,7 +10,7 @@ export class LiteTranscoder_UASTC_BC7 extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_bc7.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_bc7.wasm";
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_R8_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_R8_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_r8_unorm.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_r8_unorm.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.R8;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RG8_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RG8_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rg8_unorm.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_rg8_unorm.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RG8;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_SRGB.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RGBA_SRGB extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (srgb)
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && isInGammaSpace;

--- a/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/liteTranscoder_UASTC_RGBA_UNORM.ts
@@ -11,7 +11,7 @@ export class LiteTranscoder_UASTC_RGBA_UNORM extends LiteTranscoder {
     /**
      * URL to use when loading the wasm module for the transcoder (unorm)
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm";
 
     public static CanTranscode(src: KTX2.SourceTextureFormat, dst: KTX2.TranscodeTarget, isInGammaSpace: boolean): boolean {
         return src === KTX2.SourceTextureFormat.UASTC4x4 && dst === KTX2.TranscodeTarget.RGBA32 && !isInGammaSpace;

--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -15,11 +15,11 @@ export class MSCTranscoder extends Transcoder {
     /**
      * URL to use when loading the MSC transcoder
      */
-    public static JSModuleURL = "ktx2Transcoders/1/msc_basis_transcoder.js";
+    public static JSModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/msc_basis_transcoder.js";
     /**
      * URL to use when loading the wasm module for the transcoder
      */
-    public static WasmModuleURL = "ktx2Transcoders/1/msc_basis_transcoder.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/ktx2Transcoders/1/msc_basis_transcoder.wasm";
 
     public static UseFromWorkerThread = true;
 

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -18,7 +18,7 @@ export class Transcoder {
     public static WasmBaseUrl = "";
 
     public static GetWasmUrl(wasmUrl: string) {
-        if(Transcoder.WasmBaseUrl && wasmUrl.startsWith("https://cdn.babylonjs.com/")){
+        if (Transcoder.WasmBaseUrl && wasmUrl.startsWith("https://cdn.babylonjs.com/")) {
             wasmUrl = wasmUrl.replace("https://cdn.babylonjs.com/", Transcoder.WasmBaseUrl);
         }
         return wasmUrl;

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -15,10 +15,13 @@ export class Transcoder {
 
     public static Name = "Transcoder";
 
-    public static WasmBaseUrl = "https://preview.babylonjs.com/";
+    public static WasmBaseUrl = "";
 
     public static GetWasmUrl(wasmUrl: string) {
-        return `${Transcoder.WasmBaseUrl}${wasmUrl}`;
+        if(Transcoder.WasmBaseUrl && wasmUrl.startsWith("https://cdn.babylonjs.com/")){
+            wasmUrl = wasmUrl.replace("https://cdn.babylonjs.com/", Transcoder.WasmBaseUrl);
+        }
+        return wasmUrl;
     }
 
     public getName(): string {

--- a/packages/tools/ktx2Decoder/src/zstddec.ts
+++ b/packages/tools/ktx2Decoder/src/zstddec.ts
@@ -30,7 +30,7 @@ const IMPORT_OBJECT = {
  * ZSTD (Zstandard) decoder.
  */
 export class ZSTDDecoder {
-    public static WasmModuleURL = "zstddec.wasm";
+    public static WasmModuleURL = "https://cdn.babylonjs.com/zstddec.wasm";
 
     init(): Promise<void> {
         if (init) {


### PR DESCRIPTION
The general idea here is this - change the ScriptBaseUrl functionality. If it is provided AND the URL is an absolute URL that starts with cdn.babylonjs.com, change this portion of the URL with the data provided in ScriptBaseURL