### PR TITLE
Custom Vertex Buffer Serialization

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -748,6 +748,21 @@ export class VertexBuffer {
     }
 
     /**
+     * Serializes the vertex buffer
+     * @param serializationObject the object to serialize in
+     * @param toArrayFn optional function to convert data to a array
+     * @returns the serialized object
+     */
+    public serialize(serializationObject: any = {}, toArrayFn?: (data: any) => any) {
+        serializationObject.kind = this._kind;
+        serializationObject.data = toArrayFn ? toArrayFn(this.getData()) : this.getData();
+        serializationObject.updatable = this._buffer.isUpdatable();
+        serializationObject.stride = this.byteStride / VertexBuffer.GetTypeByteLength(this.type);
+
+        return serializationObject;
+    }
+
+    /**
      * Enumerates each value of this vertex buffer as numbers.
      * @param count the number of values to enumerate
      * @param callback the callback function called for each value
@@ -820,6 +835,26 @@ export class VertexBuffer {
      * Additional matrix weights (for bones)
      */
     public static readonly MatricesWeightsExtraKind = "matricesWeightsExtra";
+    /**
+     * List of all known kinds
+     */
+    public static KnownKinds = [
+        this.PositionKind,
+        this.NormalKind,
+        this.TangentKind,
+        this.UVKind,
+        this.UV2Kind,
+        this.UV3Kind,
+        this.UV4Kind,
+        this.UV5Kind,
+        this.UV6Kind,
+        this.ColorKind,
+        this.ColorInstanceKind,
+        this.MatricesIndicesKind,
+        this.MatricesWeightsKind,
+        this.MatricesIndicesExtraKind,
+        this.MatricesWeightsExtraKind,
+    ];
 
     /**
      * Deduces the stride given a kind.

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -3,6 +3,7 @@ import type { ThinEngine } from "../Engines/thinEngine";
 import { DataBuffer } from "./dataBuffer";
 import type { Mesh } from "../Meshes/mesh";
 import { Logger } from "../Misc/logger";
+import { RandomGUID } from "../Misc/guid";
 
 /**
  * Class used to store data that will be store in GPU memory
@@ -18,6 +19,14 @@ export class Buffer {
     private _isAlreadyOwned = false;
     private _isDisposed = false;
     private _label?: string;
+    private _id: string;
+
+    /**
+     * Gets the id of the buffer
+     */
+    public get id(): string {
+        return this._id;
+    }
 
     /**
      * Gets a boolean indicating if the Buffer is disposed
@@ -65,6 +74,7 @@ export class Buffer {
         this._instanced = instanced;
         this._divisor = divisor || 1;
         this._label = label;
+        this._id = RandomGUID();
 
         if (data instanceof DataBuffer) {
             this._data = null;
@@ -80,6 +90,19 @@ export class Buffer {
             // by default
             this.create();
         }
+    }
+
+    /**
+     * Serializes the vertex buffer
+     * @param serializationObject the object to serialize in
+     * @param toArrayFn optional function to convert data to a array
+     * @returns the serialized object
+     */
+    public serialize(serializationObject: any = {}, toArrayFn?: (data: any) => any) {
+        serializationObject.data = toArrayFn ? toArrayFn(this.getData()) : this.getData();
+        serializationObject.updatable = this._updatable;
+        serializationObject.byteStride = this.byteStride;
+        return serializationObject;
     }
 
     /**
@@ -274,6 +297,10 @@ export class Buffer {
             this._data = null;
             this._buffer = null;
         }
+    }
+
+    public static Parse(bufferData: any, engine: ThinEngine) {
+        return new Buffer(engine, bufferData.data, bufferData.updatable, bufferData.byteStride, true, false, true);
     }
 }
 
@@ -745,21 +772,6 @@ export class VertexBuffer {
         }
 
         this._isDisposed = true;
-    }
-
-    /**
-     * Serializes the vertex buffer
-     * @param serializationObject the object to serialize in
-     * @param toArrayFn optional function to convert data to a array
-     * @returns the serialized object
-     */
-    public serialize(serializationObject: any = {}, toArrayFn?: (data: any) => any) {
-        serializationObject.kind = this._kind;
-        serializationObject.data = toArrayFn ? toArrayFn(this.getData()) : this.getData();
-        serializationObject.updatable = this._buffer.isUpdatable();
-        serializationObject.stride = this.byteStride / VertexBuffer.GetTypeByteLength(this.type);
-
-        return serializationObject;
     }
 
     /**

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -26,6 +26,9 @@ export class Buffer {
      * Gets the id of the buffer
      */
     public get id(): string {
+        if (!this._id) {
+            this._id = RandomGUID();
+        }
         return this._id;
     }
 
