### PR TITLE
fix stack panel GUI warnings

### DIFF
--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -165,7 +165,7 @@ export class StackPanel extends Container {
                     child._top.ignoreAdaptiveScaling = true;
                 }
 
-                if (child._height.isPercentage && !child._automaticSize && !(child as TextBlock).resizeToFit) {
+                if (child._height.isPercentage && !child._automaticSize && !(child as TextBlock).resizeToFit && !(child as Container).adaptHeightToChildren) {
                     if (!this.ignoreLayoutWarnings) {
                         Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                     }


### PR DESCRIPTION
This is to cover a case that wasn't covered in https://github.com/BabylonJS/Babylon.js/pull/14452
Forum discussion: https://forum.babylonjs.com/t/control-is-using-height-in-percentage-mode-inside-a-vertical-stackpanel-warnings-after-update-to-6-25-0/45071/4