### PR TITLE
SceneLoader related types cleanup

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -173,7 +173,7 @@ export class ArrayItem {
 /** @internal */
 export interface IAnimationTargetInfo {
     /** @internal */
-    target: any;
+    target: unknown;
 
     /** @internal */
     properties: Array<AnimationPropertyInfo>;
@@ -184,7 +184,7 @@ export interface IAnimationTargetInfo {
  */
 export class GLTFLoader implements IGLTFLoader {
     /** @internal */
-    public readonly _completePromises = new Array<Promise<any>>();
+    public readonly _completePromises = new Array<Promise<unknown>>();
 
     /** @internal */
     public _assetContainer: Nullable<AssetContainer> = null;
@@ -331,7 +331,7 @@ export class GLTFLoader implements IGLTFLoader {
      * @internal
      */
     public importMeshAsync(
-        meshesNames: any,
+        meshesNames: string | readonly string[] | null | undefined,
         scene: Scene,
         container: Nullable<AssetContainer>,
         data: IGLTFLoaderData,
@@ -413,7 +413,7 @@ export class GLTFLoader implements IGLTFLoader {
                 this._parent._setState(GLTFLoaderState.LOADING);
                 this._extensionsOnLoading();
 
-                const promises = new Array<Promise<any>>();
+                const promises = new Array<Promise<unknown>>();
 
                 // Block the marking of materials dirty until the scene is loaded.
                 const oldBlockMaterialDirtyMechanism = this._babylonScene.blockMaterialDirtyMechanism;
@@ -645,7 +645,7 @@ export class GLTFLoader implements IGLTFLoader {
             return extensionPromise;
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         this.logOpen(`${context} ${scene.name || ""}`);
 
@@ -809,7 +809,7 @@ export class GLTFLoader implements IGLTFLoader {
             throw new Error(`${context}: Invalid recursive node hierarchy`);
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         this.logOpen(`${context} ${node.name || ""}`);
 
@@ -928,7 +928,7 @@ export class GLTFLoader implements IGLTFLoader {
             ArrayItem.Assign(primitives);
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         this.logOpen(`${context} ${mesh.name || ""}`);
 
@@ -995,7 +995,7 @@ export class GLTFLoader implements IGLTFLoader {
         const shouldInstance = this._disableInstancedMesh === 0 && this._parent.createInstances && node.skin == undefined && !mesh.primitives[0].targets;
 
         let babylonAbstractMesh: AbstractMesh;
-        let promise: Promise<any>;
+        let promise: Promise<unknown>;
 
         if (shouldInstance && primitive._instanceData) {
             this._babylonScene._blockEntityCollection = !!this._assetContainer;
@@ -1004,7 +1004,7 @@ export class GLTFLoader implements IGLTFLoader {
             this._babylonScene._blockEntityCollection = false;
             promise = primitive._instanceData.promise;
         } else {
-            const promises = new Array<Promise<any>>();
+            const promises = new Array<Promise<unknown>>();
 
             this._babylonScene._blockEntityCollection = !!this._assetContainer;
             const babylonMesh = new Mesh(name, this._babylonScene);
@@ -1080,7 +1080,7 @@ export class GLTFLoader implements IGLTFLoader {
             throw new Error(`${context}: Attributes are missing`);
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         const babylonGeometry = new Geometry(babylonMesh.name, this._babylonScene);
 
@@ -1206,7 +1206,7 @@ export class GLTFLoader implements IGLTFLoader {
             return Promise.resolve();
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         const morphTargetManager = babylonMesh.morphTargetManager!;
         for (let index = 0; index < morphTargetManager.numTargets; index++) {
@@ -1220,7 +1220,7 @@ export class GLTFLoader implements IGLTFLoader {
     }
 
     private _loadMorphTargetVertexDataAsync(context: string, babylonGeometry: Geometry, attributes: { [name: string]: number }, babylonMorphTarget: MorphTarget): Promise<void> {
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         const loadAttribute = (attribute: string, kind: string, setData: (babylonVertexBuffer: VertexBuffer, data: Float32Array) => void) => {
             if (attributes[attribute] == undefined) {
@@ -1489,7 +1489,7 @@ export class GLTFLoader implements IGLTFLoader {
             return extensionPromise;
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         this.logOpen(`${context} ${camera.name || ""}`);
 
@@ -1586,7 +1586,7 @@ export class GLTFLoader implements IGLTFLoader {
         this._babylonScene._blockEntityCollection = false;
         animation._babylonAnimationGroup = babylonAnimationGroup;
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         ArrayItem.Assign(animation.channels);
         ArrayItem.Assign(animation.samplers);
@@ -2048,7 +2048,7 @@ export class GLTFLoader implements IGLTFLoader {
             throw new Error(`${context}: Material type not supported`);
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         if (properties) {
             if (properties.baseColorFactor) {
@@ -2190,7 +2190,7 @@ export class GLTFLoader implements IGLTFLoader {
             return extensionPromise;
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         promises.push(this.loadMaterialBasePropertiesAsync(context, material, babylonMaterial));
 
@@ -2215,7 +2215,7 @@ export class GLTFLoader implements IGLTFLoader {
             throw new Error(`${context}: Material type not supported`);
         }
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         babylonMaterial.emissiveColor = material.emissiveFactor ? Color3.FromArray(material.emissiveFactor) : new Color3(0, 0, 0);
         if (material.doubleSided) {
@@ -2371,12 +2371,12 @@ export class GLTFLoader implements IGLTFLoader {
         sampler: ISampler,
         image: IImage,
         assign: (babylonTexture: BaseTexture) => void = () => {},
-        textureLoaderOptions?: any,
+        textureLoaderOptions?: unknown,
         useSRGBBuffer?: boolean
     ): Promise<BaseTexture> {
         const samplerData = this._loadSampler(`/samplers/${sampler.index}`, sampler);
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         const deferred = new Deferred<void>();
         this._babylonScene._blockEntityCollection = !!this._assetContainer;
@@ -2676,7 +2676,7 @@ export class GLTFLoader implements IGLTFLoader {
     private _compileMaterialsAsync(): Promise<void> {
         this._parent._startPerformanceCounter("Compile materials");
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         if (this._gltf.materials) {
             for (const material of this._gltf.materials) {
@@ -2708,7 +2708,7 @@ export class GLTFLoader implements IGLTFLoader {
     private _compileShadowGeneratorsAsync(): Promise<void> {
         this._parent._startPerformanceCounter("Compile shadow generators");
 
-        const promises = new Array<Promise<any>>();
+        const promises = new Array<Promise<unknown>>();
 
         const lights = this._babylonScene.lights;
         for (const light of lights) {
@@ -2871,7 +2871,7 @@ export class GLTFLoader implements IGLTFLoader {
      * @param actionAsync The action to run
      * @returns The promise returned by actionAsync or null if the extension does not exist
      */
-    public static LoadExtensionAsync<TExtension = any, TResult = void>(
+    public static LoadExtensionAsync<TExtension = unknown, TResult = void>(
         context: string,
         property: IProperty,
         extensionName: string,
@@ -2899,7 +2899,7 @@ export class GLTFLoader implements IGLTFLoader {
      * @param actionAsync The action to run
      * @returns The promise returned by actionAsync or null if the extra does not exist
      */
-    public static LoadExtraAsync<TExtra = any, TResult = void>(
+    public static LoadExtraAsync<TExtra = unknown, TResult = void>(
         context: string,
         property: IProperty,
         extensionName: string,

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -11,7 +11,6 @@ import type { Material } from "core/Materials/material";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type {
     ISceneLoaderPluginFactory,
-    ISceneLoaderPlugin,
     ISceneLoaderPluginAsync,
     ISceneLoaderProgressEvent,
     ISceneLoaderPluginExtensions,
@@ -156,7 +155,7 @@ export enum GLTFLoaderState {
 /** @internal */
 export interface IGLTFLoader extends IDisposable {
     importMeshAsync: (
-        meshesNames: any,
+        meshesNames: string | readonly string[] | null | undefined,
         scene: Scene,
         container: Nullable<AssetContainer>,
         data: IGLTFLoaderData,
@@ -587,7 +586,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
         scene: Scene,
         fileOrUrl: File | string | ArrayBufferView,
         rootUrl: string,
-        onSuccess: (data: any, responseURL?: string) => void,
+        onSuccess: (data: unknown, responseURL?: string) => void,
         onProgress?: (ev: ISceneLoaderProgressEvent) => void,
         useArrayBuffer?: boolean,
         onError?: (request?: WebRequest, exception?: LoadFileError) => void,
@@ -684,7 +683,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
         scene: Scene,
         data: ArrayBufferView,
         rootUrl: string,
-        onSuccess: (data: any, responseURL?: string) => void,
+        onSuccess: (data: unknown, responseURL?: string) => void,
         onError?: (request?: WebRequest, exception?: LoadFileError) => void,
         fileName?: string
     ): void {
@@ -706,9 +705,9 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
      * @internal
      */
     public importMeshAsync(
-        meshesNames: any,
+        meshesNames: string | readonly string[] | null | undefined,
         scene: Scene,
-        data: any,
+        data: IGLTFLoaderData,
         rootUrl: string,
         onProgress?: (event: ISceneLoaderProgressEvent) => void,
         fileName?: string
@@ -726,7 +725,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
     /**
      * @internal
      */
-    public loadAsync(scene: Scene, data: any, rootUrl: string, onProgress?: (event: ISceneLoaderProgressEvent) => void, fileName?: string): Promise<void> {
+    public loadAsync(scene: Scene, data: IGLTFLoaderData, rootUrl: string, onProgress?: (event: ISceneLoaderProgressEvent) => void, fileName?: string): Promise<void> {
         return Promise.resolve().then(() => {
             this.onParsedObservable.notifyObservers(data);
             this.onParsedObservable.clear();
@@ -740,7 +739,13 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
     /**
      * @internal
      */
-    public loadAssetContainerAsync(scene: Scene, data: any, rootUrl: string, onProgress?: (event: ISceneLoaderProgressEvent) => void, fileName?: string): Promise<AssetContainer> {
+    public loadAssetContainerAsync(
+        scene: Scene,
+        data: IGLTFLoaderData,
+        rootUrl: string,
+        onProgress?: (event: ISceneLoaderProgressEvent) => void,
+        fileName?: string
+    ): Promise<AssetContainer> {
         return Promise.resolve().then(() => {
             this.onParsedObservable.notifyObservers(data);
             this.onParsedObservable.clear();
@@ -805,7 +810,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
     /**
      * @internal
      */
-    public directLoad(scene: Scene, data: string): Promise<any> {
+    public directLoad(scene: Scene, data: string): Promise<Object> {
         if (
             data.startsWith("base64," + GLTFFileLoader._MagicBase64Encoded) || // this is technically incorrect, but will continue to support for backcompat.
             data.startsWith(";base64," + GLTFFileLoader._MagicBase64Encoded) ||
@@ -836,7 +841,7 @@ export class GLTFFileLoader implements IDisposable, ISceneLoaderPluginAsync, ISc
     public rewriteRootURL?(rootUrl: string, responseURL?: string): string;
 
     /** @internal */
-    public createPlugin(): ISceneLoaderPlugin | ISceneLoaderPluginAsync {
+    public createPlugin(): ISceneLoaderPluginAsync {
         return new GLTFFileLoader();
     }
 


### PR DESCRIPTION
I recently spent a bit of time going through the `SceneLoader` and `GLTFFileLoader` code in preparation for improving gltf loader options and found some parts of the code hard to grok due to a lot of use of `any`, a lot of casting, and some seemingly somewhat incorrect types. I cleaned this up as I was going through the code to understand it, and wanted to get these changes reviewed separately from upcoming glft loader options changes. The changes in this PR are:

- Lots of replacement of `any` with `unknown` (safer and easier to understand expectations when reading the code).
- Some replacements of `any` with specific types where they were in fact known (`meshNames` parameter, `directLoad` return type, `IGLTFLoaderData` in some cases).
- Added a `ISceneLoaderPluginInternal` interface with the `onDisposeObservable` property. It seems like the intent was to hide this from the public contract, but it's hard to say for sure from the given code. Alternatively this could be added as an optional property to `ISceneLoaderPluginBase` if we want it to be public.
- Registered plugins were tracked as `ISceneLoaderPlugin | ISceneLoaderPluginAsync | ISceneLoaderPluginFactory`, but really `SceneLoader.RegisterPlugin` requires the plugin to be `ISceneLoaderPlugin | ISceneLoaderPluginAsync` and optionally allows it to be `ISceneLoaderPluginFactory`. Therefore I updated this type to be `(ISceneLoaderPlugin | ISceneLoaderPluginAsync) & Partial<ISceneLoaderPluginFactory> & Partial<ISceneLoaderPluginInternal>` which matches what is actually happening and removes the need for some casts.