### PR TITLE
WebGPU: Add support for the predeclared alias in WGSL

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.ts
@@ -94,6 +94,7 @@ export class WebGPUClearQuad {
             }
 
             renderPass2 = this._device.createRenderBundleEncoder({
+                label: "clearQuadRenderBundle",
                 colorFormats: this._cacheRenderPipeline.colorFormats,
                 depthStencilFormat: this._depthTextureFormat,
                 sampleCount: WebGPUTextureHelper.GetSample(sampleCount),
@@ -131,6 +132,7 @@ export class WebGPUClearQuad {
             bindGroups = this._bindGroups[key] = [];
             bindGroups.push(
                 this._device.createBindGroup({
+                    label: `clearQuadBindGroup0-${key}`,
                     layout: bindGroupLayouts[0],
                     entries: [],
                 })
@@ -138,6 +140,7 @@ export class WebGPUClearQuad {
             if (!WebGPUShaderProcessingContext._SimplifiedKnownBindings) {
                 bindGroups.push(
                     this._device.createBindGroup({
+                        label: `clearQuadBindGroup1-${key}`,
                         layout: bindGroupLayouts[1],
                         entries: [],
                     })
@@ -145,6 +148,7 @@ export class WebGPUClearQuad {
             }
             bindGroups.push(
                 this._device.createBindGroup({
+                    label: `clearQuadBindGroup${WebGPUShaderProcessingContext._SimplifiedKnownBindings ? 1 : 2}-${key}`,
                     layout: bindGroupLayouts[WebGPUShaderProcessingContext._SimplifiedKnownBindings ? 1 : 2],
                     entries: [
                         {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessor.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessor.ts
@@ -38,6 +38,21 @@ export abstract class WebGPUShaderProcessor implements IShaderProcessor {
         mat2x2: 4,
         mat3x3: 12,
         mat4x4: 16,
+        mat2x2f: 4,
+        mat3x3f: 12,
+        mat4x4f: 16,
+        vec2i: 2,
+        vec3i: 3,
+        vec4i: 4,
+        vec2u: 2,
+        vec3u: 3,
+        vec4u: 4,
+        vec2f: 2,
+        vec3f: 3,
+        vec4f: 4,
+        vec2h: 1,
+        vec3h: 2,
+        vec4h: 2,
     };
 
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsWGSL.ts
@@ -466,7 +466,10 @@ export class WebGPUShaderProcessorWGSL extends WebGPUShaderProcessor {
                     name = structName;
                     binding = knownUBO.binding;
                     if (binding.groupIndex === -1) {
-                        binding = this._webgpuProcessingContext.getNextFreeUBOBinding();
+                        binding = this._webgpuProcessingContext.availableBuffers[name]?.binding;
+                        if (!binding) {
+                            binding = this._webgpuProcessingContext.getNextFreeUBOBinding();
+                        }
                     }
                 } else {
                     binding = this._webgpuProcessingContext.getNextFreeUBOBinding();


### PR DESCRIPTION
This will fix the "clear quad" issue in https://playground.babylonjs.com/#W7E7CF#12.