### PR TITLE
GreasedLineMesh: fix index offset of instanced line

### DIFF
--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -141,7 +141,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
             const currVertexPositionsOffsetLength = p.length * 2;
             const positions = vertexPositionsArr.subarray(vertexPositionsOffset, vertexPositionsOffset + currVertexPositionsOffsetLength);
             vertexPositionsOffset += currVertexPositionsOffsetLength;
-            indicesOffset += (p.length - 1) * 2;
+            indicesOffset += (p.length - 3) * 2;
 
             const previous = new Float32Array(positions.length);
             const next = new Float32Array(positions.length);


### PR DESCRIPTION
This should fix https://github.com/BabylonJS/Babylon.js/pull/14934#issuecomment-2040401440
Before this: https://playground.babylonjs.com/?snapshot=refs/pull/14934/merge#H1LRZ3#498
After this: https://playground.babylonjs.com/?snapshot=refs/pull/14934/merge#H1LRZ3#499
Thank you for reporting this @Baggins800