### PR TITLE
Save engine type when storing snippet

### DIFF
--- a/packages/tools/playground/src/tools/loadManager.ts
+++ b/packages/tools/playground/src/tools/loadManager.ts
@@ -143,6 +143,27 @@ export class LoadManager {
                             code = decoder.decode((DecodeBase64ToBinary || DecodeBase64ToBinaryReproduced)(encodedData));
                         }
 
+                        // check the engine
+                        if (payload.engine && ["WebGL1", "WebGL2", "WebGPU"].includes(payload.engine)) {
+                            // check if an engine is forced in the URL
+                            const url = new URL(window.location.href);
+                            const engineInURL = url.searchParams.get("engine") || url.search.includes("webgpu");
+                            // get the current engine
+                            const currentEngine = Utilities.ReadStringFromStore("engineVersion", "WebGL2", true);
+                            if (!engineInURL && currentEngine !== payload.engine) {
+                                if (
+                                    window.confirm(
+                                        `The engine version in this playground (${payload.engine}) is different from the one you are currently using (${currentEngine}).
+Confirm to switch to ${payload.engine}, cancel to keep ${currentEngine}`
+                                    )
+                                ) {
+                                    // we need to change the engine
+                                    Utilities.StoreStringToStore("engineVersion", payload.engine, true);
+                                    window.location.reload();
+                                }
+                            }
+                        }
+
                         this.globalState.onCodeLoaded.notifyObservers(code);
 
                         this.globalState.onMetadataUpdatedObservable.notifyObservers();

--- a/packages/tools/playground/src/tools/saveManager.ts
+++ b/packages/tools/playground/src/tools/saveManager.ts
@@ -70,10 +70,12 @@ export class SaveManager {
         for (let i = 0; i < buffer.length; i++) {
             testData += String.fromCharCode(buffer[i]);
         }
+        const activeEngineVersion = Utilities.ReadStringFromStore("engineVersion", "WebGL2", true);
 
         const payLoad = JSON.stringify({
             code: this.globalState.currentCode,
             unicode: testData !== this.globalState.currentCode ? EncodeArrayBufferToBase64(buffer) : undefined,
+            engine: activeEngineVersion,
         });
 
         const dataToSend = {


### PR DESCRIPTION
This is a suggestion to solve an issue with WebGPU-only playgrounds.

When storing a snippet while using a specific engine type (webgl2/webgpu) the engine type will be stored as part of the snippet. 
When loaded the current used engine will be compared with the engine of the snippet. If it is not the same a prompt will ask if you want to switch to the other engine. It is still possible to cancel and continue in the current engine. If the snippet will be saved again, the current engine will be stored again (i.e. - engine type is per snippet version and is not a metadata item).

It is possible to override this behavior by adding `?webgpu` or `?engine=ENGINE-TYPE` to the URL. This way it doesn't matter what the snippet engine is, the URL-type will be used (works with webgpu).

Of course, this will only be enabled to snippets that are stored after this is merged. If there is no engine, the current behavior will be maintained.