### PR TITLE
Morph targets: Add missing morph count uniforms to some renderers/materials

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -659,9 +659,9 @@ export abstract class EffectLayer {
         const manager = (<Mesh>mesh).morphTargetManager;
         let morphInfluencers = 0;
         if (manager) {
-            if (manager.numInfluencers > 0) {
+            morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
+            if (morphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
-                morphInfluencers = manager.numInfluencers;
                 defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
                 if (manager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");
@@ -695,6 +695,7 @@ export abstract class EffectLayer {
                 "viewProjection",
                 "glowColor",
                 "morphTargetInfluences",
+                "morphTargetCount",
                 "boneTextureWidth",
                 "diffuseMatrix",
                 "emissiveMatrix",

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1547,9 +1547,9 @@ export class ShadowGenerator implements IShadowGenerator {
             const manager = (<Mesh>mesh).morphTargetManager;
             let morphInfluencers = 0;
             if (manager) {
-                if (manager.numInfluencers > 0) {
+                morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
+                if (morphInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
-                    morphInfluencers = manager.numInfluencers;
                     defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
                     if (manager.isUsingTextureForTargets) {
                         defines.push("#define MORPHTARGETS_TEXTURE");
@@ -1595,6 +1595,7 @@ export class ShadowGenerator implements IShadowGenerator {
                     "depthValuesSM",
                     "biasAndScaleSM",
                     "morphTargetInfluences",
+                    "morphTargetCount",
                     "boneTextureWidth",
                     "softTransparentShadowSM",
                     "morphTargetTextureInfo",

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -201,7 +201,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         if (manager?.isUsingTextureForTargets) {
             injectionCode += "for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {\n";
             injectionCode += "if (i >= morphTargetCount) break;\n";
-            
+
             injectionCode += `vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;\n`;
             injectionCode += `${positionOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${position.associatedVariableName}) * morphTargetInfluences[i];\n`;
             injectionCode += `vertexID += 1.0;\n`;

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -197,45 +197,32 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
             injectionCode += `float vertexID;\n`;
         }
 
-        for (let index = 0; index < repeatCount; index++) {
-            injectionCode += `#ifdef MORPHTARGETS\n`;
-            if (manager?.isUsingTextureForTargets) {
-                injectionCode += `vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;\n`;
-                injectionCode += `${positionOutput.associatedVariableName} += (readVector3FromRawSampler(${index}, vertexID) - ${position.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
-                injectionCode += `vertexID += 1.0;\n`;
-            } else {
-                injectionCode += `${positionOutput.associatedVariableName} += (position${index} - ${position.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
-            }
+        injectionCode += `#ifdef MORPHTARGETS\n`;
+        if (manager?.isUsingTextureForTargets) {
+            injectionCode += "for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {\n";
+            injectionCode += "if (i >= morphTargetCount) break;\n";
+            
+            injectionCode += `vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;\n`;
+            injectionCode += `${positionOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${position.associatedVariableName}) * morphTargetInfluences[i];\n`;
+            injectionCode += `vertexID += 1.0;\n`;
 
             if (hasNormals) {
                 injectionCode += `#ifdef MORPHTARGETS_NORMAL\n`;
-                if (manager?.isUsingTextureForTargets) {
-                    injectionCode += `${normalOutput.associatedVariableName} += (readVector3FromRawSampler(${index}, vertexID) - ${normal.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
-                    injectionCode += `vertexID += 1.0;\n`;
-                } else {
-                    injectionCode += `${normalOutput.associatedVariableName} += (normal${index} - ${normal.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
-                }
+                injectionCode += `${normalOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${normal.associatedVariableName}) * morphTargetInfluences[i];\n`;
+                injectionCode += `vertexID += 1.0;\n`;
                 injectionCode += `#endif\n`;
             }
 
             if (hasUVs) {
                 injectionCode += `#ifdef MORPHTARGETS_UV\n`;
-                if (manager?.isUsingTextureForTargets) {
-                    injectionCode += `${uvOutput.associatedVariableName} += (readVector3FromRawSampler(${index}, vertexID).xy - ${uv.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
-                    injectionCode += `vertexID += 1.0;\n`;
-                } else {
-                    injectionCode += `${uvOutput.associatedVariableName}.xy += (uv_${index} - ${uv.associatedVariableName}.xy) * morphTargetInfluences[${index}];\n`;
-                }
+                injectionCode += `${uvOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv.associatedVariableName}) * morphTargetInfluences[i];\n`;
+                injectionCode += `vertexID += 1.0;\n`;
                 injectionCode += `#endif\n`;
             }
 
             if (hasTangents) {
                 injectionCode += `#ifdef MORPHTARGETS_TANGENT\n`;
-                if (manager?.isUsingTextureForTargets) {
-                    injectionCode += `${tangentOutput.associatedVariableName}.xyz += (readVector3FromRawSampler(${index}, vertexID) - ${tangent.associatedVariableName}.xyz) * morphTargetInfluences[${index}];\n`;
-                } else {
-                    injectionCode += `${tangentOutput.associatedVariableName}.xyz += (tangent${index} - ${tangent.associatedVariableName}.xyz) * morphTargetInfluences[${index}];\n`;
-                }
+                injectionCode += `${tangentOutput.associatedVariableName}.xyz += (readVector3FromRawSampler(i, vertexID) - ${tangent.associatedVariableName}.xyz) * morphTargetInfluences[i];\n`;
 
                 if (tangent.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
                     injectionCode += `${tangentOutput.associatedVariableName}.w = ${tangent.associatedVariableName}.w;\n`;
@@ -245,8 +232,37 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `#endif\n`;
             }
 
-            injectionCode += `#endif\n`;
+            injectionCode += "}\n";
+        } else {
+            for (let index = 0; index < repeatCount; index++) {
+                injectionCode += `${positionOutput.associatedVariableName} += (position${index} - ${position.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
+
+                if (hasNormals) {
+                    injectionCode += `#ifdef MORPHTARGETS_NORMAL\n`;
+                    injectionCode += `${normalOutput.associatedVariableName} += (normal${index} - ${normal.associatedVariableName}) * morphTargetInfluences[${index}];\n`;
+                    injectionCode += `#endif\n`;
+                }
+
+                if (hasUVs) {
+                    injectionCode += `#ifdef MORPHTARGETS_UV\n`;
+                    injectionCode += `${uvOutput.associatedVariableName}.xy += (uv_${index} - ${uv.associatedVariableName}.xy) * morphTargetInfluences[${index}];\n`;
+                    injectionCode += `#endif\n`;
+                }
+
+                if (hasTangents) {
+                    injectionCode += `#ifdef MORPHTARGETS_TANGENT\n`;
+                    injectionCode += `${tangentOutput.associatedVariableName}.xyz += (tangent${index} - ${tangent.associatedVariableName}.xyz) * morphTargetInfluences[${index}];\n`;
+
+                    if (tangent.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
+                        injectionCode += `${tangentOutput.associatedVariableName}.w = ${tangent.associatedVariableName}.w;\n`;
+                    } else {
+                        injectionCode += `${tangentOutput.associatedVariableName}.w = 1.;\n`;
+                    }
+                    injectionCode += `#endif\n`;
+                }
+            }
         }
+        injectionCode += `#endif\n`;
 
         state.compilationString = state.compilationString.replace(this._repeatableContentAnchor, injectionCode);
 
@@ -293,6 +309,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const comments = `//${this.name}`;
 
         state.uniforms.push("morphTargetInfluences");
+        state.uniforms.push("morphTargetCount");
         state.uniforms.push("morphTargetTextureInfo");
         state.uniforms.push("morphTargetTextureIndices");
         state.samplers.push("morphTargets");

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -152,7 +152,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         if ((<Mesh>mesh).morphTargetManager) {
             const morphTargetManager = (<Mesh>mesh).morphTargetManager;
 
-            if (morphTargetManager?.isUsingTextureForTargets && morphTargetManager.numInfluencers !== defines["NUM_MORPH_INFLUENCERS"]) {
+            if (morphTargetManager?.isUsingTextureForTargets && (morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers) !== defines["NUM_MORPH_INFLUENCERS"]) {
                 defines.markAsAttributesDirty();
             }
         }

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -754,7 +754,7 @@ export class ShaderMaterial extends PushMaterial {
             const uv = manager.supportsUVs && defines.indexOf("#define UV1") !== -1;
             const tangent = manager.supportsTangents && defines.indexOf("#define TANGENT") !== -1;
             const normal = manager.supportsNormals && defines.indexOf("#define NORMAL") !== -1;
-            numInfluencers = manager.numInfluencers;
+            numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
             if (uv) {
                 defines.push("#define MORPHTARGETS_UV");
             }
@@ -797,6 +797,7 @@ export class ShaderMaterial extends PushMaterial {
             if (numInfluencers > 0) {
                 uniforms = uniforms.slice();
                 uniforms.push("morphTargetInfluences");
+                uniforms.push("morphTargetCount");
                 uniforms.push("morphTargetTextureInfo");
                 uniforms.push("morphTargetTextureIndices");
             }

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -407,9 +407,8 @@ export class DepthRenderer {
         const morphTargetManager = (mesh as Mesh).morphTargetManager;
         let numMorphInfluencers = 0;
         if (morphTargetManager) {
-            if (morphTargetManager.numInfluencers > 0) {
-                numMorphInfluencers = morphTargetManager.numInfluencers;
-
+            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
+            if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 
@@ -468,6 +467,7 @@ export class DepthRenderer {
                 "diffuseMatrix",
                 "depthValues",
                 "morphTargetInfluences",
+                "morphTargetCount",
                 "morphTargetTextureInfo",
                 "morphTargetTextureIndices",
             ];

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -49,6 +49,7 @@ const uniforms = [
     "vTangentSpaceParams",
     "vBumpInfos",
     "morphTargetInfluences",
+    "morphTargetCount",
     "morphTargetTextureInfo",
     "morphTargetTextureIndices",
     "boneTextureWidth",
@@ -613,9 +614,8 @@ export class GeometryBufferRenderer {
         const morphTargetManager = (mesh as Mesh).morphTargetManager;
         let numMorphInfluencers = 0;
         if (morphTargetManager) {
-            if (morphTargetManager.numInfluencers > 0) {
-                numMorphInfluencers = morphTargetManager.numInfluencers;
-
+            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
+            if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
                 if (morphTargetManager.isUsingTextureForTargets) {

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -305,8 +305,8 @@ export class OutlineRenderer implements ISceneComponent {
         const morphTargetManager = (mesh as Mesh).morphTargetManager;
         let numMorphInfluencers = 0;
         if (morphTargetManager) {
-            if (morphTargetManager.numInfluencers > 0) {
-                numMorphInfluencers = morphTargetManager.numInfluencers;
+            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
+            if (numMorphInfluencers > 0) {
 
                 defines.push("#define MORPHTARGETS");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
@@ -343,6 +343,7 @@ export class OutlineRenderer implements ISceneComponent {
                 "color",
                 "logarithmicDepthConstant",
                 "morphTargetInfluences",
+                "morphTargetCount",
                 "morphTargetTextureInfo",
                 "morphTargetTextureIndices",
             ];

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -307,7 +307,6 @@ export class OutlineRenderer implements ISceneComponent {
         if (morphTargetManager) {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
-
                 defines.push("#define MORPHTARGETS");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 


### PR DESCRIPTION
MorphTarget optimizations added in #14734 were not being applied to some renderers.

This PullRequest will prevent some renderers or materials that do not use `MaterialHelper.PrepareDefinesForMorphTargets` from being recompiled by morph influence changes.

@Popov72 