### PR TITLE
Add missing side-effects import to nativeEngine.ts

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -57,6 +57,8 @@ import { NativeShaderProcessingContext } from "./Native/nativeShaderProcessingCo
 import type { ShaderLanguage } from "../Materials/shaderLanguage";
 import type { WebGLHardwareTexture } from "./WebGL/webGLHardwareTexture";
 
+import "../Buffers/buffer.align";
+
 declare const _native: INative;
 
 const onNativeObjectInitialized = new Observable<INative>();


### PR DESCRIPTION
Without this, UMD works, but ES6 will not.