### PR TITLE
RenderTargetTexture: Fix wrong transformation matrix set on scene when multiple scenes are defined

### DIFF
--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1028,7 +1028,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         if (sceneCamera) {
             scene.activeCamera = sceneCamera;
             // Do not avoid setting uniforms when multiple scenes are active as another camera may have overwrite these
-            if (scene.getEngine().scenes.length > 1 || (this.activeCamera && this.activeCamera !== scene.activeCamera)) {
+            if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
                 scene.setTransformMatrix(scene.activeCamera.getViewMatrix(), scene.activeCamera.getProjectionMatrix(true));
             }
             engine.setViewport(scene.activeCamera.viewport);

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1027,7 +1027,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         if (sceneCamera) {
             scene.activeCamera = sceneCamera;
-            // Do not avoid setting uniforms when multiple scenes are active as another camera may have overwrite these
             if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
                 scene.setTransformMatrix(scene.activeCamera.getViewMatrix(), scene.activeCamera.getProjectionMatrix(true));
             }

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4300,6 +4300,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         // Restore framebuffer after rendering to targets
         if (needRebind && !this.prePass) {
             this._bindFrameBuffer(this._activeCamera, false);
+            this.updateTransformMatrix();
         }
 
         this.onAfterRenderTargetsRenderObservable.notifyObservers(this);


### PR DESCRIPTION
This PR set the scene transformation matrix at the end of the `RenderTargetTexture.render` call as soon as two or more scenes are created:

#6363 

Without this change, this PG does not work: https://playground.babylonjs.com/#01KDKN

However, the PG is wrong! As `scene2.render()` is never called, the scene transformation matrix is not updated. In this case, it's the user responsibility to call `scene.updateTransformationMatrix(true)` so that the transformation matrix is up to date.

Here's the corrected PG: https://playground.babylonjs.com/#01KDKN#14

