### PR TITLE
allow simple casting to IComputeShaderPath

### DIFF
--- a/packages/dev/core/src/Compute/computeEffect.ts
+++ b/packages/dev/core/src/Compute/computeEffect.ts
@@ -17,23 +17,21 @@ import type { Engine } from "../Engines/engine";
  *  * object: `{ compute: "custom" }`, used with `Effect.ShadersStore["customVertexShader"]` and `Effect.ShadersStore["customFragmentShader"]`
  *  * string: `"./COMMON_NAME"`, used with external files COMMON_NAME.vertex.fx and COMMON_NAME.fragment.fx in index.html folder.
  */
-export type IComputeShaderPath =
-    | {
-          /**
-           * Directly pass the shader code
-           */
-          computeSource?: string;
-          /**
-           * Used with Effect.ShadersStore. If the `vertex` is set to `"custom`, then
-           * Babylon.js will read from Effect.ShadersStore["customVertexShader"]
-           */
-          compute?: string;
-          /**
-           * Used with shader code in script tags
-           */
-          computeElement?: string;
-      }
-    | string;
+export type IComputeShaderPath = {
+    /**
+     * Directly pass the shader code
+     */
+    computeSource?: string;
+    /**
+     * Used with Effect.ShadersStore. If the `vertex` is set to `"custom`, then
+     * Babylon.js will read from Effect.ShadersStore["customVertexShader"]
+     */
+    compute?: string;
+    /**
+     * Used with shader code in script tags
+     */
+    computeElement?: string;
+};
 
 /**
  * Options to be used when creating a compute effect.
@@ -74,7 +72,7 @@ export class ComputeEffect {
     /**
      * Name of the effect.
      */
-    public name: IComputeShaderPath;
+    public name: IComputeShaderPath | string;
     /**
      * String container all the define statements that should be set on the shader.
      */
