### PR TITLE
Add directly constructed Nodes to rootNodes

### DIFF
--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -101,7 +101,7 @@ export class Bone extends Node {
         bindMatrix: Nullable<Matrix> = null,
         index: Nullable<number> = null
     ) {
-        super(name, skeleton.getScene());
+        super(name, skeleton.getScene(), false);
         this._skeleton = skeleton;
         this._localMatrix = localMatrix?.clone() ?? Matrix.Identity();
         this._restMatrix = restMatrix ?? this._localMatrix.clone();

--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -453,7 +453,7 @@ export class Camera extends Node {
      * @param setActiveOnSceneIfNoneActive Defines if the camera should be set as active after creation if no other camera have been defined in the scene
      */
     constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
-        super(name, scene);
+        super(name, scene, false);
 
         this.getScene().addCamera(this);
 

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -370,7 +370,7 @@ export abstract class Light extends Node implements ISortableLight {
      * @param scene The scene the light belongs too
      */
     constructor(name: string, scene?: Scene) {
-        super(name, scene);
+        super(name, scene, false);
         this.getScene().addLight(this);
         this._uniformBuffer = new UniformBuffer(this.getScene().getEngine(), undefined, undefined, name);
         this._buildUniformLayout();

--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -185,7 +185,7 @@ export class TransformNode extends Node {
     public onAfterWorldMatrixUpdateObservable = new Observable<TransformNode>();
 
     constructor(name: string, scene: Nullable<Scene> = null, isPure = true) {
-        super(name, scene);
+        super(name, scene, false);
 
         if (isPure) {
             this.getScene().addTransformNode(this);

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -349,13 +349,18 @@ export class Node implements IBehaviorAware<Node> {
      * Creates a new Node
      * @param name the name and id to be given to this node
      * @param scene the scene this node will be added to
+     * @param isPure indicates this Node is just a Node, and not a derived class like Mesh or Camera
      */
-    constructor(name: string, scene: Nullable<Scene> = null) {
+    public constructor(name: string, scene: Nullable<Scene> = null, isPure = true) {
         this.name = name;
         this.id = name;
         this._scene = <Scene>(scene || EngineStore.LastCreatedScene);
         this.uniqueId = this._scene.getUniqueId();
         this._initCache();
+
+        if (isPure) {
+            this._addToSceneRootNodes();
+        }
     }
 
     /**


### PR DESCRIPTION
This is in response to this forum post: https://forum.babylonjs.com/t/root-node-not-shown-in-inspector-but-transformnodes-are/50432

When a `Node` is created directly (not a subclass of `Node`), it does not get added to the `rootNodes` of the `Scene`. However, if you set the `parent` on that `Node` and then set it back to `null`, then it does get added to `rootNodes`. From what I can tell, this is just wrong behavior and is a bug. My proposed fix is to add an optional parameter to the `Node` constructor that controls whether it gets added to the `rootNodes`. This is the same pattern that already existed for the same purpose with `TransformNode` and it's derived classes (e.g. `AbstratMesh`). That said, I personally don't love this pattern because as far as I can tell the `isPure` idea is meant to be an implementation detail to deal with the subclassing, but is publicly exposed (I know there is already a lot of this across the API). An alternative would be to just add this to the `Node` constructor and not change any of the subclasses:

```ts
if (this.constructor === Node) {
    this._addToSceneRootNodes();
}
```

This would just be saying "if a `Node` is directly constructed, add it to the scene's rootNodes, otherwise it must be a subclass, and the subclass is responsible for deciding how to add it to the rootNodes." Thoughts @deltakosh or anyone else?