### PR TITLE
WebXR world scaling factor

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -310,6 +310,13 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         // set the observables
         this.onBeforeCameraTeleport = _options.xrInput.xrCamera.onBeforeCameraTeleport;
         this.onAfterCameraTeleport = _options.xrInput.xrCamera.onAfterCameraTeleport;
+
+        this.parabolicCheckRadius *= this._xrSessionManager.worldScalingFactor;
+        _xrSessionManager.onWorldScaleFactorChangedObservable.add((values) => {
+            this.parabolicCheckRadius = (this.parabolicCheckRadius / values.previousScaleFactor) * values.newScaleFactor;
+
+            this._options.teleportationTargetMesh?.scaling.scaleInPlace(values.newScaleFactor / values.previousScaleFactor);
+        });
     }
 
     /**
@@ -847,6 +854,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         }
 
         this._options.teleportationTargetMesh = teleportationTarget;
+        this._options.teleportationTargetMesh.scaling.setAll(this._xrSessionManager.worldScalingFactor);
         // hide the teleportation target mesh right after creating it.
         this._setTargetMeshVisibility(false);
     }
@@ -982,14 +990,14 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         // do the movement forward here
         if (this._options.teleportationTargetMesh && this._options.teleportationTargetMesh.isVisible) {
             const height = this._options.xrInput.xrCamera.realWorldHeight;
-            this._options.xrInput.xrCamera.onBeforeCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
+            this.onBeforeCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
             this._options.xrInput.xrCamera.position.copyFrom(this._options.teleportationTargetMesh.position);
             this._options.xrInput.xrCamera.position.y += height;
             Quaternion.FromEulerAngles(0, controllerData.teleportationState.currentRotation - (this._xrSessionManager.scene.useRightHandedSystem ? Math.PI : 0), 0).multiplyToRef(
                 this._options.xrInput.xrCamera.rotationQuaternion,
                 this._options.xrInput.xrCamera.rotationQuaternion
             );
-            this._options.xrInput.xrCamera.onAfterCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
+            this.onAfterCameraTeleport.notifyObservers(this._options.xrInput.xrCamera.position);
         }
     }
 }

--- a/packages/dev/core/src/XR/features/WebXREyeTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXREyeTracking.ts
@@ -92,7 +92,7 @@ export class WebXREyeTracking extends WebXRAbstractFeature {
         if (this._latestEyeSpace && this._gazeRay) {
             const pose = frame.getPose(this._latestEyeSpace, this._xrSessionManager.referenceSpace);
             if (pose) {
-                this._gazeRay.origin.set(pose.transform.position.x, pose.transform.position.y, pose.transform.position.z);
+                this._gazeRay.origin.set(pose.transform.position.x, pose.transform.position.y, pose.transform.position.z).scaleInPlace(this._xrSessionManager.worldScalingFactor);
                 const quat = pose.transform.orientation;
                 TmpVectors.Quaternion[0].set(quat.x, quat.y, quat.z, quat.w);
 

--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -390,12 +390,17 @@ export class WebXRHand implements IDisposable {
      * @param handMesh The rigged hand mesh that will be tracked to the user's hand.
      * @param rigMapping The mapping from XRHandJoint to bone names to use with the mesh.
      */
