### PR TITLE
Gizmo manager enhancement

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -91,6 +91,10 @@ export interface IBoundingBoxGizmo extends IGizmo {
     setEnabledScaling(enable: boolean, homogeneousScaling?: boolean): void;
     /** Enables a pointer drag behavior on the bounding box of the gizmo */
     enableDragBehavior(): void;
+    /**
+     * Force release the drag action by code
+     */
+    releaseDrag(): void;
 
     /** Default material used to render when gizmo is not disabled or hovered */
     coloredMaterial: StandardMaterial;
@@ -114,6 +118,8 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
     protected _renderObserver: Nullable<Observer<Scene>> = null;
     protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     protected _scaleDragSpeed = 0.2;
+    protected _rotateSpheresDragBehavior: PointerDragBehavior;
+    protected _scaleBoxesDragBehavior: PointerDragBehavior;
     /**
      * boolean updated when a rotation sphere or scale box is dragged
      */
@@ -419,19 +425,19 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             sphere.isNearGrabbable = true;
 
             // Drag behavior
-            const _dragBehavior = new PointerDragBehavior({});
-            _dragBehavior.moveAttached = false;
-            _dragBehavior.updateDragPlane = false;
-            sphere.addBehavior(_dragBehavior);
+            this._rotateSpheresDragBehavior = new PointerDragBehavior({});
+            this._rotateSpheresDragBehavior.moveAttached = false;
+            this._rotateSpheresDragBehavior.updateDragPlane = false;
+            sphere.addBehavior(this._rotateSpheresDragBehavior);
             const startingTurnDirection = new Vector3(1, 0, 0);
             let totalTurnAmountOfDrag = 0;
             let previousProjectDist = 0;
-            _dragBehavior.onDragStartObservable.add(() => {
+            this._rotateSpheresDragBehavior.onDragStartObservable.add(() => {
                 startingTurnDirection.copyFrom(sphere.forward);
                 totalTurnAmountOfDrag = 0;
                 previousProjectDist = 0;
             });
-            _dragBehavior.onDragObservable.add((event) => {
+            this._rotateSpheresDragBehavior.onDragObservable.add((event) => {
                 this.onRotationSphereDragObservable.notifyObservers({});
                 if (this.attachedMesh) {
                     const originalParent = this.attachedMesh.parent;
@@ -509,12 +515,12 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             });
 
             // Selection/deselection
-            _dragBehavior.onDragStartObservable.add(() => {
+            this._rotateSpheresDragBehavior.onDragStartObservable.add(() => {
                 this.onDragStartObservable.notifyObservers({});
                 this._dragging = true;
                 this._selectNode(sphere);
             });
-            _dragBehavior.onDragEndObservable.add((event) => {
+            this._rotateSpheresDragBehavior.onDragEndObservable.add((event) => {
                 this.onRotationSphereDragEndObservable.notifyObservers({});
                 this._dragging = false;
                 this._selectNode(null);
@@ -545,13 +551,13 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
 
                     // Dragging logic
                     const dragAxis = new Vector3(i - 1, j - 1, k - 1).normalize();
-                    const _dragBehavior = new PointerDragBehavior({ dragAxis: dragAxis });
-                    _dragBehavior.updateDragPlane = false;
-                    _dragBehavior.moveAttached = false;
+                    this._scaleBoxesDragBehavior = new PointerDragBehavior({ dragAxis: dragAxis });
+                    this._scaleBoxesDragBehavior.updateDragPlane = false;
+                    this._scaleBoxesDragBehavior.moveAttached = false;
                     let totalRelativeDragDistance = 0;
                     let previousScale = 0;
-                    box.addBehavior(_dragBehavior);
-                    _dragBehavior.onDragObservable.add((event) => {
+                    box.addBehavior(this._scaleBoxesDragBehavior);
+                    this._scaleBoxesDragBehavior.onDragObservable.add((event) => {
                         this.onScaleBoxDragObservable.notifyObservers({});
                         if (this.attachedMesh) {
                             const originalParent = this.attachedMesh.parent;
@@ -632,7 +638,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                     });
 
                     // Selection/deselection
-                    _dragBehavior.onDragStartObservable.add(() => {
+                    this._scaleBoxesDragBehavior.onDragStartObservable.add(() => {
                         this.onDragStartObservable.notifyObservers({});
                         this._dragging = true;
                         this._selectNode(box);
@@ -641,7 +647,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                         this._incrementalStartupValue.copyFrom(this.attachedMesh!.scaling);
                         this._incrementalAnchorStartupValue.copyFrom(this._anchorMesh!.scaling);
                     });
-                    _dragBehavior.onDragEndObservable.add((event) => {
+                    this._scaleBoxesDragBehavior.onDragEndObservable.add((event) => {
                         this.onScaleBoxDragEndObservable.notifyObservers({});
                         this._dragging = false;
                         this._selectNode(null);
@@ -932,6 +938,15 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this._dragMesh.rotationQuaternion = new Quaternion();
         this._pointerDragBehavior.useObjectOrientationForDragging = false;
         this._dragMesh.addBehavior(this._pointerDragBehavior);
+    }
+
+    /**
+     * Force release the drag action by code
+     */
+    public releaseDrag() {
+        this._scaleBoxesDragBehavior.releaseDrag();
+        this._rotateSpheresDragBehavior.releaseDrag();
+        this._pointerDragBehavior.releaseDrag();
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -51,6 +51,8 @@ export interface IBoundingBoxGizmo extends IGizmo {
      * The distance away from the object which the draggable meshes should appear world sized when fixedDragMeshScreenSize is set to true
      */
     fixedDragMeshScreenSizeDistanceFactor: number;
+    /** True when a rotation sphere or scale box or a attached mesh is dragged */
+    readonly isDragging: boolean;
     /** Fired when a rotation sphere or scale box is dragged */
     onDragStartObservable: Observable<{}>;
     /** Fired when a scale box is dragged */
@@ -112,6 +114,10 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
     protected _renderObserver: Nullable<Observer<Scene>> = null;
     protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
     protected _scaleDragSpeed = 0.2;
+    /**
+     * boolean updated when a rotation sphere or scale box is dragged
+     */
+    protected _dragging = false;
 
     private _tmpQuaternion = new Quaternion();
     private _tmpVector = new Vector3(0, 0, 0);
@@ -270,6 +276,11 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
      */
     public get pointerDragBehavior(): PointerDragBehavior {
         return this._pointerDragBehavior;
+    }
+
+    /** True when a rotation sphere or scale box or a attached mesh is dragged */
+    public get isDragging() {
+        return this._dragging || this._pointerDragBehavior.dragging;
     }
 
     /**
@@ -500,10 +511,12 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
             // Selection/deselection
             _dragBehavior.onDragStartObservable.add(() => {
                 this.onDragStartObservable.notifyObservers({});
+                this._dragging = true;
                 this._selectNode(sphere);
             });
             _dragBehavior.onDragEndObservable.add((event) => {
                 this.onRotationSphereDragEndObservable.notifyObservers({});
+                this._dragging = false;
                 this._selectNode(null);
                 this._updateDummy();
                 this._unhoverMeshOnTouchUp(event.pointerInfo, sphere);
@@ -621,6 +634,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                     // Selection/deselection
                     _dragBehavior.onDragStartObservable.add(() => {
                         this.onDragStartObservable.notifyObservers({});
+                        this._dragging = true;
                         this._selectNode(box);
                         totalRelativeDragDistance = 0;
                         previousScale = 0;
@@ -629,6 +643,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                     });
                     _dragBehavior.onDragEndObservable.add((event) => {
                         this.onScaleBoxDragEndObservable.notifyObservers({});
+                        this._dragging = false;
                         this._selectNode(null);
                         this._updateDummy();
                         this._unhoverMeshOnTouchUp(event.pointerInfo, box);

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -153,6 +153,21 @@ export class GizmoManager implements IDisposable {
     public get coordinatesMode(): GizmoCoordinatesMode {
         return this._coordinatesMode;
     }
+
+    /**
+     * The mesh the gizmo's is attached to
+     */
+    public get attachedMesh() {
+        return this._attachedMesh;
+    }
+
+    /**
+     * The node the gizmo's is attached to
+     */
+    public get attachedNode() {
+        return this._attachedNode;
+    }
+
     /**
      * Instantiates a gizmo manager
      * @param _scene the scene to overlay the gizmos on top of

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -107,6 +107,21 @@ export class GizmoManager implements IDisposable {
     }
 
     /**
+     * True when the mouse pointer is dragging a gizmo mesh
+     */
+    public get isDragging() {
+        let dragging = false;
+
+        [this.gizmos.positionGizmo, this.gizmos.rotationGizmo, this.gizmos.scaleGizmo, this.gizmos.boundingBoxGizmo].forEach((gizmo) => {
+            if (gizmo && gizmo.isDragging) {
+                dragging = true;
+            }
+        });
+
+        return dragging;
+    }
+
+    /**
      * Ratio for the scale of the gizmo (Default: 1)
      */
     public set scaleRatio(value: number) {

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -386,6 +386,15 @@ export class GizmoManager implements IDisposable {
     }
 
     /**
+     * Force release the drag action by code
+     */
+    public releaseDrag() {
+        [this.gizmos.positionGizmo, this.gizmos.rotationGizmo, this.gizmos.scaleGizmo, this.gizmos.boundingBoxGizmo].forEach((gizmo) => {
+            gizmo?.releaseDrag();
+        });
+    }
+
+    /**
      * Disposes of the gizmo manager
      */
     public dispose() {

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -55,6 +55,10 @@ export interface IPositionGizmo extends IGizmo {
      * @param cache Gizmo axis definition used for reactive gizmo UI
      */
     addToAxisCache(mesh: Mesh, cache: GizmoAxisCache): void;
+    /**
+     * Force release the drag action by code
+     */
+    releaseDrag(): void;
 }
 
 /**
@@ -331,6 +335,17 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
      */
     public addToAxisCache(mesh: Mesh, cache: GizmoAxisCache) {
         this._gizmoAxisCache.set(mesh, cache);
+    }
+    /**
+     * Force release the drag action by code
+     */
+    public releaseDrag() {
+        this.xGizmo.dragBehavior.releaseDrag();
+        this.yGizmo.dragBehavior.releaseDrag();
+        this.zGizmo.dragBehavior.releaseDrag();
+        this.xPlaneGizmo.dragBehavior.releaseDrag();
+        this.yPlaneGizmo.dragBehavior.releaseDrag();
+        this.zPlaneGizmo.dragBehavior.releaseDrag();
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -34,6 +34,8 @@ export interface IPositionGizmo extends IGizmo {
     yPlaneGizmo: IPlaneDragGizmo;
     /** Internal gizmo used for interactions on the xy plane */
     zPlaneGizmo: IPlaneDragGizmo;
+    /** True when the mouse pointer is dragging a gizmo mesh */
+    readonly isDragging: boolean;
     /** Fires an event when any of it's sub gizmos are dragged */
     onDragStartObservable: Observable<unknown>;
     /** Fires an event when any of it's sub gizmos are being dragged */
@@ -142,6 +144,17 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
      */
     public get isHovered() {
         return this.xGizmo.isHovered || this.yGizmo.isHovered || this.zGizmo.isHovered || this.xPlaneGizmo.isHovered || this.yPlaneGizmo.isHovered || this.zPlaneGizmo.isHovered;
+    }
+
+    public get isDragging() {
+        return (
+            this.xGizmo.dragBehavior.dragging ||
+            this.yGizmo.dragBehavior.dragging ||
+            this.zGizmo.dragBehavior.dragging ||
+            this.xPlaneGizmo.dragBehavior.dragging ||
+            this.yPlaneGizmo.dragBehavior.dragging ||
+            this.zPlaneGizmo.dragBehavior.dragging
+        );
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -45,6 +45,10 @@ export interface IRotationGizmo extends IGizmo {
      * @param cache Gizmo axis definition used for reactive gizmo UI
      */
     addToAxisCache(mesh: Mesh, cache: GizmoAxisCache): void;
+    /**
+     * Force release the drag action by code
+     */
+    releaseDrag(): void;
 }
 
 /**
@@ -344,6 +348,15 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
      */
     public addToAxisCache(mesh: Mesh, cache: GizmoAxisCache) {
         this._gizmoAxisCache.set(mesh, cache);
+    }
+
+    /**
+     * Force release the drag action by code
+     */
+    public releaseDrag() {
+        this.xGizmo.dragBehavior.releaseDrag();
+        this.yGizmo.dragBehavior.releaseDrag();
+        this.zGizmo.dragBehavior.releaseDrag();
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -21,6 +21,8 @@ import type { GizmoManager } from "./gizmoManager";
  * Interface for rotation gizmo
  */
 export interface IRotationGizmo extends IGizmo {
+    /** True when the mouse pointer is dragging a gizmo mesh */
+    readonly isDragging: boolean;
     /** Internal gizmo used for interactions on the x axis */
     xGizmo: IPlaneRotationGizmo;
     /** Internal gizmo used for interactions on the y axis */
@@ -171,6 +173,13 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
      */
     public get isHovered() {
         return this.xGizmo.isHovered || this.yGizmo.isHovered || this.zGizmo.isHovered;
+    }
+
+    /**
+     * True when the mouse pointer is dragging a gizmo mesh
+     */
+    public get isDragging() {
+        return this.xGizmo.dragBehavior.dragging || this.yGizmo.dragBehavior.dragging || this.zGizmo.dragBehavior.dragging;
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -22,6 +22,8 @@ import type { GizmoManager } from "./gizmoManager";
  * Interface for scale gizmo
  */
 export interface IScaleGizmo extends IGizmo {
+    /** True when the mouse pointer is dragging a gizmo mesh */
+    readonly isDragging: boolean;
     /** Internal gizmo used for interactions on the x axis */
     xGizmo: IAxisScaleGizmo;
     /** Internal gizmo used for interactions on the y axis */
@@ -160,6 +162,13 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
      */
     public get isHovered() {
         return this.xGizmo.isHovered || this.yGizmo.isHovered || this.zGizmo.isHovered;
+    }
+
+    /**
+     * True when the mouse pointer is dragging a gizmo mesh
+     */
+    public get isDragging() {
+        return this.xGizmo.dragBehavior.dragging || this.yGizmo.dragBehavior.dragging || this.zGizmo.dragBehavior.dragging || this.uniformScaleGizmo.dragBehavior.dragging;
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -50,6 +50,10 @@ export interface IScaleGizmo extends IGizmo {
      * @param cache Gizmo axis definition used for reactive gizmo UI
      */
     addToAxisCache(mesh: Mesh, cache: GizmoAxisCache): void;
+    /**
+     * Force release the drag action by code
+     */
+    releaseDrag(): void;
 
     /** Default material used to render when gizmo is not disabled or hovered */
     coloredMaterial: StandardMaterial;
@@ -373,6 +377,16 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
      */
     public addToAxisCache(mesh: Mesh, cache: GizmoAxisCache) {
         this._gizmoAxisCache.set(mesh, cache);
+    }
+
+    /**
+     * Force release the drag action by code
+     */
+    public releaseDrag() {
+        this.xGizmo.dragBehavior.releaseDrag();
+        this.yGizmo.dragBehavior.releaseDrag();
+        this.zGizmo.dragBehavior.releaseDrag();
+        this.uniformScaleGizmo.dragBehavior.releaseDrag();
     }
 
     /**


### PR DESCRIPTION
been working with gizmo manager for a quite a while and it's super painful to check if we're dragging a gizmo (gizmo axis or bounding box sphere/cubes) so I added a isDragging variable for that. 

while on it, a releaseDrag method both on each gizmo (position, rotation, scale,boundingBox) and on gizmo manager can be quite handy and will save the developers so much time. 

also, we can attach mesh/node but if we want to get that specific mesh/node we have to check which gizmo is enabled and get the data from there. so I added getters for the attachedMesh and attachedNode.