### PR TITLE
WebGPU: Fix vertex buffer creation when byte offset is not a multiple of 4

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.align.ts
+++ b/packages/dev/core/src/Buffers/buffer.align.ts
@@ -13,19 +13,19 @@ declare module "./buffer" {
     export interface VertexBuffer {
         /**
          * Gets the effective byte stride, that is the byte stride of the buffer that is actually sent to the GPU.
-         * It could be different from VertexBuffer.byteStride if a new buffer must be created under the hood because of the forceVertexBufferStrideMultiple4Bytes engine flag.
+         * It could be different from VertexBuffer.byteStride if a new buffer must be created under the hood because of the forceVertexBufferStrideAndOffsetMultiple4Bytes engine flag.
          */
         effectiveByteStride: number;
 
         /**
          * Gets the effective byte offset, that is the byte offset of the buffer that is actually sent to the GPU.
-         * It could be different from VertexBuffer.byteOffset if a new buffer must be created under the hood because of the forceVertexBufferStrideMultiple4Bytes engine flag.
+         * It could be different from VertexBuffer.byteOffset if a new buffer must be created under the hood because of the forceVertexBufferStrideAndOffsetMultiple4Bytes engine flag.
          */
         effectiveByteOffset: number;
 
         /**
          * Gets the effective buffer, that is the buffer that is actually sent to the GPU.
-         * It could be different from VertexBuffer.getBuffer() if a new buffer must be created under the hood because of the forceVertexBufferStrideMultiple4Bytes engine flag.
+         * It could be different from VertexBuffer.getBuffer() if a new buffer must be created under the hood because of the forceVertexBufferStrideAndOffsetMultiple4Bytes engine flag.
          */
         effectiveBuffer: Nullable<DataBuffer>;
 
@@ -84,7 +84,7 @@ VertexBuffer.prototype.getWrapperBuffer = function (): Buffer {
 VertexBuffer.prototype._alignBuffer = function (): void {
     const data = this._buffer.getData();
 
-    if (!this.engine._features.forceVertexBufferStrideMultiple4Bytes || this.byteStride % 4 === 0 || !data) {
+    if (!this.engine._features.forceVertexBufferStrideAndOffsetMultiple4Bytes || (this.byteStride % 4 === 0 && this.byteOffset % 4 === 0) || !data) {
         return;
     }
 

--- a/packages/dev/core/src/Engines/engineFeatures.ts
+++ b/packages/dev/core/src/Engines/engineFeatures.ts
@@ -69,8 +69,8 @@ export interface EngineFeatures {
     /**  Indicates that the engine supports sprite instancing */
     supportSpriteInstancing: boolean;
 
-    /** Indicates that the stride of a vertex buffer must always be a multiple of 4 bytes */
-    forceVertexBufferStrideMultiple4Bytes: boolean;
+    /** Indicates that the stride and (byte) offset of a vertex buffer must always be a multiple of 4 bytes */
+    forceVertexBufferStrideAndOffsetMultiple4Bytes: boolean;
 
     /** @internal */
     _collectUbosUpdatedInFrame: boolean;

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -305,7 +305,7 @@ export class NativeEngine extends Engine {
             needToAlwaysBindUniformBuffers: false,
             supportRenderPasses: true,
             supportSpriteInstancing: false,
-            forceVertexBufferStrideMultiple4Bytes: false,
+            forceVertexBufferStrideAndOffsetMultiple4Bytes: false,
             _collectUbosUpdatedInFrame: false,
         };
 

--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -190,7 +190,7 @@ export class NullEngine extends Engine {
             needToAlwaysBindUniformBuffers: false,
             supportRenderPasses: true,
             supportSpriteInstancing: false,
-            forceVertexBufferStrideMultiple4Bytes: false,
+            forceVertexBufferStrideAndOffsetMultiple4Bytes: false,
             _collectUbosUpdatedInFrame: false,
         };
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1451,7 +1451,7 @@ export class ThinEngine {
             needToAlwaysBindUniformBuffers: false,
             supportRenderPasses: false,
             supportSpriteInstancing: true,
-            forceVertexBufferStrideMultiple4Bytes: false,
+            forceVertexBufferStrideAndOffsetMultiple4Bytes: false,
             _collectUbosUpdatedInFrame: false,
         };
     }

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -889,7 +889,7 @@ export class WebGPUEngine extends Engine {
             needToAlwaysBindUniformBuffers: true,
             supportRenderPasses: true,
             supportSpriteInstancing: true,
-            forceVertexBufferStrideMultiple4Bytes: true,
+            forceVertexBufferStrideAndOffsetMultiple4Bytes: true,
             _collectUbosUpdatedInFrame: false,
         };
     }


### PR DESCRIPTION
This PR will fix this PG: https://playground.babylonjs.com/?webgpu#AVFNTW#6
