### PR TITLE
Fix VertexData.ExtractFrom functions to support 3-component colors

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -562,7 +562,11 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     /** Defines alpha to use when rendering overlay */
     public overlayAlpha = 0.5;
 
-    /** Gets or sets a boolean indicating that this mesh contains vertex color data with alpha values */
+    /**
+     * Gets or sets a boolean indicating that this mesh needs to use vertex alpha data to render.
+     * This property is misnamed and should be `useVertexAlpha`. Note that the mesh will be rendered
+     * with alpha blending when this flag is set even if vertex alpha data is missing from the geometry.
+     */
     public get hasVertexAlpha(): boolean {
         return this._internalAbstractMeshDataInfo._hasVertexAlpha;
     }

--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -1416,7 +1416,23 @@ export class VertexData {
         }
 
         if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.ColorKind)) {
-            result.colors = meshOrGeometry.getVerticesData(VertexBuffer.ColorKind, copyWhenShared, forceCopy);
+            const geometry = (meshOrGeometry as Mesh).geometry || (meshOrGeometry as Geometry);
+            const vertexBuffer = geometry.getVertexBuffer(VertexBuffer.ColorKind)!;
+            const colors = geometry.getVerticesData(VertexBuffer.ColorKind, copyWhenShared, forceCopy)!;
+            if (vertexBuffer.getSize() === 3) {
+                const newColors = new Float32Array((colors.length * 4) / 3);
+                for (let i = 0, j = 0; i < colors.length; i += 3, j += 4) {
+                    newColors[j] = colors[i];
+                    newColors[j + 1] = colors[i + 1];
+                    newColors[j + 2] = colors[i + 2];
+                    newColors[j + 3] = 1;
+                }
+                result.colors = newColors;
+            } else if (vertexBuffer.getSize() === 4) {
+                result.colors = colors;
+            } else {
+                throw new Error(`Unexpected number of color components: ${vertexBuffer.getSize()}`);
+            }
         }
 
         if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.MatricesIndicesKind)) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/babylon-objexport-obj-mesh-serialization-bug/50856.

This is a fix for the first problem indicated in the forum post. The issue is that the vertex alpha flag is inconsistently handled between mesh, geometry, and vertex data causing `mesh.flipFaces` to create new vertex data with the wrong stride for colors. This change makes the flag more consistent across the board.