### PR TITLE
Animations: Fix loop relative mode to start at the current value of the animated object

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -1149,9 +1149,13 @@ Scene.prototype._processLateAnimationBindings = function (): void {
                     let startIndex = 0;
                     let normalizer = 1.0;
 
+                    const originalAnimationIsLoopRelative = originalAnimation && originalAnimation._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE;
+
                     if (holder.totalWeight < 1.0) {
                         // We need to mix the original value in
-                        if (originalAnimation && originalValue.scale) {
+                        if (originalAnimationIsLoopRelative) {
+                            finalValue = originalValue.clone();
+                        } else if (originalAnimation && originalValue.scale) {
                             finalValue = originalValue.scale(1.0 - holder.totalWeight);
                         } else if (originalAnimation) {
                             finalValue = originalValue * (1.0 - holder.totalWeight);
@@ -1172,6 +1176,14 @@ Scene.prototype._processLateAnimationBindings = function (): void {
                             }
                         } else {
                             finalValue = originalAnimation.currentValue;
+                        }
+
+                        if (originalAnimationIsLoopRelative) {
+                            if (finalValue.addToRef) {
+                                finalValue.addToRef(originalValue, finalValue);
+                            } else {
+                                finalValue += originalValue;
+                            }
                         }
 
                         startIndex = 1;

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -415,7 +415,15 @@ export class RuntimeAnimation {
         if (weight !== -1.0) {
             this._scene._registerTargetForLateAnimationBinding(this, this._originalValue[targetIndex]);
         } else {
-            destination[this._targetPath] = this._currentValue;
+            if (this._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+                if (this._currentValue.addToRef) {
+                    this._currentValue.addToRef(this._originalValue[targetIndex], destination[this._targetPath]);
+                } else {
+                    destination[this._targetPath] = this._originalValue[targetIndex] + this._currentValue;
+                }
+            } else {
+                destination[this._targetPath] = this._currentValue;
+            }
         }
 
         if (target.markAsDirty) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/issue-with-relative-animation/46042/4

I don't know if we should make the change (there's a workaround, see the thread), as it is a breaking change (except if we consider it to be a bug, but it will still break existing animations that use the relative loop mode)...

PG to test: https://playground.babylonjs.com/#SK7C9Y#7

Animations should start from the starting position, but this is not the case.