### PR TITLE
Add interpolation option for varying in WGSL

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -111,11 +111,13 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
     }
 
     public varyingProcessor(varying: string, isFragment: boolean, preProcessors: { [key: string]: string }) {
-        const varyingRegex = /\s*varying\s+(?:(?:highp)?|(?:lowp)?)\s*(\S+)\s*:\s*(.+)\s*;/gm;
+        const varyingRegex = /\s*(flat|linear|perspective)?\s*(center|centroid|sample)?\s*varying\s+(?:(?:highp)?|(?:lowp)?)\s*(\S+)\s*:\s*(.+)\s*;/gm;
         const match = varyingRegex.exec(varying);
         if (match !== null) {
-            const varyingType = match[2];
-            const name = match[1];
+            const interpolationType = match[1] ?? "perspective";
+            const interpolationSampling = match[2] ?? "center";
+            const varyingType = match[4];
+            const name = match[3];
             let location: number;
             if (isFragment) {
                 location = this._webgpuProcessingContext.availableVaryings[name];
@@ -125,7 +127,7 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
             } else {
                 location = this._webgpuProcessingContext.getVaryingNextLocation(varyingType, this._getArraySize(name, varyingType, preProcessors)[2]);
                 this._webgpuProcessingContext.availableVaryings[name] = location;
-                this._varyingsWGSL.push(`  @location(${location}) ${name} : ${varyingType},`);
+                this._varyingsWGSL.push(`  @location(${location}) @interpolate(${interpolationType}, ${interpolationSampling}) ${name} : ${varyingType},`);
                 this._varyingNamesWGSL.push(name);
             }
 


### PR DESCRIPTION
In the current version, when preprocessing a WGSL shader the interpolation options are ignored making it impossible to use non `f32` based types which require `@interpolate(flat)`. With the proposed changes both interpolation type and sampling can be specified in a similar fashion as in GLSL shaders.

Reference: https://www.w3.org/TR/WGSL/#interpolation