### PR TITLE
Fix dispatch indirect call

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.computeShader.ts
@@ -141,7 +141,7 @@ WebGPUEngine.prototype._computeDispatch = function (
     }
 
     if (buffer !== undefined) {
-        computePass.dispatchWorkgroupsIndirect(buffer.underlyingResource(), <number>offset);
+        computePass.dispatchWorkgroupsIndirect(buffer.underlyingResource, <number>offset);
     } else {
         if (<number>x + <number>y + <number>z > 0) {
             computePass.dispatchWorkgroups(<number>x, <number>y, <number>z);


### PR DESCRIPTION
Currently when using my recently added #14970 , it says
```
Uncaught TypeError: buffer.underlyingResource is not a function
    at WebGPUEngine._computeDispatch
```

Apparently I screwed up and thought it was a function, but it actually was a getter. This fixes that.

It's a bit suspicious that Typescript didn't catch it though.