### PR TITLE
Fix dynamic texture when context restored

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.dynamicTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.dynamicTexture.ts
@@ -104,5 +104,12 @@ ThinEngine.prototype.updateDynamicTexture = function (
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
     }
 
+    if (format) {
+        texture.format = format;
+    }
+
+    texture._dynamicTextureSource = source;
+    texture._premulAlpha = premulAlpha;
+    texture.invertY = invertY || false;
     texture.isReady = true;
 };

--- a/packages/dev/core/src/Materials/Textures/internalTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/internalTexture.ts
@@ -251,6 +251,12 @@ export class InternalTexture extends TextureSampler {
     /** @internal */
     public _gammaSpace: Nullable<boolean> = null;
 
+    /** @internal */
+    public _premulAlpha = false;
+
+    /** @internal */
+    public _dynamicTextureSource: Nullable<ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | OffscreenCanvas> = null;
+
     private _engine: ThinEngine;
     private _uniqueId: number;
 
@@ -437,7 +443,9 @@ export class InternalTexture extends TextureSampler {
             case InternalTextureSource.Dynamic:
                 proxy = this._engine.createDynamicTexture(this.baseWidth, this.baseHeight, this.generateMipMaps, this.samplingMode);
                 proxy._swapAndDie(this, false);
-                this._engine.updateDynamicTexture(this, this._engine.getRenderingCanvas()!, this.invertY, undefined, undefined, true);
+                if (this._dynamicTextureSource) {
+                    this._engine.updateDynamicTexture(this, this._dynamicTextureSource, this.invertY, this._premulAlpha, this.format, true);
+                }
 
                 // The engine will make sure to update content so no need to flag it as isReady = true
                 break;
@@ -568,6 +576,7 @@ export class InternalTexture extends TextureSampler {
         if (this._references === 0) {
             this._engine._releaseTexture(this);
             this._hardwareTexture = null;
+            this._dynamicTextureSource = null;
         }
     }
 }


### PR DESCRIPTION
https://forum.babylonjs.com/t/restoring-webgl-context-fails-for-dynamictextures/46093