### PR TITLE
CreateText does not align text on z

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/textBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/textBuilder.ts
@@ -340,7 +340,7 @@ export function CreateText(
         const bbox = newMesh?.getBoundingInfo();
         newMesh.position.x = -bbox?.boundingBox.extendSizeWorld._x;
         newMesh.position.y = -bbox?.boundingBox.extendSizeWorld._y;
-        newMesh.position.z = -bbox?.boundingBox.extendSizeWorld._z;
+
         newMesh.name = name;
 
         newMesh.rotation.x = -Math.PI / 2;


### PR DESCRIPTION
https://forum.babylonjs.com/t/meshbuilder-createtext/40958/13

[breaking change]: The created text will not be positioned at the same position as before along z but this is a necessary bug fix.