### PR TITLE
Add vscode launch config for "Run and Debug current unit test file (Dev)", and add "Jest Runner" to recommended VSCode extension list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "webhint.vscode-webhint",
-        "IronGeek.vscode-env"
+        "IronGeek.vscode-env",
+        "firsttris.vscode-jest-runner"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -329,6 +329,30 @@
             */
             "type": "node",
             "request": "launch",
+            "name": "Run and Debug current unit test file (Dev)",
+            "runtimeArgs": [
+                "--inspect-brk",
+                "${workspaceRoot}/node_modules/jest/bin/jest.js",
+                "--runInBand",
+                "--selectProjects",
+                "unit",
+                "--test-path-pattern",
+                "${fileBasenameNoExtension}"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "port": 9229,
+            // "outFiles": ["${workspaceRoot}/**/dist/**/*"], // debugging sources
+            // "envFile": "${workspaceRoot}/.env",
+            "preLaunchTask": "Build (Dev)"
+        },
+        {
+            /*
+            Launch tests
+            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            */
+            "type": "node",
+            "request": "launch",
             "name": "Run validation tests - WebGL2 (Dev)",
             "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "--selectProjects", "visualization", "-i", "webgl2"],
             "console": "integratedTerminal",


### PR DESCRIPTION
This VSCode launch config will build then run just the unit test file current selected in VSCode, making it easier to iterate quickly on a single unit test file.