### PR TITLE
Fix GetFontOffset missing in ThinEngine

### DIFF
--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -10,7 +10,7 @@ import type { Nullable } from "../types";
 import { passPixelShader } from "../Shaders/pass.fragment";
 import { Scalar } from "../Maths/math.scalar";
 import type { AbstractEngine } from "../Engines/abstractEngine";
-import { EngineStore } from "..";
+import { EngineStore } from "../Engines/engineStore";
 
 type DumpToolsEngine = {
     canvas: HTMLCanvasElement | OffscreenCanvas;

--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -10,6 +10,7 @@ import type { Nullable } from "../types";
 import { passPixelShader } from "../Shaders/pass.fragment";
 import { Scalar } from "../Maths/math.scalar";
 import type { AbstractEngine } from "../Engines/abstractEngine";
+import { EngineStore } from "..";
 
 type DumpToolsEngine = {
     canvas: HTMLCanvasElement | OffscreenCanvas;
@@ -45,6 +46,13 @@ export class DumpTools {
                 canvas = document.createElement("canvas");
                 engine = new ThinEngine(canvas, false, options);
             }
+            // remove this engine from the list of instances to avoid using it for other purposes
+            EngineStore.Instances.pop();
+            // However, make sure to dispose it when no other engines are left
+            EngineStore.OnEnginesDisposedObservable.add((e) => {
+                // guaranteed to run when no other instances are left
+                e.dispose();
+            });
             engine.getCaps().parallelShaderCompile = undefined;
             const renderer = new EffectRenderer(engine);
             const wrapper = new EffectWrapper({
@@ -60,7 +68,7 @@ export class DumpTools {
                 wrapper,
             };
         }
-        return DumpTools._DumpToolsEngine!;
+        return DumpTools._DumpToolsEngine;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -27,6 +27,7 @@ import type { IPointerEvent } from "core/Events/deviceInputEvents";
 import type { IAnimatable } from "core/Animations/animatable.interface";
 import type { Animation } from "core/Animations/animation";
 import type { BaseGradient } from "./gradient/BaseGradient";
+import type { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Root class used for all 2D controls
@@ -2428,7 +2429,7 @@ export class Control implements IAnimatable {
             "px " +
             this._getStyleProperty("fontFamily", "Arial");
 
-        this._fontOffset = Control._GetFontOffset(this._font);
+        this._fontOffset = Control._GetFontOffset(this._font, this._host.getScene()?.getEngine());
 
         //children need to be refreshed
         this.getDescendants().forEach((child) => child._markAllAsDirty());
@@ -2662,12 +2663,12 @@ export class Control implements IAnimatable {
     /**
      * @internal
      */
-    public static _GetFontOffset(font: string): { ascent: number; height: number; descent: number } {
+    public static _GetFontOffset(font: string, engineToUse?: AbstractEngine): { ascent: number; height: number; descent: number } {
         if (Control._FontHeightSizes[font]) {
             return Control._FontHeightSizes[font];
         }
 
-        const engine = EngineStore.LastCreatedEngine;
+        const engine = engineToUse || EngineStore.LastCreatedEngine;
         if (!engine) {
             throw new Error("Invalid engine. Unable to create a canvas.");
         }

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -927,7 +927,7 @@ export class InputText extends Control implements IFocusableControl {
         }
 
         if (!this._fontOffset || this._wasDirty) {
-            this._fontOffset = Control._GetFontOffset(context.font);
+            this._fontOffset = Control._GetFontOffset(context.font, this._host.getScene()?.getEngine());
         }
 
         // Text

--- a/packages/dev/gui/src/2D/controls/inputTextArea.ts
+++ b/packages/dev/gui/src/2D/controls/inputTextArea.ts
@@ -568,7 +568,7 @@ export class InputTextArea extends InputText {
      */
     protected override _preMeasure(parentMeasure: Measure, context: ICanvasRenderingContext): void {
         if (!this._fontOffset || this._wasDirty) {
-            this._fontOffset = Control._GetFontOffset(context.font);
+            this._fontOffset = Control._GetFontOffset(context.font, this._host.getScene()?.getEngine());
         }
 
         let text = this._beforeRenderText(this._textWrapper).text;

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -351,7 +351,7 @@ export class TextBlock extends Control {
 
     protected override _processMeasures(parentMeasure: Measure, context: ICanvasRenderingContext): void {
         if (!this._fontOffset || this.isDirty) {
-            this._fontOffset = Control._GetFontOffset(context.font);
+            this._fontOffset = Control._GetFontOffset(context.font, this._host.getScene()?.getEngine());
         }
         super._processMeasures(parentMeasure, context);
 
@@ -664,7 +664,7 @@ export class TextBlock extends Control {
             if (context) {
                 this._applyStates(context);
                 if (!this._fontOffset) {
-                    this._fontOffset = Control._GetFontOffset(context.font);
+                    this._fontOffset = Control._GetFontOffset(context.font, this._host.getScene()?.getEngine());
                 }
                 const lines = this._lines
                     ? this._lines


### PR DESCRIPTION
Issue described here - https://forum.babylonjs.com/t/issue-with-double-engine-instancing-after-creating-a-screenshot/50241?u=raananw

There are two fixes for the same issue in this PR:

1) Take the ThinEngine instance created in DumpTools out of the list of instances in the EngineStore. Of course, making sure it is disposed when no other engines are available.
2) Provide the engine set in the ADT for the getFontOffset call in GUI's Control. This avoids using LastCreatedInstance to get the font offset.
