### PR TITLE
Fix incorrect range check when reading glTF buffer

### DIFF
--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -48,8 +48,12 @@ function readAsync(arrayBuffer: ArrayBuffer, byteOffset: number, byteLength: num
 
 function readViewAsync(arrayBufferView: ArrayBufferView, byteOffset: number, byteLength: number): Promise<Uint8Array> {
     try {
-        if (arrayBufferView.byteOffset + byteOffset + byteLength > arrayBufferView.buffer.byteLength) {
-            throw new Error("Array length out of bounds.");
+        if (byteOffset < 0 || byteOffset >= arrayBufferView.byteLength) {
+            throw new RangeError("Offset is out of range.");
+        }
+
+        if (byteOffset + byteLength > arrayBufferView.byteLength) {
+            throw new RangeError("Length is out of range.");
         }
 
         return Promise.resolve(new Uint8Array(arrayBufferView.buffer, arrayBufferView.byteOffset + byteOffset, byteLength));
@@ -669,10 +673,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
         );
     }
 
-    /**
-     * @internal
-     */
-    _loadBinary(
+    private _loadBinary(
         scene: Scene,
         data: ArrayBufferView,
         rootUrl: string,


### PR DESCRIPTION
This is a follow up to #14540 which still has an incorrect range check. The intention of the `readViewAsync` checks is to make sure the arguments fit within the given array buffer view.

I've tested against the PG from [the forum issue](https://forum.babylonjs.com/t/gltffileloader-array-length-out-of-bounds/45849) to make sure it still works.