### PR TITLE
make vision OS emulator work

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -67,7 +67,7 @@ type XRHandedness = "none" | "left" | "right";
 /**
  * InputSource target ray modes
  */
-type XRTargetRayMode = "gaze" | "tracked-pointer" | "screen";
+type XRTargetRayMode = "gaze" | "tracked-pointer" | "screen" | "transient-pointer";
 
 /**
  * Eye types

--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -167,6 +167,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             case "gaze":
                 return this._attachGazeMode(xrController);
             case "screen":
+            case "transient-pointer":
                 return this._attachScreenRayMode(xrController);
         }
     };

--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -497,6 +497,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                 // set the ray and position
 
                 let hitPossible = false;
+                const controlSelectionFeature = controllerData.xrController.inputSource.targetRayMode !== "transient-pointer";
                 controllerData.xrController.getWorldPointerRayToRef(this._tmpRay);
                 if (this.straightRayEnabled) {
                     // first check if direct ray possible
@@ -514,14 +515,14 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     });
                     if (pick && pick.pickedMesh && this._options.pickBlockerMeshes && this._options.pickBlockerMeshes.indexOf(pick.pickedMesh) !== -1) {
                         controllerData.teleportationState.blocked = true;
-                        this._setTargetMeshVisibility(false);
+                        this._setTargetMeshVisibility(false, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                         return;
                     } else if (pick && pick.pickedPoint) {
                         controllerData.teleportationState.blocked = false;
                         hitPossible = true;
                         this._setTargetMeshPosition(pick);
-                        this._setTargetMeshVisibility(true);
+                        this._setTargetMeshVisibility(true, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                     }
                 }
@@ -547,26 +548,26 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     });
                     if (pick && pick.pickedMesh && this._options.pickBlockerMeshes && this._options.pickBlockerMeshes.indexOf(pick.pickedMesh) !== -1) {
                         controllerData.teleportationState.blocked = true;
-                        this._setTargetMeshVisibility(false);
+                        this._setTargetMeshVisibility(false, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                         return;
                     } else if (pick && pick.pickedPoint) {
                         controllerData.teleportationState.blocked = false;
                         hitPossible = true;
                         this._setTargetMeshPosition(pick);
-                        this._setTargetMeshVisibility(true);
+                        this._setTargetMeshVisibility(true, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                     }
                 }
 
                 // if needed, set visible:
-                this._setTargetMeshVisibility(hitPossible);
+                this._setTargetMeshVisibility(hitPossible, false, controlSelectionFeature);
             } else {
-                this._setTargetMeshVisibility(false);
+                this._setTargetMeshVisibility(false, false, true);
             }
         } else {
             this._disposeBezierCurve();
-            this._setTargetMeshVisibility(false);
+            this._setTargetMeshVisibility(false, false, true);
         }
     }
 
@@ -912,7 +913,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
         this.onTargetMeshPositionUpdatedObservable.notifyObservers(pickInfo);
     }
 
-    private _setTargetMeshVisibility(visible: boolean, force?: boolean) {
+    private _setTargetMeshVisibility(visible: boolean, force?: boolean, controlSelectionFeature?: boolean) {
         if (!this._options.teleportationTargetMesh) {
             return;
         }
@@ -929,11 +930,11 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                 this._quadraticBezierCurve.dispose();
                 this._quadraticBezierCurve = null;
             }
-            if (this._selectionFeature) {
+            if (this._selectionFeature && controlSelectionFeature) {
                 this._selectionFeature.attach();
             }
         } else {
-            if (this._selectionFeature) {
+            if (this._selectionFeature && controlSelectionFeature) {
                 this._selectionFeature.detach();
             }
         }


### PR DESCRIPTION
Vision OS emulator 1.1 delivers transient pointer input events, which were not supported until this PR.

Note - this is for the emulator only, the real device should have proper hand support.