### PR TITLE
2D GUI ellipse arcing

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2715,13 +2715,16 @@ export class Control implements IAnimatable {
     /**
      * @internal
      */
-    protected static drawEllipse(x: number, y: number, width: number, height: number, context: ICanvasRenderingContext): void {
+    protected static drawEllipse(x: number, y: number, width: number, height: number, arc: number, context: ICanvasRenderingContext): void {
         context.translate(x, y);
         context.scale(width, height);
 
         context.beginPath();
-        context.arc(0, 0, 1, 0, 2 * Math.PI);
-        context.closePath();
+        context.arc(0, 0, 1, 0, 2 * Math.PI * arc);
+
+        if (arc >= 1) {
+            context.closePath();
+        }
 
         context.scale(1 / width, 1 / height);
         context.translate(-x, -y);

--- a/packages/dev/gui/src/2D/controls/ellipse.ts
+++ b/packages/dev/gui/src/2D/controls/ellipse.ts
@@ -24,6 +24,23 @@ export class Ellipse extends Container {
         this._markAsDirty();
     }
 
+    private _arc = 1;
+
+    /** Gets or sets arcing of the ellipse (ratio of the circumference between 0 and 1) */
+    @serialize()
+    public get arc(): number {
+        return this._arc;
+    }
+
+    public set arc(value: number) {
+        if (this._arc === value) {
+            return;
+        }
+
+        this._arc = value;
+        this._markAsDirty();
+    }
+
     /**
      * Creates a new Ellipse
      * @param name defines the control name
@@ -51,6 +68,7 @@ export class Ellipse extends Container {
             this._currentMeasure.top + this._currentMeasure.height / 2,
             this._currentMeasure.width / 2 - this._thickness / 2,
             this._currentMeasure.height / 2 - this._thickness / 2,
+            this._arc,
             context
         );
 
@@ -93,6 +111,7 @@ export class Ellipse extends Container {
             this._currentMeasure.top + this._currentMeasure.height / 2,
             this._currentMeasure.width / 2,
             this._currentMeasure.height / 2,
+            this._arc,
             context
         );
 
@@ -105,6 +124,7 @@ export class Ellipse extends Container {
             this._currentMeasure.top + this._currentMeasure.height / 2,
             this._currentMeasure.width / 2 - this._highlightLineWidth / 2,
             this._currentMeasure.height / 2 - this._highlightLineWidth / 2,
+            this._arc,
             context
         );
         context.stroke();

--- a/packages/dev/gui/src/2D/controls/radioButton.ts
+++ b/packages/dev/gui/src/2D/controls/radioButton.ts
@@ -140,6 +140,7 @@ export class RadioButton extends Control {
             this._currentMeasure.top + this._currentMeasure.height / 2,
             this._currentMeasure.width / 2 - this._thickness / 2,
             this._currentMeasure.height / 2 - this._thickness / 2,
+            1,
             context
         );
 
@@ -168,6 +169,7 @@ export class RadioButton extends Control {
                 this._currentMeasure.top + this._currentMeasure.height / 2,
                 offsetWidth / 2 - this._thickness / 2,
                 offseHeight / 2 - this._thickness / 2,
+                1,
                 context
             );
 


### PR DESCRIPTION
Allow Arcing of the 2D GUI Ellipse control.

Let's us create Semi-circles, and opens open a wide range of new GUI design options.
It's something i've felt have been lacking for a while, with the only option being doing it through images.

Unfortunately the starting angle(0) of context.arc() function is on the far right end of the ellipse for some reason.. 
would have been great to have to start/end at the top, i think leave it to the dev to control with rotation of the control.

Ref use-case; https://forum.babylonjs.com/t/loading-timer-circular-ui/51364

**PG samples**
Note that when a single ellipse is arced, and both filled (background) and stroked (thickness) the border/thickness is not connected/closed.
as that would require an additional property to force closePath() on context even when arcing.
https://playground.babylonjs.com/?snapshot=refs/pull/15207/merge#IC5LC6#3