### PR TITLE
Fix camera not being reattached after a two pointer SixDofDragBehavior

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
@@ -371,7 +371,7 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
                         if (this._pointerCamera.inputs && this._pointerCamera.inputs.attachedToElement) {
                             this._pointerCamera.detachControl();
                             this._attachedToElement = true;
-                        } else {
+                        } else if (!this.allowMultiPointer || this.currentDraggingPointerIds.length === 0) {
                             this._attachedToElement = false;
                         }
                     }


### PR DESCRIPTION
Forum post: https://forum.babylonjs.com/t/unselected-meshes-move-alongside-the-selected-mesh/46627

When there was more than one pointer activating the SixDofDragBehavior, the `_attachedToElement` property was being set to false, and the camera was not reattached because of it.