### PR TITLE
Fix adding child nodes to the html twin tree

### DIFF
--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
@@ -1,6 +1,6 @@
 import { getAccessibleTexture, isVisible, getDirectChildrenOf } from "./htmlTwinItem";
 import type { AccessibilityEntity, HTMLTwinItem } from "./htmlTwinItem";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useReducer, useState } from "react";
 import { SceneContext } from "./htmlTwinSceneContext";
 import { HTMLTwinAccessibilityItem } from "./htmlTwinAccessibilityItem";
 import { Container } from "gui/2D/controls/container";
@@ -40,6 +40,8 @@ export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: S
     const [isVisibleState, setIsVisibleState] = useState(isVisible(props.node));
     const sceneContext = useContext(SceneContext);
     const [description, setDescription] = useState(twinItem?.getDescription(options));
+    // From https://legacy.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+    const [, forceUpdate] = useReducer((x) => x + 1, 0);
     const children = getDirectChildrenOf(props.node);
 
     useEffect(() => {
@@ -81,12 +83,12 @@ export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: S
         if (node instanceof Container) {
             controlAddedObservable = node.onControlAddedObservable;
             controlAddedObserver = controlAddedObservable.add(() => {
-                setChildren(getDirectChildrenOf(props.node).slice(0));
+                forceUpdate();
             });
 
             controlRemovedObservable = node.onControlRemovedObservable;
             controlRemovedObserver = controlRemovedObservable.add(() => {
-                setChildren(getDirectChildrenOf(props.node).slice(0));
+                forceUpdate();
             });
         }
         return () => {
@@ -105,17 +107,18 @@ export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: S
 
     if (isVisibleState) {
         const accessibleTexture = getAccessibleTexture(props.node);
-        if (accessibleTexture) {
-            return <HTMLTwinItemAdapter node={accessibleTexture.rootContainer} scene={scene} options={options} />;
-        } else {
-            return (
-                <HTMLTwinAccessibilityItem description={description} a11yItem={twinItem}>
-                    {children.map((child: AccessibilityEntity) => (
-                        <HTMLTwinItemAdapter node={child} key={child.uniqueId} scene={scene} options={options} />
-                    ))}
-                </HTMLTwinAccessibilityItem>
-            );
-        }
+        return (
+            <>
+                {accessibleTexture && <HTMLTwinItemAdapter node={accessibleTexture.rootContainer} scene={scene} options={options} />}
+                {(!!description || children.length > 0) && (
+                    <HTMLTwinAccessibilityItem description={description} a11yItem={twinItem}>
+                        {children.map((child: AccessibilityEntity) => (
+                            <HTMLTwinItemAdapter node={child} key={child.uniqueId} scene={scene} options={options} />
+                        ))}
+                    </HTMLTwinAccessibilityItem>
+                )}
+            </>
+        );
     } else {
         return null;
     }

--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
@@ -40,7 +40,7 @@ export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: S
     const [isVisibleState, setIsVisibleState] = useState(isVisible(props.node));
     const sceneContext = useContext(SceneContext);
     const [description, setDescription] = useState(twinItem?.getDescription(options));
-    const [children, setChildren] = useState(getDirectChildrenOf(props.node));
+    const children = getDirectChildrenOf(props.node);
 
     useEffect(() => {
         setDescription(twinItem?.getDescription(options));


### PR DESCRIPTION
Related forum issue: https://forum.babylonjs.com/t/accessibility-not-working-on-nested-node/49563