### PR TITLE
If checkbox's default color is not set, use white.

### DIFF
--- a/packages/dev/gui/src/2D/controls/checkbox.ts
+++ b/packages/dev/gui/src/2D/controls/checkbox.ts
@@ -127,7 +127,8 @@ export class Checkbox extends Control {
         }
 
         if (this._isChecked) {
-            context.fillStyle = this._isEnabled ? this.color : this._disabledColorItem;
+            // Color is white if not set
+            context.fillStyle = this._isEnabled ? (this.color ? this.color : "#ffffff") : this._disabledColorItem;
             const offsetWidth = actualWidth * this._checkSizeRatio;
             const offsetHeight = actualHeight * this._checkSizeRatio;
 


### PR DESCRIPTION
This helps avoid confusion with the default transparent color, which doesn't show if the box is checked or not.

Forum topic: https://forum.babylonjs.com/t/checkbox-look-the-same-regardles-checked-value/47481