### PR TITLE
use generic type parameter for typecasting

### DIFF
--- a/packages/dev/core/src/Behaviors/behavior.ts
+++ b/packages/dev/core/src/Behaviors/behavior.ts
@@ -43,5 +43,11 @@ export interface IBehaviorAware<T> {
      * @param name defines the name to search
      * @returns the behavior or null if not found
      */
+    getBehaviorByName<B extends Behavior<T> = Behavior<T>>(name: string): Nullable<B>;
+    /**
+     * Gets a behavior using its name to search
+     * @param name defines the name to search
+     * @returns the behavior or null if not found
+     */
     getBehaviorByName(name: string): Nullable<Behavior<T>>;
 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -420,6 +420,13 @@ export class NodeMaterial extends PushMaterial {
      * @param name defines the name of the block to retrieve
      * @returns the required block or null if not found
      */
+    public getBlockByName<T extends NodeMaterialBlock>(name: string): Nullable<T>;
+
+    /**
+     * Get a block by its name
+     * @param name defines the name of the block to retrieve
+     * @returns the required block or null if not found
+     */
     public getBlockByName(name: string) {
         let result = null;
         for (const block of this.attachedBlocks) {
@@ -435,6 +442,13 @@ export class NodeMaterial extends PushMaterial {
 
         return result;
     }
+
+    /**
+     * Get a block using a predicate
+     * @param predicate defines the predicate used to find the good candidate
+     * @returns the required block or null if not found
+     */
+    public getBlockByPredicate<T extends NodeMaterialBlock>(predicate: (block: NodeMaterialBlock) => boolean): Nullable<T>;
 
     /**
      * Get a block using a predicate

--- a/packages/dev/core/src/Materials/Textures/internalTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/internalTexture.ts
@@ -281,6 +281,12 @@ export class InternalTexture extends TextureSampler {
      * Gets the Engine the texture belongs to.
      * @returns The babylon engine
      */
+    public getEngine<T extends ThinEngine>(): T;
+
+    /**
+     * Gets the Engine the texture belongs to.
+     * @returns The babylon engine
+     */
     public getEngine(): ThinEngine {
         return this._engine;
     }

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -464,6 +464,12 @@ export class Effect implements IDisposable {
      * The pipeline context for this effect
      * @returns the associated pipeline context
      */
+    public getPipelineContext<T extends IPipelineContext>(): Nullable<T>;
+
+    /**
+     * The pipeline context for this effect
+     * @returns the associated pipeline context
+     */
     public getPipelineContext(): Nullable<IPipelineContext> {
         return this._pipelineContext;
     }

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -150,6 +150,13 @@ export class MaterialPluginManager {
      * @param name name of the plugin
      * @returns the plugin if found, else null
      */
+    public getPlugin<T extends MaterialPluginBase>(name: string): Nullable<T>;
+
+    /**
+     * Gets a plugin from the list of plugins managed by this manager
+     * @param name name of the plugin
+     * @returns the plugin if found, else null
+     */
     public getPlugin(name: string): Nullable<MaterialPluginBase> {
         for (let i = 0; i < this._plugins.length; ++i) {
             if (this._plugins[i].name === name) {

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -136,6 +136,13 @@ export class NodeGeometry {
      * @param name defines the name of the block to retrieve
      * @returns the required block or null if not found
      */
+    public getBlockByName<T extends NodeGeometryBlock>(name: string): Nullable<T>;
+
+    /**
+     * Get a block by its name
+     * @param name defines the name of the block to retrieve
+     * @returns the required block or null if not found
+     */
     public getBlockByName(name: string) {
         let result = null;
         for (const block of this.attachedBlocks) {
@@ -151,6 +158,13 @@ export class NodeGeometry {
 
         return result;
     }
+
+    /**
+     * Get a block using a predicate
+     * @param predicate defines the predicate used to find the good candidate
+     * @returns the required block or null if not found
+     */
+    public getBlockByPredicate<T extends NodeGeometryBlock>(predicate: (block: NodeGeometryBlock) => boolean): Nullable<T>;
 
     /**
      * Get a block using a predicate

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -453,6 +453,13 @@ export class WebXRFeaturesManager implements IDisposable {
      * @param featureName the name of the feature to load
      * @returns the feature class, if found
      */
+    public getEnabledFeature<T extends IWebXRFeature>(featureName: string): T;
+
+    /**
+     * get the implementation of an enabled feature.
+     * @param featureName the name of the feature to load
+     * @returns the feature class, if found
+     */
     public getEnabledFeature(featureName: string): IWebXRFeature {
         return this._features[featureName] && this._features[featureName].featureImplementation;
     }

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -433,6 +433,14 @@ export class Node implements IBehaviorAware<Node> {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/behaviors
      * @returns null if behavior was not found else the requested behavior
      */
+    public getBehaviorByName<T extends Behavior<Node>>(name: string): Nullable<T>;
+
+    /**
+     * Gets an attached behavior by name
+     * @param name defines the name of the behavior to look for
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+     * @returns null if behavior was not found else the requested behavior
+     */
     public getBehaviorByName(name: string): Nullable<Behavior<Node>> {
         for (const behavior of this._behaviors) {
             if (behavior.name === name) {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1502,6 +1502,14 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param name defines the name of the component to retrieve
      * @returns the component or null if not present
      */
+    public _getComponent<T extends ISceneComponent>(name: string): Nullable<T>;
+
+    /**
+     * @internal
+     * Gets a component from the scene.
+     * @param name defines the name of the component to retrieve
+     * @returns the component or null if not present
+     */
     public _getComponent(name: string): Nullable<ISceneComponent> {
         for (const component of this._components) {
             if (component.name === name) {
@@ -1807,6 +1815,12 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public isCachedMaterialInvalid(material: Material, effect: Effect, visibility: number = 1) {
         return this._cachedEffect !== effect || this._cachedMaterial !== material || this._cachedVisibility !== visibility;
     }
+
+    /**
+     * Gets the engine associated with the scene
+     * @returns an Engine
+     */
+    public getEngine<T extends Engine>(): T;
 
     /**
      * Gets the engine associated with the scene
@@ -2938,6 +2952,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param id defines the camera's Id
      * @returns the new active camera or null if none found.
      */
+    public setActiveCameraById<T extends Camera>(id: string): Nullable<T>;
+
+    /**
+     * sets the active camera of the scene using its Id
+     * @param id defines the camera's Id
+     * @returns the new active camera or null if none found.
+     */
     public setActiveCameraById(id: string): Nullable<Camera> {
         const camera = this.getCameraById(id);
 
@@ -2948,6 +2969,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * sets the active camera of the scene using its name
+     * @param name defines the camera's name
+     * @returns the new active camera or null if none found.
+     */
+    public setActiveCameraByName<T extends Camera>(name: string): Nullable<T>;
 
     /**
      * sets the active camera of the scene using its name
@@ -3005,9 +3033,25 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param allowMultiMaterials determines whether multimaterials should be considered
      * @returns the material or null if none found.
      */
+    public getMaterialByUniqueID<T extends Material>(uniqueId: number, allowMultiMaterials?: boolean): Nullable<T>;
+
+    /**
+     * Get a material using its unique id
+     * @param uniqueId defines the material's unique id
+     * @param allowMultiMaterials determines whether multimaterials should be considered
+     * @returns the material or null if none found.
+     */
     public getMaterialByUniqueID(uniqueId: number, allowMultiMaterials: boolean = false): Nullable<Material> {
         return this._getMaterial(allowMultiMaterials, (m) => m.uniqueId === uniqueId);
     }
+
+    /**
+     * get a material using its id
+     * @param id defines the material's Id
+     * @param allowMultiMaterials determines whether multimaterials should be considered
+     * @returns the material or null if none found.
+     */
+    public getMaterialById<T extends Material>(id: string, allowMultiMaterials?: boolean): Nullable<T>;
 
     /**
      * get a material using its id
@@ -3025,9 +3069,25 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param allowMultiMaterials determines whether multimaterials should be considered
      * @returns the material or null if none found.
      */
+    public getMaterialByName<T extends Material>(name: string, allowMultiMaterials?: boolean): Nullable<T>;
+
+    /**
+     * Gets a material using its name
+     * @param name defines the material's name
+     * @param allowMultiMaterials determines whether multimaterials should be considered
+     * @returns the material or null if none found.
+     */
     public getMaterialByName(name: string, allowMultiMaterials: boolean = false): Nullable<Material> {
         return this._getMaterial(allowMultiMaterials, (m) => m.name === name);
     }
+
+    /**
+     * Gets a last added material using a given id
+     * @param id defines the material's id
+     * @param allowMultiMaterials determines whether multimaterials should be considered
+     * @returns the last material with the given id or null if none found.
+     */
+    public getLastMaterialById<T extends Material>(id: string, allowMultiMaterials?: boolean): Nullable<T>;
 
     /**
      * Gets a last added material using a given id
@@ -3057,6 +3117,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param uniqueId defines the texture's unique id
      * @returns the texture or null if none found.
      */
+    public getTextureByUniqueId<T extends BaseTexture>(uniqueId: number): Nullable<T>;
+
+    /**
+     * Get a texture using its unique id
+     * @param uniqueId defines the texture's unique id
+     * @returns the texture or null if none found.
+     */
     public getTextureByUniqueId(uniqueId: number): Nullable<BaseTexture> {
         for (let index = 0; index < this.textures.length; index++) {
             if (this.textures[index].uniqueId === uniqueId) {
@@ -3066,6 +3133,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * Gets a texture using its name
+     * @param name defines the texture's name
+     * @returns the texture or null if none found.
+     */
+    public getTextureByName<T extends BaseTexture>(name: string): Nullable<T>;
 
     /**
      * Gets a texture using its name
@@ -3087,6 +3161,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param id defines the Id to look for
      * @returns the camera or null if not found
      */
+    public getCameraById<T extends Camera>(id: string): Nullable<T>;
+
+    /**
+     * Gets a camera using its Id
+     * @param id defines the Id to look for
+     * @returns the camera or null if not found
+     */
     public getCameraById(id: string): Nullable<Camera> {
         for (let index = 0; index < this.cameras.length; index++) {
             if (this.cameras[index].id === id) {
@@ -3102,6 +3183,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param uniqueId defines the unique Id to look for
      * @returns the camera or null if not found
      */
+    public getCameraByUniqueId<T extends Camera>(uniqueId: number): Nullable<T>;
+
+    /**
+     * Gets a camera using its unique Id
+     * @param uniqueId defines the unique Id to look for
+     * @returns the camera or null if not found
+     */
     public getCameraByUniqueId(uniqueId: number): Nullable<Camera> {
         for (let index = 0; index < this.cameras.length; index++) {
             if (this.cameras[index].uniqueId === uniqueId) {
@@ -3111,6 +3199,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * Gets a camera using its name
+     * @param name defines the camera's name
+     * @returns the camera or null if none found.
+     */
+    public getCameraByName<T extends Camera>(name: string): Nullable<T>;
 
     /**
      * Gets a camera using its name
@@ -3168,6 +3263,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param name defines the light's name
      * @returns the light or null if none found.
      */
+    public getLightByName<T extends Light>(name: string): Nullable<T>;
+
+    /**
+     * Gets a light node using its name
+     * @param name defines the light's name
+     * @returns the light or null if none found.
+     */
     public getLightByName(name: string): Nullable<Light> {
         for (let index = 0; index < this.lights.length; index++) {
             if (this.lights[index].name === name) {
@@ -3183,6 +3285,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param id defines the light's Id
      * @returns the light or null if none found.
      */
+    public getLightById<T extends Light>(id: string): Nullable<T>;
+
+    /**
+     * Gets a light node using its Id
+     * @param id defines the light's Id
+     * @returns the light or null if none found.
+     */
     public getLightById(id: string): Nullable<Light> {
         for (let index = 0; index < this.lights.length; index++) {
             if (this.lights[index].id === id) {
@@ -3192,6 +3301,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * Gets a light node using its scene-generated unique Id
+     * @param uniqueId defines the light's unique Id
+     * @returns the light or null if none found.
+     */
+    public getLightByUniqueId<T extends Light>(uniqueId: number): Nullable<T>;
 
     /**
      * Gets a light node using its scene-generated unique Id
@@ -3325,6 +3441,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param id defines the Id to search for
      * @returns the mesh found or null if not found at all
      */
+    public getMeshById<T extends AbstractMesh>(id: string): Nullable<T>;
+
+    /**
+     * Gets the first added mesh found of a given Id
+     * @param id defines the Id to search for
+     * @returns the mesh found or null if not found at all
+     */
     public getMeshById(id: string): Nullable<AbstractMesh> {
         for (let index = 0; index < this.meshes.length; index++) {
             if (this.meshes[index].id === id) {
@@ -3392,6 +3515,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * @param uniqueId defines the unique Id to search for
      * @returns the found mesh or null if not found at all.
      */
+    public getMeshByUniqueId<T extends AbstractMesh>(uniqueId: number): Nullable<T>;
+
+    /**
+     * Gets a mesh with its auto-generated unique Id
+     * @param uniqueId defines the unique Id to search for
+     * @returns the found mesh or null if not found at all.
+     */
     public getMeshByUniqueId(uniqueId: number): Nullable<AbstractMesh> {
         for (let index = 0; index < this.meshes.length; index++) {
             if (this.meshes[index].uniqueId === uniqueId) {
@@ -3401,6 +3531,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * Gets a the last added mesh using a given Id
+     * @param id defines the Id to search for
+     * @returns the found mesh or null if not found at all.
+     */
+    public getLastMeshById<T extends AbstractMesh>(id: string): Nullable<T>;
 
     /**
      * Gets a the last added mesh using a given Id
@@ -3533,6 +3670,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
 
         return null;
     }
+
+    /**
+     * Gets a mesh using a given name
+     * @param name defines the name to search for
+     * @returns the found mesh or null if not found at all.
+     */
+    public getMeshByName<T extends AbstractMesh>(name: string): Nullable<T>;
 
     /**
      * Gets a mesh using a given name
@@ -3674,6 +3818,13 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         }
         return null;
     }
+
+    /**
+     * Gets a post process using a given name (if many are found, this function will pick the first one)
+     * @param name defines the name to search for
+     * @returns the found post process or null if not found at all.
+     */
+    public getPostProcessByName<T extends PostProcess>(name: string): Nullable<T>;
 
     /**
      * Gets a post process using a given name (if many are found, this function will pick the first one)

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -287,6 +287,15 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     public getChildren(): Array<Container> {
         return [this._rootContainer];
     }
+
+    /**
+     * Will return all controls that are inside this texture
+     * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
+     * @param predicate defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored
+     * @returns all child controls
+     */
+    public getDescendants<T extends Control>(directDescendantsOnly?: boolean, predicate?: (control: Control) => boolean): T[];
+
     /**
      * Will return all controls that are inside this texture
      * @param directDescendantsOnly defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered
@@ -302,9 +311,23 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * @param typeName defines the type name to search for
      * @returns an array of all controls found
      */
+    public getControlsByType<T extends Control>(typeName: string): T[];
+
+    /**
+     * Will return all controls with the given type name
+     * @param typeName defines the type name to search for
+     * @returns an array of all controls found
+     */
     public getControlsByType(typeName: string): Control[] {
         return this._rootContainer.getDescendants(false, (control) => control.typeName === typeName);
     }
+
+    /**
+     * Will return the first control with the given name
+     * @param name defines the name to search for
+     * @returns the first control found or null
+     */
+    public getControlByName<T extends Control>(name: string): Nullable<T>;
 
     /**
      * Will return the first control with the given name

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -172,6 +172,13 @@ export class Container extends Control {
      * @param name defines the child name to look for
      * @returns the child control if found
      */
+    public getChildByName<T extends Control>(name: string): Nullable<T>;
+
+    /**
+     * Gets a child using its name
+     * @param name defines the child name to look for
+     * @returns the child control if found
+     */
     public getChildByName(name: string): Nullable<Control> {
         for (const child of this.children) {
             if (child.name === name) {
@@ -181,6 +188,14 @@ export class Container extends Control {
 
         return null;
     }
+
+    /**
+     * Gets a child using its type and its name
+     * @param name defines the child name to look for
+     * @param type defines the child type to look for
+     * @returns the child control if found
+     */
+    public getChildByType<T extends Control>(name: string, type: string): Nullable<T>;
 
     /**
      * Gets a child using its type and its name

--- a/packages/dev/gui/src/3D/controls/control3D.ts
+++ b/packages/dev/gui/src/3D/controls/control3D.ts
@@ -172,6 +172,14 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/behaviors
      * @returns null if behavior was not found else the requested behavior
      */
+    public getBehaviorByName<T extends Behavior<Control3D> = Behavior<Control3D>>(name: string): Nullable<T>;
+
+    /**
+     * Gets an attached behavior by name
+     * @param name defines the name of the behavior to look for
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+     * @returns null if behavior was not found else the requested behavior
+     */
     public getBehaviorByName(name: string): Nullable<Behavior<Control3D>> {
         for (const behavior of this._behaviors) {
             if (behavior.name === name) {


### PR DESCRIPTION
use generic type parameter for typecasting and type inferencing

- [x]  NodeMaterial.getBlockByName/getBlockByPredicate
- [x]  NodeGeometry.getBlockByName/getBlockByPredicate
- [x]  MaterialPluginManager.getPlugin
- [x]  IBehaviorAware/Node/Control3D.getBehaviorByName
- [x]  Scene.setActiveCameraById/setActiveCameraByName
- [x]  Scene.getMaterialByUniqueID/getMaterialById/getMaterialByName/getLastMaterialById
- [x]  Scene.getMeshByUniqueID/getMeshById/getMeshByName/getLastMeshById
- [x]  Scene.getTextureByUniqueId/getTextureByName
- [x]  Scene.getCameraByUniqueId/getCameraById/getCameraByName
- [x]  Scene.getLightByUniqueId/getLightById/getLightByName
- [x]  Scene.getPostProcessByName
- [x]  Scene._getComponent
- [x]  Scene.getEngine
- [x] InternalTexture.getEngine
- [x]  AdvancedDynamicTexture.getControlByName/getDescendants/getControlsByType
- [x]  Container.getChildByName/getChildByType
- [x]  WebXRFeaturesManager.getEnabledFeature
- [x]  Effect.getPipelineContext
