### PR TITLE
Resume audio context when Vision Pro enters XR immersive mode

### DIFF
--- a/packages/dev/core/src/Audio/Interfaces/IAudioEngine.ts
+++ b/packages/dev/core/src/Audio/Interfaces/IAudioEngine.ts
@@ -93,4 +93,7 @@ export interface IAudioEngine extends IDisposable {
      * @param analyser The analyser to connect to the engine
      */
     connectToAnalyser(analyser: Analyser): void;
+
+    /** @internal */
+    _resumeAudioContextOnStateChange(): void;
 }

--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -177,7 +177,7 @@ export class AudioEngine implements IAudioEngine {
 
     /** @internal */
     public _resumeAudioContextOnStateChange(): void {
-        this._audioContext.addEventListener(
+        this._audioContext?.addEventListener(
             "statechange",
             () => {
                 if (this.unlocked && this._audioContext?.state !== "running") {

--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -200,6 +200,13 @@ export class AudioEngine implements IAudioEngine {
                     // Do not wait for the promise to unlock.
                     this._triggerRunningState();
                 }
+
+                // This keeps the audio context running when the user enters immersive mode on Apple's Vision Pro.
+                this._audioContext.addEventListener("statechange", () => {
+                    if (this.unlocked && this._audioContext?.state !== "running") {
+                        this._audioContext?.resume();
+                    }
+                });
             }
         } catch (e) {
             this.canUseWebAudio = false;

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -10,6 +10,7 @@ import { WebXRFeatureName, WebXRFeaturesManager } from "./webXRFeaturesManager";
 import { Logger } from "../Misc/logger";
 import { UniversalCamera } from "../Cameras/universalCamera";
 import { Quaternion, Vector3 } from "../Maths/math.vector";
+import { Engine } from "../Engines/engine";
 import type { ThinEngine } from "../Engines/thinEngine";
 
 /**
@@ -180,6 +181,9 @@ export class WebXRExperienceHelper implements IDisposable {
                 this.camera.rotationQuaternion.set(0, 0, 0, 1);
                 this.onInitialXRPoseSetObservable.notifyObservers(this.camera);
             }
+
+            // Vision Pro suspends the audio context when entering XR, so we resume it here if needed.
+            Engine.audioEngine?._resumeAudioContextOnStateChange();
 
             this.sessionManager.onXRSessionEnded.addOnce(() => {
                 // when using the back button and not the exit button (default on mobile), the session is ending but the EXITING state was not set

--- a/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
@@ -129,7 +129,8 @@ export class MockedAudioObjects {
                 suspend: jest.fn().mockName("suspend").mockImplementation(() => {
                     this.audioContext.state = "suspended";
                     return Promise.resolve();
-                })
+                }),
+                addEventListener: jest.fn().mockName("addEventListener"),
             };
         }) as any;
     }


### PR DESCRIPTION
The Apple Vision Pro suspends the audio context when entering XR immersive mode.

This change fixes the issue by listening to audio context state changes when XR immersive mode is entered, and resuming the audio context after it is suspended if the user has previously unlocked the audio engine with a user interaction.

Tested on playground https://playground.babylonjs.com/#KR5CRQ#17.