### PR TITLE
Fix WebGLRenderbuffer memory leak from MSAA RenderTargetTextures

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3502,7 +3502,7 @@ export class ThinEngine extends AbstractEngine {
      * @internal
      */
     public _releaseTexture(texture: InternalTexture): void {
-        this._deleteTexture(texture._hardwareTexture?.underlyingResource);
+        this._deleteTexture(texture._hardwareTexture as WebGLHardwareTexture);
 
         // Unbind channels
         this.unbindAllTextures();
@@ -3529,10 +3529,8 @@ export class ThinEngine extends AbstractEngine {
         }
     }
 
-    protected _deleteTexture(texture: Nullable<WebGLTexture>): void {
-        if (texture) {
-            this._gl.deleteTexture(texture);
-        }
+    protected _deleteTexture(texture: WebGLHardwareTexture): void {
+        texture.release()
     }
 
     protected _setProgram(program: WebGLProgram): void {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3502,7 +3502,7 @@ export class ThinEngine extends AbstractEngine {
      * @internal
      */
     public _releaseTexture(texture: InternalTexture): void {
-        this._deleteTexture(texture._hardwareTexture as WebGLHardwareTexture);
+        this._deleteTexture(texture._hardwareTexture as Nullable<WebGLHardwareTexture>);
 
         // Unbind channels
         this.unbindAllTextures();
@@ -3529,8 +3529,8 @@ export class ThinEngine extends AbstractEngine {
         }
     }
 
-    protected _deleteTexture(texture: WebGLHardwareTexture): void {
-        texture.release()
+    protected _deleteTexture(texture: Nullable<WebGLHardwareTexture>): void {
+        texture?.release()
     }
 
     protected _setProgram(program: WebGLProgram): void {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3530,7 +3530,7 @@ export class ThinEngine extends AbstractEngine {
     }
 
     protected _deleteTexture(texture: Nullable<WebGLHardwareTexture>): void {
-        texture?.release()
+        texture?.release();
     }
 
     protected _setProgram(program: WebGLProgram): void {


### PR DESCRIPTION
Forum thread with more info:
https://forum.babylonjs.com/t/babylon-leaks-msaa-renderbuffers-on-resize-dispose-with-webgl/51228

The short version is that renderbuffers created by MSAA RenderTargetTextures were never deleted, causing a (sometimes big) memory leak. In our project it could be several gigabytes of leaked memory in a few seconds.
The proposed solution here is that thinEngine should use the `webGLHardwareTexture`'s function `release` to let it delete its resources, instead of directly deleting (only) the WebGLTexture from the context directly.