### PR TITLE
Allow changing CleanUrl from Tools

### DIFF
--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -87,6 +87,7 @@ export const FileToolsOptions: {
     PreprocessUrl: (url: string) => string;
     ScriptBaseUrl: string;
     ScriptPreprocessUrl: (url: string) => string;
+    CleanUrl: (url: string) => string;
 } = {
     /**
      * Gets or sets the retry strategy to apply when an error happens while loading an asset.
@@ -126,6 +127,13 @@ export const FileToolsOptions: {
      * @returns the processed url
      */
     ScriptPreprocessUrl: (url: string) => url,
+
+    /**
+     * Gets or sets a function used to clean the url before using it to load assets
+     * @param url defines the url to clean
+     * @returns the cleaned url
+     */
+    CleanUrl: (url: string) => url,
 };
 
 /**
@@ -133,8 +141,7 @@ export const FileToolsOptions: {
  * @param url defines the url to clean
  * @returns the cleaned url
  */
-// eslint-disable-next-line prefer-const
-export let CleanUrl = (url: string): string => {
+const CleanUrl = (url: string): string => {
     url = url.replace(/#/gm, "%23");
     return url;
 };
@@ -835,15 +842,12 @@ export let FileTools: {
     SetCorsBehavior: (url: string | string[], element: { crossOrigin: string | null }) => void;
 };
 /**
- * @param DecodeBase64UrlToBinary
- * @param DecodeBase64UrlToString
- * @param FileToolsOptions
  * @internal
  */
 export const _injectLTSFileTools = (
     DecodeBase64UrlToBinary: (uri: string) => ArrayBuffer,
     DecodeBase64UrlToString: (uri: string) => string,
-    FileToolsOptions: { DefaultRetryStrategy: any; BaseUrl: any; CorsBehavior: any; PreprocessUrl: any },
+    FileToolsOptions: { DefaultRetryStrategy: any; BaseUrl: any; CorsBehavior: any; PreprocessUrl: any; CleanUrl: any },
     IsBase64DataUrl: (uri: string) => boolean,
     IsFileURL: () => boolean,
     LoadFile: (

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -77,6 +77,17 @@ export class ReadFileError extends RuntimeError {
         BaseError._setPrototypeOf(this, ReadFileError.prototype);
     }
 }
+
+/**
+ * Removes unwanted characters from an url
+ * @param url defines the url to clean
+ * @returns the cleaned url
+ */
+const CleanUrl = (url: string): string => {
+    url = url.replace(/#/gm, "%23");
+    return url;
+};
+
 /**
  * @internal
  */
@@ -133,17 +144,7 @@ export const FileToolsOptions: {
      * @param url defines the url to clean
      * @returns the cleaned url
      */
-    CleanUrl: (url: string) => url,
-};
-
-/**
- * Removes unwanted characters from an url
- * @param url defines the url to clean
- * @returns the cleaned url
- */
-const CleanUrl = (url: string): string => {
-    url = url.replace(/#/gm, "%23");
-    return url;
+    CleanUrl,
 };
 
 /**
@@ -208,7 +209,7 @@ export const LoadImage = (
         url = URL.createObjectURL(input);
         usingObjectURL = true;
     } else {
-        url = CleanUrl(input);
+        url = FileToolsOptions.CleanUrl(input);
         url = FileToolsOptions.PreprocessUrl(input);
     }
 
@@ -530,7 +531,7 @@ export const RequestFile = (
     onError?: (error: RequestFileError) => void,
     onOpened?: (request: WebRequest) => void
 ): IFileRequest => {
-    url = CleanUrl(url);
+    url = FileToolsOptions.CleanUrl(url);
     url = FileToolsOptions.PreprocessUrl(url);
 
     const loadUrl = FileToolsOptions.BaseUrl + url;

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -47,6 +47,17 @@ export class Tools {
     }
 
     /**
+     * Gets or sets the clean URL function to use to load assets
+     */
+    public static get CleanUrl() {
+        return FileToolsOptions.CleanUrl;
+    }
+
+    public static set CleanUrl(value: (url: string) => string) {
+        FileToolsOptions.CleanUrl = value;
+    }
+
+    /**
      * This function checks whether a URL is absolute or not.
      * It will also detect data and blob URLs
      * @param url the url to check


### PR DESCRIPTION
This moves CleanUrl to FileToolsOptions, and proxy the change to tools (similar to BaseUrl)