### PR TITLE
Adding loadeddata event listener in videoTexture

### DIFF
--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -213,6 +213,7 @@ export class VideoTexture extends Texture {
             this.video.setAttribute("playsinline", "");
             this.video.addEventListener("paused", this._updateInternalTexture);
             this.video.addEventListener("seeked", this._updateInternalTexture);
+            this.video.addEventListener("loadeddata", this._updateInternalTexture);
             this.video.addEventListener("emptied", this._reset);
 
             if (this._settings.autoPlay) {
@@ -447,6 +448,7 @@ export class VideoTexture extends Texture {
         if (!this._settings.independentVideoSource) {
             this.video.removeEventListener("paused", this._updateInternalTexture);
             this.video.removeEventListener("seeked", this._updateInternalTexture);
+            this.video.removeEventListener("loadeddata", this._updateInternalTexture);
             this.video.removeEventListener("emptied", this._reset);
             this.video.removeEventListener("resize", this._resizeInternalTexture);
             this.video.pause();


### PR DESCRIPTION
When in XR, due to interesting network conditions, the video, once updated, is stuck in a readyState === 1, and then stops updating.
This adds an extra update call when the video's readyState has changed (i.e. update the video texture, setting it ready, when the video is ready to be played). This solves ths issue, presented in this PG (enter XR, force keyboard event keydown "p"):

https://playground.babylonjs.com/#YJLYCB#10