### PR TITLE
Adding new debug tools to the scene Inspector : copyCommandToClipboard & window.debugNode

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -12,6 +12,7 @@ import type { ISoundOptions } from "./Interfaces/ISoundOptions";
 import { EngineStore } from "../Engines/engineStore";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import type { Observer } from "../Misc/observable";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * Defines a sound that can be played in the application.
@@ -1306,3 +1307,6 @@ export class Sound {
         }
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.Sound", Sound);

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -17,6 +17,7 @@ import type { ArcRotateCameraMouseWheelInput } from "../Cameras/Inputs/arcRotate
 import { ArcRotateCameraInputsManager } from "../Cameras/arcRotateCameraInputsManager";
 import { Epsilon } from "../Maths/math.constants";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 import type { TransformNode } from "core/Meshes/transformNode";
@@ -1360,3 +1361,6 @@ export class ArcRotateCamera extends TargetCamera {
         return "ArcRotateCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.ArcRotateCamera", ArcRotateCamera);

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -10,6 +10,7 @@ import { FlyCameraInputsManager } from "./flyCameraInputsManager";
 import type { FlyCameraMouseInput } from "../Cameras/Inputs/flyCameraMouseInput";
 import type { FlyCameraKeyboardInput } from "../Cameras/Inputs/flyCameraKeyboardInput";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 
@@ -451,3 +452,6 @@ export class FlyCamera extends TargetCamera {
         return "FlyCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FlyCamera", FlyCamera);

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -7,6 +7,8 @@ import { TmpVectors, Vector3 } from "../Maths/math.vector";
 import { Node } from "../node";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { FollowCameraInputsManager } from "./followCameraInputsManager";
+import { RegisterClass } from "../Misc/typeStore";
+
 Node.AddNodeConstructor("FollowCamera", (name, scene) => {
     return () => new FollowCamera(name, Vector3.Zero(), scene);
 });
@@ -307,3 +309,7 @@ export class ArcFollowCamera extends TargetCamera {
         return "ArcFollowCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FollowCamera", FollowCamera);
+RegisterClass("BABYLON.ArcFollowCamera", ArcFollowCamera);

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -9,6 +9,7 @@ import { FreeCameraInputsManager } from "./freeCameraInputsManager";
 import type { FreeCameraMouseInput } from "../Cameras/Inputs/freeCameraMouseInput";
 import type { FreeCameraKeyboardMoveInput } from "../Cameras/Inputs/freeCameraKeyboardMoveInput";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 
@@ -454,3 +455,6 @@ export class FreeCamera extends TargetCamera {
         return "FreeCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FreeCamera", FreeCamera);

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -7,6 +7,8 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
+import { RegisterClass } from "../Misc/typeStore";
+
 Node.AddNodeConstructor("Light_Type_1", (name, scene) => {
     return () => new DirectionalLight(name, Vector3.Zero(), scene);
 });
