### PR TITLE
Unity Toolkit Workaround

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -597,7 +597,7 @@ export class Tools {
      * @param scriptUrl defines the url of the script to laod
      * @returns a promise request object
      */
-    public static LoadScriptAsync(scriptUrl: string): Promise<void> {
+    public static LoadScriptAsync(scriptUrl: string, scriptId?: string): Promise<void> {
         return new Promise((resolve, reject) => {
             this.LoadScript(
                 scriptUrl,
@@ -606,7 +606,8 @@ export class Tools {
                 },
                 (message, exception) => {
                     reject(exception || new Error(message));
-                }
+                },
+                scriptId
             );
         });
     }

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -594,7 +594,8 @@ export class Tools {
     /**
      * Load an asynchronous script (identified by an url). When the url returns, the
      * content of this file is added into a new script element, attached to the DOM (body element)
-     * @param scriptUrl defines the url of the script to laod
+     * @param scriptUrl defines the url of the script to load
+     * @param scriptId defines the id of the script element
      * @returns a promise request object
      */
     public static LoadScriptAsync(scriptUrl: string, scriptId?: string): Promise<void> {

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -193,8 +193,10 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
             // Check for Unity Toolkit
             if ((location.href.indexOf("UnityToolkit") !== -1 || Utilities.ReadBoolFromStore("unity-toolkit", false)) && !this._unityToolkitWasLoaded) {
-                await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/babylon.toolkit.js");
-                await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/unity.playground.js");
+                // BUG: Something in this._loadScriptAsync vs BABYLON.Tools.LoadScriptAsync is causing runtime fails in following scripts
+                // They both load fine from the playground using BABYLON.Tools.LoadScriptAsync for now. Need to debug diffrence in two loaders
+                // await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/babylon.toolkit.js");
+                // await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/unity.playground.js");
                 this._unityToolkitWasLoaded = true;
             }
 

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -88,6 +88,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
     private async _loadScriptAsync(url: string): Promise<void> {
         return new Promise((resolve) => {
             const script = document.createElement("script");
+            script.setAttribute("type", "text/javascript");
             script.src = url;
             script.onload = () => {
                 resolve();
@@ -193,10 +194,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
             // Check for Unity Toolkit
             if ((location.href.indexOf("UnityToolkit") !== -1 || Utilities.ReadBoolFromStore("unity-toolkit", false)) && !this._unityToolkitWasLoaded) {
-                // BUG: Something in this._loadScriptAsync vs BABYLON.Tools.LoadScriptAsync is causing runtime fails in following scripts
-                // They both load fine from the playground using BABYLON.Tools.LoadScriptAsync for now. Need to debug diffrence in two loaders
-                // await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/babylon.toolkit.js");
-                // await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/unity.playground.js");
+                await this._loadScriptAsync("https://cdn.jsdelivr.net/gh/BabylonJS/UnityExporter@master/Redist/Runtime/babylon.toolkit.js");
                 this._unityToolkitWasLoaded = true;
             }
 

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -89,7 +89,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         return new Promise((resolve) => {
             const script = document.createElement("script");
             script.setAttribute("type", "text/javascript");
-            script.src = url;
+            script.setAttribute("src", url);
             script.onload = () => {
                 resolve();
             };


### PR DESCRIPTION
Workaround to temp disable the Unity Toolkit scripts loading from playground loadScriptAsync. But load from BABYLON.Tools.LoadScriptAsync while debugging the issue