### PR TITLE
Flow Graph Context Logger

### DIFF
--- a/packages/dev/core/src/FlowGraph/flowGraphContext.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphContext.ts
@@ -6,6 +6,7 @@ import type { FlowGraphBlock } from "./flowGraphBlock";
 import type { FlowGraphDataConnection } from "./flowGraphDataConnection";
 import type { FlowGraphEventCoordinator } from "./flowGraphEventCoordinator";
 import type { FlowGraph } from "./flowGraph";
+import { Observable } from "../Misc/observable";
 
 function isMeshClassName(className: string) {
     return (
@@ -95,6 +96,10 @@ export class FlowGraphContext {
      * Incremented for every block executed.
      */
     private _executionId = 0;
+    /**
+     * Observable that is triggered when a node is executed.
+     */
+    public onNodeExecutedObservable: Observable<FlowGraphBlock> = new Observable<FlowGraphBlock>();
 
     constructor(params: IFlowGraphContextConfiguration) {
         this._configuration = params;
@@ -250,11 +255,23 @@ export class FlowGraphContext {
 
     /**
      * @internal
+     * Function that notifies the node executed observable
+     * @param node
+     */
+    public _notifyExecuteNode(node: FlowGraphBlock) {
+        this.onNodeExecutedObservable.notifyObservers(node);
+    }
+
+    /**
+     * @internal
      */
     public _increaseExecutionId() {
         this._executionId++;
     }
-
+    /**
+     * A monotonically increasing ID for each execution.
+     * Incremented for every block executed.
+     */
     public get executionId() {
         return this._executionId;
     }

--- a/packages/dev/core/src/FlowGraph/flowGraphContextLogger.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphContextLogger.ts
@@ -1,0 +1,13 @@
+import type { FlowGraphContext } from "./flowGraphContext";
+
+/**
+ * @experimental
+ * This class is a decorator for the context which logs the nodes that were executed.
+ */
+export class FlowGraphContextLogger {
+    constructor(private _context: FlowGraphContext) {
+        this._context.onNodeExecutedObservable.add((node) => {
+            console.log(`Node executed: ${node.getClassName()}`);
+        });
+    }
+}

--- a/packages/dev/core/src/FlowGraph/flowGraphContextLogger.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphContextLogger.ts
@@ -1,3 +1,4 @@
+import { Tools } from "../Misc/tools";
 import type { FlowGraphContext } from "./flowGraphContext";
 
 /**
@@ -7,7 +8,7 @@ import type { FlowGraphContext } from "./flowGraphContext";
 export class FlowGraphContextLogger {
     constructor(private _context: FlowGraphContext) {
         this._context.onNodeExecutedObservable.add((node) => {
-            console.log(`Node executed: ${node.getClassName()}`);
+            Tools.Log(`Node executed: ${node.getClassName()}`);
         });
     }
 }

--- a/packages/dev/core/src/FlowGraph/flowGraphDataConnection.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphDataConnection.ts
@@ -18,7 +18,12 @@ export class FlowGraphDataConnection<T> extends FlowGraphConnection<FlowGraphBlo
      * @param ownerBlock
      * @param richType
      */
-    public constructor(name: string, connectionType: FlowGraphConnectionType, ownerBlock: FlowGraphBlock, public richType: RichType<T>) {
+    public constructor(
+        name: string,
+        connectionType: FlowGraphConnectionType,
+        ownerBlock: FlowGraphBlock,
+        public richType: RichType<T>
+    ) {
         super(name, connectionType, ownerBlock);
     }
 

--- a/packages/dev/core/src/FlowGraph/flowGraphDataConnection.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphDataConnection.ts
@@ -18,12 +18,7 @@ export class FlowGraphDataConnection<T> extends FlowGraphConnection<FlowGraphBlo
      * @param ownerBlock
      * @param richType
      */
-    public constructor(
-        name: string,
-        connectionType: FlowGraphConnectionType,
-        ownerBlock: FlowGraphBlock,
-        public richType: RichType<T>
-    ) {
+    public constructor(name: string, connectionType: FlowGraphConnectionType, ownerBlock: FlowGraphBlock, public richType: RichType<T>) {
         super(name, connectionType, ownerBlock);
     }
 
@@ -63,6 +58,7 @@ export class FlowGraphDataConnection<T> extends FlowGraphConnection<FlowGraphBlo
      */
     public getValue(context: FlowGraphContext): T {
         if (this.connectionType === FlowGraphConnectionType.Output) {
+            context._notifyExecuteNode(this._ownerBlock);
             this._ownerBlock._updateOutputs(context);
             return this._getValueOrDefault(context);
         }

--- a/packages/dev/core/src/FlowGraph/flowGraphEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphEventBlock.ts
@@ -11,6 +11,7 @@ export abstract class FlowGraphEventBlock extends FlowGraphAsyncExecutionBlock {
      * @internal
      */
     public _execute(context: FlowGraphContext): void {
+        context._notifyExecuteNode(this);
         this.onDone._activateSignal(context);
     }
 }

--- a/packages/dev/core/src/FlowGraph/flowGraphSignalConnection.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphSignalConnection.ts
@@ -23,6 +23,7 @@ export class FlowGraphSignalConnection extends FlowGraphConnection<FlowGraphExec
      */
     public _activateSignal(context: FlowGraphContext): void {
         if (this.connectionType === FlowGraphConnectionType.Input) {
+            context._notifyExecuteNode(this._ownerBlock);
             this._ownerBlock._execute(context, this);
             context._increaseExecutionId();
         } else {

--- a/packages/dev/core/src/FlowGraph/index.ts
+++ b/packages/dev/core/src/FlowGraph/index.ts
@@ -7,5 +7,6 @@ export * from "./flowGraphEventCoordinator";
 export * from "./flowGraphRichTypes";
 export * from "./flowGraphContext";
 export * from "./flowGraphCoordinator";
+export * from "./flowGraphContextLogger";
 // eslint-disable-next-line import/no-internal-modules
 export * from "./Blocks/index";


### PR DESCRIPTION
# Changes
- Add a new observable in the context, `onNodeExecutedObservable`, which is notified every time a node is executed. This observable can be subscribed to for various functionalities, such as logging
- Add the FlowGraphContextLogger, which is subscribed to the observable above and logs when each node is executed.