### PR TITLE
Fix missing internal sized formats for MSAA render targets

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -479,7 +479,7 @@ ThinEngine.prototype.updateMultipleRenderTargetTextureSampleCount = function (
                 texture.height,
                 samples,
                 -1 /* not used */,
-                this._getRGBAMultiSampleBufferFormat(texture.type, texture.format),
+                this._getRGBABufferInternalSizedFormat(texture.type, texture.format, texture._useSRGBBuffer),
                 attachment
             );
 

--- a/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
@@ -263,7 +263,7 @@ ThinEngine.prototype.updateRenderTargetTextureSampleCount = function (rtWrapper:
             rtWrapper.texture.height,
             samples,
             -1 /* not used */,
-            this._getRGBAMultiSampleBufferFormat(rtWrapper.texture.type),
+            this._getRGBABufferInternalSizedFormat(rtWrapper.texture.type, rtWrapper.texture.format, rtWrapper.texture._useSRGBBuffer),
             gl.COLOR_ATTACHMENT0,
             false
         );

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5937,30 +5937,6 @@ export class ThinEngine {
     /**
      * @internal
      */
-    public _getRGBAMultiSampleBufferFormat(type: number, format = Constants.TEXTUREFORMAT_RGBA): number {
-        switch (type) {
-            case Constants.TEXTURETYPE_FLOAT:
-                switch (format) {
-                    case Constants.TEXTUREFORMAT_R:
-                        return this._gl.R32F;
-                    default:
-                        return this._gl.RGBA32F;
-                }
-            case Constants.TEXTURETYPE_HALF_FLOAT:
-                switch (format) {
-                    case Constants.TEXTUREFORMAT_R:
-                        return this._gl.R16F;
-                    default:
-                        return this._gl.RGBA16F;
-                }
-        }
-
-        return this._gl.RGBA8;
-    }
-
-    /**
-     * @internal
-     */
     public _loadFile(
         url: string,
         onSuccess: (data: string | ArrayBuffer, responseURL?: string) => void,


### PR DESCRIPTION
Original issue described here: https://forum.babylonjs.com/t/using-msaa-causes-opengl-errors-with-certain-color-renderable-formats/45994

Fixed by removing `thinEngine._getRGBAMultiSampleBufferFormat` as when creating an MSAA render target, I think you always want the same format in your resolved render target, as in your MSAA render target.

Does not validate the formats are color-renderable. But it didn't do that before either, and the function for creating normal render targets doesn't do that either, as far as I can see.