### PR TITLE
PBR: Fix crash when using refraction

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -289,7 +289,7 @@ struct subSurfaceOutParams
         float thickness = vThicknessParam.y;
     #endif
 
-    #ifdef SS_REFRACTIONINTENSITY_TEXTURE
+    #if defined(SS_REFRACTION) && defined(SS_REFRACTIONINTENSITY_TEXTURE)
         #ifdef SS_USE_GLTF_TEXTURES
             refractionIntensity *= refractionIntensityMap.r;
         #else


### PR DESCRIPTION
See https://forum.babylonjs.com/t/shader-compilation-error-when-loading-gltf-model-using-assetcontainer/49249