### PR TITLE
Gaussian Splatting: fix minor issue

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -110,7 +110,7 @@ export class GaussianSplattingMesh extends Mesh {
      */
     public render(subMesh: SubMesh, enableAlphaMode: boolean, effectiveMeshReplacement?: AbstractMesh): Mesh {
         if (!this.material) {
-            this._material = new GaussianSplattingMaterial(name + "_material", this._scene);
+            this._material = new GaussianSplattingMaterial(this.name + "_material", this._scene);
             this.material = this._material;
         }
 


### PR DESCRIPTION
It was using `window.name` instead of `this.name`