### PR TITLE
Fix for animations with relative loop mode.

### DIFF
--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -2,8 +2,7 @@ import type { IEasingFunction, EasingFunction } from "./easing";
 import { Vector3, Quaternion, Vector2, Matrix, TmpVectors } from "../Maths/math.vector";
 import { Color3, Color4 } from "../Maths/math.color";
 import { Scalar } from "../Maths/math.scalar";
-
-import type { Nullable } from "../types";
+import type { DeepImmutable, Nullable } from "../types";
 import type { Scene } from "../scene";
 import { SerializationHelper } from "../Misc/decorators";
 import { RegisterClass } from "../Misc/typeStore";
@@ -16,9 +15,28 @@ import type { IAnimatable } from "./animatable.interface";
 import { Size } from "../Maths/math.size";
 import { WebRequest } from "../Misc/webRequest";
 import { Constants } from "../Engines/constants";
-
 import type { Animatable } from "./animatable";
 import type { RuntimeAnimation } from "./runtimeAnimation";
+
+// Static values to help the garbage collector
+
+// Quaternion
+export const _staticOffsetValueQuaternion: DeepImmutable<Quaternion> = Object.freeze(new Quaternion(0, 0, 0, 0));
+
+// Vector3
+export const _staticOffsetValueVector3: DeepImmutable<Vector3> = Object.freeze(Vector3.Zero());
+
+// Vector2
+export const _staticOffsetValueVector2: DeepImmutable<Vector2> = Object.freeze(Vector2.Zero());
+
+// Size
+export const _staticOffsetValueSize: DeepImmutable<Size> = Object.freeze(Size.Zero());
+
+// Color3
+export const _staticOffsetValueColor3: DeepImmutable<Color3> = Object.freeze(Color3.Black());
+
+// Color4
+export const _staticOffsetValueColor4: DeepImmutable<Color4> = Object.freeze(new Color4(0, 0, 0, 0));
 
 /**
  * Options to be used when creating an additive animation
@@ -1002,7 +1020,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return floatValue;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return state.offsetValue * state.repeatCount + floatValue;
+                        return (state.offsetValue ?? 0) * state.repeatCount + floatValue;
                 }
                 break;
             }
@@ -1017,7 +1035,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return quatValue;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return quatValue.addInPlace(state.offsetValue.scale(state.repeatCount));
+                        return quatValue.addInPlace((state.offsetValue ?? _staticOffsetValueQuaternion).scale(state.repeatCount));
                 }
 
                 return quatValue;
@@ -1033,7 +1051,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return vec3Value.add(state.offsetValue.scale(state.repeatCount));
+                        return vec3Value.add((state.offsetValue ?? _staticOffsetValueVector3).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1048,7 +1066,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec2Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return vec2Value.add(state.offsetValue.scale(state.repeatCount));
+                        return vec2Value.add((state.offsetValue ?? _staticOffsetValueVector2).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1060,7 +1078,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return this.sizeInterpolateFunction(startValue, endValue, gradient);
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return this.sizeInterpolateFunction(startValue, endValue, gradient).add(state.offsetValue.scale(state.repeatCount));
+                        return this.sizeInterpolateFunction(startValue, endValue, gradient).add((state.offsetValue ?? _staticOffsetValueSize).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1075,7 +1093,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return color3Value.add(state.offsetValue.scale(state.repeatCount));
+                        return color3Value.add((state.offsetValue ?? _staticOffsetValueColor3).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1090,7 +1108,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color4Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return color4Value.add(state.offsetValue.scale(state.repeatCount));
+                        return color4Value.add((state.offsetValue ?? _staticOffsetValueColor4).scale(state.repeatCount));
                 }
                 break;
             }

--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -78,7 +78,7 @@ export interface IMakeAnimationAdditiveOptions {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export class _IAnimationState {
+export interface _IAnimationState {
     key: number;
     repeatCount: number;
     workValue?: any;
@@ -1035,7 +1035,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return quatValue;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return quatValue.addInPlace((state.offsetValue ?? _staticOffsetValueQuaternion).scale(state.repeatCount));
+                        return quatValue.addInPlace((state.offsetValue || _staticOffsetValueQuaternion).scale(state.repeatCount));
                 }
 
                 return quatValue;
@@ -1051,7 +1051,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return vec3Value.add((state.offsetValue ?? _staticOffsetValueVector3).scale(state.repeatCount));
+                        return vec3Value.add((state.offsetValue || _staticOffsetValueVector3).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1066,7 +1066,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec2Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return vec2Value.add((state.offsetValue ?? _staticOffsetValueVector2).scale(state.repeatCount));
+                        return vec2Value.add((state.offsetValue || _staticOffsetValueVector2).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1078,7 +1078,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return this.sizeInterpolateFunction(startValue, endValue, gradient);
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return this.sizeInterpolateFunction(startValue, endValue, gradient).add((state.offsetValue ?? _staticOffsetValueSize).scale(state.repeatCount));
+                        return this.sizeInterpolateFunction(startValue, endValue, gradient).add((state.offsetValue || _staticOffsetValueSize).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1093,7 +1093,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return color3Value.add((state.offsetValue ?? _staticOffsetValueColor3).scale(state.repeatCount));
+                        return color3Value.add((state.offsetValue || _staticOffsetValueColor3).scale(state.repeatCount));
                 }
                 break;
             }
@@ -1108,7 +1108,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color4Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
-                        return color4Value.add((state.offsetValue ?? _staticOffsetValueColor4).scale(state.repeatCount));
+                        return color4Value.add((state.offsetValue || _staticOffsetValueColor4).scale(state.repeatCount));
                 }
                 break;
             }

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -1,32 +1,19 @@
-import type { DeepImmutable, Nullable } from "../types";
-import { Quaternion, Vector3, Vector2, Matrix } from "../Maths/math.vector";
-import { Color3 } from "../Maths/math.color";
+import type { Nullable } from "../types";
+import { Matrix } from "../Maths/math.vector";
 import type { _IAnimationState } from "./animation";
-import { Animation } from "./animation";
+import {
+    Animation,
+    _staticOffsetValueColor3,
+    _staticOffsetValueColor4,
+    _staticOffsetValueQuaternion,
+    _staticOffsetValueSize,
+    _staticOffsetValueVector2,
+    _staticOffsetValueVector3,
+} from "./animation";
 import type { AnimationEvent } from "./animationEvent";
-
 import type { Animatable } from "./animatable";
-
 import type { Scene } from "../scene";
 import type { IAnimationKey } from "./animationKey";
-import { Size } from "../Maths/math.size";
-
-// Static values to help the garbage collector
-
-// Quaternion
-const _staticOffsetValueQuaternion: DeepImmutable<Quaternion> = Object.freeze(new Quaternion(0, 0, 0, 0));
-
-// Vector3
-const _staticOffsetValueVector3: DeepImmutable<Vector3> = Object.freeze(Vector3.Zero());
-
-// Vector2
-const _staticOffsetValueVector2: DeepImmutable<Vector2> = Object.freeze(Vector2.Zero());
-
-// Size
-const _staticOffsetValueSize: DeepImmutable<Size> = Object.freeze(Size.Zero());
-
-// Color3
-const _staticOffsetValueColor3: DeepImmutable<Color3> = Object.freeze(Color3.Black());
 
 /**
  * Defines a runtime animation
@@ -600,6 +587,10 @@ export class RuntimeAnimation {
                 // Color3
                 case Animation.ANIMATIONTYPE_COLOR3:
                     offsetValue = _staticOffsetValueColor3;
+                    break;
+                case Animation.ANIMATIONTYPE_COLOR4:
+                    offsetValue = _staticOffsetValueColor4;
+                    break;
             }
         }
 

--- a/packages/dev/core/src/Maths/math.size.ts
+++ b/packages/dev/core/src/Maths/math.size.ts
@@ -145,6 +145,14 @@ export class Size implements ISize {
         return r;
     }
     /**
+     * Scales the width and height
+     * @param scale the scale to multiply the width and height by
+     * @returns a new Size set with the multiplication result of the current Size and the given floats.
+     */
+    public scale(scale: number): Size {
+        return new Size(this.width * scale, this.height * scale);
+    }
+    /**
      * Creates a new Size set at the linear interpolation "amount" between "start" and "end"
      * @param start starting size to lerp between
      * @param end end size to lerp between


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/ace-input-value-doesnt-change/46022
The reason for the errors in ACE was that, when editing values/moving the playhead/etc, the `_interpolate` function was called, but the animation state's `offsetValue` is undefined at the time. Since `offsetValue` is defined as optional, I added a check for the undefined case, returning the previously defined `_staticOffsetValueXXX` values.