### PR TITLE
NME: Fix preview for some of the pre-defined meshes

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/heightToNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/heightToNormalBlock.ts
@@ -125,9 +125,9 @@ export class HeightToNormalBlock extends NodeMaterialBlock {
 
         const heightToNormal = `
             vec4 heightToNormal(in float height, in vec3 position, in vec3 tangent, in vec3 normal) {
-                ${startCode}
                 ${this.automaticNormalizationTangent ? "tangent = normalize(tangent);" : ""}
                 ${this.automaticNormalizationNormal ? "normal = normalize(normal);" : ""}
+                ${startCode}
                 vec3 worlddX = dFdx(position);
                 vec3 worlddY = dFdy(position);
                 vec3 crossX = cross(normal, worlddX);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2786,6 +2786,17 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this.setVerticesData(VertexBuffer.NormalKind, data, (<VertexBuffer>this.getVertexBuffer(VertexBuffer.NormalKind)).isUpdatable());
         }
 
+        // Tangents
+        if (this.isVerticesDataPresent(VertexBuffer.TangentKind)) {
+            data = <FloatArray>this.getVerticesData(VertexBuffer.TangentKind);
+            for (index = 0; index < data.length; index += 4) {
+                Vector3.TransformNormalFromFloatsToRef(data[index], data[index + 1], data[index + 2], transform, temp)
+                    .normalize()
+                    .toArray(data, index);
+            }
+            this.setVerticesData(VertexBuffer.TangentKind, data, (<VertexBuffer>this.getVertexBuffer(VertexBuffer.TangentKind)).isUpdatable());
+        }
+
         // flip faces?
         if (transform.determinant() < 0) {
             this.flipFaces();

--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -420,20 +420,21 @@ export class PreviewManager {
             const bakeTransformation = (mesh: Mesh) => {
                 mesh.bakeCurrentTransformIntoVertices();
                 mesh.refreshBoundingInfo();
+                mesh.parent = null;
             };
 
             if (this._globalState.mode === NodeMaterialModes.Material) {
                 switch (this._globalState.previewType) {
                     case PreviewType.Box:
                         SceneLoader.AppendAsync("https://assets.babylonjs.com/meshes/", "roundedCube.glb", this._scene).then(() => {
-                            bakeTransformation(this._scene.meshes[1] as Mesh);
+                            bakeTransformation(this._scene.getMeshByName("__root__")!.getChildMeshes(true)[0] as Mesh);
                             this._meshes.push(...this._scene.meshes);
                             this._prepareScene();
                         });
                         return;
                     case PreviewType.Sphere:
                         SceneLoader.AppendAsync("https://assets.babylonjs.com/meshes/", "previewSphere.glb", this._scene).then(() => {
-                            bakeTransformation(this._scene.meshes[1] as Mesh);
+                            bakeTransformation(this._scene.getMeshByName("__root__")!.getChildMeshes(true)[0] as Mesh);
                             this._meshes.push(...this._scene.meshes);
                             this._prepareScene();
                         });
@@ -459,7 +460,7 @@ export class PreviewManager {
                         return;
                     case PreviewType.Plane: {
                         SceneLoader.AppendAsync("https://assets.babylonjs.com/meshes/", "highPolyPlane.glb", this._scene).then(() => {
-                            bakeTransformation(this._scene.meshes[1] as Mesh);
+                            bakeTransformation(this._scene.getMeshByName("__root__")!.getChildMeshes(true)[0] as Mesh);
                             this._meshes.push(...this._scene.meshes);
                             this._prepareScene();
                         });


### PR DESCRIPTION
See https://forum.babylonjs.com/t/pbr-node-material-with-coarse-roughness-issue-with-non-omni-lights/47812/5

Concerned meshes: sphere, cube, plane

The problem was that we bake the current transformation but don't move the mesh to the top of the hierarchy (`parent=nullhttps://forum.babylonjs.com/t/pbr-node-material-with-coarse-roughness-issue-with-non-omni-lights/47812/5). So, the parent transformation is applied two times, one time during baking and another time when rendering the mesh.

Also, there was a bug in the baking method, because tangents were not transformed.