### PR TITLE
KTXTextureLoader - Push instead of unshift

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -144,4 +144,4 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.unshift(new _KTXTextureLoader());
+Engine._TextureLoaders.push(new _KTXTextureLoader());


### PR DESCRIPTION
Reasoning is this - if someone registers a different KTX Loader for the same mime types before this one is created, this one is still prioritized because it is being unshifted into the first position instead of being pushed to the last position.

Since this is the only loader for ktx2 we have in our repo, there is no reason using unshift