### PR TITLE
Allow setting a static worker pool in the ktx2container  instead of passing it in the constructor

### DIFF
--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -237,6 +237,13 @@ export class KhronosTextureContainer2 {
     };
 
     /**
+     * If provided, this worker pool will be used instead of creating a new one.
+     * This is useful when loading the WASM and the js modules on your own and
+     * you want to use the ktxTextureLoader and not construct this class directly.
+     */
+    public static WorkerPool?: AutoReleaseWorkerPool;
+
+    /**
      * Default number of workers used to handle data decoding
      */
     public static DefaultNumWorkers = KhronosTextureContainer2.GetDefaultNumWorkers();
@@ -306,8 +313,9 @@ export class KhronosTextureContainer2 {
      */
     public constructor(engine: ThinEngine, numWorkersOrOptions: number | IKhronosTextureContainer2Options = KhronosTextureContainer2.DefaultNumWorkers) {
         this._engine = engine;
-        if (typeof numWorkersOrOptions === "object" && numWorkersOrOptions.workerPool) {
-            KhronosTextureContainer2._WorkerPoolPromise = Promise.resolve(numWorkersOrOptions.workerPool);
+        const workerPoolOption = (typeof numWorkersOrOptions === "object" && numWorkersOrOptions.workerPool) || KhronosTextureContainer2.WorkerPool;
+        if (workerPoolOption) {
+            KhronosTextureContainer2._WorkerPoolPromise = Promise.resolve(workerPoolOption);
         } else {
             // set the KTX2 decoder module
             if (typeof numWorkersOrOptions === "object") {


### PR DESCRIPTION
This will allow using the @babylonjs/ktx2decoder package when using ktx2 in glTF without first constructing the class.
