### PR TITLE
Add triangle predicates to pointer down and up events.

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -586,7 +586,14 @@ export class InputManager {
                 const pickResult =
                     scene.skipPointerUpPicking || (scene._registeredActions === 0 && !this._checkForPicking() && !scene.onPointerUp)
                         ? null
-                        : scene.pick(this._unTranslatedPointerX, this._unTranslatedPointerY, scene.pointerUpPredicate, scene.pointerUpFastCheck, scene.cameraToUseForPointers);
+                        : scene.pick(
+                              this._unTranslatedPointerX,
+                              this._unTranslatedPointerY,
+                              scene.pointerUpPredicate,
+                              scene.pointerUpFastCheck,
+                              scene.cameraToUseForPointers,
+                              scene.pointerUpTrianglePredicate
+                          );
                 this._currentPickResult = pickResult;
                 if (pickResult) {
                     act = pickResult.hit && pickResult.pickedMesh ? pickResult.pickedMesh._getActionManagerForTrigger() : null;
@@ -881,7 +888,8 @@ export class InputManager {
                     this._unTranslatedPointerY,
                     scene.pointerDownPredicate,
                     scene.pointerDownFastCheck,
-                    scene.cameraToUseForPointers
+                    scene.cameraToUseForPointers,
+                    scene.pointerDownTrianglePredicate
                 );
             }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -867,6 +867,16 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
     public pointerMoveTrianglePredicate: ((p0: Vector3, p1: Vector3, p2: Vector3, ray: Ray) => boolean) | undefined;
 
     /**
+     * Gets or sets a predicate used to select candidate faces for a pointer down event
+     */
+    public pointerDownTrianglePredicate: ((p0: Vector3, p1: Vector3, p2: Vector3, ray: Ray) => boolean) | undefined;
+
+    /**
+     * Gets or sets a predicate used to select candidate faces for a pointer up event
+     */
+    public pointerUpTrianglePredicate: ((p0: Vector3, p1: Vector3, p2: Vector3, ray: Ray) => boolean) | undefined;
+
+    /**
      * This observable event is triggered when any ponter event is triggered. It is registered during Scene.attachControl() and it is called BEFORE the 3D engine process anything (mesh/sprite picking for instance).
      * You have the possibility to skip the process and the call to onPointerObservable by setting PointerInfoPre.skipOnPointerObservable to true
      */


### PR DESCRIPTION
This PR adds `scene.pointerDownTrianglePredicate` and `scene.pointerUpTrianglePredicate`, which function analogous to the already implemented `scene.pointerMoveTrianglePredicate`. This allows to set triangle predicates for use with `ActionManager` or Behaviors like `PointerDragBehavior`, which currently is not possible.

There should be no performance impact when not setting the predicates, as is with `pointerMoveTrianglePredicate`.

Relevant forum post: https://forum.babylonjs.com/t/triangle-predicate-for-picking-triggers-in-actionmanager-and-pointerdragbehaviour/47761

I hope this fits all the guidelines. :)
Open for review!