### PR TITLE
Mesh: Add a setIndexBuffer method

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -54,6 +54,7 @@ export class Geometry implements IGetSetVerticesData {
     private _engine: Engine;
     private _meshes: Mesh[];
     private _totalVertices = 0;
+    private _totalIndices?: number;
     /** @internal */
     public _loadedUniqueId: string;
     /** @internal */
@@ -551,6 +552,29 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /**
+     * Sets the index buffer for this geometry.
+     * @param indexBuffer Defines the index buffer to use for this geometry
+     * @param totalVertices Defines the total number of vertices used by the buffer
+     * @param totalIndices Defines the total number of indices in the index buffer
+     */
+    public setIndexBuffer(indexBuffer: DataBuffer, totalVertices: number, totalIndices: number): void {
+        this._indices = [];
+        this._indexBufferIsUpdatable = false;
+        this._indexBuffer = indexBuffer;
+        this._totalVertices = totalVertices;
+        this._totalIndices = totalIndices;
+
+        indexBuffer.is32Bits = this._totalIndices > 65535;
+
+        for (const mesh of this._meshes) {
+            mesh._createGlobalSubMesh(true);
+            mesh.synchronizeInstances();
+        }
+
+        this._notifyUpdate();
+    }
+
+    /**
      * Creates a new index buffer
      * @param indices defines the indices to store in the index buffer
      * @param totalVertices defines the total number of vertices (could be null)
@@ -588,7 +612,7 @@ export class Geometry implements IGetSetVerticesData {
         if (!this.isReady()) {
             return 0;
         }
-        return this._indices.length;
+        return this._totalIndices !== undefined ? this._totalIndices : this._indices.length;
     }
 
     /**

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -564,7 +564,7 @@ export class Geometry implements IGetSetVerticesData {
         this._totalVertices = totalVertices;
         this._totalIndices = totalIndices;
 
-        indexBuffer.is32Bits = this._totalIndices > 65535;
+        indexBuffer.is32Bits ||= this._totalIndices > 65535;
 
         for (const mesh of this._meshes) {
             mesh._createGlobalSubMesh(true);

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -555,31 +555,16 @@ export class Geometry implements IGetSetVerticesData {
      * Sets the index buffer for this geometry.
      * @param indexBuffer Defines the index buffer to use for this geometry
      * @param totalVertices Defines the total number of vertices used by the buffer
-     * @param indicesArrayOrTotalIndices Defines the content of the index buffer OR the total number of indices in the index buffer
-     * @param updatable defines if the index buffer must be flagged as updatable (false by default)
+     * @param totalIndices Defines the total number of indices in the index buffer
      */
-    public setIndexBuffer(indexBuffer: Nullable<DataBuffer>, totalVertices: Nullable<number>, indicesArrayOrTotalIndices: number | IndicesArray, updatable: boolean = false): void {
-        if (typeof indicesArrayOrTotalIndices === "number") {
-            this._indices = [];
-            this._totalIndices = indicesArrayOrTotalIndices;
+    public setIndexBuffer(indexBuffer: DataBuffer, totalVertices: number, totalIndices: number): void {
+        this._indices = [];
+        this._indexBufferIsUpdatable = false;
+        this._indexBuffer = indexBuffer;
+        this._totalVertices = totalVertices;
+        this._totalIndices = totalIndices;
 
-            if (indexBuffer) {
-                indexBuffer.is32Bits ||= this._totalIndices > 65535;
-            }
-        } else {
-            this._indices = indicesArrayOrTotalIndices;
-            this._totalIndices = undefined;
-        }
-
-        this._indexBufferIsUpdatable = updatable;
-
-        if (indexBuffer) {
-            this._indexBuffer = indexBuffer;
-        }
-
-        if (totalVertices != undefined) {
-            this._totalVertices = totalVertices;
-        }
+        indexBuffer.is32Bits = this._totalIndices > 65535;
 
         for (const mesh of this._meshes) {
             mesh._createGlobalSubMesh(true);
@@ -600,12 +585,23 @@ export class Geometry implements IGetSetVerticesData {
             this._engine._releaseBuffer(this._indexBuffer);
         }
 
-        let indexBuffer: Nullable<DataBuffer> = null;
+        this._indices = indices;
+        this._indexBufferIsUpdatable = updatable;
         if (this._meshes.length !== 0 && this._indices) {
-            indexBuffer = this._engine.createIndexBuffer(this._indices, updatable);
+            this._indexBuffer = this._engine.createIndexBuffer(this._indices, updatable);
         }
 
-        this.setIndexBuffer(indexBuffer, totalVertices, indices, updatable);
+        if (totalVertices != undefined) {
+            // including null and undefined
+            this._totalVertices = totalVertices;
+        }
+
+        for (const mesh of this._meshes) {
+            mesh._createGlobalSubMesh(true);
+            mesh.synchronizeInstances();
+        }
+
+        this._notifyUpdate();
     }
 
     /**

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -48,6 +48,7 @@ import type { IPhysicsEnabledObject, PhysicsImpostor } from "../Physics/v1/physi
 import type { ICreateCapsuleOptions } from "./Builders/capsuleBuilder";
 import type { LinesMesh } from "./linesMesh";
 import type { GroundMesh } from "./groundMesh";
+import type { DataBuffer } from "core/Buffers/dataBuffer";
 
 /**
  * @internal
@@ -1681,6 +1682,20 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         oldGeometry.releaseForMesh(this, true);
         geometry.applyToMesh(this);
         return this;
+    }
+
+    /**
+     * Sets the index buffer of this mesh.
+     * @param indexBuffer Defines the index buffer to use for this mesh
+     * @param totalVertices Defines the total number of vertices used by the buffer
+     * @param totalIndices Defines the total number of indices in the index buffer
+     */
+    public setIndexBuffer(indexBuffer: DataBuffer, totalVertices: number, totalIndices: number): void {
+        let geometry = this._geometry;
+        if (!geometry) {
+            geometry = new Geometry(Geometry.RandomId(), this.getScene(), undefined, undefined, this);
+        }
+        geometry.setIndexBuffer(indexBuffer, totalVertices, totalIndices);
     }
 
     /**


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-to-keep-buffers-on-the-gpu-when-using-compute-shaders-for-instancing-or-vertex-data-generation/45951/6