### PR TITLE
WebGPU: Reseting ubos in flushFramebuffer does not work

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -2628,11 +2628,6 @@ export class WebGPUEngine extends Engine {
 
         this._device.queue.submit(this._commandBuffers);
 
-        // Now that the command buffers have been submitted, we can reset the ubo as we can reuse the same GPU buffer(s)
-        for (let i = 0; i < this._uniformBuffers.length; ++i) {
-            this._uniformBuffers[i]._checkNewFrame(true);
-        }
-
         this._uploadEncoder = this._device.createCommandEncoder(this._uploadEncoderDescriptor);
         this._renderEncoder = this._device.createCommandEncoder(this._renderEncoderDescriptor);
 

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -676,11 +676,8 @@ export class UniformBuffer {
         }
     }
 
-    /**
-     * @internal
-     */
-    public _checkNewFrame(force = false): void {
-        if (force || (this._engine._features.trackUbosInFrame && this._currentFrameId !== this._engine.frameId)) {
+    private _checkNewFrame(): void {
+        if (this._engine._features.trackUbosInFrame && this._currentFrameId !== this._engine.frameId) {
             this._currentFrameId = this._engine.frameId;
             this._createBufferOnWrite = false;
             if (this._buffers && this._buffers.length > 0) {


### PR DESCRIPTION
Rollback one of the change from #14611 ([this PG](https://playground.babylonjs.com/?webgpu#XDNVAY#0) fails because of it, for eg).