@@ -135,7 +133,7 @@ export class ComputeEffect {
      * @param engine The engine the effect is created for
      * @param key Effect Key identifying uniquely compiled shader variants
      */
-    constructor(baseName: IComputeShaderPath, options: IComputeEffectCreationOptions, engine: Engine, key = "") {
+    constructor(baseName: IComputeShaderPath | string, options: IComputeEffectCreationOptions, engine: Engine, key = "") {
         this.name = baseName;
         this._key = key;
 
@@ -151,7 +149,7 @@ export class ComputeEffect {
         this._shaderRepository = ShaderStore.GetShadersRepository(this._shaderLanguage);
         this._includeShaderStore = ShaderStore.GetIncludesShadersStore(this._shaderLanguage);
 
-        let computeSource: IComputeShaderPath | HTMLElement;
+        let computeSource: IComputeShaderPath | HTMLElement | string;
 
         const hostDocument = IsWindowObjectExist() ? this._engine.getHostDocument() : null;
 

--- a/packages/dev/core/src/Compute/computeShader.ts
+++ b/packages/dev/core/src/Compute/computeShader.ts
@@ -55,7 +55,7 @@ type ComputeBindingListInternal = { [key: string]: { type: ComputeBindingType; o
  */
 export class ComputeShader {
     private _engine: ThinEngine;
-    private _shaderPath: IComputeShaderPath;
+    private _shaderPath: IComputeShaderPath | string;
     private _options: IComputeShaderOptions;
     private _effect: ComputeEffect;
     private _cachedDefines: string;
@@ -123,7 +123,7 @@ export class ComputeShader {
      *  * string: try first to find the code in ShaderStore.ShadersStoreWGSL[shaderPath + "ComputeShader"]. If not, assumes it is a file with name shaderPath.compute.fx in index.html folder.
      * @param options Define the options used to create the shader
      */
-    constructor(name: string, engine: ThinEngine, shaderPath: IComputeShaderPath, options: Partial<IComputeShaderOptions> = {}) {
+    constructor(name: string, engine: ThinEngine, shaderPath: IComputeShaderPath | string, options: Partial<IComputeShaderOptions> = {}) {
         this.name = name;
         this._engine = engine;
         this.uniqueId = UniqueIdGenerator.UniqueId;

--- a/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
@@ -42,12 +42,14 @@ declare module "../../Engines/thinEngine" {
          * @returns The new compute effect
          */
         createComputeEffect(
-            baseName: IComputeShaderPath & {
-                /**
-                 * @internal
-                 */
-                computeToken?: string;
-            },
+            baseName:
+                | string
+                | (IComputeShaderPath & {
+                      /**
+                       * @internal
+                       */
+                      computeToken?: string;
+                  }),
             options: IComputeEffectCreationOptions
         ): ComputeEffect;
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
@@ -24,7 +24,7 @@ WebGPUEngine.prototype.createComputeContext = function (): IComputeContext | und
     return new WebGPUComputeContext(this._device, this._cacheSampler);
 };
 
-WebGPUEngine.prototype.createComputeEffect = function (baseName: IComputeShaderPath & { computeToken?: string }, options: IComputeEffectCreationOptions): ComputeEffect {
+WebGPUEngine.prototype.createComputeEffect = function (baseName: string | (IComputeShaderPath & { computeToken?: string }), options: IComputeEffectCreationOptions): ComputeEffect {
     const compute = typeof baseName === "string" ? baseName : baseName.computeToken || baseName.computeSource || baseName.computeElement || baseName.compute;
 
     const name = compute + "@" + options.defines;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -2924,7 +2924,7 @@ export class ThinEngine {
      * @returns the new Effect
      */
     public createEffect(
-        baseName: IShaderPath & { vertexToken?: string; fragmentToken?: string },
+        baseName: string | (IShaderPath & { vertexToken?: string; fragmentToken?: string }),
         attributesNamesOrOptions: string[] | IEffectCreationOptions,
         uniformsNamesOrEngine: string[] | ThinEngine,
         samplers?: string[],

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -1766,7 +1766,7 @@ export class WebGPUEngine extends Engine {
      * @returns the new Effect
      */
     public createEffect(
-        baseName: IShaderPath & { vertexToken?: string; fragmentToken?: string },
+        baseName: string | (IShaderPath & { vertexToken?: string; fragmentToken?: string }),
         attributesNamesOrOptions: string[] | IEffectCreationOptions,
         uniformsNamesOrEngine: string[] | Engine,
         samplers?: string[],

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -28,36 +28,34 @@ import type { PostProcess } from "../PostProcesses/postProcess";
  *  * object: `{ vertex: "custom", fragment: "custom" }`, used with `Effect.ShadersStore["customVertexShader"]` and `Effect.ShadersStore["customFragmentShader"]`
  *  * string: `"./COMMON_NAME"`, used with external files COMMON_NAME.vertex.fx and COMMON_NAME.fragment.fx in index.html folder.
  */
-export type IShaderPath =
-    | {
-          /**
-           * Directly pass the shader code
-           */
-          vertexSource?: string;
-          /**
-           * Directly pass the shader code
-           */
-          fragmentSource?: string;
-          /**
-           * Used with Effect.ShadersStore. If the `vertex` is set to `"custom`, then
-           * Babylon.js will read from Effect.ShadersStore["customVertexShader"]
-           */
-          vertex?: string;
-          /**
-           * Used with Effect.ShadersStore. If the `fragment` is set to `"custom`, then
-           * Babylon.js will read from Effect.ShadersStore["customFragmentShader"]
-           */
-          fragment?: string;
-          /**
-           * Used with shader code in script tags
-           */
-          vertexElement?: string;
-          /**
-           * Used with shader code in script tags
-           */
-          fragmentElement?: string;
-      }
-    | string;
+export type IShaderPath = {
+    /**
+     * Directly pass the shader code
+     */
+    vertexSource?: string;
+    /**
+     * Directly pass the shader code
+     */
+    fragmentSource?: string;
+    /**
+     * Used with Effect.ShadersStore. If the `vertex` is set to `"custom`, then
+     * Babylon.js will read from Effect.ShadersStore["customVertexShader"]
+     */
+    vertex?: string;
+    /**
+     * Used with Effect.ShadersStore. If the `fragment` is set to `"custom`, then
+     * Babylon.js will read from Effect.ShadersStore["customFragmentShader"]
+     */
+    fragment?: string;
+    /**
+     * Used with shader code in script tags
+     */
+    vertexElement?: string;
+    /**
+     * Used with shader code in script tags
+     */
+    fragmentElement?: string;
+};
 
 /**
  * Options to be used when creating an effect.
@@ -145,7 +143,7 @@ export class Effect implements IDisposable {
     /**
      * Name of the effect.
      */
-    public name: IShaderPath;
+    public name: IShaderPath | string;
     /**
      * String container all the define statements that should be set on the shader.
      */
@@ -275,7 +273,7 @@ export class Effect implements IDisposable {
      * @param shaderLanguage the language the shader is written in (default: GLSL)
      */
     constructor(
-        baseName: IShaderPath,
+        baseName: IShaderPath | string,
         attributesNamesOrOptions: string[] | IEffectCreationOptions,
         uniformsNamesOrEngine: string[] | ThinEngine,
         samplers: Nullable<string[]> = null,

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -108,7 +108,7 @@ export interface IShaderMaterialOptions {
  * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/shaders/shaderMaterial
  */
 export class ShaderMaterial extends PushMaterial {
-    private _shaderPath: IShaderPath;
+    private _shaderPath: IShaderPath | string;
     private _options: IShaderMaterialOptions;
     private _textures: { [name: string]: BaseTexture } = {};
     private _textureArrays: { [name: string]: BaseTexture[] } = {};
@@ -162,7 +162,7 @@ export class ShaderMaterial extends PushMaterial {
      * @param options Define the options used to create the shader
      * @param storeEffectOnSubMeshes true to store effect on submeshes, false to store the effect directly in the material class.
      */
-    constructor(name: string, scene: Scene, shaderPath: IShaderPath, options: Partial<IShaderMaterialOptions> = {}, storeEffectOnSubMeshes = true) {
+    constructor(name: string, scene: Scene, shaderPath: IShaderPath | string, options: Partial<IShaderMaterialOptions> = {}, storeEffectOnSubMeshes = true) {
         super(name, scene, storeEffectOnSubMeshes);
         this._shaderPath = shaderPath;
 
@@ -186,7 +186,7 @@ export class ShaderMaterial extends PushMaterial {
      * Gets the shader path used to define the shader code
      * It can be modified to trigger a new compilation
      */
-    public get shaderPath(): IShaderPath {
+    public get shaderPath() {
         return this._shaderPath;
     }
 
@@ -194,7 +194,7 @@ export class ShaderMaterial extends PushMaterial {
      * Sets the shader path used to define the shader code
      * It can be modified to trigger a new compilation
      */
-    public set shaderPath(shaderPath: IShaderPath) {
+    public set shaderPath(shaderPath: IShaderPath | string) {
         this._shaderPath = shaderPath;
     }
 


### PR DESCRIPTION
Without this change, casting to IComputeShaderPath would not allow to use the properties from the object. so if we do this:

```
(computeShader.shaderPath as IComputeShaderPath).computeSource
```

it will still fail, saying it doesn't exist on string. I avoid using generics here, this is just a simple solution to a simple problem :-)