### PR TITLE
Allows SkeletonViewer to render skeleton without mesh

### DIFF
--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -20,7 +20,7 @@ import type { Observer } from "../Misc/observable";
 
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
 import { ExtrudeShapeCustom } from "../Meshes/Builders/shapeBuilder";
-import { TransformNode } from "core/Meshes";
+import { TransformNode } from "../Meshes";
 
 /**
  * Class used to render a debug view of a given skeleton

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -20,6 +20,7 @@ import type { Observer } from "../Misc/observable";
 
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
 import { ExtrudeShapeCustom } from "../Meshes/Builders/shapeBuilder";
+import { TransformNode } from "core/Meshes";
 
 /**
  * Class used to render a debug view of a given skeleton
@@ -388,7 +389,7 @@ export class SkeletonViewer {
         /** defines the skeleton to render */
         public skeleton: Skeleton,
         /** defines the mesh attached to the skeleton */
-        public mesh: AbstractMesh,
+        public mesh: Nullable<AbstractMesh>,
         /** The Scene scope*/
         scene: Scene,
         /** defines a boolean indicating if bones matrices must be forced to update before rendering (true by default)  */
@@ -416,11 +417,13 @@ export class SkeletonViewer {
         options.displayOptions.localAxesSize = options.displayOptions.localAxesSize ?? 0.075;
         options.computeBonesUsingShaders = options.computeBonesUsingShaders ?? true;
         options.useAllBones = options.useAllBones ?? true;
+
         this._boneIndices = new Set();
 
         if (!options.useAllBones) {
-            const initialMeshBoneIndices = mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
-            const initialMeshBoneWeights = mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
+            const initialMeshBoneIndices = mesh?.getVerticesData(VertexBuffer.MatricesIndicesKind);
+            const initialMeshBoneWeights = mesh?.getVerticesData(VertexBuffer.MatricesWeightsKind);
+
             if (initialMeshBoneIndices && initialMeshBoneWeights) {
                 for (let i = 0; i < initialMeshBoneIndices.length; ++i) {
                     const index = initialMeshBoneIndices[i],
@@ -526,11 +529,18 @@ export class SkeletonViewer {
         position.z = tmat.m[14];
     }
 
-    private _getLinesForBonesWithLength(bones: Bone[], meshMat: Matrix): void {
+    private _getLinesForBonesWithLength(bones: Bone[], mesh: Nullable<AbstractMesh>): void {
         const len = bones.length;
 
-        const mesh = this.mesh;
-        const meshPos = mesh.position;
+        let matrix;
+        let meshPos;
+        if (mesh) {
+            matrix = mesh.getWorldMatrix();
+            meshPos = mesh.position;
+        } else {
+            matrix = new Matrix();
+            meshPos = bones[0].position;
+        }
         let idx = 0;
         for (let i = 0; i < len; i++) {
             const bone = bones[i];
@@ -543,8 +553,8 @@ export class SkeletonViewer {
                 points = [Vector3.Zero(), Vector3.Zero()];
                 this._debugLines[idx] = points;
             }
-            this._getBonePosition(points[0], bone, meshMat);
-            this._getBonePosition(points[1], bone, meshMat, 0, bone.length, 0);
+            this._getBonePosition(points[0], bone, matrix);
+            this._getBonePosition(points[1], bone, matrix, 0, bone.length, 0);
             points[0].subtractInPlace(meshPos);
             points[1].subtractInPlace(meshPos);
             idx++;
@@ -556,7 +566,15 @@ export class SkeletonViewer {
         let boneNum = 0;
 
         const mesh = this.mesh;
-        const meshPos = mesh.position;
+        let transformNode;
+        let meshPos;
+        if (mesh) {
+            transformNode = mesh;
+            meshPos = mesh.position;
+        } else {
+            transformNode = new TransformNode("");
+            meshPos = bones[0].position;
+        }
         for (let i = len - 1; i >= 0; i--) {
             const childBone = bones[i];
             const parentBone = childBone.getParent();
@@ -568,8 +586,8 @@ export class SkeletonViewer {
                 points = [Vector3.Zero(), Vector3.Zero()];
                 this._debugLines[boneNum] = points;
             }
-            childBone.getAbsolutePositionToRef(mesh, points[0]);
-            parentBone.getAbsolutePositionToRef(mesh, points[1]);
+            childBone.getAbsolutePositionToRef(transformNode, points[0]);
+            parentBone.getAbsolutePositionToRef(transformNode, points[1]);
             points[0].subtractInPlace(meshPos);
             points[1].subtractInPlace(meshPos);
             boneNum++;
@@ -877,7 +895,7 @@ export class SkeletonViewer {
         if (this.skeleton.bones[0].length === undefined) {
             this._getLinesForBonesNoLength(this.skeleton.bones);
         } else {
-            this._getLinesForBonesWithLength(this.skeleton.bones, this.mesh.getWorldMatrix());
+            this._getLinesForBonesWithLength(this.skeleton.bones, this.mesh);
         }
 
         const targetScene = this._utilityLayer.utilityLayerScene;
@@ -889,7 +907,11 @@ export class SkeletonViewer {
             } else {
                 CreateLineSystem("", { lines: this._debugLines, updatable: true, instance: this._debugMesh }, targetScene);
             }
-            this._debugMesh.position.copyFrom(this.mesh.position);
+            if (this.mesh) {
+                this._debugMesh.position.copyFrom(this.mesh.position);
+            } else {
+                this._debugMesh.position.copyFrom(this.skeleton.bones[0].position);
+            }
             this._debugMesh.color = this.color;
         }
     }

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -20,7 +20,7 @@ import type { Observer } from "../Misc/observable";
 
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
 import { ExtrudeShapeCustom } from "../Meshes/Builders/shapeBuilder";
-import { TransformNode } from "../Meshes";
+import { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Class used to render a debug view of a given skeleton

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -592,6 +592,9 @@ export class SkeletonViewer {
             points[1].subtractInPlace(meshPos);
             boneNum++;
         }
+        if (!mesh) {
+            transformNode.dispose();
+        }
     }
 
     /**

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
@@ -15,7 +15,6 @@ import { CustomPropertyGridComponent } from "../customPropertyGridComponent";
 import { OptionsLineComponent } from "shared-ui-components/lines/optionsLineComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { ButtonLineComponent } from "shared-ui-components/lines/buttonLineComponent";
-import type { AbstractMesh } from "core/Meshes";
 
 interface ISkeletonPropertyGridComponentProps {
     globalState: GlobalState;
@@ -83,10 +82,11 @@ export class SkeletonPropertyGridComponent extends React.Component<ISkeletonProp
             }
         } else {
             for (let index = 0; index < this._skeletonViewers.length; index++) {
-                if (this._skeletonViewers[index].mesh) {
-                    (this._skeletonViewers[index].mesh as AbstractMesh).reservedDataStore.skeletonViewer = null;
+                const skeletonViewer = this._skeletonViewers[index];
+                if (skeletonViewer.mesh) {
+                    skeletonViewer.mesh.reservedDataStore.skeletonViewer = null;
                 }
-                this._skeletonViewers[index].dispose();
+                skeletonViewer.dispose();
             }
             this._skeletonViewers = [];
         }

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
@@ -15,6 +15,7 @@ import { CustomPropertyGridComponent } from "../customPropertyGridComponent";
 import { OptionsLineComponent } from "shared-ui-components/lines/optionsLineComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { ButtonLineComponent } from "shared-ui-components/lines/buttonLineComponent";
+import {AbstractMesh} from "core/Meshes";
 
 interface ISkeletonPropertyGridComponentProps {
     globalState: GlobalState;
@@ -82,7 +83,9 @@ export class SkeletonPropertyGridComponent extends React.Component<ISkeletonProp
             }
         } else {
             for (let index = 0; index < this._skeletonViewers.length; index++) {
-                this._skeletonViewers[index].mesh.reservedDataStore.skeletonViewer = null;
+                if (this._skeletonViewers[index].mesh) {
+                    ((this._skeletonViewers[index].mesh) as AbstractMesh).reservedDataStore.skeletonViewer = null;
+                }
                 this._skeletonViewers[index].dispose();
             }
             this._skeletonViewers = [];

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
@@ -15,7 +15,7 @@ import { CustomPropertyGridComponent } from "../customPropertyGridComponent";
 import { OptionsLineComponent } from "shared-ui-components/lines/optionsLineComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { ButtonLineComponent } from "shared-ui-components/lines/buttonLineComponent";
-import {AbstractMesh} from "core/Meshes";
+import type { AbstractMesh } from "core/Meshes";
 
 interface ISkeletonPropertyGridComponentProps {
     globalState: GlobalState;
@@ -84,7 +84,7 @@ export class SkeletonPropertyGridComponent extends React.Component<ISkeletonProp
         } else {
             for (let index = 0; index < this._skeletonViewers.length; index++) {
                 if (this._skeletonViewers[index].mesh) {
-                    ((this._skeletonViewers[index].mesh) as AbstractMesh).reservedDataStore.skeletonViewer = null;
+                    (this._skeletonViewers[index].mesh as AbstractMesh).reservedDataStore.skeletonViewer = null;
                 }
                 this._skeletonViewers[index].dispose();
             }


### PR DESCRIPTION
Allows SkeletonViewer to render skeleton without mesh, handling null mesh.

Tested in the following playgrounds:
Broke in Master:
https://playground.babylonjs.com/#HJEBQF#5

Works with the PR:
https://babylonsnapshots.z22.web.core.windows.net/refs/pull/14538/merge/index.html#HJEBQF#5
https://babylonsnapshots.z22.web.core.windows.net/refs/pull/14538/merge/index.html#HJEBQF#6