### PR TITLE
fix(ShaderMaterial): correct serialization key spelling mistake

### DIFF
--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -1480,9 +1480,9 @@ export class ShaderMaterial extends PushMaterial {
         }
 
         // Floats
-        serializationObject.FloatArrays = {};
+        serializationObject.floatsArrays = {};
         for (name in this._floatsArrays) {
-            serializationObject.FloatArrays[name] = this._floatsArrays[name];
+            serializationObject.floatsArrays[name] = this._floatsArrays[name];
         }
 
         // Color3


### PR DESCRIPTION
correct spelling mistake of serializationObject of `ShaderMaterial`
the key about `floatsArray` in serialized and deserialized object are inconsistent，then deserializing `floatsArray` will fail.

serialize
<img width="595" alt="截屏2024-01-01 04 49 18" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/e6d7a971-8298-4f71-9754-341b96436d04">

Parse
<img width="560" alt="截屏2024-01-01 04 50 08" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/85ac61b9-16d7-4ce5-ac7e-07a4e212b884">
