### PR TITLE
NME: Fix missing alphaMode property parsing

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2290,6 +2290,10 @@ export class NodeMaterial extends PushMaterial {
             this.forceAlphaBlending = source.forceAlphaBlending;
         }
 
+        if (source.alphaMode !== undefined) {
+            this.alphaMode = source.alphaMode;
+        }
+
         if (!merge) {
             this._mode = source.mode ?? NodeMaterialModes.Material;
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/node-materiel-editor-does-not-load-alpha-mode/48396