### PR TITLE
Flow graph path

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
@@ -1,29 +1,27 @@
-import type { AbstractMesh } from "../../../Meshes/abstractMesh";
+import { AbstractMesh } from "../../../Meshes/abstractMesh";
 import { FlowGraphEventBlock } from "../../flowGraphEventBlock";
 import { PointerEventTypes } from "../../../Events/pointerEvents";
-import type { FlowGraphContext } from "core/FlowGraph/flowGraphContext";
+import type { FlowGraphContext } from "../../flowGraphContext";
 import type { IFlowGraphBlockConfiguration } from "../../flowGraphBlock";
 import { RegisterClass } from "../../../Misc/typeStore";
+import type { FlowGraphPath } from "../../flowGraphPath";
+import { Tools } from "../../../Misc/tools";
 /**
  * @experimental
  */
 export interface IFlowGraphMeshPickEventBlockConfiguration extends IFlowGraphBlockConfiguration {
-    meshVariableName: string;
+    path: FlowGraphPath;
 }
 /**
  * @experimental
  * A block that activates when a mesh is picked.
  */
 export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
-    private _meshVariableName: string;
-
     public constructor(public config: IFlowGraphMeshPickEventBlockConfiguration) {
+        if (config.path.hasTemplateStrings) {
+            Tools.Warn("Template strings are not supported in the path of mesh pick event blocks.");
+        }
         super(config);
-    }
-
-    public configure() {
-        super.configure();
-        this._meshVariableName = this.config.meshVariableName;
     }
 
     /**
@@ -32,7 +30,11 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
     public _preparePendingTasks(context: FlowGraphContext): void {
         let pickObserver = context._getExecutionVariable(this, "meshPickObserver");
         if (!pickObserver) {
-            const mesh = context.getVariable(this._meshVariableName) as AbstractMesh;
+            const mesh = this.config.path.getProperty(context);
+            if (!mesh || !(mesh instanceof AbstractMesh)) {
+                throw new Error("Mesh pick event block requires a valid mesh");
+            }
+            context._setExecutionVariable(this, "mesh", mesh);
             pickObserver = mesh.getScene().onPointerObservable.add((pointerInfo) => {
                 if (pointerInfo.type === PointerEventTypes.POINTERPICK && pointerInfo.pickInfo?.pickedMesh === mesh) {
                     this._execute(context);
@@ -53,13 +55,14 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
      * @internal
      */
     public _cancelPendingTasks(context: FlowGraphContext): void {
-        const mesh = context.getVariable(this._meshVariableName) as AbstractMesh;
+        const mesh = context._getExecutionVariable(this, "mesh");
         const pickObserver = context._getExecutionVariable(this, "meshPickObserver");
         const disposeObserver = context._getExecutionVariable(this, "meshDisposeObserver");
 
         mesh.getScene().onPointerObservable.remove(pickObserver);
         mesh.onDisposeObservable.remove(disposeObserver);
 
+        context._deleteExecutionVariable(this, "mesh");
         context._deleteExecutionVariable(this, "meshPickObserver");
         context._deleteExecutionVariable(this, "meshDisposeObserver");
     }

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
@@ -27,13 +27,16 @@ export class FlowGraphSetPropertyBlock<ValueT> extends FlowGraphWithOnDoneExecut
      * Input connection: The value to set on the property.
      */
     public readonly value: FlowGraphDataConnection<ValueT>;
