### PR TITLE
PBRCustomMaterial & CustomMaterial support MaterialPlugin

### DIFF
--- a/packages/dev/materials/src/custom/customMaterial.ts
+++ b/packages/dev/materials/src/custom/customMaterial.ts
@@ -132,47 +132,50 @@ export class CustomMaterial extends StandardMaterial {
         if (Effect.ShadersStore[name + "VertexShader"] && Effect.ShadersStore[name + "PixelShader"]) {
             return name;
         }
-
-        Effect.ShadersStore[name + "VertexShader"] = this.VertexShader.replace("#define CUSTOM_VERTEX_BEGIN", this.CustomParts.Vertex_Begin ? this.CustomParts.Vertex_Begin : "")
-            .replace(
-                "#define CUSTOM_VERTEX_DEFINITIONS",
-                (this._customUniform ? this._customUniform.join("\n") : "") + (this.CustomParts.Vertex_Definitions ? this.CustomParts.Vertex_Definitions : "")
-            )
-            .replace("#define CUSTOM_VERTEX_MAIN_BEGIN", this.CustomParts.Vertex_MainBegin ? this.CustomParts.Vertex_MainBegin : "")
-            .replace("#define CUSTOM_VERTEX_UPDATE_POSITION", this.CustomParts.Vertex_Before_PositionUpdated ? this.CustomParts.Vertex_Before_PositionUpdated : "")
-            .replace("#define CUSTOM_VERTEX_UPDATE_NORMAL", this.CustomParts.Vertex_Before_NormalUpdated ? this.CustomParts.Vertex_Before_NormalUpdated : "")
-            .replace("#define CUSTOM_VERTEX_MAIN_END", this.CustomParts.Vertex_MainEnd ? this.CustomParts.Vertex_MainEnd : "");
-
-        if (this.CustomParts.Vertex_After_WorldPosComputed) {
-            Effect.ShadersStore[name + "VertexShader"] = Effect.ShadersStore[name + "VertexShader"].replace(
-                "#define CUSTOM_VERTEX_UPDATE_WORLDPOS",
-                this.CustomParts.Vertex_After_WorldPosComputed
-            );
-        }
-
-        Effect.ShadersStore[name + "PixelShader"] = this.FragmentShader.replace(
-            "#define CUSTOM_FRAGMENT_BEGIN",
-            this.CustomParts.Fragment_Begin ? this.CustomParts.Fragment_Begin : ""
-        )
-            .replace("#define CUSTOM_FRAGMENT_MAIN_BEGIN", this.CustomParts.Fragment_MainBegin ? this.CustomParts.Fragment_MainBegin : "")
-            .replace(
-                "#define CUSTOM_FRAGMENT_DEFINITIONS",
-                (this._customUniform ? this._customUniform.join("\n") : "") + (this.CustomParts.Fragment_Definitions ? this.CustomParts.Fragment_Definitions : "")
-            )
-            .replace("#define CUSTOM_FRAGMENT_UPDATE_DIFFUSE", this.CustomParts.Fragment_Custom_Diffuse ? this.CustomParts.Fragment_Custom_Diffuse : "")
-            .replace("#define CUSTOM_FRAGMENT_UPDATE_ALPHA", this.CustomParts.Fragment_Custom_Alpha ? this.CustomParts.Fragment_Custom_Alpha : "")
-            .replace("#define CUSTOM_FRAGMENT_BEFORE_LIGHTS", this.CustomParts.Fragment_Before_Lights ? this.CustomParts.Fragment_Before_Lights : "")
-            .replace("#define CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR", this.CustomParts.Fragment_Before_FragColor ? this.CustomParts.Fragment_Before_FragColor : "")
-            .replace("#define CUSTOM_FRAGMENT_MAIN_END", this.CustomParts.Fragment_MainEnd ? this.CustomParts.Fragment_MainEnd : "");
-
-        if (this.CustomParts.Fragment_Before_Fog) {
-            Effect.ShadersStore[name + "PixelShader"] = Effect.ShadersStore[name + "PixelShader"].replace(
-                "#define CUSTOM_FRAGMENT_BEFORE_FOG",
-                this.CustomParts.Fragment_Before_Fog
-            );
-        }
+        Effect.ShadersStore[name + "VertexShader"] = this._injectCustomCode(this.VertexShader, "vertex");
+        Effect.ShadersStore[name + "PixelShader"] = this._injectCustomCode(this.FragmentShader, "fragment");
 
         return name;
+    }
+
+    protected _injectCustomCode(code: string, shaderType: string): string {
+        const customCode = this._getCustomCode(shaderType);
+
+        for (const point in customCode) {
+            const injectedCode = customCode[point];
+
+            if (injectedCode && injectedCode.length > 0) {
+                const fullPointName = "#define " + point;
+                code = code.replace(fullPointName, "\n" + injectedCode + "\n" + fullPointName);
+            }
+        }
+
+        return code;
+    }
+
+    protected _getCustomCode(shaderType: string): { [pointName: string]: string } {
+        if (shaderType === "vertex") {
+            return {
+                CUSTOM_VERTEX_BEGIN: this.CustomParts.Vertex_Begin,
+                CUSTOM_VERTEX_DEFINITIONS: (this._customUniform?.join("\n") || "") + (this.CustomParts.Vertex_Definitions || ""),
+                CUSTOM_VERTEX_MAIN_BEGIN: this.CustomParts.Vertex_MainBegin,
+                CUSTOM_VERTEX_UPDATE_POSITION: this.CustomParts.Vertex_Before_PositionUpdated,
+                CUSTOM_VERTEX_UPDATE_NORMAL: this.CustomParts.Vertex_Before_NormalUpdated,
+                CUSTOM_VERTEX_MAIN_END: this.CustomParts.Vertex_MainEnd,
+                CUSTOM_VERTEX_UPDATE_WORLDPOS: this.CustomParts.Vertex_After_WorldPosComputed,
+            };
+        }
+        return {
+            CUSTOM_FRAGMENT_BEGIN: this.CustomParts.Fragment_Begin,
+            CUSTOM_FRAGMENT_DEFINITIONS: (this._customUniform?.join("\n") || "") + (this.CustomParts.Fragment_Definitions || ""),
+            CUSTOM_FRAGMENT_MAIN_BEGIN: this.CustomParts.Fragment_MainBegin,
+            CUSTOM_FRAGMENT_UPDATE_DIFFUSE: this.CustomParts.Fragment_Custom_Diffuse,
+            CUSTOM_FRAGMENT_UPDATE_ALPHA: this.CustomParts.Fragment_Custom_Alpha,
+            CUSTOM_FRAGMENT_BEFORE_LIGHTS: this.CustomParts.Fragment_Before_Lights,
+            CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: this.CustomParts.Fragment_Before_FragColor,
+            CUSTOM_FRAGMENT_MAIN_END: this.CustomParts.Fragment_MainEnd,
+            CUSTOM_FRAGMENT_BEFORE_FOG: this.CustomParts.Fragment_Before_Fog,
+        };
     }
 
     constructor(name: string, scene?: Scene) {

--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -159,56 +159,53 @@ export class PBRCustomMaterial extends PBRMaterial {
         if (Effect.ShadersStore[name + "VertexShader"] && Effect.ShadersStore[name + "PixelShader"]) {
             return name;
         }
-
-        Effect.ShadersStore[name + "VertexShader"] = this.VertexShader.replace("#define CUSTOM_VERTEX_BEGIN", this.CustomParts.Vertex_Begin ? this.CustomParts.Vertex_Begin : "")
-            .replace(
-                "#define CUSTOM_VERTEX_DEFINITIONS",
-                (this._customUniform ? this._customUniform.join("\n") : "") + (this.CustomParts.Vertex_Definitions ? this.CustomParts.Vertex_Definitions : "")
-            )
-            .replace("#define CUSTOM_VERTEX_MAIN_BEGIN", this.CustomParts.Vertex_MainBegin ? this.CustomParts.Vertex_MainBegin : "")
-            .replace("#define CUSTOM_VERTEX_UPDATE_POSITION", this.CustomParts.Vertex_Before_PositionUpdated ? this.CustomParts.Vertex_Before_PositionUpdated : "")
-            .replace("#define CUSTOM_VERTEX_UPDATE_NORMAL", this.CustomParts.Vertex_Before_NormalUpdated ? this.CustomParts.Vertex_Before_NormalUpdated : "")
-            .replace("#define CUSTOM_VERTEX_MAIN_END", this.CustomParts.Vertex_MainEnd ? this.CustomParts.Vertex_MainEnd : "");
-
-        if (this.CustomParts.Vertex_After_WorldPosComputed) {
-            Effect.ShadersStore[name + "VertexShader"] = Effect.ShadersStore[name + "VertexShader"].replace(
-                "#define CUSTOM_VERTEX_UPDATE_WORLDPOS",
-                this.CustomParts.Vertex_After_WorldPosComputed
-            );
-        }
-
-        Effect.ShadersStore[name + "PixelShader"] = this.FragmentShader.replace(
-            "#define CUSTOM_FRAGMENT_BEGIN",
-            this.CustomParts.Fragment_Begin ? this.CustomParts.Fragment_Begin : ""
-        )
-            .replace("#define CUSTOM_FRAGMENT_MAIN_BEGIN", this.CustomParts.Fragment_MainBegin ? this.CustomParts.Fragment_MainBegin : "")
-            .replace(
-                "#define CUSTOM_FRAGMENT_DEFINITIONS",
-                (this._customUniform ? this._customUniform.join("\n") : "") + (this.CustomParts.Fragment_Definitions ? this.CustomParts.Fragment_Definitions : "")
-            )
-            .replace("#define CUSTOM_FRAGMENT_UPDATE_ALBEDO", this.CustomParts.Fragment_Custom_Albedo ? this.CustomParts.Fragment_Custom_Albedo : "")
-            .replace("#define CUSTOM_FRAGMENT_UPDATE_ALPHA", this.CustomParts.Fragment_Custom_Alpha ? this.CustomParts.Fragment_Custom_Alpha : "")
-            .replace("#define CUSTOM_FRAGMENT_BEFORE_LIGHTS", this.CustomParts.Fragment_Before_Lights ? this.CustomParts.Fragment_Before_Lights : "")
-            .replace(
-                "#define CUSTOM_FRAGMENT_UPDATE_METALLICROUGHNESS",
-                this.CustomParts.Fragment_Custom_MetallicRoughness ? this.CustomParts.Fragment_Custom_MetallicRoughness : ""
-            )
-            .replace("#define CUSTOM_FRAGMENT_UPDATE_MICROSURFACE", this.CustomParts.Fragment_Custom_MicroSurface ? this.CustomParts.Fragment_Custom_MicroSurface : "")
-            .replace(
-                "#define CUSTOM_FRAGMENT_BEFORE_FINALCOLORCOMPOSITION",
-                this.CustomParts.Fragment_Before_FinalColorComposition ? this.CustomParts.Fragment_Before_FinalColorComposition : ""
-            )
-            .replace("#define CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR", this.CustomParts.Fragment_Before_FragColor ? this.CustomParts.Fragment_Before_FragColor : "")
-            .replace("#define CUSTOM_FRAGMENT_MAIN_END", this.CustomParts.Fragment_MainEnd ? this.CustomParts.Fragment_MainEnd : "");
-
-        if (this.CustomParts.Fragment_Before_Fog) {
-            Effect.ShadersStore[name + "PixelShader"] = Effect.ShadersStore[name + "PixelShader"].replace(
-                "#define CUSTOM_FRAGMENT_BEFORE_FOG",
-                this.CustomParts.Fragment_Before_Fog
-            );
-        }
+        Effect.ShadersStore[name + "VertexShader"] = this._injectCustomCode(this.VertexShader, "vertex");
+        Effect.ShadersStore[name + "PixelShader"] = this._injectCustomCode(this.FragmentShader, "fragment");
 
         return name;
+    }
+
+    protected _injectCustomCode(code: string, shaderType: string): string {
+        const customCode = this._getCustomCode(shaderType);
+
+        for (const point in customCode) {
+            const injectedCode = customCode[point];
+
+            if (injectedCode && injectedCode.length > 0) {
+                const fullPointName = "#define " + point;
+                code = code.replace(fullPointName, "\n" + injectedCode + "\n" + fullPointName);
+            }
+        }
+
+        return code;
+    }
+
+    protected _getCustomCode(shaderType: string): { [pointName: string]: string } {
+        if (shaderType === "vertex") {
+            return {
+                CUSTOM_VERTEX_BEGIN: this.CustomParts.Vertex_Begin,
+                CUSTOM_VERTEX_DEFINITIONS: (this._customUniform?.join("\n") || "") + (this.CustomParts.Vertex_Definitions || ""),
+                CUSTOM_VERTEX_MAIN_BEGIN: this.CustomParts.Vertex_MainBegin,
+                CUSTOM_VERTEX_UPDATE_POSITION: this.CustomParts.Vertex_Before_PositionUpdated,
+                CUSTOM_VERTEX_UPDATE_NORMAL: this.CustomParts.Vertex_Before_NormalUpdated,
+                CUSTOM_VERTEX_MAIN_END: this.CustomParts.Vertex_MainEnd,
+                CUSTOM_VERTEX_UPDATE_WORLDPOS: this.CustomParts.Vertex_After_WorldPosComputed,
+            };
+        }
+        return {
+            CUSTOM_FRAGMENT_BEGIN: this.CustomParts.Fragment_Begin,
+            CUSTOM_FRAGMENT_MAIN_BEGIN: this.CustomParts.Fragment_MainBegin,
+            CUSTOM_FRAGMENT_DEFINITIONS: (this._customUniform?.join("\n") || "") + (this.CustomParts.Fragment_Definitions || ""),
+            CUSTOM_FRAGMENT_UPDATE_ALBEDO: this.CustomParts.Fragment_Custom_Albedo,
+            CUSTOM_FRAGMENT_UPDATE_ALPHA: this.CustomParts.Fragment_Custom_Alpha,
+            CUSTOM_FRAGMENT_BEFORE_LIGHTS: this.CustomParts.Fragment_Before_Lights,
+            CUSTOM_FRAGMENT_UPDATE_METALLICROUGHNESS: this.CustomParts.Fragment_Custom_MetallicRoughness,
+            CUSTOM_FRAGMENT_UPDATE_MICROSURFACE: this.CustomParts.Fragment_Custom_MicroSurface,
+            CUSTOM_FRAGMENT_BEFORE_FINALCOLORCOMPOSITION: this.CustomParts.Fragment_Before_FinalColorComposition,
+            CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: this.CustomParts.Fragment_Before_FragColor,
+            CUSTOM_FRAGMENT_MAIN_END: this.CustomParts.Fragment_MainEnd,
+            CUSTOM_FRAGMENT_BEFORE_FOG: this.CustomParts.Fragment_Before_Fog,
+        };
     }
 
     constructor(name: string, scene?: Scene) {


### PR DESCRIPTION
`PBRCustomMaterial` is a subclass of `PBRMaterial`,  but does not support MaterialPlugin.

In the implementation of PBRCustomMaterial, the shader injection point is removed ,  causing material plugin to be unable to inject custom code.

`CustomMaterial` has the same problem.

This playground https://www.babylonjs-playground.com/#VNLCRN can reproduce the issue. 
In the playground, PBRCustomMaterial using MeshDebugPluginMaterial, does not rendering wireframe.

The playgroud rendering result is as follows
<img width="406" alt="截屏2023-12-08 23 33 18" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/3f31574c-d501-417e-a125-8998c0f71594">
**red** mesh use `PBRCustomMaterial`, **green** mesh use `PBRMaterial`
**yellow** mesh use `CustomMaterial`, **blue** mesh use `StandardMaterial`

I hope to fix the problem by this commit.
In the commit, 
1. reorganize the shader creation  in `PBRCustomMaterial` and `CustomMaterial`
2. replace the shader code only if the corresponding injected code is not empty
3. retain injection points

After fixing this issue, the above plaground rendering result is as follows

<img width="406" alt="截屏2023-12-08 23 38 49" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/2aec0c4d-a3e8-46f8-a029-aff3b7737a99">

