### PR TITLE
Better feature handling

### DIFF
--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -243,8 +243,8 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         return this._xrNavigator.xr.requestSession(xrSessionMode, xrSessionInit).then((session: XRSession) => {
             this.session = session;
             this._sessionMode = xrSessionMode;
-            this.onXRSessionInit.notifyObservers(session);
             this.inXRSession = true;
+            this.onXRSessionInit.notifyObservers(session);
 
             // handle when the session is ended (By calling session.end or device ends its own session eg. pressing home button on phone)
             this.session.addEventListener(


### PR DESCRIPTION
A feature that is a native WebXR feature will not attach if the session was not enabled with it, or that the session doesn't support it.

In addition, a warning will be shown if the feature was initialized after the session has started.