### PR TITLE
Mesh: Fix bounding infos when calling convertToUnIndexedMesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3131,6 +3131,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             return newData;
         };
 
+        // Save mesh bounding info
+        const meshBoundingInfo = this.getBoundingInfo();
+
         // Save previous submeshes
         const previousSubmeshes = this.geometry ? this.subMeshes.slice(0) : [];
 
@@ -3189,8 +3192,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         // Update submeshes
         this.releaseSubMeshes();
         for (const previousOne of previousSubmeshes) {
-            SubMesh.AddToMesh(previousOne.materialIndex, previousOne.indexStart, previousOne.indexCount, previousOne.indexStart, previousOne.indexCount, this);
+            const boundingInfo = previousOne.getBoundingInfo();
+            const subMesh = SubMesh.AddToMesh(previousOne.materialIndex, previousOne.indexStart, previousOne.indexCount, previousOne.indexStart, previousOne.indexCount, this);
+            subMesh.setBoundingInfo(boundingInfo);
         }
+
+        this.setBoundingInfo(meshBoundingInfo);
 
         this.synchronizeInstances();
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/object-display-truncated-by-camera/50632/8

I preferred to save and restore the existing submeshes / mesh bounding info rather than recalculate them with a call to `mesh.refreshBoundingInfo(true)`, because the bounding info may come from a glTF file, in which case the extents may be different from the extents calculated by `refreshBoundingInfo`. In addition, the user may have defined a custom bounding info.