-    public setHandMesh(handMesh: AbstractMesh, rigMapping: Nullable<XRHandMeshRigMapping>) {
+    public setHandMesh(handMesh: AbstractMesh, rigMapping: Nullable<XRHandMeshRigMapping>, xrSessionManager?: WebXRSessionManager) {
         this._handMesh = handMesh;
 
         // Avoid any strange frustum culling. We will manually control visibility via attach and detach.
         handMesh.alwaysSelectAsActiveMesh = true;
-        handMesh.getChildMeshes().forEach((mesh) => (mesh.alwaysSelectAsActiveMesh = true));
+        handMesh.getChildMeshes().forEach((mesh) => {
+            mesh.alwaysSelectAsActiveMesh = true;
+        });
+        if (xrSessionManager) {
+            handMesh.scaling.setAll(xrSessionManager.worldScalingFactor);
+        }
 
         // Link the bones in the hand mesh to the transform nodes that will be bound to the WebXR tracked joints.
         if (this._handMesh.skeleton) {
@@ -414,7 +419,7 @@ export class WebXRHand implements IDisposable {
      * @param xrFrame The latest frame received from WebXR.
      * @param referenceSpace The current viewer reference space.
      */
-    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace) {
+    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace, xrSessionManager: WebXRSessionManager) {
         const hand = this.xrController.inputSource.hand;
         if (!hand) {
             return;
@@ -450,6 +455,8 @@ export class WebXRHand implements IDisposable {
             const jointTransform = this._jointTransforms[jointIdx];
             Matrix.FromArrayToRef(this._jointTransformMatrices, jointIdx * 16, this._tempJointMatrix);
             this._tempJointMatrix.decompose(undefined, jointTransform.rotationQuaternion!, jointTransform.position);
+
+            // jointTransform.position.scaleInPlace(xrSessionManager.worldScalingFactor);
 
             // The radius we need to make the joint in order for it to roughly cover the joints of the user's real hand.
             const scaledJointRadius = this._jointRadii[jointIdx] * this._jointScaleFactor;
@@ -799,8 +806,14 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
                 };
 
                 // Apply meshes to existing hands if already tracking.
-                this._trackingHands.left?.setHandMesh(this._handResources.handMeshes.left, this._handResources.rigMappings.left);
-                this._trackingHands.right?.setHandMesh(this._handResources.handMeshes.right, this._handResources.rigMappings.right);
+                this._trackingHands.left?.setHandMesh(this._handResources.handMeshes.left, this._handResources.rigMappings.left, this._xrSessionManager);
+                this._trackingHands.right?.setHandMesh(this._handResources.handMeshes.right, this._handResources.rigMappings.right, this._xrSessionManager);
+            });
+            this._xrSessionManager.onWorldScaleFactorChangedObservable.add((scalingFactors) => {
+                if (this._handResources.handMeshes) {
+                    this._handResources.handMeshes.left.scaling.scaleInPlace(scalingFactors.newScaleFactor / scalingFactors.previousScaleFactor);
+                    this._handResources.handMeshes.right.scaling.scaleInPlace(scalingFactors.newScaleFactor / scalingFactors.previousScaleFactor);
+                }
             });
         }
 
@@ -812,8 +825,8 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
     }
 
     protected _onXRFrame(_xrFrame: XRFrame): void {
-        this._trackingHands.left?.updateFromXRFrame(_xrFrame, this._xrSessionManager.referenceSpace);
-        this._trackingHands.right?.updateFromXRFrame(_xrFrame, this._xrSessionManager.referenceSpace);
+        this._trackingHands.left?.updateFromXRFrame(_xrFrame, this._xrSessionManager.referenceSpace, this._xrSessionManager);
+        this._trackingHands.right?.updateFromXRFrame(_xrFrame, this._xrSessionManager.referenceSpace, this._xrSessionManager);
     }
 
     private _attachHand = (xrController: WebXRInputSource) => {

--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -456,7 +456,6 @@ export class WebXRHand implements IDisposable {
             Matrix.FromArrayToRef(this._jointTransformMatrices, jointIdx * 16, this._tempJointMatrix);
             this._tempJointMatrix.decompose(undefined, jointTransform.rotationQuaternion!, jointTransform.position);
 
-
             // The radius we need to make the joint in order for it to roughly cover the joints of the user's real hand.
             const scaledJointRadius = this._jointRadii[jointIdx] * this._jointScaleFactor;
 

--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -456,7 +456,6 @@ export class WebXRHand implements IDisposable {
             Matrix.FromArrayToRef(this._jointTransformMatrices, jointIdx * 16, this._tempJointMatrix);
             this._tempJointMatrix.decompose(undefined, jointTransform.rotationQuaternion!, jointTransform.position);
 
-            // jointTransform.position.scaleInPlace(xrSessionManager.worldScalingFactor);
 
             // The radius we need to make the joint in order for it to roughly cover the joints of the user's real hand.
             const scaledJointRadius = this._jointRadii[jointIdx] * this._jointScaleFactor;

--- a/packages/dev/core/src/XR/features/WebXRHitTest.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTest.ts
@@ -246,7 +246,7 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
             }
             const pos = pose.transform.position;
             const quat = pose.transform.orientation;
-            this._tmpPos.set(pos.x, pos.y, pos.z);
+            this._tmpPos.set(pos.x, pos.y, pos.z).scaleInPlace(this._xrSessionManager.worldScalingFactor);
             this._tmpQuat.set(quat.x, quat.y, quat.z, quat.w);
             Matrix.FromFloat32ArrayToRefScaled(pose.transform.matrix, 0, 1, this._tmpMat);
             if (!this._xrSessionManager.scene.useRightHandedSystem) {

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -452,7 +452,9 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                         const indexTipPose = _xrFrame.getJointPose!(xrIndexTip, this._xrSessionManager.referenceSpace);
                         if (indexTipPose && indexTipPose.transform) {
                             const axisRHSMultiplier = this._scene.useRightHandedSystem ? 1 : -1;
-                            TmpVectors.Vector3[0].set(indexTipPose.transform.position.x, indexTipPose.transform.position.y, indexTipPose.transform.position.z * axisRHSMultiplier).scaleInPlace(this._xrSessionManager.worldScalingFactor);
+                            TmpVectors.Vector3[0]
+                                .set(indexTipPose.transform.position.x, indexTipPose.transform.position.y, indexTipPose.transform.position.z * axisRHSMultiplier)
+                                .scaleInPlace(this._xrSessionManager.worldScalingFactor);
                             TmpVectors.Quaternion[0].set(
                                 indexTipPose.transform.orientation.x,
                                 indexTipPose.transform.orientation.y,

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -452,7 +452,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                         const indexTipPose = _xrFrame.getJointPose!(xrIndexTip, this._xrSessionManager.referenceSpace);
                         if (indexTipPose && indexTipPose.transform) {
                             const axisRHSMultiplier = this._scene.useRightHandedSystem ? 1 : -1;
-                            TmpVectors.Vector3[0].set(indexTipPose.transform.position.x, indexTipPose.transform.position.y, indexTipPose.transform.position.z * axisRHSMultiplier);
+                            TmpVectors.Vector3[0].set(indexTipPose.transform.position.x, indexTipPose.transform.position.y, indexTipPose.transform.position.z * axisRHSMultiplier).scaleInPlace(this._xrSessionManager.worldScalingFactor);
                             TmpVectors.Quaternion[0].set(
                                 indexTipPose.transform.orientation.x,
                                 indexTipPose.transform.orientation.y,

--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -128,11 +128,13 @@ export class WebXRCamera extends FreeCamera {
     /**
      * Return the user's height, unrelated to the current ground.
      * This will be the y position of this camera, when ground level is 0.
+     * 
+     * Note - this value is multiplied by the worldScalingFactor (if set), so it will be in the same units as the scene.
      */
     public get realWorldHeight(): number {
         const basePose = this._xrSessionManager.currentFrame && this._xrSessionManager.currentFrame.getViewerPose(this._xrSessionManager.baseReferenceSpace);
         if (basePose && basePose.transform) {
-            return basePose.transform.position.y;
+            return basePose.transform.position.y * this._xrSessionManager.worldScalingFactor;
         } else {
             return 0;
         }
@@ -234,7 +236,7 @@ export class WebXRCamera extends FreeCamera {
                 return;
             }
             const pos = pose.transform.position;
-            this._referencedPosition.set(pos.x, pos.y, pos.z);
+            this._referencedPosition.set(pos.x, pos.y, pos.z).scaleInPlace(this._xrSessionManager.worldScalingFactor);
 
             this._referenceQuaternion.set(orientation.x, orientation.y, orientation.z, orientation.w);
             if (!this._scene.useRightHandedSystem) {
@@ -280,7 +282,7 @@ export class WebXRCamera extends FreeCamera {
 
             currentRig.parent = this.parent;
 
-            currentRig.position.set(pos.x, pos.y, pos.z);
+            currentRig.position.set(pos.x, pos.y, pos.z).scaleInPlace(this._xrSessionManager.worldScalingFactor);
             currentRig.rotationQuaternion.set(orientation.x, orientation.y, orientation.z, orientation.w);
             if (!this._scene.useRightHandedSystem) {
                 currentRig.position.z *= -1;
@@ -361,9 +363,9 @@ export class WebXRCamera extends FreeCamera {
             transformMat.decompose(undefined, this._referenceQuaternion, this._referencedPosition);
             const transform = new XRRigidTransform(
                 {
-                    x: this._referencedPosition.x,
-                    y: this._referencedPosition.y,
-                    z: this._referencedPosition.z,
+                    x: this._referencedPosition.x / this._xrSessionManager.worldScalingFactor,
+                    y: this._referencedPosition.y / this._xrSessionManager.worldScalingFactor,
+                    z: this._referencedPosition.z / this._xrSessionManager.worldScalingFactor,
                 },
                 {
                     x: this._referenceQuaternion.x,

--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -128,7 +128,7 @@ export class WebXRCamera extends FreeCamera {
     /**
      * Return the user's height, unrelated to the current ground.
      * This will be the y position of this camera, when ground level is 0.
-     * 
+     *
      * Note - this value is multiplied by the worldScalingFactor (if set), so it will be in the same units as the scene.
      */
     public get realWorldHeight(): number {

--- a/packages/dev/core/src/XR/webXRInput.ts
+++ b/packages/dev/core/src/XR/webXRInput.ts
@@ -100,7 +100,7 @@ export class WebXRInput implements IDisposable {
         this._frameObserver = this.xrSessionManager.onXRFrameObservable.add((frame) => {
             // Update controller pose info
             this.controllers.forEach((controller) => {
-                controller.updateFromXRFrame(frame, this.xrSessionManager.referenceSpace, this.xrCamera);
+                controller.updateFromXRFrame(frame, this.xrSessionManager.referenceSpace, this.xrCamera, this.xrSessionManager);
             });
         });
 

--- a/packages/dev/core/src/XR/webXRInputSource.ts
+++ b/packages/dev/core/src/XR/webXRInputSource.ts
@@ -7,6 +7,7 @@ import type { WebXRAbstractMotionController } from "./motionController/webXRAbst
 import { WebXRMotionControllerManager } from "./motionController/webXRMotionControllerManager";
 import { Tools } from "../Misc/tools";
 import type { WebXRCamera } from "./webXRCamera";
+import type { WebXRSessionManager } from "./webXRSessionManager";
 
 let idCount = 0;
 
@@ -182,14 +183,14 @@ export class WebXRInputSource {
      * @param referenceSpace reference space to use
      * @param xrCamera the xr camera, used for parenting
      */
-    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace, xrCamera: WebXRCamera) {
+    public updateFromXRFrame(xrFrame: XRFrame, referenceSpace: XRReferenceSpace, xrCamera: WebXRCamera, xrSessionManager: WebXRSessionManager) {
         const pose = xrFrame.getPose(this.inputSource.targetRaySpace, referenceSpace);
         this._lastXRPose = pose;
 
         // Update the pointer mesh
         if (pose) {
             const pos = pose.transform.position;
-            this.pointer.position.set(pos.x, pos.y, pos.z);
+            this.pointer.position.set(pos.x, pos.y, pos.z).scaleInPlace(xrSessionManager.worldScalingFactor);
             const orientation = pose.transform.orientation;
             this.pointer.rotationQuaternion!.set(orientation.x, orientation.y, orientation.z, orientation.w);
             if (!this._scene.useRightHandedSystem) {
@@ -198,6 +199,7 @@ export class WebXRInputSource {
                 this.pointer.rotationQuaternion!.w *= -1;
             }
             this.pointer.parent = xrCamera.parent;
+            this.pointer.scaling.setAll(xrSessionManager.worldScalingFactor);
         }
 
         // Update the grip mesh if it exists
@@ -206,7 +208,7 @@ export class WebXRInputSource {
             if (pose) {
                 const pos = pose.transform.position;
                 const orientation = pose.transform.orientation;
-                this.grip.position.set(pos.x, pos.y, pos.z);
+                this.grip.position.set(pos.x, pos.y, pos.z).scaleInPlace(xrSessionManager.worldScalingFactor);
                 this.grip.rotationQuaternion!.set(orientation.x, orientation.y, orientation.z, orientation.w);
                 if (!this._scene.useRightHandedSystem) {
                     this.grip.position.z *= -1;
@@ -215,6 +217,7 @@ export class WebXRInputSource {
                 }
             }
             this.grip.parent = xrCamera.parent;
+            this.grip.scaling.setAll(xrSessionManager.worldScalingFactor);
         }
         if (this.motionController) {
             // either update buttons only or also position, if in gamepad mode

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -77,6 +77,32 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
      */
     public inXRSession: boolean = false;
 
+    private _worldScalingFactor: number = 1;
+
+    /**
+     * Observable raised when the world scale has changed
+     */
+    public onWorldScaleFactorChangedObservable: Observable<{
+        previousScaleFactor: number;
+        newScaleFactor: number;
+    }> = new Observable(undefined, true);
+
+    /**
+     * Scale factor to apply to all XR-related elements (camera, controllers)
+     */
+    public get worldScalingFactor(): number {
+        return this._worldScalingFactor;
+    }
+
+    public set worldScalingFactor(value: number) {
+        const oldValue = this._worldScalingFactor;
+        this._worldScalingFactor = value;
+        this.onWorldScaleFactorChangedObservable.notifyObservers({
+            previousScaleFactor: oldValue,
+            newScaleFactor: value,
+        });
+    }
+
     /**
      * Constructs a WebXRSessionManager, this must be initialized within a user action before usage
      * @param scene The scene which the session should be created for


### PR DESCRIPTION
Fixes #12441

The webxr session manager now has a world scaling factor that allows to set the units in which your world is defined. i.e., if, in your world, 1 unit is 1 cm, you would define the factor to be 100. the native XR component will still maintain the 1 unit 1 meter relation, but the data from and to XR are scaled correctly according to the scale factor.

Controllers and hands are scaled as well. So is the teleportation ring.

Note - any other values should be scaled by the dev itself. For example, the ray's distance will be in world scale. Another example - to define gestures for the hands components you would need to use the components' absolute position and scale the distances accordingly.