### PR TITLE
 Add WebDeviceInputSystem unit tests to cover pointermove before pointerdown cases

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -56,6 +56,11 @@ export class NullEngineOptions {
      * Make the matrix computations to be performed in 64 bits instead of 32 bits. False by default
      */
     useHighPrecisionMatrix?: boolean;
+
+    /**
+     * If supplied, the HTMLCanvasElement to use (e.g. as the inputElement)
+     */
+    renderingCanvas?: HTMLCanvasElement;
 }
 
 /**
@@ -192,6 +197,10 @@ export class NullEngine extends Engine {
             forceVertexBufferStrideAndOffsetMultiple4Bytes: false,
             _collectUbosUpdatedInFrame: false,
         };
+
+        if (options.renderingCanvas) {
+            this._renderingCanvas = options.renderingCanvas;
+        }
 
         Logger.Log(`Babylon.js v${Engine.Version} - Null engine`);
 

--- a/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
@@ -57,7 +57,7 @@ describe("WebDeviceInputSystem", () => {
     });
 
     describe("when pointerdown comes before pointermove", () => {
-        describe("initial pointerdown", () => {
+        describe("pointerdown", () => {
             it("should raise deviceConnected", () => {
                 // Act
                 raiseOnPointerDown({ pointerType: "touch", button: 0, pointerId: 1 });

--- a/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
@@ -53,8 +53,8 @@ describe("WebDeviceInputSystem", () => {
     });
 
     afterEach(() => {
-        engine.dispose();
         wdis.dispose();
+        engine.dispose();
         window.PointerEvent = undefined;
     });
 

--- a/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
@@ -2,9 +2,13 @@
  * @jest-environment jsdom
  */
 
+jest.mock("core/Misc/logger");
+
 import { WebDeviceInputSystem } from "core/DeviceInput/webDeviceInputSystem";
 import { NullEngine, NullEngineOptions } from "core/Engines/nullEngine";
 import { Logger } from "core/Misc/logger";
