### PR TITLE
ArcRotateCamera: Fix alpha offset inversion to not include beta = 0

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -914,7 +914,7 @@ export class ArcRotateCamera extends TargetCamera {
             const handednessMultiplier = this._calculateHandednessMultiplier();
             let inertialAlphaOffset = this.inertialAlphaOffset * handednessMultiplier;
 
-            if (this.beta <= 0) {
+            if (this.beta < 0) {
                 inertialAlphaOffset *= -1;
             }
 


### PR DESCRIPTION
User @Starryi found a bug where the camera work invert alpha rotation when the beta angle was 0.  Based on their approach, I've generalized their fix to just exclude a 0 beta angle from that inversion.

Original PR: https://github.com/BabylonJS/Babylon.js/pull/14609
(Thanks for @Starryi for the find and initial fix)