### PR TITLE
Fix for native (internal API change)

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -55,6 +55,7 @@ import { checkNonFloatVertexBuffers } from "../Buffers/buffer.nonFloatVertexBuff
 import type { ShaderProcessingContext } from "./Processors/shaderProcessingOptions";
 import { NativeShaderProcessingContext } from "./Native/nativeShaderProcessingContext";
 import type { ShaderLanguage } from "../Materials/shaderLanguage";
+import type { WebGLHardwareTexture } from "./WebGL/webGLHardwareTexture";
 
 declare const _native: INative;
 
@@ -1552,9 +1553,9 @@ export class NativeEngine extends Engine {
         return this._engine.createTexture();
     }
 
-    protected override _deleteTexture(texture: Nullable<WebGLTexture>): void {
+    protected override _deleteTexture(texture: Nullable<WebGLHardwareTexture>): void {
         if (texture) {
-            this._engine.deleteTexture(texture as NativeTexture);
+            this._engine.deleteTexture(texture.underlyingResource as NativeTexture);
         }
     }
 


### PR DESCRIPTION
After merging #15184 I realized it will be problematic to native (as native is using the same `_releaseTexture` as ThinEngine).