### PR TITLE
Cameras: cameraDirection will now properly decrease when gravity is applied

### DIFF
--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -342,7 +342,7 @@ export class FlyCamera extends TargetCamera {
         // Copy displacement vector (scaled in _updatePosition) into temporary to manipulate it
         const scaledDisplacement = TmpVectors.Vector3[0].copyFrom(displacement);
 
-        //add gravity to the direction to prevent the dual-collision checking
+        // Add gravity to the direction to prevent the dual-collision checking
         if (this.applyGravity) {
             // Apply gravity to current displacement, then scale by relative inertia (if applicable)
             const relativeGravity = TmpVectors.Vector3[1].copyFrom(this.getScene().gravity);

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -12,6 +12,7 @@ import type { FlyCameraKeyboardInput } from "../Cameras/Inputs/flyCameraKeyboard
 import { Tools } from "../Misc/tools";
 
 import type { Collider } from "../Collisions/collider";
+import { Constants } from "core/Engines/constants";
 
 /**
  * This is a flying camera, designed for 3D movement and rotation in all directions,
@@ -339,22 +340,20 @@ export class FlyCamera extends TargetCamera {
         this._collider._radius = this.ellipsoid;
         this._collider.collisionMask = this._collisionMask;
 
-        // Copy displacement vector (scaled in _updatePosition) into temporary to manipulate it
-        const scaledDisplacement = TmpVectors.Vector3[0].copyFrom(displacement);
+        // Copy and scale displacement vector (scaled in _updatePosition) into temporary to manipulate it
+        const scaledDisplacement = TmpVectors.Vector3[0].copyFrom(displacement).scaleInPlace(scaleFactor);
 
         // Add gravity to the direction to prevent the dual-collision checking
         if (this.applyGravity) {
             // Apply gravity to current displacement, then scale by relative inertia (if applicable)
             const relativeGravity = TmpVectors.Vector3[1].copyFrom(this.getScene().gravity);
-            if (this.inertia !== 0) {
-                relativeGravity.scaleInPlace(relativeInertia);
-            }
+            // Since gravity is a constant and we don't need to scale by the scale factor
+            // but instead by the ratio of the frame's delta time to the standard
+            const deltaRatio = this._currentDeltaTime / Constants.STANDARD_TIME_STEP;
+            relativeGravity.scaleInPlace(deltaRatio);
             // Take relative gravity and add to scaled displacement
             scaledDisplacement.addInPlace(relativeGravity);
         }
-
-        // Scale by our scaling factor before using in function
-        scaledDisplacement.scaleInPlace(scaleFactor);
 
         coordinator.getNewPosition(this._oldPosition, scaledDisplacement, this._collider, 3, null, this._onCollisionPositionChange, this.uniqueId);
     }

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -347,10 +347,8 @@ export class FreeCamera extends TargetCamera {
     /**
      * @internal
      */
-    public _collideWithWorld(displacement: Vector3): void {
+    public _collideWithWorld(displacement: Vector3, relativeInertia: number, scaleFactor: number): void {
         let globalPosition: Vector3;
-        const relativeInertia = this._getInertiaRelativeToTime();
-        const scaleFactor = this._getRelativeScaleFactor(relativeInertia);
 
         if (this.parent) {
             globalPosition = Vector3.TransformCoordinates(this.position, this.parent.getWorldMatrix());
@@ -369,22 +367,22 @@ export class FreeCamera extends TargetCamera {
         this._collider._radius = this.ellipsoid;
         this._collider.collisionMask = this._collisionMask;
 
-        // Copy displacement vector into temporary to manipulate it
+        // Copy displacement vector (scaled in _updatePosition) into temporary to manipulate it
         const scaledDisplacement = TmpVectors.Vector3[0].copyFrom(displacement);
 
         //add gravity to the direction to prevent the dual-collision checking
         if (this.applyGravity) {
-            // Apply gravity to current displacement
-            scaledDisplacement.addInPlace(this.getScene().gravity);
+            // Apply gravity to current displacement, then scale by relative inertia (if applicable)
+            const relativeGravity = TmpVectors.Vector3[1].copyFrom(this.getScene().gravity);
+            if (this.inertia !== 0) {
+                relativeGravity.scaleInPlace(relativeInertia);
+            }
+            // Take relative gravity and add to scaled displacement
+            scaledDisplacement.addInPlace(relativeGravity);
         }
 
-        // Scale original displacement by relative inertia (decay over time to zero)
-        displacement.scaleInPlace(relativeInertia);
-
-        // If inertia is not zero, apply both relative inertia and scale factor
-        if (this.inertia !== 0) {
-            scaledDisplacement.scaleInPlace(relativeInertia * scaleFactor);
-        }
+        // Scale by our scaling factor before using in function
+        scaledDisplacement.scaleInPlace(scaleFactor);
 
         coordinator.getNewPosition(this._oldPosition, scaledDisplacement, this._collider, 3, null, this._onCollisionPositionChange, this.uniqueId);
     }
@@ -440,11 +438,11 @@ export class FreeCamera extends TargetCamera {
     }
 
     /** @internal */
-    public _updatePosition(): void {
+    public _updatePosition(relativeInertia: number, scaleFactor: number): void {
         if (this.checkCollisions && this.getScene().collisionsEnabled) {
-            this._collideWithWorld(this.cameraDirection);
+            this._collideWithWorld(this.cameraDirection, relativeInertia, scaleFactor);
         } else {
-            super._updatePosition();
+            super._updatePosition(relativeInertia, scaleFactor);
         }
     }
 

--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -365,8 +365,7 @@ export class TargetCamera extends Camera {
             if (this.inertia === 0) {
                 this._updatePosition(relativeInertia, scaleFactor);
                 this.cameraDirection.scaleInPlace(0);
-            }
-            else {
+            } else {
                 this.cameraDirection.scaleInPlace(relativeInertia);
                 this._updatePosition(relativeInertia, scaleFactor);
             }


### PR DESCRIPTION
Recently an issue was found where the FreeCamera was not slowing down when gravity was active.  This PR modifies the `_collideWithWorld` function to fix that issue.

Forum Link: https://forum.babylonjs.com/t/bug-free-camera-never-stop/45546/4

Proof for using deltaTime ratio as scaling factor for gravity:
Given the following variables:
**r = initial offset
n = inertia
a = relative inertia (with respect to frame deltaTime ratio; currentDeltaTime/standardDeltaTime) = n^t
s = scale factor
t = deltaTime ratio = currentDeltaTime/standardDeltaTime
g = gravity
x = scaling ratio to apply to gravity**

Working from our previous proof for relative inertia and scale factor (https://github.com/BabylonJS/Babylon.js/pull/14482), we know that a frames worth of work looks something like:
sra = rn^t + ... + rn

When working with gravity applied, the equation will look more like:
sra + xg = (rn^t + g) + ... + (rn + g)

`x` in this scenario is some ratio to multiply gravity by so that the same amount of gravity is applied to each frame as though it was 60 FPS.  Next, let's reorganize things:
sra + xg = rn^t + ... + rn + (g + ... + g) = rn^t + ... + rn + t*g

We know that there are t terms for our geometric sum so that means if we are adding gravity to each, we have `t` number of `g` values.  Therefore, we have `tg` at the end.  By our first line, we know that `sra = rn^t + ... + rn` so we can use substitution to make things cleaner:
sra + xg = sra + tg

If we subtract `sra` from each side, we get:
xg = tg
x = t

Therefore, since gravity is just a constant and is unaffected by inertia, we can just multiply it by `t` (our deltaTime ratio).