### PR TITLE
Change usage of side orientation, deprecate Mesh overrideMaterialSide…

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -874,7 +874,7 @@ export abstract class EffectLayer {
         }
 
         // Culling
-        let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+        let sideOrientation = material.sideOrientation ?? renderingMesh.sideOrientation;
         const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
         if (mainDeterminant < 0) {
             sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1173,7 +1173,7 @@ export class ShadowGenerator implements IShadowGenerator {
 
         // Culling
         const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-        let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+        let sideOrientation = material.sideOrientation ?? renderingMesh.sideOrientation;
         if (detNeg) {
             sideOrientation =
                 sideOrientation === Constants.MATERIAL_ClockWiseSideOrientation ? Constants.MATERIAL_CounterClockWiseSideOrientation : Constants.MATERIAL_ClockWiseSideOrientation;

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -411,10 +411,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     }
 
     /**
-     * Stores the value for side orientation
+     * Stores the value for side orientation. If null, use the mesh's `sideOrientation` instead.
      */
     @serialize()
-    public sideOrientation: number;
+    public sideOrientation: Nullable<number> = null;
 
     /**
      * Callback triggered when the material is compiled
@@ -932,12 +932,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         this._drawWrapper = new DrawWrapper(this._scene.getEngine(), false);
         this._drawWrapper.materialContext = this._materialContext;
 
-        if (this._scene.useRightHandedSystem) {
-            this.sideOrientation = Material.ClockWiseSideOrientation;
-        } else {
-            this.sideOrientation = Material.CounterClockWiseSideOrientation;
-        }
-
         this._uniformBuffer = new UniformBuffer(this._scene.getEngine(), undefined, undefined, name);
         this._useUBO = this.getScene().getEngine().supportsUniformBuffers;
 
@@ -1189,7 +1183,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public _preBind(effect?: Effect | DrawWrapper, overrideOrientation: Nullable<number> = null): boolean {
         const engine = this._scene.getEngine();
 
-        const orientation = overrideOrientation == null ? this.sideOrientation : overrideOrientation;
+        const orientation = this.sideOrientation == null ? overrideOrientation : this.sideOrientation;
         const reverse = orientation === Material.ClockWiseSideOrientation;
 
         engine.enableEffect(effect ? effect : this._getDrawWrapper());

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -75,7 +75,7 @@ export function CreateDecal(
 ): Mesh {
     const hasSkeleton = !!sourceMesh.skeleton;
     const useLocalComputation = options.localMode || hasSkeleton;
-    const meshHasOverridenMaterial = (sourceMesh as Mesh).overrideMaterialSideOrientation !== null && (sourceMesh as Mesh).overrideMaterialSideOrientation !== undefined;
+    const meshHasOverridenMaterial = (sourceMesh as Mesh).sideOrientation !== null && (sourceMesh as Mesh).sideOrientation !== undefined;
 
     const indices = <IndicesArray>sourceMesh.getIndices();
     const positions = hasSkeleton ? sourceMesh.getPositionData(true, true) : sourceMesh.getVerticesData(VertexBuffer.PositionKind);

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -192,7 +192,7 @@ export class DepthRenderer {
 
             // Culling
             const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-            let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+            let sideOrientation = material.sideOrientation ?? renderingMesh.sideOrientation;
             if (detNeg) {
                 sideOrientation =
                     sideOrientation === Constants.MATERIAL_ClockWiseSideOrientation

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -890,11 +890,11 @@ export class GeometryBufferRenderer {
                 let sideOrientation: Nullable<number>;
                 const instanceDataStorage = (renderingMesh as Mesh)._instanceDataStorage;
 
-                if (!instanceDataStorage.isFrozen && (material.backFaceCulling || renderingMesh.overrideMaterialSideOrientation !== null)) {
+                if (!instanceDataStorage.isFrozen && (material.backFaceCulling || renderingMesh.sideOrientation !== null)) {
                     const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
-                    sideOrientation = renderingMesh.overrideMaterialSideOrientation;
+                    sideOrientation = material.sideOrientation;
                     if (sideOrientation === null) {
-                        sideOrientation = material.sideOrientation;
+                        sideOrientation = renderingMesh.sideOrientation;
                     }
                     if (mainDeterminant < 0) {
                         sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
@@ -39,6 +39,7 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
         material.depthFunction = material.depthFunction ?? 0;
 
         const orientationOptions = [
+            { label: "None", value: "" },
             { label: "Clockwise", value: Material.ClockWiseSideOrientation },
             { label: "Counterclockwise", value: Material.CounterClockWiseSideOrientation },
         ];
@@ -126,7 +127,12 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
                         target={material}
                         propertyName="sideOrientation"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
-                        onSelect={(value) => this.setState({ mode: value })}
+                        onSelect={(value) => {
+                            const parsedValue = isNaN(value as number) ? null : (value as number);
+                            material.sideOrientation = parsedValue;
+                            this.setState({ mode: value });
+                        }}
+                        allowNullValue={true}
                     />
                     <CheckBoxLineComponent
                         label="Disable lighting"

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -44,6 +44,7 @@ import "core/Physics/v1/physicsEngineComponent";
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
 import { Tools } from "core/Misc/tools";
 import { PhysicsBodyGridComponent } from "./physics/physicsBodyGridComponent";
+import { Material } from "core/Materials/material";
 
 interface IMeshPropertyGridComponentProps {
     globalState: GlobalState;
@@ -474,6 +475,21 @@ export class MeshPropertyGridComponent extends React.Component<
                             onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                         />
                     )}
+                    <OptionsLineComponent
+                        label="Orientation"
+                        target={mesh}
+                        propertyName="sideOrientation"
+                        options={[
+                            { label: "None", value: "" },
+                            { label: "Clockwise", value: Material.ClockWiseSideOrientation },
+                            { label: "CounterClockwise", value: Material.CounterClockWiseSideOrientation },
+                        ]}
+                        allowNullValue={true}
+                        onSelect={(value) => {
+                            const parsedValue = isNaN(value as number) ? null : (value as number);
+                            mesh.sideOrientation = parsedValue;
+                        }}
+                    />
                     {mesh.isAnInstance && <TextLineComponent label="Source" value={(mesh as any).sourceMesh.name} onLink={() => this.onSourceMeshLink()} />}
                     <ButtonLineComponent
                         label="Dispose"

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
+import type { Nullable } from "core/types";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Null_Value = Number.MAX_SAFE_INTEGER;
@@ -80,7 +81,13 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
     }
 
     updateValue(valueString: string) {
-        const value = this.props.valuesAreStrings ? valueString : parseInt(valueString);
+        let value: Nullable<number | string> = valueString;
+        if (!this.props.valuesAreStrings) {
+            value = parseInt(valueString);
+            if (isNaN(value)) {
+                value = "NaN";
+            }
+        }
         this._localChange = true;
 
         const store = this.props.extractValue ? this.props.extractValue(this.props.target) : this.props.target[this.props.propertyName];


### PR DESCRIPTION
…Orientation for sideOrientation.

Closes https://github.com/BabylonJS/ThePirateCove/issues/668

I'm not 100% certain on this, so I'd really appreciate the reviews 😄 The idea is that the mesh's side orientation should only take effect when the material's side orientation is `null`, which it is by default now. There is also an option on the Inspector to allow changing the mesh's side orientation.

An example PG with the combinations of mesh/material side orientation: #9I1HPV#3