### PR TITLE
Fix undeclared identifier error in NodeMaterial shader

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -371,11 +371,15 @@ export class LightBlock extends NodeMaterialBlock {
 
         if (this.light) {
             state.compilationString += state._emitCodeFromInclude("lightFragment", comments, {
-                replaceStrings: [{ search: /{X}/g, replace: this._lightId.toString() }],
+                replaceStrings: [
+                    { search: /{X}/g, replace: this._lightId.toString() },
+                    { search: /vPositionW/g, replace: worldPosVariableName + ".xyz" },
+                ],
             });
         } else {
             state.compilationString += state._emitCodeFromInclude("lightFragment", comments, {
                 repeatKey: "maxSimultaneousLights",
+                replaceStrings: [{ search: /vPositionW/g, replace: worldPosVariableName + ".xyz" }],
             });
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1116,9 +1116,7 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         state._emitFunctionFromInclude("imageProcessingDeclaration", comments);
         state._emitFunctionFromInclude("imageProcessingFunctions", comments);
 
-        state._emitFunctionFromInclude("shadowsFragmentFunctions", comments, {
-            replaceStrings: [{ search: /vPositionW/g, replace: worldPosVarName + ".xyz" }],
-        });
+        state._emitFunctionFromInclude("shadowsFragmentFunctions", comments);
 
         state._emitFunctionFromInclude("pbrDirectLightingSetupFunctions", comments, {
             replaceStrings: [{ search: /vPositionW/g, replace: worldPosVarName + ".xyz" }],
@@ -1331,11 +1329,15 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
 
         if (this.light) {
             state.compilationString += state._emitCodeFromInclude("lightFragment", comments, {
-                replaceStrings: [{ search: /{X}/g, replace: this._lightId.toString() }],
+                replaceStrings: [
+                    { search: /{X}/g, replace: this._lightId.toString() },
+                    { search: /vPositionW/g, replace: worldPosVarName + ".xyz" },
+                ],
             });
         } else {
             state.compilationString += state._emitCodeFromInclude("lightFragment", comments, {
                 repeatKey: "maxSimultaneousLights",
+                replaceStrings: [{ search: /vPositionW/g, replace: worldPosVarName + ".xyz" }],
             });
         }
 


### PR DESCRIPTION
[this playground](https://www.babylonjs-playground.com/#TN9A7W) can reproduce the bug
the crash info as follow
<img width="1230" alt="截屏2023-11-01 21 00 29" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/40c3f974-4830-4743-bdea-f27087ffb594">

in [this commit](https://github.com/BabylonJS/Babylon.js/commit/a421cc939416902d462aa2554f38749f0fde2034), vPositionW is removed from shadowsFragmentFunctions.fx and used by lightFragment.fx
But PBRMetallicRoughnessBlock still only replaces 'vPositionW' in shadowsFragmentFunctions.fx.

So, if a mesh use nodematerial using PBRBlock and receiveShadows, the final shader code will have 'vPositionW' , then
the error reported.

