### PR TITLE
Dot normal angle

### DIFF
--- a/packages/dev/core/src/Maths/math.path.ts
+++ b/packages/dev/core/src/Maths/math.path.ts
@@ -1,6 +1,6 @@
 import type { DeepImmutable, Nullable } from "../types";
 import { Scalar } from "./math.scalar";
-import { Vector2, Vector3, Quaternion, Matrix } from "./math.vector";
+import { Vector2, Vector3, type Vector4, Quaternion, Matrix } from "./math.vector";
 import { Epsilon } from "./math.constants";
 
 /**
@@ -82,7 +82,7 @@ export class Angle {
     }
 
     /**
-     * Gets a new Angle object valued with the gradient angle, in radians, of the line joining two points
+     * Gets a new Angle object with a value of the angle (in radians) between the line connecting the two points and the x-axis
      * @param a defines first point as the origin
      * @param b defines point
      * @returns a new Angle
@@ -90,6 +90,21 @@ export class Angle {
     public static BetweenTwoPoints(a: DeepImmutable<Vector2>, b: DeepImmutable<Vector2>): Angle {
         const delta = b.subtract(a);
         const theta = Math.atan2(delta.y, delta.x);
+        return new Angle(theta);
+    }
+
+    /**
+     * Gets the angle between the two vectors
+     * @param a defines first point as the origin
+     * @param b defines point
+     * @returns Returns an new Angle between 0 and PI
+     */
+    public static BetweenTwoVectors<Vec extends Vector2 | Vector3 | Vector4>(a: DeepImmutable<Vec>, b: DeepImmutable<Vec>): Angle {
+        const na = a.normalizeToNew() as Vec;
+        const nb = b.normalizeToNew() as Vec;
+        let cosv = na.dot(nb as any);
+        cosv = Scalar.Clamp(cosv, -1, 1);
+        const theta = Math.acos(cosv);
         return new Angle(theta);
     }
 

--- a/packages/dev/core/src/Maths/math.path.ts
+++ b/packages/dev/core/src/Maths/math.path.ts
@@ -1,6 +1,7 @@
 import type { DeepImmutable, Nullable } from "../types";
 import { Scalar } from "./math.scalar";
-import { Vector2, Vector3, type Vector4, Quaternion, Matrix } from "./math.vector";
+import { Vector2, Vector3, Quaternion, Matrix } from "./math.vector";
+import type { Vector4 } from "./math.vector";
 import { Epsilon } from "./math.constants";
 
 /**

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -754,8 +754,8 @@ export class Vector2 {
      * @param vector defines the vector to normalize
      * @returns a new Vector2
      */
-    public static Normalize(vector: DeepImmutable<Vector2>): Vector2 {
-        const result = Vector2.Zero();
+    public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
+        const result = new (vector.constructor as Vector2Constructor<T>)();
         Vector2.NormalizeToRef(vector, result);
         return result;
     }
