### PR TITLE
fix clone for ADT

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1279,11 +1279,12 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     }
 
     /**
-     * Clones the ADT
+     * Clones the ADT. If no mesh is defined, the GUI will be considered as a fullscreen GUI
      * @param newName defines the name of the new ADT
+     * @param attachToMesh defines if the new ADT should be attached to a mesh
      * @returns the clone of the ADT
      */
-    public clone(newName?: string): AdvancedDynamicTexture {
+    public clone(newName?: string, attachToMesh?: AbstractMesh): AdvancedDynamicTexture {
         const scene = this.getScene();
 
         if (!scene) {
@@ -1291,7 +1292,12 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         }
         const size = this.getSize();
         const data = this.serializeContent();
-        const clone = new AdvancedDynamicTexture(newName ?? "Clone of " + this.name, size.width, size.height, scene, !this.noMipmap, this.samplingMode);
+        let clone;
+        if (attachToMesh) {
+            clone = AdvancedDynamicTexture.CreateForMesh(attachToMesh, size.width, size.height);
+        } else {
+            clone = AdvancedDynamicTexture.CreateFullscreenUI(newName ?? "Clone of " + this.name);
+        }
         clone.parseSerializedObject(data);
 
         return clone;

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -1293,8 +1293,12 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         const size = this.getSize();
         const data = this.serializeContent();
         let clone;
-        if (attachToMesh) {
-            clone = AdvancedDynamicTexture.CreateForMesh(attachToMesh, size.width, size.height);
+        if (!this._isFullscreen) {
+            if (attachToMesh) {
+                clone = AdvancedDynamicTexture.CreateForMesh(attachToMesh, size.width, size.height);
+            } else {
+                clone = new AdvancedDynamicTexture(newName ?? "Clone of " + this.name, size.width, size.height, scene, !this.noMipmap, this.samplingMode);
+            }
         } else {
             clone = AdvancedDynamicTexture.CreateFullscreenUI(newName ?? "Clone of " + this.name);
         }


### PR DESCRIPTION
ADT clone was cloning the ADT but did neither attach it to a mesh nor create the layer that is needed for fullscreen UI