### PR TITLE
ShaderMaterial: Make sure the color attribute is not duplicated

### DIFF
--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -700,7 +700,9 @@ export class ShaderMaterial extends PushMaterial {
         }
 
         if (mesh && mesh.isVerticesDataPresent(VertexBuffer.ColorKind)) {
-            attribs.push(VertexBuffer.ColorKind);
+            if (attribs.indexOf(VertexBuffer.ColorKind) === -1) {
+                attribs.push(VertexBuffer.ColorKind);
+            }
             defines.push("#define VERTEXCOLOR");
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/linemesh-is-not-fully-backwards-compatible-in-webgpu/45339