### PR TITLE
Fix issue with movement and 6DOF in XR

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -289,7 +289,7 @@ export class InputManager {
         if (pickResult) {
             pi.originalPickingInfo = pickResult;
             pi.ray = pickResult.ray;
-            if (pickResult.originMesh) {
+            if (evt.pointerType === "xr-near" && pickResult.originMesh) {
                 pi.nearInteractionPickingInfo = pickResult;
             }
         }

--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -459,6 +459,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             if (controllerData.pick && controllerData.xrController) {
                 controllerData.pick.aimTransform = controllerData.xrController.pointer;
                 controllerData.pick.gripTransform = controllerData.xrController.grip || null;
+                controllerData.pick.originMesh = controllerData.xrController.pointer;
             }
 
             const pick = controllerData.pick;


### PR DESCRIPTION
Fixes #12439

The z factor of 6DoF behavior was incorrect. If we define originMesh (which the XR controller has) it uses the right z factor. Also made sure there is no change to xr near interaction.