### PR TITLE
Store the requested texture format in InternalTexture

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -174,6 +174,27 @@ export interface HostInformation {
     isMobile: boolean;
 }
 
+export type PrepareTextureProcessFunction = (
+    width: number,
+    height: number,
+    img: HTMLImageElement | ImageBitmap | { width: number; height: number },
+    extension: string,
+    texture: InternalTexture,
+    continuationCallback: () => void
+) => boolean;
+
+export type PrepareTextureFunction = (
+    texture: InternalTexture,
+    extension: string,
+    scene: Nullable<ISceneLike>,
+    img: HTMLImageElement | ImageBitmap | { width: number; height: number },
+    invertY: boolean,
+    noMipmap: boolean,
+    isCompressed: boolean,
+    processFunction: PrepareTextureProcessFunction,
+    samplingMode: number
+) => void;
+
 /**
  * The parent class for specialized engines (WebGL, WebGPU)
  */
@@ -1596,32 +1617,8 @@ export abstract class AbstractEngine {
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
         onLoad: Nullable<(texture: InternalTexture) => void> = null,
         onError: Nullable<(message: string, exception: any) => void> = null,
-        prepareTexture: (
-            texture: InternalTexture,
-            extension: string,
-            scene: Nullable<ISceneLike>,
-            img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-            invertY: boolean,
-            noMipmap: boolean,
-            isCompressed: boolean,
-            processFunction: (
-                width: number,
-                height: number,
-                img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-                extension: string,
-                texture: InternalTexture,
-                continuationCallback: () => void
-            ) => boolean,
-            samplingMode: number
-        ) => void,
-        prepareTextureProcessFunction: (
-            width: number,
-            height: number,
-            img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-            extension: string,
-            texture: InternalTexture,
-            continuationCallback: () => void
-        ) => boolean,
+        prepareTexture: PrepareTextureFunction,
+        prepareTextureProcess: PrepareTextureProcessFunction,
         buffer: Nullable<string | ArrayBuffer | ArrayBufferView | HTMLImageElement | Blob | ImageBitmap> = null,
         fallback: Nullable<InternalTexture> = null,
         format: Nullable<number> = null,
@@ -1712,7 +1709,7 @@ export abstract class AbstractEngine {
                         null,
                         onError,
                         prepareTexture,
-                        prepareTextureProcessFunction,
+                        prepareTextureProcess,
                         buffer,
                         texture
                     );
@@ -1735,7 +1732,7 @@ export abstract class AbstractEngine {
                     onLoad,
                     onError,
                     prepareTexture,
-                    prepareTextureProcessFunction,
+                    prepareTextureProcess,
                     buffer,
                     texture,
                     format,
@@ -1807,7 +1804,7 @@ export abstract class AbstractEngine {
                     texture._buffer = img;
                 }
 
-                prepareTexture(texture, extension, scene, img, texture.invertY, noMipmap, false, prepareTextureProcessFunction, samplingMode);
+                prepareTexture(texture, extension, scene, img, texture.invertY, noMipmap, false, prepareTextureProcess, samplingMode);
             };
             // According to the WebGL spec section 6.10, ImageBitmaps must be inverted on creation.
             // So, we pass imageOrientation to _FileToolsLoadImage() as it may create an ImageBitmap.

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3055,9 +3055,7 @@ export class ThinEngine extends AbstractEngine {
      * @returns The options to pass to texImage2D or texImage3D calls.
      * @internal
      */
-    public _getTexImageParametersForCreateTexture(babylonFormat: Nullable<number>, useSRGBBuffer: boolean): TexImageParameters {
-        babylonFormat = babylonFormat ?? Constants.TEXTUREFORMAT_UNDEFINED;
-
+    public _getTexImageParametersForCreateTexture(babylonFormat: number, useSRGBBuffer: boolean): TexImageParameters {
         let format: number, internalFormat: number;
         if (this.webGLVersion === 1) {
             // In WebGL 1, format and internalFormat must be the same and taken from a limited set of values, see https://docs.gl/es2/glTexImage2D.

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3612,7 +3612,6 @@ export class ThinEngine extends AbstractEngine {
         texture.isReady = true;
         texture.type = texture.type !== -1 ? texture.type : Constants.TEXTURETYPE_UNSIGNED_BYTE;
         texture.format =
-            //texture.format !== -1 ? texture.format : extension === ".jpg" && !texture._useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : format ?? Constants.TEXTUREFORMAT_RGBA;
             texture.format !== -1 ? texture.format : format ?? (extension === ".jpg" && !texture._useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA);
 
         if (

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -34,7 +34,7 @@ import {
     deleteStateObject,
 } from "./thinEngine.functions";
 
-import type { AbstractEngineOptions, ISceneLike } from "./abstractEngine";
+import type { AbstractEngineOptions, ISceneLike, PrepareTextureFunction } from "./abstractEngine";
 import type { PostProcess } from "../PostProcesses/postProcess";
 import type { PerformanceMonitor } from "../Misc/performanceMonitor";
 import { IsWrapper } from "../Materials/drawWrapper.functions";
@@ -2988,24 +2988,7 @@ export class ThinEngine extends AbstractEngine {
             samplingMode,
             onLoad,
             onError,
-            (
-                texture: InternalTexture,
-                extension: string,
-                scene: Nullable<ISceneLike>,
-                img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-                invertY: boolean,
-                noMipmap: boolean,
-                isCompressed: boolean,
-                processFunction: (
-                    width: number,
-                    height: number,
-                    img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-                    extension: string,
-                    texture: InternalTexture,
-                    continuationCallback: () => void
-                ) => boolean,
-                samplingMode: number
-            ) => this._prepareWebGLTexture(texture, extension, scene, img, invertY, noMipmap, isCompressed, processFunction, samplingMode, format),
+            (...args: Parameters<PrepareTextureFunction>) => this._prepareWebGLTexture(...args, format),
             (potWidth, potHeight, img, extension, texture, continuationCallback) => {
                 const gl = this._gl;
                 const isPot = img.width === potWidth && img.height === potHeight;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3012,7 +3012,7 @@ export class ThinEngine extends AbstractEngine {
 
                 texture._creationFlags = creationFlags ?? 0;
 
-                const tip = this._getTexImageParametersForCreateTexture(texture.format, extension, texture._useSRGBBuffer);
+                const tip = this._getTexImageParametersForCreateTexture(texture.format, texture._useSRGBBuffer);
                 if (isPot) {
                     gl.texImage2D(gl.TEXTURE_2D, 0, tip.internalFormat, tip.format, tip.type, img as any);
                     return false;
@@ -3072,7 +3072,7 @@ export class ThinEngine extends AbstractEngine {
      * @returns The options to pass to texImage2D or texImage3D calls.
      * @internal
      */
-    public _getTexImageParametersForCreateTexture(babylonFormat: Nullable<number>, fileExtension: string, useSRGBBuffer: boolean): TexImageParameters {
+    public _getTexImageParametersForCreateTexture(babylonFormat: Nullable<number>, useSRGBBuffer: boolean): TexImageParameters {
         babylonFormat = babylonFormat ?? Constants.TEXTUREFORMAT_UNDEFINED;
 
         let format: number, internalFormat: number;
@@ -3612,6 +3612,7 @@ export class ThinEngine extends AbstractEngine {
         texture.isReady = true;
         texture.type = texture.type !== -1 ? texture.type : Constants.TEXTURETYPE_UNSIGNED_BYTE;
         texture.format =
+            //texture.format !== -1 ? texture.format : extension === ".jpg" && !texture._useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : format ?? Constants.TEXTUREFORMAT_RGBA;
             texture.format !== -1 ? texture.format : format ?? (extension === ".jpg" && !texture._useSRGBBuffer ? Constants.TEXTUREFORMAT_RGB : Constants.TEXTUREFORMAT_RGBA);
 
         if (

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -34,7 +34,7 @@ import {
     deleteStateObject,
 } from "./thinEngine.functions";
 
-import type { AbstractEngineOptions, ISceneLike, PrepareTextureFunction } from "./abstractEngine";
+import type { AbstractEngineOptions, ISceneLike, PrepareTextureFunction, PrepareTextureProcessFunction } from "./abstractEngine";
 import type { PostProcess } from "../PostProcesses/postProcess";
 import type { PerformanceMonitor } from "../Misc/performanceMonitor";
 import { IsWrapper } from "../Materials/drawWrapper.functions";
@@ -3556,14 +3556,7 @@ export class ThinEngine extends AbstractEngine {
         invertY: boolean,
         noMipmap: boolean,
         isCompressed: boolean,
-        processFunction: (
-            width: number,
-            height: number,
-            img: HTMLImageElement | ImageBitmap | { width: number; height: number },
-            extension: string,
-            texture: InternalTexture,
-            continuationCallback: () => void
-        ) => boolean,
+        processFunction: PrepareTextureProcessFunction,
         samplingMode: number,
         format: Nullable<number>
     ): void {

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -3,152 +3,111 @@ import { Engine, ThinEngine } from "core/Engines";
 describe("ThinEngine", () => {
     describe("getTexImageParametersForCreateTexture", () => {
         let thinEngine: ThinEngine;
-        
+
         beforeEach(() => {
-            const fakeConstProvider: any = new Proxy({}, {
-                get: (_, propertyName) => {
-                    return propertyName;
+            const fakeConstProvider: any = new Proxy(
+                {},
+                {
+                    get: (_, propertyName) => {
+                        return propertyName;
+                    },
                 }
-            });
+            );
             thinEngine = new ThinEngine(null);
             thinEngine._gl = fakeConstProvider;
             thinEngine._glSRGBExtensionValues = fakeConstProvider;
         });
-        
+
         it("gets tex image parameters for WebGL 1", () => {
-            test([
-                "<undefined>",
-                "TEXTUREFORMAT_ALPHA",
-                "TEXTUREFORMAT_LUMINANCE",
-                "TEXTUREFORMAT_LUMINANCE_ALPHA",
-                "TEXTUREFORMAT_RGB",
-                "TEXTUREFORMAT_RGBA"
-            ], `
-Babylon format                Ext. SRGB  Int. format     Format          Type
-==============                ==== ====  ===========     ======          ====
-<undefined>                   .jpg false RGB             RGB             UNSIGNED_BYTE
-<undefined>                   .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
-<undefined>                   .png false RGBA            RGBA            UNSIGNED_BYTE
-<undefined>                   .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .png true  ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .jpg false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .jpg true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .png false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .png true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .jpg false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg true  SRGB            SRGB            UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png false RGB             RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png true  SRGB            SRGB            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png false RGBA            RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE`.trimStart());
+            test(
+                ["<undefined>", "TEXTUREFORMAT_ALPHA", "TEXTUREFORMAT_LUMINANCE", "TEXTUREFORMAT_LUMINANCE_ALPHA", "TEXTUREFORMAT_RGB", "TEXTUREFORMAT_RGBA"],
+                `
+Babylon format                SRGB  Int. format     Format          Type
+==============                ====  ===========     ======          ====
+<undefined>                   false RGBA            RGBA            UNSIGNED_BYTE
+<undefined>                   true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             false RGB             RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             true  SRGB            SRGB            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            false RGBA            RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE`.trimStart()
+            );
         });
 
         it("gets tex image parameters for WebGL 2", () => {
             thinEngine._webGLVersion = 2;
-            test([
-                "<undefined>",
-                "TEXTUREFORMAT_ALPHA",
-                "TEXTUREFORMAT_LUMINANCE",
-                "TEXTUREFORMAT_LUMINANCE_ALPHA",
-                "TEXTUREFORMAT_R",
-                "TEXTUREFORMAT_RED",
-                "TEXTUREFORMAT_RG",
-                "TEXTUREFORMAT_RGB",
-                "TEXTUREFORMAT_RGBA",
-                "TEXTUREFORMAT_R_INTEGER",
-                "TEXTUREFORMAT_RG_INTEGER",
-                "TEXTUREFORMAT_RED_INTEGER",
-                "TEXTUREFORMAT_RGB_INTEGER",
-                "TEXTUREFORMAT_RGBA_INTEGER"
-            ], `
-Babylon format                Ext. SRGB  Int. format     Format          Type
-==============                ==== ====  ===========     ======          ====
-<undefined>                   .jpg false RGB8            RGB             UNSIGNED_BYTE
-<undefined>                   .jpg true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
-<undefined>                   .png false RGBA8           RGBA            UNSIGNED_BYTE
-<undefined>                   .png true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .jpg false ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .jpg true  ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .png false ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_ALPHA           .png true  ALPHA           ALPHA           UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .jpg false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .jpg true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .png false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE       .png true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .jpg false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .jpg true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .png false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_LUMINANCE_ALPHA .png true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
-TEXTUREFORMAT_R               .jpg false R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_R               .jpg true  R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_R               .png false R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_R               .png true  R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_RED             .jpg false R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_RED             .jpg true  R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_RED             .png false R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_RED             .png true  R8              RED             UNSIGNED_BYTE
-TEXTUREFORMAT_RG              .jpg false RG8             RG              UNSIGNED_BYTE
-TEXTUREFORMAT_RG              .jpg true  RG8             RG              UNSIGNED_BYTE
-TEXTUREFORMAT_RG              .png false RG8             RG              UNSIGNED_BYTE
-TEXTUREFORMAT_RG              .png true  RG8             RG              UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg false RGB8            RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .jpg true  SRGB8           RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png false RGB8            RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGB             .png true  SRGB8           RGB             UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg false RGBA8           RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .jpg true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png false RGBA8           RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA            .png true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
-TEXTUREFORMAT_R_INTEGER       .jpg false R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_R_INTEGER       .jpg true  R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_R_INTEGER       .png false R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_R_INTEGER       .png true  R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RG_INTEGER      .jpg false RG8UI           RG_INTEGER      UNSIGNED_BYTE
-TEXTUREFORMAT_RG_INTEGER      .jpg true  RG8UI           RG_INTEGER      UNSIGNED_BYTE
-TEXTUREFORMAT_RG_INTEGER      .png false RG8UI           RG_INTEGER      UNSIGNED_BYTE
-TEXTUREFORMAT_RG_INTEGER      .png true  RG8UI           RG_INTEGER      UNSIGNED_BYTE
-TEXTUREFORMAT_RED_INTEGER     .jpg false R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RED_INTEGER     .jpg true  R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RED_INTEGER     .png false R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RED_INTEGER     .png true  R8UI            RED_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RGB_INTEGER     .jpg false RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RGB_INTEGER     .jpg true  RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RGB_INTEGER     .png false RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RGB_INTEGER     .png true  RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA_INTEGER    .jpg false RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA_INTEGER    .jpg true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA_INTEGER    .png false RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
-TEXTUREFORMAT_RGBA_INTEGER    .png true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE`.trimStart());
+            test(
+                [
+                    "<undefined>",
+                    "TEXTUREFORMAT_ALPHA",
+                    "TEXTUREFORMAT_LUMINANCE",
+                    "TEXTUREFORMAT_LUMINANCE_ALPHA",
+                    "TEXTUREFORMAT_R",
+                    "TEXTUREFORMAT_RED",
+                    "TEXTUREFORMAT_RG",
+                    "TEXTUREFORMAT_RGB",
+                    "TEXTUREFORMAT_RGBA",
+                    "TEXTUREFORMAT_R_INTEGER",
+                    "TEXTUREFORMAT_RG_INTEGER",
+                    "TEXTUREFORMAT_RED_INTEGER",
+                    "TEXTUREFORMAT_RGB_INTEGER",
+                    "TEXTUREFORMAT_RGBA_INTEGER",
+                ],
+                `
+Babylon format                SRGB  Int. format     Format          Type
+==============                ====  ===========     ======          ====
+<undefined>                   false RGBA8           RGBA            UNSIGNED_BYTE
+<undefined>                   true  RGBA8           RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           false ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_ALPHA           true  ALPHA           ALPHA           UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE       true  LUMINANCE       LUMINANCE       UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA false LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_LUMINANCE_ALPHA true  LUMINANCE_ALPHA LUMINANCE_ALPHA UNSIGNED_BYTE
+TEXTUREFORMAT_R               false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_R               true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             false R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RED             true  R8              RED             UNSIGNED_BYTE
+TEXTUREFORMAT_RG              false RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RG              true  RG8             RG              UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             false RGB8            RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGB             true  SRGB8           RGB             UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            false RGBA8           RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA            true  SRGB8_ALPHA8    RGBA            UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_R_INTEGER       true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      false RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RG_INTEGER      true  RG8UI           RG_INTEGER      UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     false R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RED_INTEGER     true  R8UI            RED_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     false RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGB_INTEGER     true  RGB8UI          RGB_INTEGER     UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    false RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE
+TEXTUREFORMAT_RGBA_INTEGER    true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYTE`.trimStart()
+            );
         });
 
         function test(formatStrs: string[], expected: string) {
             const results = [
-                "Babylon format                Ext. SRGB  Int. format     Format          Type",
-                "==============                ==== ====  ===========     ======          ===="
+                "Babylon format                SRGB  Int. format     Format          Type",
+                "==============                ====  ===========     ======          ====",
             ];
             for (const formatStr of formatStrs) {
                 const format = formatStr === "<undefined>" ? undefined : (Engine as any)[formatStr];
-                for (const fileExtension of [".jpg", ".png"]) {
-                    for (const useSRGBBuffer of [false, true]) {
-                        const texImageParams = thinEngine._getTexImageParametersForCreateTexture(format, fileExtension, useSRGBBuffer);
-                        results.push(
-                            formatStr.padEnd(30) +
-                            fileExtension.padEnd(5) +
+                for (const useSRGBBuffer of [false, true]) {
+                    const texImageParams = thinEngine._getTexImageParametersForCreateTexture(format, useSRGBBuffer);
+                    results.push(
+                        formatStr.padEnd(30) +
                             useSRGBBuffer.toString().padEnd(6) +
                             (texImageParams.internalFormat as any).padEnd(16) +
                             (texImageParams.format as any).padEnd(16) +
                             texImageParams.type
-                        );
-                    }
+                    );
                 }
             }
             expect(results.join("\n")).toEqual(expected);

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -20,12 +20,10 @@ describe("ThinEngine", () => {
 
         it("gets tex image parameters for WebGL 1", () => {
             test(
-                ["<undefined>", "TEXTUREFORMAT_ALPHA", "TEXTUREFORMAT_LUMINANCE", "TEXTUREFORMAT_LUMINANCE_ALPHA", "TEXTUREFORMAT_RGB", "TEXTUREFORMAT_RGBA"],
+                ["TEXTUREFORMAT_ALPHA", "TEXTUREFORMAT_LUMINANCE", "TEXTUREFORMAT_LUMINANCE_ALPHA", "TEXTUREFORMAT_RGB", "TEXTUREFORMAT_RGBA"],
                 `
 Babylon format                SRGB  Int. format     Format          Type
 ==============                ====  ===========     ======          ====
-<undefined>                   false RGBA            RGBA            UNSIGNED_BYTE
-<undefined>                   true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           false ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           true  ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_LUMINANCE       false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
@@ -43,7 +41,6 @@ TEXTUREFORMAT_RGBA            true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYT
             thinEngine._webGLVersion = 2;
             test(
                 [
-                    "<undefined>",
                     "TEXTUREFORMAT_ALPHA",
                     "TEXTUREFORMAT_LUMINANCE",
                     "TEXTUREFORMAT_LUMINANCE_ALPHA",
@@ -61,8 +58,6 @@ TEXTUREFORMAT_RGBA            true  SRGB8_ALPHA8    SRGB8_ALPHA8    UNSIGNED_BYT
                 `
 Babylon format                SRGB  Int. format     Format          Type
 ==============                ====  ===========     ======          ====
-<undefined>                   false RGBA8           RGBA            UNSIGNED_BYTE
-<undefined>                   true  RGBA8           RGBA            UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           false ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_ALPHA           true  ALPHA           ALPHA           UNSIGNED_BYTE
 TEXTUREFORMAT_LUMINANCE       false LUMINANCE       LUMINANCE       UNSIGNED_BYTE
@@ -98,7 +93,7 @@ TEXTUREFORMAT_RGBA_INTEGER    true  RGBA8UI         RGBA_INTEGER    UNSIGNED_BYT
                 "==============                ====  ===========     ======          ====",
             ];
             for (const formatStr of formatStrs) {
-                const format = formatStr === "<undefined>" ? undefined : (Engine as any)[formatStr];
+                const format = (Engine as any)[formatStr];
                 for (const useSRGBBuffer of [false, true]) {
                     const texImageParams = thinEngine._getTexImageParametersForCreateTexture(format, useSRGBBuffer);
                     results.push(


### PR DESCRIPTION
This is addressing the issue described here: https://forum.babylonjs.com/t/texture-textureformat-does-not-return-right-value/50128/3

For WebGL (ThinEngine), the requested texture format is ignored in some cases when assigning the InternalTexture format. I believe it is correctly respected for compressed textures due to the texture loader assigning the format. If the format is unspecified, the deduced default texture format is also stored. But in other cases, the requested texture format is not stored correctly in the InternalTexture (even though it does affect how the texture is loaded).

This change makes it work more like WebGPU (WebGPUEngine) - when a texture is created the requested format is stored in the InternalTexture within the `prepareTexture` callback. Since this happens before the `prepareTextureProcessFunction` callback, in the WebGL case `prepareTextureProcessFunction` can be simplified to just use the InternalTexture format which by this time has correctly been assigned.