### PR TITLE
BoudingBoxGizmo Scale Boxes Fix

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -849,7 +849,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         scaleBoxes[index].position.set(this._boundingDimensions.x * (i / 2), this._boundingDimensions.y * (j / 2), this._boundingDimensions.z * (k / 2));
                         scaleBoxes[index].position.addInPlace(new Vector3(-this._boundingDimensions.x / 2, -this._boundingDimensions.y / 2, -this._boundingDimensions.z / 2));
                         if (this.fixedDragMeshScreenSize && this.gizmoLayer.utilityLayerScene.activeCamera) {
-                            scaleBoxes[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.position, this._tmpVector);
+                            scaleBoxes[index].absolutePosition.subtractToRef(this.gizmoLayer.utilityLayerScene.activeCamera.globalPosition, this._tmpVector);
                             const distanceFromCamera = (this.scaleBoxSize * this._tmpVector.length()) / this.fixedDragMeshScreenSizeDistanceFactor;
                             scaleBoxes[index].scaling.set(distanceFromCamera, distanceFromCamera, distanceFromCamera);
                         } else if (this.fixedDragMeshBoundsSize) {


### PR DESCRIPTION
There was a bug where if the active utility layers camera was a child of an object the calculations would use the local position instead of the desired global position.