### PR TITLE
DynamicTexture: add sanity check in dispose

### DIFF
--- a/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
@@ -217,7 +217,7 @@ export class DynamicTexture extends Texture {
         super.dispose();
 
         if (this._ownCanvas) {
-            this._canvas.remove();
+            this._canvas?.remove();
         }
         (this._canvas as any) = null;
         (this._context as any) = null;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/detached-element-memory-leak-when-disposing-dynamic-textures/46668/4