+    /**
+     * Input connection: The template strings to substitute in the path.
+     */
     public readonly templateStringInputs: FlowGraphDataConnection<number>[] = [];
 
     public constructor(public config: IFlowGraphSetPropertyBlockConfiguration) {
         super(config);
 
         this.value = this._registerDataInput("value", RichTypeAny);
-        for (const templateString in config.path.templateSubstitutions) {
+        for (const templateString of config.path.getTemplateStrings()) {
             this.templateStringInputs.push(this._registerDataInput(templateString, RichTypeNumber));
         }
     }
@@ -42,7 +45,7 @@ export class FlowGraphSetPropertyBlock<ValueT> extends FlowGraphWithOnDoneExecut
         for (const templateStringInput of this.templateStringInputs) {
             const templateStringValue = templateStringInput.getValue(context);
             const templateString = templateStringInput.name;
-            this.config.path.addTemplateSubstitution(templateString, templateStringValue);
+            this.config.path.setTemplateSubstitution(templateString, templateStringValue);
         }
         const value = this.value.getValue(context);
         this.config.path.setProperty(context, value);

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
@@ -4,6 +4,7 @@ import type { FlowGraphDataConnection } from "../../flowGraphDataConnection";
 import { FlowGraphWithOnDoneExecutionBlock } from "../../flowGraphWithOnDoneExecutionBlock";
 import { RegisterClass } from "../../../Misc/typeStore";
 import type { IFlowGraphBlockConfiguration } from "../../flowGraphBlock";
+import type { FlowGraphPath } from "../../flowGraphPath";
 
 /**
  * @experimental
@@ -14,17 +15,7 @@ export interface IFlowGraphSetPropertyBlockConfiguration extends IFlowGraphBlock
      * The path of the entity whose property will be set. Needs a corresponding
      * entity on the context variables.
      */
-    path: string;
-    /**
-     * The property to set on the target object.
-     */
-    property: string;
-    /**
-     * A string that will be substituted by a node with the same name, if encountered enclosed by \{\}.
-     * It will create an input data node which expects a number. The value of the node will be used
-     * to substitute the string.
-     */
-    subString: string;
+    path: FlowGraphPath;
 }
 
 /**
@@ -36,35 +27,25 @@ export class FlowGraphSetPropertyBlock<ValueT> extends FlowGraphWithOnDoneExecut
      * Input connection: The value to set on the property.
      */
     public readonly value: FlowGraphDataConnection<ValueT>;
+    public readonly templateStringInputs: FlowGraphDataConnection<number>[] = [];
 
     public constructor(public config: IFlowGraphSetPropertyBlockConfiguration) {
         super(config);
 
         this.value = this._registerDataInput("value", RichTypeAny);
-        this._registerDataInput(config.subString, RichTypeNumber);
-    }
-
-    private _setProperty(target: any, property: string, value: any): void {
-        const splitProp = property.split(".");
-
-        let currentTarget = target;
-        for (let i = 0; i < splitProp.length - 1; i++) {
-            currentTarget = currentTarget[splitProp[i]];
+        for (const templateString in config.path.templateSubstitutions) {
+            this.templateStringInputs.push(this._registerDataInput(templateString, RichTypeNumber));
         }
-
-        currentTarget[splitProp[splitProp.length - 1]] = value;
     }
 
     public _execute(context: FlowGraphContext): void {
-        const target = context._getTargetFromPath(this.config.path, this.config.subString, this);
-        const property = this.config.property;
-        const value = this.value.getValue(context);
-
-        if (target && property) {
-            this._setProperty(target, property, value);
-        } else {
-            throw new Error("Invalid target or property");
+        for (const templateStringInput of this.templateStringInputs) {
+            const templateStringValue = templateStringInput.getValue(context);
+            const templateString = templateStringInput.name;
+            this.config.path.addTemplateSubstitution(templateString, templateStringValue);
         }
+        const value = this.value.getValue(context);
+        this.config.path.setProperty(value);
 
         this.onDone._activateSignal(context);
     }

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
@@ -45,7 +45,7 @@ export class FlowGraphSetPropertyBlock<ValueT> extends FlowGraphWithOnDoneExecut
             this.config.path.addTemplateSubstitution(templateString, templateStringValue);
         }
         const value = this.value.getValue(context);
-        this.config.path.setProperty(value);
+        this.config.path.setProperty(context, value);
 
         this.onDone._activateSignal(context);
     }

