### PR TITLE
Support custom plugin when clone material

### DIFF
--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -1293,7 +1293,11 @@ export class BackgroundMaterial extends PushMaterial {
      * @returns The cloned material.
      */
     public clone(name: string): BackgroundMaterial {
-        return SerializationHelper.Clone(() => new BackgroundMaterial(name, this.getScene()), this);
+        const result = SerializationHelper.Clone(() => new BackgroundMaterial(name, this.getScene()), this);
+
+        this.onClonedObservable.notifyObservers(result);
+
+        return result;
     }
 
     /**

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2265,6 +2265,8 @@ export class NodeMaterial extends PushMaterial {
         clone._buildId = this._buildId;
         clone.build(false, !shareEffect);
 
+        this.onClonedObservable.notifyObservers(clone);
+
         return clone;
     }
 

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -783,6 +783,8 @@ export class PBRMaterial extends PBRBaseMaterial {
 
         this._clonePlugins(clone, rootUrl);
 
+        this.onClonedObservable.notifyObservers(clone);
+
         return clone;
     }
 

--- a/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
@@ -93,6 +93,8 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
         this.sheen.copyTo(clone.sheen);
         this.subSurface.copyTo(clone.subSurface);
 
+        this.onClonedObservable.notifyObservers(clone);
+
         return clone;
     }
 

--- a/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
@@ -90,6 +90,8 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
         this.sheen.copyTo(clone.sheen);
         this.subSurface.copyTo(clone.subSurface);
 
+        this.onClonedObservable.notifyObservers(clone);
+
         return clone;
     }
 

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -528,6 +528,19 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         return this._onEffectCreatedObservable;
     }
 
+    protected _onClonedObservable: Nullable<Observable<Material>>;
+
+    /**
+     * An event triggered when the material is cloned
+     */
+    public get onClonedObservable(): Observable<Material> {
+        if (!this._onClonedObservable) {
+            this._onClonedObservable = new Observable<Material>();
+        }
+
+        return this._onClonedObservable;
+    }
+
     /**
      * Stores the value of the alpha mode
      */

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1409,8 +1409,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         // Copy the properties of the current plugins to the cloned material's plugins
         if (this.pluginManager) {
             for (const plugin of this.pluginManager._plugins) {
-                const targetPlugin = targetMaterial.pluginManager!.getPlugin(plugin.name)!;
-                plugin.copyTo(targetPlugin);
+                const targetPlugin = targetMaterial.pluginManager!.getPlugin(plugin.name);
+                if (targetPlugin) {
+                    plugin.copyTo(targetPlugin);
+                }
             }
         }
     }

--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -180,6 +180,8 @@ export class MultiMaterial extends Material {
             newMultiMaterial.subMaterials.push(subMaterial);
         }
 
+        this.onClonedObservable.notifyObservers(newMultiMaterial);
+
         return newMultiMaterial;
     }
 

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -1398,6 +1398,8 @@ export class ShaderMaterial extends PushMaterial {
             result.setStorageBuffer(key, this._storageBuffers[key]);
         }
 
+        this.onClonedObservable.notifyObservers(result);
+
         return result;
     }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1995,6 +1995,8 @@ export class StandardMaterial extends PushMaterial {
 
         this._clonePlugins(result, rootUrl);
 
+        this.onClonedObservable.notifyObservers(result);
+
         return result;
     }
 


### PR DESCRIPTION
If `PBRMaterial` or `StandardMaterial` has custom plugins, and when clone material, an error will be thrown.

Playground below can reproduce the issue
https://www.babylonjs-playground.com/#X55BQW 

The reason for this problem is that the name of custom plugin doesnt start with `BABYLON.`, 

so `material._parsePlugins` doesnt instantiate the custom plugin for cloned material.
<img width="690" alt="截屏2023-12-30 00 45 21" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/a0f58581-9b49-4144-83db-a1775ca09338">


and then in `material._clonePlugins`, `pluginManager!.getPlugin(plugin.name)` will return null
<img width="748" alt="截屏2023-12-30 00 44 36" src="https://github.com/BabylonJS/Babylon.js/assets/33159342/24fa3e9e-a454-42cd-9a3c-6154b468904e">


and because `_clonePlugins` doesnt support custom plugin, so add `material.onClonedObservable`, then
 the user can decides how to clone a custom material plugin when clone event is triggered.
such as:
```
originMaterial.colorify = new ColorifyPluginMaterial(originMaterial);
originMaterial.colorify.color = BABYLON.Color3.Red();

// clone custom plugin
originMaterial.onClonedObservable.add((cloned) => {
       cloned.colorify = new ColorifyPluginMaterial(cloned);
       cloned.colorify.color = originMaterial.colorify.color.clone();
});
```