### PR TITLE
feat(gizmo): custom colors for gizmos

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ The first golden rule is a really important one because we want our users to tru
 
 ### Performance
 
-Babylon.js is a 3D rendering engine. So every piece of code has to be scrutinized to look for potential bottlenecks or slow downs. Ultimately the goal is to render more with less resources.
+Babylon.js is a 3D rendering engine. So every piece of code has to be scrutinized to look for potential bottlenecks or slowdowns. Ultimately the goal is to render more with less resources.
 
 ### Simplicity
 
@@ -58,7 +58,7 @@ If you intend to only update the doc, this [documentation](https://doc.babylonjs
 
 To validate your PR, please follow these steps:
 
-- Run "npm run build:dev" locally and make sure that no error is generated
+- Run `npm run build:dev` locally and make sure that no error is generated
 - Make sure that all public functions and classes are commented using JSDoc/TSDoc syntax
 - Run `npm run test:unit` for unit tests, and check the buildSystem.md file for information regarding the visualization tests.
 
@@ -71,4 +71,4 @@ In order to not bloat the core engine with unwanted or unnecessary features (tha
 - Is there a general use case for this feature?
 - Does this feature already exist in a similar framework?
 
-If your PR is does not fall into the core category you can consider using our [Extensions repo](https://github.com/BabylonJS/Extensions) for more high level features.
+If your PR does not fall into the core category you can consider using our [Extensions repo](https://github.com/BabylonJS/Extensions) for more high level features.

--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -16,6 +16,7 @@ import type { Scene } from "../scene";
 import type { PositionGizmo } from "./positionGizmo";
 import { Color3 } from "../Maths/math.color";
 import { TmpVectors } from "../Maths/math.vector";
+
 /**
  * Interface for axis drag gizmo
  */
@@ -82,13 +83,24 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
     public get disableMaterial() {
         return this._disableMaterial;
     }
+
     /**
      * @internal
      */
     public static _CreateArrow(scene: Scene, material: StandardMaterial, thickness: number = 1, isCollider = false): TransformNode {
         const arrow = new TransformNode("arrow", scene);
-        const cylinder = CreateCylinder("cylinder", { diameterTop: 0, height: 0.075, diameterBottom: 0.0375 * (1 + (thickness - 1) / 4), tessellation: 96 }, scene);
-        const line = CreateCylinder("cylinder", { diameterTop: 0.005 * thickness, height: 0.275, diameterBottom: 0.005 * thickness, tessellation: 96 }, scene);
+        const cylinder = CreateCylinder("cylinder", {
+            diameterTop: 0,
+            height: 0.075,
+            diameterBottom: 0.0375 * (1 + (thickness - 1) / 4),
+            tessellation: 96
+        }, scene);
+        const line = CreateCylinder("cylinder", {
+            diameterTop: 0.005 * thickness,
+            height: 0.275,
+            diameterBottom: 0.005 * thickness,
+            tessellation: 96
+        }, scene);
 
         // Position arrow pointing in its drag axis
         cylinder.parent = arrow;
@@ -127,13 +139,17 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
      * @param gizmoLayer The utility layer the gizmo will be added to
      * @param parent
      * @param thickness display gizmo axis thickness
+     * @param hoverColor The color of the gizmo when hovering over and dragging
+     * @param disableColor The Color of the gizmo when its disabled
      */
     constructor(
         dragAxis: Vector3,
         color: Color3 = Color3.Gray(),
         gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer,
         parent: Nullable<PositionGizmo> = null,
-        thickness: number = 1
+        thickness: number = 1,
+        hoverColor: Color3 = Color3.Yellow(),
+        disableColor: Color3 = Color3.Gray(),
     ) {
         super(gizmoLayer);
         this._parent = parent;
@@ -144,10 +160,10 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
         this._coloredMaterial.specularColor = color.subtract(new Color3(0.1, 0.1, 0.1));
 
         this._hoverMaterial = new StandardMaterial("", gizmoLayer.utilityLayerScene);
-        this._hoverMaterial.diffuseColor = Color3.Yellow();
+        this._hoverMaterial.diffuseColor = hoverColor;
 
         this._disableMaterial = new StandardMaterial("", gizmoLayer.utilityLayerScene);
-        this._disableMaterial.diffuseColor = Color3.Gray();
+        this._disableMaterial.diffuseColor = disableColor;
         this._disableMaterial.alpha = 0.4;
 
         // Build Mesh + Collider
@@ -253,6 +269,7 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
             this._setGizmoMeshMaterial(cache.gizmoMeshes, newState ? cache.material : cache.disableMaterial);
         });
     }
+
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
@@ -274,6 +291,7 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
             }
         }
     }
