### PR TITLE
TrailMesh: Fix wrong starting position when the generator is a TransformNode

### DIFF
--- a/packages/dev/core/src/Meshes/trailMesh.ts
+++ b/packages/dev/core/src/Meshes/trailMesh.ts
@@ -74,7 +74,7 @@ export class TrailMesh extends Mesh {
         if (this._generator instanceof AbstractMesh && this._generator.hasBoundingInfo) {
             meshCenter = this._generator.getBoundingInfo().boundingBox.centerWorld;
         } else {
-            meshCenter = this._generator.position;
+            meshCenter = this._generator.absolutePosition;
         }
         const alpha: number = (2 * Math.PI) / this._sectionPolygonPointsCount;
         for (let i: number = 0; i <= this._sectionPolygonPointsCount; i++) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/trail-mesh-always-starts-from-0-0-0-when-generator-is-a-child-node/48317