### PR TITLE
Simplify worker code in local dependency scenarios

### DIFF
--- a/packages/dev/core/src/Misc/khronosTextureContainer2Worker.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2Worker.ts
@@ -109,7 +109,7 @@ export function workerFunction(KTX2DecoderModule: any): void {
                     applyConfig(urls);
                 }
                 if (event.data.wasmBinaries) {
-                    applyConfig(undefined, event.data.wasmBinaries);
+                    applyConfig(undefined, { ...event.data.wasmBinaries, jsDecoderModule: KTX2DecoderModule });
                 }
                 ktx2Decoder = new KTX2DecoderModule.KTX2Decoder();
                 postMessage({ action: "init" });

--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -50,8 +50,9 @@ export class MSCTranscoder extends Transcoder {
         this._mscBasisTranscoderPromise = (
             MSCTranscoder.WasmBinary ? Promise.resolve(MSCTranscoder.WasmBinary) : WASMMemoryManager.LoadWASM(Transcoder.GetWasmUrl(MSCTranscoder.WasmModuleURL))
         ).then((wasmBinary) => {
-            if (MSCTranscoder.JSModule) {
-                MSC_TRANSCODER = MSCTranscoder.JSModule;
+            if (MSCTranscoder.JSModule && typeof MSC_TRANSCODER === "undefined") {
+                // this must be set on the global scope for the MSC transcoder to work. Mainly due to back-compat with the old way of loading the MSC transcoder.
+                (globalThis as any).MSC_TRANSCODER = MSCTranscoder.JSModule;
             } else {
                 if (MSCTranscoder.UseFromWorkerThread) {
                     importScripts(Transcoder.GetWasmUrl(MSCTranscoder.JSModuleURL));


### PR DESCRIPTION
This will simplify the worker code needed to get ktx2decoder working without using our CDN.
It is possible to use it without this, so this is not a bug, just a small improvement.