### PR TITLE
Reset unneeded dump tools instead of just the dump-engine

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -2608,6 +2608,7 @@ export abstract class AbstractEngine {
         // no more engines left in the engine store? Notify!
         if (!EngineStore.Instances.length) {
             EngineStore.OnEnginesDisposedObservable.notifyObservers(this);
+            EngineStore.OnEnginesDisposedObservable.clear();
         }
 
         // Observables

--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -52,8 +52,9 @@ export class DumpTools {
             EngineStore.OnEnginesDisposedObservable.add((e) => {
                 // guaranteed to run when no other instances are left
                 // only dispose if it's not the current engine
-                if (engine && e !== engine && !engine.isDisposed) {
-                    engine.dispose();
+                if (engine && e !== engine && !engine.isDisposed && EngineStore.Instances.length === 0) {
+                    // Dump the engine and the associated resources
+                    DumpTools.Dispose();
                 }
             });
             engine.getCaps().parallelShaderCompile = undefined;


### PR DESCRIPTION
This solves the issue on two tests failing the first time (and working on the second run).

Follow up of #15059