### PR TITLE
GeometryBufferRenderer: Use bone texture if supported

### DIFF
--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -51,6 +51,7 @@ const uniforms = [
     "morphTargetInfluences",
     "morphTargetTextureInfo",
     "morphTargetTextureIndices",
+    "boneTextureWidth",
 ];
 addClipPlaneUniforms(uniforms);
 
@@ -570,7 +571,7 @@ export class GeometryBufferRenderer {
         }
 
         // Bones
-        if (mesh.useBones && mesh.computeBonesUsingShaders) {
+        if (mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
             attribs.push(VertexBuffer.MatricesIndicesKind);
             attribs.push(VertexBuffer.MatricesWeightsKind);
             if (mesh.numBoneInfluencers > 4) {
@@ -578,9 +579,12 @@ export class GeometryBufferRenderer {
                 attribs.push(VertexBuffer.MatricesWeightsExtraKind);
             }
             defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
-            defines.push("#define BonesPerMesh " + (mesh.skeleton ? mesh.skeleton.bones.length + 1 : 0));
+            defines.push("#define BONETEXTURE " + mesh.skeleton.isUsingTextureForMatrices);
+            defines.push("#define BonesPerMesh " + (mesh.skeleton.bones.length + 1));
         } else {
             defines.push("#define NUM_BONE_INFLUENCERS 0");
+            defines.push("#define BONETEXTURE false");
+            defines.push("#define BonesPerMesh 0");
         }
 
         // Morph targets
@@ -629,7 +633,7 @@ export class GeometryBufferRenderer {
                     {
                         attributes: attribs,
                         uniformsNames: uniforms,
-                        samplers: ["diffuseSampler", "bumpSampler", "reflectivitySampler", "albedoSampler", "morphTargets"],
+                        samplers: ["diffuseSampler", "bumpSampler", "reflectivitySampler", "albedoSampler", "morphTargets", "boneSampler"],
                         defines: join,
                         onCompiled: null,
                         fallbacks: null,
@@ -950,7 +954,16 @@ export class GeometryBufferRenderer {
 
                 // Bones
                 if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {
-                    effect.setMatrices("mBones", renderingMesh.skeleton.getTransformMatrices(renderingMesh));
+                    const skeleton = renderingMesh.skeleton;
+
+                    if (skeleton.isUsingTextureForMatrices && effect.getUniformIndex("boneTextureWidth") > -1) {
+                        const boneTexture = skeleton.getTransformMatrixTexture(renderingMesh);
+                        effect.setTexture("boneSampler", boneTexture);
+                        effect.setFloat("boneTextureWidth", 4.0 * (skeleton.bones.length + 1));
+                    } else {
+                        effect.setMatrices("mBones", renderingMesh.skeleton.getTransformMatrices(renderingMesh));
+                    }
+
                     if (this._enableVelocity) {
                         effect.setMatrices("mPreviousBones", this._previousBonesTransformationMatrices[renderingMesh.uniqueId]);
                     }

--- a/packages/dev/core/src/Shaders/ShadersInclude/bonesDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/bonesDeclaration.fx
@@ -12,9 +12,10 @@
             uniform float boneTextureWidth;
         #else
             uniform mat4 mBones[BonesPerMesh];
-            #ifdef BONES_VELOCITY_ENABLED
-                uniform mat4 mPreviousBones[BonesPerMesh];
-            #endif
+        #endif
+
+        #ifdef BONES_VELOCITY_ENABLED
+            uniform mat4 mPreviousBones[BonesPerMesh];
         #endif
 
         #ifdef BONETEXTURE


### PR DESCRIPTION
See https://forum.babylonjs.com/t/error-on-new-ssrrenderingpipeline/41812/16

We used uniforms even when bone texture was supported because of the velocity target (which only supports passing previous bone data through uniforms). The PR let use bone texture for the model while still using uniforms for previous bone data.