@@ -75,7 +78,6 @@ export class Buffer {
         this._instanced = instanced;
         this._divisor = divisor || 1;
         this._label = label;
-        this._id = RandomGUID();
 
         if (data instanceof DataBuffer) {
             this._data = null;
@@ -480,10 +482,17 @@ export class VertexBuffer {
      */
     public readonly engine: ThinEngine;
 
+    private _id: string;
+
     /**
      * The id of the Vertex Buffer
      */
-    public id: string;
+    public get id(): string {
+        if (!this._id) {
+            this._id = RandomGUID();
+        }
+        return this._id;
+    }
 
     /**
      * Gets the max possible amount of vertices stored within the current vertex buffer.
@@ -622,8 +631,6 @@ export class VertexBuffer {
 
         this._alignBuffer();
         this._computeHashCode();
-
-        this.id = RandomGUID();
     }
 
     /**

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -847,26 +847,6 @@ export class VertexBuffer {
      * Additional matrix weights (for bones)
      */
     public static readonly MatricesWeightsExtraKind = "matricesWeightsExtra";
-    /**
-     * List of all known kinds
-     */
-    public static KnownKinds = [
-        this.PositionKind,
-        this.NormalKind,
-        this.TangentKind,
-        this.UVKind,
-        this.UV2Kind,
-        this.UV3Kind,
-        this.UV4Kind,
-        this.UV5Kind,
-        this.UV6Kind,
-        this.ColorKind,
-        this.ColorInstanceKind,
-        this.MatricesIndicesKind,
-        this.MatricesWeightsKind,
-        this.MatricesIndicesExtraKind,
-        this.MatricesWeightsExtraKind,
-    ];
 
     /**
      * Deduces the stride given a kind.

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1089,110 +1089,93 @@ export class Geometry implements IGetSetVerticesData {
 
     /**
      * Serialize all vertices data into a JSON object
+     * @param serializationBuffers an object where to store the buffers
      * @returns a JSON representation of the current geometry data
      */
-    public serializeVerticeData(): any {
+    public serializeVerticeData(serializationBuffers: any): any {
         const serializationObject = this.serialize();
 
-        if (this.isVerticesDataPresent(VertexBuffer.PositionKind)) {
-            serializationObject.positions = this._toNumberArray(this.getVerticesData(VertexBuffer.PositionKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.PositionKind)) {
-                serializationObject.positions._updatable = true;
+        const serializeData = (kind: string, kindName: string, object: any) => {
+            if (this.isVerticesDataPresent(kind)) {
+                const vertexBuffer = this.getVertexBuffer(kind)!;
+                const buffer = vertexBuffer.getWrapperBuffer();
+                if (!buffer) {
+                    Tools.Warn("Geometry.serializeVerticeData: buffer is not available for vertex data: " + kind);
+                    return;
+                }
+                if (serializationBuffers[buffer.id] === undefined) {
+                    serializationBuffers[buffer.id] = buffer.serialize({}, this._toNumberArray);
+                }
+                object[kindName] = {
+                    bufferId: buffer.id,
+                    byteOffset: vertexBuffer.byteOffset,
+                    byteStride: vertexBuffer.byteStride,
+                    isUpdatable: vertexBuffer.isUpdatable(),
+                    attributeSize: vertexBuffer.byteStride / 4, // size of float
+                    kind,
+                };
             }
+        };
+        if (this.isVerticesDataPresent(VertexBuffer.PositionKind)) {
+            serializeData(VertexBuffer.PositionKind, "positions", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
-            serializationObject.normals = this._toNumberArray(this.getVerticesData(VertexBuffer.NormalKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.NormalKind)) {
-                serializationObject.normals._updatable = true;
-            }
+            serializeData(VertexBuffer.NormalKind, "normals", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.TangentKind)) {
-            serializationObject.tangents = this._toNumberArray(this.getVerticesData(VertexBuffer.TangentKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.TangentKind)) {
-                serializationObject.tangents._updatable = true;
-            }
+            serializeData(VertexBuffer.TangentKind, "tangents", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UVKind)) {
-            serializationObject.uvs = this._toNumberArray(this.getVerticesData(VertexBuffer.UVKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UVKind)) {
-                serializationObject.uvs._updatable = true;
-            }
+            serializeData(VertexBuffer.UVKind, "uvs", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
-            serializationObject.uvs2 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV2Kind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UV2Kind)) {
-                serializationObject.uvs2._updatable = true;
-            }
+            serializeData(VertexBuffer.UV2Kind, "uvs2", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV3Kind)) {
-            serializationObject.uvs3 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV3Kind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UV3Kind)) {
-                serializationObject.uvs3._updatable = true;
-            }
+            serializeData(VertexBuffer.UV3Kind, "uvs3", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV4Kind)) {
-            serializationObject.uvs4 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV4Kind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UV4Kind)) {
-                serializationObject.uvs4._updatable = true;
-            }
+            serializeData(VertexBuffer.UV4Kind, "uvs4", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV5Kind)) {
-            serializationObject.uvs5 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV5Kind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UV5Kind)) {
-                serializationObject.uvs5._updatable = true;
-            }
+            serializeData(VertexBuffer.UV5Kind, "uvs5", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV6Kind)) {
-            serializationObject.uvs6 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV6Kind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.UV6Kind)) {
-                serializationObject.uvs6._updatable = true;
-            }
+            serializeData(VertexBuffer.UV6Kind, "uvs6", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.ColorKind)) {
-            serializationObject.colors = this._toNumberArray(this.getVerticesData(VertexBuffer.ColorKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.ColorKind)) {
-                serializationObject.colors._updatable = true;
-            }
+            serializeData(VertexBuffer.ColorKind, "colors", serializationObject);
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.MatricesIndicesKind)) {
-            serializationObject.matricesIndices = this._toNumberArray(this.getVerticesData(VertexBuffer.MatricesIndicesKind));
+            serializeData(VertexBuffer.MatricesIndicesKind, "matricesIndices", serializationObject);
             serializationObject.matricesIndices._isExpanded = true;
-            if (this.isVertexBufferUpdatable(VertexBuffer.MatricesIndicesKind)) {
-                serializationObject.matricesIndices._updatable = true;
-            }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsKind)) {
-            serializationObject.matricesWeights = this._toNumberArray(this.getVerticesData(VertexBuffer.MatricesWeightsKind));
-            if (this.isVertexBufferUpdatable(VertexBuffer.MatricesWeightsKind)) {
-                serializationObject.matricesWeights._updatable = true;
-            }
+            serializeData(VertexBuffer.MatricesWeightsKind, "matricesWeights", serializationObject);
         }
 
         serializationObject.indices = this._toNumberArray(this.getIndices());
 
         // Serialize custom vertex data
