### PR TITLE
Changed Array Buffer View import to randomize name to avoid bad caching

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -21,6 +21,7 @@ import type { Geometry } from "../Meshes/geometry";
 import type { Light } from "../Lights/light";
 import { RuntimeError, ErrorCodes } from "../Misc/error";
 import type { ISpriteManager } from "../Sprites/spriteManager";
+import { RandomGUID } from "../Misc/guid";
 
 /**
  * Type used for the success callback of ImportMesh
@@ -660,7 +661,7 @@ export class SceneLoader {
             file = sceneFile;
         } else if (ArrayBuffer.isView(sceneFilename)) {
             url = "";
-            name = "arrayBuffer";
+            name = RandomGUID();
             rawData = sceneFilename as ArrayBufferView;
         } else if (typeof sceneFilename === "string" && sceneFilename.startsWith("data:")) {
             url = sceneFilename;


### PR DESCRIPTION
Changed FileInfo name when loading model using an Array Buffer View to be random. Otherwise, texture caching will wrongly cache textures from models loaded using Array Buffer View because they are not uniquely identifiable by their URL. 

This aims to solve the following user issue without the URL work around:
https://forum.babylonjs.com/t/sceneloader-load-material-bug-when-scenefilename-is-arraybufferview/48515