### PR TITLE
Detect procedural texture readyness.

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -275,6 +275,24 @@ export class ProceduralTexture extends Texture {
     }
 
     /**
+     * Executes a function when the texture will be ready to be drawn.
+     * @param func The callback to be used.
+     */
+    public executeWhenReady(func: (texture: ProceduralTexture) => void): void {
+        if (this.isReady()) {
+            func(this);
+            return;
+        }
+
+        const effect = this.getEffect();
+        if (effect) {
+            effect.executeWhenCompiled(() => {
+                func(this);
+            });
+        }
+    }
+
+    /**
      * Is the texture ready to be used ? (rendered at least once)
      * @returns true if ready, otherwise, false.
      */


### PR DESCRIPTION
https://forum.babylonjs.com/t/webgl-warning-when-binding-procedural-texture-to-postprocess/46047/6