### PR TITLE
Draco - fix for fallback and tests update

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -211,7 +211,7 @@ export class DracoCompression implements IDisposable {
 
                     return new AutoReleaseWorkerPool(numberOfWorkers as number, () => {
                         const worker = new Worker(workerBlobUrl);
-                        return initializeWebWorker(worker, decoderWasmBinary!, decoderInfo.url);
+                        return initializeWebWorker(worker, decoderWasmBinary, decoderInfo.url);
                     });
                 });
             } else {

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -252,7 +252,7 @@ export const evaluatePrepareScene = async ({
         replace?: string;
         playgroundId?: string;
     };
-    globalConfig: { root: string; snippetUrl: any; pgRoot: string };
+    globalConfig: ReturnType<typeof getGlobalConfig>;
 }) => {
     window.seed = 1;
     window.Math.random = function () {
@@ -283,7 +283,8 @@ export const evaluatePrepareScene = async ({
                 .replace(/\/scenes\//g, globalConfig.pgRoot + "/scenes/")
                 .replace(/("|')scenes\//g, "$1" + globalConfig.pgRoot + "/scenes/")
                 .replace(/("|')\.\.\/\.\.https/g, "$1" + "https")
-                .replace("http://", "https://");
+                .replace("http://", "https://")
+                .replace(/https:\/\/cdn.babylonjs.com/g, globalConfig.baseUrl);
 
             if (sceneMetadata.replace) {
                 const split = sceneMetadata.replace.split(",");

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -519,17 +519,23 @@
         },
         {
             "title": "Draco Mesh Compression (decodeMeshAsync, numWorkers = 1)",
-            "playgroundId": "#22MFU2#4",
+            "playgroundId": "#22MFU2#77",
             "referenceImage": "draco.png"
         },
         {
             "title": "Draco Mesh Compression (decodeMeshToGeometryAsync, numWorkers = 0)",
-            "playgroundId": "#22MFU2#65",
+            "playgroundId": "#22MFU2#78",
             "referenceImage": "draco.png"
         },
         {
             "title": "Draco Mesh Compression (decodeMeshToGeometryAsync, numWorkers = 1)",
-            "playgroundId": "#22MFU2#65",
+            "playgroundId": "#22MFU2#78",
+            "replace": "numWorkers = 0, numWorkers = 1",
+            "referenceImage": "draco.png"
+        },
+        {
+            "title": "Draco Mesh Compression (fallback)",
+            "playgroundId": "#22MFU2#75",
             "replace": "numWorkers = 0, numWorkers = 1",
             "referenceImage": "draco.png"
         },


### PR DESCRIPTION
When using the fallback URL to use draco the function was still assuming that the wasm binary was populated. This fixes this issue.

The tests were using the wrapper as fallback and the fallback as the base wrapper, so the wasm file was downloaded but was never tested. This PR also fixes that and adds a test to test the fallback approach without the .wasm file being downloaded at all.