### PR TITLE
Gizmos: add additional transform property

### DIFF
--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -15,7 +15,7 @@ import { DynamicTexture } from "../Materials/Textures/dynamicTexture";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Effect } from "../Materials/effect";
 
-import type { ISkeletonViewerOptions, IBoneWeightShaderOptions, ISkeletonMapShaderOptions, ISkeletonMapShaderColorMapKnot, ISkeletonViewerDisplayOptions } from "./ISkeletonViewer";
+import type { ISkeletonViewerOptions, IBoneWeightShaderOptions, ISkeletonMapShaderOptions, ISkeletonMapShaderColorMapKnot } from "./ISkeletonViewer";
 import type { Observer } from "../Misc/observable";
 
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
@@ -625,104 +625,6 @@ export class SkeletonViewer {
         return;
     }
 
-    private _createSpur(anchorPoint: Vector3, bone: Bone, childPoint: Vector3, childBone: Nullable<Bone>, displayOptions: ISkeletonViewerDisplayOptions, utilityLayerScene: Scene) {
-        const dir = childPoint.subtract(anchorPoint);
-        const h = dir.length();
-        const up = dir.normalize().scale(h);
-
-        const midStep = displayOptions.midStep || 0.165;
-        const midStepFactor = displayOptions.midStepFactor || 0.215;
-
-        const up0 = up.scale(midStep);
-
-        const spur = ExtrudeShapeCustom(
-            "skeletonViewer",
-            {
-                shape: [new Vector3(1, -1, 0), new Vector3(1, 1, 0), new Vector3(-1, 1, 0), new Vector3(-1, -1, 0), new Vector3(1, -1, 0)],
-                path: [Vector3.Zero(), up0, up],
-                scaleFunction: (i: number) => {
-                    switch (i) {
-                        case 0:
-                        case 2:
-                            return 0;
-                        case 1:
-                            return h * midStepFactor;
-                    }
-                    return 0;
-                },
-                sideOrientation: Mesh.DEFAULTSIDE,
-                updatable: false,
-            },
-            utilityLayerScene
-        );
-
-        const numVertices = spur.getTotalVertices();
-        const mwk: number[] = [],
-            mik: number[] = [];
-
-        for (let i = 0; i < numVertices; i++) {
-            mwk.push(1, 0, 0, 0);
-
-            // Select verts at end of spur (ie vert 10 to 14) and bind to child
-            // bone if spurFollowsChild is enabled.
-            if (childBone && displayOptions.spurFollowsChild && i > 9) {
-                mik.push(childBone.getIndex(), 0, 0, 0);
-            } else {
-                mik.push(bone.getIndex(), 0, 0, 0);
-            }
-        }
-
-        spur.position = anchorPoint.clone();
-
-        spur.setVerticesData(VertexBuffer.MatricesWeightsKind, mwk, false);
-        spur.setVerticesData(VertexBuffer.MatricesIndicesKind, mik, false);
-        spur.convertToFlatShadedMesh();
-
-        return spur;
-    }
-
-    private _getBoundingSphereForBone(boneIndex: number) {
-        if (!this.mesh) {
-            return null;
-        }
-
-        const positions = this.mesh.getVerticesData(VertexBuffer.PositionKind);
-        const indices = this.mesh.getIndices();
-        const boneWeights = this.mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
-        const boneIndices = this.mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
-        if (!positions || !indices || !boneWeights || !boneIndices) {
-            return null;
-        }
-
-        const min = new Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-        const max = new Vector3(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
-
-        let found = 0;
-        for (let i = 0; i < indices.length; ++i) {
-            const vertexIndex = indices[i];
-
-            for (let b = 0; b < 4; ++b) {
-                const bIndex = boneIndices[vertexIndex * 4 + b];
-                const bWeight = boneWeights[vertexIndex * 4 + b];
-
-                if (bIndex === boneIndex && bWeight > 1e-5) {
-                    Vector3.FromArrayToRef(positions, vertexIndex * 3, TmpVectors.Vector3[0]);
-                    min.minimizeInPlace(TmpVectors.Vector3[0]);
-                    max.maximizeInPlace(TmpVectors.Vector3[0]);
-                    found++;
-                    break;
-                }
-            }
-        }
-
-        return found > 1
-            ? {
-                  center: Vector3.Center(min, max),
-                  radius: Vector3.Distance(min, max) / 2,
-              }
-            : null;
-    }
-
     /**
      * function to build and bind sphere joint points and spur bone representations.
      * @param spheresOnly
@@ -773,42 +675,73 @@ export class SkeletonViewer {
 
                 boneAbsoluteBindPoseTransform.decompose(undefined, undefined, anchorPoint);
 
-                if (bone.children.length > 0) {
-                    bone.children.forEach((bc) => {
-                        const childAbsoluteBindPoseTransform: Matrix = new Matrix();
-                        bc.getLocalMatrix().multiplyToRef(boneAbsoluteBindPoseTransform, childAbsoluteBindPoseTransform);
-                        const childPoint = new Vector3();
-                        childAbsoluteBindPoseTransform.decompose(undefined, undefined, childPoint);
-                        const distanceFromParent = Vector3.Distance(anchorPoint, childPoint);
-                        if (distanceFromParent > longestBoneLength) {
-                            longestBoneLength = distanceFromParent;
-                        }
-                        if (spheresOnly) {
-                            return;
-                        }
+                bone.children.forEach((bc) => {
+                    const childAbsoluteBindPoseTransform: Matrix = new Matrix();
+                    bc.getLocalMatrix().multiplyToRef(boneAbsoluteBindPoseTransform, childAbsoluteBindPoseTransform);
+                    const childPoint = new Vector3();
+                    childAbsoluteBindPoseTransform.decompose(undefined, undefined, childPoint);
+                    const distanceFromParent = Vector3.Distance(anchorPoint, childPoint);
+                    if (distanceFromParent > longestBoneLength) {
+                        longestBoneLength = distanceFromParent;
+                    }
+                    if (spheresOnly) {
+                        return;
+                    }
 
-                        spurs.push(this._createSpur(anchorPoint, bone, childPoint, bc, displayOptions, utilityLayerScene));
-                    });
-                } else {
-                    const boundingSphere = this._getBoundingSphereForBone(bone.getIndex());
-                    if (boundingSphere) {
-                        if (boundingSphere.radius > longestBoneLength) {
-                            longestBoneLength = boundingSphere.radius;
-                        }
-                        if (!spheresOnly) {
-                            let childPoint;
-                            const parentBone = bone.getParent();
-                            if (parentBone) {
-                                this._getAbsoluteBindPoseToRef(parentBone, boneAbsoluteBindPoseTransform);
-                                boneAbsoluteBindPoseTransform.decompose(undefined, undefined, TmpVectors.Vector3[0]);
-                                childPoint = anchorPoint.subtract(TmpVectors.Vector3[0]).normalize().scale(boundingSphere.radius).add(anchorPoint);
-                            } else {
-                                childPoint = boundingSphere.center.subtract(anchorPoint).normalize().scale(boundingSphere.radius).add(anchorPoint);
-                            }
-                            spurs.push(this._createSpur(anchorPoint, bone, childPoint, null, displayOptions, utilityLayerScene));
+                    const dir = childPoint.clone().subtract(anchorPoint.clone());
+                    const h = dir.length();
+                    const up = dir.normalize().scale(h);
+
+                    const midStep = displayOptions.midStep || 0.165;
+                    const midStepFactor = displayOptions.midStepFactor || 0.215;
+
+                    const up0 = up.scale(midStep);
+
+                    const spur = ExtrudeShapeCustom(
+                        "skeletonViewer",
+                        {
+                            shape: [new Vector3(1, -1, 0), new Vector3(1, 1, 0), new Vector3(-1, 1, 0), new Vector3(-1, -1, 0), new Vector3(1, -1, 0)],
+                            path: [Vector3.Zero(), up0, up],
+                            scaleFunction: (i: number) => {
+                                switch (i) {
+                                    case 0:
+                                    case 2:
+                                        return 0;
+                                    case 1:
+                                        return h * midStepFactor;
+                                }
+                                return 0;
+                            },
+                            sideOrientation: Mesh.DEFAULTSIDE,
+                            updatable: false,
+                        },
+                        utilityLayerScene
+                    );
+
+                    const numVertices = spur.getTotalVertices();
+                    const mwk: number[] = [],
+                        mik: number[] = [];
+
+                    for (let i = 0; i < numVertices; i++) {
+                        mwk.push(1, 0, 0, 0);
+
+                        // Select verts at end of spur (ie vert 10 to 14) and bind to child
+                        // bone if spurFollowsChild is enabled.
+                        if (displayOptions.spurFollowsChild && i > 9) {
+                            mik.push(bc.getIndex(), 0, 0, 0);
+                        } else {
+                            mik.push(bone.getIndex(), 0, 0, 0);
                         }
                     }
-                }
+
+                    spur.position = anchorPoint.clone();
+
+                    spur.setVerticesData(VertexBuffer.MatricesWeightsKind, mwk, false);
+                    spur.setVerticesData(VertexBuffer.MatricesIndicesKind, mik, false);
+                    spur.convertToFlatShadedMesh();
+
+                    spurs.push(spur);
+                });
 
                 const sphereBaseSize = displayOptions.sphereBaseSize || 0.2;
 

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -111,6 +111,13 @@ export interface IGizmo extends IDisposable {
      * @param mesh The mesh to replace the default mesh of the gizmo
      */
     setCustomMesh(mesh: Mesh): void;
+
+    /**
+     * Additional transform applied to the gizmo.
+     * It's useful when the gizmo is attached to a bone: if the bone is part of a skeleton attached to a mesh, you should define the mesh as additionalTransformNode if you want the gizmo to be displayed at the bone's correct location.
+     * Otherwise, as the gizmo is relative to the skeleton root, the mesh transformation will not be taken into account.
+     */
+    additionalTransformNode?: TransformNode;
 }
 /**
  * Renders gizmos on top of an existing scene which provide controls for position, rotation, etc.
@@ -123,6 +130,7 @@ export class Gizmo implements IGizmo {
     protected _attachedMesh: Nullable<AbstractMesh> = null;
     protected _attachedNode: Nullable<Node> = null;
     protected _customRotationQuaternion: Nullable<Quaternion> = null;
+    protected _additionalTransformNode?: TransformNode;
     /**
      * Ratio for the scale of the gizmo (Default: 1)
      */
