### PR TITLE
Fix Matrix getRowToRef function

### DIFF
--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -5974,7 +5974,7 @@ export class Matrix {
      * @returns result input
      */
     public getRowToRef<T extends Vector4>(index: number, rowVector: T): T {
-        if (index >= 0 && index < 3) {
+        if (index >= 0 && index <= 3) {
             const i = index * 4;
             rowVector.x = this._m[i + 0];
             rowVector.y = this._m[i + 1];


### PR DESCRIPTION
https://forum.babylonjs.com/t/matrix-getrowtoref-incorrectly-handles-4th-row/45995/2