### PR TITLE
Make DoubleTap work on touch devices

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -87,7 +87,13 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 this.onTouch(null, offsetX, offsetY);
                 this._pointA = null;
                 this._pointB = null;
-            } else if (p.type !== PointerEventTypes.POINTERDOWN && isTouch && this._pointA?.pointerId !== evt.pointerId && this._pointB?.pointerId !== evt.pointerId) {
+            } else if (
+                p.type !== PointerEventTypes.POINTERDOWN &&
+                p.type !== PointerEventTypes.POINTERDOUBLETAP &&
+                isTouch &&
+                this._pointA?.pointerId !== evt.pointerId &&
+                this._pointB?.pointerId !== evt.pointerId
+            ) {
                 return; // If we get a non-down event for a touch that we're not tracking, ignore it
             } else if (p.type === PointerEventTypes.POINTERDOWN && (this._currentActiveButton === -1 || isTouch)) {
                 try {


### PR DESCRIPTION
DoubleTap is not a multitouch event, and should be triggered even if both points are null (which is the case with double tap on touch devices).
They are both null because pointerup is triggered prior to doubletap.