### PR TITLE
Allow Draco in NullEngine on node

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -20,9 +20,9 @@ interface MeshData {
     totalVertices: number;
 }
 
-function createDecoderAsync(wasmBinary?: ArrayBuffer): Promise<{ module: DecoderModule }> {
+function createDecoderAsync(wasmBinary?: ArrayBuffer, jsModule?: DracoDecoderModule): Promise<{ module: DecoderModule }> {
     return new Promise((resolve) => {
-        DracoDecoderModule({ wasmBinary }).then((module) => {
+        (jsModule || DracoDecoderModule)({ wasmBinary }).then((module) => {
             resolve({ module });
         });
     });
@@ -50,6 +50,19 @@ export interface IDracoCompressionConfiguration {
          * The url to the fallback JavaScript module.
          */
         fallbackUrl?: string;
+        /**
+         * Optional worker pool to use for async decoding instead of creating a new worker pool.
+         */
+        workerPool?: AutoReleaseWorkerPool;
+        /**
+         * Optional ArrayBuffer of the WebAssembly binary
+         */
+        wasmBinary?: ArrayBuffer;
+
+        /**
+         * The decoder module if already available.
+         */
+        jsModule?: any /* DecoderModule */;
     };
 }
 
@@ -167,17 +180,17 @@ export class DracoCompression implements IDisposable {
      * @param numWorkers The number of workers for async operations Or an options object. Specify `0` to disable web workers and run synchronously in the current context.
      */
     constructor(numWorkers: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
+        const decoder = DracoCompression.Configuration.decoder;
         // check if the decoder binary and worker pool was injected
         // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
-        if (typeof numWorkers === "object" && numWorkers.workerPool) {
+        if (decoder.workerPool || (typeof numWorkers === "object" && numWorkers.workerPool)) {
             // set the promise accordingly
-            this._workerPoolPromise = Promise.resolve(numWorkers.workerPool);
+            this._workerPoolPromise = Promise.resolve(decoder.workerPool || (numWorkers as IDracoCompressionOptions).workerPool!);
         } else {
             // to avoid making big changes to the decider, if wasmBinary is provided use it in the wasmBinaryPromise
-            const wasmBinaryProvided = typeof numWorkers === "object" && numWorkers.wasmBinary;
+            const wasmBinaryProvided = decoder.wasmBinary || (typeof numWorkers === "object" && numWorkers.wasmBinary);
 
             // code maintained here for back-compat with no changes
-            const decoder = DracoCompression.Configuration.decoder;
 
             const decoderInfo: { url: string | undefined; wasmBinaryPromise: Promise<ArrayBuffer | undefined> } =
                 decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object"
@@ -203,12 +216,16 @@ export class DracoCompression implements IDisposable {
                 });
             } else {
                 this._decoderModulePromise = decoderInfo.wasmBinaryPromise.then(async (decoderWasmBinary) => {
-                    if (!decoderInfo.url) {
-                        throw new Error("Draco decoder module is not available");
-                    }
+                    if (typeof DracoDecoderModule === "undefined") {
+                        if (!decoder.jsModule) {
+                            if (!decoderInfo.url) {
+                                throw new Error("Draco decoder module is not available");
+                            }
 
-                    await Tools.LoadBabylonScriptAsync(decoderInfo.url);
-                    return await createDecoderAsync(decoderWasmBinary as ArrayBuffer);
+                            await Tools.LoadBabylonScriptAsync(decoderInfo.url);
+                        }
+                    }
+                    return await createDecoderAsync(decoderWasmBinary as ArrayBuffer, decoder.jsModule);
                 });
             }
         }


### PR DESCRIPTION
After these changes it will be possible to use Draco in Node environment using the following code:

```javascript
const Draco = require("./draco_decoder_gltf.js");
const wasm = fs.readFileSync("./draco_decoder_gltf.wasm");

BABYLON.DracoCompression.Configuration.decoder.wasmBinary = wasm;
BABYLON.DracoCompression.Configuration.decoder.jsModule = Draco;
```

Dependencies are not included in the UMD version, and node doesn't fully support ESM, so it will still be required to download the resources once from our CDN and keep them locally on the project directory. A different approach could be to install @babylonjs/core and just require the module and wasm from the assets directory.

This PR also makes it possible to easily override the worker pool configuration option, to allow a more streamlined way of using the decompressor. Setting the static workerPool will avoid creating your own instance of the DracoCompression class:

```javascript
// index.js

import wasm from "@babylonjs/dependencies/draco/draco_decoder_gltf.wasm?arraybuffer"; // also works from "draco3dgltf" package
import { AutoReleaseWorkerPool } from "@babylonjs/core/Misc/workerPool.js";
import { DracoCompression } from "@babylonjs/core/Meshes/Compression/dracoCompression.js";
import { initializeWebWorker } from "@babylonjs/core/Meshes/Compression/dracoCompressionWorker.js";
import { Tools } from "@babylonjs/core/Misc/tools.js";
import { VertexBuffer } from "@babylonjs/core/Meshes/buffer.js";

const workerPool = new AutoReleaseWorkerPool(4, () => {
  const worker = new Worker(new URL("./worker.js", import.meta.url), {
    type: "module",
  });
  return initializeWebWorker(worker, wasm);
});

DracoCompression.Configuration.decoder.workerPool = workerPool;

// worker.js
import { workerFunction } from "@babylonjs/core/Meshes/Compression/dracoCompressionWorker.js";
import "@babylonjs/dependencies/draco/draco_decoder_gltf.js";

workerFunction();
```