### PR TITLE
Basic inspector for V2 physics

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -406,6 +406,7 @@ export interface IPhysicsEnginePluginV2 {
     setShapeFilterCollideMask(shape: PhysicsShape, collideMask: number): void;
     getShapeFilterCollideMask(shape: PhysicsShape): number;
     setMaterial(shape: PhysicsShape, material: PhysicsMaterial): void;
+    getMaterial(shape: PhysicsShape): PhysicsMaterial;
     setDensity(shape: PhysicsShape, density: number): void;
     getDensity(shape: PhysicsShape): number;
     addChild(shape: PhysicsShape, newChild: PhysicsShape, translation?: Vector3, rotation?: Quaternion, scale?: Vector3): void;

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1270,11 +1270,11 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
 
     /**
      * Gets the transform infos of a given transform node.
-     * @param node - The transform node.
-     * @returns An array containing the position and orientation of the node.
      * This code is useful for getting the position and orientation of a given transform node.
      * It first checks if the node has a rotation quaternion, and if not, it creates one from the node's rotation.
      * It then creates an array containing the position and orientation of the node and returns it.
+     * @param node - The transform node.
+     * @returns An array containing the position and orientation of the node.
      */
     private _getTransformInfos(node: TransformNode): any[] {
         if (node.parent) {

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1235,6 +1235,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
     /**
      * Gets the material associated with a physics shape.
      * @param shape - The shape to get the material from.
+     * @returns The material associated with the shape.
      */
     public getMaterial(shape: PhysicsShape): PhysicsMaterial {
         const hkMaterial = this._hknp.HP_Shape_GetMaterial(shape._pluginData)[1];

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1233,6 +1233,21 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
     }
 
     /**
+     * Gets the material associated with a physics shape.
+     * @param shape - The shape to get the material from.
+     */
+    public getMaterial(shape: PhysicsShape): PhysicsMaterial {
+        const hkMaterial = this._hknp.HP_Shape_GetMaterial(shape._pluginData)[1];
+        return {
+            staticFriction: hkMaterial[0],
+            friction: hkMaterial[1],
+            restitution: hkMaterial[2],
+            frictionCombine: this._nativeToMaterialCombine(hkMaterial[3]),
+            restitutionCombine: this._nativeToMaterialCombine(hkMaterial[4]),
+        };
+    }
+
+    /**
      * Sets the density of a physics shape.
      * @param shape - The physics shape to set the density of.
      * @param density - The density to set.
@@ -2087,6 +2102,23 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
                 return this._hknp.MaterialCombine.ARITHMETIC_MEAN;
             case PhysicsMaterialCombineMode.MULTIPLY:
                 return this._hknp.MaterialCombine.MULTIPLY;
+        }
+    }
+
+    private _nativeToMaterialCombine(mat: any): PhysicsMaterialCombineMode {
+        switch (mat) {
+            case this._hknp.MaterialCombine.GEOMETRIC_MEAN:
+                return PhysicsMaterialCombineMode.GEOMETRIC_MEAN;
+            case this._hknp.MaterialCombine.MINIMUM:
+                return PhysicsMaterialCombineMode.MINIMUM;
+            case this._hknp.MaterialCombine.MAXIMUM:
+                return PhysicsMaterialCombineMode.MAXIMUM;
+            case this._hknp.MaterialCombine.ARITHMETIC_MEAN:
+                return PhysicsMaterialCombineMode.ARITHMETIC_MEAN;
+            case this._hknp.MaterialCombine.MULTIPLY:
+                return PhysicsMaterialCombineMode.MULTIPLY;
+            default:
+                throw new Error("Unrecognized material combine mode: " + mat);
         }
     }
 

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -180,11 +180,9 @@ export class PhysicsBody {
      * This method is useful for setting the shape of the physics body, which is necessary for the physics engine to accurately simulate the body's behavior.
      * The shape is used to calculate the body's mass, inertia, and other properties.
      */
-    public set shape(shape: Nullable<PhysicsShape> = null) {
-        if (shape) {
-            this._shape = shape;
-            this._physicsPlugin.setShape(this, shape);
-        }
+    public set shape(shape: Nullable<PhysicsShape>) {
+        this._shape = shape;
+        this._physicsPlugin.setShape(this, shape);
     }
 
     /**

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -180,7 +180,7 @@ export class PhysicsBody {
      * This method is useful for setting the shape of the physics body, which is necessary for the physics engine to accurately simulate the body's behavior.
      * The shape is used to calculate the body's mass, inertia, and other properties.
      */
-    public set shape(shape: Nullable<PhysicsShape> | undefined) {
+    public set shape(shape: Nullable<PhysicsShape> = null) {
         if (shape) {
             this._shape = shape;
             this._physicsPlugin.setShape(this, shape);

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -62,6 +62,8 @@ export class PhysicsBody {
 
     private _isDisposed = false;
 
+    private _shape: Nullable<PhysicsShape> | undefined;
+
     /**
      * Constructs a new physics body for the given node.
      * @param transformNode - The Transform Node to construct the physics body for. For better performance, it is advised that this node does not have a parent.
@@ -168,6 +170,7 @@ export class PhysicsBody {
      * The shape is used to calculate the body's mass, inertia, and other properties.
      */
     public set shape(shape: Nullable<PhysicsShape>) {
+        this._shape = shape;
         this._physicsPlugin.setShape(this, shape);
     }
 
@@ -180,8 +183,9 @@ export class PhysicsBody {
      * This method is useful for retrieving the physics shape associated with this object,
      * which can be used to apply physical forces to the object or to detect collisions.
      */
-    public get shape(): Nullable<PhysicsShape> {
-        return this._physicsPlugin.getShape(this);
+    public get shape(): Nullable<PhysicsShape> | undefined {
+        return this._shape;
+        // return this._physicsPlugin.getShape(this);
     }
 
     /**

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -62,7 +62,7 @@ export class PhysicsBody {
 
     private _isDisposed = false;
 
-    private _shape: Nullable<PhysicsShape> | undefined;
+    private _shape: Nullable<PhysicsShape> = null;
 
     private _motionType: PhysicsMotionType;
 

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -64,6 +64,8 @@ export class PhysicsBody {
 
     private _shape: Nullable<PhysicsShape> | undefined;
 
+    private _motionType: PhysicsMotionType;
+
     /**
      * Constructs a new physics body for the given node.
      * @param transformNode - The Transform Node to construct the physics body for. For better performance, it is advised that this node does not have a parent.
@@ -101,6 +103,8 @@ export class PhysicsBody {
         }
 
         this.startAsleep = startsAsleep;
+
+        this._motionType = motionType;
 
         // instances?
         const m = transformNode as Mesh;
@@ -163,15 +167,24 @@ export class PhysicsBody {
     }
 
     /**
+     * Get the motion type of the physics body. Can be STATIC, DYNAMIC, or ANIMATED.
+     */
+    public get motionType(): PhysicsMotionType {
+        return this._motionType;
+    }
+
+    /**
      * Sets the shape of the physics body.
      * @param shape - The shape of the physics body.
      *
      * This method is useful for setting the shape of the physics body, which is necessary for the physics engine to accurately simulate the body's behavior.
      * The shape is used to calculate the body's mass, inertia, and other properties.
      */
-    public set shape(shape: Nullable<PhysicsShape>) {
-        this._shape = shape;
-        this._physicsPlugin.setShape(this, shape);
+    public set shape(shape: Nullable<PhysicsShape> | undefined) {
+        if (shape) {
+            this._shape = shape;
+            this._physicsPlugin.setShape(this, shape);
+        }
     }
 
     /**
@@ -185,7 +198,6 @@ export class PhysicsBody {
      */
     public get shape(): Nullable<PhysicsShape> | undefined {
         return this._shape;
-        // return this._physicsPlugin.getShape(this);
     }
 
     /**
@@ -625,5 +637,6 @@ export class PhysicsBody {
         this._pluginData = null;
         this._pluginDataInstances.length = 0;
         this._isDisposed = true;
+        this.shape = null;
     }
 }

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -196,7 +196,7 @@ export class PhysicsBody {
      * This method is useful for retrieving the physics shape associated with this object,
      * which can be used to apply physical forces to the object or to detect collisions.
      */
-    public get shape(): Nullable<PhysicsShape> | undefined {
+    public get shape(): Nullable<PhysicsShape> {
         return this._shape;
     }
 

--- a/packages/dev/core/src/Physics/v2/physicsShape.ts
+++ b/packages/dev/core/src/Physics/v2/physicsShape.ts
@@ -166,6 +166,9 @@ export class PhysicsShape {
      * @returns The material of the physics shape.
      */
     public get material(): PhysicsMaterial {
+        if (!this._material) {
+            this._material = this._physicsPlugin.getMaterial(this);
+        }
         return this._material;
     }
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -43,6 +43,7 @@ import "core/Physics/v1/physicsEngineComponent";
 
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
 import { Tools } from "core/Misc/tools";
+import { PhysicsBodyGridComponent } from "./physicsBodyGridComponent";
 
 interface IMeshPropertyGridComponentProps {
     globalState: GlobalState;
@@ -677,6 +678,14 @@ export class MeshPropertyGridComponent extends React.Component<
                         />
                         <TextLineComponent label="Type" value={this.convertPhysicsTypeToString()} />
                     </LineContainerComponent>
+                )}
+                {mesh.physicsBody && (
+                    <PhysicsBodyGridComponent
+                        lockObject={this.props.lockObject}
+                        globalState={this.props.globalState}
+                        body={mesh.physicsBody}
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                 )}
                 <LineContainerComponent title="OCCLUSIONS" closed={true} selection={this.props.globalState}>
                     <OptionsLineComponent

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -43,7 +43,7 @@ import "core/Physics/v1/physicsEngineComponent";
 
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
 import { Tools } from "core/Misc/tools";
-import { PhysicsBodyGridComponent } from "./physicsBodyGridComponent";
+import { PhysicsBodyGridComponent } from "./physics/physicsBodyGridComponent";
 
 interface IMeshPropertyGridComponentProps {
     globalState: GlobalState;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
@@ -6,11 +6,12 @@ import type { Observable } from "core/Misc/observable";
 import { PhysicsShapeType } from "core/Physics/v2/IPhysicsEnginePlugin";
 import type { PhysicsBody } from "core/Physics/v2/physicsBody";
 import type { GlobalState } from "inspector/components/globalState";
-import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { LineContainerComponent } from "shared-ui-components/lines/lineContainerComponent";
 import { TextLineComponent } from "shared-ui-components/lines/textLineComponent";
 import type { PropertyChangedEvent } from "shared-ui-components/propertyChangedEvent";
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+import { PhysicsMassPropertiesGridComponent } from "./physicsMassPropertiesGridComponent";
+import { PhysicsMaterialGridComponent } from "./physicsMaterialGridComponent";
 
 export interface IPhysicsBodyGridComponentProps {
     lockObject: LockObject;
@@ -20,40 +21,20 @@ export interface IPhysicsBodyGridComponentProps {
 }
 
 export function PhysicsBodyGridComponent(props: IPhysicsBodyGridComponentProps) {
-    const massProperties = props.body.getMassProperties();
-    const material = props.body.shape?.material;
-
     return (
         <LineContainerComponent title="PHYSICS" closed={true} selection={props.globalState}>
-            <FloatLineComponent
+            <PhysicsMassPropertiesGridComponent
                 lockObject={props.lockObject}
-                label="Mass"
-                target={massProperties}
-                propertyName="mass"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                body={props.body}
+                globalState={props.globalState}
             />
-            <FloatLineComponent
+            <PhysicsMaterialGridComponent
                 lockObject={props.lockObject}
-                label="Dynamic Friction"
-                target={material}
-                propertyName="friction"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                body={props.body}
+                globalState={props.globalState}
             />
-            <FloatLineComponent
-                lockObject={props.lockObject}
-                label="Restitution"
-                target={material}
-                propertyName="restitution"
-                onPropertyChangedObservable={props.onPropertyChangedObservable}
-            />
-            <FloatLineComponent
-                lockObject={props.lockObject}
-                label="Static Friction"
-                target={material}
-                propertyName="staticFriction"
-                onPropertyChangedObservable={props.onPropertyChangedObservable}
-            />
-
             <TextLineComponent label="Type" value={_convertPhysicsShapeTypeToString(props.body.shape?.type)} />
         </LineContainerComponent>
     );

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
@@ -35,6 +35,7 @@ export interface IPhysicsBodyGridComponentProps {
 
 /**
  * Component that allows displaying and tweaking a physics body's properties.
+ * @param props the component props
  */
 export function PhysicsBodyGridComponent(props: IPhysicsBodyGridComponentProps) {
     const numInstances = props.body._pluginDataInstances?.length ?? 0;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsBodyGridComponent.tsx
@@ -36,6 +36,7 @@ export interface IPhysicsBodyGridComponentProps {
 /**
  * Component that allows displaying and tweaking a physics body's properties.
  * @param props the component props
+ * @returns the component
  */
 export function PhysicsBodyGridComponent(props: IPhysicsBodyGridComponentProps) {
     const numInstances = props.body._pluginDataInstances?.length ?? 0;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
@@ -33,6 +33,7 @@ export interface IPhysicsMassPropertiesGridComponentProps {
 
 /**
  * Component that displays the mass properties of a physics body.
+ * @param props the component props
  */
 export function PhysicsMassPropertiesGridComponent(props: IPhysicsMassPropertiesGridComponentProps) {
     const massProperties = props.body.getMassProperties(props.instanceIndex);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
@@ -6,17 +6,41 @@ import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponen
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
 
 /**
- * Component that displays the mass properties of a physics body.
+ * Properties of the physics mass properties grid component.
  */
 export interface IPhysicsMassPropertiesGridComponentProps {
+    /**
+     * Lock object
+     */
     lockObject: LockObject;
+    /**
+     * Callback raised on the property changed event
+     */
     onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
+    /**
+     * Physics body to edit
+     */
     body: PhysicsBody;
+    /**
+     * Global state
+     */
     globalState: GlobalState;
+    /**
+     * Index of the instance to edit
+     */
+    instanceIndex?: number;
 }
 
+/**
+ * Component that displays the mass properties of a physics body.
+ */
 export function PhysicsMassPropertiesGridComponent(props: IPhysicsMassPropertiesGridComponentProps) {
-    const massProperties = props.body.getMassProperties();
+    const massProperties = props.body.getMassProperties(props.instanceIndex);
+
+    const changeMass = (value: number) => {
+        massProperties.mass = value;
+        props.body.setMassProperties(massProperties, props.instanceIndex);
+    };
 
     return (
         <>
@@ -26,6 +50,7 @@ export function PhysicsMassPropertiesGridComponent(props: IPhysicsMassProperties
                 target={massProperties}
                 propertyName="mass"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                onChange={changeMass}
             />
         </>
     );

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
@@ -34,6 +34,7 @@ export interface IPhysicsMassPropertiesGridComponentProps {
 /**
  * Component that displays the mass properties of a physics body.
  * @param props the component props
+ * @returns the component
  */
 export function PhysicsMassPropertiesGridComponent(props: IPhysicsMassPropertiesGridComponentProps) {
     const massProperties = props.body.getMassProperties(props.instanceIndex);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMassPropertiesGridComponent.tsx
@@ -1,0 +1,32 @@
+import type { Observable } from "core/Misc/observable";
+import type { PhysicsBody } from "core/Physics/v2/physicsBody";
+import type { GlobalState } from "inspector/components/globalState";
+import type { PropertyChangedEvent } from "inspector/components/propertyChangedEvent";
+import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+
+/**
+ * Component that displays the mass properties of a physics body.
+ */
+export interface IPhysicsMassPropertiesGridComponentProps {
+    lockObject: LockObject;
+    onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
+    body: PhysicsBody;
+    globalState: GlobalState;
+}
+
+export function PhysicsMassPropertiesGridComponent(props: IPhysicsMassPropertiesGridComponentProps) {
+    const massProperties = props.body.getMassProperties();
+
+    return (
+        <>
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Mass"
+                target={massProperties}
+                propertyName="mass"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+        </>
+    );
+}

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
@@ -1,0 +1,44 @@
+import type { Observable } from "core/Misc/observable";
+import type { PhysicsBody } from "core/Physics/v2/physicsBody";
+import type { GlobalState } from "inspector/components/globalState";
+import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import type { PropertyChangedEvent } from "shared-ui-components/propertyChangedEvent";
+import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+
+/**
+ * Component that displays the physic material properties of a physics body.
+ */
+export interface IPhysicsMaterialGridComponentProps {
+    lockObject: LockObject;
+    onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
+    body: PhysicsBody;
+    globalState: GlobalState;
+}
+export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponentProps) {
+    const material = props.body.shape?.material;
+    return (
+        <>
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Dynamic Friction"
+                target={material}
+                propertyName="friction"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Restitution"
+                target={material}
+                propertyName="restitution"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Static Friction"
+                target={material}
+                propertyName="staticFriction"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+        </>
+    );
+}

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
@@ -29,6 +29,7 @@ export interface IPhysicsMaterialGridComponentProps {
 
 /**
  * Component that displays the physic material properties of a physics body.
+ * @param props the component props
  */
 export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponentProps) {
     const material = props.body.shape?.material;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
@@ -6,14 +6,30 @@ import type { PropertyChangedEvent } from "shared-ui-components/propertyChangedE
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
 
 /**
- * Component that displays the physic material properties of a physics body.
+ * Properties of the physics material grid component.
  */
 export interface IPhysicsMaterialGridComponentProps {
+    /**
+     * Lock object
+     */
     lockObject: LockObject;
+    /**
+     * Callback raised on the property changed event
+     */
     onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
+    /**
+     * Physics body to edit
+     */
     body: PhysicsBody;
+    /**
+     * Global state
+     */
     globalState: GlobalState;
 }
+
+/**
+ * Component that displays the physic material properties of a physics body.
+ */
 export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponentProps) {
     const material = props.body.shape?.material;
     return (
@@ -24,6 +40,7 @@ export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponen
                 target={material}
                 propertyName="friction"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                disabled={true}
             />
             <FloatLineComponent
                 lockObject={props.lockObject}
@@ -31,6 +48,7 @@ export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponen
                 target={material}
                 propertyName="restitution"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                disabled={true}
             />
             <FloatLineComponent
                 lockObject={props.lockObject}
@@ -38,6 +56,7 @@ export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponen
                 target={material}
                 propertyName="staticFriction"
                 onPropertyChangedObservable={props.onPropertyChangedObservable}
+                disabled={true}
             />
         </>
     );

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physics/physicsMaterialGridComponent.tsx
@@ -30,6 +30,7 @@ export interface IPhysicsMaterialGridComponentProps {
 /**
  * Component that displays the physic material properties of a physics body.
  * @param props the component props
+ * @returns the component
  */
 export function PhysicsMaterialGridComponent(props: IPhysicsMaterialGridComponentProps) {
     const material = props.body.shape?.material;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physicsBodyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/physicsBodyGridComponent.tsx
@@ -1,0 +1,83 @@
+/**
+ * Component that allows displaying and tweaking a physics body's properties.
+ */
+
+import type { Observable } from "core/Misc/observable";
+import { PhysicsShapeType } from "core/Physics/v2/IPhysicsEnginePlugin";
+import type { PhysicsBody } from "core/Physics/v2/physicsBody";
+import type { GlobalState } from "inspector/components/globalState";
+import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import { LineContainerComponent } from "shared-ui-components/lines/lineContainerComponent";
+import { TextLineComponent } from "shared-ui-components/lines/textLineComponent";
+import type { PropertyChangedEvent } from "shared-ui-components/propertyChangedEvent";
+import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+
+export interface IPhysicsBodyGridComponentProps {
+    lockObject: LockObject;
+    onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
+    body: PhysicsBody;
+    globalState: GlobalState;
+}
+
+export function PhysicsBodyGridComponent(props: IPhysicsBodyGridComponentProps) {
+    const massProperties = props.body.getMassProperties();
+    const material = props.body.shape?.material;
+
+    return (
+        <LineContainerComponent title="PHYSICS" closed={true} selection={props.globalState}>
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Mass"
+                target={massProperties}
+                propertyName="mass"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Dynamic Friction"
+                target={material}
+                propertyName="friction"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Restitution"
+                target={material}
+                propertyName="restitution"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+            <FloatLineComponent
+                lockObject={props.lockObject}
+                label="Static Friction"
+                target={material}
+                propertyName="staticFriction"
+                onPropertyChangedObservable={props.onPropertyChangedObservable}
+            />
+
+            <TextLineComponent label="Type" value={_convertPhysicsShapeTypeToString(props.body.shape?.type)} />
+        </LineContainerComponent>
+    );
+}
+
+function _convertPhysicsShapeTypeToString(type?: PhysicsShapeType) {
+    switch (type) {
+        case PhysicsShapeType.BOX:
+            return "Box";
+        case PhysicsShapeType.SPHERE:
+            return "Sphere";
+        case PhysicsShapeType.CYLINDER:
+            return "Cylinder";
+        case PhysicsShapeType.CAPSULE:
+            return "Capsule";
+        case PhysicsShapeType.CONTAINER:
+            return "Container";
+        case PhysicsShapeType.CONVEX_HULL:
+            return "Convex Hull";
+        case PhysicsShapeType.MESH:
+            return "Mesh";
+        case PhysicsShapeType.HEIGHTFIELD:
+            return "Heightfield";
+        default:
+            return "Unknown";
+    }
+}

--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -31,6 +31,7 @@ interface IFloatLineComponentProps {
     unit?: React.ReactNode;
     onDragStart?: (newValue: number) => void;
     onDragStop?: (newValue: number) => void;
+    disabled?: boolean;
 }
 
 export class FloatLineComponent extends React.Component<IFloatLineComponentProps, { value: string; dragging: boolean }> {
@@ -235,6 +236,7 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
                                 placeholder={placeholder}
                                 onFocus={() => this.lock()}
                                 onChange={(evt) => this.updateValue(evt.target.value)}
+                                disabled={this.props.disabled}
                             />
                             {this.props.arrows && (
                                 <InputArrowsComponent


### PR DESCRIPTION
Related to [#13711](https://github.com/BabylonJS/Babylon.js/issues/13711)
This adds a basic interface for physics properties on the inspector, following the same style as V1 physics. One possible evolution would be to display physics bodies and shapes in their own entity tree, instead of being a property of the mesh.
<img width="776" alt="image" src="https://github.com/BabylonJS/Babylon.js/assets/6002144/f712e0fe-5869-4dae-adde-68caecea5a5c">

When the body is instanced, it is possible to select an instance through the first line:
<img width="792" alt="image" src="https://github.com/BabylonJS/Babylon.js/assets/6002144/776e9e64-9430-48ab-b2a6-48b799ebaa90">

Only the mass is editable, because friction/restitution are properties of a shape, which can be shared between different bodies, so changing it could affect other bodies.