### PR TITLE
Fix erratic glTF progress values

### DIFF
--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -902,8 +902,9 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
             onError,
             onOpened
         ) as IFileRequestInfo;
-        request.onCompleteObservable.add((request) => {
-            this._requests.splice(this._requests.indexOf(request), 1);
+        request.onCompleteObservable.add(() => {
+            request._lengthComputable = true;
+            request._total = request._loaded;
         });
         this._requests.push(request);
         return request;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/sceneloader-load-progress-rollback/50805.

The main problem is that we were removing the file requests from the array which is used for calculating the total. But even if I stop doing this, it won't always work properly if there are requests with `lengthComputable = false`. To solve this, we can force the lengthComputable to true and set the total value to loaded to make sure the progress is counted.