### PR TITLE
WebDeviceInputSystem: Removed move handling code from _pointerDownEvent

### DIFF
--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -508,9 +508,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
             const pointer = this._inputs[deviceType][deviceSlot];
             if (pointer) {
-                const previousHorizontal = pointer[PointerInput.Horizontal];
-                const previousVertical = pointer[PointerInput.Vertical];
-
                 if (deviceType === DeviceType.Mouse) {
                     // Mouse; Set pointerId if undefined
                     if (evt.pointerId === undefined) {
@@ -547,11 +544,6 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                 deviceEvent.inputIndex = evt.button + 2;
 
                 this._onInputChanged(deviceType, deviceSlot, deviceEvent);
-
-                if (previousHorizontal !== evt.clientX || previousVertical !== evt.clientY) {
-                    deviceEvent.inputIndex = PointerInput.Move;
-                    this._onInputChanged(deviceType, deviceSlot, deviceEvent);
-                }
             }
         };
 


### PR DESCRIPTION
In the `WebDeviceInputSystem`, when we receive a `pointerdown` event, we will call the observers associated with down events (from within `_pointerDownEvent`) and then call the ones associated with move.  After looking more closely at this, I believe that we do not need to do this as the pointer position will still be updated in the InputManager's down code.  This PR removes this move call from the code that handled the `pointerdown` events.