### PR TITLE
Don't clip the grid's children in a scrollview

### DIFF
--- a/packages/dev/gui/src/2D/controls/scrollViewers/scrollViewer.ts
+++ b/packages/dev/gui/src/2D/controls/scrollViewers/scrollViewer.ts
@@ -229,6 +229,8 @@ export class ScrollViewer extends Rectangle {
         this._dragSpace.thickness = 1;
         this._grid.addControl(this._dragSpace, 1, 1);
 
+        this._grid.clipChildren = false;
+
         // Colors
         if (!this._useImageBar) {
             this.barColor = "grey";


### PR DESCRIPTION
Fixing #14968