### PR TITLE
Teleportation fixes

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerTeleportation.ts
@@ -173,6 +173,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                 baseRotation: number;
                 rotating: boolean;
                 blocked: boolean;
+                initialHit: boolean;
+                mainComponentUsed: boolean;
             };
             onAxisChangedObserver?: Nullable<Observer<IWebXRMotionControllerAxesValue>>;
             onButtonChangedObserver?: Nullable<Observer<WebXRControllerComponent>>;
@@ -537,11 +539,16 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     });
                     const floorMeshPicked = pick && pick.pickedMesh && this._floorMeshes.indexOf(pick.pickedMesh) !== -1;
                     if (pick && pick.pickedMesh && !floorMeshPicked) {
+                        if (controllerData.teleportationState.mainComponentUsed && !controllerData.teleportationState.initialHit) {
+                            controllerData.teleportationState.forward = false;
+                            return;
+                        }
                         controllerData.teleportationState.blocked = true;
                         this._setTargetMeshVisibility(false, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                         return;
                     } else if (pick && pick.pickedPoint) {
+                        controllerData.teleportationState.initialHit = true;
                         controllerData.teleportationState.blocked = false;
                         hitPossible = true;
                         this._setTargetMeshPosition(pick);
@@ -577,11 +584,16 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                     });
                     const floorMeshPicked = pick && pick.pickedMesh && this._floorMeshes.indexOf(pick.pickedMesh) !== -1;
                     if (pick && pick.pickedMesh && !floorMeshPicked) {
+                        if (controllerData.teleportationState.mainComponentUsed && !controllerData.teleportationState.initialHit) {
+                            controllerData.teleportationState.forward = false;
+                            return;
+                        }
                         controllerData.teleportationState.blocked = true;
                         this._setTargetMeshVisibility(false, false, controlSelectionFeature);
                         this._showParabolicPath(pick);
                         return;
                     } else if (pick && pick.pickedPoint) {
+                        controllerData.teleportationState.initialHit = true;
                         controllerData.teleportationState.blocked = false;
                         hitPossible = true;
                         this._setTargetMeshPosition(pick);
@@ -592,16 +604,6 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
 
                 // if needed, set visible:
                 this._setTargetMeshVisibility(hitPossible, false, controlSelectionFeature);
-                // if hit not possible, mark forward to be false
-                if (!hitPossible) {
-                    // but only if main component is used
-                    if (
-                        !(controllerData.xrController.inputSource.targetRayMode === "tracked-pointer" && controllerData.xrController.inputSource.gamepad) ||
-                        this._options.useMainComponentOnly
-                    ) {
-                        controllerData.teleportationState.forward = false;
-                    }
-                }
             } else {
                 this._setTargetMeshVisibility(false, false, true);
             }
@@ -625,6 +627,8 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                 currentRotation: 0,
                 baseRotation: 0,
                 blocked: false,
+                initialHit: false,
+                mainComponentUsed: false,
             },
         };
         const controllerData = this._controllers[xrController.uniqueId];
@@ -642,6 +646,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                         if (!mainComponent) {
                             return;
                         }
+                        controllerData.teleportationState.mainComponentUsed = true;
                         controllerData.teleportationComponent = mainComponent;
                         controllerData.onButtonChangedObserver = mainComponent.onButtonStateChangedObservable.add(() => {
                             if (!this.teleportationEnabled) {
@@ -651,6 +656,7 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                             const teleportLocal = () => {
                                 // simulate "forward" thumbstick push
                                 controllerData.teleportationState.forward = true;
+                                controllerData.teleportationState.initialHit = false;
                                 this._currentTeleportationControllerId = controllerData.xrController.uniqueId;
                                 controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
                                 controllerData.teleportationState.currentRotation = 0;
@@ -791,10 +797,12 @@ export class WebXRMotionControllerTeleportation extends WebXRAbstractFeature {
                 });
             }
         } else {
+            controllerData.teleportationState.mainComponentUsed = true;
             let breakObserver = false;
             const teleportLocal = () => {
                 this._currentTeleportationControllerId = controllerData.xrController.uniqueId;
                 controllerData.teleportationState.forward = true;
+                controllerData.teleportationState.initialHit = false;
                 controllerData.teleportationState.baseRotation = this._options.xrInput.xrCamera.rotationQuaternion.toEulerAngles().y;
                 controllerData.teleportationState.currentRotation = 0;
                 const timeToSelect = this._options.timeToTeleport || 3000;


### PR DESCRIPTION
1. Added blocked predicate (optional) to define a function to select blocker meshes
2. If using the main component and the initial hit is not a teleportation surface, the teleportation will be canceled.