### PR TITLE
glTF transmission: Fix rendering sprites and particle systems in the opaque texture

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -270,6 +270,8 @@ class TransmissionHelper {
         this._opaqueRenderTarget.lodGenerationScale = this._options.lodGenerationScale;
         this._opaqueRenderTarget.lodGenerationOffset = this._options.lodGenerationOffset;
         this._opaqueRenderTarget.samples = this._options.samples;
+        this._opaqueRenderTarget.renderSprites = true;
+        this._opaqueRenderTarget.renderParticles = true;
 
         let sceneImageProcessingapplyByPostProcess: boolean;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/sprite-not-showing-behind-a-glass-material/45874/4