### PR TITLE
PBR custom materials: Fix default shader name

### DIFF
--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -224,7 +224,7 @@ export class PBRCustomMaterial extends PBRMaterial {
         this.FragmentShader = this.FragmentShader.replace(/#include<pbrBlockFinalColorComposition>/g, Effect.IncludesShadersStore["pbrBlockFinalColorComposition"]);
 
         PBRCustomMaterial.ShaderIndexer++;
-        this._createdShaderName = "custom_" + PBRCustomMaterial.ShaderIndexer;
+        this._createdShaderName = "custompbr_" + PBRCustomMaterial.ShaderIndexer;
     }
 
     protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null): void {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/compute-shaders-ocean-demo-is-not-working/46139

There was a name collision with the `CustomMaterial`, which also uses "custom_" as the prefix name.