### PR TITLE
Add no-throw-literal eslint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -262,6 +262,7 @@ const rules = {
         "prefer-rest-params": "off",
         "no-fallthrough": "warn",
         "no-async-promise-executor": "warn",
+        "no-throw-literal": "error",
         // "prettier/prettier": "error" // add this if we want to use prettier error reporting.
     },
 };

--- a/packages/dev/core/src/Animations/pathCursor.ts
+++ b/packages/dev/core/src/Animations/pathCursor.ts
@@ -65,6 +65,7 @@ export class PathCursor {
      */
     public move(step: number): PathCursor {
         if (Math.abs(step) > 1) {
+            // eslint-disable-next-line no-throw-literal
             throw "step size should be less than 1.";
         }
 

--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -181,6 +181,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             optionCount++;
         }
         if (optionCount > 1) {
+            // eslint-disable-next-line no-throw-literal
             throw "Multiple drag modes specified in dragBehavior options. Only one expected";
         }
     }

--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -41,6 +41,7 @@ export class DeviceEventFactory {
             case DeviceType.Touch:
                 return this._CreatePointerEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo, pointerId);
             default:
+                // eslint-disable-next-line no-throw-literal
                 throw `Unable to generate event for device ${DeviceType[deviceType]}`;
         }
     }

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -122,6 +122,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         const device = this._inputs[deviceType][deviceSlot];
 
         if (!device) {
+            // eslint-disable-next-line no-throw-literal
             throw `Unable to find device ${DeviceType[deviceType]}`;
         }
 
@@ -131,6 +132,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
         const currentValue = device[inputIndex];
         if (currentValue === undefined) {
+            // eslint-disable-next-line no-throw-literal
             throw `Unable to find input ${inputIndex} for device ${DeviceType[deviceType]} in slot ${deviceSlot}`;
         }
 
@@ -302,6 +304,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
      */
     private _registerDevice(deviceType: DeviceType, deviceSlot: number, numberOfInputs: number): void {
         if (deviceSlot === undefined) {
+            // eslint-disable-next-line no-throw-literal
             throw `Unable to register device ${DeviceType[deviceType]} to undefined slot.`;
         }
 

--- a/packages/dev/core/src/Engines/Extensions/engine.multiview.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiview.ts
@@ -39,6 +39,7 @@ Engine.prototype.createMultiviewRenderTargetTexture = function (width: number, h
     const gl = this._gl;
 
     if (!this.getCaps().multiview) {
+        // eslint-disable-next-line no-throw-literal
         throw "Multiview is not supported";
     }
 
@@ -100,6 +101,7 @@ Engine.prototype.bindMultiviewFramebuffer = function (_multiviewTexture: RenderT
             ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, multiviewTexture._depthStencilTextureArray, 0, 0, 2);
         }
     } else {
+        // eslint-disable-next-line no-throw-literal
         throw "Invalid multiview frame buffer";
     }
 };

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.readTexture.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.readTexture.ts
@@ -25,5 +25,6 @@ WebGPUEngine.prototype._readTexturePixels = function (
 };
 
 WebGPUEngine.prototype._readTexturePixelsSync = function (): ArrayBufferView {
+    // eslint-disable-next-line no-throw-literal
     throw "_readTexturePixelsSync is unsupported in WebGPU!";
 };

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -360,6 +360,7 @@ export abstract class WebGPUCacheRenderPipeline {
             // If we want more than 10 attachments we need to change this method (and the StatePosition enum) but 10 seems plenty: note that WebGPU only supports 8 at the time (2021/12/13)!
             // As we need ~39 different values we are using 6 bits to encode a texture format, meaning we can encode 5 texture formats in 32 bits
             // We are using 2x32 bit values to handle 10 textures
+            // eslint-disable-next-line no-throw-literal
             throw "Can't handle more than 10 attachments for a MRT in cache render pipeline!";
         }
         (this.mrtTextureArray as any) = textureArray;
