### PR TITLE
Improve hasVertexAlpha handling

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -825,9 +825,10 @@ export class VertexBuffer {
     /**
      * Deduces the stride given a kind.
      * @param kind The kind string to deduce
+     * @param colorHasAlpha Whether the color component has alpha or not
      * @returns The deduced stride
      */
-    public static DeduceStride(kind: string): number {
+    public static DeduceStride(kind: string, colorHasAlpha = true): number {
         switch (kind) {
             case VertexBuffer.UVKind:
             case VertexBuffer.UV2Kind:
@@ -840,6 +841,7 @@ export class VertexBuffer {
             case VertexBuffer.PositionKind:
                 return 3;
             case VertexBuffer.ColorKind:
+                return colorHasAlpha ? 4 : 3;
             case VertexBuffer.ColorInstanceKind:
             case VertexBuffer.MatricesIndicesKind:
             case VertexBuffer.MatricesIndicesExtraKind:

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -84,7 +84,6 @@ class _FacetDataStorage {
  **/
 // eslint-disable-next-line @typescript-eslint/naming-convention
 class _InternalAbstractMeshDataInfo {
-    public _hasVertexAlpha = false;
     public _useVertexColors = true;
     public _numBoneInfluencers = 4;
     public _applyFog = true;
@@ -563,18 +562,8 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public overlayAlpha = 0.5;
 
     /** Gets or sets a boolean indicating that this mesh contains vertex color data with alpha values */
-    public get hasVertexAlpha(): boolean {
-        return this._internalAbstractMeshDataInfo._hasVertexAlpha;
-    }
-    public set hasVertexAlpha(value: boolean) {
-        if (this._internalAbstractMeshDataInfo._hasVertexAlpha === value) {
-            return;
-        }
-
-        this._internalAbstractMeshDataInfo._hasVertexAlpha = value;
-        this._markSubMeshesAsAttributesDirty();
-        this._markSubMeshesAsMiscDirty();
-    }
+    public abstract get hasVertexAlpha(): boolean;
+    public abstract set hasVertexAlpha(value: boolean);
 
     /** Gets or sets a boolean indicating that this mesh needs to use vertex color data to render (if this kind of vertex data is available in the geometry) */
     public get useVertexColors(): boolean {

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -131,6 +131,9 @@ export class Geometry implements IGetSetVerticesData {
      */
     public useBoundingInfoFromGeometry = false;
 
+    /** Gets or sets a boolean indicating that this geometry contains vertex color data with alpha values */
+    public hasVertexAlpha = false;
+
     /**
      * Creates a new geometry
      * @param id defines the unique ID

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -190,6 +190,14 @@ export class InstancedMesh extends AbstractMesh {
         return this._sourceMesh.getTotalIndices();
     }
 
+    /** Gets or sets a boolean indicating that this mesh contains vertex color data with alpha values */
+    public override get hasVertexAlpha(): boolean {
+        return this._sourceMesh ? this._sourceMesh.hasVertexAlpha : false;
+    }
+    public override set hasVertexAlpha(value: boolean) {
+        Logger.Warn("Setting hasVertexAlpha on an instanced mesh has no effect");
+    }
+
     /**
      * The source mesh of the instance
      */

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -534,6 +534,21 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         this._instanceDataStorage.forceMatrixUpdates = value;
     }
 
+    /** Gets or sets a boolean indicating that this mesh contains vertex color data with alpha values */
+    public override get hasVertexAlpha(): boolean {
+        return this._geometry ? this._geometry.hasVertexAlpha : false;
+    }
+    public override set hasVertexAlpha(value: boolean) {
+        if (!this._geometry) {
+            Logger.Warn(`No geometry is availble to set hasVertexAlpha`);
+            return;
+        }
+
+        this._geometry.hasVertexAlpha = value;
+        this._markSubMeshesAsAttributesDirty();
+        this._markSubMeshesAsMiscDirty();
+    }
+
     /**
      * @constructor
      * @param name The value used by scene.getMeshByName() to do a lookup.


### PR DESCRIPTION
See https://forum.babylonjs.com/t/babylon-objexport-obj-mesh-serialization-bug/50856.

This is a fix for the first problem indicated in the forum post. The issue is that the vertex alpha flag is inconsistently handled between mesh, geometry, and vertex data causing `mesh.flipFaces` to create new vertex data with the wrong stride for colors. This change makes the flag more consistent across the board.