### PR TITLE
Better handling of StackPanel layout warning

### DIFF
--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -619,6 +619,30 @@ export class Container extends Control {
         this._measureForChildren.copyFrom(this._currentMeasure);
     }
 
+    public isWidthFullyDefined(): boolean {
+        if (this.adaptWidthToChildren) {
+            for (const child of this.children) {
+                if (!child.isWidthFullyDefined()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return super.isWidthFullyDefined();
+    }
+
+    public isHeightFullyDefined(): boolean {
+        if (this.adaptHeightToChildren) {
+            for (const child of this.children) {
+                if (!child.isHeightFullyDefined()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return super.isHeightFullyDefined();
+    }
+
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -37,6 +37,8 @@ export class Container extends Control {
     protected _renderToIntermediateTexture: boolean = false;
     /** @internal */
     protected _intermediateTexture: Nullable<DynamicTexture> = null;
+    protected _cachedIsWidthFullyDefined?: boolean;
+    protected _cachedIsHeightFullyDefined?: boolean;
 
     /** Gets or sets boolean indicating if children should be rendered to an intermediate texture rather than directly to host, useful for alpha blending */
     @serialize()
@@ -620,27 +622,39 @@ export class Container extends Control {
     }
 
     public isWidthFullyDefined(): boolean {
+        if (!this._isDirty && this._cachedIsWidthFullyDefined !== undefined) {
+            return this._cachedIsWidthFullyDefined;
+        }
         if (this.adaptWidthToChildren) {
             for (const child of this.children) {
                 if (!child.isWidthFullyDefined()) {
+                    this._cachedIsWidthFullyDefined = false;
                     return false;
                 }
             }
+            this._cachedIsWidthFullyDefined = true;
             return true;
         }
-        return super.isWidthFullyDefined();
+        this._cachedIsWidthFullyDefined = super.isWidthFullyDefined();
+        return this._cachedIsWidthFullyDefined;
     }
 
     public isHeightFullyDefined(): boolean {
+        if (!this._isDirty && this._cachedIsHeightFullyDefined !== undefined) {
+            return this._cachedIsHeightFullyDefined;
+        }
         if (this.adaptHeightToChildren) {
             for (const child of this.children) {
                 if (!child.isHeightFullyDefined()) {
+                    this._cachedIsHeightFullyDefined = false;
                     return false;
                 }
             }
+            this._cachedIsHeightFullyDefined = true;
             return true;
         }
-        return super.isHeightFullyDefined();
+        this._cachedIsHeightFullyDefined = super.isHeightFullyDefined();
+        return this._cachedIsHeightFullyDefined;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -619,11 +619,6 @@ export class Container extends Control {
         this._measureForChildren.copyFrom(this._currentMeasure);
     }
 
-    protected _cacheFullyDefinedDim: { width?: boolean; height?: boolean } = {
-        width: undefined,
-        height: undefined,
-    };
-
     protected _getAdaptDimTo(dim: "width" | "height"): boolean {
         if (dim === "width") {
             return this.adaptWidthToChildren;
@@ -633,22 +628,15 @@ export class Container extends Control {
     }
 
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
-        const hasChildDirty = this.children.some((c) => c.isDirty);
-        if (!hasChildDirty && !this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
-            return this._cacheFullyDefinedDim[dim]!;
-        }
         if (this._getAdaptDimTo(dim)) {
             for (const child of this.children) {
                 if (!child.isDimensionFullyDefined(dim)) {
-                    this._cacheFullyDefinedDim[dim] = false;
                     return false;
                 }
             }
-            this._cacheFullyDefinedDim[dim] = true;
             return true;
         }
-        this._cacheFullyDefinedDim[dim] = super.isDimensionFullyDefined(dim);
-        return this._cacheFullyDefinedDim[dim]!;
+        return super.isDimensionFullyDefined(dim);
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -633,7 +633,8 @@ export class Container extends Control {
     }
 
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
-        if (!this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
+        const hasChildDirty = this.children.some((c) => c.isDirty);
+        if (!hasChildDirty && !this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
             return this._cacheFullyDefinedDim[dim]!;
         }
         if (this._getAdaptDimTo(dim)) {

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2425,6 +2425,22 @@ export class Control implements IAnimatable {
     }
 
     /**
+     * A fully defined width means that it is possible to know what size it will occupy
+     * by querying only it and its children, and not its parent.
+     */
+    public isWidthFullyDefined(): boolean {
+        return this._width.isPixel;
+    }
+
+    /**
+     * A fully defined height means that it is possible to know what size it will occupy
+     * by querying only it and its children, and not its parent.
+     */
+    public isHeightFullyDefined(): boolean {
+        return this._height.isPixel;
+    }
+
+    /**
      * Clones a control and its descendants
      * @param host the texture where the control will be instantiated. Can be empty, in which case the control will be created on the same texture
      * @returns the cloned control

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2424,20 +2424,16 @@ export class Control implements IAnimatable {
         this.getDescendants().forEach((child) => child._markAllAsDirty());
     }
 
-    /**
-     * A fully defined width means that it is possible to know what size it will occupy
-     * by querying only it and its children, and not its parent.
-     */
-    public isWidthFullyDefined(): boolean {
-        return this._width.isPixel;
+    public isDimensionFullyDefined(dim: "width" | "height"): boolean {
+        return this.getDimension(dim).isPixel;
     }
 
-    /**
-     * A fully defined height means that it is possible to know what size it will occupy
-     * by querying only it and its children, and not its parent.
-     */
-    public isHeightFullyDefined(): boolean {
-        return this._height.isPixel;
+    public getDimension(dim: "width" | "height"): ValueAndUnit {
+        if (dim === "width") {
+            return this._width;
+        } else {
+            return this._height;
+        }
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2424,10 +2424,21 @@ export class Control implements IAnimatable {
         this.getDescendants().forEach((child) => child._markAllAsDirty());
     }
 
+    /**
+     * A control has a dimension fully defined if that dimension doesn't depend on the parent's dimension.
+     * As an example, a control that has dimensions in pixels is fully defined, while in percentage is not fully defined.
+     * @param dim the dimension to check (width or height)
+     * @returns if the dimension is fully defined
+     */
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
         return this.getDimension(dim).isPixel;
     }
 
+    /**
+     * Gets the dimension of the control along a specified axis
+     * @param dim the dimension to retrieve (width or height)
+     * @returns the dimension value along the specified axis
+     */
     public getDimension(dim: "width" | "height"): ValueAndUnit {
         if (dim === "width") {
             return this._width;

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -1,5 +1,3 @@
-import { Tools } from "core/Misc/tools";
-
 import { Container } from "./container";
 import type { Measure } from "../measure";
 import { Control } from "./control";
@@ -7,6 +5,7 @@ import { RegisterClass } from "core/Misc/typeStore";
 import { serialize } from "core/Misc/decorators";
 import type { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import type { ICanvasRenderingContext } from "core/Engines/ICanvas";
+import { Logger } from "core/Misc/logger";
 
 /**
  * Class used to create a 2D stack panel container
@@ -164,7 +163,7 @@ export class StackPanel extends Container {
                 }
 
                 if (!this.ignoreLayoutWarnings && !child.isDimensionFullyDefined("height")) {
-                    Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
+                    Logger.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`, 1);
                 } else {
                     stackHeight += child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }
@@ -176,7 +175,7 @@ export class StackPanel extends Container {
                 }
 
                 if (!this.ignoreLayoutWarnings && !child.isDimensionFullyDefined("width")) {
-                    Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
+                    Logger.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`, 1);
                 } else {
                     stackWidth += child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -232,24 +232,16 @@ export class StackPanel extends Container {
     }
 
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
-        const hasChildDirty = this._children.some((c) => c.isDirty);
-        if (!hasChildDirty && !this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
-            return this._cacheFullyDefinedDim[dim]!;
-        }
-
         if (dim === "height" ? this.isVertical : !this.isVertical && !this._getManualDim(dim)) {
             for (const child of this._children) {
                 if (!child.isDimensionFullyDefined(dim)) {
-                    this._cacheFullyDefinedDim[dim] = false;
                     return false;
                 }
             }
-            this._cacheFullyDefinedDim[dim] = true;
             return true;
         }
 
-        this._cacheFullyDefinedDim[dim] = this.getDimension(dim).isPixel || this._getAdaptDimTo(dim);
-        return this._cacheFullyDefinedDim[dim]!;
+        return this.getDimension(dim).isPixel || this._getAdaptDimTo(dim);
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -225,27 +225,39 @@ export class StackPanel extends Container {
     }
 
     public isWidthFullyDefined(): boolean {
+        if (!this._isDirty && this._cachedIsWidthFullyDefined !== undefined) {
+            return this._cachedIsWidthFullyDefined;
+        }
         if (!this.isVertical && !this._manualWidth) {
             for (const child of this._children) {
                 if (!child.isWidthFullyDefined()) {
+                    this._cachedIsWidthFullyDefined = false;
                     return false;
                 }
             }
+            this._cachedIsWidthFullyDefined = true;
             return true;
         }
-        return this._width.isPixel || this.adaptWidthToChildren;
+        this._cachedIsWidthFullyDefined = this._width.isPixel || this.adaptWidthToChildren;
+        return this._cachedIsWidthFullyDefined;
     }
 
     public isHeightFullyDefined(): boolean {
+        if (!this._isDirty && this._cachedIsHeightFullyDefined !== undefined) {
+            return this._cachedIsHeightFullyDefined;
+        }
         if (this.isVertical && !this._manualHeight) {
             for (const child of this._children) {
                 if (!child.isHeightFullyDefined()) {
+                    this._cachedIsHeightFullyDefined = false;
                     return false;
                 }
             }
+            this._cachedIsHeightFullyDefined = true;
             return true;
         }
-        return this._height.isPixel || this.adaptHeightToChildren;
+        this._cachedIsHeightFullyDefined = this._height.isPixel || this.adaptHeightToChildren;
+        return this._cachedIsHeightFullyDefined;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -165,10 +165,8 @@ export class StackPanel extends Container {
                     child._top.ignoreAdaptiveScaling = true;
                 }
 
-                if (child._height.isPercentage && !child._automaticSize && !(child as TextBlock).resizeToFit && !(child as Container).adaptHeightToChildren) {
-                    if (!this.ignoreLayoutWarnings) {
-                        Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
-                    }
+                if (!this.isHeightFullyDefined() && !this.ignoreLayoutWarnings) {
+                    Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                 } else {
                     stackHeight += child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }
@@ -179,16 +177,8 @@ export class StackPanel extends Container {
                     child._left.ignoreAdaptiveScaling = true;
                 }
 
-                if (
-                    child._width.isPercentage &&
-                    !child._automaticSize &&
-                    child.getClassName() === "TextBlock" &&
-                    (child as TextBlock).textWrapping !== TextWrapping.Clip &&
-                    !(child as TextBlock).forceResizeWidth
-                ) {
-                    if (!this.ignoreLayoutWarnings) {
-                        Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
-                    }
+                if (!this.isWidthFullyDefined() && !this.ignoreLayoutWarnings) {
+                    Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                 } else {
                     stackWidth += child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels + (index < childrenCount - 1 ? this._spacing : 0);
                 }
@@ -234,6 +224,30 @@ export class StackPanel extends Container {
         }
 
         super._postMeasure();
+    }
+
+    public isWidthFullyDefined(): boolean {
+        if (!this.isVertical && !this._manualWidth) {
+            for (const child of this._children) {
+                if (!child.isWidthFullyDefined()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return this._width.isPixel;
+    }
+
+    public isHeightFullyDefined(): boolean {
+        if (this.isVertical && !this._manualHeight) {
+            for (const child of this._children) {
+                if (!child.isHeightFullyDefined()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return this._height.isPixel;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -163,7 +163,7 @@ export class StackPanel extends Container {
                     child._top.ignoreAdaptiveScaling = true;
                 }
 
-                if (!child.isDimensionFullyDefined("height") && !this.ignoreLayoutWarnings) {
+                if (!this.ignoreLayoutWarnings && !child.isDimensionFullyDefined("height")) {
                     Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                 } else {
                     stackHeight += child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels + (index < childrenCount - 1 ? this._spacing : 0);
@@ -175,7 +175,7 @@ export class StackPanel extends Container {
                     child._left.ignoreAdaptiveScaling = true;
                 }
 
-                if (!child.isDimensionFullyDefined("width") && !this.ignoreLayoutWarnings) {
+                if (!this.ignoreLayoutWarnings && !child.isDimensionFullyDefined("width")) {
                     Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                 } else {
                     stackWidth += child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels + (index < childrenCount - 1 ? this._spacing : 0);
@@ -233,7 +233,8 @@ export class StackPanel extends Container {
     }
 
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
-        if (this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
+        const hasChildDirty = this._children.some((c) => c.isDirty);
+        if (!hasChildDirty && !this._isDirty && this._cacheFullyDefinedDim[dim] !== undefined) {
             return this._cacheFullyDefinedDim[dim]!;
         }
 

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -163,7 +163,7 @@ export class StackPanel extends Container {
                     child._top.ignoreAdaptiveScaling = true;
                 }
 
-                if (!this.isHeightFullyDefined() && !this.ignoreLayoutWarnings) {
+                if (!child.isHeightFullyDefined() && !this.ignoreLayoutWarnings) {
                     Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using height in percentage mode inside a vertical StackPanel`);
                 } else {
                     stackHeight += child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels + (index < childrenCount - 1 ? this._spacing : 0);
@@ -175,7 +175,7 @@ export class StackPanel extends Container {
                     child._left.ignoreAdaptiveScaling = true;
                 }
 
-                if (!this.isWidthFullyDefined() && !this.ignoreLayoutWarnings) {
+                if (!child.isWidthFullyDefined() && !this.ignoreLayoutWarnings) {
                     Tools.Warn(`Control (Name:${child.name}, UniqueId:${child.uniqueId}) is using width in percentage mode inside a horizontal StackPanel`);
                 } else {
                     stackWidth += child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels + (index < childrenCount - 1 ? this._spacing : 0);

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -7,8 +7,6 @@ import { RegisterClass } from "core/Misc/typeStore";
 import { serialize } from "core/Misc/decorators";
 import type { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import type { ICanvasRenderingContext } from "core/Engines/ICanvas";
-import type { TextBlock } from "./textBlock";
-import { TextWrapping } from "./textBlock";
 
 /**
  * Class used to create a 2D stack panel container
@@ -235,7 +233,7 @@ export class StackPanel extends Container {
             }
             return true;
         }
-        return this._width.isPixel;
+        return this._width.isPixel || this.adaptWidthToChildren;
     }
 
     public isHeightFullyDefined(): boolean {
@@ -247,7 +245,7 @@ export class StackPanel extends Container {
             }
             return true;
         }
-        return this._height.isPixel;
+        return this._height.isPixel || this.adaptHeightToChildren;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -646,6 +646,20 @@ export class TextBlock extends Control {
         return newHeight;
     }
 
+    public isWidthFullyDefined(): boolean {
+        if (this.resizeToFit) {
+            return true;
+        }
+        return super.isWidthFullyDefined();
+    }
+
+    public isHeightFullyDefined(): boolean {
+        if (this.resizeToFit) {
+            return true;
+        }
+        return super.isHeightFullyDefined();
+    }
+
     /**
      * Given a width constraint applied on the text block, find the expected height
      * @returns expected height

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -646,18 +646,11 @@ export class TextBlock extends Control {
         return newHeight;
     }
 
-    public isWidthFullyDefined(): boolean {
+    public isDimensionFullyDefined(dim: "width" | "height"): boolean {
         if (this.resizeToFit) {
             return true;
         }
-        return super.isWidthFullyDefined();
-    }
-
-    public isHeightFullyDefined(): boolean {
-        if (this.resizeToFit) {
-            return true;
-        }
-        return super.isHeightFullyDefined();
+        return super.isDimensionFullyDefined(dim);
     }
 
     /**


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/control-is-using-height-in-percentage-mode-inside-a-vertical-stackpanel-warnings-after-update-to-6-25-0/45071

This PR tries to make more consistent the handling of cases where to display a warning about sizes inside a StackPanel. The main reason this warning should be displayed is in cases where it is not possible to determine the sizes of all controls inside the StackPanel by using just the controls themselves and their children. I'm calling "fully defined" the width/height of controls that can be determined using just the size of the control and its children - i.e, the control doesn't depend on its parent for sizing. A regular Control would be fully defined if its size is expressed in pixels instead of percentage. And a Container control would be fully defined if it has `adaptWidth/HeightToChildren` set to true and all its children are fully defined. For a StackPanel, we want its width (in horizontal mode) or height (in vertical mode) to be fully defined, because they adapt to their children. So we display the warning when the corresponding dimension is not fully defined. I didn't reword the warning itself because I couldn't think of a better phrasing, but it might be good to change the phrasing too.