### PR TITLE
Adding new debug tools to the scene Inspector : copyCommandToClipboar…

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -12,6 +12,7 @@ import type { ISoundOptions } from "./Interfaces/ISoundOptions";
 import { EngineStore } from "../Engines/engineStore";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import type { Observer } from "../Misc/observable";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * Defines a sound that can be played in the application.
@@ -1306,3 +1307,6 @@ export class Sound {
         }
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.Sound", Sound);

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -17,6 +17,7 @@ import type { ArcRotateCameraMouseWheelInput } from "../Cameras/Inputs/arcRotate
 import { ArcRotateCameraInputsManager } from "../Cameras/arcRotateCameraInputsManager";
 import { Epsilon } from "../Maths/math.constants";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 import type { TransformNode } from "core/Meshes/transformNode";
@@ -1360,3 +1361,6 @@ export class ArcRotateCamera extends TargetCamera {
         return "ArcRotateCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.ArcRotateCamera", ArcRotateCamera);

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -10,6 +10,7 @@ import { FlyCameraInputsManager } from "./flyCameraInputsManager";
 import type { FlyCameraMouseInput } from "../Cameras/Inputs/flyCameraMouseInput";
 import type { FlyCameraKeyboardInput } from "../Cameras/Inputs/flyCameraKeyboardInput";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 
@@ -451,3 +452,6 @@ export class FlyCamera extends TargetCamera {
         return "FlyCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FlyCamera", FlyCamera);

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -7,6 +7,8 @@ import { TmpVectors, Vector3 } from "../Maths/math.vector";
 import { Node } from "../node";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { FollowCameraInputsManager } from "./followCameraInputsManager";
+import { RegisterClass } from "../Misc/typeStore";
+
 Node.AddNodeConstructor("FollowCamera", (name, scene) => {
     return () => new FollowCamera(name, Vector3.Zero(), scene);
 });
@@ -307,3 +309,7 @@ export class ArcFollowCamera extends TargetCamera {
         return "ArcFollowCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FollowCamera", FollowCamera);
+RegisterClass("BABYLON.ArcFollowCamera", ArcFollowCamera);

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -9,6 +9,7 @@ import { FreeCameraInputsManager } from "./freeCameraInputsManager";
 import type { FreeCameraMouseInput } from "../Cameras/Inputs/freeCameraMouseInput";
 import type { FreeCameraKeyboardMoveInput } from "../Cameras/Inputs/freeCameraKeyboardMoveInput";
 import { Tools } from "../Misc/tools";
