### PR TITLE
GS - Use the right viewport value for position calculation

### DIFF
--- a/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
@@ -92,8 +92,8 @@ void main () {
     vec2 vCenter = vec2(pos2d);
     gl_Position = vec4(
         vCenter 
-        + (position.x * majorAxis * 1. / viewport 
-        + position.y * minorAxis * 1. / viewport) * pos2d.w, pos2d.zw);
+        + (position.x * majorAxis * 1. / viewport.x 
+        + position.y * minorAxis * 1. / viewport.y) * pos2d.w, pos2d.zw);
 
 #include<clipPlaneVertex>
 #include<fogVertex>


### PR DESCRIPTION
Can be tested in #45KYTJ#40

Main issue - https://forum.babylonjs.com/t/gaussian-splats-rotate-incorrectly-in-vr/50256?u=raananw