### PR TITLE
Animation: Allow to pass a custom delta time to the scene animate method

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -678,7 +678,7 @@ declare module "../scene" {
     }
 }
 
-Scene.prototype._animate = function (): void {
+Scene.prototype._animate = function (customDeltaTime?: number): void {
     if (!this.animationsEnabled) {
         return;
     }
@@ -692,7 +692,7 @@ Scene.prototype._animate = function (): void {
         this._animationTimeLast = now;
     }
 
-    this.deltaTime = this.useConstantAnimationDeltaTime ? 16.0 : (now - this._animationTimeLast) * this.animationTimeScale;
+    this.deltaTime = customDeltaTime !== undefined ? customDeltaTime : this.useConstantAnimationDeltaTime ? 16.0 : (now - this._animationTimeLast) * this.animationTimeScale;
     this._animationTimeLast = now;
 
     const animatables = this._activeAnimatables;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4440,7 +4440,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     };
 
     /** @internal */
-    public _animate(): void {
+    public _animate(customDeltaTime?: number): void {
         // Nothing to do as long as Animatable have not been imported.
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/how-can-i-step-physics-and-animations-manually-when-lockstep-is-active/47689/3