### PR TITLE
Animations: Fix broken loop when speedRatio is negative

### DIFF
--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -518,11 +518,11 @@ export class RuntimeAnimation {
         this._previousElapsedTime = elapsedTimeSinceAnimationStart;
         this._previousAbsoluteFrame = absoluteFrame;
 
-        if (!loop && to >= from && absoluteFrame >= frameRange) {
+        if (!loop && to >= from && (absoluteFrame >= frameRange && speedRatio > 0 || absoluteFrame <= 0 && speedRatio < 0)) {
             // If we are out of range and not looping get back to caller
             returnValue = false;
             highLimitValue = animation._getKeyValue(this._maxValue);
-        } else if (!loop && from >= to && absoluteFrame <= frameRange) {
+        } else if (!loop && from >= to && (absoluteFrame <= frameRange && speedRatio < 0 || absoluteFrame >= 0 && speedRatio > 0)) {
             returnValue = false;
             highLimitValue = animation._getKeyValue(this._minValue);
         } else if (this._animationState.loopMode !== Animation.ANIMATIONLOOPMODE_CYCLE) {

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -518,11 +518,11 @@ export class RuntimeAnimation {
         this._previousElapsedTime = elapsedTimeSinceAnimationStart;
         this._previousAbsoluteFrame = absoluteFrame;
 
-        if (!loop && to >= from && (absoluteFrame >= frameRange && speedRatio > 0 || absoluteFrame <= 0 && speedRatio < 0)) {
+        if (!loop && to >= from && ((absoluteFrame >= frameRange && speedRatio > 0) || (absoluteFrame <= 0 && speedRatio < 0))) {
             // If we are out of range and not looping get back to caller
             returnValue = false;
             highLimitValue = animation._getKeyValue(this._maxValue);
-        } else if (!loop && from >= to && (absoluteFrame <= frameRange && speedRatio < 0 || absoluteFrame >= 0 && speedRatio > 0)) {
+        } else if (!loop && from >= to && ((absoluteFrame <= frameRange && speedRatio < 0) || (absoluteFrame >= 0 && speedRatio > 0))) {
             returnValue = false;
             highLimitValue = animation._getKeyValue(this._minValue);
         } else if (this._animationState.loopMode !== Animation.ANIMATIONLOOPMODE_CYCLE) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/animationgroup-play-backwards-issue/47502/5 and https://forum.babylonjs.com/t/gltf-animation-loops-when-i-click-how-to-stop-the-loop/38477.
