### PR TITLE
Allow skipping typekit font loading using options or global variable

### DIFF
--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -157,6 +157,11 @@ export interface IInspectorOptions {
      * List of context menu items that should be completely overridden by custom items from the contextMenu property.
      */
     contextMenuOverride?: IInspectorContextMenuType[];
+
+    /**
+     * Should the default font loading be skipped
+     */
+    skipDefaultFontLoading?: boolean;
 }
 
 declare module "../scene" {

--- a/packages/dev/inspector/src/inspector.ts
+++ b/packages/dev/inspector/src/inspector.ts
@@ -388,6 +388,14 @@ export class Inspector {
             ...userOptions,
         };
 
+        // load the font, unless asked to skip it
+        if (!options.skipDefaultFontLoading || (globalThis as any)?.BABYLON_SKIP_FONT_LOADING !== true) {
+            const font = document.createElement("link");
+            font.rel = "stylesheet";
+            font.href = "https://use.typekit.net/cta4xsb.css";
+            document.head.appendChild(font);
+        }
+
         // Prepare state
         if (!this._GlobalState.onPropertyChangedObservable) {
             this._GlobalState.init(this.OnPropertyChangedObservable);

--- a/packages/dev/sharedUiComponents/src/components/Fonts.scss
+++ b/packages/dev/sharedUiComponents/src/components/Fonts.scss
@@ -1,4 +1,3 @@
-@import url(https://use.typekit.net/xfi0rwe.css);
 :local(.fontRegular) {
     font-family: "acumin-pro-condensed";
     font-size: 14px;


### PR DESCRIPTION
If anyone is not interested in using Adobe fonts, this will prevent loading them.

In this case the browser will decide the replacement font.