### PR TITLE
Spotlight: Fix wrong projected texture when light is parented

### DIFF
--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -314,7 +314,7 @@ export class SpotLight extends ShadowLight {
         this._projectionTextureViewLightDirty = false;
         this._projectionTextureDirty = true;
 
-        this.getAbsolutePosition().addToRef(this.direction, this._projectionTextureViewTargetVector);
+        this.getAbsolutePosition().addToRef(this.getShadowDirection(), this._projectionTextureViewTargetVector);
         Matrix.LookAtLHToRef(this.getAbsolutePosition(), this._projectionTextureViewTargetVector, this._projectionTextureUpDirection, this._projectionTextureViewLightMatrix);
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/flashlight-follow-camera/20623/6