### PR TITLE
Fix #14856

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
@@ -150,11 +150,16 @@ export class ImageSourceBlock extends NodeMaterialBlock {
         return serializationObject;
     }
 
-    public override _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
-        super._deserialize(serializationObject, scene, rootUrl);
+    public override _deserialize(serializationObject: any, scene: Scene, rootUrl: string, urlRewriter?: (url: string) => string) {
+        super._deserialize(serializationObject, scene, rootUrl, urlRewriter);
 
         if (serializationObject.texture && !NodeMaterial.IgnoreTexturesAtLoadTime && serializationObject.texture.url !== undefined) {
-            rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;
+            if (serializationObject.texture.url.indexOf("data:") === 0) {
+                rootUrl = "";
+            } else if (urlRewriter) {
+                serializationObject.texture.url = urlRewriter(serializationObject.texture.url);
+                serializationObject.texture.name = serializationObject.texture.url;
+            }
             this.texture = Texture.Parse(serializationObject.texture, scene, rootUrl) as Texture;
         }
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -694,7 +694,7 @@ export class TextureBlock extends NodeMaterialBlock {
         return serializationObject;
     }
 
-    public override _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
+    public override _deserialize(serializationObject: any, scene: Scene, rootUrl: string, urlRewriter?: (url: string) => string) {
         super._deserialize(serializationObject, scene, rootUrl);
 
         this.convertToGammaSpace = serializationObject.convertToGammaSpace;
@@ -703,7 +703,12 @@ export class TextureBlock extends NodeMaterialBlock {
         this.disableLevelMultiplication = !!serializationObject.disableLevelMultiplication;
 
         if (serializationObject.texture && !NodeMaterial.IgnoreTexturesAtLoadTime && serializationObject.texture.url !== undefined) {
-            rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;
+            if (serializationObject.texture.url.indexOf("data:") === 0) {
+                rootUrl = "";
+            } else if (urlRewriter) {
+                serializationObject.texture.url = urlRewriter(serializationObject.texture.url);
+                serializationObject.texture.name = serializationObject.texture.url;
+            }
             this.texture = Texture.Parse(serializationObject.texture, scene, rootUrl) as Texture;
         }
     }

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -858,7 +858,7 @@ export class NodeMaterialBlock {
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public _deserialize(serializationObject: any, scene: Scene, rootUrl: string) {
+    public _deserialize(serializationObject: any, scene: Scene, rootUrl: string, urlRewriter?: (url: string) => string) {
         this.name = serializationObject.name;
         this.comments = serializationObject.comments;
         this.visibleInInspector = !!serializationObject.visibleInInspector;


### PR DESCRIPTION
I went down a slightly different path to offer more flexibility. Now when parsing your node material you can provide an url rewriter to change the urls the way you want:

See this PG when this PR will be merged: https://playground.babylonjs.com/#3DMXME