### PR TITLE
feat(gizmo): set custom rotation color

### DIFF
--- a/packages/dev/core/src/Gizmos/axisDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/axisDragGizmo.ts
@@ -56,7 +56,7 @@ export class AxisDragGizmo extends Gizmo implements IAxisDragGizmo {
     public snapDistance = 0;
     /**
      * Event that fires each time the gizmo snaps to a new location.
-     * * snapDistance is the the change in distance
+     * * snapDistance is the change in distance
      */
     public onSnapObservable = new Observable<{ snapDistance: number }>();
 

--- a/packages/dev/core/src/Gizmos/planeDragGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeDragGizmo.ts
@@ -34,9 +34,9 @@ export interface IPlaneDragGizmo extends IGizmo {
 
     /** Default material used to render when gizmo is not disabled or hovered */
     coloredMaterial: StandardMaterial;
-    /** Material used to render when gizmo is hovered with mouse*/
+    /** Material used to render when gizmo is hovered with mouse */
     hoverMaterial: StandardMaterial;
-    /** Material used to render when gizmo is disabled. typically grey.*/
+    /** Material used to render when gizmo is disabled. typically grey. */
     disableMaterial: StandardMaterial;
 }
 
@@ -55,7 +55,7 @@ export class PlaneDragGizmo extends Gizmo implements IPlaneDragGizmo {
     public snapDistance = 0;
     /**
      * Event that fires each time the gizmo snaps to a new location.
-     * * snapDistance is the the change in distance
+     * * snapDistance is the change in distance
      */
     public onSnapObservable = new Observable<{ snapDistance: number }>();
 

--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -43,9 +43,11 @@ export interface IPlaneRotationGizmo extends IGizmo {
 
     /** Default material used to render when gizmo is not disabled or hovered */
     coloredMaterial: StandardMaterial;
-    /** Material used to render when gizmo is hovered with mouse*/
+    /** Material used to render when gizmo is hovered with mouse */
     hoverMaterial: StandardMaterial;
-    /** Material used to render when gizmo is disabled. typically grey.*/
+    /** Color used to render the drag angle sector when gizmo is rotated with mouse */
+    rotationColor: Color3;
+    /** Material used to render when gizmo is disabled. typically grey. */
     disableMaterial: StandardMaterial;
 }
 
@@ -90,12 +92,17 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         return this._coloredMaterial;
     }
 
-    /** Material used to render when gizmo is hovered with mouse*/
+    /** Material used to render when gizmo is hovered with mouse */
     public get hoverMaterial() {
         return this._hoverMaterial;
     }
 
-    /** Material used to render when gizmo is disabled. typically grey.*/
+    /** Color used to render the drag angle sector when gizmo is rotated with mouse */
+    public set rotationColor(color: Color3) {
+        this._rotationShaderMaterial.setColor3("rotationColor", color);
+    }
+
+    /** Material used to render when gizmo is disabled. typically grey. */
     public get disableMaterial() {
         return this._disableMaterial;
     }
@@ -128,7 +135,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
         varying vec2 vUV;
         varying vec3 vPosition;
         uniform vec3 angles;
-        uniform vec3 hoverColor;
+        uniform vec3 rotationColor;
 
         #define twopi 6.283185307
 
@@ -152,7 +159,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                 intensity += max(step(start, angle) - step(end, angle), 0.);
                 angle += twopi;
             }
-            gl_FragColor = vec4(hoverColor, min(intensity * 0.25, 0.8)) * opacity;
+            gl_FragColor = vec4(rotationColor, min(intensity * 0.25, 0.8)) * opacity;
         }
     `;
 
@@ -225,11 +232,11 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
             },
             {
                 attributes: ["position", "uv"],
-                uniforms: ["worldViewProjection", "angles", "hoverColor"],
+                uniforms: ["worldViewProjection", "angles", "rotationColor"],
             }
         );
         this._rotationShaderMaterial.backFaceCulling = false;
-        this._rotationShaderMaterial.setColor3("hoverColor", hoverColor);
+        this.rotationColor = hoverColor;
 
         this._rotationDisplayPlane.material = this._rotationShaderMaterial;
         this._rotationDisplayPlane.visibility = 0.999;


### PR DESCRIPTION
### What

- adds setter to allow changing color of the drag angle sector drawn by the rotation shader  
  <img src="https://github.com/BabylonJS/Babylon.js/assets/12933406/059a53a1-aceb-41a7-aed5-2962fba9b369" height="40">
- relates to https://github.com/BabylonJS/Babylon.js/pull/14525

### Why

- to allow changing the color after the gizmo is created
- to allow having different color for mesh (torus) and drag angle sector

### Visuals

|Before [PG](https://playground.babylonjs.com/#VJ0MJD#1)|After [PG](https://babylonsnapshots.z22.web.core.windows.net/refs/pull/14534/merge/index.html#VJ0MJD#1) (blue & yellow)|
|-|-|
|![babylonjs-gizmo-before](https://github.com/BabylonJS/Babylon.js/assets/12933406/00b727a4-19e8-4bb2-aaa2-5896120333ee)|![babylonjs-gizmo-after](https://github.com/BabylonJS/Babylon.js/assets/12933406/2b80ad0f-1e33-4f98-8f79-a1177f09603e)|

