### PR TITLE
Mesh: Fix setPivotMatrix when cloning mesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -671,7 +671,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             this.parent = source.parent;
 
             // Pivot
-            this.setPivotMatrix(source.getPivotMatrix());
+            this.setPivotMatrix(source.getPivotMatrix(), this._postMultiplyPivotMatrix);
 
             this.id = name + "." + source.id;
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/pivot-matrix-are-not-being-copied-while-cloning-the-mesh-bug-or-feature/48478