@@ -211,6 +219,19 @@ export class Gizmo implements IGizmo {
         });
         mesh.parent = this._rootMesh;
         this._customMeshSet = true;
+    }
+
+    /**
+     * Additional transform applied to the gizmo.
+     * It's useful when the gizmo is attached to a bone: if the bone is part of a skeleton attached to a mesh, you should define the mesh as additionalTransformNode if you want the gizmo to be displayed at the bone's correct location.
+     * Otherwise, as the gizmo is relative to the skeleton root, the mesh transformation will not be taken into account.
+     */
+    public get additionalTransformNode() {
+        return this._additionalTransformNode;
+    }
+
+    public set additionalTransformNode(value: TransformNode | undefined) {
+        this._additionalTransformNode = value;
     }
 
     protected _updateGizmoRotationToMatchAttachedMesh = true;
@@ -376,6 +397,12 @@ export class Gizmo implements IGizmo {
             } else {
                 this._rootMesh.scaling.setAll(this.scaleRatio);
             }
+        }
+
+        if (this.additionalTransformNode) {
+            this._rootMesh.computeWorldMatrix(true);
+            this._rootMesh.getWorldMatrix().multiplyToRef(this.additionalTransformNode.getWorldMatrix(), TmpVectors.Matrix[0]);
+            TmpVectors.Matrix[0].decompose(this._rootMesh.scaling, this._rootMesh.rotationQuaternion!, this._rootMesh.position);
         }
     }
 

