### PR TITLE
feat: Added a default configuration to DebugLayer

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -160,9 +160,6 @@ export interface IInspectorOptions {
 }
 
 declare module "../scene" {
-    /**
-     *
-     */
     export interface Scene {
         /**
          * @internal

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -160,6 +160,9 @@ export interface IInspectorOptions {
 }
 
 declare module "../scene" {
+    /**
+     *
+     */
     export interface Scene {
         /**
          * @internal
@@ -262,9 +265,9 @@ export class DebugLayer {
     }
 
     /**
-     * the default configuration of the inspector
+     * the default configuration of the inspector at the class level
      */
-    public config: IInspectorOptions = {
+    public static Config: IInspectorOptions = {
         overlay: false,
         showExplorer: true,
         showInspector: true,
@@ -272,6 +275,13 @@ export class DebugLayer {
         handleResize: true,
         enablePopup: true,
     };
+
+    /**
+     * the default configuration of the inspector
+     * DebugLayer.Config is inherited when the instance is created
+     * After it is created, changes to DebugLayer.Config are not synchronized to the instance configuration
+     */
+    public config: IInspectorOptions = { ...DebugLayer.Config };
 
     /**
      * Instantiates a new debug layer.
@@ -286,9 +296,7 @@ export class DebugLayer {
         if (!this._scene) {
             return;
         }
-        if (config) {
-            this.config = config;
-        }
+        Object.assign(this.config, config);
         this._scene.onDisposeObservable.add(() => {
             // Debug layer
             if (this._scene._debugLayer) {

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -224,6 +224,18 @@ export class DebugLayer {
      */
     public static InspectorURL = `v${Engine.Version}/inspector/babylon.inspector.bundle.js`;
 
+    /**
+     * The default configuration of the inspector
+     */
+    public static Config: IInspectorOptions = {
+        overlay: false,
+        showExplorer: true,
+        showInspector: true,
+        embedMode: false,
+        handleResize: true,
+        enablePopup: true,
+    };
+
     private _scene: Scene;
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -260,18 +272,6 @@ export class DebugLayer {
 
         return this._onSelectionChangedObservable;
     }
-
-    /**
-     * the default configuration of the inspector at the class level
-     */
-    public static Config: IInspectorOptions = {
-        overlay: false,
-        showExplorer: true,
-        showInspector: true,
-        embedMode: false,
-        handleResize: true,
-        enablePopup: true,
-    };
 
     /**
      * Instantiates a new debug layer.

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -322,7 +322,7 @@ export class DebugLayer {
         }
 
         const userOptions: IInspectorOptions = {
-            ...(this.constructor as typeof DebugLayer).Config,
+            ...DebugLayer.Config,
             ...config,
         };
 

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -277,26 +277,17 @@ export class DebugLayer {
     };
 
     /**
-     * the default configuration of the inspector
-     * DebugLayer.Config is inherited when the instance is created
-     * After it is created, changes to DebugLayer.Config are not synchronized to the instance configuration
-     */
-    public config: IInspectorOptions = { ...DebugLayer.Config };
-
-    /**
      * Instantiates a new debug layer.
      * The debug layer (aka Inspector) is the go to tool in order to better understand
      * what is happening in your scene
      * @see https://doc.babylonjs.com/toolsAndResources/inspector
      * @param scene Defines the scene to inspect
-     * @param config the default configuration of the inspector
      */
-    constructor(scene?: Scene, config?: IInspectorOptions) {
+    constructor(scene?: Scene) {
         this._scene = scene || <Scene>EngineStore.LastCreatedScene;
         if (!this._scene) {
             return;
         }
-        Object.assign(this.config, config);
         this._scene.onDisposeObservable.add(() => {
             // Debug layer
             if (this._scene._debugLayer) {
@@ -331,7 +322,7 @@ export class DebugLayer {
         }
 
         const userOptions: IInspectorOptions = {
-            ...this.config,
+            ...(this.constructor as typeof DebugLayer).Config,
             ...config,
         };
 

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -262,16 +262,32 @@ export class DebugLayer {
     }
 
     /**
+     * the default configuration of the inspector
+     */
+    public config: IInspectorOptions = {
+        overlay: false,
+        showExplorer: true,
+        showInspector: true,
+        embedMode: false,
+        handleResize: true,
+        enablePopup: true,
+    };
+
+    /**
      * Instantiates a new debug layer.
      * The debug layer (aka Inspector) is the go to tool in order to better understand
      * what is happening in your scene
      * @see https://doc.babylonjs.com/toolsAndResources/inspector
      * @param scene Defines the scene to inspect
+     * @param config the default configuration of the inspector
      */
-    constructor(scene?: Scene) {
+    constructor(scene?: Scene, config?: IInspectorOptions) {
         this._scene = scene || <Scene>EngineStore.LastCreatedScene;
         if (!this._scene) {
             return;
+        }
+        if (config) {
+            this.config = config;
         }
         this._scene.onDisposeObservable.add(() => {
             // Debug layer
@@ -307,12 +323,7 @@ export class DebugLayer {
         }
 
         const userOptions: IInspectorOptions = {
-            overlay: false,
-            showExplorer: true,
-            showInspector: true,
-            embedMode: false,
-            handleResize: true,
-            enablePopup: true,
+            ...this.config,
             ...config,
         };
 


### PR DESCRIPTION
If you need to configure DebugLayer, you need to pass your own configuration every time you call DebugLayer.show(config), which is more troublesome, and when you wrap the SDK based on babylon, you need to replace the show method in order to solve this problem;

The best solution would be to give DebugLayer a default config item, which is more configurable and compatible with previous code