+
     public get isEnabled(): boolean {
         return this._isEnabled;
     }

--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -89,18 +89,26 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
      */
     public static _CreateArrow(scene: Scene, material: StandardMaterial, thickness: number = 1, isCollider = false): TransformNode {
         const arrow = new TransformNode("arrow", scene);
-        const cylinder = CreateCylinder("cylinder", {
-            diameterTop: 0,
-            height: 0.075,
-            diameterBottom: 0.0375 * (1 + (thickness - 1) / 4),
-            tessellation: 96
-        }, scene);
-        const line = CreateCylinder("cylinder", {
-            diameterTop: 0.005 * thickness,
-            height: 0.275,
-            diameterBottom: 0.005 * thickness,
-            tessellation: 96
-        }, scene);
+        const cylinder = CreateCylinder(
+            "cylinder",
+            {
+                diameterTop: 0,
+                height: 0.075,
+                diameterBottom: 0.0375 * (1 + (thickness - 1) / 4),
+                tessellation: 96,
+            },
+            scene
+        );
+        const line = CreateCylinder(
+            "cylinder",
+            {
+                diameterTop: 0.005 * thickness,
+                height: 0.275,
+                diameterBottom: 0.005 * thickness,
+                tessellation: 96,
+            },
+            scene
+        );
 
         // Position arrow pointing in its drag axis
         cylinder.parent = arrow;
@@ -149,7 +157,7 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
         parent: Nullable<PositionGizmo> = null,
         thickness: number = 1,
         hoverColor: Color3 = Color3.Yellow(),
-        disableColor: Color3 = Color3.Gray(),
+        disableColor: Color3 = Color3.Gray()
     ) {
         super(gizmoLayer);
         this._parent = parent;

--- a/packages/dev/core/src/Gizmos/planeDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeDragGizmo.ts
@@ -26,7 +26,7 @@ export interface IPlaneDragGizmo extends IGizmo {
     snapDistance: number;
     /**
      * Event that fires each time the gizmo snaps to a new location.
-     * * snapDistance is the the change in distance
+     * * snapDistance is the change in distance
      */
     onSnapObservable: Observable<{ snapDistance: number }>;
     /** If the gizmo is enabled */
@@ -82,6 +82,7 @@ export class PlaneDragGizmo extends Gizmo implements IPlaneDragGizmo {
     public get disableMaterial() {
         return this._disableMaterial;
     }
+
     /**
      * @internal
      */
@@ -205,6 +206,7 @@ export class PlaneDragGizmo extends Gizmo implements IPlaneDragGizmo {
             this._setGizmoMeshMaterial(cache.gizmoMeshes, newState ? this._coloredMaterial : this._disableMaterial);
         });
     }
+
     protected _attachedNodeChanged(value: Nullable<Node>) {
         if (this.dragBehavior) {
             this.dragBehavior.enabled = value ? true : false;
@@ -224,9 +226,11 @@ export class PlaneDragGizmo extends Gizmo implements IPlaneDragGizmo {
             }
         }
     }
+
     public get isEnabled(): boolean {
         return this._isEnabled;
     }
+
     /**
      * Disposes of the gizmo
      */

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -178,7 +178,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         useEulerRotation = false,
         thickness: number = 1,
         hoverColor: Color3 = Color3.Yellow(),
-        disableColor: Color3 = Color3.Gray(),
+        disableColor: Color3 = Color3.Gray()
     ) {
         super(gizmoLayer);
         this._parent = parent;
@@ -200,10 +200,14 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         const { rotationMesh, collider } = this._createGizmoMesh(this._gizmoMesh, thickness, tessellation);
 
         // Setup Rotation Circle
-        this._rotationDisplayPlane = CreatePlane("rotationDisplay", {
-            size: 0.6,
-            updatable: false
-        }, this.gizmoLayer.utilityLayerScene);
+        this._rotationDisplayPlane = CreatePlane(
+            "rotationDisplay",
+            {
+                size: 0.6,
+                updatable: false,
+            },
+            this.gizmoLayer.utilityLayerScene
+        );
         this._rotationDisplayPlane.rotation.z = Math.PI * 0.5;
         this._rotationDisplayPlane.parent = this._gizmoMesh;
         this._rotationDisplayPlane.setEnabled(false);

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -122,14 +122,20 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
             vUV = uv;
         }`;
 
+    protected static defaultHoverColor = Color3.Yellow();
+
+    protected static get _RotationGizmoFragmentShader() {
+        return PlaneRotationGizmo._createRotationGizmoFragmentShader(PlaneRotationGizmo.defaultHoverColor);
+    }
+
     protected static _createRotationGizmoFragmentShader(color: Color3) {
         let r = `${color.r}`;
         let g = `${color.g}`;
         let b = `${color.b}`;
 
-        r = r.includes('.') ? r : `${r}.`;
-        g = g.includes('.') ? g : `${g}.`;
-        b = b.includes('.') ? b : `${b}.`;
+        r = r.includes(".") ? r : `${r}.`;
+        g = g.includes(".") ? g : `${g}.`;
+        b = b.includes(".") ? b : `${b}.`;
 
         return `
             precision highp float;
