### PR TITLE
fix: fix property name error

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -486,8 +486,8 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Gets or Set the mouse wheel delta percentage or how fast is the camera zooming.
-     * It will be used instead of pinchPrecision if different from 0.
-     * It defines the percentage of current camera.radius to use as delta when pinch zoom is used.
+     * It will be used instead of wheelPrecision if different from 0.
+     * It defines the percentage of current camera.radius to use as delta when wheel zoom is used.
      */
     public get wheelDeltaPercentage(): number {
         const mousewheel = <ArcRotateCameraMouseWheelInput>this.inputs.attached["mousewheel"];

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -307,7 +307,7 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Gets or Set the pointer pinch delta percentage or how fast is the camera zooming.
-     * It will be used instead of pinchDeltaPrecision if different from 0.
+     * It will be used instead of pinchPrecision if different from 0.
      * It defines the percentage of current camera.radius to use as delta when pinch zoom is used.
      */
     public get pinchDeltaPercentage(): number {
@@ -486,7 +486,7 @@ export class ArcRotateCamera extends TargetCamera {
 
     /**
      * Gets or Set the mouse wheel delta percentage or how fast is the camera zooming.
-     * It will be used instead of pinchDeltaPrecision if different from 0.
+     * It will be used instead of pinchPrecision if different from 0.
      * It defines the percentage of current camera.radius to use as delta when pinch zoom is used.
      */
     public get wheelDeltaPercentage(): number {


### PR DESCRIPTION
The `pinchDeltaPrecision` in the comments should be `pinchPrecision`. There is no `pinchDeltaPrecision` property.