### PR TITLE
refactor: change the way arrays are literals

### DIFF
--- a/packages/dev/core/src/Actions/abstractActionManager.ts
+++ b/packages/dev/core/src/Actions/abstractActionManager.ts
@@ -17,7 +17,7 @@ export abstract class AbstractActionManager implements IDisposable {
     public hoverCursor: string = "";
 
     /** Gets the list of actions */
-    public actions = new Array<IAction>();
+    public actions: IAction[] = [];
 
     /**
      * Gets or sets a boolean indicating that the manager is recursive meaning that it can trigger action from children

--- a/packages/dev/core/src/Actions/actionManager.ts
+++ b/packages/dev/core/src/Actions/actionManager.ts
@@ -477,7 +477,7 @@ export class ActionManager extends AbstractActionManager {
             }
 
             // Parameters with multiple values such as Vector3 etc.
-            const split = new Array<number>();
+            const split: number[] = [];
             for (let i = 0; i < values.length; i++) {
                 split.push(parseFloat(values[i]));
             }
@@ -507,7 +507,7 @@ export class ActionManager extends AbstractActionManager {
                 return;
             }
 
-            const parameters = new Array<any>();
+            const parameters: any[] = [];
             let target: any = null;
             let propertyPath: Nullable<string> = null;
             const combine = parsedAction.combine && parsedAction.combine.length > 0;
@@ -520,7 +520,7 @@ export class ActionManager extends AbstractActionManager {
             }
 
             if (combine) {
-                const actions = new Array<Action>();
+                const actions: Action[] = [];
                 for (let j = 0; j < parsedAction.combine.length; j++) {
                     traverse(parsedAction.combine[j], ActionManager.NothingTrigger, condition, action, actions);
                 }

--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -1524,7 +1524,7 @@ export class Animation {
                         }
 
                         if (serializationObject.length) {
-                            const output = new Array<Animation>();
+                            const output: Animation[] = [];
                             for (const serializedAnimation of serializationObject) {
                                 output.push(this.Parse(serializedAnimation));
                             }
@@ -1565,7 +1565,7 @@ export class Animation {
 
                         if (snippet.animations) {
                             const serializationObject = JSON.parse(snippet.animations);
-                            const outputs = new Array<Animation>();
+                            const outputs: Animation[] = [];
                             for (const serializedAnimation of serializationObject.animations) {
                                 const output = this.Parse(serializedAnimation);
                                 output.snippetId = snippetId;

--- a/packages/dev/core/src/Animations/pathCursor.ts
+++ b/packages/dev/core/src/Animations/pathCursor.ts
@@ -18,7 +18,7 @@ export class PathCursor {
     /**
      * The animation array of the path cursor
      */
-    animations = new Array<Animation>();
+    animations = [] as Animation[];
 
     /**
      * Initializes the path cursor

--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -340,8 +340,8 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
         }
         this.scene = scene;
 
-        scene.soundTracks = new Array<SoundTrack>();
-        scene.sounds = new Array<Sound>();
+        scene.soundTracks = [] as SoundTrack[];
+        scene.sounds = [] as Sound[];
     }
 
     /**

--- a/packages/dev/core/src/Audio/soundTrack.ts
+++ b/packages/dev/core/src/Audio/soundTrack.ts
@@ -52,7 +52,7 @@ export class SoundTrack {
             return;
         }
         this._scene = scene;
-        this.soundCollection = new Array();
+        this.soundCollection = [];
         this._options = options;
 
         if (!this._options.mainTrack && this._scene.soundTracks) {

--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -21,10 +21,10 @@ export class Bone extends Node {
     /**
      * Gets the list of child bones
      */
-    public children = new Array<Bone>();
+    public children: Bone[] = [];
 
     /** Gets the animations associated with this bone */
-    public animations = new Array<Animation>();
+    public animations: Animation[] = [];
 
     /**
      * Gets or sets bone length

--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -25,7 +25,7 @@ export class Skeleton implements IAnimatable {
     /**
      * Defines the list of child bones
      */
-    public bones = new Array<Bone>();
+    public bones: Bone[] = [];
     /**
      * Defines an estimate of the dimension of the skeleton at rest
      */
@@ -884,7 +884,7 @@ export class Skeleton implements IAnimatable {
      * Sorts bones per internal index
      */
     public sortBones(): void {
-        const bones = new Array<Bone>();
+        const bones: Bone[] = [];
         const visited = new Array<boolean>(this.bones.length);
         for (let index = 0; index < this.bones.length; index++) {
             this._sortBones(index, bones, visited);

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -367,7 +367,7 @@ export class Camera extends Node {
      *
      * To change the final output target of the camera, camera.outputRenderTarget should be used instead (eg. webXR renders to a render target corresponding to an HMD)
      */
-    public customRenderTargets = new Array<RenderTargetTexture>();
+    public customRenderTargets: RenderTargetTexture[] = [];
     /**
      * When set, the camera will render to this render target instead of the default canvas
      *

--- a/packages/dev/core/src/Culling/Octrees/octree.ts
+++ b/packages/dev/core/src/Culling/Octrees/octree.ts
@@ -19,7 +19,7 @@ export class Octree<T> {
     /**
      * Content stored in the octree
      */
-    public dynamicContent = new Array<T>();
+    public dynamicContent: T[] = [];
 
     private _maxBlockCapacity: number;
     private _selectionContent: SmartArrayNoDuplicate<T>;

--- a/packages/dev/core/src/Culling/Octrees/octreeBlock.ts
+++ b/packages/dev/core/src/Culling/Octrees/octreeBlock.ts
@@ -22,7 +22,7 @@ export class OctreeBlock<T> {
     /**
      * Gets the content of the current block
      */
-    public entries = new Array<T>();
+    public entries: T[] = [];
 
     /**
      * Gets the list of block children

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -866,7 +866,7 @@ Scene.prototype._internalMultiPick = function (
     if (!PickingInfo) {
         return null;
     }
-    const pickingInfos = new Array<PickingInfo>();
+    const pickingInfos: PickingInfo[] = [];
     const computeWorldMatrixForCamera = !!(this.activeCameras && this.activeCameras.length > 1 && this.cameraToUseForPointers !== this.activeCamera);
     const currentCamera = this.cameraToUseForPointers || this.activeCamera;
 

--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -172,14 +172,14 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: TextureSize, o
     const defaultFormat = Constants.TEXTUREFORMAT_RGBA;
     const defaultTarget = Constants.TEXTURE_2D;
 
-    let types = new Array<number>();
-    let samplingModes = new Array<number>();
-    let useSRGBBuffers = new Array<boolean>();
-    let formats = new Array<number>();
-    let targets = new Array<number>();
-    let faceIndex = new Array<number>();
-    let layerIndex = new Array<number>();
-    let layers = new Array<number>();
+    let types: number[] = [];
+    let samplingModes: number[] = [];
+    let useSRGBBuffers: boolean[] = [];
+    let formats: number[] = [];
+    let targets: number[] = [];
+    let faceIndex: number[] = [];
+    let layerIndex: number[] = [];
+    let layers: number[] = [];
 
     const rtWrapper = this._createHardwareRenderTargetWrapper(true, false, size) as WebGLRenderTargetWrapper;
 

--- a/packages/dev/core/src/Engines/Extensions/engine.textureSelector.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.textureSelector.ts
@@ -74,7 +74,7 @@ Object.defineProperty(Engine.prototype, "texturesSupported", {
         // Next PVRTC & DXT, which are probably superior to ETC1/2.
         // Likely no hardware which supports both PVR & DXT, so order matters little.
         // ETC2 is newer and handles ETC1 (no alpha capability), so check for first.
-        const texturesSupported = new Array<string>();
+        const texturesSupported: string[] = [];
         if (this._caps.astc) {
             texturesSupported.push("-astc.ktx");
         }

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.multiRender.ts
@@ -56,14 +56,14 @@ WebGPUEngine.prototype.createMultipleRenderTarget = function (size: TextureSize,
     const defaultFormat = Constants.TEXTUREFORMAT_RGBA;
     const defaultTarget = Constants.TEXTURE_2D;
 
-    let types = new Array<number>();
-    let samplingModes = new Array<number>();
-    let useSRGBBuffers = new Array<boolean>();
-    let formats = new Array<number>();
-    let targets = new Array<number>();
-    let faceIndex = new Array<number>();
-    let layerIndex = new Array<number>();
-    let layers = new Array<number>();
+    let types: number[] = [];
+    let samplingModes: number[] = [];
+    let useSRGBBuffers: boolean[] = [];
+    let formats: number[] = [];
+    let targets: number[] = [];
+    let faceIndex: number[] = [];
+    let layerIndex: number[] = [];
+    let layers: number[] = [];
 
     const rtWrapper = this._createHardwareRenderTargetWrapper(true, false, size) as WebGPURenderTargetWrapper;
 

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -393,7 +393,7 @@ export class Engine extends ThinEngine {
     /**
      * Gets the list of created scenes
      */
-    public scenes = new Array<Scene>();
+    public scenes: Scene[] = [];
 
     /** @internal */
     public _virtualScenes = new Array<Scene>();
@@ -406,7 +406,7 @@ export class Engine extends ThinEngine {
     /**
      * Gets the list of created postprocesses
      */
-    public postProcesses = new Array<PostProcess>();
+    public postProcesses: PostProcess[] = [];
 
     /**
      * Gets a boolean indicating if the pointer is currently locked

--- a/packages/dev/core/src/Engines/engineStore.ts
+++ b/packages/dev/core/src/Engines/engineStore.ts
@@ -10,7 +10,7 @@ import type { Scene } from "../scene";
  */
 export class EngineStore {
     /** Gets the list of created engines */
-    public static Instances = new Array<Engine>();
+    public static Instances: Engine[] = [];
 
     /**
      * Notifies when an engine was disposed.

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -610,7 +610,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this._rootMesh.addChild(this._scaleBoxesParent);
 
         // Hover color change
-        const pointerIds = new Array<AbstractMesh>();
+        const pointerIds: AbstractMesh[] = [];
         this._pointerObserver = gizmoLayer.utilityLayerScene.onPointerObservable.add((pointerInfo) => {
             if (!pointerIds[(<IPointerEvent>pointerInfo.event).pointerId]) {
                 this._rotateSpheresParent

--- a/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
+++ b/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
@@ -13,7 +13,7 @@ import { EngineStore } from "../Engines/engineStore";
 AbstractScene.AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
     if (parsedData.effectLayers) {
         if (!container.effectLayers) {
-            container.effectLayers = new Array<EffectLayer>();
+            container.effectLayers = [] as EffectLayer[];
         }
 
         for (let index = 0; index < parsedData.effectLayers.length; index++) {
@@ -90,7 +90,7 @@ export class EffectLayerSceneComponent implements ISceneSerializableComponent {
             return;
         }
         this._engine = this.scene.getEngine();
-        this.scene.effectLayers = new Array<EffectLayer>();
+        this.scene.effectLayers = [] as EffectLayer[];
     }
 
     /**

--- a/packages/dev/core/src/Layers/layerSceneComponent.ts
+++ b/packages/dev/core/src/Layers/layerSceneComponent.ts
@@ -44,7 +44,7 @@ export class LayerSceneComponent implements ISceneComponent {
             return;
         }
         this._engine = this.scene.getEngine();
-        this.scene.layers = new Array<Layer>();
+        this.scene.layers = [] as Layer[];
     }
 
     /**

--- a/packages/dev/core/src/LensFlares/lensFlareSystem.ts
+++ b/packages/dev/core/src/LensFlares/lensFlareSystem.ts
@@ -27,7 +27,7 @@ export class LensFlareSystem {
     /**
      * List of lens flares used in this system.
      */
-    public lensFlares = new Array<LensFlare>();
+    public lensFlares: LensFlare[] = [];
 
     /**
      * Define a limit from the border the lens flare can be visible.

--- a/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
+++ b/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
@@ -12,7 +12,7 @@ AbstractScene.AddParser(SceneComponentConstants.NAME_LENSFLARESYSTEM, (parsedDat
     // Lens flares
     if (parsedData.lensFlareSystems !== undefined && parsedData.lensFlareSystems !== null) {
         if (!container.lensFlareSystems) {
-            container.lensFlareSystems = new Array<LensFlareSystem>();
+            container.lensFlareSystems = [] as LensFlareSystem[];
         }
 
         for (let index = 0, cache = parsedData.lensFlareSystems.length; index < cache; index++) {
@@ -126,7 +126,7 @@ export class LensFlareSystemSceneComponent implements ISceneSerializableComponen
     constructor(scene: Scene) {
         this.scene = scene;
 
-        scene.lensFlareSystems = new Array<LensFlareSystem>();
+        scene.lensFlareSystems = [] as LensFlareSystem[];
     }
 
     /**

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1361,7 +1361,7 @@ export class ShadowGenerator implements IShadowGenerator {
             return;
         }
 
-        const subMeshes = new Array<SubMesh>();
+        const subMeshes: SubMesh[] = [];
         for (const mesh of renderList) {
             subMeshes.push(...mesh.subMeshes);
         }

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -353,8 +353,8 @@ export abstract class Light extends Node implements ISortableLight {
         this._uniformBuffer = new UniformBuffer(this.getScene().getEngine(), undefined, undefined, name);
         this._buildUniformLayout();
 
-        this.includedOnlyMeshes = new Array<AbstractMesh>();
-        this.excludedMeshes = new Array<AbstractMesh>();
+        this.includedOnlyMeshes = [] as AbstractMesh[];
+        this.excludedMeshes = [] as AbstractMesh[];
 
         this._resyncMeshes();
     }

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -621,7 +621,7 @@ SceneLoader.RegisterPlugin({
                 meshesNames = [meshesNames];
             }
 
-            const hierarchyIds = new Array<number>();
+            const hierarchyIds: number[] = [];
             const parsedIdToNodeMap = new Map<number, Node>();
 
             // Transform nodes (the overall idea is to load all of them as this is super fast and then get rid of the ones we don't need)

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -801,9 +801,9 @@ export class SceneLoader {
 
                 if ((<any>plugin).importMesh) {
                     const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                    const meshes = new Array<AbstractMesh>();
-                    const particleSystems = new Array<IParticleSystem>();
-                    const skeletons = new Array<Skeleton>();
+                    const meshes: AbstractMesh[] = [];
+                    const particleSystems: IParticleSystem[] = [];
+                    const skeletons: Skeleton[] = [];
 
                     if (!syncedPlugin.importMesh(meshNames, scene, data, fileInfo.rootUrl, meshes, particleSystems, skeletons, errorHandler)) {
                         return;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -319,7 +319,7 @@ export class NodeMaterial extends PushMaterial {
     /**
      * Gets an array of blocks that needs to be serialized even if they are not yet connected
      */
-    public attachedBlocks = new Array<NodeMaterialBlock>();
+    public attachedBlocks: NodeMaterialBlock[] = [];
 
     /**
      * Specifies the mode of the node material

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -107,12 +107,12 @@ export class NodeMaterialConnectionPoint {
     /**
      * Gets or sets the additional types supported by this connection point
      */
-    public acceptedConnectionPointTypes = new Array<NodeMaterialBlockConnectionPointTypes>();
+    public acceptedConnectionPointTypes: NodeMaterialBlockConnectionPointTypes[] = [];
 
     /**
      * Gets or sets the additional types excluded by this connection point
      */
-    public excludedConnectionPointTypes = new Array<NodeMaterialBlockConnectionPointTypes>();
+    public excludedConnectionPointTypes: NodeMaterialBlockConnectionPointTypes[] = [];
 
     /**
      * Observable triggered when this point is connected

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -12,19 +12,19 @@ export class NodeMaterialBuildState {
     /**
      * Gets the list of emitted attributes
      */
-    public attributes = new Array<string>();
+    public attributes: string[] = [];
     /**
      * Gets the list of emitted uniforms
      */
-    public uniforms = new Array<string>();
+    public uniforms: string[] = [];
     /**
      * Gets the list of emitted constants
      */
-    public constants = new Array<string>();
+    public constants: string[] = [];
     /**
      * Gets the list of emitted samplers
      */
-    public samplers = new Array<string>();
+    public samplers: string[] = [];
     /**
      * Gets the list of emitted functions
      */

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
@@ -12,12 +12,12 @@ export class NodeMaterialBuildStateSharedData {
     /**
      * Gets the list of emitted varyings
      */
-    public temps = new Array<string>();
+    public temps: string[] = [];
 
     /**
      * Gets the list of emitted varyings
      */
-    public varyings = new Array<string>();
+    public varyings: string[] = [];
 
     /**
      * Gets the varying declaration string
@@ -32,52 +32,52 @@ export class NodeMaterialBuildStateSharedData {
     /**
      * Input blocks
      */
-    public inputBlocks = new Array<InputBlock>();
+    public inputBlocks: InputBlock[] = [];
 
     /**
      * Input blocks
      */
-    public textureBlocks = new Array<NodeMaterialTextureBlocks>();
+    public textureBlocks: NodeMaterialTextureBlocks[] = [];
 
     /**
      * Bindable blocks (Blocks that need to set data to the effect)
      */
-    public bindableBlocks = new Array<NodeMaterialBlock>();
+    public bindableBlocks: NodeMaterialBlock[] = [];
 
     /**
      * Bindable blocks (Blocks that need to set data to the effect) that will always be called (by bindForSubMesh), contrary to bindableBlocks that won't be called if _mustRebind() returns false
      */
-    public forcedBindableBlocks = new Array<NodeMaterialBlock>();
+    public forcedBindableBlocks: NodeMaterialBlock[] = [];
 
     /**
      * List of blocks that can provide a compilation fallback
      */
-    public blocksWithFallbacks = new Array<NodeMaterialBlock>();
+    public blocksWithFallbacks: NodeMaterialBlock[] = [];
 
     /**
      * List of blocks that can provide a define update
      */
-    public blocksWithDefines = new Array<NodeMaterialBlock>();
+    public blocksWithDefines: NodeMaterialBlock[] = [];
 
     /**
      * List of blocks that can provide a repeatable content
      */
-    public repeatableContentBlocks = new Array<NodeMaterialBlock>();
+    public repeatableContentBlocks: NodeMaterialBlock[] = [];
 
     /**
      * List of blocks that can provide a dynamic list of uniforms
      */
-    public dynamicUniformBlocks = new Array<NodeMaterialBlock>();
+    public dynamicUniformBlocks: NodeMaterialBlock[] = [];
 
     /**
      * List of blocks that can block the isReady function for the material
      */
-    public blockingBlocks = new Array<NodeMaterialBlock>();
+    public blockingBlocks: NodeMaterialBlock[] = [];
 
     /**
      * Gets the list of animated inputs
      */
-    public animatedInputs = new Array<InputBlock>();
+    public animatedInputs: InputBlock[] = [];
 
     /**
      * Build Id used to avoid multiple recompilations

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
@@ -35,7 +35,7 @@ export class ProceduralTextureSceneComponent implements ISceneComponent {
      */
     constructor(scene: Scene) {
         this.scene = scene;
-        this.scene.proceduralTextures = new Array<ProceduralTexture>();
+        this.scene.proceduralTextures = [] as ProceduralTexture[];
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/baseTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/baseTexture.ts
@@ -466,7 +466,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
     /**
      * Define the list of animation attached to the texture.
      */
-    public animations = new Array<Animation>();
+    public animations: Animation[] = [];
 
     /**
      * An event triggered when the texture is disposed.

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -516,7 +516,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         this._gammaSpace = gammaSpace;
         this._coordinatesMode = Texture.PROJECTION_MODE;
-        this.renderList = new Array<AbstractMesh>();
+        this.renderList = [] as AbstractMesh[];
         this.name = name;
         this.isRenderTarget = true;
         this._initialSizeParameter = size;

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1397,7 +1397,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     public getBindedMeshes(): AbstractMesh[] {
         if (this.meshMap) {
-            const result = new Array<AbstractMesh>();
+            const result: AbstractMesh[] = [];
             for (const meshId in this.meshMap) {
                 const mesh = this.meshMap[meshId];
                 if (mesh) {

--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -51,7 +51,7 @@ export class MultiMaterial extends Material {
 
         this.getScene().addMultiMaterial(this);
 
-        this.subMaterials = new Array<Material>();
+        this.subMaterials = [] as Material[];
 
         this._storeEffectOnSubMeshes = true; // multimaterial is considered like a push material
     }

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -1599,7 +1599,7 @@ export class ShaderMaterial extends PushMaterial {
         // Texture arrays
         for (name in source.textureArrays) {
             const array = source.textureArrays[name];
-            const textureArray = new Array<Texture>();
+            const textureArray: Texture[] = [];
 
             for (let index = 0; index < array.length; index++) {
                 textureArray.push(<Texture>Texture.Parse(array[index], scene, rootUrl));

--- a/packages/dev/core/src/Maths/math.path.ts
+++ b/packages/dev/core/src/Maths/math.path.ts
@@ -968,7 +968,7 @@ export class Curve3 {
      */
     public static CreateQuadraticBezier(v0: DeepImmutable<Vector3>, v1: DeepImmutable<Vector3>, v2: DeepImmutable<Vector3>, nbPoints: number): Curve3 {
         nbPoints = nbPoints > 2 ? nbPoints : 3;
-        const bez = new Array<Vector3>();
+        const bez: Vector3[] = [];
         const equation = (t: number, val0: number, val1: number, val2: number) => {
             const res = (1.0 - t) * (1.0 - t) * val0 + 2.0 * t * (1.0 - t) * val1 + t * t * val2;
             return res;
@@ -990,7 +990,7 @@ export class Curve3 {
      */
     public static CreateCubicBezier(v0: DeepImmutable<Vector3>, v1: DeepImmutable<Vector3>, v2: DeepImmutable<Vector3>, v3: DeepImmutable<Vector3>, nbPoints: number): Curve3 {
         nbPoints = nbPoints > 3 ? nbPoints : 4;
-        const bez = new Array<Vector3>();
+        const bez: Vector3[] = [];
         const equation = (t: number, val0: number, val1: number, val2: number, val3: number) => {
             const res = (1.0 - t) * (1.0 - t) * (1.0 - t) * val0 + 3.0 * t * (1.0 - t) * (1.0 - t) * val1 + 3.0 * t * t * (1.0 - t) * val2 + t * t * t * val3;
             return res;
@@ -1011,7 +1011,7 @@ export class Curve3 {
      * @returns the created Curve3
      */
     public static CreateHermiteSpline(p1: DeepImmutable<Vector3>, t1: DeepImmutable<Vector3>, p2: DeepImmutable<Vector3>, t2: DeepImmutable<Vector3>, nSeg: number): Curve3 {
-        const hermite = new Array<Vector3>();
+        const hermite: Vector3[] = [];
         const step = 1.0 / nSeg;
         for (let i = 0; i <= nSeg; i++) {
             hermite.push(Vector3.Hermite(p1, t1, p2, t2, i * step));
@@ -1027,7 +1027,7 @@ export class Curve3 {
      * @returns the created Curve3
      */
     public static CreateCatmullRomSpline(points: DeepImmutable<Vector3[]>, nbPoints: number, closed?: boolean): Curve3 {
-        const catmullRom = new Array<Vector3>();
+        const catmullRom: Vector3[] = [];
         const step = 1.0 / nbPoints;
         let amount = 0.0;
         if (closed) {
@@ -1043,7 +1043,7 @@ export class Curve3 {
             }
             catmullRom.push(catmullRom[0]);
         } else {
-            const totalPoints = new Array<Vector3>();
+            const totalPoints: Vector3[] = [];
             totalPoints.push(points[0].clone());
             Array.prototype.push.apply(totalPoints, points);
             totalPoints.push(points[points.length - 1].clone());
@@ -1073,7 +1073,7 @@ export class Curve3 {
      * @returns the created Curve3
      */
     public static ArcThru3Points(first: Vector3, second: Vector3, third: Vector3, steps: number = 32, closed: boolean = false, fullCircle: boolean = false): Curve3 {
-        const arc = new Array<Vector3>();
+        const arc: Vector3[] = [];
         const vec1 = second.subtract(first);
         const vec2 = third.subtract(second);
         const vec3 = first.subtract(third);

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -102,7 +102,7 @@ export class Vector2 {
      * @returns a new array with 2 elements: the Vector2 coordinates.
      */
     public asArray(): number[] {
-        const result = new Array<number>();
+        const result: number[] = [];
         this.toArray(result, 0);
         return result;
     }
@@ -3065,7 +3065,7 @@ export class Vector4 {
      * @returns the resulting array
      */
     public asArray(): number[] {
-        const result = new Array<number>();
+        const result: number[] = [];
 
         this.toArray(result, 0);
 

--- a/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
@@ -90,11 +90,11 @@ export function CreateCylinderVertexData(options: {
         }
     }
 
-    const indices = new Array<number>();
-    const positions = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
-    const colors = new Array<number>();
+    const indices: number[] = [];
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
+    const colors: number[] = [];
 
     const angleStep = (Math.PI * 2 * arc) / tessellation;
     let angle: number;

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -253,7 +253,7 @@ export function CreateDecal(
         let clipResult: Nullable<DecalVertex[]> = null;
 
         if (vertices.length > 3) {
-            clipResult = new Array<DecalVertex>();
+            clipResult = [] as DecalVertex[];
         }
 
         for (let index = 0; index < vertices.length; index += 3) {

--- a/packages/dev/core/src/Meshes/Builders/discBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/discBuilder.ts
@@ -31,10 +31,10 @@ export function CreateDiscVertexData(options: {
     frontUVs?: Vector4;
     backUVs?: Vector4;
 }): VertexData {
-    const positions = new Array<number>();
-    const indices = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
+    const positions: number[] = [];
+    const indices: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
 
     const radius = options.radius || 0.5;
     const tessellation = options.tessellation || 64;

--- a/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
@@ -67,10 +67,10 @@ export function CreateGoldbergVertexData(options: GoldbergVertexDataOption, gold
     const sizeZ: number = options.sizeZ || size || 1;
     const sideOrientation = options.sideOrientation === 0 ? 0 : options.sideOrientation || VertexData.DEFAULTSIDE;
 
-    const positions = new Array<number>();
-    const indices = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
+    const positions: number[] = [];
+    const indices: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
 
     let minX = Infinity;
     let maxX = -Infinity;

--- a/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
@@ -105,10 +105,10 @@ export function CreateTiledGroundVertexData(options: {
     const subdivisions = options.subdivisions || { w: 1, h: 1 };
     const precision = options.precision || { w: 1, h: 1 };
 
-    const indices = new Array<number>();
-    const positions = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
+    const indices: number[] = [];
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
     let row: number, col: number, tileRow: number, tileCol: number;
 
     subdivisions.h = subdivisions.h < 1 ? 1 : subdivisions.h;

--- a/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
@@ -249,10 +249,10 @@ export function CreateIcoSphereVertexData(options: {
         0, //  15 - 19
     ];
 
-    const indices = new Array<number>();
-    const positions = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
+    const indices: number[] = [];
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
 
     let current_indice = 0;
     // prepare array of 3 vector (empty) (to be worked in place, shared for each face)

--- a/packages/dev/core/src/Meshes/Builders/latheBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/latheBuilder.ts
@@ -65,7 +65,7 @@ export function CreateLathe(
     const sideOrientation = Mesh._GetDefaultSideOrientation(options.sideOrientation);
     const cap = options.cap || Mesh.NO_CAP;
     const pi2 = Math.PI * 2;
-    const paths = new Array();
+    const paths = [];
     const invertUV = options.invertUV || false;
 
     let i = 0;

--- a/packages/dev/core/src/Meshes/Builders/linesBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/linesBuilder.ts
@@ -71,8 +71,8 @@ export function CreateDashedLinesVertexData(options: { points: Vector3[]; dashSi
     const dashNb = options.dashNb || 200;
     const points = options.points;
 
-    const positions = new Array<number>();
-    const indices = new Array<number>();
+    const positions: number[] = [];
+    const indices: number[] = [];
 
     const curvect = Vector3.Zero();
     let lg = 0;

--- a/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
@@ -490,14 +490,14 @@ export function CreatePolyhedronVertexData(options: {
     const flat = options.flat === undefined ? true : options.flat;
     const sideOrientation = options.sideOrientation === 0 ? 0 : options.sideOrientation || VertexData.DEFAULTSIDE;
 
-    const positions = new Array<number>();
-    const indices = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
-    const colors = new Array<number>();
+    const positions: number[] = [];
+    const indices: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
+    const colors: number[] = [];
     let index = 0;
     let faceIdx = 0; // face cursor in the array "indexes"
-    const indexes = new Array<number>();
+    const indexes: number[] = [];
     let i = 0;
     let f = 0;
     let u: number, v: number, ang: number, x: number, y: number, tmp: number;

--- a/packages/dev/core/src/Meshes/Builders/shapeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/shapeBuilder.ts
@@ -298,7 +298,7 @@ function _ExtrudeShapeGeneric(
         const rotationMatrix: Matrix = TmpVectors.Matrix[0];
 
         for (let i = 0; i < curve.length; i++) {
-            const shapePath = new Array<Vector3>();
+            const shapePath: Vector3[] = [];
             const angleStep = rotate(i, distances[i]);
             const scaleRatio = scl(i, distances[i]);
             Matrix.RotationAxisToRef(tangents[i], angle, rotationMatrix);

--- a/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
@@ -40,10 +40,10 @@ export function CreateTorusKnotVertexData(options: {
     frontUVs?: Vector4;
     backUVs?: Vector4;
 }): VertexData {
-    const indices = new Array<number>();
-    const positions = new Array<number>();
-    const normals = new Array<number>();
-    const uvs = new Array<number>();
+    const indices: number[] = [];
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
 
     const radius = options.radius || 2;
     const tube = options.tube || 0.5;

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVerticesBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVerticesBlock.ts
@@ -160,7 +160,7 @@ export class InstantiateOnVerticesBlock extends NodeGeometryBlock implements INo
             let vertexCount = this._vertexData.positions.length / 3;
             const additionalVertexData: VertexData[] = [];
             const currentPosition = new Vector3();
-            const alreadyDone = new Array<number>();
+            const alreadyDone: number[] = [];
             let vertices = this._vertexData.positions;
             this._currentLoopIndex = 0;
 

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -88,7 +88,7 @@ export class NodeGeometry {
     /**
      * Gets an array of blocks that needs to be serialized even if they are not yet connected
      */
-    public attachedBlocks = new Array<NodeGeometryBlock>();
+    public attachedBlocks: NodeGeometryBlock[] = [];
 
     /**
      * Observable raised when the geometry is built

--- a/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
@@ -64,12 +64,12 @@ export class NodeGeometryConnectionPoint {
     /**
      * Gets or sets the additional types supported by this connection point
      */
-    public acceptedConnectionPointTypes = new Array<NodeGeometryBlockConnectionPointTypes>();
+    public acceptedConnectionPointTypes: NodeGeometryBlockConnectionPointTypes[] = [];
 
     /**
      * Gets or sets the additional types excluded by this connection point
      */
-    public excludedConnectionPointTypes = new Array<NodeGeometryBlockConnectionPointTypes>();
+    public excludedConnectionPointTypes: NodeGeometryBlockConnectionPointTypes[] = [];
 
     /**
      * Observable triggered when this point is connected

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -2021,7 +2021,7 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
                 this.subMeshes[0].dispose();
             }
         } else {
-            this.subMeshes = new Array<SubMesh>();
+            this.subMeshes = [] as SubMesh[];
         }
         return this;
     }
@@ -2202,10 +2202,10 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
     private _initFacetData(): AbstractMesh {
         const data = this._internalAbstractMeshDataInfo._facetData;
         if (!data.facetNormals) {
-            data.facetNormals = new Array<Vector3>();
+            data.facetNormals = [] as Vector3[];
         }
         if (!data.facetPositions) {
-            data.facetPositions = new Array<Vector3>();
+            data.facetPositions = [] as Vector3[];
         }
         if (!data.facetPartitioning) {
             data.facetPartitioning = new Array<number[]>();
@@ -2549,8 +2549,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         const facetData = this._internalAbstractMeshDataInfo._facetData;
         if (facetData.facetDataEnabled) {
             facetData.facetDataEnabled = false;
-            facetData.facetPositions = new Array<Vector3>();
-            facetData.facetNormals = new Array<Vector3>();
+            facetData.facetPositions = [] as Vector3[];
+            facetData.facetNormals = [] as Vector3[];
             facetData.facetPartitioning = new Array<number[]>();
             facetData.facetParameters = null;
             facetData.depthSortedIndices = new Uint32Array(0);

--- a/packages/dev/core/src/Meshes/csg.ts
+++ b/packages/dev/core/src/Meshes/csg.ts
@@ -343,8 +343,8 @@ class Node {
         if (!this._plane) {
             return polygons.slice();
         }
-        let front = new Array<CSGPolygon>(),
-            back = new Array<CSGPolygon>();
+        let front: CSGPolygon[] = [],
+            back = [] as CSGPolygon[];
         for (let i = 0; i < polygons.length; i++) {
             this._plane.splitPolygon(polygons[i], front, back, front, back);
         }
@@ -403,8 +403,8 @@ class Node {
         if (!this._plane) {
             this._plane = polygons[0].plane.clone();
         }
-        const front = new Array<CSGPolygon>(),
-            back = new Array<CSGPolygon>();
+        const front: CSGPolygon[] = [],
+            back = [] as CSGPolygon[];
         for (let i = 0; i < polygons.length; i++) {
             this._plane.splitPolygon(polygons[i], this._polygons, this._polygons, front, back);
         }
@@ -456,7 +456,7 @@ export class CSG {
      */
     public static FromVertexData(data: VertexData): CSG {
         let vertex: Vertex, polygon: CSGPolygon, vertices: Vertex[];
-        const polygons = new Array<CSGPolygon>();
+        const polygons: CSGPolygon[] = [];
 
         const indices = data.indices;
         const positions = data.positions;
@@ -518,7 +518,7 @@ export class CSG {
             vertColor: Color4 | undefined = undefined,
             polygon: CSGPolygon,
             vertices: Vertex[];
-        const polygons = new Array<CSGPolygon>();
+        const polygons: CSGPolygon[] = [];
         let matrix: Matrix,
             meshPosition: Vector3,
             meshRotation: Vector3,
@@ -945,7 +945,7 @@ export class CSG {
             let materialIndexOffset = 0,
                 materialMaxIndex;
 
-            mesh.subMeshes = new Array<SubMesh>();
+            mesh.subMeshes = [] as SubMesh[];
 
             for (const m in subMeshDict) {
                 materialMaxIndex = -1;

--- a/packages/dev/core/src/Meshes/geodesicMesh.ts
+++ b/packages/dev/core/src/Meshes/geodesicMesh.ts
@@ -393,7 +393,7 @@ export class _PrimaryIsoTriangle {
      */
 
     public build(m: number, n: number) {
-        const vertices = new Array<_IsoVector>();
+        const vertices: _IsoVector[] = [];
 
         const O: _IsoVector = _IsoVector.Zero();
         const A: _IsoVector = new _IsoVector(m, n);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -96,8 +96,8 @@ class _InstanceDataStorage {
 export class _InstancesBatch {
     public mustReturn = false;
     public visibleInstances = new Array<Nullable<Array<InstancedMesh>>>();
-    public renderSelf = new Array<boolean>();
-    public hardwareInstancedRendering = new Array<boolean>();
+    public renderSelf: boolean[] = [];
+    public hardwareInstancedRendering: boolean[] = [];
 }
 
 /**
@@ -387,7 +387,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * Note also that the order of the InstancedMesh wihin the array is not significant and might change.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/copies/instances
      */
-    public instances = new Array<InstancedMesh>();
+    public instances: InstancedMesh[] = [];
 
     /**
      * Gets the file containing delay loading data for this mesh
@@ -1167,7 +1167,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      */
     public getVerticesDataKinds(bypassInstanceData?: boolean): string[] {
         if (!this._geometry) {
-            const result = new Array<string>();
+            const result: string[] = [];
             if (this._delayInfo) {
                 this._delayInfo.forEach(function (kind) {
                     result.push(kind);
@@ -2530,7 +2530,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         let maxUsedWeights: number = 0;
         let numberNotNormalized: number = 0;
         const numInfluences: number = matricesWeightsExtra === null ? 4 : 8;
-        const usedWeightCounts = new Array<number>();
+        const usedWeightCounts: number[] = [];
         for (let a = 0; a <= numInfluences; a++) {
             usedWeightCounts[a] = 0;
         }
@@ -2711,7 +2711,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @returns an array of IAnimatable
      */
     public getAnimatables(): IAnimatable[] {
-        const results = new Array<IAnimatable>();
+        const results: IAnimatable[] = [];
 
         if (this.material) {
             results.push(this.material);
@@ -3406,7 +3406,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
             for (let i = 0; i < currentIndices.length; i += 3) {
                 facet = [currentIndices[i], currentIndices[i + 1], currentIndices[i + 2]]; //facet vertex indices
-                pstring = new Array();
+                pstring = [];
                 for (let j = 0; j < 3; j++) {
                     pstring[j] = "";
                     for (let k = 0; k < 3; k++) {
@@ -3554,11 +3554,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             return this;
         }
 
-        const vectorPositions = new Array<Vector3>();
+        const vectorPositions: Vector3[] = [];
         for (let pos = 0; pos < positions.length; pos = pos + 3) {
             vectorPositions.push(Vector3.FromArray(positions, pos));
         }
-        const dupes = new Array<number>();
+        const dupes: number[] = [];
 
         AsyncLoop.SyncAsyncForLoop(
             vectorPositions.length,

--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -585,7 +585,7 @@ export class VertexData {
             return [this];
         }
 
-        const result = new Array<VertexData>();
+        const result: VertexData[] = [];
         for (const materialInfo of this.materialInfos) {
             const vertexData = new VertexData();
 

--- a/packages/dev/core/src/Meshes/meshSimplification.ts
+++ b/packages/dev/core/src/Meshes/meshSimplification.ts
@@ -420,7 +420,7 @@ export class QuadraticErrorSimplification implements ISimplifier {
 
                             this._calculateError(v0, v1, p);
 
-                            const delTr = new Array<DecimationTriangle>();
+                            const delTr: DecimationTriangle[] = [];
 
                             if (this._isFlipped(v0, v1, p, deleted0, delTr)) {
                                 continue;
@@ -433,7 +433,7 @@ export class QuadraticErrorSimplification implements ISimplifier {
                                 continue;
                             }
 
-                            const uniqueArray = new Array<DecimationTriangle>();
+                            const uniqueArray: DecimationTriangle[] = [];
                             delTr.forEach((deletedT) => {
                                 if (uniqueArray.indexOf(deletedT) === -1) {
                                     deletedT.deletePending = true;

--- a/packages/dev/core/src/Meshes/polygonMesh.ts
+++ b/packages/dev/core/src/Meshes/polygonMesh.ts
@@ -27,10 +27,10 @@ class IndexedVector2 extends Vector2 {
  * Defines points to create a polygon
  */
 class PolygonPoints {
-    elements = new Array<IndexedVector2>();
+    elements = [] as IndexedVector2[];
 
     add(originalPoints: Array<Vector2>): Array<IndexedVector2> {
-        const result = new Array<IndexedVector2>();
+        const result: IndexedVector2[] = [];
         originalPoints.forEach((point) => {
             const newPoint = new IndexedVector2(point, this.elements.length);
             result.push(newPoint);
@@ -95,7 +95,7 @@ export class Polygon {
      * @returns points that make the resulting circle
      */
     static Circle(radius: number, cx: number = 0, cy: number = 0, numberOfSides: number = 32): Vector2[] {
-        const result = new Array<Vector2>();
+        const result: Vector2[] = [];
 
         let angle = 0;
         const increment = (Math.PI * 2) / numberOfSides;
@@ -238,9 +238,9 @@ export class PolygonMeshBuilder {
     buildVertexData(depth: number = 0, smoothingThreshold: number = 2): VertexData {
         const result = new VertexData();
 
-        const normals = new Array<number>();
-        const positions = new Array<number>();
-        const uvs = new Array<number>();
+        const normals: number[] = [];
+        const positions: number[] = [];
+        const uvs: number[] = [];
 
         const bounds = this._points.computeBounds();
         this._points.elements.forEach((p) => {
@@ -249,7 +249,7 @@ export class PolygonMeshBuilder {
             uvs.push((p.x - bounds.min.x) / bounds.width, (p.y - bounds.min.y) / bounds.height);
         });
 
-        const indices = new Array<number>();
+        const indices: number[] = [];
 
         const res = this.bjsEarcut(this._epoints, this._eholes, 2);
 

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.ts
@@ -331,7 +331,7 @@ Mesh.prototype.thinInstanceGetWorldMatrices = function (): Matrix[] {
     const matrixData = this._thinInstanceDataStorage.matrixData;
 
     if (!this._thinInstanceDataStorage.worldMatrices) {
-        this._thinInstanceDataStorage.worldMatrices = new Array<Matrix>();
+        this._thinInstanceDataStorage.worldMatrices = [] as Matrix[];
 
         for (let i = 0; i < this._thinInstanceDataStorage.instancesCount; ++i) {
             this._thinInstanceDataStorage.worldMatrices[i] = Matrix.FromArray(matrixData, i * 16);

--- a/packages/dev/core/src/Misc/dds.ts
+++ b/packages/dev/core/src/Misc/dds.ts
@@ -431,7 +431,7 @@ export class DDSTools {
     ) {
         let sphericalPolynomialFaces: Nullable<Array<ArrayBufferView>> = null;
         if (info.sphericalPolynomial) {
-            sphericalPolynomialFaces = new Array<ArrayBufferView>();
+            sphericalPolynomialFaces = [] as ArrayBufferView[];
         }
         const ext = !!engine.getCaps().s3tc;
 

--- a/packages/dev/core/src/Misc/filesInput.ts
+++ b/packages/dev/core/src/Misc/filesInput.ts
@@ -227,7 +227,7 @@ export class FilesInput {
         }
 
         if (this._filesToLoad && this._filesToLoad.length > 0) {
-            const files = new Array<File>();
+            const files: File[] = [];
             const folders = [];
             const items = event.dataTransfer ? event.dataTransfer.items : null;
 

--- a/packages/dev/core/src/Misc/sceneOptimizer.ts
+++ b/packages/dev/core/src/Misc/sceneOptimizer.ts
@@ -404,7 +404,7 @@ export class MergeMeshesOptimization extends SceneOptimization {
         let globalLength = globalPool.length;
 
         for (let index = 0; index < globalLength; index++) {
-            const currentPool = new Array<Mesh>();
+            const currentPool: Mesh[] = [];
             const current = globalPool[index];
 
             // Checks
@@ -470,7 +470,7 @@ export class SceneOptimizerOptions {
     /**
      * Gets the list of optimizations to apply
      */
-    public optimizations = new Array<SceneOptimization>();
+    public optimizations: SceneOptimization[] = [];
 
     /**
      * Creates a new list of options used by SceneOptimizer

--- a/packages/dev/core/src/Morph/morphTarget.ts
+++ b/packages/dev/core/src/Morph/morphTarget.ts
@@ -19,7 +19,7 @@ export class MorphTarget implements IAnimatable {
     /**
      * Gets or sets the list of animations
      */
-    public animations = new Array<Animation>();
+    public animations: Animation[] = [];
 
     private _scene: Nullable<Scene>;
     private _positions: Nullable<FloatArray> = null;

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -986,7 +986,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         const engine = this._engine;
-        const data = new Array<float>();
+        const data: float[] = [];
 
         this._attributesStrideSize = 21;
         this._targetIndex = 0;

--- a/packages/dev/core/src/Particles/particleSystem.ts
+++ b/packages/dev/core/src/Particles/particleSystem.ts
@@ -1248,7 +1248,7 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
         this._stopped = false;
         this._actualFrame = 0;
         if (this._subEmitters && this._subEmitters.length != 0) {
-            this.activeSubSystems = new Array<ParticleSystem>();
+            this.activeSubSystems = [] as ParticleSystem[];
         }
 
         // Reset emit gradient so it acts the same on every start
@@ -1437,7 +1437,7 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
         this.activeSubSystems.forEach((subSystem) => {
             subSystem.stop(true);
         });
-        this.activeSubSystems = new Array<ParticleSystem>();
+        this.activeSubSystems = [] as ParticleSystem[];
     }
 
     private _createParticle: () => Particle = () => {

--- a/packages/dev/core/src/Particles/particleSystemComponent.ts
+++ b/packages/dev/core/src/Particles/particleSystemComponent.ts
@@ -135,7 +135,7 @@ declare module "../Meshes/mesh" {
 }
 
 Mesh.prototype.getEmittedParticleSystems = function (): IParticleSystem[] {
-    const results = new Array<IParticleSystem>();
+    const results: IParticleSystem[] = [];
     for (let index = 0; index < this.getScene().particleSystems.length; index++) {
         const particleSystem = this.getScene().particleSystems[index];
         if (particleSystem.emitter === this) {
@@ -146,7 +146,7 @@ Mesh.prototype.getEmittedParticleSystems = function (): IParticleSystem[] {
 };
 
 Mesh.prototype.getHierarchyEmittedParticleSystems = function (): IParticleSystem[] {
-    const results = new Array<IParticleSystem>();
+    const results: IParticleSystem[] = [];
     const descendants = this.getDescendants();
     descendants.push(this);
 

--- a/packages/dev/core/src/Particles/particleSystemSet.ts
+++ b/packages/dev/core/src/Particles/particleSystemSet.ts
@@ -33,7 +33,7 @@ export class ParticleSystemSet implements IDisposable {
     /**
      * Gets the particle system list
      */
-    public systems = new Array<IParticleSystem>();
+    public systems: IParticleSystem[] = [];
 
     /**
      * Gets or sets the emitter node used with this set

--- a/packages/dev/core/src/Physics/v1/Plugins/cannonJSPlugin.ts
+++ b/packages/dev/core/src/Physics/v1/Plugins/cannonJSPlugin.ts
@@ -392,7 +392,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
 
                 const transform = object.computeWorldMatrix(true);
                 // convert rawVerts to object space
-                const transformedVertices = new Array<number>();
+                const transformedVertices: number[] = [];
                 let index: number;
                 for (index = 0; index < rawVerts.length; index += 3) {
                     Vector3.TransformCoordinates(Vector3.FromArray(rawVerts, index), transform).toArray(transformedVertices, index);
@@ -438,7 +438,7 @@ export class CannonJSPlugin implements IPhysicsEnginePlugin {
         let pos = <FloatArray>object.getVerticesData(VertexBuffer.PositionKind);
         const transform = object.computeWorldMatrix(true);
         // convert rawVerts to object space
-        const transformedVertices = new Array<number>();
+        const transformedVertices: number[] = [];
         let index: number;
         for (index = 0; index < pos.length; index += 3) {
             Vector3.TransformCoordinates(Vector3.FromArray(pos, index), transform).toArray(transformedVertices, index);

--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -153,7 +153,7 @@ export class PostProcess {
     /**
      * Animations to be used for the post processing
      */
-    public animations = new Array<Animation>();
+    public animations: Animation[] = [];
 
     /**
      * Enable Pixel Perfect mode where texture is not scaled to be power of 2.

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -85,14 +85,14 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
      * Array containing the excluded meshes not rendered in the internal pass
      */
     @serialize()
-    public excludedMeshes = new Array<AbstractMesh>();
+    public excludedMeshes: AbstractMesh[] = [];
 
     /**
      * Array containing the only meshes rendered in the internal pass.
      * If this array is not empty, only the meshes from this array are rendered in the internal pass
      */
     @serialize()
-    public includedMeshes = new Array<AbstractMesh>();
+    public includedMeshes: AbstractMesh[] = [];
 
     /**
      * Controls the overall intensity of the post-process

--- a/packages/dev/core/src/Probes/reflectionProbe.ts
+++ b/packages/dev/core/src/Probes/reflectionProbe.ts
@@ -111,7 +111,7 @@ export class ReflectionProbe {
 
         // Create the scene field if not exist.
         if (!this._scene.reflectionProbes) {
-            this._scene.reflectionProbes = new Array<ReflectionProbe>();
+            this._scene.reflectionProbes = [] as ReflectionProbe[];
         }
         this._scene.reflectionProbes.push(this);
 

--- a/packages/dev/core/src/Rendering/edgesRenderer.ts
+++ b/packages/dev/core/src/Rendering/edgesRenderer.ts
@@ -100,7 +100,7 @@ InstancedLinesMesh.prototype.enableEdgesRendering = function (epsilon = 0.95, ch
  * FaceAdjacencies Helper class to generate edges
  */
 class FaceAdjacencies {
-    public edges = new Array<number>();
+    public edges: number[] = [];
     public p0: Vector3;
     public p1: Vector3;
     public p2: Vector3;
@@ -776,8 +776,8 @@ export class EdgesRenderer implements IEdgesRenderer {
         }
 
         // First let's find adjacencies
-        const adjacencies = new Array<FaceAdjacencies>();
-        const faceNormals = new Array<Vector3>();
+        const adjacencies: FaceAdjacencies[] = [];
+        const faceNormals: Vector3[] = [];
         let index: number;
         let faceAdjacencies: FaceAdjacencies;
 

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -114,7 +114,7 @@ export class SpriteManager implements ISpriteManager {
     public snippetId: string;
 
     /** Gets the list of sprites */
-    public sprites = new Array<Sprite>();
+    public sprites: Sprite[] = [];
     /** Gets or sets the rendering group id (0 by default) */
     public renderingGroupId = 0;
     /** Gets or sets camera layer mask */

--- a/packages/dev/core/src/Sprites/spriteMap.ts
+++ b/packages/dev/core/src/Sprites/spriteMap.ts
@@ -351,7 +351,7 @@ export class SpriteMap implements ISpriteMap {
      * @returns RawTexture of the frameMap
      */
     private _createFrameBuffer(): RawTexture {
-        const data = new Array();
+        const data = [];
         //Do two Passes
         for (let i = 0; i < this.spriteCount; i++) {
             data.push(0, 0, 0, 0); //frame
@@ -397,7 +397,7 @@ export class SpriteMap implements ISpriteMap {
      * @returns RawTexture of the tileMap
      */
     private _createTileBuffer(buffer: any, _layer: number = 0): RawTexture {
-        let data = new Array();
+        let data = [];
         const _ty = this.options.stageSize!.y || 0;
         const _tx = this.options.stageSize!.x || 0;
 
@@ -434,7 +434,7 @@ export class SpriteMap implements ISpriteMap {
             return;
         }
 
-        let p = new Array();
+        let p = [];
         if (pos instanceof Vector2) {
             p.push(pos);
         } else {
@@ -463,7 +463,7 @@ export class SpriteMap implements ISpriteMap {
      * @returns RawTexture of the animationMap
      */
     private _createTileAnimationBuffer(buffer: Nullable<ArrayBufferView>): RawTexture {
-        const data = new Array();
+        const data = [];
         let floatArray;
         if (!buffer) {
             for (let i = 0; i < this.spriteCount; i++) {

--- a/packages/dev/core/src/Sprites/spriteSceneComponent.ts
+++ b/packages/dev/core/src/Sprites/spriteSceneComponent.ts
@@ -144,7 +144,7 @@ Scene.prototype._internalMultiPickSprites = function (ray: Ray, predicate?: (spr
         return null;
     }
 
-    let pickingInfos = new Array<PickingInfo>();
+    let pickingInfos: PickingInfo[] = [];
 
     if (!camera) {
         if (!this.activeCamera) {
@@ -275,7 +275,7 @@ export class SpriteSceneComponent implements ISceneComponent {
      */
     constructor(scene: Scene) {
         this.scene = scene;
-        this.scene.spriteManagers = new Array<ISpriteManager>();
+        this.scene.spriteManagers = [] as ISpriteManager[];
         this.scene._tempSpritePickingRay = Ray ? Ray.Zero() : null;
         this.scene.onBeforeSpritesRenderingObservable = new Observable<Scene>();
         this.scene.onAfterSpritesRenderingObservable = new Observable<Scene>();

--- a/packages/dev/core/src/XR/features/WebXRFeaturePointSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRFeaturePointSystem.ts
@@ -115,8 +115,8 @@ export class WebXRFeaturePointSystem extends WebXRAbstractFeature {
             }
 
             const numberOfFeaturePoints: number = featurePointRawData.length / 5;
-            const updatedFeaturePoints = new Array();
-            const addedFeaturePoints = new Array();
+            const updatedFeaturePoints = [];
+            const addedFeaturePoints = [];
             for (let i = 0; i < numberOfFeaturePoints; i++) {
                 const rawIndex: number = i * 5;
                 const id = featurePointRawData[rawIndex + 4];

--- a/packages/dev/core/src/abstractScene.ts
+++ b/packages/dev/core/src/abstractScene.ts
@@ -108,35 +108,35 @@ export abstract class AbstractScene {
     /**
      * Gets the list of root nodes (ie. nodes with no parent)
      */
-    public rootNodes = new Array<Node>();
+    public rootNodes: Node[] = [];
 
     /** All of the cameras added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras
      */
-    public cameras = new Array<Camera>();
+    public cameras: Camera[] = [];
 
     /**
      * All of the lights added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
      */
-    public lights = new Array<Light>();
+    public lights: Light[] = [];
 
     /**
      * All of the (abstract) meshes added to this scene
      */
-    public meshes = new Array<AbstractMesh>();
+    public meshes: AbstractMesh[] = [];
 
     /**
      * The list of skeletons added to the scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons
      */
-    public skeletons = new Array<Skeleton>();
+    public skeletons: Skeleton[] = [];
 
     /**
      * All of the particle systems added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro
      */
-    public particleSystems = new Array<IParticleSystem>();
+    public particleSystems: IParticleSystem[] = [];
 
     /**
      * Gets a list of Animations associated with the scene
@@ -147,13 +147,13 @@ export abstract class AbstractScene {
      * All of the animation groups added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/animation/groupAnimations
      */
-    public animationGroups = new Array<AnimationGroup>();
+    public animationGroups: AnimationGroup[] = [];
 
     /**
      * All of the multi-materials added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/multiMaterials
      */
-    public multiMaterials = new Array<MultiMaterial>();
+    public multiMaterials: MultiMaterial[] = [];
 
     /**
      * All of the materials added to this scene
@@ -162,18 +162,18 @@ export abstract class AbstractScene {
      * Note also that the order of the Material within the array is not significant and might change.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/materials_introduction
      */
-    public materials = new Array<Material>();
+    public materials: Material[] = [];
 
     /**
      * The list of morph target managers added to the scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/dynamicMeshMorph
      */
-    public morphTargetManagers = new Array<MorphTargetManager>();
+    public morphTargetManagers: MorphTargetManager[] = [];
 
     /**
      * The list of geometries used in the scene.
      */
-    public geometries = new Array<Geometry>();
+    public geometries: Geometry[] = [];
 
     /**
      * All of the transform nodes added to this scene
@@ -182,18 +182,18 @@ export abstract class AbstractScene {
      * Note also that the order of the TransformNode within the array is not significant and might change.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/transform_node
      */
-    public transformNodes = new Array<TransformNode>();
+    public transformNodes: TransformNode[] = [];
 
     /**
      * ActionManagers available on the scene.
      * @deprecated
      */
-    public actionManagers = new Array<AbstractActionManager>();
+    public actionManagers: AbstractActionManager[] = [];
 
     /**
      * Textures to keep.
      */
-    public textures = new Array<BaseTexture>();
+    public textures: BaseTexture[] = [];
 
     /** @internal */
     protected _environmentTexture: Nullable<BaseTexture> = null;
@@ -213,13 +213,13 @@ export abstract class AbstractScene {
     /**
      * The list of postprocesses added to the scene
      */
-    public postProcesses = new Array<PostProcess>();
+    public postProcesses: PostProcess[] = [];
 
     /**
      * @returns all meshes, lights, cameras, transformNodes and bones
      */
     public getNodes(): Array<Node> {
-        let nodes = new Array<Node>();
+        let nodes: Node[] = [];
         nodes = nodes.concat(this.meshes);
         nodes = nodes.concat(this.lights);
         nodes = nodes.concat(this.cameras);

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -981,7 +981,7 @@ export class AssetContainer extends AbstractScene {
             }
         });
 
-        const newAnimationGroups = new Array<AnimationGroup>();
+        const newAnimationGroups: AnimationGroup[] = [];
 
         // Copy new animation groups
         this.animationGroups.slice().forEach((animationGroupInAC) => {
@@ -1061,7 +1061,7 @@ export class AssetContainer extends AbstractScene {
             return;
         }
 
-        const nodesToVisit = new Array<Node>();
+        const nodesToVisit: Node[] = [];
         const visitedNodes = new Set<Node>();
 
         nodesToVisit.push(root);

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -165,7 +165,7 @@ export class Node implements IBehaviorAware<Node> {
     /**
      * Gets a list of Animations associated with the node
      */
-    public animations = new Array<Animation>();
+    public animations: Animation[] = [];
     protected _ranges: { [name: string]: Nullable<AnimationRange> } = {};
 
     /**
@@ -673,7 +673,7 @@ export class Node implements IBehaviorAware<Node> {
      * @returns all children nodes of all types
      */
     public getDescendants(directDescendantsOnly?: boolean, predicate?: (node: Node) => boolean): Node[] {
-        const results = new Array<Node>();
+        const results: Node[] = [];
 
         this._getDescendants(results, directDescendantsOnly, predicate);
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -458,7 +458,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * Use this array to add regular expressions used to disable offline support for specific urls
      */
-    public disableOfflineSupportExceptionRules = new Array<RegExp>();
+    public disableOfflineSupportExceptionRules: RegExp[] = [];
 
     /**
      * An event triggered when the scene is disposed.
@@ -1304,7 +1304,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * The list of user defined render targets added to the scene
      */
-    public customRenderTargets = new Array<RenderTargetTexture>();
+    public customRenderTargets: RenderTargetTexture[] = [];
 
     /**
      * Defines if texture loading must be delayed
@@ -1315,7 +1315,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     /**
      * Gets the list of meshes imported to the scene through SceneLoader
      */
-    public importedMeshesFiles = new Array<string>();
+    public importedMeshesFiles: string[] = [];
 
     // Probes
     /**
@@ -1648,7 +1648,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     constructor(engine: Engine, options?: SceneOptions) {
         super();
 
-        this.activeCameras = new Array<Camera>();
+        this.activeCameras = [] as Camera[];
 
         const fullOptions = {
             useGeometryUniqueIdsMap: true,
@@ -4763,7 +4763,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         this._pointerDownStage.clear();
         this._pointerUpStage.clear();
 
-        this.importedMeshesFiles = new Array<string>();
+        this.importedMeshesFiles = [] as string[];
 
         if (this.stopAllAnimations) {
             // Ensures that no animatable notifies a callback that could start a new animation group, constantly adding new animatables to the active list...

--- a/packages/dev/core/test/unit/Misc/babylon.arrayTools.test.ts
+++ b/packages/dev/core/test/unit/Misc/babylon.arrayTools.test.ts
@@ -10,7 +10,7 @@ import { _ObserveArray } from "core/Misc/arrayTools";
         it("should be able to listen to push", () => {
             const listener = jest.fn();
 
-            const array = new Array<number>();
+            const array: number[] = [];
             array.push(1);
             expect(listener).not.toBeCalled();
 
@@ -22,7 +22,7 @@ import { _ObserveArray } from "core/Misc/arrayTools";
         });
 
         it("should have updated values in callback", (done) => {
-            const array = new Array<number>();
+            const array: number[] = [];
             array.push(1);
             const listener = () => {
                 expect(array.length).toEqual(2);
@@ -88,7 +88,7 @@ import { _ObserveArray } from "core/Misc/arrayTools";
         });
 
         it("should stop listening to in a chain", () => {
-            const array = new Array<number>();
+            const array: number[] = [];
 
             const listener1 = jest.fn();
             const listener2 = jest.fn();

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1443,7 +1443,7 @@ export class Control implements IAnimatable {
      * @returns all child controls
      */
     public getDescendants(directDescendantsOnly?: boolean, predicate?: (control: Control) => boolean): Control[] {
-        const results = new Array<Control>();
+        const results: Control[] = [];
 
         this.getDescendantsToRef(results, directDescendantsOnly, predicate);
 

--- a/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
@@ -197,7 +197,7 @@ export class FluentMaterial extends PushMaterial {
             ];
 
             const samplers = ["albedoSampler"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -355,7 +355,7 @@ export class FluentBackplateMaterial extends PushMaterial {
                 "Global_Right_Index_Tip_Position",
             ];
             const samplers: string[] = ["_Blob_Texture_", "_Iridescent_Map_"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
@@ -414,7 +414,7 @@ export class FluentButtonMaterial extends PushMaterial {
                 "Global_Right_Index_Tip_Proximity",
             ];
             const samplers: string[] = ["_Blob_Texture_"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlBackglowMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlBackglowMaterial.ts
@@ -229,7 +229,7 @@ export class MRDLBackglowMaterial extends PushMaterial {
                 "_Bias_",
             ];
             const samplers: string[] = [];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
@@ -338,7 +338,7 @@ export class MRDLBackplateMaterial extends PushMaterial {
                 "_Fade_Out_",
             ];
             const samplers: string[] = ["_Iridescent_Map_"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlFrontplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlFrontplateMaterial.ts
@@ -412,7 +412,7 @@ export class MRDLFrontplateMaterial extends PushMaterial {
                 "_Use_Global_Right_Index_",
             ];
             const samplers: string[] = [];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlInnerquadMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlInnerquadMaterial.ts
@@ -173,7 +173,7 @@ export class MRDLInnerquadMaterial extends PushMaterial {
                 "_Glow_Falloff_",
             ];
             const samplers: string[] = [];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
@@ -657,7 +657,7 @@ export class MRDLSliderBarMaterial extends PushMaterial {
                 "Global_Right_Index_Tip_Proximity",
             ];
             const samplers: string[] = ["_Rim_Texture_", "_Iridescence_Texture_"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
@@ -658,7 +658,7 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
                 "Global_Right_Index_Tip_Proximity",
             ];
             const samplers: string[] = ["_Rim_Texture_", "_Iridescence_Texture_"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curve.ts
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/graph/curve.ts
@@ -13,7 +13,7 @@ export interface KeyEntry {
 
 export class Curve {
     public static readonly SampleRate = 50;
-    public keys = new Array<KeyEntry>();
+    public keys: KeyEntry[] = [];
     public animation: Animation;
     public color: string;
     public onDataUpdatedObservable = new Observable<void>();

--- a/packages/dev/loaders/src/OBJ/objFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.ts
@@ -233,7 +233,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
     private _parseSolid(meshesNames: any, scene: Scene, data: string, rootUrl: string): Promise<Array<AbstractMesh>> {
         let fileToLoad: string = ""; //The name of the mtlFile to load
         const materialsFromMTLFile: MTLFileLoader = new MTLFileLoader();
-        const materialToUse = new Array<string>();
+        const materialToUse: string[] = [];
         const babylonMeshesArray: Array<Mesh> = []; //The mesh for babylon
 
         // Main function

--- a/packages/dev/loaders/src/glTF/1.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/1.0/glTFLoader.ts
@@ -677,10 +677,10 @@ const importMesh = (gltfRuntime: IGLTFRuntime, node: IGLTFNode, meshes: string[]
     const subMaterials: Material[] = [];
 
     let vertexData: Nullable<VertexData> = null;
-    const verticesStarts = new Array<number>();
-    const verticesCounts = new Array<number>();
-    const indexStarts = new Array<number>();
-    const indexCounts = new Array<number>();
+    const verticesStarts: number[] = [];
+    const verticesCounts: number[] = [];
+    const indexStarts: number[] = [];
+    const indexCounts: number[] = [];
 
     for (let meshIndex = 0; meshIndex < meshes.length; meshIndex++) {
         const meshId = meshes[meshIndex];
@@ -1795,8 +1795,8 @@ export class GLTFLoader implements IGLTFLoader {
                 // Create nodes
                 this._createNodes(gltfRuntime);
 
-                const meshes = new Array<AbstractMesh>();
-                const skeletons = new Array<Skeleton>();
+                const meshes: AbstractMesh[] = [];
+                const skeletons: Skeleton[] = [];
 
                 // Fill arrays of meshes and skeletons
                 for (const nde in gltfRuntime.nodes) {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -358,7 +358,7 @@ export class MSFT_lod implements IGLTFLoaderExtension {
             throw new Error("maxLODsToLoad must be greater than zero");
         }
 
-        const properties = new Array<T>();
+        const properties: T[] = [];
 
         for (let i = ids.length - 1; i >= 0; i--) {
             properties.push(ArrayItem.Get(`${context}/ids/${ids[i]}`, array, ids[i]));
@@ -372,7 +372,7 @@ export class MSFT_lod implements IGLTFLoaderExtension {
     }
 
     private _disposeTransformNode(babylonTransformNode: TransformNode): void {
-        const babylonMaterials = new Array<Material>();
+        const babylonMaterials: Material[] = [];
         const babylonMaterial = (babylonTransformNode as Mesh).material;
         if (babylonMaterial) {
             babylonMaterials.push(babylonMaterial);

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -661,7 +661,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _getGeometries(): Geometry[] {
-        const geometries = new Array<Geometry>();
+        const geometries: Geometry[] = [];
 
         const nodes = this._gltf.nodes;
         if (nodes) {
@@ -679,7 +679,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _getMeshes(): AbstractMesh[] {
-        const meshes = new Array<AbstractMesh>();
+        const meshes: AbstractMesh[] = [];
 
         // Root mesh is always first, if available.
         if (this._rootBabylonMesh) {
@@ -699,7 +699,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _getTransformNodes(): TransformNode[] {
-        const transformNodes = new Array<TransformNode>();
+        const transformNodes: TransformNode[] = [];
 
         const nodes = this._gltf.nodes;
         if (nodes) {
@@ -717,7 +717,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _getSkeletons(): Skeleton[] {
-        const skeletons = new Array<Skeleton>();
+        const skeletons: Skeleton[] = [];
 
         const skins = this._gltf.skins;
         if (skins) {
@@ -732,7 +732,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _getAnimationGroups(): AnimationGroup[] {
-        const animationGroups = new Array<AnimationGroup>();
+        const animationGroups: AnimationGroup[] = [];
 
         const animations = this._gltf.animations;
         if (animations) {
@@ -1362,7 +1362,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         const paths: { [joint: number]: Array<INode> } = {};
         for (const index of joints) {
-            const path = new Array<INode>();
+            const path: INode[] = [];
             let node = ArrayItem.Get(`${context}/${index}`, this._gltf.nodes, index);
             while (node.index !== -1) {
                 path.unshift(node);

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -504,7 +504,7 @@ describe("Babylon Scene Loader", function () {
                 const promises = new Array<Promise<void>>();
                 const data: { [key: string]: any } = {};
 
-                const setRequestHeaderCalls = new Array<string>();
+                const setRequestHeaderCalls: string[] = [];
                 const origSetRequestHeader = BABYLON.WebRequest.prototype.setRequestHeader;
                 BABYLON.WebRequest.prototype.setRequestHeader = function (...args) {
                     console.log(args);

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -204,7 +204,7 @@ export class CellMaterial extends PushMaterial {
                 "diffuseMatrix",
             ];
             const samplers = ["diffuseSampler"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -293,7 +293,7 @@ export class FurMaterial extends PushMaterial {
             addClipPlaneUniforms(uniforms);
             const samplers = ["diffuseSampler", "heightTexture", "furTexture"];
 
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -198,7 +198,7 @@ export class GradientMaterial extends PushMaterial {
             ];
             addClipPlaneUniforms(uniforms);
             const samplers: string[] = [];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -274,7 +274,7 @@ export class LavaMaterial extends PushMaterial {
             addClipPlaneUniforms(uniforms);
 
             const samplers = ["diffuseSampler", "noiseTexture"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
                 uniformsNames: uniforms,

--- a/packages/dev/materials/src/mix/mixMaterial.ts
+++ b/packages/dev/materials/src/mix/mixMaterial.ts
@@ -314,7 +314,7 @@ export class MixMaterial extends PushMaterial {
                 "diffuse8Sampler",
             ];
 
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -237,7 +237,7 @@ export class NormalMaterial extends PushMaterial {
                 "diffuseMatrix",
             ];
             const samplers = ["diffuseSampler"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{

--- a/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
@@ -175,9 +175,9 @@ export class ShadowOnlyMaterial extends PushMaterial {
             const shaderName = "shadowOnly";
             const join = defines.toString();
             const uniforms = ["world", "view", "viewProjection", "vEyePosition", "vLightsType", "vFogInfos", "vFogColor", "pointSize", "alpha", "shadowColor", "mBones"];
-            const samplers = new Array<string>();
+            const samplers: string[] = [];
 
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -193,7 +193,7 @@ export class SimpleMaterial extends PushMaterial {
                 "diffuseMatrix",
             ];
             const samplers = ["diffuseSampler"];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
             MaterialHelper.PrepareUniformsAndSamplersList(<IEffectCreationOptions>{

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -261,7 +261,7 @@ export class TerrainMaterial extends PushMaterial {
             ];
             const samplers = ["textureSampler", "diffuse1Sampler", "diffuse2Sampler", "diffuse3Sampler", "bump1Sampler", "bump2Sampler", "bump3Sampler"];
 
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
 

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -251,7 +251,7 @@ export class TriPlanarMaterial extends PushMaterial {
             ];
             const samplers = ["diffuseSamplerX", "diffuseSamplerY", "diffuseSamplerZ", "normalSamplerX", "normalSamplerY", "normalSamplerZ"];
 
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
 

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -511,7 +511,7 @@ export class WaterMaterial extends PushMaterial {
                 "refractionSampler",
                 "reflectionSampler",
             ];
-            const uniformBuffers = new Array<string>();
+            const uniformBuffers: string[] = [];
 
             if (ImageProcessingConfiguration) {
                 ImageProcessingConfiguration.PrepareUniforms(uniforms, defines);

--- a/packages/tools/nodeEditor/src/graphSystem/properties/teleportOutNodePropertyComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/teleportOutNodePropertyComponent.tsx
@@ -30,7 +30,7 @@ export class TeleportOutPropertyTabComponent extends React.Component<IPropertyCo
         const block = this.props.nodeData.data as NodeMaterialTeleportOutBlock;
 
         const options = [{ label: "None", value: -1 }];
-        const teleporters = new Array<NodeMaterialTeleportInBlock>();
+        const teleporters: NodeMaterialTeleportInBlock[] = [];
 
         const nodeGeometry = (this.props.stateManager.data as GlobalState).nodeMaterial;
 

--- a/packages/tools/nodeGeometryEditor/src/graphSystem/properties/teleportOutNodePropertyComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/graphSystem/properties/teleportOutNodePropertyComponent.tsx
@@ -30,7 +30,7 @@ export class TeleportOutPropertyTabComponent extends React.Component<IPropertyCo
         const block = this.props.nodeData.data as TeleportOutBlock;
 
         const options = [{ label: "None", value: -1 }];
-        const teleporters = new Array<TeleportInBlock>();
+        const teleporters: TeleportInBlock[] = [];
 
         const nodeGeometry = (this.props.stateManager.data as GlobalState).nodeGeometry;
 


### PR DESCRIPTION
change the way arrays are literals

Changed all the way in which arrays were created by constructors to array literals throughout the project, because array literals are more performant.