### PR TITLE
Rename internal classes in CSG

### DIFF
--- a/packages/dev/core/src/Meshes/csg.ts
+++ b/packages/dev/core/src/Meshes/csg.ts
@@ -87,7 +87,7 @@ class Vertex {
 /**
  * Represents a plane in 3D space.
  */
-class Plane {
+class CSGPlane {
     /**
      * Initializes the plane
      * @param normal The normal for the plane
@@ -110,7 +110,7 @@ class Plane {
      * @param b Point b
      * @param c Point c
      */
-    public static FromPoints(a: Vector3, b: Vector3, c: Vector3): Nullable<Plane> {
+    public static FromPoints(a: Vector3, b: Vector3, c: Vector3): Nullable<CSGPlane> {
         const v0 = c.subtract(a);
         const v1 = b.subtract(a);
 
@@ -119,15 +119,15 @@ class Plane {
         }
 
         const n = Vector3.Normalize(Vector3.Cross(v0, v1));
-        return new Plane(n, Vector3.Dot(n, a));
+        return new CSGPlane(n, Vector3.Dot(n, a));
     }
 
     /**
      * Clone, or make a deep copy of the plane
      * @returns a new Plane
      */
-    public clone(): Plane {
-        return new Plane(this.normal.clone(), this.w);
+    public clone(): CSGPlane {
+        return new CSGPlane(this.normal.clone(), this.w);
     }
 
     /**
@@ -150,7 +150,7 @@ class Plane {
      * @param front Will contain the polygons in front of the plane
      * @param back Will contain the polygons begind the plane
      */
-    public splitPolygon(polygon: Polygon, coplanarFront: Polygon[], coplanarBack: Polygon[], front: Polygon[], back: Polygon[]): void {
+    public splitPolygon(polygon: CSGPolygon, coplanarFront: CSGPolygon[], coplanarBack: CSGPolygon[], front: CSGPolygon[], back: CSGPolygon[]): void {
         const COPLANAR = 0;
         const FRONT = 1;
         const BACK = 2;
@@ -164,7 +164,7 @@ class Plane {
         let t: number;
         for (i = 0; i < polygon.vertices.length; i++) {
             t = Vector3.Dot(this.normal, polygon.vertices[i].pos) - this.w;
-            const type = t < -Plane.EPSILON ? BACK : t > Plane.EPSILON ? FRONT : COPLANAR;
+            const type = t < -CSGPlane.EPSILON ? BACK : t > CSGPlane.EPSILON ? FRONT : COPLANAR;
             polygonType |= type;
             types.push(type);
         }
@@ -202,16 +202,16 @@ class Plane {
                         b.push(v.clone());
                     }
                 }
-                let poly: Polygon;
+                let poly: CSGPolygon;
                 if (f.length >= 3) {
-                    poly = new Polygon(f, polygon.shared);
+                    poly = new CSGPolygon(f, polygon.shared);
                     if (poly.plane) {
                         front.push(poly);
                     }
                 }
 
                 if (b.length >= 3) {
-                    poly = new Polygon(b, polygon.shared);
+                    poly = new CSGPolygon(b, polygon.shared);
 
                     if (poly.plane) {
                         back.push(poly);
@@ -232,7 +232,7 @@ class Plane {
  * polygons that are clones of each other or were split from the same polygon.
  * This can be used to define per-polygon properties (such as surface color)
  */
-class Polygon {
+class CSGPolygon {
     /**
      * Vertices of the polygon
      */
@@ -244,7 +244,7 @@ class Polygon {
     /**
      * A plane formed from the vertices of the polygon
      */
-    public plane: Plane;
+    public plane: CSGPlane;
 
     /**
      * Initializes the polygon
@@ -254,15 +254,15 @@ class Polygon {
     constructor(vertices: Vertex[], shared: any) {
         this.vertices = vertices;
         this.shared = shared;
-        this.plane = <Plane>Plane.FromPoints(vertices[0].pos, vertices[1].pos, vertices[2].pos);
+        this.plane = <CSGPlane>CSGPlane.FromPoints(vertices[0].pos, vertices[1].pos, vertices[2].pos);
     }
 
     /**
      * Clones, or makes a deep copy, or the polygon
      */
-    public clone(): Polygon {
+    public clone(): CSGPolygon {
         const vertices = this.vertices.map((v) => v.clone());
-        return new Polygon(vertices, this.shared);
+        return new CSGPolygon(vertices, this.shared);
     }
 
     /**
@@ -284,16 +284,16 @@ class Polygon {
  * no distinction between internal and leaf nodes
  */
 class Node {
-    private _plane: Nullable<Plane> = null;
+    private _plane: Nullable<CSGPlane> = null;
     private _front: Nullable<Node> = null;
     private _back: Nullable<Node> = null;
-    private _polygons = new Array<Polygon>();
+    private _polygons = new Array<CSGPolygon>();
 
     /**
      * Initializes the node
      * @param polygons A collection of polygons held in the node
      */
-    constructor(polygons?: Array<Polygon>) {
+    constructor(polygons?: Array<CSGPolygon>) {
         if (polygons) {
             this.build(polygons);
         }
@@ -339,12 +339,12 @@ class Node {
      * @param polygons Polygons to remove from the BSP
      * @returns Polygons clipped from the BSP
      */
-    clipPolygons(polygons: Polygon[]): Polygon[] {
+    clipPolygons(polygons: CSGPolygon[]): CSGPolygon[] {
         if (!this._plane) {
             return polygons.slice();
         }
-        let front = new Array<Polygon>(),
-            back = new Array<Polygon>();
+        let front = new Array<CSGPolygon>(),
+            back = new Array<CSGPolygon>();
         for (let i = 0; i < polygons.length; i++) {
             this._plane.splitPolygon(polygons[i], front, back, front, back);
         }
@@ -378,7 +378,7 @@ class Node {
      * Return a list of all polygons in this BSP tree
      * @returns List of all polygons in this BSP tree
      */
-    allPolygons(): Polygon[] {
+    allPolygons(): CSGPolygon[] {
         let polygons = this._polygons.slice();
         if (this._front) {
             polygons = polygons.concat(this._front.allPolygons());
@@ -396,15 +396,15 @@ class Node {
      * (no heuristic is used to pick a good split)
      * @param polygons Polygons used to construct the BSP tree
      */
-    build(polygons: Polygon[]): void {
+    build(polygons: CSGPolygon[]): void {
         if (!polygons.length) {
             return;
         }
         if (!this._plane) {
             this._plane = polygons[0].plane.clone();
         }
-        const front = new Array<Polygon>(),
-            back = new Array<Polygon>();
+        const front = new Array<CSGPolygon>(),
+            back = new Array<CSGPolygon>();
         for (let i = 0; i < polygons.length; i++) {
             this._plane.splitPolygon(polygons[i], this._polygons, this._polygons, front, back);
         }
@@ -427,7 +427,7 @@ class Node {
  * Class for building Constructive Solid Geometry
  */
 export class CSG {
-    private _polygons = new Array<Polygon>();
+    private _polygons = new Array<CSGPolygon>();
     /**
      * The world matrix
      */
@@ -455,8 +455,8 @@ export class CSG {
      * @returns the new CSG
      */
     public static FromVertexData(data: VertexData): CSG {
-        let vertex: Vertex, polygon: Polygon, vertices: Vertex[];
-        const polygons = new Array<Polygon>();
+        let vertex: Vertex, polygon: CSGPolygon, vertices: Vertex[];
+        const polygons = new Array<CSGPolygon>();
 
         const indices = data.indices;
         const positions = data.positions;
@@ -484,7 +484,7 @@ export class CSG {
                 vertices.push(vertex);
             }
 
-            polygon = new Polygon(vertices, { subMeshId: 0, meshId: currentCSGMeshId, materialIndex: 0 });
+            polygon = new CSGPolygon(vertices, { subMeshId: 0, meshId: currentCSGMeshId, materialIndex: 0 });
 
             // To handle the case of degenerated triangle
             // polygon.plane == null <=> the polygon does not represent 1 single plane <=> the triangle is degenerated
@@ -516,9 +516,9 @@ export class CSG {
             uv: Vector2 | undefined = undefined,
             position: Vector3,
             vertColor: Color4 | undefined = undefined,
-            polygon: Polygon,
+            polygon: CSGPolygon,
             vertices: Vertex[];
-        const polygons = new Array<Polygon>();
+        const polygons = new Array<CSGPolygon>();
         let matrix: Matrix,
             meshPosition: Vector3,
             meshRotation: Vector3,
@@ -575,7 +575,7 @@ export class CSG {
                     vertices.push(vertex);
                 }
 
-                polygon = new Polygon(vertices, { subMeshId: sm, meshId: currentCSGMeshId, materialIndex: subMeshes[sm].materialIndex });
+                polygon = new CSGPolygon(vertices, { subMeshId: sm, meshId: currentCSGMeshId, materialIndex: subMeshes[sm].materialIndex });
 
                 // To handle the case of degenerated triangle
                 // polygon.plane == null <=> the polygon does not represent 1 single plane <=> the triangle is degenerated
@@ -600,7 +600,7 @@ export class CSG {
      * Construct a CSG solid from a list of `CSG.Polygon` instances.
      * @param polygons Polygons used to construct a CSG solid
      */
-    private static _FromPolygons(polygons: Polygon[]): CSG {
+    private static _FromPolygons(polygons: CSGPolygon[]): CSG {
         const csg = new CSG();
         csg._polygons = polygons;
         return csg;
@@ -770,7 +770,7 @@ export class CSG {
      * Coordinates here are in world space
      * @returns the final vertex data
      */
-    public toVertexData(onBeforePolygonProcessing: Nullable<(polygon: Polygon) => void> = null, onAfterPolygonProcessing: Nullable<() => void> = null): VertexData {
+    public toVertexData(onBeforePolygonProcessing: Nullable<(polygon: CSGPolygon) => void> = null, onAfterPolygonProcessing: Nullable<() => void> = null): VertexData {
         const matrix = this.matrix.clone();
         matrix.invert();
 


### PR DESCRIPTION
CSG didn't export the internal declarations until 6.22.1 . In this version a new function was added (in #14368) that used those internal classes, which forced typescript to export them as well.

As they are only internal classes this is not exactly a breaking change. It is out of the question to not export these classes, as this will fail the build due to missing declarations.