+
+const mockTraceWarn = Logger.Warn as jest.Mock<any, any>;
 
 describe("WebDeviceInputSystem", () => {
     let engine: NullEngine;
@@ -14,9 +18,9 @@ describe("WebDeviceInputSystem", () => {
     let mockOnDeviceDisconnected: jest.Mock<any, any>;
     let renderElement: HTMLCanvasElement;
     let addEventListenerSpy: jest.SpyInstance;
-    let raiseOnPointerDown = (evt: any) => {};
-    let raiseOnPointerMove = (evt: any) => {};
-    let raiseOnPointerUp = (evt: any) => {};
+    let raiseOnPointerDown: (evt: any) => {};
+    let raiseOnPointerMove: (evt: any) => {};
+    let raiseOnPointerUp: (evt: any) => {};
 
     beforeEach(() => {
         // So that GetPointerPrefix knows we are going to simulate pointer events
@@ -46,8 +50,6 @@ describe("WebDeviceInputSystem", () => {
         nullEngineOptions.renderingCanvas = renderElement;
         engine = new NullEngine(nullEngineOptions);
         wdis = new WebDeviceInputSystem(engine, mockOnDeviceConnected, mockOnDeviceDisconnected, mockOnInputChanged);
-
-        Logger.Warn = jest.fn();
     });
 
     afterEach(() => {
@@ -64,7 +66,7 @@ describe("WebDeviceInputSystem", () => {
 
                 // Assert
                 expect(mockOnDeviceConnected).toHaveBeenCalled();
-                expect(Logger.Warn).not.toHaveBeenCalled();
+                expect(mockTraceWarn).not.toHaveBeenCalled();
             });
         });
         describe("many pointerdown, pointermove, pointerup cycles", () => {
@@ -81,7 +83,7 @@ describe("WebDeviceInputSystem", () => {
                     raiseOnPointerUp({ pointerType: "touch", button: 0, pointerId });
 
                     // Assert
-                    expect(Logger.Warn).not.toHaveBeenCalled();
+                    expect(mockTraceWarn).not.toHaveBeenCalled();
                     expect(mockOnDeviceConnected).toHaveBeenCalled();
                     expect(mockOnInputChanged).toHaveBeenCalled();
                     expect(mockOnDeviceDisconnected).toHaveBeenCalled();
@@ -98,7 +100,7 @@ describe("WebDeviceInputSystem", () => {
 
                 // Assert
                 expect(mockOnDeviceConnected).toHaveBeenCalled();
-                expect(Logger.Warn).not.toHaveBeenCalled();
+                expect(mockTraceWarn).not.toHaveBeenCalled();
             });
         });
         describe("subsequent pointermove", () => {
@@ -112,7 +114,7 @@ describe("WebDeviceInputSystem", () => {
 
                 // Assert
                 expect(mockOnDeviceConnected).not.toHaveBeenCalled();
-                expect(Logger.Warn).not.toHaveBeenCalled();
+                expect(mockTraceWarn).not.toHaveBeenCalled();
             });
         });
         describe("many pointermove, pointerdown, pointerup cycles", () => {
@@ -129,7 +131,7 @@ describe("WebDeviceInputSystem", () => {
                     raiseOnPointerUp({ pointerType: "touch", button: 0, pointerId });
 
                     // Assert
-                    expect(Logger.Warn).not.toHaveBeenCalled();
+                    expect(mockTraceWarn).not.toHaveBeenCalled();
                     expect(mockOnDeviceConnected).toHaveBeenCalled();
                     expect(mockOnInputChanged).toHaveBeenCalled();
                     expect(mockOnDeviceDisconnected).toHaveBeenCalled();

--- a/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.webDeviceInputSystem.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { WebDeviceInputSystem } from "core/DeviceInput/webDeviceInputSystem";
+import { NullEngine, NullEngineOptions } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
+
+describe("WebDeviceInputSystem", () => {
+    let engine: NullEngine;
+    let wdis: WebDeviceInputSystem;
+    let mockOnInputChanged: jest.Mock<any, any>;
+    let mockOnDeviceConnected: jest.Mock<any, any>;
+    let mockOnDeviceDisconnected: jest.Mock<any, any>;
+    let renderElement: HTMLCanvasElement;
+    let addEventListenerSpy: jest.SpyInstance;
+    let raiseOnPointerDown = (evt: any) => {};
+    let raiseOnPointerMove = (evt: any) => {};
+    let raiseOnPointerUp = (evt: any) => {};
+
+    beforeEach(() => {
+        // So that GetPointerPrefix knows we are going to simulate pointer events
+        window.PointerEvent = jest.fn() as any;
+
+        renderElement = document.createElement("canvas");
+        addEventListenerSpy = jest.spyOn(renderElement, "addEventListener");
+        addEventListenerSpy.mockImplementation((type, listener) => {
+            switch (type) {
+                case "pointerdown":
+                    raiseOnPointerDown = listener;
+                    break;
+                case "pointermove":
+                    raiseOnPointerMove = listener;
+                    break;
+                case "pointerup":
+                    raiseOnPointerUp = listener;
+                    break;
+            }
+        });
+
+        mockOnInputChanged = jest.fn();
+        mockOnDeviceConnected = jest.fn();
+        mockOnDeviceDisconnected = jest.fn();
+
+        const nullEngineOptions = new NullEngineOptions();
+        nullEngineOptions.renderingCanvas = renderElement;
+        engine = new NullEngine(nullEngineOptions);
+        wdis = new WebDeviceInputSystem(engine, mockOnDeviceConnected, mockOnDeviceDisconnected, mockOnInputChanged);
+
+        Logger.Warn = jest.fn();
+    });
+
+    afterEach(() => {
+        engine.dispose();
+        wdis.dispose();
+        window.PointerEvent = undefined;
+    });
+
+    describe("when pointerdown comes before pointermove", () => {
+        describe("initial pointerdown", () => {
+            it("should raise deviceConnected", () => {
+                // Act
+                raiseOnPointerDown({ pointerType: "touch", button: 0, pointerId: 1 });
+
+                // Assert
+                expect(mockOnDeviceConnected).toHaveBeenCalled();
+                expect(Logger.Warn).not.toHaveBeenCalled();
+            });
+        });
+        describe("many pointerdown, pointermove, pointerup cycles", () => {
+            it("should work and raise no warnings", () => {
+                for (let pointerId = 0; pointerId < 25; pointerId++) {
+                    // Arrange
+                    mockOnInputChanged.mockClear();
+                    mockOnDeviceConnected.mockClear();
+                    mockOnDeviceDisconnected.mockClear();
+
+                    // Act
+                    raiseOnPointerDown({ pointerType: "touch", button: 0, pointerId });
+                    raiseOnPointerMove({ pointerType: "touch", button: -1, pointerId });
+                    raiseOnPointerUp({ pointerType: "touch", button: 0, pointerId });
+
+                    // Assert
+                    expect(Logger.Warn).not.toHaveBeenCalled();
+                    expect(mockOnDeviceConnected).toHaveBeenCalled();
+                    expect(mockOnInputChanged).toHaveBeenCalled();
+                    expect(mockOnDeviceDisconnected).toHaveBeenCalled();
+                }
+            });
+        });
+    });
+
+    describe("when pointermove comes before pointerdown", () => {
+        describe("initial pointermove", () => {
+            it("should raise deviceConnected", () => {
+                // Act
+                raiseOnPointerMove({ pointerType: "touch", button: -1, pointerId: 1 });
+
+                // Assert
+                expect(mockOnDeviceConnected).toHaveBeenCalled();
+                expect(Logger.Warn).not.toHaveBeenCalled();
+            });
+        });
+        describe("subsequent pointermove", () => {
+            it("should not raise deviceConnected again", () => {
+                // Arrange
+                raiseOnPointerMove({ pointerType: "touch", button: -1, pointerId: 1 });
+                mockOnDeviceConnected.mockReset();
+
+                // Act
+                raiseOnPointerMove({ pointerType: "touch", button: -1, pointerId: 1 });
+
+                // Assert
+                expect(mockOnDeviceConnected).not.toHaveBeenCalled();
+                expect(Logger.Warn).not.toHaveBeenCalled();
+            });
+        });
+        describe("many pointermove, pointerdown, pointerup cycles", () => {
+            it("should work and raise no warnings", () => {
+                for (let pointerId = 0; pointerId < 25; pointerId++) {
+                    // Arrange
+                    mockOnInputChanged.mockClear();
+                    mockOnDeviceConnected.mockClear();
+                    mockOnDeviceDisconnected.mockClear();
+
+                    // Act
+                    raiseOnPointerMove({ pointerType: "touch", button: -1, pointerId });
+                    raiseOnPointerDown({ pointerType: "touch", button: 0, pointerId });
+                    raiseOnPointerUp({ pointerType: "touch", button: 0, pointerId });
+
+                    // Assert
+                    expect(Logger.Warn).not.toHaveBeenCalled();
+                    expect(mockOnDeviceConnected).toHaveBeenCalled();
+                    expect(mockOnInputChanged).toHaveBeenCalled();
+                    expect(mockOnDeviceDisconnected).toHaveBeenCalled();
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
These unit tests protect against regressions of the fix which addressed the bug where systems which call pointermove before pointedown got the WebDeviceInputSystem into a bad state where it would no longer accept additional touch events.  See commit: https://github.com/BabylonJS/Babylon.js/commit/aa2398ea386c16739839384e7d50fb6bfe032f55