### PR TITLE
Add back check to make sure there are active render loops before queuing a new one

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -910,7 +910,7 @@ export abstract class AbstractEngine {
             }
         }
 
-        if (this._frameHandler === 0) {
+        if (this._activeRenderLoops.length > 0 && this._frameHandler === 0) {
             this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
         }
     }

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -731,7 +731,7 @@ export class Engine extends ThinEngine {
             }
         }
 
-        if (this._frameHandler === 0) {
+        if (this._activeRenderLoops.length > 0 && this._frameHandler === 0) {
             // Register new frame
             if (this.customAnimationFrameRequester) {
                 this.customAnimationFrameRequester.requestID = this._queueNewFrame(


### PR DESCRIPTION
This is a follow up to #14868. The main reason for adding this check is to make Babylon Native work again, but it also prevents an additional queuing of a new frame if `stopRenderLoop` is called during render.