### PR TITLE
Allow different versions in PG and Sandbox

### DIFF
--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -2,7 +2,7 @@
 // Version
 var Versions = {
     Latest: [
-        "https://preview.babylonjs.com/timestamp.js?t=" + Date.now(),
+        "https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(),
         "https://preview.babylonjs.com/babylon.js",
         "https://preview.babylonjs.com/gui/babylon.gui.min.js",
         "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js",
@@ -138,6 +138,7 @@ let checkBabylonVersionAsync = function () {
     let activeVersion = readStringFromStore("version", "Latest");
 
     if ((window.location.hostname === "localhost" && window.location.search.indexOf("dist") === -1) || window.location.search.indexOf("local") !== -1) {
+        // eslint-disable-next-line no-console
         console.log("Using local version. To use preview add ?dist=true to the url");
         activeVersion = "local";
     }
@@ -145,17 +146,27 @@ let checkBabylonVersionAsync = function () {
     let snapshot = "";
     // see if a snapshot should be used
     if (window.location.search.indexOf("snapshot=") !== -1) {
-        snapshot = window.location.search.split("=")[1];
+        snapshot = window.location.search.split("snapshot=")[1];
         // cleanup, just in case
         snapshot = snapshot.split("&")[0];
         activeVersion = "Latest";
     }
 
-    let versions = Versions[activeVersion] || Versions["Latest"];
+    let version = "";
+    if (window.location.search.indexOf("version=") !== -1) {
+        version = window.location.search.split("version=")[1];
+        // cleanup, just in case
+        version = version.split("&")[0];
+        activeVersion = "Latest";
+    }
+
+    let frameworkScripts = Versions[activeVersion] || Versions["Latest"];
     if (snapshot) {
-        versions = versions.map((v) => v.replace("https://preview.babylonjs.com", "https://babylonsnapshots.z22.web.core.windows.net/" + snapshot));
+        frameworkScripts = frameworkScripts.map((v) => v.replace("https://preview.babylonjs.com", "https://babylonsnapshots.z22.web.core.windows.net/" + snapshot));
+    } else if(version) {
+        frameworkScripts = frameworkScripts.map((v) => v.replace("https://preview.babylonjs.com", "https://cdn.babylonjs.com/v" + version));
     } else if (window.location.href.includes("debug.html")) {
-        versions = versions.map((v) => {
+        frameworkScripts = frameworkScripts.map((v) => {
             if (!v.includes("https://preview.babylonjs.com") && !v.includes("https://cdn.jsdelivr.net/gh/BabylonJS/Babylon.js")) {
                 return v;
             }
@@ -171,7 +182,7 @@ let checkBabylonVersionAsync = function () {
     }
 
     return new Promise((resolve) => {
-        loadInSequence(versions, 0, resolve);
+        loadInSequence(frameworkScripts, 0, resolve);
     });
 };
 

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -258,7 +258,7 @@ class Playground {
         }
 
         let version = "";
-        if(window.location.search.indexOf("version=") !== -1) {
+        if (window.location.search.indexOf("version=") !== -1) {
             version = window.location.search.split("version=")[1];
             // cleanup, just in case
             version = version.split("&")[0];

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -249,11 +249,21 @@ class Playground {
         let snapshot = "";
         // see if a snapshot should be used
         if (window.location.search.indexOf("snapshot=") !== -1) {
-            snapshot = window.location.search.split("=")[1];
+            snapshot = window.location.search.split("snapshot=")[1];
             // cleanup, just in case
             snapshot = snapshot.split("&")[0];
             for (let index = 0; index < declarations.length; index++) {
                 declarations[index] = declarations[index].replace("https://preview.babylonjs.com", "https://babylonsnapshots.z22.web.core.windows.net/" + snapshot);
+            }
+        }
+
+        let version = "";
+        if(window.location.search.indexOf("version=") !== -1) {
+            version = window.location.search.split("version=")[1];
+            // cleanup, just in case
+            version = version.split("&")[0];
+            for (let index = 0; index < declarations.length; index++) {
+                declarations[index] = declarations[index].replace("https://preview.babylonjs.com", "https://cdn.babylonjs.com/v" + version);
             }
         }
 

--- a/packages/tools/sandbox/public/index.js
+++ b/packages/tools/sandbox/public/index.js
@@ -35,7 +35,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: [
-        "https://preview.babylonjs.com/timestamp.js?t=" + Date.now(),
+        "https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(),
         "https://preview.babylonjs.com/babylon.js",
         "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js",
         "https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js",
@@ -72,15 +72,25 @@ let checkBabylonVersionAsync = function () {
     let snapshot = "";
     // see if a snapshot should be used
     if (window.location.search.indexOf("snapshot=") !== -1) {
-        snapshot = window.location.search.split("=")[1];
+        snapshot = window.location.search.split("snapshot=")[1];
         // cleanup, just in case
         snapshot = snapshot.split("&")[0];
+        activeVersion = "dist";
+    }
+
+    let version = "";
+    if (window.location.search.indexOf("version=") !== -1) {
+        version = window.location.search.split("version=")[1];
+        // cleanup, just in case
+        version = version.split("&")[0];
         activeVersion = "dist";
     }
 
     let versions = Versions[activeVersion] || Versions["dist"];
     if (snapshot && activeVersion === "dist") {
         versions = versions.map((v) => v.replace("https://preview.babylonjs.com", "https://babylonsnapshots.z22.web.core.windows.net/" + snapshot));
+    } else if (version && activeVersion === "dist") {
+        versions = versions.map((v) => v.replace("https://preview.babylonjs.com", "https://cdn.babylonjs.com/v" + version));
     }
 
     return new Promise((resolve, _reject) => {
@@ -93,15 +103,3 @@ checkBabylonVersionAsync().then(() => {
         BABYLON.Sandbox.Show(hostElement);
     });
 });
-
-/**
- *     <script src="https://preview.babylonjs.com/babylon.js"></script>
-
-    <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js"></script>
-    <script src="https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="https://preview.babylonjs.com/gui/babylon.gui.min.js"></script>
-
-    <script src="https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js"></script>
-    <script src="dist/babylon.sandbox.js"></script>
- */


### PR DESCRIPTION
This PR will allow adding `version=6.22.0` to a PG or sandbox URL to force a specific babylon version

Note that this works only from version 5.40 and up. For earlier versions we still have the version selector in the playground itself.