--- a/packages/dev/core/src/FlowGraph/flowGraphContext.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphContext.ts
@@ -44,11 +44,11 @@ export class FlowGraphContext {
     /**
      * These are the variables set by the blocks.
      */
-    private _executionVariables: Map<string, any> = new Map();
+    private _executionVariables: { [key: string]: any } = {};
     /**
      * These are the values for the data connection points
      */
-    private _connectionValues: Map<string, any> = new Map();
+    private _connectionValues: { [key: string]: any } = {};
     /**
      * These are the variables set by the graph.
      */
@@ -109,7 +109,7 @@ export class FlowGraphContext {
      * @param value
      */
     public _setExecutionVariable(block: FlowGraphBlock, name: string, value: any) {
-        this._executionVariables.set(this._getUniqueIdPrefixedName(block, name), value);
+        this._executionVariables[this._getUniqueIdPrefixedName(block, name)] = value;
     }
 
     /**
@@ -120,7 +120,7 @@ export class FlowGraphContext {
      */
     public _getExecutionVariable(block: FlowGraphBlock, name: string, defaultValue?: any): any {
         if (this._hasExecutionVariable(block, name)) {
-            return this._executionVariables.get(this._getUniqueIdPrefixedName(block, name));
+            return this._executionVariables[this._getUniqueIdPrefixedName(block, name)];
         } else {
             return defaultValue;
         }
@@ -133,7 +133,7 @@ export class FlowGraphContext {
      * @param name
      */
     public _deleteExecutionVariable(block: FlowGraphBlock, name: string) {
-        this._executionVariables.delete(this._getUniqueIdPrefixedName(block, name));
+        delete this._executionVariables[this._getUniqueIdPrefixedName(block, name)];
     }
 
     /**
@@ -144,7 +144,7 @@ export class FlowGraphContext {
      * @returns
      */
     public _hasExecutionVariable(block: FlowGraphBlock, name: string) {
-        return this._executionVariables.has(this._getUniqueIdPrefixedName(block, name));
+        return this._getUniqueIdPrefixedName(block, name) in this._executionVariables;
     }
 
     /**
@@ -154,7 +154,7 @@ export class FlowGraphContext {
      * @returns
      */
     public _hasConnectionValue(connectionPoint: FlowGraphDataConnection<any>) {
-        return this._connectionValues.has(connectionPoint.uniqueId);
+        return connectionPoint.uniqueId in this._connectionValues;
     }
 
     /**
@@ -164,7 +164,7 @@ export class FlowGraphContext {
      * @param value
      */
     public _setConnectionValue<T>(connectionPoint: FlowGraphDataConnection<T>, value: T) {
-        this._connectionValues.set(connectionPoint.uniqueId, value);
+        this._connectionValues[connectionPoint.uniqueId] = value;
     }
 
     /**
@@ -174,7 +174,7 @@ export class FlowGraphContext {
      * @returns
      */
     public _getConnectionValue<T>(connectionPoint: FlowGraphDataConnection<T>): T {
-        return this._connectionValues.get(connectionPoint.uniqueId);
+        return this._connectionValues[connectionPoint.uniqueId];
     }
 
     /**
@@ -254,9 +254,9 @@ export class FlowGraphContext {
             valueSerializationFunction(key, this._userVariables[key], serializationObject._userVariables);
         }
         serializationObject._connectionValues = {};
-        this._connectionValues.forEach((value, key) => {
-            valueSerializationFunction(key, value, serializationObject._connectionValues);
-        });
+        for (const key in this._connectionValues) {
+            valueSerializationFunction(key, this._connectionValues[key], serializationObject._connectionValues);
+        }
     }
 
     public getClassName() {
@@ -279,11 +279,11 @@ export class FlowGraphContext {
         result.uniqueId = serializationObject.uniqueId;
         for (const key in serializationObject._userVariables) {
             const value = valueParseFunction(key, serializationObject._userVariables, result._configuration.scene);
-            result._userVariables.set(key, value);
+            result._userVariables[key] = value;
         }
         for (const key in serializationObject._connectionValues) {
             const value = valueParseFunction(key, serializationObject._connectionValues, result._configuration.scene);
-            result._connectionValues.set(key, value);
+            result._connectionValues[key] = value;
         }
 
         return result;

--- a/packages/dev/core/src/FlowGraph/flowGraphPath.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPath.ts
@@ -5,7 +5,6 @@ const SEPARATORS = /\/|\./;
  * This class represents a path of type /x/{y}/z/.../w that is evaluated
  * on a target object. The string between curly braces ({y} in the example)
  * is a special template string that is replaced during runtime.
- * Possible issue: serializing this structure? it would have to serialize the target too
  */
 export class FlowGraphPath {
     private path: string;
@@ -19,6 +18,8 @@ export class FlowGraphPath {
         const templateStrings = this._getTemplateStringsInPath(path);
         this.hasTemplateStrings = templateStrings.length > 0;
         for (const templateString of templateStrings) {
+            // Part of the path enclosed in curly braces = template string, we'll set a default
+            // value on the template substitutions for now
             this.templateSubstitutions[templateString] = -1;
         }
     }
@@ -27,12 +28,10 @@ export class FlowGraphPath {
         return Object.keys(this.templateSubstitutions);
     }
 
-    _getTemplateStringsInPath(path: string): string[] {
+    private _getTemplateStringsInPath(path: string): string[] {
         const splitPath = path.split(SEPARATORS).filter((part) => part !== "");
         const templateStrings: string[] = [];
         for (const partPath of splitPath) {
-            // Part of the path enclosed in curly braces = template string, we'll set a default
-            // value on the template substitutions for now
             if (partPath.startsWith("{") && partPath.endsWith("}")) {
                 templateStrings.push(partPath.slice(1, partPath.length - 1));
             }
@@ -44,8 +43,8 @@ export class FlowGraphPath {
         this.templateSubstitutions[template] = value;
     }
 
-    _evaluateTemplates(): string {
-        let finalPath = this.path.slice(0); // copy the path so we don't replace on it?
+    private _evaluateTemplates(): string {
+        let finalPath = this.path.slice(0); // copy the path so we don't replace on it.
         for (const template in this.templateSubstitutions) {
             if (this.templateSubstitutions[template] === -1) {
                 throw new Error(`Template string ${template} has no value`);
@@ -55,7 +54,7 @@ export class FlowGraphPath {
         return finalPath;
     }
 
-    _evaluatePath(context: FlowGraphContext, setValue = false, value?: any): any {
+    private _evaluatePath(context: FlowGraphContext, setValue = false, value?: any): any {
         const finalPath = this._evaluateTemplates();
         const splitPath = finalPath.split(SEPARATORS).filter((part) => part !== "");
         let currentTarget = context._userVariables;
@@ -80,11 +79,4 @@ export class FlowGraphPath {
     setProperty(context: FlowGraphContext, value: any) {
         this._evaluatePath(context, true, value);
     }
-
-    // TODO: implement this, define the necessary parameters, etc.
-    animateProperty(animationParams: {}) {}
-
-    // TODO: implement this
-    // for this to work, the path should refer to an animation object.
-    startAnimation() {}
 }

--- a/packages/dev/core/src/FlowGraph/flowGraphPath.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPath.ts
@@ -1,3 +1,5 @@
+import type { FlowGraphContext } from "./flowGraphContext";
+
 /*
  * This class represents a path of type /x/{y}/z/.../w that is evaluated
  * on a target object. The string between curly braces ({y} in the example)
@@ -6,8 +8,6 @@
  */
 export class FlowGraphPath {
     path: string;
-    // todo: use context instead!
-    target: any; // target should be an object where the path is evaluated
     separator: string = "/"; // the separator between path parts
     templateSubstitutions: {
         [key: string]: any;
@@ -27,13 +27,13 @@ export class FlowGraphPath {
         return finalPath;
     }
 
-    _evaluatePath(setValue = false, value?: any): any {
+    _evaluatePath(context: FlowGraphContext, setValue = false, value?: any): any {
         const finalPath = this._evaluateTemplates();
         const splitPath = finalPath.split(this.separator).filter((part) => part !== "");
-        let currentTarget = this.target;
+        let currentTarget = context._userVariables;
         for (let i = 0; i < (setValue ? splitPath.length - 1 : splitPath.length); i++) {
             if (currentTarget === undefined) {
-                throw new Error(`Could not find path ${finalPath} in target object`);
+                throw new Error(`Could not find path ${finalPath} in target context`);
             }
             const pathPart = splitPath[i];
             currentTarget = currentTarget[pathPart];
@@ -45,12 +45,12 @@ export class FlowGraphPath {
         return currentTarget;
     }
 
-    getProperty(): any {
-        return this._evaluatePath();
+    getProperty(context: FlowGraphContext): any {
+        return this._evaluatePath(context);
     }
 
-    setProperty(value: any) {
-        this._evaluatePath(true, value);
+    setProperty(context: FlowGraphContext, value: any) {
+        this._evaluatePath(context, true, value);
     }
 
     animateProperty(animationParams: {}) {}

--- a/packages/dev/core/src/FlowGraph/flowGraphPath.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPath.ts
@@ -1,5 +1,6 @@
 import type { FlowGraphContext } from "./flowGraphContext";
 
+const SEPARATORS = /\/|\./;
 /*
  * This class represents a path of type /x/{y}/z/.../w that is evaluated
  * on a target object. The string between curly braces ({y} in the example)
@@ -7,29 +8,54 @@ import type { FlowGraphContext } from "./flowGraphContext";
  * Possible issue: serializing this structure? it would have to serialize the target too
  */
 export class FlowGraphPath {
-    path: string;
-    separator: string = "/"; // the separator between path parts
-    templateSubstitutions: {
-        [key: string]: any;
+    private path: string;
+    private templateSubstitutions: {
+        [key: string]: number;
     } = {}; // this is a map of template strings to values that are substituted during runtime
 
-    addTemplateSubstitution(template: string, value: any) {
+    constructor(path: string) {
+        this.path = path;
+        const templateStrings = this._getTemplateStringsInPath(path);
+        for (const templateString of templateStrings) {
+            this.templateSubstitutions[templateString] = -1;
+        }
+    }
+
+    getTemplateStrings(): string[] {
+        return Object.keys(this.templateSubstitutions);
+    }
+
+    _getTemplateStringsInPath(path: string): string[] {
+        const splitPath = path.split(SEPARATORS).filter((part) => part !== "");
+        const templateStrings: string[] = [];
+        for (const partPath of splitPath) {
+            // Part of the path enclosed in curly braces = template string, we'll set a default
+            // value on the template substitutions for now
+            if (partPath.startsWith("{") && partPath.endsWith("}")) {
+                templateStrings.push(partPath.slice(1, partPath.length - 1));
+            }
+        }
+        return templateStrings;
+    }
+
+    setTemplateSubstitution(template: string, value: number) {
         this.templateSubstitutions[template] = value;
     }
 
     _evaluateTemplates(): string {
         let finalPath = this.path.slice(0); // copy the path so we don't replace on it?
         for (const template in this.templateSubstitutions) {
-            finalPath = finalPath.replace(`{${template}}`, this.templateSubstitutions[template]);
+            if (this.templateSubstitutions[template] === -1) {
+                throw new Error(`Template string ${template} has no value`);
+            }
+            finalPath = finalPath.replace(`{${template}}`, this.templateSubstitutions[template].toString());
         }
-        // Should we check here if there is any unsubstituted template left and
-        // throw an error/return something?
         return finalPath;
     }
 
     _evaluatePath(context: FlowGraphContext, setValue = false, value?: any): any {
         const finalPath = this._evaluateTemplates();
-        const splitPath = finalPath.split(this.separator).filter((part) => part !== "");
+        const splitPath = finalPath.split(SEPARATORS).filter((part) => part !== "");
         let currentTarget = context._userVariables;
         for (let i = 0; i < (setValue ? splitPath.length - 1 : splitPath.length); i++) {
             if (currentTarget === undefined) {
@@ -53,10 +79,10 @@ export class FlowGraphPath {
         this._evaluatePath(context, true, value);
     }
 
+    // TODO: implement this, define the necessary parameters, etc.
     animateProperty(animationParams: {}) {}
 
-    startAnimation() {
-        // get gltf animation
-        // get the corresponding babylon animation
-    }
+    // TODO: implement this
+    // for this to work, the path should refer to an animation object.
+    startAnimation() {}
 }

--- a/packages/dev/core/src/FlowGraph/flowGraphPath.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPath.ts
@@ -12,10 +12,12 @@ export class FlowGraphPath {
     private templateSubstitutions: {
         [key: string]: number;
     } = {}; // this is a map of template strings to values that are substituted during runtime
+    public hasTemplateStrings: boolean = false;
 
     constructor(path: string) {
         this.path = path;
         const templateStrings = this._getTemplateStringsInPath(path);
+        this.hasTemplateStrings = templateStrings.length > 0;
         for (const templateString of templateStrings) {
             this.templateSubstitutions[templateString] = -1;
         }

--- a/packages/dev/core/src/FlowGraph/flowGraphPath.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPath.ts
@@ -1,0 +1,62 @@
+/*
+ * This class represents a path of type /x/{y}/z/.../w that is evaluated
+ * on a target object. The string between curly braces ({y} in the example)
+ * is a special template string that is replaced during runtime.
+ * Possible issue: serializing this structure? it would have to serialize the target too
+ */
+export class FlowGraphPath {
+    path: string;
+    // todo: use context instead!
+    target: any; // target should be an object where the path is evaluated
+    separator: string = "/"; // the separator between path parts
+    templateSubstitutions: {
+        [key: string]: any;
+    } = {}; // this is a map of template strings to values that are substituted during runtime
+
+    addTemplateSubstitution(template: string, value: any) {
+        this.templateSubstitutions[template] = value;
+    }
+
+    _evaluateTemplates(): string {
+        let finalPath = this.path.slice(0); // copy the path so we don't replace on it?
+        for (const template in this.templateSubstitutions) {
+            finalPath = finalPath.replace(`{${template}}`, this.templateSubstitutions[template]);
+        }
+        // Should we check here if there is any unsubstituted template left and
+        // throw an error/return something?
+        return finalPath;
+    }
+
+    _evaluatePath(setValue = false, value?: any): any {
+        const finalPath = this._evaluateTemplates();
+        const splitPath = finalPath.split(this.separator).filter((part) => part !== "");
+        let currentTarget = this.target;
+        for (let i = 0; i < (setValue ? splitPath.length - 1 : splitPath.length); i++) {
+            if (currentTarget === undefined) {
+                throw new Error(`Could not find path ${finalPath} in target object`);
+            }
+            const pathPart = splitPath[i];
+            currentTarget = currentTarget[pathPart];
+        }
+        if (setValue) {
+            currentTarget[splitPath[splitPath.length - 1]] = value;
+            currentTarget = value;
+        }
+        return currentTarget;
+    }
+
+    getProperty(): any {
+        return this._evaluatePath();
+    }
+
+    setProperty(value: any) {
+        this._evaluatePath(true, value);
+    }
+
+    animateProperty(animationParams: {}) {}
+
+    startAnimation() {
+        // get gltf animation
+        // get the corresponding babylon animation
+    }
+}

--- a/packages/dev/core/src/FlowGraph/index.ts
+++ b/packages/dev/core/src/FlowGraph/index.ts
@@ -7,5 +7,6 @@ export * from "./flowGraphRichTypes";
 export * from "./flowGraphContext";
 export * from "./flowGraphCoordinator";
 export * from "./flowGraphContextLogger";
+export * from "./flowGraphPath";
 // eslint-disable-next-line import/no-internal-modules
 export * from "./Blocks/index";

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
@@ -260,7 +260,7 @@ describe("Flow Graph Execution Nodes", () => {
 
         const path = new FlowGraphPath();
         path.path = "/{nodeIndex}/position";
-        path.target = {
+        flowGraphContext._userVariables = {
             0: mesh0,
             1: mesh1,
         };

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
@@ -258,19 +258,21 @@ describe("Flow Graph Execution Nodes", () => {
         const sceneReady = new FlowGraphSceneReadyEventBlock();
         flowGraph.addEventBlock(sceneReady);
 
-        const path = new FlowGraphPath();
-        path.path = "/{nodeIndex}/position";
+        const path = new FlowGraphPath("/{nodeIndex}/position");
         flowGraphContext._userVariables = {
             0: mesh0,
             1: mesh1,
         };
-        path.addTemplateSubstitution("nodeIndex", 0);
 
         const setProperty = new FlowGraphSetPropertyBlock<Vector3>({
             path,
         });
         sceneReady.onDone.connectTo(setProperty.onStart);
-        setProperty.getDataInput("nodeIndex")!.setValue(1, flowGraphContext);
+
+        const nodeIndexInput = setProperty.getDataInput("nodeIndex")!;
+        expect(nodeIndexInput).toBeDefined();
+
+        nodeIndexInput.setValue(1, flowGraphContext);
         setProperty.value.setValue(new Vector3(1, 2, 3), flowGraphContext);
 
         flowGraphContext.setVariable("myMesh0", mesh0);

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
@@ -258,25 +258,22 @@ describe("Flow Graph Execution Nodes", () => {
         const sceneReady = new FlowGraphSceneReadyEventBlock();
         flowGraph.addEventBlock(sceneReady);
 
-        const path = new FlowGraphPath("/{nodeIndex}/position");
         flowGraphContext._userVariables = {
             0: mesh0,
             1: mesh1,
         };
+        const path = new FlowGraphPath("/{nodeIndex}/position");
 
         const setProperty = new FlowGraphSetPropertyBlock<Vector3>({
             path,
         });
         sceneReady.onDone.connectTo(setProperty.onStart);
 
-        const nodeIndexInput = setProperty.getDataInput("nodeIndex")!;
+        const nodeIndexInput = setProperty.getDataInput("nodeIndex");
         expect(nodeIndexInput).toBeDefined();
 
-        nodeIndexInput.setValue(1, flowGraphContext);
+        nodeIndexInput!.setValue(1, flowGraphContext);
         setProperty.value.setValue(new Vector3(1, 2, 3), flowGraphContext);
-
-        flowGraphContext.setVariable("myMesh0", mesh0);
-        flowGraphContext.setVariable("myMesh1", mesh1);
 
         flowGraph.start();
 

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
@@ -9,6 +9,7 @@ import {
     FlowGraphForLoopBlock,
     FlowGraphLogBlock,
     FlowGraphMultiGateBlock,
+    FlowGraphPath,
     FlowGraphSceneReadyEventBlock,
     FlowGraphSceneTickEventBlock,
     FlowGraphSetPropertyBlock,
@@ -257,10 +258,16 @@ describe("Flow Graph Execution Nodes", () => {
         const sceneReady = new FlowGraphSceneReadyEventBlock();
         flowGraph.addEventBlock(sceneReady);
 
+        const path = new FlowGraphPath();
+        path.path = "/{nodeIndex}/position";
+        path.target = {
+            0: mesh0,
+            1: mesh1,
+        };
+        path.addTemplateSubstitution("nodeIndex", 0);
+
         const setProperty = new FlowGraphSetPropertyBlock<Vector3>({
-            path: "myMesh{nodeIndex}",
-            property: "position",
-            subString: "nodeIndex",
+            path,
         });
         sceneReady.onDone.connectTo(setProperty.onStart);
         setProperty.getDataInput("nodeIndex")!.setValue(1, flowGraphContext);

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
@@ -1,0 +1,35 @@
+import { FlowGraphPath } from "core/FlowGraph/flowGraphPath";
+
+describe("Flow Graph Utilities Test", () => {
+    it("Flow Graph Valid Path", () => {
+        const path = new FlowGraphPath();
+        path.path = "/x/{y}/z";
+        path.target = {
+            x: {
+                k: {
+                    z: 1,
+                },
+            },
+        };
+        path.addTemplateSubstitution("y", "k");
+
+        expect(path.getProperty()).toBe(1);
+
+        path.setProperty(2);
+        expect(path.getProperty()).toBe(2);
+    });
+
+    it("Flow Graph Invalid Path", () => {
+        const path = new FlowGraphPath();
+        path.path = "/a/b/c";
+        path.target = {
+            a: {
+                k: {
+                    c: 1,
+                },
+            },
+        };
+
+        expect(() => path.getProperty()).toThrow();
+    });
+});

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
@@ -18,22 +18,27 @@ describe("Flow Graph Utilities Test", () => {
     it("Flow Graph Valid Path", () => {
         context._userVariables = {
             x: {
-                k: {
+                1: {
                     z: 1,
                 },
             },
         };
 
-        const path = new FlowGraphPath();
-        path.path = "/x/{y}/z";
+        const path = new FlowGraphPath("/x/{y}/z");
 
-        path.addTemplateSubstitution("y", "k");
+        // We haven't specified what we want to substitute for y, so we can't evaluate the path
+        expect(() => path.getProperty(context)).toThrow();
+
+        path.setTemplateSubstitution("y", 1);
 
         expect(path.getProperty(context)).toBe(1);
 
         path.setProperty(context, 2);
-        expect(context._userVariables.x.k.z).toBe(2);
+        expect(context._userVariables.x[1].z).toBe(2);
         expect(path.getProperty(context)).toBe(2);
+
+        const path2 = new FlowGraphPath("/x/1.z"); // the path can also be separated by dots
+        expect(path2.getProperty(context)).toBe(2);
     });
 
     it("Flow Graph Invalid Path", () => {
@@ -45,8 +50,7 @@ describe("Flow Graph Utilities Test", () => {
             },
         };
 
-        const path = new FlowGraphPath();
-        path.path = "/a/b/c";
+        const path = new FlowGraphPath("/a/b/c");
 
         expect(() => path.getProperty(context)).toThrow();
     });

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphUtils.test.ts
@@ -1,28 +1,43 @@
+import { NullEngine } from "core/Engines";
+import { FlowGraphContext, FlowGraphCoordinator } from "core/FlowGraph";
 import { FlowGraphPath } from "core/FlowGraph/flowGraphPath";
+import { Scene } from "core/scene";
 
 describe("Flow Graph Utilities Test", () => {
+    let engine;
+    let scene: Scene;
+    let coordinator: FlowGraphCoordinator;
+    let context: FlowGraphContext;
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        coordinator = new FlowGraphCoordinator({ scene });
+        context = new FlowGraphContext({ scene, coordinator });
+    });
+
     it("Flow Graph Valid Path", () => {
-        const path = new FlowGraphPath();
-        path.path = "/x/{y}/z";
-        path.target = {
+        context._userVariables = {
             x: {
                 k: {
                     z: 1,
                 },
             },
         };
+
+        const path = new FlowGraphPath();
+        path.path = "/x/{y}/z";
+
         path.addTemplateSubstitution("y", "k");
 
-        expect(path.getProperty()).toBe(1);
+        expect(path.getProperty(context)).toBe(1);
 
-        path.setProperty(2);
-        expect(path.getProperty()).toBe(2);
+        path.setProperty(context, 2);
+        expect(context._userVariables.x.k.z).toBe(2);
+        expect(path.getProperty(context)).toBe(2);
     });
 
     it("Flow Graph Invalid Path", () => {
-        const path = new FlowGraphPath();
-        path.path = "/a/b/c";
-        path.target = {
+        context._userVariables = {
             a: {
                 k: {
                     c: 1,
@@ -30,6 +45,9 @@ describe("Flow Graph Utilities Test", () => {
             },
         };
 
-        expect(() => path.getProperty()).toThrow();
+        const path = new FlowGraphPath();
+        path.path = "/a/b/c";
+
+        expect(() => path.getProperty(context)).toThrow();
     });
 });


### PR DESCRIPTION
# Changes
A new class called `FlowGraphPath` was introduced. The intention behind this class is to serve as a generic implementation of the glTF Object Model (https://github.com/KhronosGroup/glTF/blob/d8c3ef5bd9e2054e2caff34c99103953aa29a610/specification/2.0/ObjectModel.adoc), as assets in the interactivity extension are referenced by this model. The path will be resolved against the user variables in the Flow Graph's context. For example, given a context with
```javascript
const context = new FlowGraphContext(...);
context._userVariables = {
 a: [ { b: 1 } ]
}
```

then, `a/0/b` would resolve to the value "1". The dot also works as an separator, so `a/0.b` should also resolve to "1".

It is also possible to perform runtime substitutions with numeric values on these paths. One example would be `a/{runTimeValue}/b`, where `runTimeValue` can be substituted for any number. The string "runTimeValue" is called a "template string", and nodes created with paths containing template strings will have an input connection for each of these values. A concrete example:

```javascript
const block = new FlowGraphSetPropertyBlock({path: new FlowGraphPath("/a/{runTimeValue}/b")});
block.getDataInput("runTimeValue").setValue(0, ... );
```
Then, at run-time, the value of the "runTimeValue" input would be evaluated, and the string `a/{runTimeValue}/b` resolved as `a/0/b`. Using template strings wouldn't make much sense in this example, as I could just have created the path with the final value I wanted, but if the "runTimeValue" input is connected to other data nodes, then we have the dynamic resolution of assets.

Besides the SetProperty block, other blocks that utilize paths are PlayAnimation and MeshPick. MeshPick is a little special because it is an Event Block - meaning it shouldn't depend on arbitrary input data to function (at least from my understanding - this can be discussed). In this case, it shouldn't receive paths with template strings.

---

Some additional changes that ended up being made: on the FlowGraphContext, I switched the `_userVariables`, `_executionVariables`, etc, i.e, the Map values, to be simple Records. The reason for that is just making the nested access in _userVariables easier, and the others were changed to keep the same style. It should have a bonus of not having any overhead from the Map class. 