@@ -185,7 +191,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         useEulerRotation = false,
         thickness: number = 1,
-        hoverColor: Color3 = Color3.Yellow(),
+        hoverColor: Color3 = PlaneRotationGizmo.defaultHoverColor,
         disableColor: Color3 = Color3.Gray()
     ) {
         super(gizmoLayer);

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -189,6 +189,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
 
         this._hoverMaterial = new StandardMaterial("", gizmoLayer.utilityLayerScene);
         this._hoverMaterial.diffuseColor = hoverColor;
+        this._hoverMaterial.specularColor = hoverColor;
 
         this._disableMaterial = new StandardMaterial("", gizmoLayer.utilityLayerScene);
         this._disableMaterial.diffuseColor = disableColor;

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -123,6 +123,14 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         }`;
 
     protected static _createRotationGizmoFragmentShader(color: Color3) {
+        let r = `${color.r}`;
+        let g = `${color.g}`;
+        let b = `${color.b}`;
+
+        r = r.includes('.') ? r : `${r}.`;
+        g = g.includes('.') ? g : `${g}.`;
+        b = b.includes('.') ? b : `${b}.`;
+
         return `
             precision highp float;
             varying vec2 vUV;
@@ -149,7 +157,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                     intensity += max(step(start, angle) - step(end, angle), 0.);
                     angle += twopi;
                 }
-                gl_FragColor = vec4(${color.asArray()}, min(intensity * 0.25, 0.8)) * opacity;
+                gl_FragColor = vec4(${r}, ${g}, ${b}, min(intensity * 0.25, 0.8)) * opacity;
             }
         `;
     }


### PR DESCRIPTION
### What

- support setting custom colors for hover & disable material for
  - plane-drag gizmo
  - plane-rotation gizmo
- related https://forum.babylonjs.com/t/setts-of-gizmo-color-when-events/22271

### Why

- to avoid setting it via accessing "private" members
- to avoid white reflection color on manually set hover material  
  ![image](https://github.com/BabylonJS/Babylon.js/assets/12933406/2949f297-5ec8-4ded-9ff4-7c1dcfde4465)

### Visuals

|Before [PG](https://playground.babylonjs.com/#VJ0MJD)|After|
|-|-|
|![babylonjs-gizmo-before](https://github.com/BabylonJS/Babylon.js/assets/12933406/18c46247-3da2-4830-9d1f-5d2ea12c5211)|![babylonjs-gizmo-after](https://github.com/BabylonJS/Babylon.js/assets/12933406/46331989-716f-4b15-b2eb-3723a8075bf0)|

