### PR TITLE
Make sure XR rig cameras render scene's custom render targets

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -288,6 +288,14 @@ export class WebXRCamera extends FreeCamera {
                     currentRig._isLeftCamera = true;
                 }
             }
+            // add any custom render targets to this camera, if available in the scene
+            const customRenderTargets = this.getScene().customRenderTargets;
+            customRenderTargets.forEach((rt) => {
+                // make sure it is not already there
+                if (currentRig.customRenderTargets.indexOf(rt) === -1) {
+                    currentRig.customRenderTargets.push(rt);
+                }
+            });
             // Update view/projection matrix
             const pos = view.transform.position;
             const orientation = view.transform.orientation;

--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -290,12 +290,14 @@ export class WebXRCamera extends FreeCamera {
             }
             // add any custom render targets to this camera, if available in the scene
             const customRenderTargets = this.getScene().customRenderTargets;
-            customRenderTargets.forEach((rt) => {
-                // make sure it is not already there
+            // use a for loop
+            for (let i = 0; i < customRenderTargets.length; i++) {
+                const rt = customRenderTargets[i];
+                // make sure we don't add the same render target twice
                 if (currentRig.customRenderTargets.indexOf(rt) === -1) {
                     currentRig.customRenderTargets.push(rt);
                 }
-            });
+            }
             // Update view/projection matrix
             const pos = view.transform.position;
             const orientation = view.transform.orientation;


### PR DESCRIPTION
Initially I have added this loop during the creation of the camera, but this way we are guaranteeing that even if the scene changes while in XR, or after leaving XR, the XR cameras will still render custom render targets correctly.

This will also allow adding RTTs direcly to the camera's custom render target, so the arrays stay independent.