### PR TITLE
Allow mipmaps for 3D RT's

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -140,7 +140,7 @@ ThinEngine.prototype.unBindMultiColorAttachmentFramebuffer = function (
 
     for (let i = 0; i < count; i++) {
         const texture = rtWrapper.textures![i];
-        if (texture?.generateMipMaps && !disableGenerateMipMaps && !texture.isCube) {
+        if (texture?.generateMipMaps && !disableGenerateMipMaps && !texture?.isCube && !texture?.is3D) {
             this._bindTextureDirectly(gl.TEXTURE_2D, texture, true);
             gl.generateMipmap(gl.TEXTURE_2D);
             this._bindTextureDirectly(gl.TEXTURE_2D, null);

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -2109,9 +2109,10 @@ export class ThinEngine {
      * @param texture texture to generate the mipmaps for
      */
     public generateMipmaps(texture: InternalTexture): void {
-        this._bindTextureDirectly(this._gl.TEXTURE_2D, texture, true);
-        this._gl.generateMipmap(this._gl.TEXTURE_2D);
-        this._bindTextureDirectly(this._gl.TEXTURE_2D, null);
+        const target = this._getTextureTarget(texture);
+        this._bindTextureDirectly(target, texture, true);
+        this._gl.generateMipmap(target);
+        this._bindTextureDirectly(target, null);
     }
 
     /**


### PR DESCRIPTION
This PR prevents `gl.generateMipmap(gl.TEXTURE_2D);` from being called for each layer in a 3D texture.
It also adds support for `engine.generateMipmaps` to generate mips for other texture types, including 3D textures.