--- a/packages/dev/core/src/Gizmos/gizmoManager.ts
+++ b/packages/dev/core/src/Gizmos/gizmoManager.ts
@@ -20,6 +20,7 @@ import type { IScaleGizmo } from "./scaleGizmo";
 import { ScaleGizmo } from "./scaleGizmo";
 import type { IBoundingBoxGizmo } from "./boundingBoxGizmo";
 import { BoundingBoxGizmo } from "./boundingBoxGizmo";
+import type { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Helps setup gizmo's in the scene to rotate/scale/position nodes
@@ -57,6 +58,7 @@ export class GizmoManager implements IDisposable {
     protected _thickness: number = 1;
     protected _scaleRatio: number = 1;
     protected _coordinatesMode = GizmoCoordinatesMode.Local;
+    protected _additionalTransformNode?: TransformNode;
 
     /** Node Caching for quick lookup */
     private _gizmoAxisCache: Map<Mesh, GizmoAxisCache> = new Map();
@@ -166,6 +168,13 @@ export class GizmoManager implements IDisposable {
      */
     public get attachedNode() {
         return this._attachedNode;
+    }
+
+    /**
+     * Additional transform node that will be used to transform all the gizmos
+     */
+    public get additionalTransformNode() {
+        return this._additionalTransformNode;
     }
 
     /**
@@ -313,6 +322,7 @@ export class GizmoManager implements IDisposable {
             this.gizmos.positionGizmo.attachedNode = null;
         }
         this._gizmosEnabled.positionGizmo = value;
+        this._setAdditionalTransformNode();
     }
     public get positionGizmoEnabled(): boolean {
         return this._gizmosEnabled.positionGizmo;
@@ -334,6 +344,7 @@ export class GizmoManager implements IDisposable {
             this.gizmos.rotationGizmo.attachedNode = null;
         }
         this._gizmosEnabled.rotationGizmo = value;
+        this._setAdditionalTransformNode();
     }
     public get rotationGizmoEnabled(): boolean {
         return this._gizmosEnabled.rotationGizmo;
@@ -353,6 +364,7 @@ export class GizmoManager implements IDisposable {
             this.gizmos.scaleGizmo.attachedNode = null;
         }
         this._gizmosEnabled.scaleGizmo = value;
+        this._setAdditionalTransformNode();
     }
     public get scaleGizmoEnabled(): boolean {
         return this._gizmosEnabled.scaleGizmo;
@@ -385,9 +397,28 @@ export class GizmoManager implements IDisposable {
             this.gizmos.boundingBoxGizmo.attachedNode = null;
         }
         this._gizmosEnabled.boundingBoxGizmo = value;
+        this._setAdditionalTransformNode();
     }
     public get boundingBoxGizmoEnabled(): boolean {
         return this._gizmosEnabled.boundingBoxGizmo;
+    }
+
+    /**
+     * Sets the additional transform applied to all the gizmos.
+     * @See Gizmo.additionalTransformNode for more detail
+     */
+    public set additionalTransformNode(node: TransformNode | undefined) {
+        this._additionalTransformNode = node;
+        this._setAdditionalTransformNode();
+    }
+
+    private _setAdditionalTransformNode() {
+        for (const key in this.gizmos) {
+            const gizmo = <Nullable<IGizmo>>(<any>this.gizmos)[key];
+            if (gizmo && (<any>this._gizmosEnabled)[key]) {
+                gizmo.additionalTransformNode = this._additionalTransformNode;
+            }
+        }
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -17,6 +17,7 @@ import { PlaneDragGizmo } from "./planeDragGizmo";
 import { UtilityLayerRenderer } from "../Rendering/utilityLayerRenderer";
 import type { PointerInfo } from "../Events/pointerEvents";
 import type { GizmoManager } from "./gizmoManager";
+import type { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Interface for position gizmo
@@ -59,6 +60,17 @@ export interface IPositionGizmo extends IGizmo {
      * Force release the drag action by code
      */
     releaseDrag(): void;
+}
+
+/**
+ * Additional options for the position gizmo
+ */
+export interface PositionGizmoOptions {
+    /**
+     * Additional transform applied to the gizmo.
+     * @See Gizmo.additionalTransformNode for more detail
+     */
+    additionalTransformNode?: TransformNode;
 }
 
 /**
@@ -161,13 +173,24 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         );
     }
 
+    public get additionalTransformNode() {
+        return this._additionalTransformNode;
+    }
+
+    public set additionalTransformNode(transformNode: TransformNode | undefined) {
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
+            gizmo.additionalTransformNode = transformNode;
+        });
+    }
+
     /**
      * Creates a PositionGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
-      @param thickness display gizmo axis thickness
+     * @param thickness display gizmo axis thickness
      * @param gizmoManager
+     * @param options More options
      */
-    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, thickness: number = 1, gizmoManager?: GizmoManager) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, thickness: number = 1, gizmoManager?: GizmoManager, options?: PositionGizmoOptions) {
         super(gizmoLayer);
         this.xGizmo = new AxisDragGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), gizmoLayer, this, thickness);
         this.yGizmo = new AxisDragGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), gizmoLayer, this, thickness);
