### PR TITLE
refactor: Change the return type of Observable.add

### DIFF
--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -195,17 +195,7 @@ export class Observable<T> {
      * @param unregisterOnFirstCall defines if the observer as to be unregistered after the next notification
      * @returns the new observer created for the callback
      */
-    public add(
-        callback: (eventData: T, eventState: EventState) => void,
-        mask: number = -1,
-        insertFirst = false,
-        scope: any = null,
-        unregisterOnFirstCall = false
-    ): Nullable<Observer<T>> {
-        if (!callback) {
-            return null;
-        }
-
+    public add(callback: (eventData: T, eventState: EventState) => void, mask: number = -1, insertFirst = false, scope: any = null, unregisterOnFirstCall = false): Observer<T> {
         const observer = new Observer(callback, mask, scope);
         observer.unregisterOnNextCall = unregisterOnFirstCall;
 
@@ -238,7 +228,7 @@ export class Observable<T> {
      * @param callback the callback that will be executed for that Observer
      * @returns the new observer created for the callback
      */
-    public addOnce(callback: (eventData: T, eventState: EventState) => void): Nullable<Observer<T>> {
+    public addOnce(callback: (eventData: T, eventState: EventState) => void): Observer<T> {
         return this.add(callback, undefined, undefined, undefined, true);
     }
 


### PR DESCRIPTION
`observable.add(callback: (eventData: T, eventState: EventState) => void, mask: number = -1, insertFirst = false, scope: any = null, unregisterOnFirstCall = false): Nullable<Observer<T>> `
1. The method has declared callback as a mandatory type, and there should be no null value judgment in the function, otherwise it is easy to have a lot of redundant dormitory judgments on the call chain
2. The return value type should also not be 'Nullable', because if 'callback' is not null, it will always return an observer