### PR TITLE
_pointerDownEvent now reuses the _activeTouchIds slot if _pointerMove…

### DIFF
--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -429,7 +429,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             const deviceType = this._getPointerType(evt);
             let deviceSlot = deviceType === DeviceType.Mouse ? 0 : this._activeTouchIds.indexOf(evt.pointerId);
 
-            // In the event that we're gettting pointermove events from touch inputs that we aren't tracking,
+            // In the event that we're getting pointermove events from touch inputs that we aren't tracking,
             // look for an available slot and retroactively connect it.
             if (deviceType === DeviceType.Touch && deviceSlot === -1) {
                 const idx = this._activeTouchIds.indexOf(-1);
@@ -487,7 +487,13 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
             let deviceSlot = deviceType === DeviceType.Mouse ? 0 : evt.pointerId;
 
             if (deviceType === DeviceType.Touch) {
-                const idx = this._activeTouchIds.indexOf(-1);
+                // See if this pointerId is already using an existing slot
+                // (possible on some devices which raise the pointerMove event before the pointerDown event, e.g. when using a pen)
+                let idx = this._activeTouchIds.indexOf(evt.pointerId);
+                if (idx === -1) {
+                    // If the pointerId wasn't already using a slot, find an open one
+                    idx = this._activeTouchIds.indexOf(-1);
+                }
 
                 if (idx >= 0) {
                     deviceSlot = idx;


### PR DESCRIPTION
On some devices, pen inputs can start with pointerMove instead of pointerDown. In that case, we were adding the pointerId to the _activeTouchIds in pointerMove, and instead of reusing that slot when pointerDown came along later, we were grabbing a second slot for the pointerId.  Then later, when pointerUp came along, we only cleaned up one of them.

With this change, pointerDown will reuse the existing slot if found - grabbing a new slot only if this pointerId doesn't already have one, so we should no longer get one pointerId in two slots.