### PR TITLE
Improve clarity about how mesh.sideOrientation works

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -426,10 +426,6 @@ export class Constants {
      * Stores the counter clock-wise side orientation
      */
     public static readonly MATERIAL_CounterClockWiseSideOrientation = 1;
-    /**
-     * Use the side orientation defined on the mesh
-     */
-    public static readonly MATERIAL_UseMeshSideOrientation = 2;
 
     /**
      * Nothing

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -426,6 +426,10 @@ export class Constants {
      * Stores the counter clock-wise side orientation
      */
     public static readonly MATERIAL_CounterClockWiseSideOrientation = 1;
+    /**
+     * Use the side orientation defined on the mesh
+     */
+    public static readonly MATERIAL_UseMeshSideOrientation = 2;
 
     /**
      * Nothing

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -876,8 +876,7 @@ export abstract class EffectLayer {
         }
 
         // Culling
-        let sideOrientation =
-            renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
+        let sideOrientation = material._getEffectiveOrientation(renderingMesh);
         const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
         if (mainDeterminant < 0) {
             sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -876,7 +876,8 @@ export abstract class EffectLayer {
         }
 
         // Culling
-        let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+        let sideOrientation =
+            renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
         const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
         if (mainDeterminant < 0) {
             sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1190,7 +1190,9 @@ export class ShadowGenerator implements IShadowGenerator {
         // We therefore need to "undo" the sideOrientation inversion that was previously performed when constructing the material.
         const useRHS = scene.useRightHandedSystem;
         const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-        let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+        let sideOrientation =
+            renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
+
         if ((detNeg && !useRHS) || (!detNeg && useRHS)) {
             sideOrientation =
                 sideOrientation === Constants.MATERIAL_ClockWiseSideOrientation ? Constants.MATERIAL_CounterClockWiseSideOrientation : Constants.MATERIAL_ClockWiseSideOrientation;

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1190,8 +1190,7 @@ export class ShadowGenerator implements IShadowGenerator {
         // We therefore need to "undo" the sideOrientation inversion that was previously performed when constructing the material.
         const useRHS = scene.useRightHandedSystem;
         const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-        let sideOrientation =
-            renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
+        let sideOrientation = material._getEffectiveOrientation(renderingMesh);
 
         if ((detNeg && !useRHS) || (!detNeg && useRHS)) {
             sideOrientation =

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1053,6 +1053,11 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         return this._scene;
     }
 
+    /** @internal */
+    public _getEffectiveOrientation(mesh: Mesh): number {
+        return mesh.sideOrientation !== null && this.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? mesh.sideOrientation : this.sideOrientation;
+    }
+
     /**
      * Enforces alpha test in opaque or blend mode in order to improve the performances of some situations.
      */

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -131,6 +131,11 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public static readonly CounterClockWiseSideOrientation = Constants.MATERIAL_CounterClockWiseSideOrientation;
 
     /**
+     * Use the side orientation defined on the mesh
+     */
+    public static readonly UseMeshSideOrientation = Constants.MATERIAL_UseMeshSideOrientation;
+
+    /**
      * The dirty texture flag value
      */
     public static readonly TextureDirtyFlag = Constants.MATERIAL_TextureDirtyFlag;
@@ -934,9 +939,9 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         this._drawWrapper.materialContext = this._materialContext;
 
         if (this._scene.useRightHandedSystem) {
-            this.sideOrientation = Material.ClockWiseSideOrientation;
+            this.sideOrientation = Constants.MATERIAL_ClockWiseSideOrientation;
         } else {
-            this.sideOrientation = Material.CounterClockWiseSideOrientation;
+            this.sideOrientation = Constants.MATERIAL_CounterClockWiseSideOrientation;
         }
 
         this._uniformBuffer = new UniformBuffer(this._scene.getEngine(), undefined, undefined, name);

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -131,11 +131,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public static readonly CounterClockWiseSideOrientation = Constants.MATERIAL_CounterClockWiseSideOrientation;
 
     /**
-     * Use the side orientation defined on the mesh
-     */
-    public static readonly UseMeshSideOrientation = Constants.MATERIAL_UseMeshSideOrientation;
-
-    /**
      * The dirty texture flag value
      */
     public static readonly TextureDirtyFlag = Constants.MATERIAL_TextureDirtyFlag;
@@ -420,7 +415,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * Stores the value for side orientation
      */
     @serialize()
-    public sideOrientation: number;
+    public sideOrientation: Nullable<number> = null;
 
     /**
      * Callback triggered when the material is compiled
@@ -938,12 +933,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         this._drawWrapper = new DrawWrapper(this._scene.getEngine(), false);
         this._drawWrapper.materialContext = this._materialContext;
 
-        if (this._scene.useRightHandedSystem) {
-            this.sideOrientation = Constants.MATERIAL_ClockWiseSideOrientation;
-        } else {
-            this.sideOrientation = Constants.MATERIAL_CounterClockWiseSideOrientation;
-        }
-
         this._uniformBuffer = new UniformBuffer(this._scene.getEngine(), undefined, undefined, name);
         this._useUBO = this.getScene().getEngine().supportsUniformBuffers;
 
@@ -1055,7 +1044,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
 
     /** @internal */
     public _getEffectiveOrientation(mesh: Mesh): number {
-        return mesh.sideOrientation !== null && this.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? mesh.sideOrientation : this.sideOrientation;
+        return this.sideOrientation !== null ? this.sideOrientation : mesh.sideOrientation;
     }
 
     /**

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -68,7 +68,6 @@ export function CreateDecal(
 ): Mesh {
     const hasSkeleton = !!sourceMesh.skeleton;
     const useLocalComputation = options.localMode || hasSkeleton;
-    const meshHasOverridenMaterial = (sourceMesh as Mesh).sideOrientation !== null;
 
     const indices = <IndicesArray>sourceMesh.getIndices();
     const positions = hasSkeleton ? sourceMesh.getPositionData(true, true) : sourceMesh.getVerticesData(VertexBuffer.PositionKind);
@@ -382,7 +381,7 @@ export function CreateDecal(
             let faceVertices: Nullable<DecalVertex[]> = oneFaceVertices;
 
             faceVertices[0] = extractDecalVector3(index, transformMatrix);
-            if (meshHasOverridenMaterial && useLocalComputation) {
+            if (useLocalComputation) {
                 faceVertices[1] = extractDecalVector3(index + 2, transformMatrix);
                 faceVertices[2] = extractDecalVector3(index + 1, transformMatrix);
             } else {

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -68,7 +68,7 @@ export function CreateDecal(
 ): Mesh {
     const hasSkeleton = !!sourceMesh.skeleton;
     const useLocalComputation = options.localMode || hasSkeleton;
-    const meshHasOverridenMaterial = (sourceMesh as Mesh).overrideMaterialSideOrientation !== null && (sourceMesh as Mesh).overrideMaterialSideOrientation !== undefined;
+    const meshHasOverridenMaterial = (sourceMesh as Mesh).sideOrientation !== null && (sourceMesh as Mesh).sideOrientation !== undefined;
 
     const indices = <IndicesArray>sourceMesh.getIndices();
     const positions = hasSkeleton ? sourceMesh.getPositionData(true, true) : sourceMesh.getVerticesData(VertexBuffer.PositionKind);

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -68,7 +68,7 @@ export function CreateDecal(
 ): Mesh {
     const hasSkeleton = !!sourceMesh.skeleton;
     const useLocalComputation = options.localMode || hasSkeleton;
-    const meshHasOverridenMaterial = (sourceMesh as Mesh).sideOrientation !== null && (sourceMesh as Mesh).sideOrientation !== undefined;
+    const meshHasOverridenMaterial = (sourceMesh as Mesh).sideOrientation !== null;
 
     const indices = <IndicesArray>sourceMesh.getIndices();
     const positions = hasSkeleton ? sourceMesh.getPositionData(true, true) : sourceMesh.getVerticesData(VertexBuffer.PositionKind);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -498,6 +498,21 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
     }
 
+    /** Gets or sets current material */
+    public override get material(): Nullable<Material> {
+        return super.material;
+    }
+    public override set material(value: Nullable<Material>) {
+        if (value && this.sideOrientation !== null && this.material && this.material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation) {
+            // We need to make sure the new one is also on useMeshMaterialSideOrientation
+            // User can revert it if they really want to after setting the propperty
+            // This is mainly to protect backward compat
+            value.sideOrientation = Constants.MATERIAL_UseMeshSideOrientation;
+        }
+
+        super.material = value;
+    }
+
     /** Gets the array buffer used to store the instanced buffer used for instances' world matrices */
     public get worldMatrixInstancedBuffer() {
         return this._instanceDataStorage.instancesData;
@@ -4664,7 +4679,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         const materialIndexArray: Array<number> = new Array<number>();
         // Merge
         const indiceArray: Array<number> = new Array<number>();
-        const currentOverrideMaterialSideOrientation = meshes[0].sideOrientation;
+        const currentsideOrientation = meshes[0].sideOrientation;
 
         for (index = 0; index < meshes.length; index++) {
             const mesh = meshes[index];
@@ -4673,7 +4688,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 return null;
             }
 
-            if (currentOverrideMaterialSideOrientation !== mesh.sideOrientation) {
+            if (currentsideOrientation !== mesh.sideOrientation) {
                 Logger.Warn("Cannot merge meshes with different sideOrientation values.");
                 return null;
             }

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2390,8 +2390,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         if (
             !instanceDataStorage.isFrozen &&
             (this._internalMeshDataInfo._effectiveMaterial.backFaceCulling ||
-            this._internalMeshDataInfo._effectiveMaterial.sideOrientation !== null ||
-             (this._internalMeshDataInfo._effectiveMaterial as any).twoSidedLighting)
+                this._internalMeshDataInfo._effectiveMaterial.sideOrientation !== null ||
+                (this._internalMeshDataInfo._effectiveMaterial as any).twoSidedLighting)
         ) {
             // Note: if two sided lighting is enabled, we need to ensure that the normal will point in the right direction even if the determinant of the world matrix is negative
             const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -444,8 +444,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /**
      * Use this property to change the original side orientation defined at construction time
+     * Will be used if the material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation
      */
-    public overrideMaterialSideOrientation: Nullable<number> = null;
+    public sideOrientation: Nullable<number> = null;
 
     /**
      * Use this property to override the Material's fillMode value
@@ -2383,15 +2384,17 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         if (
             !instanceDataStorage.isFrozen &&
             (this._internalMeshDataInfo._effectiveMaterial.backFaceCulling ||
-                this.overrideMaterialSideOrientation !== null ||
+                (this.sideOrientation !== null && this._internalMeshDataInfo._effectiveMaterial.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation) ||
                 (this._internalMeshDataInfo._effectiveMaterial as any).twoSidedLighting)
         ) {
             // Note: if two sided lighting is enabled, we need to ensure that the normal will point in the right direction even if the determinant of the world matrix is negative
             const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
-            sideOrientation = this.overrideMaterialSideOrientation;
-            if (sideOrientation == null) {
+            if (this.sideOrientation == null || this._internalMeshDataInfo._effectiveMaterial.sideOrientation !== Constants.MATERIAL_UseMeshSideOrientation) {
                 sideOrientation = this._internalMeshDataInfo._effectiveMaterial.sideOrientation;
+            } else {
+                sideOrientation = this.sideOrientation;
             }
+
             if (mainDeterminant < 0) {
                 sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
             }
@@ -3087,8 +3090,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         // Decide if normals should be flipped
         const flipNormalGeneration =
-            this.overrideMaterialSideOrientation ===
-            (this._scene.useRightHandedSystem ? Constants.MATERIAL_CounterClockWiseSideOrientation : Constants.MATERIAL_ClockWiseSideOrientation);
+            this.sideOrientation === (this._scene.useRightHandedSystem ? Constants.MATERIAL_CounterClockWiseSideOrientation : Constants.MATERIAL_ClockWiseSideOrientation);
 
         // Generate new normals
         for (let index = 0; index < indices.length; index += 3) {
@@ -3679,7 +3681,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         serializationObject.ellipsoidOffset = this.ellipsoidOffset.asArray();
         serializationObject.doNotSyncBoundingInfo = this.doNotSyncBoundingInfo;
         serializationObject.isBlocker = this.isBlocker;
-        serializationObject.overrideMaterialSideOrientation = this.overrideMaterialSideOrientation;
+        serializationObject.sideOrientation = this.sideOrientation;
 
         // Parent
         if (this.parent) {
@@ -4066,8 +4068,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             mesh.ellipsoidOffset = Vector3.FromArray(parsedMesh.ellipsoidOffset);
         }
 
-        if (parsedMesh.overrideMaterialSideOrientation !== undefined) {
-            mesh.overrideMaterialSideOrientation = parsedMesh.overrideMaterialSideOrientation;
+        if (parsedMesh.sideOrientation !== undefined) {
+            mesh.sideOrientation = parsedMesh.sideOrientation;
         }
 
         if (parsedMesh.isBlocker !== undefined) {
@@ -4662,7 +4664,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         const materialIndexArray: Array<number> = new Array<number>();
         // Merge
         const indiceArray: Array<number> = new Array<number>();
-        const currentOverrideMaterialSideOrientation = meshes[0].overrideMaterialSideOrientation;
+        const currentOverrideMaterialSideOrientation = meshes[0].sideOrientation;
 
         for (index = 0; index < meshes.length; index++) {
             const mesh = meshes[index];
@@ -4671,8 +4673,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 return null;
             }
 
-            if (currentOverrideMaterialSideOrientation !== mesh.overrideMaterialSideOrientation) {
-                Logger.Warn("Cannot merge meshes with different overrideMaterialSideOrientation values.");
+            if (currentOverrideMaterialSideOrientation !== mesh.sideOrientation) {
+                Logger.Warn("Cannot merge meshes with different sideOrientation values.");
                 return null;
             }
 
@@ -4757,7 +4759,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         // Setting properties
         meshSubclass.checkCollisions = source.checkCollisions;
-        meshSubclass.overrideMaterialSideOrientation = source.overrideMaterialSideOrientation;
+        meshSubclass.sideOrientation = source.sideOrientation;
 
         // Cleaning
         if (disposeSource) {
@@ -4829,7 +4831,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /** @internal */
     public override _shouldConvertRHS() {
-        return this.overrideMaterialSideOrientation === Material.CounterClockWiseSideOrientation;
+        return this.sideOrientation === Material.CounterClockWiseSideOrientation;
     }
 
     /** @internal */

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -4831,7 +4831,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /** @internal */
     public override _shouldConvertRHS() {
-        return this.sideOrientation === Material.CounterClockWiseSideOrientation;
+        return this._scene.useRightHandedSystem && this.sideOrientation === Material.CounterClockWiseSideOrientation;
     }
 
     /** @internal */

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -192,8 +192,7 @@ export class DepthRenderer {
 
             // Culling
             const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-            let sideOrientation =
-                renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
+            let sideOrientation = material._getEffectiveOrientation(renderingMesh);
 
             if (detNeg) {
                 sideOrientation =

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -192,7 +192,9 @@ export class DepthRenderer {
 
             // Culling
             const detNeg = effectiveMesh._getWorldMatrixDeterminant() < 0;
-            let sideOrientation = renderingMesh.overrideMaterialSideOrientation ?? material.sideOrientation;
+            let sideOrientation =
+                renderingMesh.sideOrientation && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? renderingMesh.sideOrientation : material.sideOrientation;
+
             if (detNeg) {
                 sideOrientation =
                     sideOrientation === Constants.MATERIAL_ClockWiseSideOrientation

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -898,17 +898,9 @@ export class GeometryBufferRenderer {
                 let sideOrientation: Nullable<number>;
                 const instanceDataStorage = (renderingMesh as Mesh)._instanceDataStorage;
 
-                if (
-                    !instanceDataStorage.isFrozen &&
-                    (material.backFaceCulling || (renderingMesh.sideOrientation !== null && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation))
-                ) {
+                if (!instanceDataStorage.isFrozen && material.backFaceCulling) {
                     const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
-
-                    if (renderingMesh.sideOrientation === null || material.sideOrientation !== Constants.MATERIAL_UseMeshSideOrientation) {
-                        sideOrientation = material.sideOrientation;
-                    } else {
-                        sideOrientation = renderingMesh.sideOrientation;
-                    }
+                    sideOrientation = material._getEffectiveOrientation(renderingMesh);
 
                     if (mainDeterminant < 0) {
                         sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -904,7 +904,7 @@ export class GeometryBufferRenderer {
                 ) {
                     const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
 
-                    if (renderingMesh.sideOrientation == null || material.sideOrientation !== Constants.MATERIAL_UseMeshSideOrientation) {
+                    if (renderingMesh.sideOrientation === null || material.sideOrientation !== Constants.MATERIAL_UseMeshSideOrientation) {
                         sideOrientation = material.sideOrientation;
                     } else {
                         sideOrientation = renderingMesh.sideOrientation;

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -898,12 +898,18 @@ export class GeometryBufferRenderer {
                 let sideOrientation: Nullable<number>;
                 const instanceDataStorage = (renderingMesh as Mesh)._instanceDataStorage;
 
-                if (!instanceDataStorage.isFrozen && (material.backFaceCulling || renderingMesh.overrideMaterialSideOrientation !== null)) {
+                if (
+                    !instanceDataStorage.isFrozen &&
+                    (material.backFaceCulling || (renderingMesh.sideOrientation !== null && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation))
+                ) {
                     const mainDeterminant = effectiveMesh._getWorldMatrixDeterminant();
-                    sideOrientation = renderingMesh.overrideMaterialSideOrientation;
-                    if (sideOrientation === null) {
+
+                    if (renderingMesh.sideOrientation == null || material.sideOrientation !== Constants.MATERIAL_UseMeshSideOrientation) {
                         sideOrientation = material.sideOrientation;
+                    } else {
+                        sideOrientation = renderingMesh.sideOrientation;
                     }
+
                     if (mainDeterminant < 0) {
                         sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
                     }

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
@@ -39,6 +39,7 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
         material.depthFunction = material.depthFunction ?? 0;
 
         const orientationOptions = [
+            { label: "<None>", value: -1 },
             { label: "Clockwise", value: Material.ClockWiseSideOrientation },
             { label: "Counterclockwise", value: Material.CounterClockWiseSideOrientation },
         ];
@@ -125,6 +126,7 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
                         options={orientationOptions}
                         target={material}
                         propertyName="sideOrientation"
+                        defaultIfNull={-1}
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                         onSelect={(value) => this.setState({ mode: value })}
                     />

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
@@ -41,6 +41,7 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
         const orientationOptions = [
             { label: "Clockwise", value: Material.ClockWiseSideOrientation },
             { label: "Counterclockwise", value: Material.CounterClockWiseSideOrientation },
+            { label: "UseMesh", value: Material.UseMeshSideOrientation },
         ];
 
         const transparencyModeOptions = [

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
@@ -41,7 +41,6 @@ export class CommonMaterialPropertyGridComponent extends React.Component<ICommon
         const orientationOptions = [
             { label: "Clockwise", value: Material.ClockWiseSideOrientation },
             { label: "Counterclockwise", value: Material.CounterClockWiseSideOrientation },
-            { label: "UseMesh", value: Material.UseMeshSideOrientation },
         ];
 
         const transparencyModeOptions = [

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -44,6 +44,7 @@ import "core/Physics/v1/physicsEngineComponent";
 import { ParentPropertyGridComponent } from "../parentPropertyGridComponent";
 import { Tools } from "core/Misc/tools";
 import { PhysicsBodyGridComponent } from "./physics/physicsBodyGridComponent";
+import { Constants } from "core/Engines/constants";
 
 interface IMeshPropertyGridComponentProps {
     globalState: GlobalState;
@@ -381,6 +382,11 @@ export class MeshPropertyGridComponent extends React.Component<
             { label: "Strict", value: AbstractMesh.OCCLUSION_TYPE_STRICT },
         ];
 
+        const orientationOptions = [
+            { label: "Clockwise", value: Constants.MATERIAL_ClockWiseSideOrientation },
+            { label: "Counterclockwise", value: Constants.MATERIAL_CounterClockWiseSideOrientation },
+        ];
+
         const sortedMaterials = scene.materials.slice(0).sort((a, b) => (a.name || "no name").localeCompare(b.name || "no name"));
 
         const materialOptions = sortedMaterials.map((m, i) => {
@@ -551,6 +557,13 @@ export class MeshPropertyGridComponent extends React.Component<
                             onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                         />
                     )}
+                    <OptionsLine
+                        label="Orientation"
+                        options={orientationOptions}
+                        target={mesh}
+                        propertyName="sideOrientation"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                     <FloatLineComponent
                         lockObject={this.props.lockObject}
                         label="Alpha index"

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -76,7 +76,6 @@ import type { AssetContainer } from "core/assetContainer";
 import type { AnimationPropertyInfo } from "./glTFLoaderAnimation";
 import { nodeAnimationData } from "./glTFLoaderAnimation";
 import type { IObjectInfo } from "core/ObjectModel/objectModelInterfaces";
-import { Constants } from "core/Engines/constants";
 
 interface TypedArrayLike extends ArrayBufferView {
     readonly length: number;

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -76,7 +76,7 @@ import type { AssetContainer } from "core/assetContainer";
 import type { AnimationPropertyInfo } from "./glTFLoaderAnimation";
 import { nodeAnimationData } from "./glTFLoaderAnimation";
 import type { IObjectInfo } from "core/ObjectModel/objectModelInterfaces";
-import { Constants } from "core/Engines";
+import { Constants } from "core/Engines/constants";
 
 interface TypedArrayLike extends ArrayBufferView {
     readonly length: number;

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -76,6 +76,7 @@ import type { AssetContainer } from "core/assetContainer";
 import type { AnimationPropertyInfo } from "./glTFLoaderAnimation";
 import { nodeAnimationData } from "./glTFLoaderAnimation";
 import type { IObjectInfo } from "core/ObjectModel/objectModelInterfaces";
+import { Constants } from "core/Engines";
 
 interface TypedArrayLike extends ArrayBufferView {
     readonly length: number;
@@ -1010,7 +1011,7 @@ export class GLTFLoader implements IGLTFLoader {
             const babylonMesh = new Mesh(name, this._babylonScene);
             babylonMesh._parentContainer = this._assetContainer;
             this._babylonScene._blockEntityCollection = false;
-            babylonMesh.overrideMaterialSideOrientation = this._babylonScene.useRightHandedSystem ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
+            babylonMesh.sideOrientation = this._babylonScene.useRightHandedSystem ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
 
             this._createMorphTargets(context, node, mesh, primitive, babylonMesh);
             promises.push(
@@ -2155,6 +2156,7 @@ export class GLTFLoader implements IGLTFLoader {
         babylonMaterial.transparencyMode = PBRMaterial.PBRMATERIAL_OPAQUE;
         babylonMaterial.metallic = 1;
         babylonMaterial.roughness = 1;
+        babylonMaterial.sideOrientation = Constants.MATERIAL_UseMeshSideOrientation;
         return babylonMaterial;
     }
 

--- a/packages/dev/serializers/src/OBJ/objSerializer.ts
+++ b/packages/dev/serializers/src/OBJ/objSerializer.ts
@@ -5,6 +5,7 @@ import type { StandardMaterial } from "core/Materials/standardMaterial";
 import type { Geometry } from "core/Meshes/geometry";
 import type { Mesh } from "core/Meshes/mesh";
 import { Material } from "core/Materials/material";
+import { Constants } from "core/Engines";
 
 /**
  * Class for generating OBJ data from a Babylon scene.
@@ -94,7 +95,10 @@ export class OBJExport {
             }
 
             const blanks: string[] = ["", "", ""];
-            const sideOrientation = mesh.overrideMaterialSideOrientation ?? mesh.material?.sideOrientation ?? mesh.getScene().defaultMaterial.sideOrientation;
+            const material = mesh.material || mesh.getScene().defaultMaterial;
+
+            const sideOrientation =
+                mesh.sideOrientation !== null && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? mesh.sideOrientation : material.sideOrientation;
             const [offset1, offset2] = sideOrientation === Material.ClockWiseSideOrientation ? [2, 1] : [1, 2];
 
             for (let i = 0; i < trunkFaces.length; i += 3) {

--- a/packages/dev/serializers/src/OBJ/objSerializer.ts
+++ b/packages/dev/serializers/src/OBJ/objSerializer.ts
@@ -5,7 +5,6 @@ import type { StandardMaterial } from "core/Materials/standardMaterial";
 import type { Geometry } from "core/Meshes/geometry";
 import type { Mesh } from "core/Meshes/mesh";
 import { Material } from "core/Materials/material";
-import { Constants } from "core/Engines/constants";
 
 /**
  * Class for generating OBJ data from a Babylon scene.
@@ -97,8 +96,7 @@ export class OBJExport {
             const blanks: string[] = ["", "", ""];
             const material = mesh.material || mesh.getScene().defaultMaterial;
 
-            const sideOrientation =
-                mesh.sideOrientation !== null && material.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation ? mesh.sideOrientation : material.sideOrientation;
+            const sideOrientation = material._getEffectiveOrientation(mesh);
             const [offset1, offset2] = sideOrientation === Material.ClockWiseSideOrientation ? [2, 1] : [1, 2];
 
             for (let i = 0; i < trunkFaces.length; i += 3) {

--- a/packages/dev/serializers/src/OBJ/objSerializer.ts
+++ b/packages/dev/serializers/src/OBJ/objSerializer.ts
@@ -5,7 +5,7 @@ import type { StandardMaterial } from "core/Materials/standardMaterial";
 import type { Geometry } from "core/Meshes/geometry";
 import type { Mesh } from "core/Meshes/mesh";
 import { Material } from "core/Materials/material";
-import { Constants } from "core/Engines";
+import { Constants } from "core/Engines/constants";
 
 /**
  * Class for generating OBJ data from a Babylon scene.

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -47,7 +47,6 @@ import { _GLTFAnimation } from "./glTFAnimation";
 import { Camera } from "core/Cameras/camera";
 import { EngineStore } from "core/Engines/engineStore";
 import { MultiMaterial } from "core/Materials/multiMaterial";
-import { Constants } from "core/Engines/constants";
 
 // Matrix that converts handedness on the X-axis.
 const convertHandednessMatrix = Matrix.Compose(new Vector3(-1, 1, 1), Quaternion.Identity(), Vector3.Zero());
@@ -1704,9 +1703,6 @@ export class _Exporter {
 
                     if (Object.keys(meshPrimitive.attributes).length > 0) {
                         const sideOrientation = babylonMaterial._getEffectiveOrientation(bufferMesh);
-                            bufferMesh.sideOrientation !== null && babylonMaterial.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation
-                                ? bufferMesh.sideOrientation
-                                : babylonMaterial.sideOrientation;
 
                         if (sideOrientation === (this._babylonScene.useRightHandedSystem ? Material.ClockWiseSideOrientation : Material.CounterClockWiseSideOrientation)) {
                             let byteOffset = indexBufferViewIndex != null ? this._bufferViews[indexBufferViewIndex].byteOffset : null;

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -47,6 +47,7 @@ import { _GLTFAnimation } from "./glTFAnimation";
 import { Camera } from "core/Cameras/camera";
 import { EngineStore } from "core/Engines/engineStore";
 import { MultiMaterial } from "core/Materials/multiMaterial";
+import { Constants } from "core/Engines/constants";
 
 // Matrix that converts handedness on the X-axis.
 const convertHandednessMatrix = Matrix.Compose(new Vector3(-1, 1, 1), Quaternion.Identity(), Vector3.Zero());
@@ -1702,7 +1703,10 @@ export class _Exporter {
                     }
 
                     if (Object.keys(meshPrimitive.attributes).length > 0) {
-                        const sideOrientation = bufferMesh.overrideMaterialSideOrientation !== null ? bufferMesh.overrideMaterialSideOrientation : babylonMaterial.sideOrientation;
+                        const sideOrientation =
+                            bufferMesh.sideOrientation !== null && babylonMaterial.sideOrientation === Constants.MATERIAL_UseMeshSideOrientation
+                                ? bufferMesh.sideOrientation
+                                : babylonMaterial.sideOrientation;
 
                         if (sideOrientation === (this._babylonScene.useRightHandedSystem ? Material.ClockWiseSideOrientation : Material.CounterClockWiseSideOrientation)) {
                             let byteOffset = indexBufferViewIndex != null ? this._bufferViews[indexBufferViewIndex].byteOffset : null;


### PR DESCRIPTION
mesh.overrideMaterialSideOrientation was renamed to mesh.sideOrientation
material.sideOrientation can now be set to BABYLON.Constants.MATERIAL._UseMeshSideOrientation to allow the mesh to override the side orientation