### PR TITLE
Fixes and enhancement on Havok & volumes

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -443,6 +443,7 @@ export interface IPhysicsEnginePluginV2 {
     removeChild(shape: PhysicsShape, childIndex: number): void;
     getNumChildren(shape: PhysicsShape): number;
     getBoundingBox(shape: PhysicsShape): BoundingBox;
+    getBodyBoundingBox(body: PhysicsBody): BoundingBox;
     disposeShape(shape: PhysicsShape): void;
     setTrigger(shape: PhysicsShape, isTrigger: boolean): void;
 

--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -187,7 +187,7 @@ export class PhysicsAggregate {
         const extents = TmpVectors.Vector3[0];
         extents.copyFrom(bb.extendSize);
         extents.scaleInPlace(2);
-        extents.multiplyInPlace(this.transformNode.scaling);
+        extents.multiplyInPlace(this.transformNode.absoluteScaling);
         // In case we had any negative scaling, we need to take the absolute value of the extents.
         extents.x = Math.abs(extents.x);
         extents.y = Math.abs(extents.y);
@@ -195,12 +195,12 @@ export class PhysicsAggregate {
 
         const min = TmpVectors.Vector3[1];
         min.copyFrom(bb.minimum);
-        min.multiplyInPlace(this.transformNode.scaling);
+        min.multiplyInPlace(this.transformNode.absoluteScaling);
 
         if (!this._options.center) {
             const center = new Vector3();
             center.copyFrom(bb.center);
-            center.multiplyInPlace(this.transformNode.scaling);
+            center.multiplyInPlace(this.transformNode.absoluteScaling);
             this._options.center = center;
         }
 

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -13,6 +13,7 @@ import type { Node } from "../../node";
 import type { Mesh } from "core/Meshes/mesh";
 import type { AbstractMesh } from "../../Meshes/abstractMesh";
 import type { TransformNode } from "../../Meshes/transformNode";
+import type { BoundingBox } from "core/Culling/boundingBox";
 
 /**
  * PhysicsBody is useful for creating a physics body that can be used in a physics engine. It allows
@@ -207,6 +208,14 @@ export class PhysicsBody {
      */
     public get shape(): Nullable<PhysicsShape> {
         return this._shape;
+    }
+
+    /**
+     * Returns the bounding box of the physics body.
+     * @returns The bounding box of the physics body.
+     */
+    public getBoundingBox(): BoundingBox {
+        return this._physicsPlugin.getBodyBoundingBox(this);
     }
 
     /**


### PR DESCRIPTION
Follow up :
- https://forum.babylonjs.com/t/physicsshape-getboundingbox-returns-empty-object/49133/5
- https://forum.babylonjs.com/t/incorrect-size-of-physics-body/50677/5
- https://forum.babylonjs.com/t/is-there-an-easy-more-efficient-way-to-set-a-havok-physics-body-box-shape-meshs-bounding-box/48512/20

Expose Shape aabb from Havok and use absoluteScaling for aggregate volume computation instead of local scaling.
