### PR TITLE
Animation: Fix makeAdditiveAnimation

### DIFF
--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -472,7 +472,7 @@ export class Animation {
         for (let index = startIndex; index <= endIndex; index++) {
             let key = animation._keys[index];
 
-            if (clippedKeys) {
+            if (clippedKeys || options.cloneOriginalAnimation) {
                 key = {
                     frame: key.frame,
                     value: key.value.clone ? key.value.clone() : key.value,
@@ -481,11 +481,13 @@ export class Animation {
                     interpolation: key.interpolation,
                     lockedTangent: key.lockedTangent,
                 };
-                if (startFrame === Number.MAX_VALUE) {
-                    startFrame = key.frame;
+                if (clippedKeys) {
+                    if (startFrame === Number.MAX_VALUE) {
+                        startFrame = key.frame;
+                    }
+                    key.frame -= startFrame;
+                    clippedKeys.push(key);
                 }
-                key.frame -= startFrame;
-                clippedKeys.push(key);
             }
 
             // If this key was duplicated to create a frame 0 key, skip it because its value has already been updated


### PR DESCRIPTION
See https://forum.babylonjs.com/t/issue-with-disappearing-model-when-cloning-animation-group-for-additive-blending/50521/6