### PR TITLE
Fix regex to ignore commented imports

### DIFF
--- a/packages/dev/buildTools/src/addJSToCompiledFiles.ts
+++ b/packages/dev/buildTools/src/addJSToCompiledFiles.ts
@@ -18,7 +18,7 @@ export function addJsExtensionsToCompiledFiles(files: string[], forceMJS: boolea
         const sourceCode = fs.readFileSync(file, "utf-8");
         const processed = processSource(sourceCode, forceMJS);
 
-        const regex = /import .* from "(\..*)";/g;
+        const regex = /^import .* from "(\..*)";/g;
         let match;
         while ((match = regex.exec(processed)) !== null) {
             if (!fs.existsSync(path.resolve(path.dirname(file), match[1]))) {


### PR DESCRIPTION
this a the post-build script. Fix is because of failed ES6 build in #15106