### PR TITLE
Mesh Pick event bubbling

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
@@ -6,6 +6,7 @@ import type { IFlowGraphBlockConfiguration } from "../../flowGraphBlock";
 import { RegisterClass } from "../../../Misc/typeStore";
 import type { FlowGraphPath } from "../../flowGraphPath";
 import { Tools } from "../../../Misc/tools";
+import { _isADescendantOf } from "../../utils";
 /**
  * @experimental
  */
@@ -24,6 +25,11 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
         super(config);
     }
 
+    public _getReferencedMesh(context: FlowGraphContext): AbstractMesh | undefined {
+        const mesh = this.config.path.getProperty(context);
+        return mesh;
+    }
+
     /**
      * @internal
      */
@@ -36,7 +42,11 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
             }
             context._setExecutionVariable(this, "mesh", mesh);
             pickObserver = mesh.getScene().onPointerObservable.add((pointerInfo) => {
-                if (pointerInfo.type === PointerEventTypes.POINTERPICK && pointerInfo.pickInfo?.pickedMesh === mesh) {
+                if (
+                    pointerInfo.type === PointerEventTypes.POINTERPICK &&
+                    pointerInfo.pickInfo?.pickedMesh &&
+                    (pointerInfo.pickInfo?.pickedMesh === mesh || _isADescendantOf(pointerInfo.pickInfo?.pickedMesh, mesh))
+                ) {
                     this._execute(context);
                 }
             });
@@ -68,12 +78,14 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
     }
 
     public getClassName(): string {
-        return "FGMeshPickEventBlock";
+        return FlowGraphMeshPickEventBlock.ClassName;
     }
 
     public serialize(serializationObject?: any): void {
         super.serialize(serializationObject);
         serializationObject.config.path = this.config.path.serialize();
     }
+
+    static ClassName = "FGMeshPickEventBlock";
 }
-RegisterClass("FGMeshPickEventBlock", FlowGraphMeshPickEventBlock);
+RegisterClass(FlowGraphMeshPickEventBlock.ClassName, FlowGraphMeshPickEventBlock);

--- a/packages/dev/core/src/FlowGraph/flowGraph.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraph.ts
@@ -8,6 +8,8 @@ import { FlowGraphExecutionBlock } from "./flowGraphExecutionBlock";
 import type { FlowGraphCoordinator } from "./flowGraphCoordinator";
 import type { FlowGraphSignalConnection } from "./flowGraphSignalConnection";
 import type { FlowGraphDataConnection } from "./flowGraphDataConnection";
