### PR TITLE
Move delegate picking to children to container

### DIFF
--- a/packages/dev/gui/src/2D/controls/button.ts
+++ b/packages/dev/gui/src/2D/controls/button.ts
@@ -31,11 +31,6 @@ export class Button extends Rectangle {
      */
     public pointerUpAnimation: () => void;
 
-    /**
-     * Gets or sets a boolean indicating that the button will let internal controls handle picking instead of doing it directly using its bounding info
-     */
-    public delegatePickingToChildren = false;
-
     private _image: Nullable<Image>;
     /**
      * Returns the image part of the button (if any)

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -39,7 +39,7 @@ export class Container extends Control {
     protected _intermediateTexture: Nullable<DynamicTexture> = null;
 
     /**
-     * Gets or sets a boolean indicating that the button will let internal controls handle picking instead of doing it directly using its bounding info
+     * Gets or sets a boolean indicating that the container will let internal controls handle picking instead of doing it directly using its bounding info
      */
     @serialize()
     public delegatePickingToChildren = false;

--- a/packages/dev/gui/src/2D/controls/container.ts
+++ b/packages/dev/gui/src/2D/controls/container.ts
@@ -38,6 +38,12 @@ export class Container extends Control {
     /** @internal */
     protected _intermediateTexture: Nullable<DynamicTexture> = null;
 
+    /**
+     * Gets or sets a boolean indicating that the button will let internal controls handle picking instead of doing it directly using its bounding info
+     */
+    @serialize()
+    public delegatePickingToChildren = false;
+
     /** Gets or sets boolean indicating if children should be rendered to an intermediate texture rather than directly to host, useful for alpha blending */
     @serialize()
     public get renderToIntermediateTexture(): boolean {
@@ -586,6 +592,21 @@ export class Container extends Control {
         // if clipChildren is off, we should still pass picking events to children even if we don't contain the pointer
         if (!contains && this.clipChildren) {
             return false;
+        }
+
+        if (this.delegatePickingToChildren) {
+            let contains = false;
+            for (let index = this._children.length - 1; index >= 0; index--) {
+                const child = this._children[index];
+                if (child.isEnabled && child.isHitTestVisible && child.isVisible && !child.notRenderable && child.contains(x, y)) {
+                    contains = true;
+                    break;
+                }
+            }
+
+            if (!contains) {
+                return false;
+            }
         }
 
         // Checking backwards to pick closest first

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/containerPropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/containerPropertyGridComponent.tsx
@@ -9,6 +9,7 @@ import clipContentsIcon from "shared-ui-components/imgs/clipContentsIcon.svg";
 import clipChildrenIcon from "shared-ui-components/imgs/clipChildrenIcon.svg";
 import autoStretchWidthIcon from "shared-ui-components/imgs/autoStretchWidthIcon.svg";
 import autoStretchHeightIcon from "shared-ui-components/imgs/autoStretchHeightIcon.svg";
+import adtIcon from "../../../../imgs/adtIcon.svg";
 import { IconComponent } from "shared-ui-components/lines/iconComponent";
 
 interface IContainerPropertyGridComponentProps {
@@ -37,6 +38,10 @@ export class ContainerPropertyGridComponent extends React.Component<IContainerPr
                 <div className="ge-divider">
                     <IconComponent icon={autoStretchHeightIcon} label={"Makes the container's height automatically adapt to its children"} />
                     <CheckBoxLineComponent label="ADAPT HEIGHT TO CHILDREN" target={proxy} propertyName="adaptHeightToChildren" />
+                </div>
+                <div className="ge-divider">
+                    <IconComponent icon={adtIcon} label={"Delegates picking to children controls"} />
+                    <CheckBoxLineComponent label="DELEGATE PICKING TO CHILDREN" target={proxy} propertyName="delegatePickingToChildren" />
                 </div>
             </>
         );


### PR DESCRIPTION
Closes [#13692](https://github.com/BabylonJS/Babylon.js/issues/13692)

With the property moved to the Container class, other types of container besides Button can have this behavior. 
PG #94FPZ3#3 shows an example with Rectangle, Button and StackPanel
PG #DLI9YW shows an example with Grid

Also added the property to GUI Editor for easier editing.