### PR TITLE
Set the XR camera's fov

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -319,8 +319,12 @@ export class WebXRCamera extends FreeCamera {
                 currentRig._projectionMatrix.toggleProjectionMatrixHandInPlace();
             }
 
+            // fov
+            const fov = Math.atan2(1, view.projectionMatrix[5]) * 2;
+            currentRig.fov = fov;
             // first camera?
             if (i === 0) {
+                this.fov = fov;
                 this._projectionMatrix.copyFrom(currentRig._projectionMatrix);
             }
 


### PR DESCRIPTION
This is important for features requiring fov, like gaussian splatting.

Though it will probably not change on ech frame, this is computed on each frame in case the camera's projection matrix changes during the session.

Note that it is also expected that left fov === right fov, but the XR camera's parent is taking the first camera's fov (left)/