@@ -176,6 +199,9 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         this.xPlaneGizmo = new PlaneDragGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), this.gizmoLayer, this);
         this.yPlaneGizmo = new PlaneDragGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), this.gizmoLayer, this);
         this.zPlaneGizmo = new PlaneDragGizmo(new Vector3(0, 0, 1), Color3.Blue().scale(0.5), this.gizmoLayer, this);
+
+        this.additionalTransformNode = options?.additionalTransformNode;
+
         // Relay drag events
         [this.xGizmo, this.yGizmo, this.zGizmo, this.xPlaneGizmo, this.yPlaneGizmo, this.zPlaneGizmo].forEach((gizmo) => {
             gizmo.dragBehavior.onDragStartObservable.add(() => {

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -85,6 +85,12 @@ export interface RotationGizmoOptions {
      * Specific options for zGizmo
      */
     zOptions?: PlaneRotationGizmoOptions;
+
+    /**
+     * Additional transform applied to the gizmo.
+     * @See Gizmo.additionalTransformNode for more detail
+     */
+    additionalTransformNode?: TransformNode;
 }
 
 /**
@@ -186,6 +192,16 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         return this.xGizmo.dragBehavior.dragging || this.yGizmo.dragBehavior.dragging || this.zGizmo.dragBehavior.dragging;
     }
 
+    public get additionalTransformNode() {
+        return this._additionalTransformNode;
+    }
+
+    public set additionalTransformNode(transformNode: TransformNode | undefined) {
+        [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
+            gizmo.additionalTransformNode = transformNode;
+        });
+    }
+
     /**
      * Creates a RotationGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
@@ -210,6 +226,9 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         this.xGizmo = new PlaneRotationGizmo(new Vector3(1, 0, 0), xColor, gizmoLayer, tessellation, this, useEulerRotation, thickness);
         this.yGizmo = new PlaneRotationGizmo(new Vector3(0, 1, 0), yColor, gizmoLayer, tessellation, this, useEulerRotation, thickness);
         this.zGizmo = new PlaneRotationGizmo(new Vector3(0, 0, 1), zColor, gizmoLayer, tessellation, this, useEulerRotation, thickness);
+
+        this.additionalTransformNode = options?.additionalTransformNode;
+
         // Relay drag events and set update scale
         [this.xGizmo, this.yGizmo, this.zGizmo].forEach((gizmo) => {
             //must set updateScale on each gizmo, as setting it on root RotationGizmo doesnt prevent individual gizmos from updating

--- a/packages/dev/core/src/Gizmos/scaleGizmo.ts
+++ b/packages/dev/core/src/Gizmos/scaleGizmo.ts
@@ -17,6 +17,7 @@ import type { Node } from "../node";
 import type { PointerInfo } from "../Events/pointerEvents";
 import { StandardMaterial } from "../Materials/standardMaterial";
 import type { GizmoManager } from "./gizmoManager";
+import type { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Interface for scale gizmo
@@ -61,6 +62,17 @@ export interface IScaleGizmo extends IGizmo {
     hoverMaterial: StandardMaterial;
     /** Material used to render when gizmo is disabled. typically grey.*/
     disableMaterial: StandardMaterial;
+}
+
+/**
+ * Additional options for the scale gizmo
+ */
+export interface ScaleGizmoOptions {
+    /**
+     * Additional transform applied to the gizmo.
+     * @See Gizmo.additionalTransformNode for more detail
+     */
+    additionalTransformNode?: TransformNode;
 }
 
 /**
@@ -175,18 +187,31 @@ export class ScaleGizmo extends Gizmo implements IScaleGizmo {
         return this.xGizmo.dragBehavior.dragging || this.yGizmo.dragBehavior.dragging || this.zGizmo.dragBehavior.dragging || this.uniformScaleGizmo.dragBehavior.dragging;
     }
 
+    public get additionalTransformNode() {
+        return this._additionalTransformNode;
+    }
+
+    public set additionalTransformNode(transformNode: TransformNode | undefined) {
+        [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {
+            gizmo.additionalTransformNode = transformNode;
+        });
+    }
+
     /**
      * Creates a ScaleGizmo
      * @param gizmoLayer The utility layer the gizmo will be added to
      * @param thickness display gizmo axis thickness
      * @param gizmoManager
+     * @param options More options
      */
-    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, thickness: number = 1, gizmoManager?: GizmoManager) {
+    constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer, thickness: number = 1, gizmoManager?: GizmoManager, options?: ScaleGizmoOptions) {
         super(gizmoLayer);
         this.uniformScaleGizmo = this._createUniformScaleMesh();
         this.xGizmo = new AxisScaleGizmo(new Vector3(1, 0, 0), Color3.Red().scale(0.5), gizmoLayer, this, thickness);
         this.yGizmo = new AxisScaleGizmo(new Vector3(0, 1, 0), Color3.Green().scale(0.5), gizmoLayer, this, thickness);
         this.zGizmo = new AxisScaleGizmo(new Vector3(0, 0, 1), Color3.Blue().scale(0.5), gizmoLayer, this, thickness);
+
+        this.additionalTransformNode = options?.additionalTransformNode;
 
         // Relay drag events
         [this.xGizmo, this.yGizmo, this.zGizmo, this.uniformScaleGizmo].forEach((gizmo) => {

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/skeletonPropertyGridComponent.tsx
@@ -61,7 +61,7 @@ export class SkeletonPropertyGridComponent extends React.Component<ISkeletonProp
                         continue;
                     }
 
-                    const viewer = new SkeletonViewer(mesh.skeleton, mesh, scene, false, 3, {
+                    const viewer = new SkeletonViewer(mesh.skeleton, mesh, scene, true, 3, {
                         displayMode: this._skeletonViewerDisplayOptions.displayMode,
                         displayOptions: {
                             sphereBaseSize: this._skeletonViewerDisplayOptions.sphereBaseSize,

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -117,7 +117,9 @@ export class SceneTreeItemComponent extends React.Component<
                     manager.attachToNode(this._selectedEntity.reservedDataStore.cameraGizmo.attachedNode);
                 } else if (className.indexOf("Bone") !== -1) {
                     manager.attachToMesh(this._selectedEntity._linkedTransformNode ? this._selectedEntity._linkedTransformNode : this._selectedEntity);
-                    manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
+                    if (!this._selectedEntity._linkedTransformNode) {
+                        manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
+                    }
                 } else {
                     manager.attachToNode(null);
                 }
@@ -442,7 +444,9 @@ export class SceneTreeItemComponent extends React.Component<
                     manager.attachToNode(this._selectedEntity.reservedDataStore.cameraGizmo.attachedNode);
                 } else if (className.indexOf("Bone") !== -1) {
                     manager.attachToMesh(this._selectedEntity._linkedTransformNode ? this._selectedEntity._linkedTransformNode : this._selectedEntity);
-                    manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
+                    if (!this._selectedEntity._linkedTransformNode) {
+                        manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
+                    }
                 }
             }
         }

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -142,6 +142,8 @@ export class SceneTreeItemComponent extends React.Component<
                 return mesh;
             }
         }
+
+        return undefined;
     }
 
     componentWillUnmount() {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -19,6 +19,7 @@ import type { CameraGizmo } from "core/Gizmos/cameraGizmo";
 import type { Camera } from "core/Cameras/camera";
 import { TmpVectors, Vector3 } from "core/Maths/math";
 import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
+import type { Bone } from "core/Bones/bone";
 
 interface ISceneTreeItemComponentProps {
     scene: Scene;
@@ -116,11 +117,31 @@ export class SceneTreeItemComponent extends React.Component<
                     manager.attachToNode(this._selectedEntity.reservedDataStore.cameraGizmo.attachedNode);
                 } else if (className.indexOf("Bone") !== -1) {
                     manager.attachToMesh(this._selectedEntity._linkedTransformNode ? this._selectedEntity._linkedTransformNode : this._selectedEntity);
+                    manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
                 } else {
                     manager.attachToNode(null);
                 }
             }
         });
