### PR TITLE
SSR: Fix in orthographic mode

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
@@ -801,6 +801,12 @@ export class SSRRenderingPipeline extends PostProcessRenderPipeline {
             defines.push("#define SSR_DECODE_NORMAL");
         }
 
+        const camera = this._cameras?.[0];
+
+        if (camera && camera.mode === Constants.ORTHOGRAPHIC_CAMERA) {
+            defines.push("#define ORTHOGRAPHIC_CAMERA");
+        }
+
         this._ssrPostProcess?.updateEffect(defines.join("\n"));
     }
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/screenSpaceRayTrace.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/screenSpaceRayTrace.fx
@@ -325,9 +325,17 @@ vec3 computeViewPosFromUVDepth(vec2 texCoord, float depth, mat4 projection, mat4
     
     ndc.xy = texCoord * 2.0 - 1.0;
 #ifdef SSRAYTRACE_RIGHT_HANDED_SCENE
-    ndc.z = -projection[2].z - projection[3].z / depth;
+    #ifdef ORTHOGRAPHIC_CAMERA
+        ndc.z = -projection[2].z * depth + projection[3].z;
+    #else
+        ndc.z = -projection[2].z - projection[3].z / depth;
+    #endif
 #else
-    ndc.z = projection[2].z + projection[3].z / depth;
+    #ifdef ORTHOGRAPHIC_CAMERA
+        ndc.z = projection[2].z * depth + projection[3].z;
+    #else
+        ndc.z = projection[2].z + projection[3].z / depth;
+    #endif
 #endif
     ndc.w = 1.0;
 

--- a/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
@@ -130,7 +130,11 @@ void main()
     #endif
     float depth = texelFetch(depthSampler, ivec2(vUV * texSize), 0).r;
     vec3 csPosition = computeViewPosFromUVDepth(vUV, depth, projection, invProjectionMatrix);
-    vec3 csViewDirection = normalize(csPosition);
+    #ifdef ORTHOGRAPHIC_CAMERA
+        vec3 csViewDirection = vec3(0., 0., 1.);
+    #else
+        vec3 csViewDirection = normalize(csPosition);
+    #endif
 
     vec3 csReflectedVector = reflect(csViewDirection, csNormal);
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/screen-space-reflections-do-not-work-with-orthographic-camera/50178