### PR TITLE
Fixed `Tensor` value typing

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeDataStream.ts
+++ b/packages/dev/core/src/Engines/Native/nativeDataStream.ts
@@ -1,3 +1,4 @@
+import type { DeepImmutable, FloatArray } from "../../types";
 import type { INative, INativeDataStream } from "./nativeInterfaces";
 
 declare const _native: INative;
@@ -85,7 +86,7 @@ export class NativeDataStream {
      * Writes a float32 array to the stream
      * @param values the values to write
      */
-    public writeFloat32Array(values: Float32Array): void {
+    public writeFloat32Array(values: DeepImmutable<FloatArray>): void {
         this._flushIfNecessary(1 + values.length);
         this._uint32s[this._position++] = values.length;
         this._float32s.set(values, this._position);

--- a/packages/dev/core/src/Engines/Native/nativeDataStream.ts
+++ b/packages/dev/core/src/Engines/Native/nativeDataStream.ts
@@ -1,4 +1,5 @@
 import type { DeepImmutable, FloatArray } from "../../types";
+
 import type { INative, INativeDataStream } from "./nativeInterfaces";
 
 declare const _native: INative;

--- a/packages/dev/core/src/Engines/Native/nativeDataStream.ts
+++ b/packages/dev/core/src/Engines/Native/nativeDataStream.ts
@@ -1,5 +1,4 @@
 import type { DeepImmutable, FloatArray } from "../../types";
-
 import type { INative, INativeDataStream } from "./nativeInterfaces";
 
 declare const _native: INative;

--- a/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
+++ b/packages/dev/core/src/Engines/Native/nativePipelineContext.ts
@@ -488,7 +488,7 @@ export class NativePipelineContext implements IPipelineContext {
      */
     public setMatrix(uniformName: string, matrix: IMatrixLike): void {
         if (this._cacheMatrix(uniformName, matrix)) {
-            if (!this._engine.setMatrices(this._uniforms[uniformName]!, matrix.asArray() as Float32Array)) {
+            if (!this._engine.setMatrices(this._uniforms[uniformName]!, matrix.asArray())) {
                 this._valueCache[uniformName] = null;
             }
         }

--- a/packages/dev/core/src/Engines/WebGL/webGLPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGL/webGLPipelineContext.ts
@@ -458,7 +458,7 @@ export class WebGLPipelineContext implements IPipelineContext {
      */
     public setMatrix(uniformName: string, matrix: IMatrixLike): void {
         if (this._cacheMatrix(uniformName, matrix)) {
-            if (!this.engine.setMatrices(this._uniforms[uniformName], matrix.asArray() as Float32Array)) {
+            if (!this.engine.setMatrices(this._uniforms[uniformName], matrix.asArray())) {
                 this._valueCache[uniformName] = null;
             }
         }

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { Nullable, IndicesArray, DataArray } from "../types";
+import type { Nullable, IndicesArray, DataArray, FloatArray, DeepImmutable } from "../types";
 import { Engine } from "../Engines/engine";
 import type { VertexBuffer } from "../Buffers/buffer";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
@@ -166,7 +166,7 @@ class CommandBufferEncoder {
         this._commandStream.writeFloat32(commandArg);
     }
 
-    public encodeCommandArgAsFloat32s(commandArg: Float32Array) {
+    public encodeCommandArgAsFloat32s(commandArg: DeepImmutable<FloatArray>) {
         this._commandStream.writeFloat32Array(commandArg);
     }
 
@@ -1365,7 +1365,7 @@ export class NativeEngine extends Engine {
         return this.setFloatArray4(uniform, new Float32Array(array));
     }
 
-    public setMatrices(uniform: WebGLUniformLocation, matrices: Float32Array): boolean {
+    public setMatrices(uniform: WebGLUniformLocation, matrices: DeepImmutable<FloatArray>): boolean {
         if (!uniform) {
             return false;
         }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -7,7 +7,7 @@ import { _WarnImport } from "../Misc/devTools";
 import type { IShaderProcessor } from "./Processors/iShaderProcessor";
 import type { ShaderProcessingContext } from "./Processors/shaderProcessingOptions";
 import type { UniformBuffer } from "../Materials/uniformBuffer";
-import type { Nullable, DataArray, IndicesArray } from "../types";
+import type { Nullable, DataArray, IndicesArray, FloatArray, DeepImmutable } from "../types";
 import type { EngineCapabilities } from "./engineCapabilities";
 import type { Observer } from "../Misc/observable";
 import { Observable } from "../Misc/observable";
@@ -3644,7 +3644,7 @@ export class ThinEngine {
      * @param matrices defines the array of float32 to store
      * @returns true if the value was set
      */
-    public setMatrices(uniform: Nullable<WebGLUniformLocation>, matrices: Iterable<GLfloat>): boolean {
+    public setMatrices(uniform: Nullable<WebGLUniformLocation>, matrices: DeepImmutable<FloatArray>): boolean {
         if (!uniform) {
             return false;
         }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3644,7 +3644,7 @@ export class ThinEngine {
      * @param matrices defines the array of float32 to store
      * @returns true if the value was set
      */
-    public setMatrices(uniform: Nullable<WebGLUniformLocation>, matrices: Float32Array): boolean {
+    public setMatrices(uniform: Nullable<WebGLUniformLocation>, matrices: Iterable<GLfloat>): boolean {
         if (!uniform) {
             return false;
         }

--- a/packages/dev/core/src/Maths/math.like.ts
+++ b/packages/dev/core/src/Maths/math.like.ts
@@ -1,4 +1,4 @@
-import type { float, int, DeepImmutable } from "../types";
+import type { float, int, DeepImmutable, Tuple } from "../types";
 
 /**
  * @internal
@@ -58,7 +58,7 @@ export interface IPlaneLike {
  * @internal
  */
 export interface IMatrixLike {
-    asArray(): DeepImmutable<Float32Array | Array<float>>;
+    asArray(): DeepImmutable<Tuple<number, 16>>;
     updateFlag: int;
 }
 

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -1300,7 +1300,7 @@ export class Vector3 implements Vector<Tuple<number, 3>>, IVector3Like {
      * @param offset defines the offset in the destination array
      * @returns the current Vector3
      */
-    public fromArray(array: FloatArray, offset: number = 0): this {
+    public fromArray(array: DeepImmutable<FloatArray>, offset: number = 0): this {
         Vector3.FromArrayToRef(array, offset, this);
         return this;
     }

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -379,7 +379,7 @@ export interface TensorStatic<T extends Tensor> {
      * @param offset defines the offset in the data source
      * @returns a new instance
      */
-    FromArray(array: ArrayLike<number>, offset?: number): T;
+    FromArray(array: Flatten<TensorValue<T>>, offset?: number): T;
 
     /**
      * Sets "result" from the given index element of the given array
@@ -388,7 +388,7 @@ export interface TensorStatic<T extends Tensor> {
      * @param result defines the target instance
      * @returns result input
      */
-    FromArrayToRef(array: ArrayLike<number>, offset: number, result: T): T;
+    FromArrayToRef(array: Flatten<TensorValue<T>>, offset: number, result: T): T;
 
     /**
      * Sets the given instance "result" with the given floats.

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -18,7 +18,7 @@ export type TensorValueElement<V extends unknown[]> = Flatten<V> extends Array<i
 /**
  * Extracts the element type of a Tensor
  */
-export type TensorElement<T> = T extends Tensor<infer V> ? TensorValueElement<V> : never;
+export type TensorElement<T extends Tensor> = TensorValueElement<TensorValue<T>>;
 
 /**
  * Describes a mathematical tensor.
@@ -59,7 +59,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in source array
      * @returns the current instance
      */
-    toArray(array: ArrayLike<TensorValueElement<V>>, index?: number): this;
+    toArray(array: TensorValueElement<V>[], index?: number): this;
 
     /**
      * Update the current instance from an array
@@ -67,7 +67,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in the destination array
      * @returns the current instance
      */
-    fromArray(array: DeepImmutable<ArrayLike<TensorValueElement<V>>>, index?: number): this;
+    fromArray(array: ArrayLike<TensorValueElement<V>>, index?: number): this;
 
     /**
      * Copy the current instance to an array
@@ -355,7 +355,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
 /**
  * Static side of Tensor
  */
-export interface TensorStatic<T extends Tensor> {
+export interface TensorStatic<T extends Tensor<any[]>> {
     /**
      * Creates a new instance from the given coordinates
      */

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -13,6 +13,7 @@ export type TensorValue = number[] | TensorValue[];
  * Extracts the value type of a Tensor
  */
 export type ValueOfTensor<T = unknown> = T extends Tensor<infer V> ? V : TensorValue;
+
 /**
  * Describes a mathematical tensor.
  * @see https://wikipedia.org/wiki/Tensor

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -1,4 +1,4 @@
-import type { DeepImmutable, Flatten, FloatArray, Length } from "../types";
+import type { DeepImmutable, Flatten, Length } from "../types";
 
 /**
  * Computes the tensor dimension of a multi-dimensional array
@@ -9,6 +9,16 @@ export type Dimension<T> = T extends Array<infer U> ? [Length<T>, ...Dimension<U
  * Extracts the value type of a Tensor
  */
 export type TensorValue<T> = T extends Tensor<infer V> ? V : never;
+
+/**
+ * Extracts the element type of a Tensor value
+ */
+export type TensorValueElement<V extends unknown[]> = Flatten<V> extends Array<infer E> ? E : never;
+
+/**
+ * Extracts the element type of a Tensor
+ */
+export type TensorElement<T> = T extends Tensor<infer V> ? TensorValueElement<V> : never;
 
 /**
  * Describes a mathematical tensor.
@@ -49,7 +59,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in source array
      * @returns the current instance
      */
-    toArray(array: FloatArray, index?: number): this;
+    toArray(array: ArrayLike<TensorValueElement<V>>, index?: number): this;
 
     /**
      * Update the current instance from an array
@@ -57,7 +67,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in the destination array
      * @returns the current instance
      */
-    fromArray(array: FloatArray, index?: number): this;
+    fromArray(array: DeepImmutable<ArrayLike<TensorValueElement<V>>>, index?: number): this;
 
     /**
      * Copy the current instance to an array
@@ -379,7 +389,7 @@ export interface TensorStatic<T extends Tensor> {
      * @param offset defines the offset in the data source
      * @returns a new instance
      */
-    FromArray(array: Flatten<TensorValue<T>>, offset?: number): T;
+    FromArray(array: DeepImmutable<ArrayLike<TensorElement<T>>>, offset?: number): T;
 
     /**
      * Sets "result" from the given index element of the given array
@@ -388,7 +398,7 @@ export interface TensorStatic<T extends Tensor> {
      * @param result defines the target instance
      * @returns result input
      */
-    FromArrayToRef(array: Flatten<TensorValue<T>>, offset: number, result: T): T;
+    FromArrayToRef(array: DeepImmutable<ArrayLike<TensorElement<T>>>, offset: number, result: T): T;
 
     /**
      * Sets the given instance "result" with the given floats.

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -1,30 +1,23 @@
-import type { DeepImmutable, Flatten, Length } from "../types";
-
+import type { DeepImmutable, Flatten, FloatArray, Length } from "../types";
 /**
  * Computes the tensor dimension of a multi-dimensional array
  */
 export type Dimension<T> = T extends Array<infer U> ? [Length<T>, ...Dimension<U>] : T extends readonly [infer U, ...infer R] ? [Length<T>, ...Dimension<U>] : [];
 
 /**
+ * Possible values for a Tensor
+ */
+export type TensorValue = number[] | TensorValue[];
+
+/**
  * Extracts the value type of a Tensor
  */
-export type TensorValue<T> = T extends Tensor<infer V> ? V : never;
-
-/**
- * Extracts the element type of a Tensor value
- */
-export type TensorValueElement<V extends unknown[]> = Flatten<V> extends Array<infer E> ? E : never;
-
-/**
- * Extracts the element type of a Tensor
- */
-export type TensorElement<T extends Tensor> = TensorValueElement<TensorValue<T>>;
-
+export type ValueOfTensor<T = unknown> = T extends Tensor<infer V> ? V : TensorValue;
 /**
  * Describes a mathematical tensor.
  * @see https://wikipedia.org/wiki/Tensor
  */
-export interface Tensor<V extends unknown[] = unknown[]> {
+export interface Tensor<V extends TensorValue = TensorValue> {
     /**
      * An array of the size of each dimension.
      * For example, [3] for a Vector3 and [4,4] for a Matrix
@@ -59,7 +52,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in source array
      * @returns the current instance
      */
-    toArray(array: TensorValueElement<V>[], index?: number): this;
+    toArray(array: FloatArray, index?: number): this;
 
     /**
      * Update the current instance from an array
@@ -67,7 +60,7 @@ export interface Tensor<V extends unknown[] = unknown[]> {
      * @param index defines the offset in the destination array
      * @returns the current instance
      */
-    fromArray(array: ArrayLike<TensorValueElement<V>>, index?: number): this;
+    fromArray(array: DeepImmutable<FloatArray>, index?: number): this;
 
     /**
      * Copy the current instance to an array
@@ -359,7 +352,7 @@ export interface TensorStatic<T extends Tensor<any[]>> {
     /**
      * Creates a new instance from the given coordinates
      */
-    new (...coords: Flatten<TensorValue<T>>): T;
+    new (...coords: Flatten<ValueOfTensor<T>>): T;
 
     /**
      * So [[static]].prototype has typings, instead of just any
@@ -389,7 +382,7 @@ export interface TensorStatic<T extends Tensor<any[]>> {
      * @param offset defines the offset in the data source
      * @returns a new instance
      */
-    FromArray(array: ArrayLike<TensorElement<T>>, offset?: number): T;
+    FromArray(array: DeepImmutable<FloatArray>, offset?: number): T;
 
     /**
      * Sets "result" from the given index element of the given array
@@ -398,13 +391,13 @@ export interface TensorStatic<T extends Tensor<any[]>> {
      * @param result defines the target instance
      * @returns result input
      */
-    FromArrayToRef(array: ArrayLike<TensorElement<T>>, offset: number, result: T): T;
+    FromArrayToRef(array: DeepImmutable<FloatArray>, offset: number, result: T): T;
 
     /**
      * Sets the given instance "result" with the given floats.
      * @param args defines the coordinates of the source with the last paramater being the result
      */
-    FromFloatsToRef(...args: [...Flatten<TensorValue<T>>, T]): T;
+    FromFloatsToRef(...args: [...Flatten<ValueOfTensor<T>>, T]): T;
 
     /**
      * Gets the dot product of the instance "left" and the instance "right"

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -389,7 +389,7 @@ export interface TensorStatic<T extends Tensor<any[]>> {
      * @param offset defines the offset in the data source
      * @returns a new instance
      */
-    FromArray(array: DeepImmutable<ArrayLike<TensorElement<T>>>, offset?: number): T;
+    FromArray(array: ArrayLike<TensorElement<T>>, offset?: number): T;
 
     /**
      * Sets "result" from the given index element of the given array
@@ -398,7 +398,7 @@ export interface TensorStatic<T extends Tensor<any[]>> {
      * @param result defines the target instance
      * @returns result input
      */
-    FromArrayToRef(array: DeepImmutable<ArrayLike<TensorElement<T>>>, offset: number, result: T): T;
+    FromArrayToRef(array: ArrayLike<TensorElement<T>>, offset: number, result: T): T;
 
     /**
      * Sets the given instance "result" with the given floats.

--- a/packages/dev/core/src/types.ts
+++ b/packages/dev/core/src/types.ts
@@ -108,7 +108,7 @@ export type Member<T, D = null> = D extends 0 ? T : T extends (infer U)[] ? Memb
 /**
  * Flattens an array
  */
-export type FlattenArray<A extends unknown[], D = null> = A extends (infer U)[] ? Member<U, D>[] : A extends unknown[] ? { [K in keyof A]: Member<A[K], D> } : A;
+export type FlattenArray<A extends unknown[], D = null> = A extends (infer U)[] ? Member<Exclude<U, A>, D>[] : A extends unknown[] ? { [K in keyof A]: Member<A[K], D> } : A;
 
 /**
  * Whether T is a tuple


### PR DESCRIPTION
Minor PR, this fixes the types of `array`. Previously, they were `ArrayLike<number>`. This has been corrected to the `Tensor`'s value.

