### PR TITLE
WebXR improvements

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -1222,7 +1222,7 @@ interface XRMesh {
     meshSpace: XRSpace;
     vertices: Float32Array;
     indices: Uint32Array;
-    lastChangedTime: number;
+    lastChangedTime: DOMHighResTimeStamp;
 }
 
 type XRMeshSet = Set<XRMesh>;

--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -677,7 +677,7 @@ interface XRJointPose extends XRPose {
 
 declare abstract class XRJointPose implements XRJointPose {}
 
-interface XRHand extends Map<string, XRJointSpace> {
+interface XRHand extends Map<XRHandJoint, XRJointSpace> {
     readonly WRIST: number;
 
     readonly THUMB_METACARPAL: number;

--- a/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
@@ -1,0 +1,112 @@
+import type { RenderTargetTexture } from "core/Materials";
+import type { Viewport } from "core/Maths/math.viewport";
+import type { WebXRLayerType } from "core/XR/webXRLayerWrapper";
+import { WebXRLayerWrapper } from "core/XR/webXRLayerWrapper";
+import { WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
+import type { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import type { Nullable } from "core/types";
+
+/**
+ * Wraps xr composition layers.
+ * @internal
+ */
+export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
+    constructor(
+        public getWidth: () => number,
+        public getHeight: () => number,
+        public readonly layer: XRCompositionLayer,
+        public readonly layerType: WebXRLayerType,
+        public readonly isMultiview: boolean,
+        public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
+    ) {
+        super(getWidth, getHeight, layer, layerType, createRTTProvider);
+    }
+}
+
+/**
+ * Provides render target textures and other important rendering information for a given XRCompositionLayer.
+ * @internal
+ */
+export class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+    protected _lastSubImages = new Map<XREye, XRWebGLSubImage>();
+    private _compositionLayer: XRCompositionLayer;
+
+    constructor(
+        protected readonly _xrSessionManager: WebXRSessionManager,
+        protected readonly _xrWebGLBinding: XRWebGLBinding,
+        public readonly layerWrapper: WebXRCompositionLayerWrapper
+    ) {
+        super(_xrSessionManager.scene, layerWrapper);
+        this._compositionLayer = layerWrapper.layer;
+    }
+
+    protected _getRenderTargetForSubImage(subImage: XRWebGLSubImage, eye: XREye) {
+        const lastSubImage = this._lastSubImages.get(eye);
+        const eyeIndex = eye == "left" ? 0 : 1;
+
+        const colorTextureWidth = subImage.colorTextureWidth ?? subImage.textureWidth;
+        const colorTextureHeight = subImage.colorTextureHeight ?? subImage.textureHeight;
+
+        if (!this._renderTargetTextures[eyeIndex] || lastSubImage?.textureWidth !== colorTextureWidth || lastSubImage?.textureHeight !== colorTextureHeight) {
+            let depthStencilTexture;
+            const depthStencilTextureWidth = subImage.depthStencilTextureWidth ?? colorTextureWidth;
+            const depthStencilTextureHeight = subImage.depthStencilTextureHeight ?? colorTextureHeight;
+            if (colorTextureWidth === depthStencilTextureWidth || colorTextureHeight === depthStencilTextureHeight) {
+                depthStencilTexture = subImage.depthStencilTexture;
+            }
+
+            this._renderTargetTextures[eyeIndex] = this._createRenderTargetTexture(
+                colorTextureWidth,
+                colorTextureHeight,
+                null,
+                subImage.colorTexture,
+                depthStencilTexture,
+                this.layerWrapper.isMultiview
+            );
+
+            this._framebufferDimensions = {
+                framebufferWidth: colorTextureWidth,
+                framebufferHeight: colorTextureHeight,
+            };
+        }
+
+        this._lastSubImages.set(eye, subImage);
+        return this._renderTargetTextures[eyeIndex];
+    }
+    private _getSubImageForEye(eye: XREye): Nullable<XRWebGLSubImage> {
+        const currentFrame = this._xrSessionManager.currentFrame;
+        if (currentFrame) {
+            return this._xrWebGLBinding.getSubImage(this._compositionLayer, currentFrame, eye);
+        }
+        return null;
+    }
+    public getRenderTargetTextureForEye(eye: XREye): Nullable<RenderTargetTexture> {
+        const subImage = this._getSubImageForEye(eye);
+        if (subImage) {
+            return this._getRenderTargetForSubImage(subImage, eye);
+        }
+        return null;
+    }
+    public getRenderTargetTextureForView(view: XRView): Nullable<RenderTargetTexture> {
+        return this.getRenderTargetTextureForEye(view.eye);
+    }
+
+    protected _setViewportForSubImage(viewport: Viewport, subImage: XRWebGLSubImage) {
+        const textureWidth = subImage.colorTextureWidth ?? subImage.textureWidth;
+        const textureHeight = subImage.colorTextureWidth ?? subImage.textureHeight;
+        const xrViewport = subImage.viewport;
+        viewport.x = xrViewport.x / textureWidth;
+        viewport.y = xrViewport.y / textureHeight;
+        viewport.width = xrViewport.width / textureWidth;
+        viewport.height = xrViewport.height / textureHeight;
+    }
+
+    public trySetViewportForView(viewport: Viewport, view: XRView): boolean {
+        const subImage = this._lastSubImages.get(view.eye) || this._getSubImageForEye(view.eye);
+        if (subImage) {
+            this._setViewportForSubImage(viewport, subImage);
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/dev/core/src/XR/features/Layers/WebXRProjectionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRProjectionLayer.ts
@@ -1,0 +1,75 @@
+import type { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { WebXRCompositionLayerRenderTargetTextureProvider, WebXRCompositionLayerWrapper } from "./WebXRCompositionLayer";
+import type { Nullable } from "core/types";
+import type { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
+import type { Viewport } from "core/Maths/math.viewport";
+
+/**
+ * Wraps xr projection layers.
+ * @internal
+ */
+export class WebXRProjectionLayerWrapper extends WebXRCompositionLayerWrapper {
+    constructor(
+        public readonly layer: XRProjectionLayer,
+        isMultiview: boolean,
+        xrGLBinding: XRWebGLBinding
+    ) {
+        super(
+            () => layer.textureWidth,
+            () => layer.textureHeight,
+            layer,
+            "XRProjectionLayer",
+            isMultiview,
+            (sessionManager) => new WebXRProjectionLayerRenderTargetTextureProvider(sessionManager, xrGLBinding, this)
+        );
+    }
+}
+
+/**
+ * Provides render target textures and other important rendering information for a given XRProjectionLayer.
+ * @internal
+ */
+class WebXRProjectionLayerRenderTargetTextureProvider extends WebXRCompositionLayerRenderTargetTextureProvider {
+    private readonly _projectionLayer: XRProjectionLayer;
+
+    constructor(
+        _xrSessionManager: WebXRSessionManager,
+        _xrWebGLBinding: XRWebGLBinding,
+        public readonly layerWrapper: WebXRProjectionLayerWrapper
+    ) {
+        super(_xrSessionManager, _xrWebGLBinding, layerWrapper);
+        this._projectionLayer = layerWrapper.layer;
+    }
+
+    private _getSubImageForView(view: XRView): XRWebGLSubImage {
+        return this._xrWebGLBinding.getViewSubImage(this._projectionLayer, view);
+    }
+
+    public getRenderTargetTextureForView(view: XRView): Nullable<RenderTargetTexture> {
+        return this._getRenderTargetForSubImage(this._getSubImageForView(view), view.eye);
+    }
+
+    public getRenderTargetTextureForEye(eye: XREye): Nullable<RenderTargetTexture> {
+        const lastSubImage = this._lastSubImages.get(eye);
+        if (lastSubImage) {
+            return this._getRenderTargetForSubImage(lastSubImage, eye);
+        }
+        return null;
+    }
+
+    public trySetViewportForView(viewport: Viewport, view: XRView): boolean {
+        const subImage = this._lastSubImages.get(view.eye) || this._getSubImageForView(view);
+        if (subImage) {
+            this._setViewportForSubImage(viewport, subImage);
+            return true;
+        }
+        return false;
+    }
+}
+
+export const defaultXRProjectionLayerInit: XRProjectionLayerInit = {
+    textureType: "texture",
+    colorFormat: 0x1908 /* WebGLRenderingContext.RGBA */,
+    depthFormat: 0x88f0 /* WebGLRenderingContext.DEPTH24_STENCIL8 */,
+    scaleFactor: 1.0,
+};

--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -423,7 +423,9 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                         typeof this._screenCoordinatesRef.x === "number" &&
                         typeof this._screenCoordinatesRef.y === "number" &&
                         !isNaN(this._screenCoordinatesRef.x) &&
-                        !isNaN(this._screenCoordinatesRef.y)
+                        !isNaN(this._screenCoordinatesRef.y) &&
+                        this._screenCoordinatesRef.x !== Infinity &&
+                        this._screenCoordinatesRef.y !== Infinity
                     ) {
                         scene.pointerX = this._screenCoordinatesRef.x;
                         scene.pointerY = this._screenCoordinatesRef.y;

--- a/packages/dev/core/src/XR/features/WebXRLayers.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.ts
@@ -5,6 +5,10 @@ import type { WebXRLayerWrapper } from "../webXRLayerWrapper";
 import { WebXRWebGLLayerWrapper } from "../webXRWebGLLayer";
 import { WebXRProjectionLayerWrapper, defaultXRProjectionLayerInit } from "./Layers/WebXRProjectionLayer";
 import { WebXRCompositionLayerRenderTargetTextureProvider, WebXRCompositionLayerWrapper } from "./Layers/WebXRCompositionLayer";
+import type { ThinTexture } from "core/Materials/Textures/thinTexture";
+import type { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
+import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { WebGLHardwareTexture } from "core/Engines/WebGL/webGLHardwareTexture";
 
 const defaultXRWebGLLayerInit: XRWebGLLayerInit = {};
 
@@ -47,6 +51,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
     private _xrWebGLBinding: XRWebGLBinding;
     private _isMultiviewEnabled = false;
     private _projectionLayerInitialized = false;
+
+    private _compositionLayerTextureMapping: WeakMap<XRCompositionLayer, ThinTexture> = new WeakMap();
+    private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRCompositionLayerRenderTargetTextureProvider> = new WeakMap();
 
     constructor(
         _xrSessionManager: WebXRSessionManager,
@@ -137,32 +144,46 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     /**
-     * Creates a new XRQuadLayer.
-     * @param params an object providing configuration options for the new XRQuadLayer.
-     * @param multiview whether the quad layer should render with multiview. Will be tru automatically if the extension initialized with multiview.
+     * Note about making it private - this function will be exposed once I decide on a proper API to support all of the XR layers' options
+     * @param options an object providing configuration options for the new XRQuadLayer.
+     * @param babylonTexture whether the quad layer should render with multiview. Will be tru automatically if the extension initialized with multiview.
      * @returns the quad layer
      */
-    public createQuadLayer(params: Partial<XRQuadLayerInit> = {}, multiview = this._isMultiviewEnabled): WebXRCompositionLayerWrapper {
-        this._extendXRLayerInit(params, multiview);
+    private _createQuadLayer(options: { params: Partial<XRQuadLayerInit> } = { params: {} }, babylonTexture: ThinTexture): WebXRCompositionLayerWrapper {
+        this._extendXRLayerInit(options.params, this._isMultiviewEnabled);
         const engine = this._xrSessionManager.scene.getEngine();
         const populatedParams: XRQuadLayerInit = {
             space: this._xrSessionManager.referenceSpace,
             viewPixelWidth: engine.framebufferDimensionsObject?.framebufferWidth ?? engine.getRenderWidth(),
             viewPixelHeight: engine.framebufferDimensionsObject?.framebufferHeight ?? engine.getRenderHeight(),
-            ...params,
+            ...options.params,
         };
-        this._validateLayerInit(populatedParams, multiview);
+        this._validateLayerInit(populatedParams, this._isMultiviewEnabled);
         const quadLayer = this._xrWebGLBinding.createQuadLayer(populatedParams);
+        // this wrapper is not really needed, but it's here for consistency
         const wrapper: WebXRCompositionLayerWrapper = new WebXRCompositionLayerWrapper(
             () => quadLayer.width,
             () => quadLayer.height,
             quadLayer,
             "XRQuadLayer",
-            multiview,
+            this._isMultiviewEnabled,
             (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, this._xrWebGLBinding, wrapper)
         );
+
+        this._compositionLayerTextureMapping.set(quadLayer, babylonTexture);
+        const rtt = wrapper.createRenderTargetTextureProvider(this._xrSessionManager) as WebXRCompositionLayerRenderTargetTextureProvider;
+        this._layerToRTTProviderMapping.set(quadLayer, rtt);
         this.addXRSessionLayer(wrapper);
         return wrapper;
+    }
+
+    /**
+     * @experimental
+     * This will support full screen ADT when used with WebXR Layers. This API might change in the future.
+     * @param texture the texture to display in the layer
+     */
+    public addFullscreenAdvancedDynamicTexture(texture: DynamicTexture) {
+        this._createQuadLayer({ params: { space: this._xrSessionManager.viewerReferenceSpace, textureType: "texture" } }, texture);
     }
 
     /**
@@ -170,7 +191,8 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * @param wrappedLayer the new layer to add to the existing ones
      */
     public addXRSessionLayer(wrappedLayer: WebXRLayerWrapper) {
-        this.setXRSessionLayers([...this._existingLayers, wrappedLayer]);
+        this._existingLayers.unshift(wrappedLayer);
+        this.setXRSessionLayers(this._existingLayers);
     }
 
     /**
@@ -182,15 +204,15 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * as the first layer in the array, which feeds the WebXR camera(s) attached to the session.
      * @param wrappedLayers An array of WebXRLayerWrapper, usually returned from the WebXRLayers createLayer functions.
      */
-    public setXRSessionLayers(wrappedLayers: Array<WebXRLayerWrapper>): void {
-        this._existingLayers = wrappedLayers;
+    public setXRSessionLayers(wrappedLayers: Array<WebXRLayerWrapper> = this._existingLayers): void {
+        // this._existingLayers = wrappedLayers;
         const renderStateInit: XRRenderStateInit = { ...this._xrSessionManager.session.renderState };
         // Clear out the layer-related fields.
         renderStateInit.baseLayer = undefined;
         renderStateInit.layers = wrappedLayers.map((wrappedLayer) => wrappedLayer.layer);
         this._xrSessionManager.updateRenderState(renderStateInit);
         if (!this._projectionLayerInitialized) {
-            this._xrSessionManager._setBaseLayerWrapper(wrappedLayers.length > 0 ? wrappedLayers[0] : null);
+            this._xrSessionManager._setBaseLayerWrapper(wrappedLayers.length > 0 ? wrappedLayers.at(-1)! : null);
         }
     }
 
@@ -207,7 +229,77 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     protected _onXRFrame(_xrFrame: XRFrame): void {
-        /* empty */
+        // Replace once the mapped internal texture of each available composition layer, apart from the last one, which is the projection layer that needs an RTT
+        const layers = this._existingLayers;
+        for (let i = 0; i < layers.length - 1; ++i) {
+            const layer = layers[i];
+            if (layer.layerType === "XRQuadLayer") {
+                const texture = this._compositionLayerTextureMapping.get(layer.layer as XRCompositionLayer);
+                // get the layer that hosts this texture
+                const babylonLayer = this._xrSessionManager.scene.layers.find((babylonLayer) => {
+                    return babylonLayer.texture === texture;
+                });
+
+                if (!babylonLayer) {
+                    continue;
+                }
+
+                // get the rtt provider
+                const rttProvider = this._layerToRTTProviderMapping.get(layer.layer as XRCompositionLayer);
+                if (!rttProvider) {
+                    continue;
+                }
+                // for each pose, render the layer
+                const pose = this._xrSessionManager.currentFrame?.getViewerPose(this._xrSessionManager.referenceSpace);
+                for (const view of pose?.views ?? []) {
+                    if (!view) {
+                        continue;
+                    }
+                    const rtt = rttProvider.getRenderTargetTextureForView(view);
+                    if (!rtt) {
+                        continue;
+                    }
+                    // check if the babylon layer has the rtt in the rtt array
+                    if (babylonLayer.renderTargetTextures.indexOf(rtt) === -1) {
+                        babylonLayer.renderTargetTextures.push(rtt);
+                        // this._xrSessionManager.scene.customRenderTargets.push(rtt);
+                        babylonLayer.renderOnlyInRenderTargetTextures = true;
+                        this._xrSessionManager.onXRSessionEnded.addOnce(() => {
+                            babylonLayer.renderTargetTextures.splice(babylonLayer.renderTargetTextures.indexOf(rtt), 1);
+                            // this._xrSessionManager.scene.customRenderTargets.splice(this._xrSessionManager.scene.customRenderTargets.indexOf(rtt), 1);
+                            babylonLayer.renderOnlyInRenderTargetTextures = false;
+                        });
+                    } else {
+                        babylonLayer.render();
+                    }
+                }
+
+                // if (!texture) {
+                //     continue;
+                // }
+                // if (!(layer as WebXRCompositionLayerWrapper)._originalInternalTexture) {
+                //     (layer as WebXRCompositionLayerWrapper)._originalInternalTexture = texture._texture;
+                //     texture._texture = null;
+                // }
+
+                // if (texture._texture === null) {
+                //     const engine = this._xrSessionManager.scene.getEngine();
+                //     const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
+                //     internalTexture.width = subImage.colorTextureWidth || subImage.textureWidth;
+                //     internalTexture.height = subImage.colorTextureHeight || subImage.textureHeight;
+                //     internalTexture._hardwareTexture = new WebGLHardwareTexture(subImage.colorTexture, engine._gl);
+                //     internalTexture.isReady = true;
+                //     texture._texture = internalTexture; // engine.wrapWebGLTexture(subImage.colorTexture, false, undefined, subImage.colorTextureWidth, subImage.colorTextureHeight);
+                //     console.log(texture._texture);
+                //     console.log((layer as WebXRCompositionLayerWrapper)._originalInternalTexture);
+                // } else {
+                //     const subImage = this._xrWebGLBinding.getSubImage(layer.layer as XRCompositionLayer, _xrFrame);
+                //     if (texture._texture._hardwareTexture?.underlyingResource !== subImage.colorTexture) {
+                //         texture._texture._hardwareTexture?.set(subImage.colorTexture);
+                //     }
+                // }
+            }
+        }
     }
 }
 

--- a/packages/dev/core/src/XR/webXRDefaultExperience.ts
+++ b/packages/dev/core/src/XR/webXRDefaultExperience.ts
@@ -12,6 +12,7 @@ import { WebXREnterExitUI } from "./webXREnterExitUI";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { WebXRManagedOutputCanvasOptions } from "./webXRManagedOutputCanvas";
 import type { IWebXRTeleportationOptions } from "./features/WebXRControllerTeleportation";
+import { WebXRHandTracking, type IWebXRHandTrackingOptions } from "./features/WebXRHandTracking";
 import { WebXRMotionControllerTeleportation } from "./features/WebXRControllerTeleportation";
 import { Logger } from "../Misc/logger";
 
@@ -37,6 +38,11 @@ export class WebXRDefaultExperienceOptions {
      * Should nearInteraction not initialize. Defaults to false.
      */
     public disableNearInteraction?: boolean;
+
+    /**
+     * Should hand tracking be disabled. Defaults to false.
+     */
+    public disableHandTracking?: boolean;
     /**
      * Floor meshes that will be used for teleport
      */
@@ -59,6 +65,11 @@ export class WebXRDefaultExperienceOptions {
      * optional configuration for near interaction
      */
     public nearInteractionOptions?: Partial<IWebXRNearInteractionOptions>;
+
+    /**
+     * optional configuration for hand tracking
+     */
+    public handSupportOptions?: Partial<IWebXRHandTrackingOptions>;
     /**
      * optional configuration for teleportation
      */
@@ -214,6 +225,14 @@ export class WebXRDefaultExperience {
                             ...options.nearInteractionOptions,
                         }
                     );
+                }
+
+                if (!options.disableHandTracking) {
+                    // Add default hand tracking
+                    result.baseExperience.featuresManager.enableFeature(WebXRHandTracking.Name, options.useStablePlugins ? "stable" : "latest", <IWebXRHandTrackingOptions>{
+                        xrInput: result.input,
+                        ...options.handSupportOptions,
+                    });
                 }
 
                 // Create the WebXR output target

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -144,7 +144,6 @@ export class WebXRExperienceHelper implements IDisposable {
         try {
             await this.sessionManager.initializeSessionAsync(sessionMode, sessionCreationOptions);
             await this.sessionManager.setReferenceSpaceTypeAsync(referenceSpaceType);
-            const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
 
             const xrRenderState: XRRenderStateInit = {
                 // if maxZ is 0 it should be "Infinity", but it doesn't work with the WebXR API. Setting to a large number.
@@ -154,6 +153,7 @@ export class WebXRExperienceHelper implements IDisposable {
 
             // The layers feature will have already initialized the xr session's layers on session init.
             if (!this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
+                const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
                 xrRenderState.baseLayer = baseLayer;
             }
 

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -308,7 +308,10 @@ export class WebXRFeaturesManager implements IDisposable {
     public attachFeature(featureName: string) {
         const feature = this._features[featureName];
         if (feature && feature.enabled && !feature.featureImplementation.attached) {
-            feature.featureImplementation.attach();
+            const attached = feature.featureImplementation.attach();
+            if (!attached) {
+                Tools.Warn(`Feature ${featureName} failed to attach`);
+            }
         }
     }
 
@@ -319,7 +322,10 @@ export class WebXRFeaturesManager implements IDisposable {
     public detachFeature(featureName: string) {
         const feature = this._features[featureName];
         if (feature && feature.featureImplementation.attached) {
-            feature.featureImplementation.detach();
+            const detached = feature.featureImplementation.detach();
+            if (!detached) {
+                Tools.Warn(`Feature ${featureName} failed to detach`);
+            }
         }
     }
 

--- a/packages/dev/core/src/XR/webXRLayerWrapper.ts
+++ b/packages/dev/core/src/XR/webXRLayerWrapper.ts
@@ -15,6 +15,7 @@ export type WebXRLayerType = "XRWebGLLayer" | WebXRCompositionLayerType | WebXRQ
  * @internal
  */
 export class WebXRLayerWrapper {
+    private _rttWrapper: Nullable<WebXRLayerRenderTargetTextureProvider> = null;
     /**
      * Check if fixed foveation is supported on this device
      */
@@ -44,6 +45,23 @@ export class WebXRLayerWrapper {
         }
     }
 
+    /**
+     * Create a render target provider for the wrapped layer.
+     * @param xrSessionManager The XR Session Manager
+     * @returns A new render target texture provider for the wrapped layer.
+     */
+    public createRenderTargetTextureProvider(xrSessionManager: WebXRSessionManager): WebXRLayerRenderTargetTextureProvider {
+        this._rttWrapper = this._createRenderTargetTextureProvider(xrSessionManager);
+        return this._rttWrapper;
+    }
+
+    public dispose(): void {
+        if (this._rttWrapper) {
+            this._rttWrapper.dispose();
+            this._rttWrapper = null;
+        }
+    }
+
     protected constructor(
         /** The width of the layer's framebuffer. */
         public getWidth: () => number,
@@ -54,6 +72,6 @@ export class WebXRLayerWrapper {
         /** The type of XR layer that is being wrapped. */
         public readonly layerType: WebXRLayerType,
         /** Create a render target provider for the wrapped layer. */
-        public createRenderTargetTextureProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
+        private _createRenderTargetTextureProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
     ) {}
 }

--- a/packages/dev/core/src/XR/webXRLayerWrapper.ts
+++ b/packages/dev/core/src/XR/webXRLayerWrapper.ts
@@ -5,9 +5,10 @@ import type { WebXRSessionManager } from "./webXRSessionManager";
 /** Covers all supported subclasses of WebXR's XRCompositionLayer */
 // TODO (rgerd): Extend for all other subclasses of XRCompositionLayer.
 export type WebXRCompositionLayerType = "XRProjectionLayer";
+export type WebXRQuadLayerType = "XRQuadLayer";
 
 /** Covers all supported subclasses of WebXR's XRLayer */
-export type WebXRLayerType = "XRWebGLLayer" | WebXRCompositionLayerType;
+export type WebXRLayerType = "XRWebGLLayer" | WebXRCompositionLayerType | WebXRQuadLayerType;
 
 /**
  * Wrapper over subclasses of XRLayer.

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -108,11 +108,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         }
 
         renderTargetTexture.disableRescaling();
-        // Firefox reality fails if skipInitialClear is set to true, so make sure only modern XR implementations set it.
-        if (typeof XRWebGLBinding !== "undefined") {
-            // WebXR pre-clears textures
-            renderTargetTexture.skipInitialClear = true;
-        }
+        // renderTargetTexture.skipInitialClear = true;
 
         this._renderTargetTextures.push(renderTargetTexture);
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4177,7 +4177,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
             const rtt = camera.outputRenderTarget;
             if (rtt.onClearObservable.hasObservers()) {
                 rtt.onClearObservable.notifyObservers(this._engine);
-            } else if (!rtt.skipInitialClear) {
+            } else if (!rtt.skipInitialClear && !camera.isRightCamera) {
                 if (this.autoClear) {
                     this._engine.clear(rtt.clearColor || this.clearColor, !rtt._cleared, true, true);
                 }

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -38,7 +38,7 @@ import type { StandardMaterial } from "core/Materials/standardMaterial";
  * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui
  */
 export class AdvancedDynamicTexture extends DynamicTexture {
-    /** Define the Uurl to load snippets */
+    /** Define the url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;
 
     /** Indicates if some optimizations can be performed in GUI GPU management (the downside is additional memory/GPU texture memory used) */


### PR DESCRIPTION
* It is now possible to add a fullscreen GUI ADT to WebXR using the XR Layers feature. This reuses the same API that is used on desktop, so the experience can work on both desktop and XR. Note - no interaction is possible in XR (as this is a layer that is rendered on top of the XR environment)
* Added the ability to add a quad XR layer. At the moment only internally, as I want to change the API and make sure we can easily support all other XR layer types.
* Firefox reality is no longer a thing - removed code directly related to it.
* Added hand tracking as an optional feature - this will allow devs to use the hand meshes directly instead of seeing the static default hand models.
* Fix an issue where the baseLayer will be created twice when using XR Layers
* Added a warning when attaching or detaching a feature didn't work as expected
* Remodelled the internal architecture of WebXR layers, imrp
* Small fixes for the webxr declaration
* Moved WebXR composition layer implementation(s) to a new directory for structure. These are internal classes so it's not a breaking change.
* Fixed an issue that is apparent when using the webxr emulator
* made small changes to the session manager's architecture.
* fixed an issue with clearing when in multiview mode and in layers
