### PR TITLE
Fix typo in glTF animation pointer data

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.data.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.data.ts
@@ -148,7 +148,7 @@ const materialsTree = {
                 anisotropyRotation: [new MaterialAnimationPropertyInfo(Animation.ANIMATIONTYPE_FLOAT, "anisotropy.angle", getFloat, () => 1)],
                 anisotropyTexture: {
                     extensions: {
-                        KHR_texture_transform: getTextureTransformTree("emissiveTexture"),
+                        KHR_texture_transform: getTextureTransformTree("anisotropyTexture"),
                     },
                 },
             },


### PR DESCRIPTION
See  https://forum.babylonjs.com/t/khr-animation-pointer-with-uv-transforms/49081/23