### PR TITLE
Make AbstractMesh a real abstract class

### DIFF
--- a/packages/dev/core/src/Behaviors/Cameras/framingBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Cameras/framingBehavior.ts
@@ -274,7 +274,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
 
     /**
      * Targets the given mesh with its children and updates zoom level accordingly.
-     * @param mesh  The mesh to target.
+     * @param mesh The mesh to target.
      * @param focusOnOriginXZ Determines if the camera should focus on 0 in the X and Z axis instead of the mesh
      * @param onAnimationEnd Callback triggered at the end of the framing animation
      */

--- a/packages/dev/core/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/baseSixDofDragBehavior.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { Behavior } from "../../Behaviors/behavior";
 import type { Mesh } from "../../Meshes/mesh";
-import { AbstractMesh } from "../../Meshes/abstractMesh";
+import type { AbstractMesh } from "../../Meshes/abstractMesh";
 import { Scene } from "../../scene";
 import type { Nullable } from "../../types";
 import type { PointerInfo } from "../../Events/pointerEvents";
@@ -10,7 +10,7 @@ import { PointerEventTypes } from "../../Events/pointerEvents";
 import { Vector3, Quaternion, TmpVectors } from "../../Maths/math.vector";
 import type { Observer } from "../../Misc/observable";
 import { Observable } from "../../Misc/observable";
-import type { TransformNode } from "../../Meshes/transformNode";
+import { TransformNode } from "../../Meshes/transformNode";
 import type { PickingInfo } from "../../Collisions/pickingInfo";
 import { Camera } from "../../Cameras/camera";
 import type { Ray } from "../../Culling/ray";
