### PR TITLE
Add vec4 support to procedural textures

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -2,7 +2,7 @@ import { serialize } from "../../../Misc/decorators";
 import { Observable } from "../../../Misc/observable";
 import type { Nullable } from "../../../types";
 import type { Scene } from "../../../scene";
-import type { Matrix, Vector3, Vector2 } from "../../../Maths/math.vector";
+import type { Matrix, Vector4, Vector3, Vector2 } from "../../../Maths/math.vector";
 import type { Color4, Color3 } from "../../../Maths/math.color";
 import type { Engine } from "../../../Engines/engine";
 import { VertexBuffer } from "../../../Buffers/buffer";
@@ -106,6 +106,7 @@ export class ProceduralTexture extends Texture {
     private _colors4: { [key: string]: Color4 } = {};
     private _vectors2: { [key: string]: Vector2 } = {};
     private _vectors3: { [key: string]: Vector3 } = {};
+    private _vectors4: { [key: string]: Vector4 } = {};
     private _matrices: { [key: string]: Matrix } = {};
 
     private _fallbackTextureUsed = false;
@@ -571,6 +572,19 @@ export class ProceduralTexture extends Texture {
     }
 
     /**
+     * Set a vec4 in the shader from a Vector4.
+     * @param name Define the name of the uniform as defined in the shader
+     * @param value Define the value to give to the uniform
+     * @returns the texture itself allowing "fluent" like uniform updates
+     */
+    public setVector4(name: string, value: Vector4): ProceduralTexture {
+        this._checkUniform(name);
+        this._vectors4[name] = value;
+
+        return this;
+    }
+
+    /**
      * Set a mat4 in the shader from a MAtrix.
      * @param name Define the name of the uniform as defined in the shader
      * @param value Define the value to give to the uniform
@@ -642,6 +656,11 @@ export class ProceduralTexture extends Texture {
             // Vector3
             for (const name in this._vectors3) {
                 this._drawWrapper.effect!.setVector3(name, this._vectors3[name]);
+            }
+
+            // Vector4
+            for (const name in this._vectors4) {
+                this._drawWrapper.effect!.setVector4(name, this._vectors4[name]);
             }
 
             // Matrix


### PR DESCRIPTION
I noticed that I can't set a general Vector4 as a shader uniform in ProceduralTexture.