### PR TITLE
add clarification to pbrmaterial docs

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -388,6 +388,7 @@ export class PBRMaterial extends PBRBaseMaterial {
 
     /**
      * Specifies if the metallic texture contains the roughness information in its green channel.
+     * Needs useRoughnessFromMetallicTextureAlpha to be false.
      */
     @serialize()
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")


### PR DESCRIPTION
Just making the useRoughnessFromMetallicTextureGreen usage a bit clearer. Related forum question: https://forum.babylonjs.com/t/metallic-roughness-specular-glossiness-gltf-sample-assets/47152