### PR TITLE
Fixed `ArcRotateCamera` panning when using parenting

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -963,6 +963,9 @@ export class ArcRotateCamera extends TargetCamera {
                         this._target.copyFrom(this._transformedDirection);
                     }
                 } else {
+                    if (this.parent) {
+                        Vector3.TransformCoordinatesToRef(this._transformedDirection, this.parent.getWorldMatrix().getRotationMatrix().transpose(), this._transformedDirection);
+                    }
                     this._target.addInPlace(this._transformedDirection);
                 }
             }


### PR DESCRIPTION
## Current behavior

The camera pans in world space when a parent is assigned.

## Expected behavior

The camera must pan in the local space of its parent.

see https://forum.babylonjs.com/t/camera-panning-issue-when-using-parenting/48014

This pull request will make this PG work: https://www.babylonjs-playground.com/#C2ZGCJ#23
