### PR TITLE
Retain forward mouselook direction when disallow UpsideDown

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -914,7 +914,7 @@ export class ArcRotateCamera extends TargetCamera {
             const handednessMultiplier = this._calculateHandednessMultiplier();
             let inertialAlphaOffset = this.inertialAlphaOffset * handednessMultiplier;
 
-            if (this.beta <= 0) {
+            if (this.beta < 0 || (this.allowUpsideDown && this.beta === 0)) {
                 inertialAlphaOffset *= -1;
             }
 


### PR DESCRIPTION
when `arcRotateCamera.beta = 0.0`, mouse panning will rotate `alpha` in opposite direction. Sometimes this behavior is not as expected, even forward and reverse alternately because `beta` is occasionally equal to or greater than 0 when pan mouse.

I can understand why when `beta < 0` is to reverse rotating the `alpha`, because the up vector is down. But when `beta = 0`, whether up vector is down or not needs to be further determined, if `allowUpsideDown = false`, mouse panning should rotate `alpha` in positive direction.

The PG that reproduces the issue is as follows
https://www.babylonjs-playground.com/#WIT6DN