### PR TITLE
Fix ray cast skipBoundingInfo with in intersects

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1955,7 +1955,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
             const subMesh = subMeshes.data[index];
 
             // Bounding test
-            if (len > 1 && !subMesh.canIntersects(ray)) {
+            if (len > 1 && !skipBoundingInfo && !subMesh.canIntersects(ray)) {
                 continue;
             }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/the-problem-when-picking-the-merged-mesh-thin-instance/45336/8