### PR TITLE
Fix: add null check for canvas before removing

### DIFF
--- a/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
@@ -214,13 +214,14 @@ export class DynamicTexture extends Texture {
      * Disposes the dynamic texture.
      */
     public dispose(): void {
-        super.dispose();
-
-        if (this._ownCanvas) {
+        if (this._ownCanvas && this._canvas) {
             this._canvas.remove();
         }
+
         (this._canvas as any) = null;
         (this._context as any) = null;
+
+        super.dispose();
     }
 
     /**


### PR DESCRIPTION
This fixes an issue in which `dispose` attempts to remove a canvas that is `undefined`