### PR TITLE
Add features object passed as option to C++ native engine for backwards compatibility

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -100,14 +100,15 @@ export interface INativeEngine {
 }
 
 /** @internal */
-interface INativeEngineFeatures {
+interface INativeEngineInfo {
+    version: string;
     nonFloatVertexBuffers: boolean;
 }
 
 /** @internal */
 interface INativeEngineConstructor {
     prototype: INativeEngine;
-    new (features: INativeEngineFeatures): INativeEngine;
+    new (info: INativeEngineInfo): INativeEngine;
 
     readonly PROTOCOL_VERSION: number;
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -100,9 +100,14 @@ export interface INativeEngine {
 }
 
 /** @internal */
+interface INativeEngineFeatures {
+    nonFloatVertexBuffers: boolean;
+}
+
+/** @internal */
 interface INativeEngineConstructor {
     prototype: INativeEngine;
-    new (): INativeEngine;
+    new (features: INativeEngineFeatures): INativeEngine;
 
     readonly PROTOCOL_VERSION: number;
 

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -102,7 +102,7 @@ export interface INativeEngine {
 /** @internal */
 interface INativeEngineInfo {
     version: string;
-    nonFloatVertexBuffers: boolean;
+    nonFloatVertexBuffers: true;
 }
 
 /** @internal */

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -199,7 +199,10 @@ export class NativeEngine extends Engine {
     // This must match the protocol version in NativeEngine.cpp
     private static readonly PROTOCOL_VERSION = 8;
 
-    private readonly _engine: INativeEngine = new _native.Engine();
+    private readonly _engine: INativeEngine = new _native.Engine({
+        nonFloatVertexBuffers: true,
+    });
+
     private readonly _camera: Nullable<INativeCamera> = _native.Camera ? new _native.Camera() : null;
 
     private readonly _commandBufferEncoder = new CommandBufferEncoder(this._engine);

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -200,6 +200,7 @@ export class NativeEngine extends Engine {
     private static readonly PROTOCOL_VERSION = 8;
 
     private readonly _engine: INativeEngine = new _native.Engine({
+        version: Engine.Version,
         nonFloatVertexBuffers: true,
     });
 


### PR DESCRIPTION
This makes it possible for the C++ native engine to check if some features are available on the JS side and then do different things based on what the flags say. This will ensure better backwards compatibility with versions.