-        serializationObject.customData = [];
+        serializationObject.customData = {};
         const allKinds = this.getVerticesDataKinds();
         for (const kind of allKinds) {
             if (VertexBuffer.KnownKinds.indexOf(kind) !== -1) {
                 continue;
             }
 
-            const buffer = this.getVertexBuffer(kind);
-            if (buffer) {
-                serializationObject.customData.push(buffer.serialize({}, this._toNumberArray));
-            }
+            serializeData(kind, kind, serializationObject.customData);
         }
 
         return serializationObject;
@@ -1585,9 +1568,10 @@ export class Geometry implements IGetSetVerticesData {
      * @param parsedVertexData defines the persisted data
      * @param scene defines the hosting scene
      * @param rootUrl defines the root url to use to load assets (like delayed data)
+     * @param parsedBuffersMap a map from buffer id to buffer
      * @returns the new geometry object
      */
-    public static Parse(parsedVertexData: any, scene: Scene, rootUrl: string): Nullable<Geometry> {
+    public static Parse(parsedVertexData: any, scene: Scene, rootUrl: string, parsedBuffersMap: Map<string, Buffer>): Nullable<Geometry> {
         const geometry = new Geometry(parsedVertexData.id, scene, undefined, parsedVertexData.updatable);
         geometry._loadedUniqueId = parsedVertexData.uniqueId;
 
@@ -1596,11 +1580,18 @@ export class Geometry implements IGetSetVerticesData {
         }
 
         const importVertexData = () => {
-            VertexData.ImportVertexData(parsedVertexData, geometry);
+            VertexData.ImportVertexData(parsedVertexData, geometry, parsedBuffersMap);
             // ImportVertexData does not import custom data to the geometry so we do this manually
             if (parsedVertexData.customData) {
-                for (const data of parsedVertexData.customData) {
-                    geometry.setVerticesData(data.kind, data.data, data.updatable, data.stride);
+                for (const kindId of Object.keys(parsedVertexData.customData)) {
+                    const data = parsedVertexData.customData[kindId];
+                    const bufferId = data.bufferId;
+                    const buffer = parsedBuffersMap.get(bufferId);
+                    if (buffer && buffer.getData()) {
+                        // const data = buffer.getData();
+                        geometry.setVerticesBuffer(buffer.createVertexBuffer(data.kind, data.byteOffset, data.attributeSize, data.byteStride, undefined, true));
+                        // geometry.setVerticesData(data.kind, buffer.getData()!, data.updatable, data.stride);
+                    }
                 }
             }
         };

--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -268,6 +268,8 @@ export class VertexData {
             case VertexBuffer.MatricesWeightsExtraKind:
                 this.matricesWeightsExtra = data;
                 break;
+            default:
+                Logger.Error(`Unknown vertex data kind '${kind}'`);
         }
     }
 

--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -3,7 +3,6 @@
 import type { Nullable, FloatArray, IndicesArray, DeepImmutable } from "../types";
 import type { Matrix, Vector2 } from "../Maths/math.vector";
 import { Vector3, Vector4, TmpVectors } from "../Maths/math.vector";
-import type { Buffer } from "../Buffers/buffer";
 import { VertexBuffer } from "../Buffers/buffer";
 import { _WarnImport } from "../Misc/devTools";
 import type { Color3 } from "../Maths/math.color";
@@ -1255,9 +1254,8 @@ export class VertexData {
      * @returns a copy of the current data
      */
     public clone() {
-        // TODO
-        // const serializationObject = this.serialize();
-        // return VertexData.Parse(serializationObject);
+        const serializationObject = this.serialize();
+        return VertexData.Parse(serializationObject);
     }
 
     /**
@@ -2211,36 +2209,82 @@ export class VertexData {
     /**
      * Creates a VertexData from serialized data
      * @param parsedVertexData the parsed data from an imported file
-     * @param parsedBufferMap a map from buffer id to buffer
      * @returns a VertexData
      */
-    public static Parse(parsedVertexData: any, parsedBufferMap: Map<string, Buffer>): VertexData {
+    public static Parse(parsedVertexData: any) {
         const vertexData = new VertexData();
 
-        const parseData = (dataName: string, vertexKind: string, dataTransformFn?: (data: any) => any) => {
-            const data = parsedVertexData[dataName];
-            if (data) {
-                const buffer = parsedBufferMap.get(data.bufferId);
-                let dataToSet = buffer ? buffer.getData() : data;
-                if (dataTransformFn) {
-                    dataToSet = dataTransformFn(dataToSet);
-                }
-                vertexData.set(dataToSet, vertexKind);
-            }
-        };
         // positions
-        parseData("positions", VertexBuffer.PositionKind);
-        parseData("normals", VertexBuffer.NormalKind);
-        parseData("tangents", VertexBuffer.TangentKind);
-        parseData("uvs", VertexBuffer.UVKind);
-        parseData("uvs2", VertexBuffer.UV2Kind);
-        parseData("uvs3", VertexBuffer.UV3Kind);
-        parseData("uvs4", VertexBuffer.UV4Kind);
-        parseData("uvs5", VertexBuffer.UV5Kind);
-        parseData("uvs6", VertexBuffer.UV6Kind);
-        parseData("colors", VertexBuffer.ColorKind, (colors: any) => Color4.CheckColors4(colors, parsedVertexData.positions.length / 3));
-        parseData("matricesIndices", VertexBuffer.MatricesIndicesKind);
-        parseData("matricesWeights", VertexBuffer.MatricesWeightsKind);
+        const positions = parsedVertexData.positions;
+        if (positions) {
+            vertexData.set(positions, VertexBuffer.PositionKind);
+        }
+
+        // normals
+        const normals = parsedVertexData.normals;
+        if (normals) {
+            vertexData.set(normals, VertexBuffer.NormalKind);
+        }
+
+        // tangents
+        const tangents = parsedVertexData.tangents;
+        if (tangents) {
+            vertexData.set(tangents, VertexBuffer.TangentKind);
+        }
+
+        // uvs
+        const uvs = parsedVertexData.uvs;
+        if (uvs) {
+            vertexData.set(uvs, VertexBuffer.UVKind);
+        }
+
+        // uv2s
+        const uvs2 = parsedVertexData.uvs2;
+        if (uvs2) {
+            vertexData.set(uvs2, VertexBuffer.UV2Kind);
+        }
+
+        // uv3s
+        const uvs3 = parsedVertexData.uvs3;
+        if (uvs3) {
+            vertexData.set(uvs3, VertexBuffer.UV3Kind);
+        }
+
+        // uv4s
+        const uvs4 = parsedVertexData.uvs4;
+        if (uvs4) {
+            vertexData.set(uvs4, VertexBuffer.UV4Kind);
+        }
+
+        // uv5s
+        const uvs5 = parsedVertexData.uvs5;
+        if (uvs5) {
+            vertexData.set(uvs5, VertexBuffer.UV5Kind);
+        }
+
+        // uv6s
+        const uvs6 = parsedVertexData.uvs6;
+        if (uvs6) {
+            vertexData.set(uvs6, VertexBuffer.UV6Kind);
+        }
+
+        // colors
+        const colors = parsedVertexData.colors;
+        if (colors) {
+            vertexData.set(Color4.CheckColors4(colors, positions.length / 3), VertexBuffer.ColorKind);
+        }
+
+        // matricesIndices
+        const matricesIndices = parsedVertexData.matricesIndices;
+        if (matricesIndices) {
+            vertexData.set(matricesIndices, VertexBuffer.MatricesIndicesKind);
+        }
+
+        // matricesWeights
+        const matricesWeights = parsedVertexData.matricesWeights;
+        if (matricesWeights) {
+            vertexData.set(matricesWeights, VertexBuffer.MatricesWeightsKind);
+        }
 
         // indices
         const indices = parsedVertexData.indices;
@@ -2270,10 +2314,9 @@ export class VertexData {
      * Applies VertexData created from the imported parameters to the geometry
      * @param parsedVertexData the parsed data from an imported file
      * @param geometry the geometry to apply the VertexData to
-     * @param parsedBufferMap a map from buffer id to buffer
      */
-    public static ImportVertexData(parsedVertexData: any, geometry: Geometry, parsedBufferMap: Map<string, Buffer>) {
-        const vertexData = VertexData.Parse(parsedVertexData, parsedBufferMap);
+    public static ImportVertexData(parsedVertexData: any, geometry: Geometry) {
+        const vertexData = VertexData.Parse(parsedVertexData);
 
         geometry.setAllVerticesData(vertexData, parsedVertexData.updatable);
     }

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -1467,6 +1467,19 @@ export class Tools {
 
         return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     }
+
+    /**
+     * Utility function to convert an array buffer to a plain array
+     * @param origin the original array
+     * @returns a plain number array
+     */
+    public static ToNumberArray(origin: Nullable<ArrayBuffer | ArrayBufferView | number[]>): number[] {
+        if (Array.isArray(origin)) {
+            return origin;
+        } else {
+            return Array.prototype.slice.call(origin);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/BabylonJS/ThePirateCove/issues/547

With these changes, when serializing a mesh/scene, there are two new top level objects, `buffers` and `vertexBuffers`. Both are mappings from id (which was added to both as GUID) to serialized objects. On the geometry itself, instead of saving the buffer data, it saves the ID of the corresponding vertex buffer. This allows shared Buffers and VertexBuffers to be serialized/parsed only once.

Playground ID: #KSBUDT#12