### PR TITLE
Fixes for native async shader compilation

### DIFF
--- a/packages/dev/core/src/Engines/IPipelineContext.ts
+++ b/packages/dev/core/src/Engines/IPipelineContext.ts
@@ -9,11 +9,11 @@ export interface IPipelineContext {
     /**
      * Gets a boolean indicating that this pipeline context is supporting asynchronous creating
      */
-    isAsync: boolean;
+    readonly isAsync: boolean;
     /**
      * Gets a boolean indicating that the context is ready to be used (like shaders / pipelines are compiled and ready for instance)
      */
-    isReady: boolean;
+    readonly isReady: boolean;
 
     /** @internal */
     _name?: string;
@@ -25,7 +25,7 @@ export interface IPipelineContext {
     _getFragmentShaderCode(): string | null;
 
     /** @internal */
-    _handlesSpectorRebuildCallback(onCompiled: (compiledObject: any) => void): void;
+    _handlesSpectorRebuildCallback?(onCompiled: (compiledObject: any) => void): void;
 
     /** @internal */
     _fillEffectInformation(

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -3,15 +3,15 @@ import type { Effect } from "../../Materials/effect";
 import type { IMatrixLike, IVector2Like, IVector3Like, IVector4Like, IColor3Like, IColor4Like, IQuaternionLike } from "../../Maths/math.like";
 import type { IPipelineContext } from "../IPipelineContext";
 import type { NativeEngine } from "../nativeEngine";
+import { NativeProgram } from "./nativeInterfaces";
 
 export class NativePipelineContext implements IPipelineContext {
-    public isParallelCompiled: boolean = true;
     public isCompiled: boolean = false;
     public compilationError?: Error;
 
-    public get isAsync(): boolean {
-        return this.isParallelCompiled;
-    }
+    public readonly isAsync: boolean;
+
+    public program: NativeProgram;
 
     public get isReady(): boolean {
         if (this.compilationError) {
@@ -31,19 +31,13 @@ export class NativePipelineContext implements IPipelineContext {
         return null;
     }
 
-    // TODO: what should this do?
-    public _handlesSpectorRebuildCallback(onCompiled: (compiledObject: any) => void): void {
-        throw new Error("Not implemented");
-    }
-
-    public nativeProgram: any;
-
     private _engine: NativeEngine;
     private _valueCache: { [key: string]: any } = {};
     private _uniforms: { [key: string]: Nullable<WebGLUniformLocation> };
 
-    constructor(engine: NativeEngine) {
+    constructor(engine: NativeEngine, isAsync: boolean) {
         this._engine = engine;
+        this.isAsync = isAsync;
     }
 
     public _fillEffectInformation(

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -734,7 +734,7 @@ export class Effect implements IDisposable {
                 }
             }
 
-            this._pipelineContext!._handlesSpectorRebuildCallback(onCompiled);
+            this._pipelineContext!._handlesSpectorRebuildCallback?.(onCompiled);
         };
         this._fallbacks = null;
         this._prepareEffect();


### PR DESCRIPTION
The main reason for this change is to make it possible to turn off async shader compilation when using native engine.