### PR TITLE
Fix opaque only picking for rotated controls

### DIFF
--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -125,7 +125,7 @@ export interface DOMMatrix {
      */
     isIdentity: boolean;
     /**
-     * The following double-precision floating-point values represent the components of a 4×4 matrix which are required in order to perform 2D rotations and translations.
+     * The following double-precision floating-point values represent the components of a matrix which are required in order to perform 2D rotations and translations.
      */
     a: number;
     b: number;

--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -113,6 +113,48 @@ export interface ITextMetrics {
 }
 
 /**
+ * Class used to abstract a matrix
+ */
+export interface DOMMatrix {
+    /**
+     * A Boolean flag whose value is true if the matrix was initialized as a 2D matrix. If false, the matrix is 3D.
+     */
+    is2D: boolean;
+    /**
+     * A Boolean whose value is true if the matrix is the identity matrix. The identity matrix is one in which every value is 0 except those on the main diagonal from top-left to bottom-right corner (in other words, where the offsets in each direction are equal).
+     */
+    isIdentity: boolean;
+    /**
+     * The following double-precision floating-point values represent the components of a 4×4 matrix which are required in order to perform 2D rotations and translations.
+     */
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+    /**
+     * The following are double-precision floating-point values representing each component of a 4×4 matrix, where m11 through m14 are the first column, m21 through m24 are the second column, and so forth.
+     */
+    m11: number;
+    m12: number;
+    m13: number;
+    m14: number;
+    m21: number;
+    m22: number;
+    m23: number;
+    m24: number;
+    m31: number;
+    m32: number;
+    m33: number;
+    m34: number;
+    m41: number;
+    m42: number;
+    m43: number;
+    m44: number;
+}
+
+/**
  * Class used to abstract canvas rendering
  */
 export interface ICanvasRenderingContext {
@@ -415,4 +457,9 @@ export interface ICanvasRenderingContext {
      * @param f Vertical translation (moving).
      */
     setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+
+    /**
+     * Retrieves the current transformation matrix being applied to the context.
+     */
+    getTransform(): DOMMatrix;
 }

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -852,6 +852,23 @@ export class Image extends Control {
         context.clearRect(0, 0, width, height);
     }
 
+    _dumpWorkingCanvas() {
+        if (!this._workingCanvas) {
+            return;
+        }
+
+        // Capture the currently drawn image of the canvas
+        const dataURL = this._workingCanvas.toDataURL("image/png");
+
+        // Create a link element to download the image
+        const link = document.createElement("a");
+        link.href = dataURL;
+        link.download = "image.png";
+
+        // Simulate a click on the link to trigger the download
+        link.click();
+    }
+
     private _drawImage(context: ICanvasRenderingContext, sx: number, sy: number, sw: number, sh: number, tx: number, ty: number, tw: number, th: number) {
         context.drawImage(this._domImage, sx, sy, sw, sh, tx, ty, tw, th);
 
@@ -860,9 +877,17 @@ export class Image extends Control {
         }
 
         const canvas = this._workingCanvas!;
-        context = canvas.getContext("2d")!;
-
-        context.drawImage(this._domImage, sx, sy, sw, sh, tx - this._currentMeasure.left, ty - this._currentMeasure.top, tw, th);
+        const workingCanvasContext = canvas.getContext("2d")!;
+        workingCanvasContext.save();
+        const ttx = tx - this._currentMeasure.left;
+        const tty = ty - this._currentMeasure.top;
+        workingCanvasContext.translate((ttx + tw) / 2, (tty + th) / 2);
+        workingCanvasContext.rotate(this.rotation);
+        workingCanvasContext.scale(this.scaleX, this.scaleY);
+        workingCanvasContext.translate(-(ttx + tw) / 2, -(tty + th) / 2);
+        workingCanvasContext.drawImage(this._domImage, sx, sy, sw, sh, ttx, tty, tw, th);
+        // this._dumpWorkingCanvas();
+        workingCanvasContext.restore();
     }
 
     public _draw(context: ICanvasRenderingContext): void {

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -852,23 +852,6 @@ export class Image extends Control {
         context.clearRect(0, 0, width, height);
     }
 
-    _dumpWorkingCanvas() {
-        if (!this._workingCanvas) {
-            return;
-        }
-
-        // Capture the currently drawn image of the canvas
-        const dataURL = this._workingCanvas.toDataURL("image/png");
-
-        // Create a link element to download the image
-        const link = document.createElement("a");
-        link.href = dataURL;
-        link.download = "image.png";
-
-        // Simulate a click on the link to trigger the download
-        link.click();
-    }
-
     private _drawImage(context: ICanvasRenderingContext, sx: number, sy: number, sw: number, sh: number, tx: number, ty: number, tw: number, th: number) {
         context.drawImage(this._domImage, sx, sy, sw, sh, tx, ty, tw, th);
 
@@ -876,17 +859,17 @@ export class Image extends Control {
             return;
         }
 
+        const transform = context.getTransform();
+
         const canvas = this._workingCanvas!;
         const workingCanvasContext = canvas.getContext("2d")!;
         workingCanvasContext.save();
         const ttx = tx - this._currentMeasure.left;
         const tty = ty - this._currentMeasure.top;
-        workingCanvasContext.translate((ttx + tw) / 2, (tty + th) / 2);
-        workingCanvasContext.rotate(this.rotation);
-        workingCanvasContext.scale(this.scaleX, this.scaleY);
+        workingCanvasContext.setTransform(transform.a, transform.b, transform.c, transform.d, (ttx + tw) / 2, (tty + th) / 2);
         workingCanvasContext.translate(-(ttx + tw) / 2, -(tty + th) / 2);
+
         workingCanvasContext.drawImage(this._domImage, sx, sy, sw, sh, ttx, tty, tw, th);
-        // this._dumpWorkingCanvas();
         workingCanvasContext.restore();
     }
 


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/gui-issue-with-detectpointeronopaqueonly-when-using-rotation/46033
Currently, when drawing a GUI Image to the secondary canvas used to test for opaque picking, the current context's rotation and scaling are not considered. This PR adds these transformations.