### PR TITLE
Add native device loss handle

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -17,6 +17,7 @@ export interface INativeEngine {
     dispose(): void;
 
     requestAnimationFrame(callback: () => void): void;
+    setDeviceLostCallback(callback: () => void): void;
 
     createVertexArray(): NativeData;
 

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -223,11 +223,13 @@ export class NativeEngine extends Engine {
             throw new Error(`Protocol version mismatch: ${_native.Engine.PROTOCOL_VERSION} (Native) !== ${NativeEngine.PROTOCOL_VERSION} (JS)`);
         }
 
-        this._engine.setDeviceLostCallback(() => {
-            this.onContextLostObservable.notifyObservers(this);
-            this._contextWasLost = true;
-            this._restoreEngineAfterContextLostSync();
-        });
+        if (this._engine.setDeviceLostCallback) {
+            this._engine.setDeviceLostCallback(() => {
+                this.onContextLostObservable.notifyObservers(this);
+                this._contextWasLost = true;
+                this._restoreEngineAfterContextLost();
+            });
+        }
 
         this._webGLVersion = 2;
         this.disableUniformBuffers = true;
@@ -428,6 +430,24 @@ export class NativeEngine extends Engine {
             this._engine.requestAnimationFrame(bindedRenderFunction);
         }
         return 0;
+    }
+
+    protected _restoreEngineAfterContextLost(): void {
+        this._clearEmptyResources();
+
+        const depthTest = this._depthCullingState.depthTest; // backup those values because the call to initEngine / wipeCaches will reset them
+        const depthFunc = this._depthCullingState.depthFunc;
+        const depthMask = this._depthCullingState.depthMask;
+        const stencilTest = this._stencilState.stencilTest;
+
+        this._rebuildGraphicsResources();
+
+        this._depthCullingState.depthTest = depthTest;
+        this._depthCullingState.depthFunc = depthFunc;
+        this._depthCullingState.depthMask = depthMask;
+        this._stencilState.stencilTest = stencilTest;
+
+        this._flagContextRestored();
     }
 
     /**

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -223,6 +223,12 @@ export class NativeEngine extends Engine {
             throw new Error(`Protocol version mismatch: ${_native.Engine.PROTOCOL_VERSION} (Native) !== ${NativeEngine.PROTOCOL_VERSION} (JS)`);
         }
 
+        this._engine.setDeviceLostCallback(() => {
+            this.onContextLostObservable.notifyObservers(this);
+            this._contextWasLost = true;
+            this._restoreEngineAfterContextLostSync();
+        });
+
         this._webGLVersion = 2;
         this.disableUniformBuffers = true;
         this._shaderPlatformName = "NATIVE";

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1039,6 +1039,51 @@ export class ThinEngine {
         }
     }
 
+    protected _restoreEngineAfterContextLostSync(): void {
+        this._dummyFramebuffer = null;
+        this._emptyTexture = null;
+        this._emptyCubeTexture = null;
+        this._emptyTexture3D = null;
+        this._emptyTexture2DArray = null;
+
+        const depthTest = this._depthCullingState.depthTest; // backup those values because the call to initEngine / wipeCaches will reset them
+        const depthFunc = this._depthCullingState.depthFunc;
+        const depthMask = this._depthCullingState.depthMask;
+        const stencilTest = this._stencilState.stencilTest;
+
+        // Ensure webgl and engine states are matching
+        this.wipeCaches(true);
+
+        // Rebuild effects
+        this._rebuildEffects();
+        this._rebuildComputeEffects?.();
+
+        // Note:
+        //  The call to _rebuildBuffers must be made before the call to _rebuildInternalTextures because in the process of _rebuildBuffers the buffers used by the post process managers will be rebuilt
+        //  and we may need to use the post process manager of the scene during _rebuildInternalTextures (in WebGL1, non-POT textures are rescaled using a post process + post process manager of the scene)
+
+        // Rebuild buffers
+        this._rebuildBuffers();
+        // Rebuild textures
+        this._rebuildInternalTextures();
+        // Rebuild textures
+        this._rebuildTextures();
+        // Rebuild textures
+        this._rebuildRenderTargetWrappers();
+
+        // Reset engine states after all the buffer/textures/... have been rebuilt
+        this.wipeCaches(true);
+
+        this._depthCullingState.depthTest = depthTest;
+        this._depthCullingState.depthFunc = depthFunc;
+        this._depthCullingState.depthMask = depthMask;
+        this._stencilState.stencilTest = stencilTest;
+
+        Logger.Warn(this.name + " context successfully restored.");
+        this.onContextRestoredObservable.notifyObservers(this);
+        this._contextWasLost = false;
+    }
+
     protected _restoreEngineAfterContextLost(initEngine: () => void): void {
         // Adding a timeout to avoid race condition at browser level
         setTimeout(async () => {

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -21,6 +21,7 @@ import type { Geometry } from "../Meshes/geometry";
 import type { Light } from "../Lights/light";
 import { RuntimeError, ErrorCodes } from "../Misc/error";
 import type { ISpriteManager } from "../Sprites/spriteManager";
+import { RandomGUID } from "../Misc/guid";
 
 /**
  * Type used for the success callback of ImportMesh
@@ -660,7 +661,7 @@ export class SceneLoader {
             file = sceneFile;
         } else if (ArrayBuffer.isView(sceneFilename)) {
             url = "";
-            name = "arrayBuffer";
+            name = RandomGUID();
             rawData = sceneFilename as ArrayBufferView;
         } else if (typeof sceneFilename === "string" && sceneFilename.startsWith("data:")) {
             url = sceneFilename;


### PR DESCRIPTION
Added capability to NativeEngine to be notified from C++ when a device loss is triggered and recreate the graphics resources accordingly. 