### PR TITLE
Add observers to WebXRCamera when a rotation is performed

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -237,6 +237,16 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
     private _rotationEnabled: boolean = true;
 
     /**
+     * Observable raised before camera rotation
+     */
+    public onBeforeCameraTeleportRotation = new Observable<Number>();
+
+    /**
+     *  Observable raised after camera rotation
+     */
+    public onAfterCameraTeleportRotation = new Observable<Quaternion>();
+
+    /**
      * Is rotation enabled when moving forward?
      * Disabling this feature will prevent the user from deciding the direction when teleporting
      */
@@ -651,10 +661,12 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                                         // rotate in the right direction positive is right
                                         controllerData.teleportationState.rotating = true;
                                         const rotation = this.rotationAngle * (axesData.x > 0 ? 1 : -1) * (this._xrSessionManager.scene.useRightHandedSystem ? -1 : 1);
+                                        this.onBeforeCameraTeleportRotation.notifyObservers(rotation);
                                         Quaternion.FromEulerAngles(0, rotation, 0).multiplyToRef(
                                             this._options.xrInput.xrCamera.rotationQuaternion,
                                             this._options.xrInput.xrCamera.rotationQuaternion
                                         );
+                                        this.onAfterCameraTeleportRotation.notifyObservers(this._options.xrInput.xrCamera.rotationQuaternion);
                                     }
                                 } else {
                                     if (this._currentTeleportationControllerId === controllerData.xrController.uniqueId) {

--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -41,6 +41,7 @@ export class WebXRCamera extends FreeCamera {
      * Notice - will also be triggered when tracking has started (at the beginning of the session)
      */
     public onTrackingStateChanged = new Observable<WebXRTrackingState>();
+
     /**
      * Should position compensation execute on first frame.
      * This is used when copying the position from a native (non XR) camera


### PR DESCRIPTION
Add observables `onBeforeCameraTeleportRotation` and `onAfterCameraTeleportRotation` to `WebXRMotionControllerTeleportation`.

```shell
npm run format:fix
```