### PR TITLE
fix: add `actualBoundingBoxAscent` and `actualBoundingBoxDescent` props to `ITextMetrics`

### DIFF
--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -116,6 +116,16 @@ export interface ITextMetrics {
      * property to the right side of the bounding rectangle of the given text
      */
     readonly actualBoundingBoxRight: number;
+    /**
+     * distance (in pixels) from the horizontal line indicated by the CanvasRenderingContext2D.textBaseline
+     * property to the top side of the bounding rectangle of the given text
+     */
+    readonly actualBoundingBoxAscent: number;
+    /**
+     * distance (in pixels) from the horizontal line indicated by the CanvasRenderingContext2D.textBaseline
+     * property to the bottom side of the bounding rectangle of the given text
+     */
+    readonly actualBoundingBoxDescent: number;
 }
 
 /**


### PR DESCRIPTION
Hi,
these mentioned properties were discussed in the following forum thread. The thread was marked as resolved with info the props will be added, but it looks like it has never happened. 


https://forum.babylonjs.com/t/upgrading-to-the-latest-babylon-5-2-0/29377/1