### PR TITLE
Morph targets: Pass the number of active targets to the shader as a uniform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "**/.rollup.cache": true,
         "**/packages/dev/**/Shaders/**/*.ts": true,
         "**/packages/dev/**/shaders/**/*.ts": true,
+        "**/packages/dev/**/ShadersWGSL/**/*.ts": true,
         "**/*.fragment.ts": true,
         "**/*.vertex.ts": true,
         "**/*.compute.ts": true,

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -239,8 +239,15 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
         return texture;
     }
 
-    public postProcessor(code: string) {
-        return code;
+    public postProcessor(code: string, defines: string[]) {
+        const defineToValue: { [key: string]: string } = {};
+        for (const define of defines) {
+            const parts = define.split(/ +/);
+            defineToValue[parts[1]] = parts.length > 2 ? parts[2] : "";
+        }
+        return code.replace(/\$(\w+)\$/g, (_, p1) => {
+            return defineToValue[p1] ?? p1;
+        });
     }
 
     public finalizeShaders(vertexCode: string, fragmentCode: string): { vertexCode: string; fragmentCode: string } {

--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -222,8 +222,8 @@ export class MaterialHelper {
             defines["MORPHTARGETS_UV"] = manager.supportsUVs && defines["UV1"];
             defines["MORPHTARGETS_TANGENT"] = manager.supportsTangents && defines["TANGENT"];
             defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"];
-            defines["MORPHTARGETS"] = manager.numInfluencers > 0;
-            defines["NUM_MORPH_INFLUENCERS"] = manager.numInfluencers;
+            defines["NUM_MORPH_INFLUENCERS"] = manager.numMaxInfluencers || manager.numInfluencers;
+            defines["MORPHTARGETS"] = defines["NUM_MORPH_INFLUENCERS"] > 0;
 
             defines["MORPHTARGETS_TEXTURE"] = manager.isUsingTextureForTargets;
         } else {
@@ -700,6 +700,7 @@ export class MaterialHelper {
 
         if (defines["NUM_MORPH_INFLUENCERS"]) {
             uniformsList.push("morphTargetInfluences");
+            uniformsList.push("morphTargetCount");
         }
 
         if (defines["BAKED_VERTEX_ANIMATION_TEXTURE"]) {
@@ -815,7 +816,7 @@ export class MaterialHelper {
     /**
      * Prepares the list of attributes required for baked vertex animations according to the effect defines.
      * @param attribs The current list of supported attribs
-     * @param mesh The mesh to prepare the morph targets attributes for
+     * @param mesh The mesh to prepare for baked vertex animations
      * @param defines The current Defines of the effect
      */
     public static PrepareAttributesForBakedVertexAnimation(attribs: string[], mesh: AbstractMesh, defines: any): void {

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -1,21 +1,27 @@
 ﻿#ifdef MORPHTARGETS
-	#ifdef MORPHTARGETS_TEXTURE	
-		vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
-		positionUpdated += (readVector3FromRawSampler({X}, vertexID) - position) * morphTargetInfluences[{X}];
-		vertexID += 1.0;
-	
-		#ifdef MORPHTARGETS_NORMAL
-			normalUpdated += (readVector3FromRawSampler({X}, vertexID)  - normal) * morphTargetInfluences[{X}];
-			vertexID += 1.0;
-		#endif
+	#ifdef MORPHTARGETS_TEXTURE
+		#if {X} == 0
+		for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {
+			if (i >= morphTargetCount) break;
 
-		#ifdef MORPHTARGETS_UV
-			uvUpdated += (readVector3FromRawSampler({X}, vertexID).xy - uv) * morphTargetInfluences[{X}];
+			vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
+			positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
 			vertexID += 1.0;
-		#endif
+		
+			#ifdef MORPHTARGETS_NORMAL
+				normalUpdated += (readVector3FromRawSampler(i, vertexID)  - normal) * morphTargetInfluences[i];
+				vertexID += 1.0;
+			#endif
 
-		#ifdef MORPHTARGETS_TANGENT
-			tangentUpdated.xyz += (readVector3FromRawSampler({X}, vertexID)  - tangent.xyz) * morphTargetInfluences[{X}];
+			#ifdef MORPHTARGETS_UV
+				uvUpdated += (readVector3FromRawSampler(i, vertexID).xy - uv) * morphTargetInfluences[i];
+				vertexID += 1.0;
+			#endif
+
+			#ifdef MORPHTARGETS_TANGENT
+				tangentUpdated.xyz += (readVector3FromRawSampler(i, vertexID)  - tangent.xyz) * morphTargetInfluences[i];
+			#endif
+		}
 		#endif
 	#else
 		positionUpdated += (position{X} - position) * morphTargetInfluences[{X}];

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -13,5 +13,7 @@
 		#ifdef MORPHTARGETS_UV
 		attribute vec2 uv_{X};
 		#endif
+	#elif {X} == 0
+		uniform int morphTargetCount;
 	#endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -1,21 +1,29 @@
 ﻿#ifdef MORPHTARGETS
-	#ifdef MORPHTARGETS_TEXTURE	
-		vertexID = f32(vertexInputs.vertexIndex) * uniforms.morphTargetTextureInfo.x;
-		positionUpdated = positionUpdated + (readVector3FromRawSampler({X}, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[{X}];
-		vertexID = vertexID + 1.0;
-	
-		#ifdef MORPHTARGETS_NORMAL
-			normalUpdated = normalUpdated + (readVector3FromRawSampler({X}, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[{X}];
-		    vertexID = vertexID + 1.0;
-		#endif
+	#ifdef MORPHTARGETS_TEXTURE
+		#if {X} == 0
+		for (var i = 0; i < $NUM_MORPH_INFLUENCERS$; i = i + 1) {
+			if (i >= uniforms.morphTargetCount) {
+				break;
+			}
 
-		#ifdef MORPHTARGETS_UV
-			uvUpdated = uvUpdated + (readVector3FromRawSampler({X}, vertexID).xy - vertexInputs.uv) * uniforms.morphTargetInfluences[{X}];
-		    vertexID = vertexID + 1.0;
-		#endif
+			vertexID = f32(vertexInputs.vertexIndex) * uniforms.morphTargetTextureInfo.x;
+			positionUpdated = positionUpdated + (readVector3FromRawSampler({X}, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[{X}];
+			vertexID = vertexID + 1.0;
+		
+			#ifdef MORPHTARGETS_NORMAL
+				normalUpdated = normalUpdated + (readVector3FromRawSampler({X}, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[{X}];
+				vertexID = vertexID + 1.0;
+			#endif
 
-		#ifdef MORPHTARGETS_TANGENT
-			tangentUpdated.xyz = tangentUpdated.xyz + (readVector3FromRawSampler({X}, vertexID)  - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[{X}];
+			#ifdef MORPHTARGETS_UV
+				uvUpdated = uvUpdated + (readVector3FromRawSampler({X}, vertexID).xy - vertexInputs.uv) * uniforms.morphTargetInfluences[{X}];
+				vertexID = vertexID + 1.0;
+			#endif
+
+			#ifdef MORPHTARGETS_TANGENT
+				tangentUpdated.xyz = tangentUpdated.xyz + (readVector3FromRawSampler({X}, vertexID)  - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[{X}];
+			#endif
+		}
 		#endif
 	#else
 		positionUpdated = positionUpdated + (position{X} - vertexInputs.position) * uniforms.morphTargetInfluences[{X}];

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -13,5 +13,7 @@
 		#ifdef MORPHTARGETS_UV
 		attribute uv_{X} : vec2<f32>;
 		#endif
+	#elif {X} == 0
+		uniform morphTargetCount: i32;
 	#endif
 #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/babylon-blendshapes-animation-player-fps-drops-and-glitch/41884/13.

This PR allows to set a maximum number of active targets, to avoid a shader recompilation each time the number of active targets changes. If non-zero, we compile the shader with `NUM_MORPH_INFLUENCERS=this value`, and `NUM_MORPH_INFLUENCERS` is used as the upper bound of a loop over the targets. We use a uniform variable to break from the loop when we reach the number of active targets.

Note that for WebGPU / WGSL, up to now, we didn't have a mean to make preprocessing variable replacements (we didn't need it)! When defining something like `#define TEST 23`, `TEST` could be used in a `#if` / `#ifdef` / `#elif` statement, but not as a replacement like in `int test = TEST;`. It works in WebGL because such replacements are automatically handled by the GLSL parser/compiler (there's no specific code in Babylon to do it).

So, I added this feature in WebGPU, but the replacement variable name should be enclosed inside $...$ (I can change the enclosing character!). I did it this way because I think this code would be too time consuming:
```typescript
const defineToValue: { [key: string]: string } = {};
// fill defineToValue with the replacement variables
code.replace(/(\w+)/g, (_, p1) => {
    return defineToValue[p1] ?? p1;
});
```
This would mean hundred or thousand (or more!) of replacements (because `(\w+)` will match a lot of time) + the possibility of wrong replacements (in case a replacement variable is a subset of a string).