### PR TITLE
Allow XR near interaction to interact with all meshes and GUI

### DIFF
--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -557,11 +557,27 @@ export class Ray {
      * @returns the new ray
      */
     public static CreateNewFromTo(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly): Ray {
-        const direction = end.subtract(origin);
-        const length = Math.sqrt(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z);
-        direction.normalize();
+        const result = new Ray(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
+        return Ray.CreateNewFromToToRef(origin, end, world, result);
+    }
 
-        return Ray.Transform(new Ray(origin, direction, length), world);
+    /**
+     * Function will create a new transformed ray starting from origin and ending at the end point. Ray's length will be set, and ray will be
+     * transformed to the given world matrix.
+     * @param origin The origin point
+     * @param end The end point
+     * @param world a matrix to transform the ray to. Default is the identity matrix.
+     * @param result the object to store the result
+     * @returns the ref ray
+     */
+    public static CreateNewFromToToRef(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly, result: Ray): Ray {
+        result.origin.copyFrom(origin);
+        const direction = end.subtractToRef(origin, result.direction);
+        const length = Math.sqrt(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z);
+        result.length = length;
+        result.direction.normalize();
+
+        return Ray.TransformToRef(result, world, result);
     }
 
     /**
@@ -582,8 +598,9 @@ export class Ray {
      * @param ray ray to transform
      * @param matrix matrix to apply
      * @param result ray to store result in
+     * @returns the updated result ray
      */
-    public static TransformToRef(ray: DeepImmutable<Ray>, matrix: DeepImmutable<Matrix>, result: Ray): void {
+    public static TransformToRef(ray: DeepImmutable<Ray>, matrix: DeepImmutable<Matrix>, result: Ray): Ray {
         Vector3.TransformCoordinatesToRef(ray.origin, matrix, result.origin);
         Vector3.TransformNormalToRef(ray.direction, matrix, result.direction);
         result.length = ray.length;
@@ -599,6 +616,8 @@ export class Ray {
             dir.z *= num;
             result.length *= len;
         }
+
+        return result;
     }
 
     /**

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -558,11 +558,11 @@ export class Ray {
      */
     public static CreateNewFromTo(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly): Ray {
         const result = new Ray(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
-        return Ray.CreateNewFromToToRef(origin, end, world, result);
+        return Ray.CreateFromToToRef(origin, end, world, result);
     }
 
     /**
-     * Function will create a new transformed ray starting from origin and ending at the end point. Ray's length will be set, and ray will be
+     * Function will update a transformed ray starting from origin and ending at the end point. Ray's length will be set, and ray will be
      * transformed to the given world matrix.
      * @param origin The origin point
      * @param end The end point
@@ -570,7 +570,7 @@ export class Ray {
      * @param result the object to store the result
      * @returns the ref ray
      */
-    public static CreateNewFromToToRef(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly, result: Ray): Ray {
+    public static CreateFromToToRef(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly, result: Ray): Ray {
         result.origin.copyFrom(origin);
         const direction = end.subtractToRef(origin, result.direction);
         const length = Math.sqrt(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z);

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -997,7 +997,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                 distance = tmp;
 
                 // ray between the sphere center and the point on the mesh
-                Ray.CreateNewFromToToRef(sphere.center, tmpVec, undefined, tmpRay);
+                Ray.CreateFromToToRef(sphere.center, tmpVec, undefined, tmpRay);
                 tmpRay.length = distance * 2;
                 intersectionInfo = tmpRay.intersectsMesh(mesh);
 

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -931,6 +931,10 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                     pickingInfo.gripTransform = controllerData.xrController.grip || null;
                     pickingInfo.originMesh = controllerData.touchCollisionMesh;
                     pickingInfo.distance = result.distance;
+                    pickingInfo.bu = result.bu;
+                    pickingInfo.bv = result.bv;
+                    pickingInfo.faceId = result.faceId;
+                    pickingInfo.subMeshId = result.subMeshId;
                 }
             }
         }
@@ -963,9 +967,10 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
         const result = TmpVectors.Vector3[0];
         const tmpVec = TmpVectors.Vector3[1];
+        const tmpRay = new Ray(Vector3.Zero(), Vector3.Zero(), 1);
 
         let distance = +Infinity;
-        let tmp, tmpDistanceSphereToCenter, tmpDistanceSurfaceToCenter;
+        let tmp, tmpDistanceSphereToCenter, tmpDistanceSurfaceToCenter, intersectionInfo;
         const center = TmpVectors.Vector3[2];
         const worldToMesh = TmpVectors.Matrix[0];
         worldToMesh.copyFrom(mesh.getWorldMatrix());
@@ -990,6 +995,12 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
 
             if (tmp !== -1 && tmp < distance) {
                 distance = tmp;
+
+                // ray between the sphere center and the point on the mesh
+                Ray.CreateNewFromToToRef(sphere.center, tmpVec, undefined, tmpRay);
+                tmpRay.length = distance * 2;
+                intersectionInfo = tmpRay.intersectsMesh(mesh);
+
                 result.copyFrom(tmpVec);
             }
         }
@@ -999,6 +1010,12 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
             pi.distance = distance;
             pi.pickedMesh = mesh;
             pi.pickedPoint = result.clone();
+            if (intersectionInfo && intersectionInfo.bu !== null && intersectionInfo.bv !== null) {
+                pi.faceId = intersectionInfo.faceId;
+                pi.subMeshId = intersectionInfo.subMeshId;
+                pi.bu = intersectionInfo.bu;
+                pi.bv = intersectionInfo.bv;
+            }
         }
 
         return pi;


### PR DESCRIPTION
This PR generates the needed data for full interaction with any object using near interaction.
bu and bv were missing, which prevented elements like the GUI from working correctly with near interaction.

PG used for testing: #9K3MRA#1484