### PR TITLE
Fix obj loader tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -414,6 +414,32 @@
             */
             "type": "node",
             "request": "launch",
+            "name": "Run single validation test - WebGL1 (Dev)",
+            "runtimeArgs": [
+                "--inspect-brk",
+                "${workspaceRoot}/node_modules/jest/bin/jest.js",
+                "--runInBand",
+                "--selectProjects",
+                "visualization",
+                "-i",
+                "webgl1",
+                "-t",
+                "${input:testName}"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "port": 9229,
+            // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
+            // "envFile": "${workspaceRoot}/.env",
+            "preLaunchTask": "CDN Serve and watch (Dev)"
+        },
+        {
+            /*
+            Launch tests
+            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            */
+            "type": "node",
+            "request": "launch",
             "name": "Run validation tests - WebGPU (Dev)",
             "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "--selectProjects", "visualization", "-i", "webgpu"],
             "console": "integratedTerminal",

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1097,7 +1097,7 @@
         },
         {
             "title": "OBJ loader test (legacy)",
-            "playgroundId": "#SYQW69#1212",
+            "playgroundId": "#SYQW69#1213",
             "referenceImage": "objTestLoaderLegacy.png"
         },
         {


### PR DESCRIPTION
The PG test had a `BABYLON.OBJFileLoader.USE_LEGACY_BEHAVIOR = true` which was bleeding into other PG tests.