### PR TITLE
Fix declaration issue

### DIFF
--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -558,7 +558,7 @@ export class Ray {
      */
     public static CreateNewFromTo(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly): Ray {
         const result = new Ray(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
-        return Ray.CreateFromToToRef(origin, end, world, result);
+        return Ray.CreateFromToToRef(origin, end, result, world);
     }
 
     /**
@@ -570,7 +570,7 @@ export class Ray {
      * @param result the object to store the result
      * @returns the ref ray
      */
-    public static CreateFromToToRef(origin: Vector3, end: Vector3, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly, result: Ray): Ray {
+    public static CreateFromToToRef(origin: Vector3, end: Vector3, result: Ray, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly): Ray {
         result.origin.copyFrom(origin);
         const direction = end.subtractToRef(origin, result.direction);
         const length = Math.sqrt(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z);

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -566,8 +566,8 @@ export class Ray {
      * transformed to the given world matrix.
      * @param origin The origin point
      * @param end The end point
-     * @param world a matrix to transform the ray to. Default is the identity matrix.
      * @param result the object to store the result
+     * @param world a matrix to transform the ray to. Default is the identity matrix.
      * @returns the ref ray
      */
     public static CreateFromToToRef(origin: Vector3, end: Vector3, result: Ray, world: DeepImmutable<Matrix> = Matrix.IdentityReadOnly): Ray {

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -997,7 +997,7 @@ export class WebXRNearInteraction extends WebXRAbstractFeature {
                 distance = tmp;
 
                 // ray between the sphere center and the point on the mesh
-                Ray.CreateFromToToRef(sphere.center, tmpVec, undefined, tmpRay);
+                Ray.CreateFromToToRef(sphere.center, tmpVec, tmpRay);
                 tmpRay.length = distance * 2;
                 intersectionInfo = tmpRay.intersectsMesh(mesh);
 


### PR DESCRIPTION
The issue (that typescript has not detected, interesting enough) is that an optional parameter cannot come before a required variable. The declaration was generated incorrectly, and the playground has no proper typings.

As this was never released (only available in the playground so far), this is not a breaking change