### PR TITLE
TriPlanar material: Fix shader crash when using instances

### DIFF
--- a/packages/dev/materials/src/triPlanar/triplanar.vertex.fx
+++ b/packages/dev/materials/src/triPlanar/triplanar.vertex.fx
@@ -101,7 +101,7 @@ void main(void)
 	vec3 worldBinormal = normalize(xbin * normalizedNormal.x + ybin * normalizedNormal.y + zbin * normalizedNormal.z);
    	vec3 worldTangent = normalize(xtan * normalizedNormal.x + ytan * normalizedNormal.y + ztan * normalizedNormal.z);
 	   
-	mat3 normalWorld = mat3(world);
+	mat3 normalWorld = mat3(finalWorld);
 
 	#ifdef NONUNIFORMSCALING
 		normalWorld = transposeMat3(inverseMat3(normalWorld));


### PR DESCRIPTION
See https://forum.babylonjs.com/t/a-serialized-mesh-with-triplanarmateriel-does-not-create-an-instance-afterwards/47954