+    }
+
+    private _getMeshFromBone(bone: Bone, scene: Scene) {
+        const skeleton = bone.getSkeleton();
+
+        // First try to find a mesh for which we've enabled the skeleton viewer
+        for (const mesh of scene.meshes) {
+            const skeletonViewer = mesh.reservedDataStore?.skeletonViewer;
+            if (skeletonViewer && skeletonViewer.skeleton === skeleton) {
+                return mesh;
+            }
+        }
+
+        // Not found, return the first mesh that uses the skeleton
+        for (const mesh of scene.meshes) {
+            if (mesh.skeleton === skeleton) {
+                return mesh;
+            }
+        }
     }
 
     componentWillUnmount() {
@@ -419,6 +440,7 @@ export class SceneTreeItemComponent extends React.Component<
                     manager.attachToNode(this._selectedEntity.reservedDataStore.cameraGizmo.attachedNode);
                 } else if (className.indexOf("Bone") !== -1) {
                     manager.attachToMesh(this._selectedEntity._linkedTransformNode ? this._selectedEntity._linkedTransformNode : this._selectedEntity);
+                    manager.additionalTransformNode = this._getMeshFromBone(this._selectedEntity, scene);
                 }
             }
         }


### PR DESCRIPTION
This PR adds a new `additionalTransformNode` property to the `Gizmo` class. The name can be changed! I had first thought of `rootTransformNode`, but there's already a `_rootMesh` in the `Gizmo` class...

It is used primarily when a gizmo is attached to a bone. Currently, the gizmo is not displayed at the right location/orientation because it does not take into account the mesh on which the skeleton is attached (the gizmo is relative to the root of the skeleton). By setting `additionalTransformNode` to the mesh, the gizmo will be correctly displayed because we will multiply the final transform with the mesh transform.

I also updated the inspector to use the new feature.

Test PG (the gizmos should be at the location of the upper bone): https://playground.babylonjs.com/#HFWCMJ#26