### PR TITLE
Fix Add Color Uniform of CustomMaterial & PBRCustomMaterial

### DIFF
--- a/packages/dev/materials/src/custom/customMaterial.ts
+++ b/packages/dev/materials/src/custom/customMaterial.ts
@@ -6,6 +6,7 @@ import { StandardMaterial } from "core/Materials/standardMaterial";
 import type { Mesh } from "core/Meshes/mesh";
 import type { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { Color3, Color4 } from "core/Maths/math.color";
 
 export class CustomShaderStructure {
     public FragmentStore: string;
@@ -71,8 +72,17 @@ export class CustomMaterial extends StandardMaterial {
                 if (ea[0] == "vec2") {
                     effect.setVector2(ea[1], this._newUniformInstances[el]);
                 } else if (ea[0] == "vec3") {
-                    effect.setVector3(ea[1], this._newUniformInstances[el]);
+                    if (this._newUniformInstances[el] instanceof Color3) {
+                        effect.setColor3(ea[1], this._newUniformInstances[el]);
+                    } else {
+                        effect.setVector3(ea[1], this._newUniformInstances[el]);
+                    }
                 } else if (ea[0] == "vec4") {
+                    if (this._newUniformInstances[el] instanceof Color4) {
+                        effect.setDirectColor4(ea[1], this._newUniformInstances[el]);
+                    } else {
+                        effect.setVector4(ea[1], this._newUniformInstances[el]);
+                    }
                     effect.setVector4(ea[1], this._newUniformInstances[el]);
                 } else if (ea[0] == "mat4") {
                     effect.setMatrix(ea[1], this._newUniformInstances[el]);

--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -8,6 +8,7 @@ import type { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
 import { ShaderCodeInliner } from "core/Engines/Processors/shaderCodeInliner";
 import type { ICustomShaderNameResolveOptions } from "core/Materials/material";
+import { Color3, Color4 } from "core/Maths/math.color";
 
 export class ShaderAlbedoParts {
     constructor() {}
@@ -77,8 +78,17 @@ export class PBRCustomMaterial extends PBRMaterial {
                 if (ea[0] == "vec2") {
                     effect.setVector2(ea[1], this._newUniformInstances[el]);
                 } else if (ea[0] == "vec3") {
-                    effect.setVector3(ea[1], this._newUniformInstances[el]);
+                    if (this._newUniformInstances[el] instanceof Color3) {
+                        effect.setColor3(ea[1], this._newUniformInstances[el]);
+                    } else {
+                        effect.setVector3(ea[1], this._newUniformInstances[el]);
+                    }
                 } else if (ea[0] == "vec4") {
+                    if (this._newUniformInstances[el] instanceof Color4) {
+                        effect.setDirectColor4(ea[1], this._newUniformInstances[el]);
+                    } else {
+                        effect.setVector4(ea[1], this._newUniformInstances[el]);
+                    }
                     effect.setVector4(ea[1], this._newUniformInstances[el]);
                 } else if (ea[0] == "mat4") {
                     effect.setMatrix(ea[1], this._newUniformInstances[el]);


### PR DESCRIPTION
In CustomMaterial & PBRCustomMaterial,  `AddUniform` can not pass color value to shader.

https://www.babylonjs-playground.com/#9ZQL2G can reproduce the bug.