@@ -23,9 +23,9 @@ import type { ArcRotateCamera } from "../../Cameras/arcRotateCamera";
 type VirtualMeshInfo = {
     dragging: boolean;
     moving: boolean;
-    dragMesh: AbstractMesh;
-    originMesh: AbstractMesh;
-    pivotMesh: AbstractMesh;
+    dragMesh: TransformNode;
+    originMesh: TransformNode;
+    pivotMesh: TransformNode;
     startingPivotPosition: Vector3;
     startingPivotOrientation: Quaternion;
     startingPosition: Vector3;
@@ -158,11 +158,11 @@ export class BaseSixDofDragBehavior implements Behavior<Mesh> {
     private _createVirtualMeshInfo() {
         // Setup virtual meshes to be used for dragging without dirtying the existing scene
 
-        const dragMesh = new AbstractMesh("", BaseSixDofDragBehavior._virtualScene);
+        const dragMesh = new TransformNode("", BaseSixDofDragBehavior._virtualScene);
         dragMesh.rotationQuaternion = new Quaternion();
-        const originMesh = new AbstractMesh("", BaseSixDofDragBehavior._virtualScene);
+        const originMesh = new TransformNode("", BaseSixDofDragBehavior._virtualScene);
         originMesh.rotationQuaternion = new Quaternion();
-        const pivotMesh = new AbstractMesh("", BaseSixDofDragBehavior._virtualScene);
+        const pivotMesh = new TransformNode("", BaseSixDofDragBehavior._virtualScene);
         pivotMesh.rotationQuaternion = new Quaternion();
 
         return {

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -6,7 +6,7 @@ import type { PointerInfo } from "../Events/pointerEvents";
 import type { Scene } from "../scene";
 import { Quaternion, Matrix, Vector3 } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
-import { Mesh } from "../Meshes/mesh";
+import type { Mesh } from "../Meshes/mesh";
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
 import { CreateBox } from "../Meshes/Builders/boxBuilder";
 import { CreateLines } from "../Meshes/Builders/linesBuilder";

--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -5,8 +5,8 @@ import type { Nullable } from "../types";
 import type { PointerInfo } from "../Events/pointerEvents";
 import type { Scene } from "../scene";
 import { Quaternion, Matrix, Vector3 } from "../Maths/math.vector";
-import { AbstractMesh } from "../Meshes/abstractMesh";
-import type { Mesh } from "../Meshes/mesh";
+import type { AbstractMesh } from "../Meshes/abstractMesh";
+import { Mesh } from "../Meshes/mesh";
 import { CreateSphere } from "../Meshes/Builders/sphereBuilder";
 import { CreateBox } from "../Meshes/Builders/boxBuilder";
 import { CreateLines } from "../Meshes/Builders/linesBuilder";
@@ -20,6 +20,7 @@ import { Color3 } from "../Maths/math.color";
 import type { LinesMesh } from "../Meshes/linesMesh";
 import { Epsilon } from "../Maths/math.constants";
 import type { IPointerEvent } from "../Events/deviceInputEvents";
+import { TransformNode } from "../Meshes/transformNode";
 
 /**
  * Interface for bounding box gizmo
@@ -111,9 +112,9 @@ export interface IBoundingBoxGizmo extends IGizmo {
  * Bounding box gizmo
  */
 export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
-    protected _lineBoundingBox: AbstractMesh;
-    protected _rotateSpheresParent: AbstractMesh;
-    protected _scaleBoxesParent: AbstractMesh;
+    protected _lineBoundingBox: TransformNode;
+    protected _rotateSpheresParent: TransformNode;
+    protected _scaleBoxesParent: TransformNode;
     protected _boundingDimensions = new Vector3(1, 1, 1);
     protected _renderObserver: Nullable<Observer<Scene>> = null;
     protected _pointerObserver: Nullable<Observer<PointerInfo>> = null;
@@ -257,7 +258,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
     /**
      * Mesh used as a pivot to rotate the attached node
      */
-    protected _anchorMesh: AbstractMesh;
+    protected _anchorMesh: TransformNode;
 
     protected _existingMeshScale = new Vector3();
 
@@ -313,7 +314,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         // Do not update the gizmo's scale so it has a fixed size to the object its attached to
         this.updateScale = false;
 
-        this._anchorMesh = new AbstractMesh("anchor", gizmoLayer.utilityLayerScene);
+        this._anchorMesh = new TransformNode("anchor", gizmoLayer.utilityLayerScene);
         // Create Materials
         this._coloredMaterial = new StandardMaterial("", gizmoLayer.utilityLayerScene);
         this._coloredMaterial.disableLighting = true;
@@ -321,7 +322,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this._hoverColoredMaterial.disableLighting = true;
 
         // Build bounding box out of lines
-        this._lineBoundingBox = new AbstractMesh("", gizmoLayer.utilityLayerScene);
+        this._lineBoundingBox = new TransformNode("", gizmoLayer.utilityLayerScene);
         this._lineBoundingBox.rotationQuaternion = new Quaternion();
         const lines = [];
         lines.push(CreateLines("lines", { points: [new Vector3(0, 0, 0), new Vector3(this._boundingDimensions.x, 0, 0)] }, gizmoLayer.utilityLayerScene));
@@ -416,7 +417,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this.setColor(color);
 
         // Create rotation spheres
-        this._rotateSpheresParent = new AbstractMesh("", gizmoLayer.utilityLayerScene);
+        this._rotateSpheresParent = new TransformNode("", gizmoLayer.utilityLayerScene);
         this._rotateSpheresParent.rotationQuaternion = new Quaternion();
         for (let i = 0; i < 12; i++) {
             const sphere = CreateSphere("", { diameter: 1 }, gizmoLayer.utilityLayerScene);
@@ -535,7 +536,7 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this._rootMesh.addChild(this._rotateSpheresParent);
 
         // Create scale cubes
-        this._scaleBoxesParent = new AbstractMesh("", gizmoLayer.utilityLayerScene);
+        this._scaleBoxesParent = new TransformNode("", gizmoLayer.utilityLayerScene);
         this._scaleBoxesParent.rotationQuaternion = new Quaternion();
         for (let i = 0; i < 3; i++) {
             for (let j = 0; j < 3; j++) {

--- a/packages/dev/core/src/Gizmos/lightGizmo.ts
+++ b/packages/dev/core/src/Gizmos/lightGizmo.ts
@@ -1,7 +1,6 @@
 import type { Nullable } from "../types";
 import { Vector3, Quaternion, TmpVectors } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
-import { AbstractMesh } from "../Meshes/abstractMesh";
 import { Mesh } from "../Meshes/mesh";
 import type { IGizmo } from "./gizmo";
 import { Gizmo } from "./gizmo";
@@ -57,7 +56,7 @@ export class LightGizmo extends Gizmo implements ILightGizmo {
      */
     constructor(gizmoLayer: UtilityLayerRenderer = UtilityLayerRenderer.DefaultUtilityLayer) {
         super(gizmoLayer);
-        this.attachedMesh = new AbstractMesh("", this.gizmoLayer.utilityLayerScene);
+        this.attachedMesh = new Mesh("", this.gizmoLayer.utilityLayerScene);
         this._attachedMeshParent = new TransformNode("parent", this.gizmoLayer.utilityLayerScene);
 
         this.attachedMesh.parent = this._attachedMeshParent;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2,10 +2,10 @@
 import type { NodeMaterialBlock } from "./nodeMaterialBlock";
 import { PushMaterial } from "../pushMaterial";
 import type { Scene } from "../../scene";
-import { AbstractMesh } from "../../Meshes/abstractMesh";
+import type { AbstractMesh } from "../../Meshes/abstractMesh";
 import { Matrix, Vector2 } from "../../Maths/math.vector";
 import { Color3, Color4 } from "../../Maths/math.color";
-import type { Mesh } from "../../Meshes/mesh";
+import { Mesh } from "../../Meshes/mesh";
 import { NodeMaterialBuildState } from "./nodeMaterialBuildState";
 import type { IEffectCreationOptions } from "../effect";
 import { Effect } from "../effect";
@@ -1098,7 +1098,7 @@ export class NodeMaterial extends PushMaterial {
 
         const defines = new NodeMaterialDefines();
 
-        const dummyMesh = new AbstractMesh(tempName + "PostProcess", this.getScene());
+        const dummyMesh = new Mesh(tempName + "PostProcess", this.getScene());
 
         let buildId = this._buildId;
 
@@ -1192,7 +1192,7 @@ export class NodeMaterial extends PushMaterial {
 
         const proceduralTexture = new ProceduralTexture(tempName, size, null, scene);
 
-        const dummyMesh = new AbstractMesh(tempName + "Procedural", this.getScene());
+        const dummyMesh = new Mesh(tempName + "Procedural", this.getScene());
         dummyMesh.reservedDataStore = {
             hidden: true,
         };
@@ -1278,7 +1278,7 @@ export class NodeMaterial extends PushMaterial {
         if (!dummyMesh) {
             dummyMesh = this.getScene().getMeshByName(this.name + "Particle");
             if (!dummyMesh) {
-                dummyMesh = new AbstractMesh(this.name + "Particle", this.getScene());
+                dummyMesh = new Mesh(this.name + "Particle", this.getScene());
                 dummyMesh.reservedDataStore = {
                     hidden: true,
                 };

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -121,7 +121,7 @@ class _InternalAbstractMeshDataInfo {
 /**
  * Class used to store all common mesh properties
  */
-export class AbstractMesh extends TransformNode implements IDisposable, ICullable, IGetSetVerticesData {
+export abstract class AbstractMesh extends TransformNode implements IDisposable, ICullable, IGetSetVerticesData {
     /** No occlusion */
     public static OCCLUSION_TYPE_NONE = 0;
     /** Occlusion set to optimistic */
@@ -2195,28 +2195,6 @@ export class AbstractMesh extends TransformNode implements IDisposable, ICullabl
         this.onRebuildObservable.clear();
 
         super.dispose(doNotRecurse, disposeMaterialAndTextures);
-    }
-
-    /**
-     * Adds the passed mesh as a child to the current mesh
-     * @param mesh defines the child mesh
-     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
-     * @returns the current mesh
-     */
-    public addChild(mesh: AbstractMesh, preserveScalingSign: boolean = false): AbstractMesh {
-        mesh.setParent(this, preserveScalingSign);
-        return this;
-    }
-
-    /**
-     * Removes the passed mesh from the current mesh children list
-     * @param mesh defines the child mesh
-     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
-     * @returns the current mesh
-     */
-    public removeChild(mesh: AbstractMesh, preserveScalingSign: boolean = false): AbstractMesh {
-        mesh.setParent(null, preserveScalingSign);
-        return this;
     }
 
     // Facet data

--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -828,6 +828,28 @@ export class TransformNode extends Node {
         return this;
     }
 
+    /**
+     * Adds the passed mesh as a child to the current mesh
+     * @param mesh defines the child mesh
+     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
+     * @returns the current mesh
+     */
+    public addChild(mesh: TransformNode, preserveScalingSign: boolean = false): this {
+        mesh.setParent(this, preserveScalingSign);
+        return this;
+    }
+
+    /**
+     * Removes the passed mesh from the current mesh children list
+     * @param mesh defines the child mesh
+     * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
+     * @returns the current mesh
+     */
+    public removeChild(mesh: TransformNode, preserveScalingSign: boolean = false): this {
+        mesh.setParent(null, preserveScalingSign);
+        return this;
+    }
+
     private _nonUniformScaling = false;
     /**
      * True if the scaling property of this object is non uniform eg. (1,2,1)

--- a/packages/dev/core/src/XR/webXRInputSource.ts
+++ b/packages/dev/core/src/XR/webXRInputSource.ts
@@ -1,5 +1,5 @@
 import { Observable } from "../Misc/observable";
-import { AbstractMesh } from "../Meshes/abstractMesh";
+import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Quaternion, Vector3 } from "../Maths/math.vector";
 import type { Ray } from "../Culling/ray";
 import type { Scene } from "../scene";
@@ -8,6 +8,7 @@ import { WebXRMotionControllerManager } from "./motionController/webXRMotionCont
 import { Tools } from "../Misc/tools";
 import type { WebXRCamera } from "./webXRCamera";
 import type { WebXRSessionManager } from "./webXRSessionManager";
+import { Mesh } from "../Meshes/mesh";
 
 let idCount = 0;
 
@@ -96,11 +97,11 @@ export class WebXRInputSource {
     ) {
         this._uniqueId = `controller-${idCount++}-${inputSource.targetRayMode}-${inputSource.handedness}`;
 
-        this.pointer = new AbstractMesh(`${this._uniqueId}-pointer`, _scene);
+        this.pointer = new Mesh(`${this._uniqueId}-pointer`, _scene);
         this.pointer.rotationQuaternion = new Quaternion();
 
         if (this.inputSource.gripSpace) {
-            this.grip = new AbstractMesh(`${this._uniqueId}-grip`, this._scene);
+            this.grip = new Mesh(`${this._uniqueId}-grip`, this._scene);
             this.grip.rotationQuaternion = new Quaternion();
         }
 

--- a/packages/tools/viewer/src/model/viewerModel.ts
+++ b/packages/tools/viewer/src/model/viewerModel.ts
@@ -39,6 +39,7 @@ import { deepmerge, extendClassWithConfig } from "../helper/index";
 import type { ObservablesManager } from "../managers/observablesManager";
 import type { ConfigurationContainer } from "../configuration/configurationContainer";
 import { TransformNode } from "core/Meshes/transformNode";
+import { Mesh } from "core/Meshes/mesh";
 
 /**
  * The current state of the model
@@ -73,7 +74,7 @@ export class ViewerModel implements IDisposable {
      * This model's root mesh (the parent of all other meshes).
      * This mesh does not(!) exist in the meshes array.
      */
-    public rootMesh: TransformNode;
+    public rootMesh: AbstractMesh;
 
     private _pivotMesh: TransformNode;
     /**
@@ -149,7 +150,7 @@ export class ViewerModel implements IDisposable {
 
         const scene = this._configurationContainer && this._configurationContainer.scene;
 
-        this.rootMesh = new TransformNode("modelRootMesh", scene);
+        this.rootMesh = new Mesh("modelRootMesh", scene);
         this._pivotMesh = new TransformNode("pivotMesh", scene);
         this._pivotMesh.parent = this.rootMesh;
         // rotate 180, gltf fun

--- a/packages/tools/viewer/src/model/viewerModel.ts
+++ b/packages/tools/viewer/src/model/viewerModel.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-internal-modules */
 import type { IDisposable } from "core/scene";
 import type { ISceneLoaderPlugin, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent } from "core/Loading/sceneLoader";
-import { AbstractMesh } from "core/Meshes/abstractMesh";
+import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { IParticleSystem } from "core/Particles/IParticleSystem";
 import type { Skeleton } from "core/Bones/skeleton";
 import { Observable } from "core/Misc/observable";

--- a/packages/tools/viewer/src/model/viewerModel.ts
+++ b/packages/tools/viewer/src/model/viewerModel.ts
@@ -38,6 +38,7 @@ import { GroupModelAnimation, AnimationPlayMode, EasingFunction, AnimationState 
 import { deepmerge, extendClassWithConfig } from "../helper/index";
 import type { ObservablesManager } from "../managers/observablesManager";
 import type { ConfigurationContainer } from "../configuration/configurationContainer";
+import { TransformNode } from "core/Meshes/transformNode";
 
 /**
  * The current state of the model
@@ -72,9 +73,9 @@ export class ViewerModel implements IDisposable {
      * This model's root mesh (the parent of all other meshes).
      * This mesh does not(!) exist in the meshes array.
      */
-    public rootMesh: AbstractMesh;
+    public rootMesh: TransformNode;
 
-    private _pivotMesh: AbstractMesh;
+    private _pivotMesh: TransformNode;
     /**
      * ParticleSystems connected to this model
      */
@@ -148,8 +149,8 @@ export class ViewerModel implements IDisposable {
 
         const scene = this._configurationContainer && this._configurationContainer.scene;
 
-        this.rootMesh = new AbstractMesh("modelRootMesh", scene);
-        this._pivotMesh = new AbstractMesh("pivotMesh", scene);
+        this.rootMesh = new TransformNode("modelRootMesh", scene);
+        this._pivotMesh = new TransformNode("pivotMesh", scene);
         this._pivotMesh.parent = this.rootMesh;
         // rotate 180, gltf fun
         this._pivotMesh.rotation.y += Math.PI;
@@ -435,11 +436,11 @@ export class ViewerModel implements IDisposable {
 
     private _configureModel() {
         // this can be changed to the meshes that have rootMesh a parent without breaking anything.
-        const meshesWithNoParent: Array<AbstractMesh> = [this.rootMesh]; //this._meshes.filter(m => m.parent === this.rootMesh);
+        const meshesWithNoParent: Array<TransformNode> = [this.rootMesh]; //this._meshes.filter(m => m.parent === this.rootMesh);
         const updateMeshesWithNoParent = (variable: string, value: any, param?: string) => {
             meshesWithNoParent.forEach((mesh) => {
                 if (param) {
-                    mesh[variable as keyof AbstractMesh][param] = value;
+                    mesh[variable as keyof TransformNode][param] = value;
                 } else {
                     (mesh as any)[variable] = value;
                 }
@@ -473,7 +474,7 @@ export class ViewerModel implements IDisposable {
                 parentIndex = this._modelConfiguration.normalize.parentIndex;
             }
 
-            let meshesToNormalize: Array<AbstractMesh> = [];
+            let meshesToNormalize: Array<TransformNode> = [];
             if (parentIndex !== undefined) {
                 meshesToNormalize.push(this._meshes[parentIndex]);
             } else {
@@ -781,8 +782,6 @@ export class ViewerModel implements IDisposable {
     public remove() {
         this.stopAllAnimations();
 
-        // hide it
-        this.rootMesh.isVisible = false;
         if (this._observablesManager) {
             this._observablesManager.onModelRemovedObservable.notifyObservers(this);
         }


### PR DESCRIPTION
Note that some calls to `new AbstractMesh` were converted to `new Mesh` instead of `new TransformNode` because various helper functions still take an `AbstractMesh` when it could in theory take `TransformNode`.