### PR TITLE
Add isSerializable flag to GUI controls

### DIFF
--- a/packages/dev/gui/package.json
+++ b/packages/dev/gui/package.json
@@ -11,6 +11,7 @@
     ],
     "scripts": {
         "build": "npm run compile",
+        "test": "jest -c ../../../jest.config.ts",
         "clean": "rimraf dist && rimraf *.tsbuildinfo",
         "precompile": "npm run compile:assets",
         "compile": "npm run compile:source",

--- a/packages/dev/gui/src/2D/controls/button.ts
+++ b/packages/dev/gui/src/2D/controls/button.ts
@@ -187,8 +187,11 @@ export class Button extends Rectangle {
      * Serializes the current button
      * @param serializationObject defines the JSON serialized object
      */
-    public serialize(serializationObject: any) {
-        super.serialize(serializationObject);
+    public serialize(serializationObject: any, force: boolean) {
+        super.serialize(serializationObject, force);
+        if (!this.isSerializable && !force) {
+            return;
+        }
 
         if (this._textBlock) {
             serializationObject.textBlockName = this._textBlock.name;

--- a/packages/dev/gui/src/2D/controls/button.ts
+++ b/packages/dev/gui/src/2D/controls/button.ts
@@ -186,6 +186,7 @@ export class Button extends Rectangle {
     /**
      * Serializes the current button
      * @param serializationObject defines the JSON serialized object
+     * @param force force serialization even if isSerializable === false
      */
     public serialize(serializationObject: any, force: boolean) {
         super.serialize(serializationObject, force);

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -642,6 +642,7 @@ export class Container extends Control {
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
+     * @param force force serialization even if isSerializable === false
      */
     public serialize(serializationObject: any, force: boolean = false) {
         super.serialize(serializationObject, force);

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -643,8 +643,11 @@ export class Container extends Control {
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
      */
-    public serialize(serializationObject: any) {
-        super.serialize(serializationObject);
+    public serialize(serializationObject: any, force: boolean = false) {
+        super.serialize(serializationObject, force);
+        if (!this.isSerializable && !force) {
+            return;
+        }
 
         if (this.backgroundGradient) {
             serializationObject.backgroundGradient = {};
@@ -658,9 +661,11 @@ export class Container extends Control {
         serializationObject.children = [];
 
         for (const child of this.children) {
-            const childSerializationObject = {};
-            child.serialize(childSerializationObject);
-            serializationObject.children.push(childSerializationObject);
+            if (child.isSerializable || force) {
+                const childSerializationObject = {};
+                child.serialize(childSerializationObject);
+                serializationObject.children.push(childSerializationObject);
+            }
         }
     }
 

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -452,6 +452,12 @@ export class Control implements IAnimatable {
     }
 
     /**
+     * Indicates if the control should be serialized. Defaults to true.
+     */
+    @serialize()
+    public isSerializable: boolean = true;
+
+    /**
      * Gets or sets a string defining the color to use for highlighting this control
      */
     public get highlightColor(): string {
@@ -2454,7 +2460,7 @@ export class Control implements IAnimatable {
      */
     public clone(host?: AdvancedDynamicTexture): Control {
         const serialization: any = {};
-        this.serialize(serialization);
+        this.serialize(serialization, true);
 
         const controlType = Tools.Instantiate("BABYLON.GUI." + serialization.className);
         const cloned = new controlType();
@@ -2482,8 +2488,12 @@ export class Control implements IAnimatable {
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
+     * @param force if the control should be serialized even if the isSerializable flag is set to false (default false)
      */
-    public serialize(serializationObject: any) {
+    public serialize(serializationObject: any, force: boolean = false) {
+        if (!this.isSerializable && !force) {
+            return;
+        }
         SerializationHelper.Serialize(this, serializationObject);
         serializationObject.name = this.name;
         serializationObject.className = this.getClassName();

--- a/packages/dev/gui/src/2D/controls/focusableButton.ts
+++ b/packages/dev/gui/src/2D/controls/focusableButton.ts
@@ -99,7 +99,7 @@ export class FocusableButton extends Button implements IFocusableControl {
     }
 
     /** @internal */
-    public displose() {
+    public dispose() {
         super.dispose();
 
         this.onBlurObservable.clear();

--- a/packages/dev/gui/src/2D/controls/grid.ts
+++ b/packages/dev/gui/src/2D/controls/grid.ts
@@ -553,6 +553,7 @@ export class Grid extends Container {
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
+     * @param force force serialization even if isSerializable === false
      */
     public serialize(serializationObject: any, force: boolean) {
         super.serialize(serializationObject, force);

--- a/packages/dev/gui/src/2D/controls/grid.ts
+++ b/packages/dev/gui/src/2D/controls/grid.ts
@@ -554,8 +554,11 @@ export class Grid extends Container {
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
      */
-    public serialize(serializationObject: any) {
-        super.serialize(serializationObject);
+    public serialize(serializationObject: any, force: boolean) {
+        super.serialize(serializationObject, force);
+        if (!this.isSerializable && !force) {
+            return;
+        }
         serializationObject.columnCount = this.columnCount;
         serializationObject.rowCount = this.rowCount;
         serializationObject.columns = [];

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -247,6 +247,7 @@ export class StackPanel extends Container {
     /**
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
+     * @param force force serialization even if isSerializable === false
      */
     public serialize(serializationObject: any, force: boolean) {
         super.serialize(serializationObject, force);

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -248,8 +248,11 @@ export class StackPanel extends Container {
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
      */
-    public serialize(serializationObject: any) {
-        super.serialize(serializationObject);
+    public serialize(serializationObject: any, force: boolean) {
+        super.serialize(serializationObject, force);
+        if (!this.isSerializable && !force) {
+            return;
+        }
         serializationObject.manualWidth = this._manualWidth;
         serializationObject.manualHeight = this._manualHeight;
     }

--- a/packages/dev/gui/test/unit/serialization.test.ts
+++ b/packages/dev/gui/test/unit/serialization.test.ts
@@ -1,0 +1,20 @@
+import { Rectangle } from "../../src/2D/controls/rectangle";
+
+describe("GUI Serialization test", () => {
+    it("Respects the isSerializable property", () => {
+        const rect = new Rectangle("rect");
+
+        const s1 = {};
+        rect.serialize(s1);
+
+        // s1 will contain something
+        expect(s1).not.toEqual({});
+
+        rect.isSerializable = false;
+        const s2 = {};
+        rect.serialize(s2);
+
+        // s2 will be empty
+        expect(s2).toEqual({});
+    });
+});

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/commonControlPropertyGridComponent.tsx
@@ -43,6 +43,7 @@ import linkedMeshOffsetIcon from "shared-ui-components/imgs/linkedMeshOffsetIcon
 import visibleIcon from "../../../../imgs/visibilityActiveIcon.svg";
 import addIcon from "shared-ui-components/imgs/addGridElementDark.svg";
 import removeIcon from "shared-ui-components/imgs/deleteGridElementDark.svg";
+import adtIcon from "../../../../imgs/adtIcon.svg";
 
 import hAlignCenterIcon from "shared-ui-components/imgs/hAlignCenterIcon.svg";
 import hAlignLeftIcon from "shared-ui-components/imgs/hAlignLeftIcon.svg";
@@ -652,6 +653,11 @@ export class CommonControlPropertyGridComponent extends React.Component<ICommonC
                         <hr className="ge" />
                     </>
                 )}
+                <TextLineComponent tooltip="" label="SERIALIZATION" value=" " color="grey"></TextLineComponent>
+                <div className="ge-divider">
+                    <IconComponent icon={adtIcon} label={"Serializable"} />
+                    <CheckBoxLineComponent label="ISSERIALIZABLE" target={proxy} propertyName="isSerializable" />
+                </div>
                 <TextLineComponent tooltip="" label="VISIBILITY" value=" " color="grey"></TextLineComponent>
                 <div className="ge-divider">
                     <IconComponent icon={visibleIcon} label={"Visible"} />


### PR DESCRIPTION
Closes https://github.com/BabylonJS/ThePirateCove/issues/475

This PR adds a isSerializable property to GUI Controls which is true by default. When it is set to false, the control (and any of its children) will not be serialized. This facilitates scenarios of mixing and editing GUI Editor controls and code-created controls. It also adds a corresponding switch on the editor, so it can be changed easily.