### PR TITLE
xrCompatible false per default, canvas made compatible on demand

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -298,7 +298,7 @@ export class ThinEngine extends AbstractEngine {
             }
 
             if (options.xrCompatible === undefined) {
-                options.xrCompatible = true;
+                options.xrCompatible = false;
             }
 
             // Exceptions

--- a/packages/dev/core/src/XR/webXRManagedOutputCanvas.ts
+++ b/packages/dev/core/src/XR/webXRManagedOutputCanvas.ts
@@ -73,6 +73,8 @@ export class WebXRManagedOutputCanvas implements WebXRRenderTarget {
      */
     public onXRLayerInitObservable: Observable<XRWebGLLayer> = new Observable();
 
+    private _canvasCompatiblePromise: Promise<void>;
+
     /**
      * Initializes the canvas to be added/removed upon entering/exiting xr
      * @param _xrSessionManager The XR Session manager
@@ -102,6 +104,8 @@ export class WebXRManagedOutputCanvas implements WebXRRenderTarget {
         _xrSessionManager.onXRSessionEnded.add(() => {
             this._removeCanvas();
         });
+
+        this._makeCanvasCompatibleAsync();
     }
 
     /**
@@ -110,6 +114,18 @@ export class WebXRManagedOutputCanvas implements WebXRRenderTarget {
     public dispose() {
         this._removeCanvas();
         this._setManagedOutputCanvas(null);
+    }
+
+    private _makeCanvasCompatibleAsync() {
+        this._canvasCompatiblePromise = new Promise<void>((resolve) => {
+            if (this.canvasContext && (this.canvasContext as any).makeXRCompatible) {
+                (this.canvasContext as any).makeXRCompatible().then(() => {
+                    resolve();
+                });
+            } else {
+                resolve();
+            }
+        });
     }
 
     /**
@@ -125,13 +141,7 @@ export class WebXRManagedOutputCanvas implements WebXRRenderTarget {
             return this.xrLayer;
         };
 
-        // support canvases without makeXRCompatible
-        if (!(this.canvasContext as any).makeXRCompatible) {
-            return Promise.resolve(createLayer());
-        }
-
-        return (this.canvasContext as any)
-            .makeXRCompatible()
+        return this._canvasCompatiblePromise
             .then(
                 // catch any error and continue. When using the emulator is throws this error for no apparent reason.
                 () => {},


### PR DESCRIPTION
This is a breaking change that should never influence any of our users.

We set the canvas to be xrCompatible per default. mainly because there was no downside for the devs, and they could override this. However, this thread has shed some light on a single issue that was found with it - https://forum.babylonjs.com/t/browser-back-forward-cache-is-blocked-when-using-babylon-js-due-to-webxr/49903, namely browser back-forward cache is blocked when using a WebXR-enabled canvas. 

This PR sets the flag to false per default and simplifies the mechanism in which a canvas is prepared for XR compatibility.

Please wait with merging this until the community has tested the snapshot, as I only have an emulator for the time being. Of course, it works correctly in both the windows XR emulator and the WebXR web-based emulator