### PR TITLE
Animations: Use a new mode for "relative from current" animation loop

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -1149,11 +1149,12 @@ Scene.prototype._processLateAnimationBindings = function (): void {
                     let startIndex = 0;
                     let normalizer = 1.0;
 
-                    const originalAnimationIsLoopRelative = originalAnimation && originalAnimation._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE;
+                    const originalAnimationIsLoopRelativeFromCurrent =
+                        originalAnimation && originalAnimation._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT;
 
                     if (holder.totalWeight < 1.0) {
                         // We need to mix the original value in
-                        if (originalAnimationIsLoopRelative) {
+                        if (originalAnimationIsLoopRelativeFromCurrent) {
                             finalValue = originalValue.clone ? originalValue.clone() : originalValue;
                         } else if (originalAnimation && originalValue.scale) {
                             finalValue = originalValue.scale(1.0 - holder.totalWeight);
@@ -1178,7 +1179,7 @@ Scene.prototype._processLateAnimationBindings = function (): void {
                             finalValue = originalAnimation.currentValue;
                         }
 
-                        if (originalAnimationIsLoopRelative) {
+                        if (originalAnimationIsLoopRelativeFromCurrent) {
                             if (finalValue.addToRef) {
                                 finalValue.addToRef(originalValue, finalValue);
                             } else {

--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -1020,6 +1020,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return floatValue;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return (state.offsetValue ?? 0) * state.repeatCount + floatValue;
                 }
                 break;
@@ -1035,6 +1036,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return quatValue;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return quatValue.addInPlace((state.offsetValue || _staticOffsetValueQuaternion).scale(state.repeatCount));
                 }
 
@@ -1051,6 +1053,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return vec3Value.add((state.offsetValue || _staticOffsetValueVector3).scale(state.repeatCount));
                 }
                 break;
@@ -1066,6 +1069,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return vec2Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return vec2Value.add((state.offsetValue || _staticOffsetValueVector2).scale(state.repeatCount));
                 }
                 break;
@@ -1078,6 +1082,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return this.sizeInterpolateFunction(startValue, endValue, gradient);
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return this.sizeInterpolateFunction(startValue, endValue, gradient).add((state.offsetValue || _staticOffsetValueSize).scale(state.repeatCount));
                 }
                 break;
@@ -1093,6 +1098,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color3Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return color3Value.add((state.offsetValue || _staticOffsetValueColor3).scale(state.repeatCount));
                 }
                 break;
@@ -1108,6 +1114,7 @@ export class Animation {
                     case Animation.ANIMATIONLOOPMODE_YOYO:
                         return color4Value;
                     case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT:
                         return color4Value.add((state.offsetValue || _staticOffsetValueColor4).scale(state.repeatCount));
                 }
                 break;
@@ -1123,7 +1130,8 @@ export class Animation {
                         }
                         return startValue;
                     }
-                    case Animation.ANIMATIONLOOPMODE_RELATIVE: {
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE:
+                    case Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT: {
                         return startValue;
                     }
                 }
@@ -1363,6 +1371,10 @@ export class Animation {
      * Yoyo Loop Mode
      */
     public static readonly ANIMATIONLOOPMODE_YOYO = 4;
+    /**
+     * Relative Loop Mode (add to current value of animated object, unlike ANIMATIONLOOPMODE_RELATIVE)
+     */
+    public static readonly ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT = 5;
 
     /**
      * @internal

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -402,7 +402,7 @@ export class RuntimeAnimation {
         if (weight !== -1.0) {
             this._scene._registerTargetForLateAnimationBinding(this, this._originalValue[targetIndex]);
         } else {
-            if (this._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE) {
+            if (this._animationState.loopMode === Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT) {
                 if (this._currentValue.addToRef) {
                     this._currentValue.addToRef(this._originalValue[targetIndex], destination[this._targetPath]);
                 } else {

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/sideBar/addAnimationComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/sideBar/addAnimationComponent.tsx
@@ -152,6 +152,10 @@ export class AddAnimationComponent extends React.Component<IAddAnimationComponen
                 loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE;
                 break;
             }
+            case "Relative from current": {
+                loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT;
+                break;
+            }
             case "Constant": {
                 loopMode = Animation.ANIMATIONLOOPMODE_CONSTANT;
                 break;
@@ -210,7 +214,7 @@ export class AddAnimationComponent extends React.Component<IAddAnimationComponen
 
     public render() {
         const types = ["Float", "Vector2", "Vector3", "Quaternion", "Color3", "Color4"];
-        const loopModes = ["Cycle", "Relative", "Constant"];
+        const loopModes = ["Cycle", "Relative", "Relative from current", "Constant"];
         const modes = ["Custom", "List"];
         const properties: string[] = [];
         let inferredType = "";

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/sideBar/editAnimationComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/curveEditor/sideBar/editAnimationComponent.tsx
@@ -87,6 +87,10 @@ export class EditAnimationComponent extends React.Component<IEditAnimationCompon
                 animation.loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE;
                 break;
             }
+            case "Relative from current": {
+                animation.loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE_FROM_CURRENT;
+                break;
+            }
             case "Constant": {
                 animation.loopMode = Animation.ANIMATIONLOOPMODE_CONSTANT;
                 break;
@@ -101,7 +105,7 @@ export class EditAnimationComponent extends React.Component<IEditAnimationCompon
             return null;
         }
 
-        const loopModes = ["Relative", "Cycle", "Constant"];
+        const loopModes = ["Relative", "Relative from current", "Cycle", "Constant"];
 
         return (
             <div id="edit-animation-pane" ref={this._root}>


### PR DESCRIPTION
Follow up to #14563 

It was breaking existing code (see https://forum.babylonjs.com/t/camera-animation-bug/46211 among others), so this PR adds a new loop mode for "relative from current".