+import { FlowGraphMeshPickEventBlock } from "./Blocks";
+import { _isADescendantOf } from "./utils";
 
 export enum FlowGraphState {
     /**
@@ -98,10 +100,34 @@ export class FlowGraph {
             this.createContext();
         }
         for (const context of this._executionContexts) {
-            for (const block of this._eventBlocks) {
+            const contextualOrder = this._getContextualOrder(context);
+            for (const block of contextualOrder) {
                 block._startPendingTasks(context);
             }
         }
+    }
+
+    private _getContextualOrder(context: FlowGraphContext): FlowGraphEventBlock[] {
+        const order: FlowGraphEventBlock[] = [];
+
+        for (const block1 of this._eventBlocks) {
+            // If the block is a mesh pick, guarantee that picks of children meshes come before picks of parent meshes
+            if (block1.getClassName() === FlowGraphMeshPickEventBlock.ClassName) {
+                let i = 0;
+                for (; i < order.length; i++) {
+                    const block2 = order[i];
+                    const mesh1 = (block1 as FlowGraphMeshPickEventBlock)._getReferencedMesh(context);
+                    const mesh2 = (block2 as FlowGraphMeshPickEventBlock)._getReferencedMesh(context);
+                    if (mesh1 && mesh2 && _isADescendantOf(mesh1, mesh2)) {
+                        break;
+                    }
+                }
+                order.splice(i, 0, block1);
+            } else {
+                order.push(block1);
+            }
+        }
+        return order;
     }
 
     /**

--- a/packages/dev/core/src/FlowGraph/utils.ts
+++ b/packages/dev/core/src/FlowGraph/utils.ts
@@ -1,0 +1,18 @@
+import type { Node } from "../node";
+
+/**
+ * Returns if mesh1 is a descendant of mesh2
+ * @param mesh1
+ * @param mesh2
+ * @returns
+ */
+export function _isADescendantOf(mesh1: Node, mesh2: Node): boolean {
+    if (mesh1.parent === null) {
+        return false;
+    }
+    const parent = mesh1.parent;
+    if (parent === mesh2) {
+        return true;
+    }
+    return _isADescendantOf(parent, mesh2);
+}

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphEventNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphEventNodes.test.ts
@@ -1,7 +1,18 @@
+import { PickingInfo } from "core/Collisions";
 import type { Engine } from "core/Engines";
 import { NullEngine } from "core/Engines";
+import { PointerEventTypes, PointerInfo } from "core/Events";
 import type { FlowGraph, FlowGraphContext } from "core/FlowGraph";
-import { FlowGraphCoordinator, FlowGraphLogBlock, FlowGraphReceiveCustomEventBlock, FlowGraphSceneReadyEventBlock, FlowGraphSendCustomEventBlock } from "core/FlowGraph";
+import {
+    FlowGraphCoordinator,
+    FlowGraphLogBlock,
+    FlowGraphMeshPickEventBlock,
+    FlowGraphPath,
+    FlowGraphReceiveCustomEventBlock,
+    FlowGraphSceneReadyEventBlock,
+    FlowGraphSendCustomEventBlock,
+} from "core/FlowGraph";
+import { Mesh } from "core/Meshes";
 import { Scene } from "core/scene";
 
 describe("Flow Graph Event Nodes", () => {
@@ -52,5 +63,49 @@ describe("Flow Graph Event Nodes", () => {
         scene.onReadyObservable.notifyObservers(scene);
 
         expect(console.log).toHaveBeenCalledWith(42);
+    });
+
+    it("Mesh Pick Event Bubbling", () => {
+        const graph = flowGraphCoordinator.createGraph();
+        const context = graph.createContext();
+
+        // We have three meshes, mesh1 is the parent of mesh2, which is the parent of mesh3
+        const mesh1 = new Mesh("mesh1", scene);
+        const mesh2 = new Mesh("mesh2", scene);
+        mesh2.parent = mesh1;
+        const mesh3 = new Mesh("mesh3", scene);
+        mesh3.parent = mesh2;
+
+        context.setVariable("meshes", [mesh1, mesh2, mesh3]);
+
+        // Create a mesh pick event on mesh1 and mesh3
+        const meshPick1 = new FlowGraphMeshPickEventBlock({ name: "MeshPick1", path: new FlowGraphPath("/meshes/0") });
+        graph.addEventBlock(meshPick1);
+        const meshPick3 = new FlowGraphMeshPickEventBlock({ name: "MeshPick3", path: new FlowGraphPath("/meshes/2") });
+        graph.addEventBlock(meshPick3);
+
+        // Create a console log block for each mesh pick
+        const meshLog1 = new FlowGraphLogBlock({ name: "MeshLog1" });
+        meshPick1.onDone.connectTo(meshLog1.onStart);
+        meshLog1.message.setValue("Mesh 1 was picked", context);
+        const meshLog3 = new FlowGraphLogBlock({ name: "MeshLog3" });
+        meshPick3.onDone.connectTo(meshLog3.onStart);
+        meshLog3.message.setValue("Mesh 3 was picked", context);
+
+        // Start the graph
+        graph.start();
+
+        // Notify that the mesh3 was picked
+        const pickInfo = new PickingInfo();
+        pickInfo.hit = true;
+        pickInfo.pickedMesh = mesh3;
+        // const mouseEvent = jest.mock("core/Events/") as any;
+        const mouseEvent = {} as any;
+        const pointerInfo = new PointerInfo(PointerEventTypes.POINTERPICK, mouseEvent, pickInfo);
+        scene.onPointerObservable.notifyObservers(pointerInfo);
+
+        // Mesh3 was picked, so we expect the pick to "bubble up" to mesh1
+        expect(console.log).toHaveBeenNthCalledWith(1, "Mesh 3 was picked");
+        expect(console.log).toHaveBeenNthCalledWith(2, "Mesh 1 was picked");
     });
 });


### PR DESCRIPTION
# Changes

Adds the functionality of "event bubbling" to the FlowGraphMeshPickEventBlock. With this, picking a child mesh will lead to any of its parents' picks also being fired. The ordering is that first the child mesh event fires, then the parents, no matter in what order the event blocks were added to the graph. For this, when we start a graph, we need to recompute the order where the event blocks fire for each context. The reordering is done so that, if two FlowGraphMeshPickEventBlocks appear in the ordering, the first one's referenced mesh is a descendant of the second one's reference mesh.