### PR TITLE
Update control.ts

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2432,7 +2432,7 @@ export class Control implements IAnimatable {
             "px " +
             this._getStyleProperty("fontFamily", "Arial");
 
-        this._fontOffset = Control._GetFontOffset(this._font, this._host.getScene()?.getEngine());
+        this._fontOffset = Control._GetFontOffset(this._font, this._host?.getScene()?.getEngine());
 
         //children need to be refreshed
         this.getDescendants().forEach((child) => child._markAllAsDirty());


### PR DESCRIPTION
fix Uncaught TypeError: Cannot read properties of undefined (reading 'getScene')

When trying to use BabylonJS version 7.6.0 or later I get a crash, I believe this proposed change should fix it, if there is more to it let me know and I can share the complete setup to reproduce the crash.