### PR TITLE
docs: fix comment for getHighestFrame

### DIFF
--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -744,8 +744,8 @@ export class Animation {
     }
 
     /**
-     * Gets the highest frame rate of the animation
-     * @returns Highest frame rate of the animation
+     * Gets the highest frame of the animation
+     * @returns Highest frame of the animation
      */
     public getHighestFrame(): number {
         let ret = 0;


### PR DESCRIPTION
I assume that the result of `getHighestFrame()` should be the frame, rather the frame **rate**.