### PR TITLE
[XR] Port teleportation observable to feature

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -247,6 +247,16 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
     public onAfterCameraTeleportRotation = new Observable<Quaternion>();
 
     /**
+     * Observable raised before camera teleportation
+     */
+    public onBeforeCameraTeleport: Observable<Vector3>;
+
+    /**
+     *  Observable raised after camera teleportation
+     */
+    public onAfterCameraTeleport: Observable<Vector3>;
+
+    /**
      * Is rotation enabled when moving forward?
      * Disabling this feature will prevent the user from deciding the direction when teleporting
      */
@@ -296,6 +306,10 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         this._blockedRayColor = this._options.blockedRayColor || new Color4(1, 0, 0, 0.75);
 
         this._setTargetMeshVisibility(false);
+
+        // set the observables
+        this.onBeforeCameraTeleport = _options.xrInput.xrCamera.onBeforeCameraTeleport;
+        this.onAfterCameraTeleport = _options.xrInput.xrCamera.onAfterCameraTeleport;
     }
 
     /**

--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -28,11 +28,13 @@ export class WebXRCamera extends FreeCamera {
 
     /**
      * Observable raised before camera teleportation
+     * @deprecated use onBeforeCameraTeleport of the teleportation feature instead
      */
     public onBeforeCameraTeleport = new Observable<Vector3>();
 
     /**
      *  Observable raised after camera teleportation
+     * @deprecated use onAfterCameraTeleport of the teleportation feature instead
      */
     public onAfterCameraTeleport = new Observable<Vector3>();
 

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManager.test.ts
@@ -5,6 +5,7 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRFeaturesManager, WebXRSessionManager, WebXRMotionControllerTeleportation, WebXRControllerMovement } from "core/XR";
+// eslint-disable-next-line import/no-internal-modules
 import "core/Animations/index";
 /**
  * WebXR Features Manager test suite.
@@ -53,7 +54,7 @@ describe("Babylon WebXR Features Manager", function () {
      */
     describe("Conflicting Features cannot be enabled simultaneously", () => {
         it("Cannot enable Movement feature while Teleportation feature is enabled", () => {
-            const teleportationFeature = subject.enableFeature(WebXRMotionControllerTeleportation.Name, undefined, { xrInput: {} });
+            const teleportationFeature = subject.enableFeature(WebXRMotionControllerTeleportation.Name, undefined, { xrInput: { xrCamera: {} } });
             expect(teleportationFeature).toBeDefined();
             expect(subject.getEnabledFeatures()).toStrictEqual([WebXRMotionControllerTeleportation.Name]);
 


### PR DESCRIPTION
See https://github.com/BabylonJS/Babylon.js/pull/14660#issuecomment-1880887068
Deprecated the actual observables, created a reference where they should be used. 
There was no proper way to do it the other way (which would be cleaner), because the feature is not guaranteed to have been initilized before the camera is constructed.