### PR TITLE
Add timeStep option to NullEngine

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -42,6 +42,9 @@ export class NullEngineOptions {
      */
     public deterministicLockstep = false;
 
+    /** Defines the seconds between each deterministic lock step */
+    timeStep?: number;
+
     /**
      * Maximum about of steps between frames (Default: 4)
      * @see https://doc.babylonjs.com/features/featuresDeepDive/animation/advanced_animations#deterministic-lockstep
@@ -96,6 +99,10 @@ export class NullEngine extends Engine {
 
         if (options.deterministicLockstep === undefined) {
             options.deterministicLockstep = false;
+        }
+
+        if (options.timeStep !== undefined) {
+            this._timeStep = options.timeStep;
         }
 
         if (options.lockstepMaxSteps === undefined) {

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -1,0 +1,40 @@
+import { NullEngine } from "core/Engines";
+
+describe("NullEngine", () => {
+    describe("constructor", () => {
+        it("returns a NullEngine", () => {
+            const nullEngine = new NullEngine();
+            expect(nullEngine).toBeInstanceOf(NullEngine);
+        });
+    });
+
+    describe("Options", () => {
+        it("returns a NullEngine with the correct options", () => {
+            const nullEngine = new NullEngine({
+                renderHeight: 128,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+            expect(nullEngine.getRenderHeight()).toBe(128);
+            expect(nullEngine.getRenderWidth()).toBe(256);
+            expect(nullEngine.isDeterministicLockStep()).toBe(false);
+            expect(nullEngine.getLockstepMaxSteps()).toBe(1);
+        });
+
+        it("supports setting timeStep option", () => {
+            const nullEngine = new NullEngine({
+                renderHeight: 128,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: true,
+                timeStep: 0.5,
+                lockstepMaxSteps: 4,
+            });
+            expect(nullEngine.isDeterministicLockStep()).toBe(true);
+            expect(nullEngine.getTimeStep()).toBe(500); // 0.5 seconds in ms
+            expect(nullEngine.getLockstepMaxSteps()).toBe(4);
+        });
+    });
+});


### PR DESCRIPTION
This allows specifying `timeStep` when creating a `NullEngine`

Ref. https://forum.babylonjs.com/t/how-to-set-nullengine-timestep-missing-from-options/48082

Also adds simple unit test for `NullEngine` and it's options.