### PR TITLE
Fixing an issue with touch camera initialization

### DIFF
--- a/packages/dev/core/src/Cameras/touchCamera.ts
+++ b/packages/dev/core/src/Cameras/touchCamera.ts
@@ -84,9 +84,11 @@ export class TouchCamera extends FreeCamera {
         const touch = <FreeCameraTouchInput>this.inputs.attached["touch"];
         const mouse = <FreeCameraMouseInput>this.inputs.attached["mouse"];
         if (mouse) {
-            mouse.touchEnabled = false;
+            // enable touch in mouse input if touch module is not enabled
+            mouse.touchEnabled = !touch;
         } else {
-            touch.allowMouse = true;
+            // allow mouse in touch input if mouse module is not available
+            touch.allowMouse = !mouse;
         }
     }
 }


### PR DESCRIPTION
The code section make an incorrect assumption - 

If mouse exists, disable touch on the mouse, and the same on the touch input, However, it doesn't take into account whether or not touch (or mouse) input is enabled on the camera.

The change here will enable touch on the mouse input if touch is not enabled, and will enable mouse on the touch if mouse module is not available.

Not sure if we should consider this as a bug or a breaking change. I think it is a bug, looking for feedback.

See issue here - https://forum.babylonjs.com/t/the-free-camera-serialization-cannot-save-the-touch-screen-swipe-perspective-information/50715?u=raananw . The serialized camer haas only mouse enabled, so touch is disabled.

Playground ID to test (using touch input or emulated touch device) - #D4DKWL#2