@@ -352,3 +354,6 @@ export class DirectionalLight extends ShadowLight {
         defines["DIRLIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.DirectionalLight", DirectionalLight);

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -7,6 +7,7 @@ import { Node } from "../node";
 import type { Effect } from "../Materials/effect";
 import { Light } from "./light";
 import type { IShadowGenerator } from "./Shadows/shadowGenerator";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_3", (name, scene) => {
     return () => new HemisphericLight(name, Vector3.Zero(), scene);
@@ -128,3 +129,6 @@ export class HemisphericLight extends Light {
         defines["HEMILIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.HemisphericLight", HemisphericLight);

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -6,6 +6,7 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_0", (name, scene) => {
     return () => new PointLight(name, Vector3.Zero(), scene);
@@ -215,3 +216,6 @@ export class PointLight extends ShadowLight {
         defines["POINTLIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.PointLight", PointLight);

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -11,6 +11,7 @@ import { ShadowLight } from "./shadowLight";
 import { Texture } from "../Materials/Textures/texture";
 import type { ProceduralTexture } from "../Materials/Textures/Procedurals/proceduralTexture";
 import type { Camera } from "../Cameras/camera";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_2", (name, scene) => {
     return () => new SpotLight(name, Vector3.Zero(), Vector3.Zero(), 0, 0, scene);
@@ -474,3 +475,6 @@ export class SpotLight extends ShadowLight {
         defines["PROJECTEDLIGHTTEXTURE" + lightIndex] = this.projectionTexture && this.projectionTexture.isReady() ? true : false;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.SpotLight", SpotLight);

--- a/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
+++ b/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
@@ -11,6 +11,7 @@ import { Mix } from "../Misc/tools.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { IImageProcessingConfigurationDefines } from "./imageProcessingConfiguration.defines";
 import { PrepareSamplersForImageProcessing, PrepareUniformsForImageProcessing } from "./imageProcessingConfiguration.functions";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This groups together the common properties used for image processing either in direct forward pass
@@ -631,3 +632,6 @@ export class ImageProcessingConfiguration {
 
 // References the dependencies.
 SerializationHelper._ImageProcessingConfigurationParser = ImageProcessingConfiguration.Parse;
+
+// Register Class Name
+RegisterClass("BABYLON.ImageProcessingConfiguration", ImageProcessingConfiguration);

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -16,6 +16,7 @@ import type { Material } from "./material";
 import type { BaseTexture } from "./Textures/baseTexture";
 import type { RenderTargetTexture } from "./Textures/renderTargetTexture";
 import { SerializationHelper } from "../Misc/decorators.serialization";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * Base class for material plugins.
@@ -305,3 +306,6 @@ export class MaterialPluginBase {
         SerializationHelper.Parse(() => this, source, scene, rootUrl);
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.MaterialPluginBase", MaterialPluginBase);

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -14,6 +14,7 @@ import type { Light } from "../Lights/light";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Tools } from "../Misc/tools";
 import type { ThinEngine } from "../Engines/thinEngine";
+import { RegisterClass } from "../Misc/typeStore";
 
 Mesh._instancedMeshFactory = (name: string, mesh: Mesh): InstancedMesh => {
     const instance = new InstancedMesh(name, mesh);
@@ -815,3 +816,6 @@ Mesh.prototype._disposeInstanceSpecificData = function () {
 
     this.instancedBuffers = {};
 };
+
+// Register Class Name
+RegisterClass("BABYLON.InstancedMesh", InstancedMesh);

--- a/packages/dev/core/src/Misc/typeStore.ts
+++ b/packages/dev/core/src/Misc/typeStore.ts
@@ -15,3 +15,15 @@ export function RegisterClass(className: string, type: Object) {
 export function GetClass(fqdn: string): any {
     return _RegisteredTypes[fqdn];
 }
+
+/**
+ * @internal
+ */
+export function GetClassName(obj: any): string {
+    for (const key in _RegisteredTypes) {
+        if (obj instanceof (_RegisteredTypes[key] as any) && !key.includes("Abstract")) {
+            return key;
+        }
+    }
+    return "Unknown";
+}

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -24,6 +24,7 @@ import type { HemisphericParticleEmitter } from "./EmitterTypes/hemisphericParti
 import type { SphereDirectedParticleEmitter, SphereParticleEmitter } from "./EmitterTypes/sphereParticleEmitter";
 import type { CylinderDirectedParticleEmitter, CylinderParticleEmitter } from "./EmitterTypes/cylinderParticleEmitter";
 import type { ConeParticleEmitter } from "./EmitterTypes/coneParticleEmitter";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This represents the base class for particle system in Babylon.
@@ -824,3 +825,6 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         throw new Error("Method not implemented.");
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.BaseParticleSystem", BaseParticleSystem);

--- a/packages/dev/core/src/abstractScene.ts
+++ b/packages/dev/core/src/abstractScene.ts
@@ -17,6 +17,7 @@ import type { Light } from "./Lights/light";
 import type { Node } from "./node";
 import type { PostProcess } from "./PostProcesses/postProcess";
 import type { Animation } from "./Animations/animation";
+import { RegisterClass } from "./Misc/typeStore";
 
 /**
  * Defines how the parser contract is defined.
@@ -228,3 +229,6 @@ export abstract class AbstractScene {
         return nodes;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.AbstractScene", AbstractScene);

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -90,6 +90,7 @@ import type { Texture } from "./Materials/Textures/texture";
 import { PointerPickingConfiguration } from "./Inputs/pointerPickingConfiguration";
 import { Logger } from "./Misc/logger";
 import type { AbstractEngine } from "./Engines/abstractEngine";
+import { RegisterClass } from "./Misc/typeStore";
 
 /**
  * Define an interface for all classes that will hold resources
@@ -5755,3 +5756,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         return this.getLastSkeletonById(id);
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.Scene", Scene);

--- a/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
+++ b/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
@@ -781,8 +781,6 @@ $line-padding-left: 2px;
                                 height: 100%;
                             }
                         }
-
-
                     }
 
                     .secondLine {
@@ -893,7 +891,6 @@ $line-padding-left: 2px;
                         .icon {
                             display: none;
                         }
-
                     }
 
                     .copy {
@@ -1180,7 +1177,6 @@ $line-padding-left: 2px;
                                 height: 100%;
                             }
                         }
-
                     }
 
                     .secondLine {

--- a/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
+++ b/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
@@ -676,11 +676,11 @@ $line-padding-left: 2px;
                     }
 
                     .radioContainer {
+                        grid-column: 2;
                         display: flex;
                         align-items: center;
 
                         .radio {
-                            grid-column: 2;
                             display: none;
 
                             &:checked + label:before {
@@ -724,6 +724,17 @@ $line-padding-left: 2px;
                             }
                         }
                     }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .vector3Line {
@@ -759,6 +770,19 @@ $line-padding-left: 2px;
                             justify-items: center;
                             cursor: pointer;
                         }
+
+                        .copy {
+                            grid-column: 4;
+                            display: grid;
+                            align-items: center;
+                            justify-items: center;
+                            cursor: pointer;
+                            img {
+                                height: 100%;
+                            }
+                        }
+
+
                     }
 
                     .secondLine {
@@ -794,7 +818,7 @@ $line-padding-left: 2px;
                     padding-left: $line-padding-left;
                     height: 30px;
                     display: grid;
-                    grid-template-columns: 1fr auto;
+                    grid-template-columns: 1fr auto 20px 10px;
 
                     .label {
                         grid-column: 1;
@@ -868,6 +892,18 @@ $line-padding-left: 2px;
 
                         .icon {
                             display: none;
+                        }
+
+                    }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
                         }
                     }
                 }
@@ -1072,6 +1108,17 @@ $line-padding-left: 2px;
                             cursor: pointer;
                         }
                     }
+
+                    .copy {
+                        grid-column: 4;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .color3Line {
@@ -1081,7 +1128,7 @@ $line-padding-left: 2px;
                     .firstLine {
                         height: 30px;
                         display: grid;
-                        grid-template-columns: 1fr auto 20px 20px;
+                        grid-template-columns: 1fr auto 20px;
 
                         .label {
                             grid-column: 1;
@@ -1115,8 +1162,16 @@ $line-padding-left: 2px;
                             }
                         }
 
-                        .copy {
+                        .expand {
                             grid-column: 3;
+                            display: grid;
+                            align-items: center;
+                            justify-items: center;
+                            cursor: pointer;
+                        }
+
+                        .copy {
+                            grid-column: 4;
                             display: grid;
                             align-items: center;
                             justify-items: center;
@@ -1126,13 +1181,6 @@ $line-padding-left: 2px;
                             }
                         }
 
-                        .expand {
-                            grid-column: 4;
-                            display: grid;
-                            align-items: center;
-                            justify-items: center;
-                            cursor: pointer;
-                        }
                     }
 
                     .secondLine {
@@ -1168,7 +1216,7 @@ $line-padding-left: 2px;
                     padding-left: $line-padding-left;
                     height: 30px;
                     display: grid;
-                    grid-template-columns: 1fr auto;
+                    grid-template-columns: 1fr auto 20px 10px;
 
                     .label {
                         grid-column: 1;
@@ -1185,6 +1233,17 @@ $line-padding-left: 2px;
 
                         select {
                             width: 115px;
+                        }
+                    }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
                         }
                     }
                 }

--- a/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
+++ b/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
@@ -1020,6 +1020,17 @@ $line-padding-left: 2px;
                             width: 110px;
                         }
                     }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .sliderLine {
@@ -1103,6 +1114,12 @@ $line-padding-left: 2px;
                             border-radius: 50%;
                             background: rgb(51, 122, 183);
                             cursor: pointer;
+                        }
+                    }
+
+                    .floatLine {
+                        .copy {
+                            display: none;
                         }
                     }
 

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -148,11 +148,11 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
     // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
-            let strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -8,6 +8,9 @@ import type { PropertyChangedEvent } from "../../propertyChangedEvent";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+import { copyCommandToClipboard, getInstanceType } from "shared-ui-components/copyCommandToClipboard";
+
+import copyIcon from "shared-ui-components/lines/copy.svg";
 
 interface IQuaternionLineComponentProps {
     label: string;
@@ -141,6 +144,19 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
         this.updateQuaternionFromEuler();
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = getInstanceType(this.props.target);
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
+            let strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
 
@@ -158,8 +174,11 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
                         {!this.props.useEuler && `X: ${quat.x.toFixed(1)}, Y: ${quat.y.toFixed(1)}, Z: ${quat.z.toFixed(1)}, W: ${quat.w.toFixed(1)}`}
                         {this.props.useEuler && `X: ${eulerDegrees.x.toFixed(2)}, Y: ${eulerDegrees.y.toFixed(2)}, Z: ${eulerDegrees.z.toFixed(2)}`}
                     </div>
-                    <div className="expand" onClick={() => this.switchExpandState()}>
+                    <div className="expand hoverIcon" onClick={() => this.switchExpandState()} title="Expand">
                         {chevron}
+                    </div>
+                    <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                        <img src={copyIcon} alt="Copy" />
                     </div>
                 </div>
                 {this.state.isExpanded && !this.props.useEuler && (

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -146,8 +146,8 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
 
     // Copy to clipboard the code this Quaternion actually does
     // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -144,6 +144,8 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
         this.updateQuaternionFromEuler();
     }
 
+    // Copy to clipboard the code this Quaternion actually does
+    // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -8,7 +8,8 @@ import type { PropertyChangedEvent } from "../../propertyChangedEvent";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
-import { copyCommandToClipboard, getInstanceType } from "shared-ui-components/copyCommandToClipboard";
+import { copyCommandToClipboard } from "shared-ui-components/copyCommandToClipboard";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "shared-ui-components/lines/copy.svg";
 
@@ -148,7 +149,7 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
     // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -21,6 +21,8 @@ import { TmpVectors, Vector3 } from "core/Maths/math";
 import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
 import type { Bone } from "core/Bones/bone";
 
+import { setDebugNode } from "../treeNodeDebugger";
+
 interface ISceneTreeItemComponentProps {
     scene: Scene;
     gizmoCamera?: Camera;
@@ -171,6 +173,7 @@ export class SceneTreeItemComponent extends React.Component<
             return;
         }
         const scene = this.props.scene;
+        setDebugNode(scene);
         this.props.onSelectionChangedObservable.notifyObservers(scene);
     }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -173,6 +173,7 @@ export class SceneTreeItemComponent extends React.Component<
             return;
         }
         const scene = this.props.scene;
+        // Put scene object into window.debugNode
         setDebugNode(scene);
         this.props.onSelectionChangedObservable.notifyObservers(scene);
     }

--- a/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
@@ -88,6 +88,7 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
         }
         this._wasSelected = true;
         const entity = this.props.entity;
+        // Put selected node into window.debugNode
         setDebugNode(entity);
         this.props.globalState.onSelectionChangedObservable.notifyObservers(entity);
     }

--- a/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
@@ -10,6 +10,8 @@ import * as ReactDOM from "react-dom";
 import * as React from "react";
 import type { GlobalState } from "../globalState";
 
+import { setDebugNode } from "./treeNodeDebugger";
+
 export interface ITreeItemSelectableComponentProps {
     entity: any;
     selectedEntity?: any;
@@ -86,6 +88,7 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
         }
         this._wasSelected = true;
         const entity = this.props.entity;
+        setDebugNode(entity);
         this.props.globalState.onSelectionChangedObservable.notifyObservers(entity);
     }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
@@ -1,7 +1,11 @@
+// window.debugNode will be able to receive any object selected in the inspector
 declare global {
     interface Window {debugNode: any;}
 }
 
 export function setDebugNode(node: any){
-    window.debugNode = node;
+    // Prevents a NodeJS env to crash on a non existing window
+    if(typeof window !== "undefined") {
+		window.debugNode = node;
+	}
 }

--- a/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
@@ -1,0 +1,7 @@
+declare global {
+    interface Window {debugNode: any;}
+}
+
+export function setDebugNode(node: any){
+    window.debugNode = node;
+}

--- a/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
@@ -1,11 +1,13 @@
 // window.debugNode will be able to receive any object selected in the inspector
 declare global {
-    interface Window {debugNode: any;}
+    interface Window {
+        debugNode: any;
+    }
 }
 
-export function setDebugNode(node: any){
+export function setDebugNode(node: any) {
     // Prevents a NodeJS env to crash on a non existing window
-    if(typeof window !== "undefined") {
-		window.debugNode = node;
-	}
+    if (typeof window !== "undefined") {
+        window.debugNode = node;
+    }
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,3 +1,5 @@
+import * as BABYLON from "core/index";
+
 export function copyCommandToClipboard(strCommand: string){
     const element = document.createElement("div");
     element.textContent = strCommand;
@@ -12,4 +14,15 @@ export function copyCommandToClipboard(strCommand: string){
 
     document.execCommand("copy");
     element.remove();
+}
+
+export function getInstanceType(target: any): string {
+    for (let className in BABYLON) {
+        try{
+            if (target instanceof (BABYLON[className as keyof typeof BABYLON] as any)){
+                return className;
+            }
+        } catch(err){}
+    }
+    return "Unknown";
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,5 +1,3 @@
-import * as BABYLON from "core/index";
-
 // Inspired by previous copyToClipboard() function which was copying Color3
 // Copies strCommand to clipboard
 export function copyCommandToClipboard(strCommand: string) {
@@ -16,19 +14,4 @@ export function copyCommandToClipboard(strCommand: string) {
 
     document.execCommand("copy");
     element.remove();
-}
-
-// Getting instance type (string) of target, for debug purpose
-// target.constructor.name actually works in dev preview mode
-// target.constructor.name returns a random letter after build, due to mangling
-// Looping on BABYLON classes to find real type
-export function getInstanceType(target: any): string {
-    for (const className in BABYLON) {
-        try {
-            if (target instanceof (BABYLON[className as keyof typeof BABYLON] as any)) {
-                return className;
-            }
-        } catch (err) {}
-    }
-    return "Unknown";
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,0 +1,15 @@
+export function copyCommandToClipboard(strCommand: string){
+    const element = document.createElement("div");
+    element.textContent = strCommand;
+    document.body.appendChild(element);
+
+    if (window.getSelection) {
+        const range = document.createRange();
+        range.selectNode(element);
+        window.getSelection()!.removeAllRanges();
+        window.getSelection()!.addRange(range);
+    }
+
+    document.execCommand("copy");
+    element.remove();
+}

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -23,7 +23,7 @@ export function copyCommandToClipboard(strCommand: string) {
 // target.constructor.name returns a random letter after build, due to mangling
 // Looping on BABYLON classes to find real type
 export function getInstanceType(target: any): string {
-    for (let className in BABYLON) {
+    for (const className in BABYLON) {
         try {
             if (target instanceof (BABYLON[className as keyof typeof BABYLON] as any)) {
                 return className;

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -2,7 +2,7 @@ import * as BABYLON from "core/index";
 
 // Inspired by previous copyToClipboard() function which was copying Color3
 // Copies strCommand to clipboard
-export function copyCommandToClipboard(strCommand: string){
+export function copyCommandToClipboard(strCommand: string) {
     const element = document.createElement("div");
     element.textContent = strCommand;
     document.body.appendChild(element);
@@ -24,11 +24,11 @@ export function copyCommandToClipboard(strCommand: string){
 // Looping on BABYLON classes to find real type
 export function getInstanceType(target: any): string {
     for (let className in BABYLON) {
-        try{
-            if (target instanceof (BABYLON[className as keyof typeof BABYLON] as any)){
+        try {
+            if (target instanceof (BABYLON[className as keyof typeof BABYLON] as any)) {
                 return className;
             }
-        } catch(err){}
+        } catch (err) {}
     }
     return "Unknown";
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,5 +1,7 @@
 import * as BABYLON from "core/index";
 
+// Inspired by previous copyToClipboard() function which was copying Color3
+// Copies strCommand to clipboard
 export function copyCommandToClipboard(strCommand: string){
     const element = document.createElement("div");
     element.textContent = strCommand;
@@ -16,6 +18,10 @@ export function copyCommandToClipboard(strCommand: string){
     element.remove();
 }
 
+// Getting instance type (string) of target, for debug purpose
+// target.constructor.name actually works in dev preview mode
+// target.constructor.name returns a random letter after build, due to mangling
+// Looping on BABYLON classes to find real type
 export function getInstanceType(target: any): string {
     for (let className in BABYLON) {
         try{

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "./../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
+
+import copyIcon from "./copy.svg";
 
 export interface ICheckBoxLineComponentProps {
     label?: string;
@@ -109,6 +112,16 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
         this.setState({ isSelected: !this.state.isSelected, isConflict: false });
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = this.props.target.constructor.name;
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        }
+    }
+
     override render() {
         const icons = this.props.large ? Icons.size40 : Icons.size30;
         const icon = this.state.isConflict ? icons.mixed : this.state.isSelected ? icons.on : icons.off;
@@ -141,6 +154,9 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
                         </label>
                     </div>
                 )}
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
+                </div>
             </div>
         );
     }

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -112,6 +112,8 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
         this.setState({ isSelected: !this.state.isSelected, isConflict: false });
     }
 
+    // Copy to clipboard the code this checkbox actually does
+    // Example : mesh.checkCollisions = true;
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -116,10 +116,10 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
     // Example : mesh.checkCollisions = true;
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "./../propertyChangedEvent";
-import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "./copy.svg";
 
@@ -116,7 +117,7 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
     // Example : mesh.checkCollisions = true;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const strCommand = targetName + "." + targetProperty + " = " + value + ";";

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "./../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
@@ -114,11 +114,13 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
 
     onCopyClick(){
         if(this.props && this.props.target){
-            let targetName = this.props.target.constructor.name;
+            let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
             let strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
         }
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -114,8 +114,8 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
 
     // Copy to clipboard the code this checkbox actually does
     // Example : mesh.checkCollisions = true;
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -167,8 +167,8 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
 
     // Copy to clipboard the code this Color3 actually does
     // Example : material.diffuseColor = new BABYLON.Vector3(0,1,0);
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -5,7 +5,7 @@ import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
 import { ColorPickerLineComponent } from "./colorPickerComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
@@ -167,7 +167,7 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
 
     onCopyClick(){
         if(this.props && this.props.target){
-            let targetName = this.props.target.constructor.name;
+            let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
             let hex = this.state.color.toHexString();
@@ -180,6 +180,8 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
             strColor += ";//(HEX : " + hex + ")";
             let strCommand = targetName + "." + targetProperty + " = " + strColor;
             copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
         }
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -5,10 +5,11 @@ import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { ColorPickerLineComponent } from "./colorPickerComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "./copy.svg";
 const emptyColor = new Color4(0, 0, 0, 0);
@@ -169,7 +170,7 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
     // Example : material.diffuseColor = new BABYLON.Vector3(0,1,0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const hex = this.state.color.toHexString();

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -169,10 +169,10 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
     // Example : material.diffuseColor = new BABYLON.Vector3(0,1,0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let hex = this.state.color.toHexString();
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const hex = this.state.color.toHexString();
             let strColor;
             if (value.a) {
                 strColor = "new BABYLON.Color4(" + value.r + ", " + value.g + ", " + value.b + ", " + value.a + ")";
@@ -180,7 +180,7 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
                 strColor = "new BABYLON.Color3(" + value.r + ", " + value.g + ", " + value.b + ")";
             }
             strColor += ";//(HEX : " + hex + ")";
-            let strCommand = targetName + "." + targetProperty + " = " + strColor;
+            const strCommand = targetName + "." + targetProperty + " = " + strColor;
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -5,6 +5,7 @@ import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { ColorPickerLineComponent } from "./colorPickerComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
@@ -130,22 +131,6 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
         this.setColor(new Color4(this.state.color.r, this.state.color.g, this.state.color.b, value));
     }
 
-    copyToClipboard() {
-        const element = document.createElement("div");
-        element.textContent = this.state.color.toHexString();
-        document.body.appendChild(element);
-
-        if (window.getSelection) {
-            const range = document.createRange();
-            range.selectNode(element);
-            window.getSelection()!.removeAllRanges();
-            window.getSelection()!.addRange(range);
-        }
-
-        document.execCommand("copy");
-        element.remove();
-    }
-
     private _convertToColor(color: string): Color4 {
         if (color === "" || color === "transparent") {
             return emptyColor;
@@ -180,6 +165,24 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
         return new Color3(color.r, color.g, color.b);
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = this.props.target.constructor.name;
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let hex = this.state.color.toHexString();
+            let strColor;
+            if (value.a) {
+                strColor = "new BABYLON.Color4(" + value.r + ", " + value.g + ", " + value.b + ", " + value.a + ")";
+            } else {
+                strColor = "new BABYLON.Color3(" + value.r + ", " + value.g + ", " + value.b + ")";
+            }
+            strColor += ";//(HEX : " + hex + ")";
+            let strCommand = targetName + "." + targetProperty + " = " + strColor;
+            copyCommandToClipboard(strCommand);
+        }
+    }
+
     override render() {
         const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
 
@@ -200,11 +203,11 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
                             }}
                         />
                     </div>
-                    <div className="copy hoverIcon" onClick={() => this.copyToClipboard()} title="Copy to clipboard">
-                        <img src={copyIcon} alt="Copy" />
-                    </div>
                     <div className="expand hoverIcon" onClick={() => this.switchExpandState()} title="Expand">
                         {chevron}
+                    </div>
+                    <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                        <img src={copyIcon} alt="Copy" />
                     </div>
                 </div>
                 {this.state.isExpanded && (

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -165,6 +165,8 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
         return new Color3(color.r, color.g, color.b);
     }
 
+    // Copy to clipboard the code this Color3 actually does
+    // Example : material.diffuseColor = new BABYLON.Vector3(0,1,0);
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -7,6 +7,10 @@ import { SliderLineComponent } from "./sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
 import { InputArrowsComponent } from "./inputArrowsComponent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 interface IFloatLineComponentProps {
     label: string;
@@ -191,6 +195,20 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
         }
     }
 
+    // Copy to clipboard the code this slider actually does
+    // Example : BaseParticleSystem.minScaleX = 1.0;
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         let valueAsNumber: number;
 
@@ -255,6 +273,9 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
                             )}
                         </div>
                         {this.props.unit}
+                        <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                            <img src={copyIcon} alt="Copy" />
+                        </div>
                     </div>
                 )}
                 {this.props.useEuler && (

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
+
+import copyIcon from "./copy.svg";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Null_Value = Number.MAX_SAFE_INTEGER;
@@ -99,6 +102,16 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
         this.raiseOnPropertyChanged(newValue, store);
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = this.props.target.constructor.name;
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        }
+    }
+
     override render() {
         return (
             <div className={"listLine" + (this.props.className ? " " + this.props.className : "")}>
@@ -116,6 +129,9 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
                             );
                         })}
                     </select>
+                </div>
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
                 </div>
             </div>
         );

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -106,10 +106,10 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
     // Example : material.sideOrientation = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -102,6 +102,8 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
         this.raiseOnPropertyChanged(newValue, store);
     }
 
+    // Copy to clipboard the code this option actually does
+    // Example : material.sideOrientation = 1;
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -104,8 +104,8 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
 
     // Copy to clipboard the code this option actually does
     // Example : material.sideOrientation = 1;
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "./copy.svg";
 
@@ -106,7 +107,7 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
     // Example : material.sideOrientation = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const strCommand = targetName + "." + targetProperty + " = " + value + ";";

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
 
 import copyIcon from "./copy.svg";
@@ -104,11 +104,13 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
 
     onCopyClick(){
         if(this.props && this.props.target){
-            let targetName = this.props.target.constructor.name;
+            let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
             let strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
         }
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -123,6 +123,8 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
         return value;
     }
 
+    // Copy to clipboard the code this slider actually does
+    // Example : ImageProcessingConfiguration.contrast = 1;
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "./floatLineComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+
+import copyIcon from "./copy.svg";
 
 interface ISliderLineComponentProps {
     label: string;
@@ -120,6 +123,16 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
         return value;
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = this.props.target.constructor.name;
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        }
+    }
+
     override render() {
         return (
             <div className="sliderLine">
@@ -162,7 +175,11 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
                         onChange={(evt) => this.onChange(evt.target.value)}
                     />
                 </div>
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
+                </div>
             </div>
+
         );
     }
 }

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "./floatLineComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
@@ -125,11 +125,13 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
 
     onCopyClick(){
         if(this.props && this.props.target){
-            let targetName = this.props.target.constructor.name;
+            let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
             let strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
         }
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "./floatLineComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "./copy.svg";
 
@@ -127,7 +128,7 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
     // Example : ImageProcessingConfiguration.contrast = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const strCommand = targetName + "." + targetProperty + " = " + value + ";";

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -125,8 +125,8 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
 
     // Copy to clipboard the code this slider actually does
     // Example : ImageProcessingConfiguration.contrast = 1;
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
@@ -183,7 +183,6 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
                     <img src={copyIcon} alt="Copy" />
                 </div>
             </div>
-
         );
     }
 }

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -127,10 +127,10 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
     // Example : ImageProcessingConfiguration.contrast = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -6,10 +6,11 @@ import { NumericInputComponent } from "../lines/numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { SliderLineComponent } from "../lines/sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+import { GetClassName } from "core/Misc/typeStore";
 
 import copyIcon from "./copy.svg";
 
@@ -112,7 +113,7 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
     // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = getInstanceType(this.props.target);
+            const targetName = GetClassName(this.props.target);
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -6,7 +6,7 @@ import { NumericInputComponent } from "../lines/numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getInstanceType } from "../copyCommandToClipboard";
 import { SliderLineComponent } from "../lines/sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
@@ -110,12 +110,14 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
 
     onCopyClick(){
         if(this.props && this.props.target){
-            let targetName = this.props.target.constructor.name;
+            let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];
             let strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
             let strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
             copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
         }
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -108,6 +108,8 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
         this.updateVector3();
     }
 
+    // Copy to clipboard the code this Vector3 actually does
+    // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
     onCopyClick(){
         if(this.props && this.props.target){
             let targetName = getInstanceType(this.props.target);

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -112,11 +112,11 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
     // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            let targetName = getInstanceType(this.props.target);
-            let targetProperty = this.props.propertyName;
-            let value = this.props.target[this.props.propertyName!];
-            let strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
-            let strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            const targetName = getInstanceType(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -6,9 +6,12 @@ import { NumericInputComponent } from "../lines/numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { SliderLineComponent } from "../lines/sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+
+import copyIcon from "./copy.svg";
 
 interface IVector3LineComponentProps {
     label: string;
@@ -105,6 +108,17 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
         this.updateVector3();
     }
 
+    onCopyClick(){
+        if(this.props && this.props.target){
+            let targetName = this.props.target.constructor.name;
+            let targetProperty = this.props.propertyName;
+            let value = this.props.target[this.props.propertyName!];
+            let strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
+            let strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            copyCommandToClipboard(strCommand);
+        }
+    }
+
     override render() {
         const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
 
@@ -124,6 +138,9 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
                     </div>
                     <div className="expand hoverIcon" onClick={() => this.switchExpandState()} title="Expand">
                         {chevron}
+                    </div>
+                    <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                        <img src={copyIcon} alt="Copy" />
                     </div>
                 </div>
                 {this.state.isExpanded && !this.props.useEuler && (

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -110,8 +110,8 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
 
     // Copy to clipboard the code this Vector3 actually does
     // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
-    onCopyClick(){
-        if(this.props && this.props.target){
+    onCopyClick() {
+        if (this.props && this.props.target) {
             let targetName = getInstanceType(this.props.target);
             let targetProperty = this.props.propertyName;
             let value = this.props.target[this.props.propertyName!];


### PR DESCRIPTION
Initiated in this topic : [scene.debugLayer : Copy last command to Clipboard](https://forum.babylonjs.com/t/scene-debuglayer-copy-last-command-to-clipboard/49796)
____
**Addind copyCommandToClipboard :**

In the right panel of the inspector, all the main component have now a copy button, which copies to the clipboard the javascript command this component is actually doing. For example : `"AbstractMesh.checkCollisions = true;"`

It is based on the `target` property of the `React.Component` considered (CheckboxLine, SliderLine, ColorLine, etc...)
* `this.props.target` is the node considered (ex : `AbstractMesh`)
* `this.props.propertyName` is the property (ex : `checkCollisions`)
* `this.props.target[this.props.propertyName!]` is the value

In order to access the Class name of the target, `this.props.target.constructor.name` works in dev preview mode, but returns a single (random) letter such as "e" after the build. I suspect this is due to the mangling + minify at build;

That's why I replaced `this.props.target.constructor.name` by the `getInstanceType()` function, which finds a `instanceof` match over BABYLON classes.

Please feel free to propose a neater solution.

([Demo Video](https://global.discourse-cdn.com/business7/uploads/babylonjs/original/3X/3/8/3833bf84f734ef25c7e7503f4f1f490c5dab4357.mp4))
____
**Addind window.debugNode :**

Also, I'm putting the reference of the selected node into `window.debugNode`;
This is soooo usefull, already since it's built on my side, I'm using it multiple times per day !
* You select a mesh and type `let mesh = window.debugNode;`
* You select a material and type `let mat = window.debugNode;`
And then you can work in the console using `mesh` and `mat` ...

([Demo Video](https://global.discourse-cdn.com/business7/uploads/babylonjs/original/3X/0/8/08c73f8152af42976194c326211e9d8cea4d91f6.mp4))