@@ -4392,14 +4392,21 @@ export class Quaternion {
      * @returns the current updated quaternion
      */
     public normalize(): this {
-        const len = this.length();
-        if (len === 0) {
+        return this.normalizeFromLength(this.length());
+    }
+
+    /**
+     * Normalize the current quaternion with the given input length.
+     * Please note that this is an in place operation.
+     * @param len the length of the quaternion
+     * @returns the current updated Quaternion
+     */
+    public normalizeFromLength(len: number): this {
+        if (len === 0 || len === 1.0) {
             return this;
         }
 
-        const inv = 1.0 / len;
-        this.scaleInPlace(inv);
-        return this;
+        return this.scaleInPlace(1.0 / len);
     }
 
     /**
@@ -4408,13 +4415,23 @@ export class Quaternion {
      * @returns the normalized quaternion
      */
     public normalizeToNew(): this {
+        const normalized = new (this.constructor as QuaternionConstructor<this>)(0, 0, 0, 1);
+        this.normalizeToRef(normalized);
+        return normalized;
+    }
+
+    /**
+     * Normalize the current Quaternion to the reference
+     * @param reference define the Quaternion to update
+     * @returns the updated Quaternion
+     */
+    public normalizeToRef<T extends Quaternion>(reference: T): T {
         const len = this.length();
-        if (len === 0) {
-            return this.clone();
+        if (len === 0 || len === 1.0) {
+            return reference.copyFromFloats(this._x, this._y, this._z, this._w);
         }
 
-        const inv = 1.0 / len;
-        return this.scale(inv);
+        return this.scaleToRef(1.0 / len, reference);
     }
 
     /**
@@ -5105,6 +5122,28 @@ export class Quaternion {
         result._z = (t2 - time) * 6 * value1._z + (3 * t2 - 4 * time + 1) * tangent1._z + (-t2 + time) * 6 * value2._z + (3 * t2 - 2 * time) * tangent2._z;
         result._w = (t2 - time) * 6 * value1._w + (3 * t2 - 4 * time + 1) * tangent1._w + (-t2 + time) * 6 * value2._w + (3 * t2 - 2 * time) * tangent2._w;
         result._isDirty = true;
+        return result;
+    }
+
+    /**
+     * Returns a new Quaternion as the normalization of the given Quaternion
+     * @param quat defines the Quaternion to normalize
+     * @returns the new Quaternion
+     */
+    public static Normalize(quat: DeepImmutable<Quaternion>): Quaternion {
+        const result = Quaternion.Zero();
+        Quaternion.NormalizeToRef(quat, result);
+        return result;
+    }
+
+    /**
+     * Sets the given Quaternion "result" with the normalization of the given first Quaternion
+     * @param quat defines the Quaternion to normalize
+     * @param result defines the Quaternion where to store the result
+     * @returns result input
+     */
+    public static NormalizeToRef<T extends Quaternion>(quat: DeepImmutable<Quaternion>, result: T): T {
+        quat.normalizeToRef(result);
         return result;
     }
 }

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -745,7 +745,7 @@ export class Vector2 {
      * @returns the dot product (float)
      */
     public static Dot(left: DeepImmutable<Vector2>, right: DeepImmutable<Vector2>): number {
-        return left.dot(right);
+        return left.x * right.x + left.y * right.y;
     }
 
     /**
@@ -2514,7 +2514,7 @@ export class Vector3 {
      * @returns the dot product
      */
     public static Dot(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>): number {
-        return left.dot(right);
+        return left._x * right._x + left._y * right._y + left._z * right._z;
     }
 
     /**
@@ -4596,7 +4596,7 @@ export class Quaternion {
      * @returns the dot product
      */
     public static Dot(left: DeepImmutable<Quaternion>, right: DeepImmutable<Quaternion>): number {
-        return left.dot(right);
+        return left._x * right._x + left._y * right._y + left._z * right._z + left._w * right._w;
     }
 
     /**

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -464,8 +464,45 @@ export class Vector2 {
      * @returns the current updated Vector2
      */
     public normalize(): this {
-        Vector2.NormalizeToRef(this, this);
-        return this;
+        return this.normalizeFromLength(this.length());
+    }
+
+    /**
+     * Normalize the current Vector2 with the given input length.
+     * Please note that this is an in place operation.
+     * @param len the length of the vector
+     * @returns the current updated Vector2
+     */
+    public normalizeFromLength(len: number): this {
+        if (len === 0 || len === 1.0) {
+            return this;
+        }
+
+        return this.scaleInPlace(1.0 / len);
+    }
+
+    /**
+     * Normalize the current Vector2 to a new vector
+     * @returns the new Vector2
+     */
+    public normalizeToNew(): this {
+        const normalized = new (this.constructor as Vector2Constructor<this>)(0, 0);
+        this.normalizeToRef(normalized);
+        return normalized;
+    }
+
+    /**
+     * Normalize the current Vector2 to the reference
+     * @param reference define the Vector2 to update
+     * @returns the updated Vector2
+     */
+    public normalizeToRef<T extends Vector2>(reference: T): T {
+        const len = this.length();
+        if (len === 0 || len === 1.0) {
+            return reference.copyFromFloats(this.x, this.y);
+        }
+
+        return this.scaleToRef(1.0 / len, reference);
     }
 
     /**
@@ -475,6 +512,15 @@ export class Vector2 {
      */
     public clone(): this {
         return new (this.constructor as Vector2Constructor<this>)(this.x, this.y);
+    }
+
+    /**
+     * Gets the dot product of the current vector and the vector "otherVector"
+     * @param otherVector defines second vector
+     * @returns the dot product (float)
+     */
+    public dot(otherVector: DeepImmutable<this>): number {
+        return this.x * otherVector.x + this.y * otherVector.y;
     }
 
     // Statics
@@ -699,7 +745,7 @@ export class Vector2 {
      * @returns the dot product (float)
      */
     public static Dot(left: DeepImmutable<Vector2>, right: DeepImmutable<Vector2>): number {
-        return left.x * right.x + left.y * right.y;
+        return left.dot(right);
     }
 
     /**
@@ -708,10 +754,10 @@ export class Vector2 {
      * @param vector defines the vector to normalize
      * @returns a new Vector2
      */
-    public static Normalize<T extends Vector2>(vector: DeepImmutable<T>): T {
-        const newVector = new (vector.constructor as Vector2Constructor<T>)();
-        this.NormalizeToRef(vector, newVector);
-        return newVector;
+    public static Normalize(vector: DeepImmutable<Vector2>): Vector2 {
+        const result = Vector2.Zero();
+        Vector2.NormalizeToRef(vector, result);
+        return result;
     }
 
     /**
@@ -722,14 +768,7 @@ export class Vector2 {
      * @returns result input
      */
     public static NormalizeToRef<T extends Vector2>(vector: DeepImmutable<Vector2>, result: T): T {
-        const len = vector.length();
-
-        if (len === 0) {
-            return result;
-        }
-
-        result.x = vector.x / len;
-        result.y = vector.y / len;
+        vector.normalizeToRef(result);
         return result;
     }
 
@@ -2475,7 +2514,16 @@ export class Vector3 {
      * @returns the dot product
      */
     public static Dot(left: DeepImmutable<Vector3>, right: DeepImmutable<Vector3>): number {
-        return left._x * right._x + left._y * right._y + left._z * right._z;
+        return left.dot(right);
+    }
+
+    /**
+     * Returns the dot product (float) between the current vectors and "otherVector"
+     * @param otherVector defines the right operand
+     * @returns the dot product
+     */
+    public dot(otherVector: DeepImmutable<this>): number {
+        return this._x * otherVector._x + this._y * otherVector._y + this._z * otherVector._z;
     }
 
     /**
@@ -3480,13 +3528,45 @@ export class Vector4 {
      * @returns the updated Vector4.
      */
     public normalize(): this {
-        const len = this.length();
+        return this.normalizeFromLength(this.length());
+    }
 
-        if (len === 0) {
+    /**
+     * Normalize the current Vector4 with the given input length.
+     * Please note that this is an in place operation.
+     * @param len the length of the vector
+     * @returns the current updated Vector4
+     */
+    public normalizeFromLength(len: number): this {
+        if (len === 0 || len === 1.0) {
             return this;
         }
 
         return this.scaleInPlace(1.0 / len);
+    }
+
+    /**
+     * Normalize the current Vector4 to a new vector
+     * @returns the new Vector4
+     */
+    public normalizeToNew(): this {
+        const normalized = new (this.constructor as Vector4Constructor<this>)(0, 0, 0, 0);
+        this.normalizeToRef(normalized);
+        return normalized;
+    }
+
+    /**
+     * Normalize the current Vector4 to the reference
+     * @param reference define the Vector4 to update
+     * @returns the updated Vector4
+     */
+    public normalizeToRef<T extends Vector4>(reference: T): T {
+        const len = this.length();
+        if (len === 0 || len === 1.0) {
+            return reference.copyFromFloats(this.x, this.y, this.z, this.w);
+        }
+
+        return this.scaleToRef(1.0 / len, reference);
     }
 
     /**
@@ -3551,6 +3631,15 @@ export class Vector4 {
     public setAll(v: number): this {
         this.x = this.y = this.z = this.w = v;
         return this;
+    }
+
+    /**
+     * Returns the dot product (float) between the current vectors and "otherVector"
+     * @param otherVector defines the right operand
+     * @returns the dot product
+     */
+    public dot(otherVector: DeepImmutable<this>): number {
+        return this.x * otherVector.x + this.y * otherVector.y + this.z * otherVector.z + this.w * otherVector.w;
     }
 
     // Statics
@@ -3655,8 +3744,7 @@ export class Vector4 {
      * @returns result input
      */
     public static NormalizeToRef<T extends Vector4>(vector: DeepImmutable<Vector4>, result: T): T {
-        result.copyFrom(vector);
-        result.normalize();
+        vector.normalizeToRef(result);
         return result;
     }
 
@@ -3843,6 +3931,16 @@ export class Vector4 {
      */
     public static FromVector3(source: Vector3, w: number = 0) {
         return new Vector4(source._x, source._y, source._z, w);
+    }
+
+    /**
+     * Returns the dot product (float) between the vectors "left" and "right"
+     * @param left defines the left operand
+     * @param right defines the right operand
+     * @returns the dot product
+     */
+    public static Dot(left: DeepImmutable<Vector4>, right: DeepImmutable<Vector4>): number {
+        return left.dot(right);
     }
 }
 
@@ -4393,6 +4491,15 @@ export class Quaternion {
         return this;
     }
 
+    /**
+     * Returns the dot product (float) between the current quaternions and "other"
+     * @param other defines the right operand
+     * @returns the dot product
+     */
+    public dot(other: DeepImmutable<this>): number {
+        return this._x * other._x + this._y * other._y + this._z * other._z + this._w * other._w;
+    }
+
     // Statics
 
     /**
@@ -4472,7 +4579,7 @@ export class Quaternion {
      * @returns the dot product
      */
     public static Dot(left: DeepImmutable<Quaternion>, right: DeepImmutable<Quaternion>): number {
-        return left._x * right._x + left._y * right._y + left._z * right._z + left._w * right._w;
+        return left.dot(right);
     }
 
     /**


### PR DESCRIPTION
- Unify dot and normalize APIs for Vector2, Vector3, Vector4, Vector2, Quaternion
- Add the BetweenTwoVectors method to Unger


The benefit of the unified API is that you can make indiscriminate calls to the union types of Vector2, Vector3, Vector4, Vector2, Quaternion, as follows:
```ts
public static BetweenTwoVectors<Vec extends Vector2 | Vector3 | Vector4>(a: DeepImmutable<Vec>, b: DeepImmutable<Vec>): Angle {
        const na = a.normalizeToNew() as Vec;
        const nb = b.normalizeToNew() as Vec;
        let cosv = na.dot(nb as any);
        cosv = Scalar.Clamp(cosv, -1, 1);
        const theta = Math.acos(cosv);
        return new Angle(theta);
}
```