+import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 
@@ -454,3 +455,6 @@ export class FreeCamera extends TargetCamera {
         return "FreeCamera";
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.FreeCamera", FreeCamera);

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -7,6 +7,8 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
+import { RegisterClass } from "../Misc/typeStore";
+
 Node.AddNodeConstructor("Light_Type_1", (name, scene) => {
     return () => new DirectionalLight(name, Vector3.Zero(), scene);
 });
@@ -352,3 +354,6 @@ export class DirectionalLight extends ShadowLight {
         defines["DIRLIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.DirectionalLight", DirectionalLight);

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -7,6 +7,7 @@ import { Node } from "../node";
 import type { Effect } from "../Materials/effect";
 import { Light } from "./light";
 import type { IShadowGenerator } from "./Shadows/shadowGenerator";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_3", (name, scene) => {
     return () => new HemisphericLight(name, Vector3.Zero(), scene);
@@ -128,3 +129,6 @@ export class HemisphericLight extends Light {
         defines["HEMILIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.HemisphericLight", HemisphericLight);

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -6,6 +6,7 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_0", (name, scene) => {
     return () => new PointLight(name, Vector3.Zero(), scene);
@@ -215,3 +216,6 @@ export class PointLight extends ShadowLight {
         defines["POINTLIGHT" + lightIndex] = true;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.PointLight", PointLight);

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -11,6 +11,7 @@ import { ShadowLight } from "./shadowLight";
 import { Texture } from "../Materials/Textures/texture";
 import type { ProceduralTexture } from "../Materials/Textures/Procedurals/proceduralTexture";
 import type { Camera } from "../Cameras/camera";
+import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_2", (name, scene) => {
     return () => new SpotLight(name, Vector3.Zero(), Vector3.Zero(), 0, 0, scene);
@@ -474,3 +475,6 @@ export class SpotLight extends ShadowLight {
         defines["PROJECTEDLIGHTTEXTURE" + lightIndex] = this.projectionTexture && this.projectionTexture.isReady() ? true : false;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.SpotLight", SpotLight);

--- a/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
+++ b/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
@@ -11,6 +11,7 @@ import { Mix } from "../Misc/tools.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { IImageProcessingConfigurationDefines } from "./imageProcessingConfiguration.defines";
 import { PrepareSamplersForImageProcessing, PrepareUniformsForImageProcessing } from "./imageProcessingConfiguration.functions";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This groups together the common properties used for image processing either in direct forward pass
@@ -643,3 +644,6 @@ export class ImageProcessingConfiguration {
 
 // References the dependencies.
 SerializationHelper._ImageProcessingConfigurationParser = ImageProcessingConfiguration.Parse;
+
+// Register Class Name
+RegisterClass("BABYLON.ImageProcessingConfiguration", ImageProcessingConfiguration);

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -16,6 +16,7 @@ import type { Material } from "./material";
 import type { BaseTexture } from "./Textures/baseTexture";
 import type { RenderTargetTexture } from "./Textures/renderTargetTexture";
 import { SerializationHelper } from "../Misc/decorators.serialization";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * Base class for material plugins.
@@ -305,3 +306,6 @@ export class MaterialPluginBase {
         SerializationHelper.Parse(() => this, source, scene, rootUrl);
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.MaterialPluginBase", MaterialPluginBase);

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -14,6 +14,7 @@ import type { Light } from "../Lights/light";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Tools } from "../Misc/tools";
 import type { ThinEngine } from "../Engines/thinEngine";
+import { RegisterClass } from "../Misc/typeStore";
 
 Mesh._instancedMeshFactory = (name: string, mesh: Mesh): InstancedMesh => {
     const instance = new InstancedMesh(name, mesh);
@@ -815,3 +816,6 @@ Mesh.prototype._disposeInstanceSpecificData = function () {
 
     this.instancedBuffers = {};
 };
+
+// Register Class Name
+RegisterClass("BABYLON.InstancedMesh", InstancedMesh);

--- a/packages/dev/core/src/Misc/typeStore.ts
+++ b/packages/dev/core/src/Misc/typeStore.ts
@@ -15,3 +15,15 @@ export function RegisterClass(className: string, type: Object) {
 export function GetClass(fqdn: string): any {
     return _RegisteredTypes[fqdn];
 }
+
+/**
+ * @internal
+ */
+export function GetClassName(obj: any): string {
+    for (const key in _RegisteredTypes) {
+        if (obj instanceof (_RegisteredTypes[key] as any) && !key.includes("Abstract")) {
+            return key;
+        }
+    }
+    return "Unknown";
+}

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -24,6 +24,7 @@ import type { HemisphericParticleEmitter } from "./EmitterTypes/hemisphericParti
 import type { SphereDirectedParticleEmitter, SphereParticleEmitter } from "./EmitterTypes/sphereParticleEmitter";
 import type { CylinderDirectedParticleEmitter, CylinderParticleEmitter } from "./EmitterTypes/cylinderParticleEmitter";
 import type { ConeParticleEmitter } from "./EmitterTypes/coneParticleEmitter";
+import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This represents the base class for particle system in Babylon.
@@ -824,3 +825,6 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         throw new Error("Method not implemented.");
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.BaseParticleSystem", BaseParticleSystem);

--- a/packages/dev/core/src/abstractScene.ts
+++ b/packages/dev/core/src/abstractScene.ts
@@ -17,6 +17,7 @@ import type { Light } from "./Lights/light";
 import type { Node } from "./node";
 import type { PostProcess } from "./PostProcesses/postProcess";
 import type { Animation } from "./Animations/animation";
+import { RegisterClass } from "./Misc/typeStore";
 
 /**
  * Defines how the parser contract is defined.
@@ -228,3 +229,6 @@ export abstract class AbstractScene {
         return nodes;
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.AbstractScene", AbstractScene);

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -90,6 +90,7 @@ import type { Texture } from "./Materials/Textures/texture";
 import { PointerPickingConfiguration } from "./Inputs/pointerPickingConfiguration";
 import { Logger } from "./Misc/logger";
 import type { AbstractEngine } from "./Engines/abstractEngine";
+import { RegisterClass } from "./Misc/typeStore";
 
 /**
  * Define an interface for all classes that will hold resources
@@ -5755,3 +5756,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         return this.getLastSkeletonById(id);
     }
 }
+
+// Register Class Name
+RegisterClass("BABYLON.Scene", Scene);

--- a/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
+++ b/packages/dev/inspector/src/components/actionTabs/actionTabs.scss
@@ -676,11 +676,11 @@ $line-padding-left: 2px;
                     }
 
                     .radioContainer {
+                        grid-column: 2;
                         display: flex;
                         align-items: center;
 
                         .radio {
-                            grid-column: 2;
                             display: none;
 
                             &:checked + label:before {
@@ -724,6 +724,17 @@ $line-padding-left: 2px;
                             }
                         }
                     }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .vector3Line {
@@ -758,6 +769,17 @@ $line-padding-left: 2px;
                             align-items: center;
                             justify-items: center;
                             cursor: pointer;
+                        }
+
+                        .copy {
+                            grid-column: 4;
+                            display: grid;
+                            align-items: center;
+                            justify-items: center;
+                            cursor: pointer;
+                            img {
+                                height: 100%;
+                            }
                         }
                     }
 
@@ -794,7 +816,7 @@ $line-padding-left: 2px;
                     padding-left: $line-padding-left;
                     height: 30px;
                     display: grid;
-                    grid-template-columns: 1fr auto;
+                    grid-template-columns: 1fr auto 20px 10px;
 
                     .label {
                         grid-column: 1;
@@ -868,6 +890,17 @@ $line-padding-left: 2px;
 
                         .icon {
                             display: none;
+                        }
+                    }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
                         }
                     }
                 }
@@ -987,6 +1020,17 @@ $line-padding-left: 2px;
                             width: 110px;
                         }
                     }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .sliderLine {
@@ -1072,6 +1116,23 @@ $line-padding-left: 2px;
                             cursor: pointer;
                         }
                     }
+
+                    .floatLine {
+                        .copy {
+                            display: none;
+                        }
+                    }
+
+                    .copy {
+                        grid-column: 4;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
+                        }
+                    }
                 }
 
                 .color3Line {
@@ -1081,7 +1142,7 @@ $line-padding-left: 2px;
                     .firstLine {
                         height: 30px;
                         display: grid;
-                        grid-template-columns: 1fr auto 20px 20px;
+                        grid-template-columns: 1fr auto 20px;
 
                         .label {
                             grid-column: 1;
@@ -1115,8 +1176,16 @@ $line-padding-left: 2px;
                             }
                         }
 
-                        .copy {
+                        .expand {
                             grid-column: 3;
+                            display: grid;
+                            align-items: center;
+                            justify-items: center;
+                            cursor: pointer;
+                        }
+
+                        .copy {
+                            grid-column: 4;
                             display: grid;
                             align-items: center;
                             justify-items: center;
@@ -1124,14 +1193,6 @@ $line-padding-left: 2px;
                             img {
                                 height: 100%;
                             }
-                        }
-
-                        .expand {
-                            grid-column: 4;
-                            display: grid;
-                            align-items: center;
-                            justify-items: center;
-                            cursor: pointer;
                         }
                     }
 
@@ -1168,7 +1229,7 @@ $line-padding-left: 2px;
                     padding-left: $line-padding-left;
                     height: 30px;
                     display: grid;
-                    grid-template-columns: 1fr auto;
+                    grid-template-columns: 1fr auto 20px 10px;
 
                     .label {
                         grid-column: 1;
@@ -1185,6 +1246,17 @@ $line-padding-left: 2px;
 
                         select {
                             width: 115px;
+                        }
+                    }
+
+                    .copy {
+                        grid-column: 3;
+                        display: grid;
+                        align-items: center;
+                        justify-items: center;
+                        cursor: pointer;
+                        img {
+                            height: 100%;
                         }
                     }
                 }

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -8,6 +8,10 @@ import type { PropertyChangedEvent } from "../../propertyChangedEvent";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
+import { copyCommandToClipboard } from "shared-ui-components/copyCommandToClipboard";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "shared-ui-components/lines/copy.svg";
 
 interface IQuaternionLineComponentProps {
     label: string;
@@ -141,6 +145,21 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
         this.updateQuaternionFromEuler();
     }
 
+    // Copy to clipboard the code this Quaternion actually does
+    // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
 
@@ -158,8 +177,11 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
                         {!this.props.useEuler && `X: ${quat.x.toFixed(1)}, Y: ${quat.y.toFixed(1)}, Z: ${quat.z.toFixed(1)}, W: ${quat.w.toFixed(1)}`}
                         {this.props.useEuler && `X: ${eulerDegrees.x.toFixed(2)}, Y: ${eulerDegrees.y.toFixed(2)}, Z: ${eulerDegrees.z.toFixed(2)}`}
                     </div>
-                    <div className="expand" onClick={() => this.switchExpandState()}>
+                    <div className="expand hoverIcon" onClick={() => this.switchExpandState()} title="Expand">
                         {chevron}
+                    </div>
+                    <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                        <img src={copyIcon} alt="Copy" />
                     </div>
                 </div>
                 {this.state.isExpanded && !this.props.useEuler && (

--- a/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/lines/quaternionLineComponent.tsx
@@ -8,9 +8,7 @@ import type { PropertyChangedEvent } from "../../propertyChangedEvent";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObject";
-import { copyCommandToClipboard } from "shared-ui-components/copyCommandToClipboard";
-import { GetClassName } from "core/Misc/typeStore";
-
+import { copyCommandToClipboard, getClassNameWithNamespace } from "shared-ui-components/copyCommandToClipboard";
 import copyIcon from "shared-ui-components/lines/copy.svg";
 
 interface IQuaternionLineComponentProps {
@@ -146,14 +144,15 @@ export class QuaternionLineComponent extends React.Component<IQuaternionLineComp
     }
 
     // Copy to clipboard the code this Quaternion actually does
-    // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1);
+    // Example : cube.rotationQuaternion = new BABYLON.Quaternion(0,0,0,1)// cube as BABYLON.Mesh;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strVector = "new BABYLON.Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
-            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            const strVector = "new " + babylonNamespace + "Quaternion(" + value.x + ", " + value.y + ", " + value.z + ", " + value.w + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -21,6 +21,8 @@ import { TmpVectors, Vector3 } from "core/Maths/math";
 import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
 import type { Bone } from "core/Bones/bone";
 
+import { setDebugNode } from "../treeNodeDebugger";
+
 interface ISceneTreeItemComponentProps {
     scene: Scene;
     gizmoCamera?: Camera;
@@ -171,6 +173,8 @@ export class SceneTreeItemComponent extends React.Component<
             return;
         }
         const scene = this.props.scene;
+        // Put scene object into window.debugNode
+        setDebugNode(scene);
         this.props.onSelectionChangedObservable.notifyObservers(scene);
     }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
@@ -10,6 +10,8 @@ import * as ReactDOM from "react-dom";
 import * as React from "react";
 import type { GlobalState } from "../globalState";
 
+import { setDebugNode } from "./treeNodeDebugger";
+
 export interface ITreeItemSelectableComponentProps {
     entity: any;
     selectedEntity?: any;
@@ -86,6 +88,8 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
         }
         this._wasSelected = true;
         const entity = this.props.entity;
+        // Put selected node into window.debugNode
+        setDebugNode(entity);
         this.props.globalState.onSelectionChangedObservable.notifyObservers(entity);
     }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
@@ -1,0 +1,13 @@
+// window.debugNode will be able to receive any object selected in the inspector
+declare global {
+    interface Window {
+        debugNode: any;
+    }
+}
+
+export function setDebugNode(node: any) {
+    // Prevents a NodeJS env to crash on a non existing window
+    if (typeof window !== "undefined") {
+        window.debugNode = node;
+    }
+}

--- a/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeNodeDebugger.ts
@@ -1,13 +1,19 @@
-// window.debugNode will be able to receive any object selected in the inspector
+// globalThis.debugNode will be able to receive any object selected in the inspector
 declare global {
-    interface Window {
+    interface GlobalThis {
         debugNode: any;
     }
 }
 
+// globalThis.debugNode receives the selected node in the inspector
 export function setDebugNode(node: any) {
-    // Prevents a NodeJS env to crash on a non existing window
-    if (typeof window !== "undefined") {
-        window.debugNode = node;
+    if (typeof globalThis !== "undefined") {
+        (globalThis as any).debugNode = node;
+        // GC to avoid memory leak on global reference
+        if (typeof node._scene !== "undefined" && node._scene.onDisposeObservable) {
+            node._scene.onDisposeObservable.add(() => {
+                (globalThis as any).debugNode = null;
+            });
+        }
     }
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,3 +1,14 @@
+import { GetClassName } from "core/Misc/typeStore";
+
+// Check if BABYLON namespace exists
+let babylonNamespace = "";
+const globalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
+if (typeof globalObject !== "undefined") {
+    if (typeof (<any>globalObject).BABYLON !== "undefined") {
+        babylonNamespace = "BABYLON.";
+    }
+}
+
 // Inspired by previous copyToClipboard() function which was copying Color3
 // Copies strCommand to clipboard
 export function copyCommandToClipboard(strCommand: string) {
@@ -14,4 +25,14 @@ export function copyCommandToClipboard(strCommand: string) {
 
     document.execCommand("copy");
     element.remove();
+}
+
+// Return the class name of the considered target
+// babylonNamespace is either "" (ES6) or "BABYLON."
+export function getClassNameWithNamespace(obj: any): { className: string; babylonNamespace: string } {
+    let className = GetClassName(obj);
+    if (className.includes("BABYLON.")) {
+        className = className.split("BABYLON.")[1];
+    }
+    return { className, babylonNamespace };
 }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,0 +1,17 @@
+// Inspired by previous copyToClipboard() function which was copying Color3
+// Copies strCommand to clipboard
+export function copyCommandToClipboard(strCommand: string) {
+    const element = document.createElement("div");
+    element.textContent = strCommand;
+    document.body.appendChild(element);
+
+    if (window.getSelection) {
+        const range = document.createRange();
+        range.selectNode(element);
+        window.getSelection()!.removeAllRanges();
+        window.getSelection()!.addRange(range);
+    }
+
+    document.execCommand("copy");
+    element.remove();
+}

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "./../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 export interface ICheckBoxLineComponentProps {
     label?: string;
@@ -109,6 +113,20 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
         this.setState({ isSelected: !this.state.isSelected, isConflict: false });
     }
 
+    // Copy to clipboard the code this checkbox actually does
+    // Example : mesh.checkCollisions = true;
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         const icons = this.props.large ? Icons.size40 : Icons.size30;
         const icon = this.state.isConflict ? icons.mixed : this.state.isSelected ? icons.on : icons.off;
@@ -141,6 +159,9 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
                         </label>
                     </div>
                 )}
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
+                </div>
             </div>
         );
     }

--- a/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/checkBoxLineComponent.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "./../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
-import { GetClassName } from "core/Misc/typeStore";
-
 import copyIcon from "./copy.svg";
 
 export interface ICheckBoxLineComponentProps {
@@ -117,10 +115,11 @@ export class CheckBoxLineComponent extends React.Component<ICheckBoxLineComponen
     // Example : mesh.checkCollisions = true;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/colorLineComponent.tsx
@@ -5,13 +5,12 @@ import { NumericInputComponent } from "./numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import { ColorPickerLineComponent } from "./colorPickerComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
-import { GetClassName } from "core/Misc/typeStore";
-
 import copyIcon from "./copy.svg";
+
 const emptyColor = new Color4(0, 0, 0, 0);
 
 export interface IColorLineComponentProps {
@@ -170,18 +169,19 @@ export class ColorLineComponent extends React.Component<IColorLineComponentProps
     // Example : material.diffuseColor = new BABYLON.Vector3(0,1,0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
             const hex = this.state.color.toHexString();
             let strColor;
             if (value.a) {
-                strColor = "new BABYLON.Color4(" + value.r + ", " + value.g + ", " + value.b + ", " + value.a + ")";
+                strColor = "new " + babylonNamespace + "Color4(" + value.r + ", " + value.g + ", " + value.b + ", " + value.a + ")";
             } else {
-                strColor = "new BABYLON.Color3(" + value.r + ", " + value.g + ", " + value.b + ")";
+                strColor = "new " + babylonNamespace + "Color3(" + value.r + ", " + value.g + ", " + value.b + ")";
             }
-            strColor += ";//(HEX : " + hex + ")";
-            const strCommand = targetName + "." + targetProperty + " = " + strColor;
+            strColor += ";// (HEX : " + hex;
+            const strCommand = targetName + "." + targetProperty + " = " + strColor + " , debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
@@ -7,9 +6,7 @@ import { SliderLineComponent } from "./sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
 import { InputArrowsComponent } from "./inputArrowsComponent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
-import { GetClassName } from "core/Misc/typeStore";
-
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import copyIcon from "./copy.svg";
 
 interface IFloatLineComponentProps {
@@ -199,10 +196,11 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
     // Example : BaseParticleSystem.minScaleX = 1.0;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -7,6 +7,10 @@ import { SliderLineComponent } from "./sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import { conflictingValuesPlaceholder } from "./targetsProxy";
 import { InputArrowsComponent } from "./inputArrowsComponent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 interface IFloatLineComponentProps {
     label: string;
@@ -191,6 +195,20 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
         }
     }
 
+    // Copy to clipboard the code this slider actually does
+    // Example : BaseParticleSystem.minScaleX = 1.0;
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         let valueAsNumber: number;
 
@@ -255,6 +273,9 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
                             )}
                         </div>
                         {this.props.unit}
+                        <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                            <img src={copyIcon} alt="Copy" />
+                        </div>
                     </div>
                 )}
                 {this.props.useEuler && (

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
-import { GetClassName } from "core/Misc/typeStore";
-
 import copyIcon from "./copy.svg";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -107,10 +105,11 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
     // Example : material.sideOrientation = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import type { IInspectableOptions } from "core/Misc/iInspectable";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Null_Value = Number.MAX_SAFE_INTEGER;
@@ -99,6 +103,20 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
         this.raiseOnPropertyChanged(newValue, store);
     }
 
+    // Copy to clipboard the code this option actually does
+    // Example : material.sideOrientation = 1;
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         return (
             <div className={"listLine" + (this.props.className ? " " + this.props.className : "")}>
@@ -116,6 +134,9 @@ export class OptionsLineComponent extends React.Component<IOptionsLineComponentP
                             );
                         })}
                     </select>
+                </div>
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
                 </div>
             </div>
         );

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "./floatLineComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 interface ISliderLineComponentProps {
     label: string;
@@ -120,6 +124,20 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
         return value;
     }
 
+    // Copy to clipboard the code this slider actually does
+    // Example : ImageProcessingConfiguration.contrast = 1;
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         return (
             <div className="sliderLine">
@@ -161,6 +179,9 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
                         onInput={(evt) => this.onInput((evt.target as HTMLInputElement).value)}
                         onChange={(evt) => this.onChange(evt.target.value)}
                     />
+                </div>
+                <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                    <img src={copyIcon} alt="Copy" />
                 </div>
             </div>
         );

--- a/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/sliderLineComponent.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 import type { Observable } from "core/Misc/observable";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import { Tools } from "core/Misc/tools";
 import { FloatLineComponent } from "./floatLineComponent";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
-import { GetClassName } from "core/Misc/typeStore";
-
 import copyIcon from "./copy.svg";
 
 interface ISliderLineComponentProps {
@@ -128,10 +126,11 @@ export class SliderLineComponent extends React.Component<ISliderLineComponentPro
     // Example : ImageProcessingConfiguration.contrast = 1;
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strCommand = targetName + "." + targetProperty + " = " + value + ";";
+            const strCommand = targetName + "." + targetProperty + " = " + value + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -6,9 +6,13 @@ import { NumericInputComponent } from "../lines/numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
 import { SliderLineComponent } from "../lines/sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
+import { GetClassName } from "core/Misc/typeStore";
+
+import copyIcon from "./copy.svg";
 
 interface IVector3LineComponentProps {
     label: string;
@@ -105,6 +109,21 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
         this.updateVector3();
     }
 
+    // Copy to clipboard the code this Vector3 actually does
+    // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
+    onCopyClick() {
+        if (this.props && this.props.target) {
+            const targetName = GetClassName(this.props.target);
+            const targetProperty = this.props.propertyName;
+            const value = this.props.target[this.props.propertyName!];
+            const strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            copyCommandToClipboard(strCommand);
+        } else {
+            copyCommandToClipboard("undefined");
+        }
+    }
+
     override render() {
         const chevron = this.state.isExpanded ? <FontAwesomeIcon icon={faMinus} /> : <FontAwesomeIcon icon={faPlus} />;
 
@@ -124,6 +143,9 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
                     </div>
                     <div className="expand hoverIcon" onClick={() => this.switchExpandState()} title="Expand">
                         {chevron}
+                    </div>
+                    <div className="copy hoverIcon" onClick={() => this.onCopyClick()} title="Copy to clipboard">
+                        <img src={copyIcon} alt="Copy" />
                     </div>
                 </div>
                 {this.state.isExpanded && !this.props.useEuler && (

--- a/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/vector3LineComponent.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 import { Vector3 } from "core/Maths/math.vector";
 import type { Observable } from "core/Misc/observable";
-
 import { NumericInputComponent } from "../lines/numericInputComponent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import type { PropertyChangedEvent } from "../propertyChangedEvent";
-import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { copyCommandToClipboard, getClassNameWithNamespace } from "../copyCommandToClipboard";
 import { SliderLineComponent } from "../lines/sliderLineComponent";
 import { Tools } from "core/Misc/tools";
 import type { LockObject } from "../tabs/propertyGrids/lockObject";
-import { GetClassName } from "core/Misc/typeStore";
-
 import copyIcon from "./copy.svg";
 
 interface IVector3LineComponentProps {
@@ -113,11 +110,12 @@ export class Vector3LineComponent extends React.Component<IVector3LineComponentP
     // Example : Mesh.position = new BABYLON.Vector3(0, 1, 0);
     onCopyClick() {
         if (this.props && this.props.target) {
-            const targetName = GetClassName(this.props.target);
+            const { className, babylonNamespace } = getClassNameWithNamespace(this.props.target);
+            const targetName = "globalThis.debugNode";
             const targetProperty = this.props.propertyName;
             const value = this.props.target[this.props.propertyName!];
-            const strVector = "new BABYLON.Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
-            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";";
+            const strVector = "new " + babylonNamespace + "Vector3(" + value.x + ", " + value.y + ", " + value.z + ")";
+            const strCommand = targetName + "." + targetProperty + " = " + strVector + ";// (debugNode as " + babylonNamespace + className + ")";
             copyCommandToClipboard(strCommand);
         } else {
             copyCommandToClipboard("undefined");

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyTab.scss
@@ -58,6 +58,10 @@
         }
     }
 
+    .copy {
+        display: none;
+    }
+
     .range {
         -webkit-appearance: none;
         width: 100%;
@@ -241,6 +245,14 @@
                     appearance: textfield;
                 }
             }
+
+            .copy {
+                display: none;
+            }
+        }
+
+        .copy {
+            display: none;
         }
     }
 
@@ -407,6 +419,10 @@
                     filter: brightness(10);
                 }
             }
+        }
+
+        .copy {
+            display: none;
         }
     }
 
@@ -803,6 +819,10 @@
                 -moz-appearance: textfield;
             }
         }
+
+        .copy {
+            display: none;
+        }
     }
 
     .vector3Line {
@@ -834,6 +854,10 @@
                 align-items: center;
                 justify-items: center;
                 cursor: pointer;
+            }
+
+            .copy {
+                display: none;
             }
         }
 
@@ -983,6 +1007,10 @@
         .hidden {
             display: none;
         }
+
+        .copy {
+            display: none;
+        }
     }
 
     .listLine {
@@ -1026,6 +1054,10 @@
                 height: 24px;
                 color: #333333;
             }
+        }
+
+        .copy {
+            display: none;
         }
     }
 
@@ -1075,6 +1107,19 @@
                 }
             }
 
+            .expand {
+                grid-column: 3;
+                display: none;
+                align-items: center;
+                justify-items: center;
+                cursor: pointer;
+
+                img {
+                    height: 100%;
+                    width: 20px;
+                }
+            }
+
             .copy {
                 grid-column: 4;
                 display: none;
@@ -1082,19 +1127,6 @@
                 justify-items: center;
                 cursor: pointer;
                 color: black;
-                img {
-                    height: 100%;
-                    width: 20px;
-                }
-            }
-
-            .expand {
-                grid-column: 4;
-                display: none;
-                align-items: center;
-                justify-items: center;
-                cursor: pointer;
-
                 img {
                     height: 100%;
                     width: 20px;

--- a/packages/tools/guiEditor/src/scss/commandBar.scss
+++ b/packages/tools/guiEditor/src/scss/commandBar.scss
@@ -12,6 +12,10 @@
     grid-column: 1;
     user-select: none;
 
+    .copy {
+        display: none;
+    }
+
     .commands-left {
         float: left;
         display: flex;
@@ -335,6 +339,10 @@
     .checkBoxLine {
         display: flex;
         align-items: center;
+
+        .copy {
+            display: none;
+        }
     }
 
     .checkBoxLine {
@@ -348,6 +356,10 @@
 
         .checkBox {
             height: 40px;
+        }
+
+        .copy {
+            display: none;
         }
     }
 

--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTab.scss
@@ -136,6 +136,14 @@
                         -moz-appearance: textfield;
                     }
                 }
+
+                .copy {
+                    display: none;
+                }
+            }
+
+            .copy {
+                display: none;
             }
         }
 
@@ -411,6 +419,10 @@
                     -moz-appearance: textfield;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .vector3Line {
@@ -442,6 +454,10 @@
                     align-items: center;
                     justify-items: center;
                     cursor: pointer;
+                }
+
+                .copy {
+                    display: none;
                 }
             }
 
@@ -614,6 +630,10 @@
                     display: none;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .listLine {
@@ -639,6 +659,10 @@
                     width: 115px;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .color3Line {
@@ -648,7 +672,7 @@
             .firstLine {
                 height: 30px;
                 display: grid;
-                grid-template-columns: 1fr auto 0px 20px 20px;
+                grid-template-columns: 1fr auto 20px;
 
                 .label {
                     grid-column: 1;
@@ -672,29 +696,22 @@
                     }
                 }
 
+                .expand {
+                    grid-column: 3;
+                    display: grid;
+                    align-items: center;
+                    justify-items: center;
+                    cursor: pointer;
+                }
+
                 .copy {
                     grid-column: 4;
                     display: grid;
                     align-items: center;
                     justify-items: center;
                     cursor: pointer;
-
                     img {
                         height: 100%;
-                        width: 24px;
-                    }
-                }
-
-                .expand {
-                    grid-column: 5;
-                    display: grid;
-                    align-items: center;
-                    justify-items: center;
-                    cursor: pointer;
-
-                    img {
-                        height: 100%;
-                        width: 20px;
                     }
                 }
             }

--- a/packages/tools/nodeEditor/src/main.scss
+++ b/packages/tools/nodeEditor/src/main.scss
@@ -243,6 +243,10 @@
                     width: 115px;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .button {

--- a/packages/tools/nodeGeometryEditor/src/components/propertyTab/propertyTab.scss
+++ b/packages/tools/nodeGeometryEditor/src/components/propertyTab/propertyTab.scss
@@ -136,6 +136,14 @@
                         -moz-appearance: textfield;
                     }
                 }
+
+                .copy {
+                    display: none;
+                }
+            }
+
+            .copy {
+                display: none;
             }
         }
 
@@ -435,6 +443,10 @@
                     -moz-appearance: textfield;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .vector3Line {
@@ -466,6 +478,10 @@
                     align-items: center;
                     justify-items: center;
                     cursor: pointer;
+                }
+
+                .copy {
+                    display: none;
                 }
             }
 
@@ -665,6 +681,10 @@
                     display: none;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .listLine {
@@ -690,6 +710,10 @@
                     width: 115px;
                 }
             }
+
+            .copy {
+                display: none;
+            }
         }
 
         .color3Line {
@@ -699,7 +723,7 @@
             .firstLine {
                 height: 30px;
                 display: grid;
-                grid-template-columns: 1fr auto 0px 20px 20px;
+                grid-template-columns: 1fr auto 20px;
 
                 .label {
                     grid-column: 1;
@@ -723,6 +747,19 @@
                     }
                 }
 
+                .expand {
+                    grid-column: 3;
+                    display: grid;
+                    align-items: center;
+                    justify-items: center;
+                    cursor: pointer;
+
+                    img {
+                        height: 100%;
+                        width: 20px;
+                    }
+                }
+
                 .copy {
                     grid-column: 4;
                     display: grid;
@@ -733,19 +770,6 @@
                     img {
                         height: 100%;
                         width: 24px;
-                    }
-                }
-
-                .expand {
-                    grid-column: 5;
-                    display: grid;
-                    align-items: center;
-                    justify-items: center;
-                    cursor: pointer;
-
-                    img {
-                        height: 100%;
-                        width: 20px;
                     }
                 }
             }

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -146,7 +146,33 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                         isActive={false}
                         onClick={() => this.onDownload()}
                     />
-                    <CommandButtonComponent globalState={this.props.globalState} tooltip="Create new" icon="new" isActive={false} onClick={() => this.onNew()} />
+                    <CommandDropdownComponent
+                        globalState={this.props.globalState}
+                        icon="new"
+                        tooltip="New Scene"
+                        items={[
+                            {
+                                label: "Create New",
+                                tooltip: "Creates the Default Playground Scene",
+                                storeKey: "new",
+                                defaultValue: "Light",
+                                subItems: ["Light", "Dark"],
+                                onClick: () => {
+                                    this.onNew();
+                                },
+                            },
+                            {
+                                label: "Create New",
+                                tooltip: "Creates the Default Playground Scene",
+                                storeKey: "new",
+                                defaultValue: "Light",
+                                subItems: ["Light", "Dark"],
+                                onClick: () => {
+                                    this.onNew();
+                                },
+                            },
+                        ]}
+                    />
                     <CommandButtonComponent globalState={this.props.globalState} tooltip="Clear code" icon="clear" isActive={false} onClick={() => this.onClear()} />
                     <CommandDropdownComponent
                         globalState={this.props.globalState}

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -146,33 +146,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                         isActive={false}
                         onClick={() => this.onDownload()}
                     />
-                    <CommandDropdownComponent
-                        globalState={this.props.globalState}
-                        icon="new"
-                        tooltip="New Scene"
-                        items={[
-                            {
-                                label: "Create New",
-                                tooltip: "Creates the Default Playground Scene",
-                                storeKey: "new",
-                                defaultValue: "Light",
-                                subItems: ["Light", "Dark"],
-                                onClick: () => {
-                                    this.onNew();
-                                },
-                            },
-                            {
-                                label: "Create New",
-                                tooltip: "Creates the Default Playground Scene",
-                                storeKey: "new",
-                                defaultValue: "Light",
-                                subItems: ["Light", "Dark"],
-                                onClick: () => {
-                                    this.onNew();
-                                },
-                            },
-                        ]}
-                    />
+                    <CommandButtonComponent globalState={this.props.globalState} tooltip="Create new" icon="new" isActive={false} onClick={() => this.onNew()} />
                     <CommandButtonComponent globalState={this.props.globalState} tooltip="Clear code" icon="clear" isActive={false} onClick={() => this.onClear()} />
                     <CommandDropdownComponent
                         globalState={this.props.globalState}


### PR DESCRIPTION
Same version than final state of [previous PR 15050](https://github.com/BabylonJS/Babylon.js/pull/15050/)
  PLUS the following :
____
Added a fix (`.SCSS` only) on some broken tools, NME, NGE, gui-editor, where copy buttons where appearing, due to modification of the sharedUI line components.
____
Built locally and tested on `Playground`, `Sandbox`, `NME`, `NGE`, `GuiEditor`