### PR TITLE
Use shader material written in wgsl as shadow depth wrapper

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -104,10 +104,9 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
     }
 
     public preProcessShaderCode(code: string): string {
-        return (
-            `struct ${WebGPUShaderProcessor.InternalsUBOName} {\n  yFactor_: f32,\n  textureOutputHeight_: f32,\n};\nvar<uniform> ${internalsVarName} : ${WebGPUShaderProcessor.InternalsUBOName};\n` +
-            RemoveComments(code)
-        );
+        const ubDeclaration = `struct ${WebGPUShaderProcessor.InternalsUBOName} {\n  yFactor_: f32,\n  textureOutputHeight_: f32,\n};\nvar<uniform> ${internalsVarName} : ${WebGPUShaderProcessor.InternalsUBOName};\n`;
+        const alreadyInjected = code.indexOf(ubDeclaration) !== -1;
+        return alreadyInjected ? code : ubDeclaration + RemoveComments(code);
     }
 
     public varyingProcessor(varying: string, isFragment: boolean, preProcessors: { [key: string]: string }) {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -104,6 +104,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
     }
 
     public preProcessShaderCode(code: string): string {
+        // Same check as in webgpuShaderProcessorsGLSL to avoid same ubDelcaration to be injected twice.
         const ubDeclaration = `struct ${WebGPUShaderProcessor.InternalsUBOName} {\n  yFactor_: f32,\n  textureOutputHeight_: f32,\n};\nvar<uniform> ${internalsVarName} : ${WebGPUShaderProcessor.InternalsUBOName};\n`;
         const alreadyInjected = code.indexOf(ubDeclaration) !== -1;
         return alreadyInjected ? code : ubDeclaration + RemoveComments(code);

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -213,6 +213,10 @@ export class Effect implements IDisposable {
     private _processCodeAfterIncludes: ShaderCustomProcessingFunction | undefined = undefined;
     private _processFinalCode: Nullable<ShaderCustomProcessingFunction> = null;
 
+    public get shaderLanguage() {
+        return this._shaderLanguage;
+    }
+
     /**
      * Instantiates an effect.
      * An effect can be used to create/manage/execute vertex and fragment shaders.

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -213,7 +213,10 @@ export class Effect implements IDisposable {
     private _processCodeAfterIncludes: ShaderCustomProcessingFunction | undefined = undefined;
     private _processFinalCode: Nullable<ShaderCustomProcessingFunction> = null;
 
-    public get shaderLanguage() {
+    /**
+     * Gets the shader language type used to write vertex and fragment source code.
+     */
+    public get shaderLanguage(): ShaderLanguage {
         return this._shaderLanguage;
     }
 

--- a/packages/dev/core/src/Materials/shadowDepthWrapper.ts
+++ b/packages/dev/core/src/Materials/shadowDepthWrapper.ts
@@ -315,7 +315,7 @@ export class ShadowDepthWrapper {
                 samplers: origEffect.getSamplers(),
                 defines: join + "\n" + origEffect.defines.replace("#define SHADOWS", "").replace(/#define SHADOW\d/g, ""),
                 indexParameters: origEffect.getIndexParameters(),
-                shaderLanguage: (this._baseMaterial as any).options.shaderLanguage,
+                shaderLanguage: (this._baseMaterial as ShaderMaterial).options?.shaderLanguage ?? ShaderLanguage.GLSL,
             },
             engine
         );

--- a/packages/dev/core/src/Materials/shadowDepthWrapper.ts
+++ b/packages/dev/core/src/Materials/shadowDepthWrapper.ts
@@ -11,7 +11,7 @@ import type { ShadowGenerator } from "../Lights/Shadows/shadowGenerator";
 import { RandomGUID } from "../Misc/guid";
 import { DrawWrapper } from "./drawWrapper";
 import { EngineStore } from "../Engines/engineStore";
-import { ShaderMaterial } from "./shaderMaterial";
+import type { ShaderMaterial } from "./shaderMaterial";
 import { ShaderLanguage } from "./shaderLanguage";
 
 /**

--- a/packages/dev/core/src/Materials/shadowDepthWrapper.ts
+++ b/packages/dev/core/src/Materials/shadowDepthWrapper.ts
@@ -11,7 +11,6 @@ import type { ShadowGenerator } from "../Lights/Shadows/shadowGenerator";
 import { RandomGUID } from "../Misc/guid";
 import { DrawWrapper } from "./drawWrapper";
 import { EngineStore } from "../Engines/engineStore";
-import type { ShaderMaterial } from "./shaderMaterial";
 import { ShaderLanguage } from "./shaderLanguage";
 
 /**
@@ -242,7 +241,6 @@ export class ShadowDepthWrapper {
             fragmentCode = origEffect.fragmentSourceCodeBeforeMigration;
 
         if (!this.doNotInjectCode) {
-            const shaderLanguage = (this._baseMaterial as ShaderMaterial).options?.shaderLanguage ?? ShaderLanguage.GLSL;
             // Declare the shadow map includes
             const vertexNormalBiasCode =
                     this._options && this._options.remappedVariables
@@ -260,7 +258,7 @@ export class ShadowDepthWrapper {
                 vertexExtraDeclartion = `#include<shadowMapVertexExtraDeclaration>`;
 
             // vertex code
-            if (shaderLanguage === ShaderLanguage.GLSL) {
+            if (origEffect.shaderLanguage === ShaderLanguage.GLSL) {
                 vertexCode = vertexCode.replace(/void\s+?main/g, `\n${vertexExtraDeclartion}\nvoid main`);
             } else {
                 vertexCode = vertexCode.replace(/@vertex/g, `\n${vertexExtraDeclartion}\n@vertex`);
@@ -315,7 +313,7 @@ export class ShadowDepthWrapper {
                 samplers: origEffect.getSamplers(),
                 defines: join + "\n" + origEffect.defines.replace("#define SHADOWS", "").replace(/#define SHADOW\d/g, ""),
                 indexParameters: origEffect.getIndexParameters(),
-                shaderLanguage: (this._baseMaterial as ShaderMaterial).options?.shaderLanguage ?? ShaderLanguage.GLSL,
+                shaderLanguage: origEffect.shaderLanguage,
             },
             engine
         );

--- a/packages/dev/core/src/Materials/shadowDepthWrapper.ts
+++ b/packages/dev/core/src/Materials/shadowDepthWrapper.ts
@@ -11,6 +11,8 @@ import type { ShadowGenerator } from "../Lights/Shadows/shadowGenerator";
 import { RandomGUID } from "../Misc/guid";
 import { DrawWrapper } from "./drawWrapper";
 import { EngineStore } from "../Engines/engineStore";
+import { ShaderMaterial } from "./shaderMaterial";
+import { ShaderLanguage } from "./shaderLanguage";
 
 /**
  * Options to be used when creating a shadow depth material
@@ -240,22 +242,29 @@ export class ShadowDepthWrapper {
             fragmentCode = origEffect.fragmentSourceCodeBeforeMigration;
 
         if (!this.doNotInjectCode) {
-            // vertex code
+            const shaderLanguage = (this._baseMaterial as ShaderMaterial).options?.shaderLanguage ?? ShaderLanguage.GLSL;
+            // Declare the shadow map includes
             const vertexNormalBiasCode =
                     this._options && this._options.remappedVariables
                         ? `#include<shadowMapVertexNormalBias>(${this._options.remappedVariables.join(",")})`
-                        : Effect.IncludesShadersStore["shadowMapVertexNormalBias"],
+                        : `#include<shadowMapVertexNormalBias>`,
                 vertexMetricCode =
                     this._options && this._options.remappedVariables
                         ? `#include<shadowMapVertexMetric>(${this._options.remappedVariables.join(",")})`
-                        : Effect.IncludesShadersStore["shadowMapVertexMetric"],
+                        : `#include<shadowMapVertexMetric>`,
                 fragmentSoftTransparentShadow =
                     this._options && this._options.remappedVariables
                         ? `#include<shadowMapFragmentSoftTransparentShadow>(${this._options.remappedVariables.join(",")})`
-                        : Effect.IncludesShadersStore["shadowMapFragmentSoftTransparentShadow"],
-                fragmentBlockCode = Effect.IncludesShadersStore["shadowMapFragment"];
+                        : `#include<shadowMapFragmentSoftTransparentShadow>`,
+                fragmentBlockCode = `#include<shadowMapFragment>`,
+                vertexExtraDeclartion = `#include<shadowMapVertexExtraDeclaration>`;
 
-            vertexCode = vertexCode.replace(/void\s+?main/g, Effect.IncludesShadersStore["shadowMapVertexExtraDeclaration"] + "\nvoid main");
+            // vertex code
+            if (shaderLanguage === ShaderLanguage.GLSL) {
+                vertexCode = vertexCode.replace(/void\s+?main/g, `\n${vertexExtraDeclartion}\nvoid main`);
+            } else {
+                vertexCode = vertexCode.replace(/@vertex/g, `\n${vertexExtraDeclartion}\n@vertex`);
+            }
             vertexCode = vertexCode.replace(/#define SHADOWDEPTH_NORMALBIAS|#define CUSTOM_VERTEX_UPDATE_WORLDPOS/g, vertexNormalBiasCode);
 
             if (vertexCode.indexOf("#define SHADOWDEPTH_METRIC") !== -1) {
@@ -306,6 +315,7 @@ export class ShadowDepthWrapper {
                 samplers: origEffect.getSamplers(),
                 defines: join + "\n" + origEffect.defines.replace("#define SHADOWS", "").replace(/#define SHADOW\d/g, ""),
                 indexParameters: origEffect.getIndexParameters(),
+                shaderLanguage: (this._baseMaterial as any).options.shaderLanguage,
             },
             engine
         );


### PR DESCRIPTION
## Allow ShaderMaterial written in WGSL to be used as shadow depth wrapper. 

[Original issue discussion](https://forum.babylonjs.com/t/shadowdepthwrapper-error-with-wgsl-shader-syntax)

### Changes involved

- Avoids GLSL specific shader includes to be called when using WGSL for shadow depth wrapper.
- This PR does not implement shadow map specific shader includes in WGSL. When option `doNotInjectCode=false`, BJS will log error in dev tool console about missing shader includes by default. The reason is BJS does not yet have full support for StandardMaterial or PBRMaterial implemented in WGSL. It is a lot of work to setup WGSL shader from scratch with transparent shadows, self shadow, etc to test the missing shader includes for shadow map. The idea is: for now, if a developer has implement a complete WGSL shader that require these shader includes, this developer can create these shader includes in WGSL, and include them in ShaderStore.IncludesShadersStoreWGSL. [This example](https://github.com/shen-lin/Babylon.js/blob/wgls-dev/packages/tools/devHost/src/createScene.ts#L30) has been tested with some dumm WGSL code included into final runtime WGSL shader. If I later on need these shader includes and I have a test case, I will implement them and add to BJS WGSL shader include.

The shader includes that could be added in the future (WGSL version) mentioned above refers to:
- shadowMapVertexExtraDeclaration
- shadowMapVertexNormalBias
- shadowMapVertexMetric
- shadowMapFragmentSoftTransparentShadow
- shadowMapFragment

### Example outcome

See [dev branch](https://github.com/shen-lin/Babylon.js/tree/wgls-dev) for test scenario setup in dev host.

Screenshot of local test result as shown below. A WGSL vertex shader is applied to animate both sphere and shadow vertex displacement.

![Screenshot 2024-01-30 at 4 26 19 PM](https://github.com/BabylonJS/Babylon.js/assets/4505448/9fc6146b-2ee9-4be5-b15d-020115759512)

