### PR TITLE
Mesh: Fix back compat for sideOrientation when parsing mesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -4109,6 +4109,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             mesh.ellipsoidOffset = Vector3.FromArray(parsedMesh.ellipsoidOffset);
         }
 
+        // For Backward compatibility ("!=" to exclude null and undefined)
+        if (parsedMesh.overrideMaterialSideOrientation != null) {
+            mesh.sideOrientation = parsedMesh.overrideMaterialSideOrientation;
+        }
+
         if (parsedMesh.sideOrientation !== undefined) {
             mesh.sideOrientation = parsedMesh.sideOrientation;
         }

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -4,7 +4,8 @@
         {
             "title": "NME Shadow Map",
             "playgroundId": "#M3QR7E#83",
-            "referenceImage": "nmeshadowmap.png"
+            "referenceImage": "nmeshadowmap.png",
+            "excludedEngines": ["webgl1"]
         },
         {
             "title": "NMEGLTF",


### PR DESCRIPTION
See https://forum.babylonjs.com/t/new-versions-7-10-7-11-have-errors-with-model-normal-maps/51320/6