### PR TITLE
Fix Matrix.multiplyByFloats and Vector3.Project in WebGPU

### DIFF
--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -2911,7 +2911,11 @@ export class Vector3 implements Vector<Tuple<number, 3>>, IVector3Like {
 
         const viewportMatrix = MathTmp.Matrix[1];
 
-        Matrix.FromValuesToRef(cw / 2.0, 0, 0, 0, 0, -ch / 2.0, 0, 0, 0, 0, 0.5, 0, cx + cw / 2.0, ch / 2.0 + cy, 0.5, 1, viewportMatrix);
+        const isNDCHalfZRange = EngineStore.LastCreatedEngine?.isNDCHalfZRange;
+        const zScale = isNDCHalfZRange ? 1 : 0.5;
+        const zOffset = isNDCHalfZRange ? 0 : 0.5;
+
+        Matrix.FromValuesToRef(cw / 2.0, 0, 0, 0, 0, -ch / 2.0, 0, 0, 0, 0, zScale, 0, cx + cw / 2.0, ch / 2.0 + cy, zOffset, 1, viewportMatrix);
 
         const matrix = MathTmp.Matrix[0];
         world.multiplyToRef(transform, matrix);

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -6557,6 +6557,12 @@ export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>>, IMatrixLike {
         return result;
     }
 
+    /**
+     * This method performs component-by-component in-place multiplication, rather than true matrix multiplication.
+     * Use multiply or multiplyToRef for matrix multiplication.
+     * @param other defines the second operand
+     * @returns the current updated matrix
+     */
     public multiplyInPlace(other: DeepImmutable<this>): this {
         const m = this._m,
             otherM = other.m;
@@ -6567,10 +6573,16 @@ export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>>, IMatrixLike {
         return this;
     }
 
+    /**
+     * This method performs a component-by-component multiplication of the current matrix with the array of transmitted numbers.
+     * Use multiply or multiplyToRef for matrix multiplication.
+     * @param floats defines the array of numbers to multiply the matrix by
+     * @returns the current updated matrix
+     */
     public multiplyByFloats(...floats: Tuple<number, 16>): this {
         const m = this._m;
         for (let i = 0; i < 16; i++) {
-            m[i] = floats[i];
+            m[i] *= floats[i];
         }
         this.markAsUpdated();
         return this;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/why-matrix-multiplyinplace-is-not-bxa/49400

I also fixed the `Vector3.Project` method in WebGPU (when NDC range is 0..1 instead of -1..1).