### PR TITLE
Fluid renderer: Don't dispose of effects when disposing of fluid objects

### DIFF
--- a/packages/dev/core/src/Materials/effectRenderer.ts
+++ b/packages/dev/core/src/Materials/effectRenderer.ts
@@ -343,12 +343,15 @@ export class EffectWrapper {
 
     /**
      * Disposes of the effect wrapper
+     * @param disposeEffect defines if the underlying effect should also be disposed (true by default)
      */
-    public dispose() {
+    public dispose(disposeEffect = true) {
         if (this._onContextRestoredObserver) {
             this.effect.getEngine().onContextRestoredObservable.remove(this._onContextRestoredObserver);
             this._onContextRestoredObserver = null;
         }
-        this.effect.dispose();
+        if (disposeEffect) {
+            this.effect.dispose();
+        }
     }
 }

--- a/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderingObject.ts
+++ b/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderingObject.ts
@@ -237,7 +237,7 @@ export abstract class FluidRenderingObject {
      * Releases the ressources used by the class
      */
     public dispose(): void {
-        this._depthEffectWrapper?.dispose();
-        this._thicknessEffectWrapper?.dispose();
+        this._depthEffectWrapper?.dispose(false);
+        this._thicknessEffectWrapper?.dispose(false);
     }
 }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/fluid-renderer-not-working-with-particle-subemitters/51367/2.

That's because effects are cached by the engine.

This means that if the same effect is used in different places in the code (which is the case in the fluid renderer, if you add several particle systems, for example), disposing of the effect in one place will cause the code to crash in all other places.

Example of PG that generates errors: https://playground.babylonjs.com/#9NHBCC#65

If you wait a few seconds, you will see these errors in the console log:

```md
WebGL: INVALID_OPERATION: useProgram: attempt to use a deleted object
[.WebGL-0000223000726A00] GL_INVALID_OPERATION: Active draw buffers with missing fragment shader outputs.
```