### PR TITLE
Relax `AssetContainer` heirarchy check to allow `InstancedMesh` parents

### DIFF
--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -235,7 +235,7 @@ export class AssetContainer extends AbstractScene {
      * @returns true if the node is contained in this container, otherwise false.
      */
     private _isNodeInContainer(node: Node) {
-        if (node instanceof Mesh && this.meshes.indexOf(node) !== -1) {
+        if (node instanceof AbstractMesh && this.meshes.indexOf(node) !== -1) {
             return true;
         }
         if (node instanceof TransformNode && this.transformNodes.indexOf(node) !== -1) {


### PR DESCRIPTION
When an `InstancedMesh` is used as a parent, `AssetContainer` logs a warning saying the node heirarchy is invalid. This change fixes the issue by changing the parent's `instanceof` check from the `Mesh` class to the `AbstractMesh` class, which includes the `InstancedMesh` class since it is also derived from `AbstractMesh`.

Related forum post:
https://forum.babylonjs.com/t/assetcontainer-throwing-warnings-with-instancedmesh/48857.

Repro playground:
https://playground.babylonjs.com/#WT9TJK.