@@ -514,6 +515,7 @@ export abstract class WebGPUCacheRenderPipeline {
             case Constants.MATERIAL_LineLoopDrawMode:
                 // return this._gl.LINE_LOOP;
                 // TODO WEBGPU. Line Loop Mode Fallback at buffer load time.
+                // eslint-disable-next-line no-throw-literal
                 throw "LineLoop is an unsupported fillmode in WebGPU";
             case Constants.MATERIAL_LineStripDrawMode:
                 return WebGPUConstants.PrimitiveTopology.LineStrip;
@@ -522,6 +524,7 @@ export abstract class WebGPUCacheRenderPipeline {
             case Constants.MATERIAL_TriangleFanDrawMode:
                 // return this._gl.TRIANGLE_FAN;
                 // TODO WEBGPU. Triangle Fan Mode Fallback at buffer load time.
+                // eslint-disable-next-line no-throw-literal
                 throw "TriangleFan is an unsupported fillmode in WebGPU";
             default:
                 return WebGPUConstants.PrimitiveTopology.TriangleList;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessingContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessingContext.ts
@@ -251,6 +251,7 @@ export class WebGPUShaderProcessingContext implements ShaderProcessingContext {
         }
 
         if (this.freeGroupIndex === _maxGroups) {
+            // eslint-disable-next-line no-throw-literal
             throw "Too many textures or UBOs have been declared and it is not supported in WebGPU.";
         }
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -222,6 +222,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             textureInfo.sampleType = sampleType;
 
             if (textureDimension === undefined) {
+                // eslint-disable-next-line no-throw-literal
                 throw `Can't get the texture dimension corresponding to the texture function "${textureFunc}"!`;
             }
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -182,12 +182,15 @@ export class WebGPUTextureHelper {
 
             // Depth and stencil formats
             case WebGPUConstants.TextureFormat.Stencil8:
+                // eslint-disable-next-line no-throw-literal
                 throw "No fixed size for Stencil8 format!";
             case WebGPUConstants.TextureFormat.Depth16Unorm:
                 return { width: 1, height: 1, length: 2 };
             case WebGPUConstants.TextureFormat.Depth24Plus:
+                // eslint-disable-next-line no-throw-literal
                 throw "No fixed size for Depth24Plus format!";
             case WebGPUConstants.TextureFormat.Depth24PlusStencil8:
+                // eslint-disable-next-line no-throw-literal
                 throw "No fixed size for Depth24PlusStencil8 format!";
             case WebGPUConstants.TextureFormat.Depth32Float:
                 return { width: 1, height: 1, length: 4 };
@@ -400,12 +403,14 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG:
                         return WebGPUConstants.TextureFormat.RG8Snorm;
                     case Constants.TEXTUREFORMAT_RGB:
+                        // eslint-disable-next-line no-throw-literal
                         throw "RGB format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RED_INTEGER:
                         return WebGPUConstants.TextureFormat.R8Sint;
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG8Sint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA8Sint;
@@ -419,6 +424,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG:
                         return WebGPUConstants.TextureFormat.RG8Unorm;
                     case Constants.TEXTUREFORMAT_RGB:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA:
                         return useSRGBBuffer ? WebGPUConstants.TextureFormat.RGBA8UnormSRGB : WebGPUConstants.TextureFormat.RGBA8Unorm;
@@ -429,14 +435,18 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG8Uint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA8Uint;
                     case Constants.TEXTUREFORMAT_ALPHA:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_ALPHA format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_LUMINANCE:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_LUMINANCE format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_LUMINANCE_ALPHA:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_LUMINANCE_ALPHA format not supported in WebGPU";
                     default:
                         return WebGPUConstants.TextureFormat.RGBA8Unorm;
@@ -448,6 +458,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG16Sint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA16Sint;
@@ -461,6 +472,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG16Uint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA16Uint;
@@ -474,6 +486,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG32Sint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA32Sint;
@@ -487,6 +500,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG_INTEGER:
                         return WebGPUConstants.TextureFormat.RG32Uint;
                     case Constants.TEXTUREFORMAT_RGB_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB_INTEGER format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
                         return WebGPUConstants.TextureFormat.RGBA32Uint;
@@ -500,6 +514,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG:
                         return WebGPUConstants.TextureFormat.RG32Float; // By default. Other possibility is RG16Float.
                     case Constants.TEXTUREFORMAT_RGB:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA:
                         return WebGPUConstants.TextureFormat.RGBA32Float; // By default. Other possibility is RGBA16Float.
@@ -513,6 +528,7 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RG:
                         return WebGPUConstants.TextureFormat.RG16Float;
                     case Constants.TEXTUREFORMAT_RGB:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGB format not supported in WebGPU";
                     case Constants.TEXTUREFORMAT_RGBA:
                         return WebGPUConstants.TextureFormat.RGBA16Float;
@@ -520,12 +536,14 @@ export class WebGPUTextureHelper {
                         return WebGPUConstants.TextureFormat.RGBA16Float;
                 }
             case Constants.TEXTURETYPE_UNSIGNED_SHORT_5_6_5:
+                // eslint-disable-next-line no-throw-literal
                 throw "TEXTURETYPE_UNSIGNED_SHORT_5_6_5 format not supported in WebGPU";
             case Constants.TEXTURETYPE_UNSIGNED_INT_10F_11F_11F_REV:
                 switch (format) {
                     case Constants.TEXTUREFORMAT_RGBA:
                         return WebGPUConstants.TextureFormat.RG11B10UFloat;
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGBA_INTEGER format not supported in WebGPU when type is TEXTURETYPE_UNSIGNED_INT_10F_11F_11F_REV";
                     default:
                         return WebGPUConstants.TextureFormat.RG11B10UFloat;
@@ -535,13 +553,16 @@ export class WebGPUTextureHelper {
                     case Constants.TEXTUREFORMAT_RGBA:
                         return WebGPUConstants.TextureFormat.RGB9E5UFloat;
                     case Constants.TEXTUREFORMAT_RGBA_INTEGER:
+                        // eslint-disable-next-line no-throw-literal
                         throw "TEXTUREFORMAT_RGBA_INTEGER format not supported in WebGPU when type is TEXTURETYPE_UNSIGNED_INT_5_9_9_9_REV";
                     default:
                         return WebGPUConstants.TextureFormat.RGB9E5UFloat;
                 }
             case Constants.TEXTURETYPE_UNSIGNED_SHORT_4_4_4_4:
+                // eslint-disable-next-line no-throw-literal
                 throw "TEXTURETYPE_UNSIGNED_SHORT_4_4_4_4 format not supported in WebGPU";
             case Constants.TEXTURETYPE_UNSIGNED_SHORT_5_5_5_1:
+                // eslint-disable-next-line no-throw-literal
                 throw "TEXTURETYPE_UNSIGNED_SHORT_5_5_5_1 format not supported in WebGPU";
             case Constants.TEXTURETYPE_UNSIGNED_INT_2_10_10_10_REV:
                 switch (format) {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureHelper.ts
@@ -684,6 +684,7 @@ export class WebGPUTextureHelper {
                 return 4;
         }
 
+        // eslint-disable-next-line no-throw-literal
         throw `Unknown format ${format}!`;
     }
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -168,7 +168,7 @@ const copyVideoToTextureVertexSource = `
         @builtin(position) Position : vec4<f32>,
         @location(0) fragUV : vec2<f32>
     }
-  
+
     @vertex
     fn main(
         @builtin(vertex_index) VertexIndex : u32
@@ -1267,6 +1267,7 @@ export class WebGPUTextureManager {
                     );
                 } else {
                     // we should never take this code path
+                    // eslint-disable-next-line no-throw-literal
                     throw "updateTexture: Can't process the texture data because a GPUTexture was provided instead of an InternalTexture!";
                 }
             }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -5218,6 +5218,7 @@ export class ThinEngine {
             if (texture && texture.isMultiview) {
                 //this._gl.bindTexture(target, texture ? texture._colorTextureArray : null);
                 Logger.Error(["_bindTextureDirectly called with a multiview texture!", target, texture]);
+                // eslint-disable-next-line no-throw-literal
                 throw "_bindTextureDirectly called with a multiview texture!";
             } else {
                 this._gl.bindTexture(target, texture?._hardwareTexture?.underlyingResource ?? null);

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -637,6 +637,7 @@ export class WebGPUEngine extends Engine {
             )
             .then((adapter: GPUAdapter | undefined) => {
                 if (!adapter) {
+                    // eslint-disable-next-line no-throw-literal
                     throw "Could not retrieve a WebGPU adapter (adapter is null).";
                 } else {
                     this._adapter = adapter!;
@@ -917,6 +918,7 @@ export class WebGPUEngine extends Engine {
 
     private _initializeContextAndSwapChain(): void {
         if (!this._renderingCanvas) {
+            // eslint-disable-next-line no-throw-literal
             throw "The rendering canvas has not been set!";
         }
         this._context = this._renderingCanvas.getContext("webgpu") as unknown as GPUCanvasContext;
@@ -1648,6 +1650,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public bindBuffersDirectly(): void {
+        // eslint-disable-next-line no-throw-literal
         throw "Not implemented on WebGPU";
     }
 
@@ -1655,6 +1658,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public updateAndBindInstancesBuffer(): void {
+        // eslint-disable-next-line no-throw-literal
         throw "Not implemented on WebGPU";
     }
 
@@ -1918,6 +1922,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public createRawShaderProgram(): WebGLProgram {
+        // eslint-disable-next-line no-throw-literal
         throw "Not available on WebGPU";
     }
 
@@ -1925,6 +1930,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public createShaderProgram(): WebGLProgram {
+        // eslint-disable-next-line no-throw-literal
         throw "Not available on WebGPU";
     }
 
@@ -2054,6 +2060,7 @@ export class WebGPUEngine extends Engine {
         ) {
             if (!effect.effect && this.dbgShowEmptyEnableEffectCalls) {
                 Logger.Log(["drawWrapper=", effect]);
+                // eslint-disable-next-line no-throw-literal
                 throw "Invalid call to enableEffect: the effect property is empty!";
             }
             return;
@@ -2750,6 +2757,7 @@ export class WebGPUEngine extends Engine {
         }
 
         if (image instanceof HTMLImageElement) {
+            // eslint-disable-next-line no-throw-literal
             throw "WebGPU engine: HTMLImageElement not supported in _uploadImageToTexture!";
         }
 
@@ -3690,6 +3698,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public _bindUnboundFramebuffer() {
+        // eslint-disable-next-line no-throw-literal
         throw "_bindUnboundFramebuffer is not implementedin WebGPU! You probably want to use restoreDefaultFramebuffer or unBindFramebuffer instead";
     }
 
@@ -3699,6 +3708,7 @@ export class WebGPUEngine extends Engine {
      * @internal
      */
     public _getSamplingParameters(): { min: number; mag: number } {
+        // eslint-disable-next-line no-throw-literal
         throw "_getSamplingParameters is not available in WebGPU";
     }
 

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -2071,6 +2071,7 @@ export class WebGPUEngine extends Engine {
             this._counters.numEnableDrawWrapper++;
             if (!this._currentMaterialContext) {
                 Logger.Log(["drawWrapper=", effect]);
+                // eslint-disable-next-line no-throw-literal
                 throw `Invalid call to enableEffect: the materialContext property is empty!`;
             }
         }

--- a/packages/dev/core/src/Gizmos/cameraGizmo.ts
+++ b/packages/dev/core/src/Gizmos/cameraGizmo.ts
@@ -171,6 +171,7 @@ export class CameraGizmo extends Gizmo implements ICameraGizmo {
      */
     public setCustomMesh(mesh: Mesh) {
         if (mesh.getScene() != this.gizmoLayer.utilityLayerScene) {
+            // eslint-disable-next-line no-throw-literal
             throw "When setting a custom mesh on a gizmo, the custom meshes scene must be the same as the gizmos (eg. gizmo.gizmoLayer.utilityLayerScene)";
         }
         if (this._cameraMesh) {

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -203,6 +203,7 @@ export class Gizmo implements IGizmo {
      */
     public setCustomMesh(mesh: Mesh) {
         if (mesh.getScene() != this.gizmoLayer.utilityLayerScene) {
+            // eslint-disable-next-line no-throw-literal
             throw "When setting a custom mesh on a gizmo, the custom meshes scene must be the same as the gizmos (eg. gizmo.gizmoLayer.utilityLayerScene)";
         }
         this._rootMesh.getChildMeshes().forEach((c) => {

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -513,6 +513,7 @@ export class SceneLoader {
         const directLoad = SceneLoader._GetDirectLoad(fileInfo.url);
 
         if (fileInfo.rawData && !pluginExtension) {
+            // eslint-disable-next-line no-throw-literal
             throw "When using ArrayBufferView to load data the file extension must be provided.";
         }
 
@@ -523,6 +524,7 @@ export class SceneLoader {
               : SceneLoader._GetPluginForFilename(fileInfo.url);
 
         if (fileInfo.rawData && !registeredPlugin.isBinary) {
+            // eslint-disable-next-line no-throw-literal
             throw "Loading from ArrayBufferView can not be used with plugins that don't support binary loading.";
         }
 
@@ -535,6 +537,7 @@ export class SceneLoader {
         }
 
         if (!plugin) {
+            // eslint-disable-next-line no-throw-literal
             throw "The loader plugin corresponding to the file type you are trying to load has not been found. If using es6, please import the plugin you wish to use before.";
         }
 
@@ -599,6 +602,7 @@ export class SceneLoader {
             };
 
             if (!plugin.loadFile && fileInfo.rawData) {
+                // eslint-disable-next-line no-throw-literal
                 throw "Plugin does not support loading ArrayBufferView.";
             }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragCoordBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragCoordBlock.ts
@@ -99,6 +99,7 @@ export class FragCoordBlock extends NodeMaterialBlock {
         super._buildBlock(state);
 
         if (state.target === NodeMaterialBlockTargets.Vertex) {
+            // eslint-disable-next-line no-throw-literal
             throw "FragCoordBlock must only be used in a fragment shader";
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/frontFacingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/frontFacingBlock.ts
@@ -37,6 +37,7 @@ export class FrontFacingBlock extends NodeMaterialBlock {
         super._buildBlock(state);
 
         if (state.target === NodeMaterialBlockTargets.Vertex) {
+            // eslint-disable-next-line no-throw-literal
             throw "FrontFacingBlock must only be used in a fragment shader";
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
@@ -80,6 +80,7 @@ export class ScreenSizeBlock extends NodeMaterialBlock {
         this._scene = state.sharedData.scene;
 
         if (state.target === NodeMaterialBlockTargets.Vertex) {
+            // eslint-disable-next-line no-throw-literal
             throw "ScreenSizeBlock must only be used in a fragment shader";
         }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -651,6 +651,7 @@ export class NodeMaterial extends PushMaterial {
 
                 for (const other of this.attachedBlocks) {
                     if (other.getClassName() === className) {
+                        // eslint-disable-next-line no-throw-literal
                         throw `Cannot have multiple blocks of type ${className} in the same NodeMaterial`;
                     }
                 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -524,6 +524,7 @@ export class NodeMaterial extends PushMaterial {
      */
     public addOutputNode(node: NodeMaterialBlock) {
         if (node.target === null) {
+            // eslint-disable-next-line no-throw-literal
             throw "This node is not meant to be an output node. You may want to explicitly set its target value.";
         }
 
@@ -739,10 +740,12 @@ export class NodeMaterial extends PushMaterial {
         const allowEmptyVertexProgram = this._mode === NodeMaterialModes.Particle;
 
         if (this._vertexOutputNodes.length === 0 && !allowEmptyVertexProgram) {
+            // eslint-disable-next-line no-throw-literal
             throw "You must define at least one vertexOutputNode";
         }
 
         if (this._fragmentOutputNodes.length === 0) {
+            // eslint-disable-next-line no-throw-literal
             throw "You must define at least one fragmentOutputNode";
         }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -414,6 +414,7 @@ export class NodeMaterialBlock {
                 output.connectTo(input);
                 notFound = false;
             } else if (!output) {
+                // eslint-disable-next-line no-throw-literal
                 throw "Unable to find a compatible match";
             } else {
                 output = this.getSiblingOutput(output);

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -482,6 +482,7 @@ export class NodeMaterialConnectionPoint {
      */
     public connectTo(connectionPoint: NodeMaterialConnectionPoint, ignoreConstraints = false): NodeMaterialConnectionPoint {
         if (!ignoreConstraints && !this.canConnectTo(connectionPoint)) {
+            // eslint-disable-next-line no-throw-literal
             throw "Cannot connect these two connectors.";
         }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
@@ -184,6 +184,7 @@ export class NodeMaterialBuildStateSharedData {
         }
 
         if (errorMessage) {
+            // eslint-disable-next-line no-throw-literal
             throw "Build of NodeMaterial failed:\n" + errorMessage;
         }
     }

--- a/packages/dev/core/src/Materials/Textures/Loaders/envTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/envTextureLoader.ts
@@ -75,6 +75,7 @@ export class _ENVTextureLoader implements IInternalTextureLoader {
      * Uploads the 2D texture data to the WebGL texture. It has already been bound once in the callback.
      */
     public loadData(): void {
+        // eslint-disable-next-line no-throw-literal
         throw ".env not supported in 2d.";
     }
 }

--- a/packages/dev/core/src/Materials/Textures/Loaders/hdrTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/hdrTextureLoader.ts
@@ -28,6 +28,7 @@ export class _HDRTextureLoader implements IInternalTextureLoader {
      * Uploads the cube texture data to the WebGL texture. It has already been bound.
      */
     public loadCubeData(): void {
+        // eslint-disable-next-line no-throw-literal
         throw ".env not supported in Cube.";
     }
 

--- a/packages/dev/core/src/Materials/Textures/Loaders/tgaTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/tgaTextureLoader.ts
@@ -27,6 +27,7 @@ export class _TGATextureLoader implements IInternalTextureLoader {
      * Uploads the cube texture data to the WebGL texture. It has already been bound.
      */
     public loadCubeData(): void {
+        // eslint-disable-next-line no-throw-literal
         throw ".env not supported in Cube.";
     }
 

--- a/packages/dev/core/src/Materials/materialPluginManager.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.ts
@@ -90,6 +90,7 @@ export class MaterialPluginManager {
         }
 
         if (this._material._uniformBufferLayoutBuilt) {
+            // eslint-disable-next-line no-throw-literal
             throw `The plugin "${plugin.name}" can't be added to the material "${this._material.name}" because this material has already been used for rendering! Please add plugins to materials before any rendering with this material occurs.`;
         }
 

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -413,6 +413,7 @@ export class UniformBuffer {
         // std140 FTW...
         if (arraySize > 0) {
             if (size instanceof Array) {
+                // eslint-disable-next-line no-throw-literal
                 throw "addUniform should not be use with Array in UBO: " + name;
             }
 

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
@@ -68,6 +68,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
         super(name, scene, _options);
 
         if (!_options.ribbonOptions) {
+            // eslint-disable-next-line no-throw-literal
             throw "'GreasedLineMeshOptions.ribbonOptions' is not set.";
         }
 
@@ -91,6 +92,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
      */
     public override addPoints(points: number[][], options: GreasedLineMeshOptions, hasPathOptions = false) {
         if (!options.ribbonOptions) {
+            // eslint-disable-next-line no-throw-literal
             throw "addPoints() on GreasedLineRibbonMesh instance requires 'GreasedLineMeshOptions.ribbonOptions'.";
         }
 
@@ -166,6 +168,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
 
     protected _setPoints(points: number[][], _options: GreasedLineMeshOptions) {
         if (!this._options.ribbonOptions) {
+            // eslint-disable-next-line no-throw-literal
             throw "No 'GreasedLineMeshOptions.ribbonOptions' provided.";
         }
         this._points = points;
@@ -184,6 +187,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
             } else {
                 if (pathOptions.ribbonOptions?.directionsAutoMode === GreasedLineRibbonAutoDirectionMode.AUTO_DIRECTIONS_NONE) {
                     if (!pathOptions.ribbonOptions!.directions) {
+                        // eslint-disable-next-line no-throw-literal
                         throw "In GreasedLineRibbonAutoDirectionMode.AUTO_DIRECTIONS_NONE 'GreasedLineMeshOptions.ribbonOptions.directions' must be defined.";
                     }
                     directionPlanes = GreasedLineRibbonMesh._GetDirectionPlanesFromDirectionsOption(subPoints.length, pathOptions.ribbonOptions!.directions);
@@ -217,6 +221,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
     private static _CreateRibbonVertexData(pathArray: Vector3[][], options: GreasedLineMeshOptions) {
         const numOfPaths = pathArray.length;
         if (numOfPaths < 2) {
+            // eslint-disable-next-line no-throw-literal
             throw "Minimum of two paths are required to create a GreasedLineRibbonMesh.";
         }
 
@@ -291,6 +296,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
         const positions = ribbonVertexData.positions;
 
         if (!this._options.widths) {
+            // eslint-disable-next-line no-throw-literal
             throw "No 'GreasedLineMeshOptions.widths' table is specified.";
         }
 
@@ -354,6 +360,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
 
     private static _ConvertToRibbonPath(points: number[], ribbonInfo: GreasedLineRibbonOptions, rightHandedSystem: boolean, directionPlane?: Vector3) {
         if (ribbonInfo.pointsMode === GreasedLineRibbonPointsMode.POINTS_MODE_POINTS && !ribbonInfo.width) {
+            // eslint-disable-next-line no-throw-literal
             throw "'GreasedLineMeshOptions.ribbonOptiosn.width' must be specified in GreasedLineRibbonPointsMode.POINTS_MODE_POINTS.";
         }
         const path1 = [];

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -229,6 +229,7 @@ export class NodeGeometry {
         this._buildWasSuccessful = false;
 
         if (!this.outputBlock) {
+            // eslint-disable-next-line no-throw-literal
             throw "You must define the outputBlock property before building the geometry";
         }
         const now = PrecisionDate.Now;

--- a/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
@@ -332,6 +332,7 @@ export class NodeGeometryConnectionPoint {
      */
     public connectTo(connectionPoint: NodeGeometryConnectionPoint, ignoreConstraints = false): NodeGeometryConnectionPoint {
         if (!ignoreConstraints && !this.canConnectTo(connectionPoint)) {
+            // eslint-disable-next-line no-throw-literal
             throw "Cannot connect these two connectors.";
         }
 

--- a/packages/dev/core/src/Meshes/Node/nodeGeometryBuildState.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometryBuildState.ts
@@ -272,6 +272,7 @@ export class NodeGeometryBuildState {
         }
 
         if (errorMessage) {
+            // eslint-disable-next-line no-throw-literal
             throw "Build of NodeGeometry failed:\n" + errorMessage;
         }
     }

--- a/packages/dev/core/src/Meshes/csg.ts
+++ b/packages/dev/core/src/Meshes/csg.ts
@@ -468,6 +468,7 @@ export class CSG {
         const vertColors = data.colors;
 
         if (!indices || !positions) {
+            // eslint-disable-next-line no-throw-literal
             throw "BABYLON.CSG: VertexData must at least contain positions and indices";
         }
 
@@ -542,6 +543,7 @@ export class CSG {
                 invertWinding = mesh.material.sideOrientation === Constants.MATERIAL_ClockWiseSideOrientation;
             }
         } else {
+            // eslint-disable-next-line no-throw-literal
             throw "BABYLON.CSG: Wrong Mesh type, must be BABYLON.Mesh";
         }
 

--- a/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/hdr.ts
@@ -84,6 +84,7 @@ export class HDRTools {
 
         let line = this._ReadStringLine(uint8array, 0);
         if (line[0] != "#" || line[1] != "?") {
+            // eslint-disable-next-line no-throw-literal
             throw "Bad HDR Format.";
         }
 
@@ -103,6 +104,7 @@ export class HDRTools {
         } while (!endOfHeader);
 
         if (!findFormat) {
+            // eslint-disable-next-line no-throw-literal
             throw "HDR Bad header format, unsupported FORMAT";
         }
 
@@ -114,12 +116,14 @@ export class HDRTools {
 
         // TODO. Support +Y and -X if needed.
         if (!match || match.length < 3) {
+            // eslint-disable-next-line no-throw-literal
             throw "HDR Bad header format, no size";
         }
         width = parseInt(match[2]);
         height = parseInt(match[1]);
 
         if (width < 8 || width > 0x7fff) {
+            // eslint-disable-next-line no-throw-literal
             throw "HDR Bad header format, unsupported size";
         }
 
@@ -199,6 +203,7 @@ export class HDRTools {
             }
 
             if (((c << 8) | d) != scanline_width) {
+                // eslint-disable-next-line no-throw-literal
                 throw "HDR Bad header format, wrong scan line width";
             }
 
@@ -216,6 +221,7 @@ export class HDRTools {
                         // a run of the same value
                         count = a - 128;
                         if (count == 0 || count > endIndex - index) {
+                            // eslint-disable-next-line no-throw-literal
                             throw "HDR Bad Format, bad scanline data (run)";
                         }
 
@@ -226,6 +232,7 @@ export class HDRTools {
                         // a non-run
                         count = a;
                         if (count == 0 || count > endIndex - index) {
+                            // eslint-disable-next-line no-throw-literal
                             throw "HDR Bad Format, bad scanline data (non-run)";
                         }
 

--- a/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/panoramaToCubemap.ts
@@ -93,10 +93,12 @@ export class PanoramaToCubeMapTools {
      */
     public static ConvertPanoramaToCubemap(float32Array: Float32Array, inputWidth: number, inputHeight: number, size: number, supersample = false): CubeMapInfo {
         if (!float32Array) {
+            // eslint-disable-next-line no-throw-literal
             throw "ConvertPanoramaToCubemap: input cannot be null";
         }
 
         if (float32Array.length != inputWidth * inputHeight * 3) {
+            // eslint-disable-next-line no-throw-literal
             throw "ConvertPanoramaToCubemap: input size is wrong";
         }
 

--- a/packages/dev/core/src/Misc/basis.ts
+++ b/packages/dev/core/src/Misc/basis.ts
@@ -152,6 +152,7 @@ export const GetInternalFormatFromBasisFormat = (basisFormat: number, engine: En
     }
 
     if (format === undefined) {
+        // eslint-disable-next-line no-throw-literal
         throw "The chosen Basis transcoder format is not currently supported";
     }
 

--- a/packages/dev/core/src/Misc/videoRecorder.ts
+++ b/packages/dev/core/src/Misc/videoRecorder.ts
@@ -112,11 +112,13 @@ export class VideoRecorder {
      */
     constructor(engine: Engine, options: Partial<VideoRecorderOptions> = {}) {
         if (!VideoRecorder.IsSupported(engine, options.canvas)) {
+            // eslint-disable-next-line no-throw-literal
             throw "Your browser does not support recording so far.";
         }
 
         const canvas = options.canvas ?? engine.getRenderingCanvas();
         if (!canvas) {
+            // eslint-disable-next-line no-throw-literal
             throw "The babylon engine must have a canvas to be recorded";
         }
 
@@ -167,10 +169,12 @@ export class VideoRecorder {
      */
     public startRecording(fileName: Nullable<string> = "babylonjs.webm", maxDuration = 7): Promise<Blob> {
         if (!this._canvas || !this._mediaRecorder) {
+            // eslint-disable-next-line no-throw-literal
             throw "Recorder has already been disposed";
         }
 
         if (this.isRecording) {
+            // eslint-disable-next-line no-throw-literal
             throw "Recording already in progress";
         }
 

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -244,6 +244,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      */
     public start(delay = this.startDelay): void {
         if (!this.targetStopDuration && this._hasTargetStopDurationDependantGradient()) {
+            // eslint-disable-next-line no-throw-literal
             throw "Particle system started with a targetStopDuration dependant gradient (eg. startSizeGradients) but no targetStopDuration set";
         }
         if (delay) {

--- a/packages/dev/core/src/Particles/particleSystem.ts
+++ b/packages/dev/core/src/Particles/particleSystem.ts
@@ -1233,6 +1233,7 @@ export class ParticleSystem extends BaseParticleSystem implements IDisposable, I
      */
     public start(delay = this.startDelay): void {
         if (!this.targetStopDuration && this._hasTargetStopDurationDependantGradient()) {
+            // eslint-disable-next-line no-throw-literal
             throw "Particle system started with a targetStopDuration dependant gradient (eg. startSizeGradients) but no targetStopDuration set";
         }
         if (delay) {

--- a/packages/dev/core/src/Physics/v1/Plugins/ammoJSPlugin.ts
+++ b/packages/dev/core/src/Physics/v1/Plugins/ammoJSPlugin.ts
@@ -996,6 +996,7 @@ export class AmmoJSPlugin implements IPhysicsEnginePlugin {
                 const childImpostor = childMesh.getPhysicsImpostor();
                 if (childImpostor) {
                     if (childImpostor.type == PhysicsImpostor.MeshImpostor) {
+                        // eslint-disable-next-line no-throw-literal
                         throw "A child MeshImpostor is not supported. Only primitive impostors are supported as children (eg. box or sphere)";
                     }
                     const shape = this._createShape(childImpostor);

--- a/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
@@ -47,6 +47,7 @@ Scene.prototype.enableDepthRenderer = function (
 ): DepthRenderer {
     camera = camera || this.activeCamera;
     if (!camera) {
+        // eslint-disable-next-line no-throw-literal
         throw "No camera available to enable depth renderer";
     }
     if (!this._depthRenderer) {

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -127,6 +127,7 @@ export class WebXRExperienceHelper implements IDisposable {
         sessionCreationOptions: XRSessionInit = {}
     ): Promise<WebXRSessionManager> {
         if (!this._supported) {
+            // eslint-disable-next-line no-throw-literal
             throw "WebXR not supported in this browser or environment";
         }
         this._setState(WebXRState.ENTERING_XR);

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -360,6 +360,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
                         },
                         (rejectionReason) => {
                             Logger.Error(rejectionReason);
+                            // eslint-disable-next-line no-throw-literal
                             throw 'XR initialization failed: required "viewer" reference space type not supported.';
                         }
                     );

--- a/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.inputManager.test.ts
@@ -233,9 +233,11 @@ describe("InputManager", () => {
                     lazyPickCt++;
                     // Check that we have pickInfo, also indirectly used to check for double lazy picking
                     if (!eventData.pickInfo) {
+                        // eslint-disable-next-line no-throw-literal
                         throw "Error: pickInfo should not be null";
                     }
                 } else {
+                    // eslint-disable-next-line no-throw-literal
                     throw "Error: Tried to lazy pick twice";
                 }
             };

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1443,6 +1443,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private static _CreateMaterial(mesh: AbstractMesh, uniqueId: string, texture: AdvancedDynamicTexture, onlyAlphaTesting: boolean): void {
         const internalClassType = GetClass("BABYLON.StandardMaterial");
         if (!internalClassType) {
+            // eslint-disable-next-line no-throw-literal
             throw "StandardMaterial needs to be imported before as it contains a side-effect required by your code.";
         }
 

--- a/packages/dev/gui/src/2D/xmlLoader.ts
+++ b/packages/dev/gui/src/2D/xmlLoader.ts
@@ -112,10 +112,12 @@ export class XmlLoader {
             if (!this._nodes[id]) {
                 this._nodes[id] = guiNode;
             } else {
+                // eslint-disable-next-line no-throw-literal
                 throw "XmlLoader Exception : Duplicate ID, every element should have an unique ID attribute";
             }
             return guiNode;
         } catch (exception) {
+            // eslint-disable-next-line no-throw-literal
             throw "XmlLoader Exception : Error parsing Control " + node.nodeName + "," + exception + ".";
         }
     }
@@ -137,12 +139,14 @@ export class XmlLoader {
                 continue;
             }
             if (rows[i].nodeName != "Row") {
+                // eslint-disable-next-line no-throw-literal
                 throw "XmlLoader Exception : Expecting Row node, received " + rows[i].nodeName;
             }
             rowNumber += 1;
             columns = rows[i].children;
 
             if (!rows[i].attributes.getNamedItem("height")) {
+                // eslint-disable-next-line no-throw-literal
                 throw "XmlLoader Exception : Height must be defined for grid rows";
             }
             height = Number(rows[i].attributes.getNamedItem("height").nodeValue);
@@ -154,15 +158,18 @@ export class XmlLoader {
                     continue;
                 }
                 if (columns[j].nodeName != "Column") {
+                    // eslint-disable-next-line no-throw-literal
                     throw "XmlLoader Exception : Expecting Column node, received " + columns[j].nodeName;
                 }
                 columnNumber += 1;
                 if (rowNumber > 0 && columnNumber > totalColumnsNumber) {
+                    // eslint-disable-next-line no-throw-literal
                     throw "XmlLoader Exception : In the Grid element, the number of columns is defined in the first row, do not add more columns in the subsequent rows.";
                 }
 
                 if (rowNumber == 0) {
                     if (!columns[j].attributes.getNamedItem("width")) {
+                        // eslint-disable-next-line no-throw-literal
                         throw "XmlLoader Exception : Width must be defined for all the grid columns in the first row";
                     }
                     width = Number(columns[j].attributes.getNamedItem("width").nodeValue);
@@ -220,11 +227,13 @@ export class XmlLoader {
         const dataSource = node.attributes.getNamedItem("dataSource").value;
 
         if (!dataSource.includes(" in ")) {
+            // eslint-disable-next-line no-throw-literal
             throw "XmlLoader Exception : Malformed XML, Data Source must include an in";
         } else {
             let isArray = true;
             const splittedSource = dataSource.split(" in ");
             if (splittedSource.length < 2) {
+                // eslint-disable-next-line no-throw-literal
                 throw "XmlLoader Exception : Malformed XML, Data Source must have an iterator and a source";
             }
             let source = splittedSource[1];

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/gui/guiTools.ts
@@ -61,11 +61,13 @@ export async function EditAdvancedDynamicTexture(adt: AdvancedDynamicTexture, em
                     await Tools.LoadScriptAsync(editorUrl);
                     guiEditorContainer = guiEditorContainer || _getGlobalGUIEditor();
                 } catch {
+                    // eslint-disable-next-line no-throw-literal
                     throw `Failed to load GUI editor from ${editorUrl}`;
                 }
             }
         } else {
             // we are in ES6 environment
+            // eslint-disable-next-line no-throw-literal
             throw `Tried to call EditAdvancedDynamicTexture without first injecting the GUI editor. You need to call InjectGUIEditor() with a reference to @babylonjs/gui-editor. It can be imported at runtime using await import("@babylonjs/gui-editor").`;
         }
     }

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -547,6 +547,7 @@ export class FurMaterial extends PushMaterial {
         let i;
 
         if (!(mat instanceof FurMaterial)) {
+            // eslint-disable-next-line no-throw-literal
             throw "The material of the source mesh must be a Fur Material";
         }
 

--- a/packages/tools/guiEditor/src/guiNodeTools.ts
+++ b/packages/tools/guiEditor/src/guiNodeTools.ts
@@ -169,6 +169,7 @@ export class GUINodeTools {
                 element.height = "40px";
                 return element;
             default:
+                // eslint-disable-next-line no-throw-literal
                 throw "Error: control type not recognized";
         }
     }


### PR DESCRIPTION
Existing instances that would fail this rule are ignored so back-compat is kept. This could be changed for the 7.0 release.