### PR TITLE
Optimizing performance of GreasedLineMesh._setPoints

### DIFF
--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -134,7 +134,8 @@ export abstract class GreasedLineBaseMesh extends Mesh {
     protected _vertexPositions: FloatArray;
 
     protected _indices: number[] | Uint16Array | Uint32Array;
-    protected _uvs: number[] | Float32Array;
+    protected _uvs: FloatArray;
+
     protected _points: number[][];
     protected _offsets: number[];
     protected _colorPointers: number[];

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -8,6 +8,7 @@ import { VertexData } from "../mesh.vertexData";
 import { DeepCopier } from "../../Misc/deepCopier";
 import { GreasedLineSimpleMaterial } from "../../Materials/GreasedLine/greasedLineSimpleMaterial";
 import type { Engine } from "../../Engines/engine";
+import type { FloatArray, IndicesArray } from "../../types";
 
 /**
  * In POINTS_MODE_POINTS every array of points will become the center (backbone) of the ribbon. The ribbon will be expanded by `width / 2` to `+direction` and `-direction` as well.
@@ -132,11 +133,8 @@ export interface GreasedLineMeshOptions {
  */
 export abstract class GreasedLineBaseMesh extends Mesh {
     protected _vertexPositions: FloatArray;
-
     protected _indices: IndicesArray;
-
     protected _uvs: FloatArray;
-
     protected _points: number[][];
     protected _offsets: number[];
     protected _colorPointers: number[];

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -131,7 +131,8 @@ export interface GreasedLineMeshOptions {
  * GreasedLineBaseMesh
  */
 export abstract class GreasedLineBaseMesh extends Mesh {
-    protected _vertexPositions: number[] | Float32Array;
+    protected _vertexPositions: FloatArray;
+
     protected _indices: number[] | Uint16Array | Uint32Array;
     protected _uvs: number[] | Float32Array;
     protected _points: number[][];

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -133,7 +133,8 @@ export interface GreasedLineMeshOptions {
 export abstract class GreasedLineBaseMesh extends Mesh {
     protected _vertexPositions: FloatArray;
 
-    protected _indices: number[] | Uint16Array | Uint32Array;
+    protected _indices: IndicesArray;
+
     protected _uvs: FloatArray;
 
     protected _points: number[][];

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -131,9 +131,9 @@ export interface GreasedLineMeshOptions {
  * GreasedLineBaseMesh
  */
 export abstract class GreasedLineBaseMesh extends Mesh {
-    protected _vertexPositions: number[];
-    protected _indices: number[];
-    protected _uvs: number[];
+    protected _vertexPositions: number[] | Float32Array;
+    protected _indices: number[] | Uint16Array | Uint32Array;
+    protected _uvs: number[] | Float32Array;
     protected _points: number[][];
     protected _offsets: number[];
     protected _colorPointers: number[];
@@ -342,7 +342,7 @@ export abstract class GreasedLineBaseMesh extends Mesh {
             colorPointers: this._colorPointers,
             lazy: this._lazy,
             updatable: this._updatable,
-            uvs: this._uvs,
+            uvs: this._uvs instanceof Float32Array ? Array.from(this._uvs) : this._uvs,
             widths: this._widths,
             ribbonOptions: this._options.ribbonOptions,
         };

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -22,8 +22,8 @@ Mesh._GreasedLineMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
  * Use the GreasedLineBuilder.CreateGreasedLine function to create an instance of this class.
  */
 export class GreasedLineMesh extends GreasedLineBaseMesh {
-    private _previousAndSide: number[];
-    private _nextAndCounters: number[];
+    private _previousAndSide: number[] | Float32Array;
+    private _nextAndCounters: number[] | Float32Array;
 
     private static _V_START = new Vector3();
     private static _V_END = new Vector3();
@@ -90,57 +90,112 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
         this._initGreasedLine();
 
         let indiceOffset = 0;
+        let vertexPositionsLen = 0,
+            indicesLength = 0,
+            uvLength = 0,
+            previousAndSideLength = 0;
+        points.forEach((p) => {
+            vertexPositionsLen += p.length * 2;
+            indicesLength += (p.length - 1) * 2;
+            uvLength += (p.length * 4) / 3;
+            previousAndSideLength += (p.length * 8) / 3;
+        });
+        const vertexPositionsArr = new Float32Array(vertexPositionsLen);
+        const indicesArr = indicesLength > 65535 ? new Uint32Array(indicesLength) : new Uint16Array(indicesLength);
+        const uvArr = new Float32Array(uvLength);
+        const previousAndSide = new Float32Array(previousAndSideLength);
+        // it's the same length here
+        const nextAndCounters = new Float32Array(previousAndSideLength);
+        let vertexPositionsOffset = 0,
+            indicesOffset = 0,
+            uvOffset = 0,
+            previousAndSideOffset = 0,
+            nextAndCountersOffset = 0;
 
         points.forEach((p) => {
-            const counters: number[] = [];
-            const positions: number[] = [];
-            const indices: number[] = [];
-
             const lengthArray = GreasedLineTools.GetLineLengthArray(p);
             const totalLength = lengthArray[lengthArray.length - 1];
             for (let j = 0, jj = 0; jj < p.length; j++, jj += 3) {
-                const partialLineLength = lengthArray[j];
-                const c = partialLineLength / totalLength;
-
-                positions.push(p[jj], p[jj + 1], p[jj + 2]);
-                positions.push(p[jj], p[jj + 1], p[jj + 2]);
-                counters.push(c);
-                counters.push(c);
+                const baseOffset = vertexPositionsOffset + jj * 2;
+                vertexPositionsArr[baseOffset + 0] = p[jj + 0];
+                vertexPositionsArr[baseOffset + 1] = p[jj + 1];
+                vertexPositionsArr[baseOffset + 2] = p[jj + 2];
+                vertexPositionsArr[baseOffset + 3] = p[jj + 0];
+                vertexPositionsArr[baseOffset + 4] = p[jj + 1];
+                vertexPositionsArr[baseOffset + 5] = p[jj + 2];
 
                 if (jj < p.length - 3) {
                     const n = j * 2 + indiceOffset;
-                    indices.push(n, n + 1, n + 2);
-                    indices.push(n + 2, n + 1, n + 3);
+                    const baseIndicesOffset = indicesOffset + jj * 2;
+                    indicesArr[baseIndicesOffset + 0] = n;
+                    indicesArr[baseIndicesOffset + 1] = n + 1;
+                    indicesArr[baseIndicesOffset + 2] = n + 2;
+                    indicesArr[baseIndicesOffset + 3] = n + 2;
+                    indicesArr[baseIndicesOffset + 4] = n + 1;
+                    indicesArr[baseIndicesOffset + 5] = n + 3;
                 }
             }
 
             indiceOffset += (p.length / 3) * 2;
+            const currVertexPositionsOffsetLength = p.length * 2;
+            const positions = vertexPositionsArr.subarray(vertexPositionsOffset, currVertexPositionsOffsetLength);
+            vertexPositionsOffset += currVertexPositionsOffsetLength;
+            indicesOffset += (p.length - 1) * 2;
 
-            const previous: number[] = [];
-            const next: number[] = [];
-            const side: number[] = [];
-            let uvs: number[] = [];
-
-            this._preprocess(positions, previous, next, side, uvs);
-
-            for (const vp of positions) {
-                this._vertexPositions.push(vp);
+            const previous = new Float32Array(positions.length);
+            const next = new Float32Array(positions.length);
+            const l = positions.length / 6;
+            let v;
+            if (GreasedLineMesh._CompareV3(0, l - 1, positions)) {
+                v = positions.subarray((l - 2) * 6, (l - 1) * 6);
+            } else {
+                v = positions.subarray(0, 6);
             }
-
-            for (const i of indices) {
-                this._indices.push(i);
+            previous.set(v);
+            previous.set(positions.subarray(6), 6);
+            next.set(positions.subarray(6));
+            if (GreasedLineMesh._CompareV3(l - 1, 0, positions)) {
+                v = positions.subarray(6, 12);
+            } else {
+                v = positions.subarray((l - 1) * 6, l * 6);
             }
+            next.set(v, next.length - 6);
 
-            for (let i = 0; i < side.length; i++) {
-                this._previousAndSide.push(previous[i * 3], previous[i * 3 + 1], previous[i * 3 + 2], side[i]);
-                this._nextAndCounters.push(next[i * 3], next[i * 3 + 1], next[i * 3 + 2], counters[i]);
+            for (let i = 0, sidesLength = positions.length / 3; i < sidesLength; i++) {
+                previousAndSide[previousAndSideOffset++] = previous[i * 3];
+                previousAndSide[previousAndSideOffset++] = previous[i * 3 + 1];
+                previousAndSide[previousAndSideOffset++] = previous[i * 3 + 2];
+                // side[i] = i % 2 ? -1 : 1;
+                // side[i] = 1 - ((i & 1) << 1);
+                previousAndSide[previousAndSideOffset++] = 1 - ((i & 1) << 1);
+                nextAndCounters[nextAndCountersOffset++] = next[i * 3];
+                nextAndCounters[nextAndCountersOffset++] = next[i * 3 + 1];
+                nextAndCounters[nextAndCountersOffset++] = next[i * 3 + 2];
+                // counters[i] = lengthArray[i >> 1] / totalLength;
+                nextAndCounters[nextAndCountersOffset++] = lengthArray[i >> 1] / totalLength;
             }
-
-            uvs = this._options.uvs ?? uvs;
-            for (const uv of uvs) {
-                this._uvs.push(uv);
+            if (this._options.uvs) {
+                const uvs = this._options.uvs;
+                for (const uv of uvs) {
+                    uvArr[uvOffset++] = uv;
+                }
+            } else {
+                for (let j = 0; j < l; j++) {
+                    // uvs
+                    const uvOffsetBase = uvOffset + j * 4;
+                    uvArr[uvOffsetBase + 0] = j / (l - 1);
+                    uvArr[uvOffsetBase + 1] = 0;
+                    uvArr[uvOffsetBase + 2] = j / (l - 1);
+                    uvArr[uvOffsetBase + 3] = 1;
+                }
+                uvOffset += l * 4;
             }
         });
+        this._vertexPositions = vertexPositionsArr;
+        this._indices = indicesArr;
+        this._uvs = uvArr;
+        this._previousAndSide = previousAndSide;
+        this._nextAndCounters = nextAndCounters;
 
         if (!this._lazy) {
             if (!this._options.colorPointers) {
@@ -306,66 +361,10 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
         return this.getBoundingInfo().boundingSphere;
     }
 
-    private static _CompareV3(positionIdx1: number, positionIdx2: number, positions: number[]) {
+    private static _CompareV3(positionIdx1: number, positionIdx2: number, positions: number[] | Float32Array) {
         const arrayIdx1 = positionIdx1 * 6;
         const arrayIdx2 = positionIdx2 * 6;
         return positions[arrayIdx1] === positions[arrayIdx2] && positions[arrayIdx1 + 1] === positions[arrayIdx2 + 1] && positions[arrayIdx1 + 2] === positions[arrayIdx2 + 2];
-    }
-
-    private static _CopyV3(positionIdx: number, positions: number[]) {
-        const arrayIdx = positionIdx * 6;
-        return [positions[arrayIdx], positions[arrayIdx + 1], positions[arrayIdx + 2]];
-    }
-
-    private _preprocess(positions: number[], previous: number[], next: number[], side: number[], uvs: number[]) {
-        const l = positions.length / 6;
-
-        let v: number[] = [];
-
-        if (GreasedLineMesh._CompareV3(0, l - 1, positions)) {
-            v = GreasedLineMesh._CopyV3(l - 2, positions);
-        } else {
-            v = GreasedLineMesh._CopyV3(0, positions);
-        }
-        previous.push(v[0], v[1], v[2]);
-        previous.push(v[0], v[1], v[2]);
-
-        for (let j = 0; j < l; j++) {
-            side.push(1);
-            side.push(-1);
-
-            // uvs
-            if (!this._options.uvs) {
-                uvs.push(j / (l - 1), 0);
-                uvs.push(j / (l - 1), 1);
-            }
-
-            if (j < l - 1) {
-                v = GreasedLineMesh._CopyV3(j, positions);
-                previous.push(v[0], v[1], v[2]);
-                previous.push(v[0], v[1], v[2]);
-            }
-            if (j > 0) {
-                v = GreasedLineMesh._CopyV3(j, positions);
-                next.push(v[0], v[1], v[2]);
-                next.push(v[0], v[1], v[2]);
-            }
-        }
-
-        if (GreasedLineMesh._CompareV3(l - 1, 0, positions)) {
-            v = GreasedLineMesh._CopyV3(1, positions);
-        } else {
-            v = GreasedLineMesh._CopyV3(l - 1, positions);
-        }
-        next.push(v[0], v[1], v[2]);
-        next.push(v[0], v[1], v[2]);
-
-        return {
-            previous,
-            next,
-            uvs,
-            side,
-        };
     }
 
     protected _createVertexBuffers() {

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -96,10 +96,10 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
             const positions: number[] = [];
             const indices: number[] = [];
 
-            const totalLength = GreasedLineTools.GetLineLength(p);
+            const lengthArray = GreasedLineTools.GetLineLengthArray(p);
+            const totalLength = lengthArray[lengthArray.length - 1];
             for (let j = 0, jj = 0; jj < p.length; j++, jj += 3) {
-                const partialLine = p.slice(0, jj + 3);
-                const partialLineLength = GreasedLineTools.GetLineLength(partialLine);
+                const partialLineLength = lengthArray[j];
                 const c = partialLineLength / totalLength;
 
                 positions.push(p[jj], p[jj + 1], p[jj + 2]);

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -12,6 +12,7 @@ import { GreasedLineTools } from "../../Misc/greasedLineTools";
 import type { GreasedLineMeshOptions } from "./greasedLineBaseMesh";
 import { GreasedLineBaseMesh } from "./greasedLineBaseMesh";
 import type { VertexData } from "../mesh.vertexData";
+import type { FloatArray } from "../../types";
 
 Mesh._GreasedLineMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
     return GreasedLineMesh.Parse(parsedMesh, scene);
@@ -22,8 +23,8 @@ Mesh._GreasedLineMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
  * Use the GreasedLineBuilder.CreateGreasedLine function to create an instance of this class.
  */
 export class GreasedLineMesh extends GreasedLineBaseMesh {
-    private _previousAndSide: number[] | Float32Array;
-    private _nextAndCounters: number[] | Float32Array;
+    private _previousAndSide: FloatArray;
+    private _nextAndCounters:FloatArray;
 
     private static _V_START = new Vector3();
     private static _V_END = new Vector3();

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -24,7 +24,7 @@ Mesh._GreasedLineMeshParser = (parsedMesh: any, scene: Scene): Mesh => {
  */
 export class GreasedLineMesh extends GreasedLineBaseMesh {
     private _previousAndSide: FloatArray;
-    private _nextAndCounters:FloatArray;
+    private _nextAndCounters: FloatArray;
 
     private static _V_START = new Vector3();
     private static _V_END = new Vector3();

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -96,7 +96,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
             previousAndSideLength = 0;
         points.forEach((p) => {
             vertexPositionsLen += p.length * 2;
-            indicesLength += (p.length - 1) * 2;
+            indicesLength += (p.length - 3) * 2;
             uvLength += (p.length * 4) / 3;
             previousAndSideLength += (p.length * 8) / 3;
         });
@@ -138,7 +138,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
 
             indiceOffset += (p.length / 3) * 2;
             const currVertexPositionsOffsetLength = p.length * 2;
-            const positions = vertexPositionsArr.subarray(vertexPositionsOffset, currVertexPositionsOffsetLength);
+            const positions = vertexPositionsArr.subarray(vertexPositionsOffset, vertexPositionsOffset + currVertexPositionsOffsetLength);
             vertexPositionsOffset += currVertexPositionsOffsetLength;
             indicesOffset += (p.length - 1) * 2;
 
@@ -152,7 +152,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
                 v = positions.subarray(0, 6);
             }
             previous.set(v);
-            previous.set(positions.subarray(6), 6);
+            previous.set(positions.subarray(0, positions.length - 6), 6);
             next.set(positions.subarray(6));
             if (GreasedLineMesh._CompareV3(l - 1, 0, positions)) {
                 v = positions.subarray(6, 12);

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -102,7 +102,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
             previousAndSideLength += (p.length * 8) / 3;
         });
         const vertexPositionsArr = new Float32Array(vertexPositionsLen);
-        const indicesArr = indicesLength > 65535 ? new Uint32Array(indicesLength) : new Uint16Array(indicesLength);
+        const indicesArr = vertexPositionsLen > 65535 ? new Uint32Array(indicesLength) : new Uint16Array(indicesLength);
         const uvArr = new Float32Array(uvLength);
         const previousAndSide = new Float32Array(previousAndSideLength);
         // it's the same length here

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
@@ -300,8 +300,15 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
             throw "No 'GreasedLineMeshOptions.widths' table is specified.";
         }
 
+        const vertexPositions = Array.isArray(this._vertexPositions) ? this._vertexPositions : Array.from(this._vertexPositions);
+        this._vertexPositions = vertexPositions;
+        const uvs = Array.isArray(this._uvs) ? this._uvs : Array.from(this._uvs);
+        this._uvs = uvs;
+        const indices = Array.isArray(this._indices) ? this._indices : Array.from(this._indices);
+        this._indices = indices;
+
         for (const p of positions) {
-            this._vertexPositions.push(p);
+            vertexPositions.push(p);
         }
 
         let pathArrayCopy = pathArray;
@@ -323,7 +330,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
             for (let pi = 0; pi < pathArrayLength; pi++) {
                 const counter = previousCounters[pi] + this._vSegmentLengths[pi][i] / this._vTotalLengths[pi];
                 this._counters.push(counter);
-                this._uvs.push(counter, v);
+                uvs.push(counter, v);
 
                 previousCounters[pi] = counter;
                 v += this._uSegmentLengths[i][pi] / this._uTotalLengths[i];
@@ -350,7 +357,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
 
         if (ribbonVertexData.indices) {
             for (let i = 0; i < ribbonVertexData.indices.length; i++) {
-                this._indices.push(ribbonVertexData.indices[i] + indiceOffset);
+                indices.push(ribbonVertexData.indices[i] + indiceOffset);
             }
         }
         indiceOffset += positions.length / 3;

--- a/packages/dev/core/src/Misc/greasedLineTools.ts
+++ b/packages/dev/core/src/Misc/greasedLineTools.ts
@@ -252,6 +252,28 @@ export class GreasedLineTools {
     }
 
     /**
+     * Gets the the length from the beginning to each point of the line as array.
+     * @param data array of line points
+     * @returns length array of the line
+     */
+    public static GetLineLengthArray(data: number[]): Float32Array {
+        const out = new Float32Array(data.length / 3);
+        let length = 0;
+        for (let index = 0, pointsLength = data.length / 3 - 1; index < pointsLength; index++) {
+            let x = data[index * 3 + 0];
+            let y = data[index * 3 + 1];
+            let z = data[index * 3 + 2];
+            x -= data[index * 3 + 3];
+            y -= data[index * 3 + 4];
+            z -= data[index * 3 + 5];
+            const currentLength = Math.sqrt(x * x + y * y + z * z);
+            length += currentLength;
+            out[index + 1] = length;
+        }
+        return out;
+    }
+
+    /**
      * Divides a segment into smaller segments.
      * A segment is a part of the line between it's two points.
      * @param point1 first point of the line


### PR DESCRIPTION
See detailed context at forum post <https://forum.babylonjs.com/t/optimizing-performance-of-greasedlinemesh-setpoints/49168>.
This proposal adds a static method `GreasedLineTools.GetLineLengthArray` which does almost the same as `GreasedLineTools.GetLineLength`, but instead of computing for the whole line, it computes the length from the beginning of the line to each point, and collect results to array.
This should simplify the loop in `GreasedLineMesh._setPoints`, eliminates the need to slice array and compute length in each loop, reducing the time complexity from `O(n^2)` to `O(n)`.