### PR TITLE
Materials: Improve management of frozen materials

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1126,7 +1126,6 @@ export class ThinEngine {
             const effect = <Effect>this._compiledEffects[key];
 
             effect._pipelineContext = null; // because _prepareEffect will try to dispose this pipeline before recreating it and that would lead to webgl errors
-            effect._wasPreviouslyReady = false;
             effect._prepareEffect();
         }
 

--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -88,8 +88,10 @@ export class GaussianSplattingMaterial extends PushMaterial {
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
         const useInstances = true;
 
-        if (subMesh.effect && this.isFrozen) {
-            if (subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+        const drawWrapper = subMesh._drawWrapper;
+
+        if (drawWrapper.effect && this.isFrozen) {
+            if (drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -161,8 +163,8 @@ export class GaussianSplattingMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = useInstances;
 
         return true;
     }
@@ -192,7 +194,7 @@ export class GaussianSplattingMaterial extends PushMaterial {
         mesh.transferToEffect(world);
 
         // Bind data
-        const mustRebind = effect._forceRebindOnNextCall || this._mustRebind(scene, effect, mesh.visibility);
+        const mustRebind = this._mustRebind(scene, effect, subMesh, mesh.visibility);
 
         if (mustRebind) {
             this.bindView(effect);
@@ -245,7 +247,7 @@ export class GaussianSplattingMaterial extends PushMaterial {
             MaterialHelper.BindLogDepth(defines, effect, scene);
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1469,8 +1469,10 @@ export class NodeMaterial extends PushMaterial {
             }
         }
 
-        if (subMesh.effect && this.isFrozen) {
-            if (subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+        const drawWrapper = subMesh._drawWrapper;
+
+        if (drawWrapper.effect && this.isFrozen) {
+            if (drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -1550,8 +1552,8 @@ export class NodeMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = useInstances;
 
         this._checkScenePerformancePriority();
 
@@ -1609,7 +1611,7 @@ export class NodeMaterial extends PushMaterial {
         // Matrices
         this.bindOnlyWorldMatrix(world);
 
-        const mustRebind = this._mustRebind(scene, effect, mesh.visibility);
+        const mustRebind = this._mustRebind(scene, effect, subMesh, mesh.visibility);
         const sharedData = this._sharedData;
 
         if (mustRebind) {
@@ -1632,7 +1634,7 @@ export class NodeMaterial extends PushMaterial {
             }
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1027,8 +1027,10 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             this.buildUniformLayout();
         }
 
-        if (subMesh.effect && this.isFrozen) {
-            if (subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+        const drawWrapper = subMesh._drawWrapper;
+
+        if (drawWrapper.effect && this.isFrozen) {
+            if (drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -1200,8 +1202,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         this._checkScenePerformancePriority();
 
@@ -2011,7 +2013,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             this.bindOnlyNormalMatrix(this._normalMatrix);
         }
 
-        const mustRebind = effect._forceRebindOnNextCall || this._mustRebind(scene, effect, mesh.visibility);
+        const mustRebind = this._mustRebind(scene, effect, subMesh, mesh.visibility);
 
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect, this.prePassConfiguration);
@@ -2022,7 +2024,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             this.bindViewProjection(effect);
             reflectionTexture = this._getReflectionTexture();
 
-            if (!ubo.useUbo || !this.isFrozen || !ubo.isSync || effect._forceRebindOnNextCall) {
+            if (!ubo.useUbo || !this.isFrozen || !ubo.isSync || subMesh._drawWrapper._forceRebindOnNextCall) {
                 // Texture uniforms
                 if (scene.texturesEnabled) {
                     if (this._albedoTexture && MaterialFlags.DiffuseTextureEnabled) {
@@ -2324,7 +2326,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             MaterialHelper.BindLogDepth(defines, this._activeEffect, scene);
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
 
         ubo.update();
     }

--- a/packages/dev/core/src/Materials/drawWrapper.ts
+++ b/packages/dev/core/src/Materials/drawWrapper.ts
@@ -13,6 +13,24 @@ export class DrawWrapper {
     public materialContext?: IMaterialContext;
     public drawContext?: IDrawContext;
 
+    /**
+     * @internal
+     * Specifies if the effect was previously ready
+     */
+    public _wasPreviouslyReady = false;
+
+    /**
+     * @internal
+     * Forces the code from bindForSubMesh to be fully run the next time it is called
+     */
+    public _forceRebindOnNextCall = true;
+
+    /**
+     * @internal
+     * Specifies if the effect was previously using instances
+     */
+    public _wasPreviouslyUsingInstances: Nullable<boolean> = null;
+
     public static IsWrapper(effect: Effect | DrawWrapper): effect is DrawWrapper {
         return (effect as Effect).getPipelineContext === undefined;
     }

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -141,25 +141,6 @@ export class Effect implements IDisposable {
     /** @internal */
     public _onBindObservable: Nullable<Observable<Effect>> = null;
 
-    /**
-     * @internal
-     * Specifies if the effect was previously ready
-     */
-    public _wasPreviouslyReady = false;
-
-    /**
-     * @internal
-     * Forces the code from bindForSubMesh to be fully run the next time it is called
-     * It is used in frozen mode to make sure the effect is properly rebound when a new effect is created
-     */
-    public _forceRebindOnNextCall = false;
-
-    /**
-     * @internal
-     * Specifies if the effect was previously using instances
-     */
-    public _wasPreviouslyUsingInstances: Nullable<boolean> = null;
-
     private _isDisposed = false;
 
     /**

--- a/packages/dev/core/src/Materials/effectRenderer.ts
+++ b/packages/dev/core/src/Materials/effectRenderer.ts
@@ -336,7 +336,6 @@ export class EffectWrapper {
 
             this._onContextRestoredObserver = creationOptions.engine.onContextRestoredObservable.add(() => {
                 this.effect._pipelineContext = null; // because _prepareEffect will try to dispose this pipeline before recreating it and that would lead to webgl errors
-                this.effect._wasPreviouslyReady = false;
                 this.effect._prepareEffect();
             });
         }

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1168,13 +1168,16 @@ export class Material implements IAnimatable, IClipPlanesHolder {
                     continue;
                 }
 
-                if (!subMesh.effect) {
-                    continue;
+                for (const drawWrapper of subMesh._drawWrappers) {
+                    if (!drawWrapper) {
+                        continue;
+                    }
+                    if (this._materialContext === drawWrapper.materialContext) {
+                        drawWrapper._wasPreviouslyReady = false;
+                        drawWrapper._wasPreviouslyUsingInstances = null;
+                        drawWrapper._forceRebindOnNextCall = forceMaterialDirty;
+                    }
                 }
-
-                subMesh.effect._wasPreviouslyReady = false;
-                subMesh.effect._wasPreviouslyUsingInstances = null;
-                subMesh.effect._forceRebindOnNextCall = forceMaterialDirty;
             }
         }
 
@@ -1235,14 +1238,11 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * @param subMesh defines the submesh to bind the material to
      */
     public bindForSubMesh(world: Matrix, mesh: Mesh, subMesh: SubMesh): void {
-        const effect = subMesh.effect;
-        if (!effect) {
-            return;
-        }
+        const drawWrapper = subMesh._drawWrapper;
 
         this._eventInfo.subMesh = subMesh;
         this._callbackPluginEventBindForSubMesh(this._eventInfo);
-        effect._forceRebindOnNextCall = false;
+        drawWrapper._forceRebindOnNextCall = false;
     }
 
     /**
@@ -1293,9 +1293,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     /**
      * Processes to execute after binding the material to a mesh
      * @param mesh defines the rendered mesh
-     * @param effect
+     * @param effect defines the effect used to bind the material
+     * @param _subMesh defines the subMesh that the material has been bound for
      */
-    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null): void {
+    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, _subMesh?: SubMesh): void {
         this._scene._cachedMaterial = this;
         if (this._needToBindSceneUbo) {
             if (effect) {

--- a/packages/dev/core/src/Materials/pushMaterial.ts
+++ b/packages/dev/core/src/Materials/pushMaterial.ts
@@ -77,16 +77,18 @@ export class PushMaterial extends Material {
         this.bindForSubMesh(world, mesh, mesh.subMeshes[0]);
     }
 
-    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null): void {
-        super._afterBind(mesh, effect);
+    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, subMesh?: SubMesh): void {
+        super._afterBind(mesh, effect, subMesh);
         this.getScene()._cachedEffect = effect;
-        if (effect) {
-            effect._forceRebindOnNextCall = false;
+        if (subMesh) {
+            subMesh._drawWrapper._forceRebindOnNextCall = false;
+        } else {
+            this._drawWrapper._forceRebindOnNextCall = false;
         }
     }
 
-    protected _mustRebind(scene: Scene, effect: Effect, visibility: number = 1) {
-        return scene.isCachedMaterialInvalid(this, effect, visibility);
+    protected _mustRebind(scene: Scene, effect: Effect, subMesh: SubMesh, visibility = 1): boolean {
+        return subMesh._drawWrapper._forceRebindOnNextCall || scene.isCachedMaterialInvalid(this, effect, visibility);
     }
 
     public dispose(forceDisposeEffect?: boolean, forceDisposeTextures?: boolean, notBoundToMesh?: boolean) {

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -656,15 +656,9 @@ export class ShaderMaterial extends PushMaterial {
         const storeEffectOnSubMeshes = subMesh && this._storeEffectOnSubMeshes;
 
         if (this.isFrozen) {
-            if (storeEffectOnSubMeshes) {
-                if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
-                    return true;
-                }
-            } else {
-                const effect = this._drawWrapper.effect;
-                if (effect && effect._wasPreviouslyReady && effect._wasPreviouslyUsingInstances === useInstances) {
-                    return true;
-                }
+            const drawWrapper = storeEffectOnSubMeshes ? subMesh._drawWrapper : this._drawWrapper;
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
+                return true;
             }
         }
 
@@ -905,7 +899,7 @@ export class ShaderMaterial extends PushMaterial {
             }
         }
 
-        effect!._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper!._wasPreviouslyUsingInstances = !!useInstances;
 
         if (!effect?.isReady() ?? true) {
             return false;
@@ -915,7 +909,7 @@ export class ShaderMaterial extends PushMaterial {
             scene.resetCachedMaterial();
         }
 
-        effect._wasPreviouslyReady = true;
+        drawWrapper!._wasPreviouslyReady = true;
 
         return true;
     }
@@ -1004,7 +998,7 @@ export class ShaderMaterial extends PushMaterial {
             }
         }
 
-        const mustRebind = mesh && storeEffectOnSubMeshes ? this._mustRebind(scene, effect, mesh.visibility) : scene.getCachedMaterial() !== this;
+        const mustRebind = mesh && storeEffectOnSubMeshes ? this._mustRebind(scene, effect, subMesh, mesh.visibility) : scene.getCachedMaterial() !== this;
 
         if (effect && mustRebind) {
             if (!useSceneUBO && this._options.uniforms.indexOf("view") !== -1) {
@@ -1183,11 +1177,12 @@ export class ShaderMaterial extends PushMaterial {
             const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
 
             if (bvaManager && bvaManager.isEnabled) {
-                mesh.bakedVertexAnimationManager?.bind(effect, !!effect._wasPreviouslyUsingInstances);
+                const drawWrapper = storeEffectOnSubMeshes ? subMesh._drawWrapper : this._drawWrapper;
+                mesh.bakedVertexAnimationManager?.bind(effect, !!drawWrapper._wasPreviouslyUsingInstances);
             }
         }
 
-        this._afterBind(mesh, effect);
+        this._afterBind(mesh, effect, subMesh);
     }
 
     /**

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -862,7 +862,7 @@ export class ShaderMaterial extends PushMaterial {
             shaderName = this.customShaderNameResolve(shaderName, uniforms, uniformBuffers, samplers, defines, attribs);
         }
 
-        const drawWrapper = storeEffectOnSubMeshes ? subMesh._getDrawWrapper() : this._drawWrapper;
+        const drawWrapper = storeEffectOnSubMeshes ? subMesh._getDrawWrapper(undefined, true) : this._drawWrapper;
         const previousEffect = drawWrapper?.effect ?? null;
         const previousDefines = drawWrapper?.defines ?? null;
         const join = defines.join("\n");

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -888,8 +888,10 @@ export class StandardMaterial extends PushMaterial {
             this.buildUniformLayout();
         }
 
-        if (subMesh.effect && this.isFrozen) {
-            if (subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+        const drawWrapper = subMesh._drawWrapper;
+
+        if (drawWrapper.effect && this.isFrozen) {
+            if (drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -1469,8 +1471,8 @@ export class StandardMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
-        subMesh.effect._wasPreviouslyUsingInstances = useInstances;
+        drawWrapper._wasPreviouslyReady = forceWasNotReadyPreviously ? false : true;
+        drawWrapper._wasPreviouslyUsingInstances = useInstances;
 
         this._checkScenePerformancePriority();
 
@@ -1566,14 +1568,14 @@ export class StandardMaterial extends PushMaterial {
             this.bindOnlyNormalMatrix(this._normalMatrix);
         }
 
-        const mustRebind = effect._forceRebindOnNextCall || this._mustRebind(scene, effect, mesh.visibility);
+        const mustRebind = this._mustRebind(scene, effect, subMesh, mesh.visibility);
 
         // Bones
         MaterialHelper.BindBonesParameters(mesh, effect);
         const ubo = this._uniformBuffer;
         if (mustRebind) {
             this.bindViewProjection(effect);
-            if (!ubo.useUbo || !this.isFrozen || !ubo.isSync || effect._forceRebindOnNextCall) {
+            if (!ubo.useUbo || !this.isFrozen || !ubo.isSync || subMesh._drawWrapper._forceRebindOnNextCall) {
                 if (StandardMaterial.FresnelEnabled && defines.FRESNEL) {
                     // Fresnel
                     if (this.diffuseFresnelParameters && this.diffuseFresnelParameters.isEnabled) {
@@ -1808,7 +1810,7 @@ export class StandardMaterial extends PushMaterial {
             }
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
         ubo.update();
     }
 

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -977,6 +977,8 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         for (const subMesh of this.subMeshes) {
             subMesh._rebuild();
         }
+
+        this.resetDrawCache();
     }
 
     /** @internal */

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2340,8 +2340,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
             this._internalMeshDataInfo._effectiveMaterial = material;
         } else if (
-            (material._storeEffectOnSubMeshes && !subMesh.effect?._wasPreviouslyReady) ||
-            (!material._storeEffectOnSubMeshes && !material.getEffect()?._wasPreviouslyReady)
+            (material._storeEffectOnSubMeshes && !subMesh._drawWrapper?._wasPreviouslyReady) ||
+            (!material._storeEffectOnSubMeshes && !material._getDrawWrapper()._wasPreviouslyReady)
         ) {
             if (oldCamera) {
                 oldCamera.maxZ = oldCameraMaxZ;

--- a/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluent/fluentMaterial.ts
@@ -134,8 +134,10 @@ export class FluentMaterial extends PushMaterial {
     }
 
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -234,7 +236,7 @@ export class FluentMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -257,7 +259,7 @@ export class FluentMaterial extends PushMaterial {
         this.bindOnlyWorldMatrix(world);
         this._activeEffect.setMatrix("viewProjection", scene.getTransformMatrix());
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             this._activeEffect.setColor4("albedoColor", this.albedoColor, this.alpha);
 
             if (defines.INNERGLOW) {
@@ -286,7 +288,7 @@ export class FluentMaterial extends PushMaterial {
             }
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getActiveTextures(): BaseTexture[] {

--- a/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -241,8 +241,10 @@ export class FluentBackplateMaterial extends PushMaterial {
     }
 
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -390,7 +392,7 @@ export class FluentBackplateMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -486,7 +488,7 @@ export class FluentBackplateMaterial extends PushMaterial {
         this._globalRightIndexTipPosition4.set(this.globalRightIndexTipPosition.x, this.globalRightIndexTipPosition.y, this.globalRightIndexTipPosition.z, 1.0);
         this._activeEffect.setVector4("Global_Right_Index_Tip_Position", this._globalRightIndexTipPosition4);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
@@ -293,8 +293,10 @@ export class FluentButtonMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -449,7 +451,7 @@ export class FluentButtonMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -541,7 +543,7 @@ export class FluentButtonMaterial extends PushMaterial {
             new Vector4(this.globalRightIndexTipPosition.x, this.globalRightIndexTipPosition.y, this.globalRightIndexTipPosition.z, 1.0)
         );
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlBackglowMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlBackglowMaterial.ts
@@ -138,8 +138,10 @@ export class MRDLBackglowMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -263,7 +265,7 @@ export class MRDLBackglowMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -310,7 +312,7 @@ export class MRDLBackglowMaterial extends PushMaterial {
         this._activeEffect.setFloat("_Falloff_", this.falloff);
         this._activeEffect.setFloat("_Bias_", this.bias);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
@@ -233,8 +233,10 @@ export class MRDLBackplateMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -372,7 +374,7 @@ export class MRDLBackplateMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -444,7 +446,7 @@ export class MRDLBackplateMaterial extends PushMaterial {
         // "Antialiasing"
         //define SMOOTH_EDGES true;
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlFrontplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlFrontplateMaterial.ts
@@ -293,8 +293,10 @@ export class MRDLFrontplateMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -446,7 +448,7 @@ export class MRDLFrontplateMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -531,7 +533,7 @@ export class MRDLFrontplateMaterial extends PushMaterial {
         // "Antialiasing"
         //define SMOOTH_EDGES true;
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlInnerquadMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlInnerquadMaterial.ts
@@ -89,8 +89,10 @@ export class MRDLInnerquadMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -207,7 +209,7 @@ export class MRDLInnerquadMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -245,7 +247,7 @@ export class MRDLInnerquadMaterial extends PushMaterial {
         this._activeEffect.setFloat("_Glow_Max_", this.glowMax);
         this._activeEffect.setFloat("_Glow_Falloff_", this.glowFalloff);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
@@ -506,8 +506,10 @@ export class MRDLSliderBarMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -692,7 +694,7 @@ export class MRDLSliderBarMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -842,7 +844,7 @@ export class MRDLSliderBarMaterial extends PushMaterial {
         this._activeEffect.setFloat("Global_Left_Index_Tip_Proximity", this.globalLeftIndexTipProximity);
         this._activeEffect.setFloat("Global_Right_Index_Tip_Proximity", this.globalRightIndexTipProximity);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
@@ -507,8 +507,10 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -692,7 +694,7 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -842,7 +844,7 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
         this._activeEffect.setFloat("Global_Left_Index_Tip_Proximity", this.globalLeftIndexTipProximity);
         this._activeEffect.setFloat("Global_Right_Index_Tip_Proximity", this.globalRightIndexTipProximity);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -98,8 +98,10 @@ export class CellMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -241,8 +243,8 @@ export class CellMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -268,7 +270,7 @@ export class CellMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this._diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this._diffuseTexture);
@@ -308,7 +310,7 @@ export class CellMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/custom/customMaterial.ts
+++ b/packages/dev/materials/src/custom/customMaterial.ts
@@ -8,6 +8,7 @@ import type { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
 import { Color3, Color4 } from "core/Maths/math.color";
 import type { Nullable } from "core/types";
+import type { SubMesh } from "core/Meshes/subMesh";
 
 /**
  * Structure of a custom shader
@@ -291,13 +292,13 @@ export class CustomMaterial extends StandardMaterial {
         this._createdShaderName = "custom_" + CustomMaterial.ShaderIndexer;
     }
 
-    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null): void {
+    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, subMesh?: SubMesh): void {
         if (!effect) {
             return;
         }
         this.AttachAfterBind(mesh, effect);
         try {
-            super._afterBind(mesh, effect);
+            super._afterBind(mesh, effect, subMesh);
         } catch (e) {}
     }
 

--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -10,6 +10,7 @@ import { ShaderCodeInliner } from "core/Engines/Processors/shaderCodeInliner";
 import type { ICustomShaderNameResolveOptions } from "core/Materials/material";
 import { Color3, Color4 } from "core/Maths/math.color";
 import type { Nullable } from "core/types";
+import type { SubMesh } from "core/Meshes/subMesh";
 
 /**
  * Albedo parts of the shader
@@ -321,13 +322,13 @@ export class PBRCustomMaterial extends PBRMaterial {
         this._createdShaderName = "custompbr_" + PBRCustomMaterial.ShaderIndexer;
     }
 
-    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null): void {
+    protected _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, subMesh?: SubMesh): void {
         if (!effect) {
             return;
         }
         this.AttachAfterBind(mesh, effect);
         try {
-            super._afterBind(mesh, effect);
+            super._afterBind(mesh, effect, subMesh);
         } catch (e) {}
     }
 

--- a/packages/dev/materials/src/fire/fireMaterial.ts
+++ b/packages/dev/materials/src/fire/fireMaterial.ts
@@ -95,8 +95,10 @@ export class FireMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -229,8 +231,8 @@ export class FireMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -256,7 +258,7 @@ export class FireMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this._diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this._diffuseTexture);
@@ -301,7 +303,7 @@ export class FireMaterial extends PushMaterial {
         // Speed
         this._activeEffect.setFloat("speed", this.speed);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -164,8 +164,10 @@ export class FurMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -330,8 +332,8 @@ export class FurMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -357,7 +359,7 @@ export class FurMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (scene.getCachedMaterial() !== this) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this._diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this._diffuseTexture);
@@ -417,7 +419,7 @@ export class FurMaterial extends PushMaterial {
             this._activeEffect.setTexture("furTexture", this.furTexture);
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -105,8 +105,10 @@ export class GradientMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -235,8 +237,8 @@ export class GradientMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -263,7 +265,7 @@ export class GradientMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, effect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Clip plane
             bindClipPlane(effect, this, scene);
 
@@ -298,7 +300,7 @@ export class GradientMaterial extends PushMaterial {
         this._activeEffect.setFloat("scale", this.scale);
         this._activeEffect.setFloat("smoothness", this.smoothness);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/grid/gridMaterial.ts
+++ b/packages/dev/materials/src/grid/gridMaterial.ts
@@ -135,8 +135,10 @@ export class GridMaterial extends PushMaterial {
     }
 
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -251,8 +253,8 @@ export class GridMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -281,7 +283,7 @@ export class GridMaterial extends PushMaterial {
         this._activeEffect.setMatrix("projection", scene.getProjectionMatrix());
 
         // Uniforms
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             this._activeEffect.setColor3("mainColor", this.mainColor);
             this._activeEffect.setColor3("lineColor", this.lineColor);
 
@@ -307,7 +309,7 @@ export class GridMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -159,8 +159,10 @@ export class LavaMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -311,8 +313,8 @@ export class LavaMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -341,7 +343,7 @@ export class LavaMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this.diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this.diffuseTexture);
@@ -396,7 +398,7 @@ export class LavaMaterial extends PushMaterial {
         this._activeEffect.setFloat("lowFrequencySpeed", this.lowFrequencySpeed);
         this._activeEffect.setFloat("movingSpeed", this.movingSpeed);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/mix/mixMaterial.ts
+++ b/packages/dev/materials/src/mix/mixMaterial.ts
@@ -156,8 +156,10 @@ export class MixMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -352,8 +354,8 @@ export class MixMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -379,7 +381,7 @@ export class MixMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this._mixTexture1) {
                 this._activeEffect.setTexture("mixMap1Sampler", this._mixTexture1);
@@ -463,7 +465,7 @@ export class MixMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -133,8 +133,10 @@ export class NormalMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -275,8 +277,8 @@ export class NormalMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -302,7 +304,7 @@ export class NormalMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this.diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this.diffuseTexture);
@@ -341,7 +343,7 @@ export class NormalMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
@@ -86,8 +86,10 @@ export class ShadowOnlyMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -227,8 +229,8 @@ export class ShadowOnlyMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -254,7 +256,7 @@ export class ShadowOnlyMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Clip plane
             bindClipPlane(effect, this, scene);
 
@@ -298,7 +300,7 @@ export class ShadowOnlyMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public clone(name: string): ShadowOnlyMaterial {

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -90,8 +90,10 @@ export class SimpleMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -230,8 +232,8 @@ export class SimpleMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -257,7 +259,7 @@ export class SimpleMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this._diffuseTexture && MaterialFlags.DiffuseTextureEnabled) {
                 this._activeEffect.setTexture("diffuseSampler", this._diffuseTexture);
@@ -297,7 +299,7 @@ export class SimpleMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/sky/skyMaterial.ts
+++ b/packages/dev/materials/src/sky/skyMaterial.ts
@@ -179,8 +179,10 @@ export class SkyMaterial extends PushMaterial {
      * @returns a boolean indicating that the submesh is ready or not
      */
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady) {
                 return true;
             }
         }
@@ -261,7 +263,7 @@ export class SkyMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyReady = true;
 
         return true;
     }
@@ -290,7 +292,7 @@ export class SkyMaterial extends PushMaterial {
         this.bindOnlyWorldMatrix(world);
         this._activeEffect.setMatrix("viewProjection", scene.getTransformMatrix());
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             bindClipPlane(effect, this, scene);
 
             // Point size
@@ -349,7 +351,7 @@ export class SkyMaterial extends PushMaterial {
 
         this._activeEffect.setVector3("sunPosition", this.sunPosition);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     /**

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -129,8 +129,10 @@ export class TerrainMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -308,8 +310,8 @@ export class TerrainMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -335,7 +337,7 @@ export class TerrainMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this.mixTexture) {
                 this._activeEffect.setTexture("textureSampler", this._mixTexture);
@@ -403,7 +405,7 @@ export class TerrainMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -135,8 +135,10 @@ export class TriPlanarMaterial extends PushMaterial {
 
     // Methods
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -289,8 +291,8 @@ export class TriPlanarMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -318,7 +320,7 @@ export class TriPlanarMaterial extends PushMaterial {
 
         this._activeEffect.setFloat("tileSize", this.tileSize);
 
-        if (scene.getCachedMaterial() !== this) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this.diffuseTextureX) {
                 this._activeEffect.setTexture("diffuseSamplerX", this.diffuseTextureX);
@@ -372,7 +374,7 @@ export class TriPlanarMaterial extends PushMaterial {
         // Fog
         MaterialHelper.BindFogParameters(scene, mesh, this._activeEffect);
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     public getAnimatables(): IAnimatable[] {

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -337,8 +337,10 @@ export class WaterMaterial extends PushMaterial {
     }
 
     public isReadyForSubMesh(mesh: AbstractMesh, subMesh: SubMesh, useInstances?: boolean): boolean {
+        const drawWrapper = subMesh._drawWrapper;
+
         if (this.isFrozen) {
-            if (subMesh.effect && subMesh.effect._wasPreviouslyReady && subMesh.effect._wasPreviouslyUsingInstances === useInstances) {
+            if (drawWrapper.effect && drawWrapper._wasPreviouslyReady && drawWrapper._wasPreviouslyUsingInstances === useInstances) {
                 return true;
             }
         }
@@ -540,8 +542,8 @@ export class WaterMaterial extends PushMaterial {
         }
 
         defines._renderId = scene.getRenderId();
-        subMesh.effect._wasPreviouslyReady = true;
-        subMesh.effect._wasPreviouslyUsingInstances = !!useInstances;
+        drawWrapper._wasPreviouslyReady = true;
+        drawWrapper._wasPreviouslyUsingInstances = !!useInstances;
 
         return true;
     }
@@ -567,7 +569,7 @@ export class WaterMaterial extends PushMaterial {
         // Bones
         MaterialHelper.BindBonesParameters(mesh, this._activeEffect);
 
-        if (this._mustRebind(scene, effect)) {
+        if (this._mustRebind(scene, effect, subMesh)) {
             // Textures
             if (this.bumpTexture && MaterialFlags.BumpTextureEnabled) {
                 this._activeEffect.setTexture("normalSampler", this.bumpTexture);
@@ -646,7 +648,7 @@ export class WaterMaterial extends PushMaterial {
             this._imageProcessingConfiguration.bind(this._activeEffect);
         }
 
-        this._afterBind(mesh, this._activeEffect);
+        this._afterBind(mesh, this._activeEffect, subMesh);
     }
 
     private _createRenderTargets(scene: Scene, renderTargetSize: Vector2): void {


### PR DESCRIPTION
Closes #13776 

Basically, I did what I explained in #13376:
> The problem is that _wasPreviouslyReady, _wasPreviouslyUsingInstances and _forceRebindOnNextCall which are currently stored on the effect should be stored on the DrawWrapper instead (that's because an effect can be shared by multiple submeshes).

I will also update the docs shortly.