### PR TITLE
Add default value to documented constructor parameters

### DIFF
--- a/packages/dev/core/src/Animations/animatable.ts
+++ b/packages/dev/core/src/Animations/animatable.ts
@@ -130,11 +130,11 @@ export class Animatable {
         scene: Scene,
         /** defines the target object */
         public target: any,
-        /** defines the starting frame number (default is 0) */
+        /** [0] defines the starting frame number (default is 0) */
         public fromFrame: number = 0,
-        /** defines the ending frame number (default is 100) */
+        /** [100] defines the ending frame number (default is 100) */
         public toFrame: number = 100,
-        /** defines if the animation must loop (default is false)  */
+        /** [false] defines if the animation must loop (default is false)  */
         public loopAnimation: boolean = false,
         speedRatio: number = 1.0,
         /** defines a callback to call when animation ends if it is not looping */
@@ -142,9 +142,9 @@ export class Animatable {
         animations?: Animation[],
         /** defines a callback to call when animation loops */
         public onAnimationLoop?: Nullable<() => void>,
-        /** defines whether the animation should be evaluated additively */
+        /** [false] defines whether the animation should be evaluated additively */
         public isAdditive: boolean = false,
-        /** defines the order in which this animatable should be processed in the list of active animatables (default: 0) */
+        /** [0] defines the order in which this animatable should be processed in the list of active animatables (default: 0) */
         public playOrder = 0
     ) {
         this._scene = scene;

--- a/packages/dev/core/src/Animations/animationGroupMask.ts
+++ b/packages/dev/core/src/Animations/animationGroupMask.ts
@@ -36,7 +36,7 @@ export class AnimationGroupMask {
     constructor(
         names?: string[],
         /**
-         * Defines the mode for the mask
+         * [0] Defines the mode for the mask
          */
         public mode: AnimationGroupMaskMode = AnimationGroupMaskMode.Include
     ) {

--- a/packages/dev/core/src/Animations/easing.ts
+++ b/packages/dev/core/src/Animations/easing.ts
@@ -112,7 +112,7 @@ export class BackEase extends EasingFunction implements IEasingFunction {
      * @param amplitude Defines the amplitude of the function
      */
     constructor(
-        /** Defines the amplitude of the function */
+        /** [1] Defines the amplitude of the function */
         public amplitude: number = 1
     ) {
         super();

--- a/packages/dev/core/src/Behaviors/Meshes/attachToBoxBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/attachToBoxBehavior.ts
@@ -23,15 +23,15 @@ class FaceDirectionInfo {
  */
 export class AttachToBoxBehavior implements Behavior<Mesh> {
     /**
-     *  The name of the behavior
+     *  ["AttachToBoxBehavior"] The name of the behavior
      */
     public name = "AttachToBoxBehavior";
     /**
-     * The distance away from the face of the mesh that the UI should be attached to (default: 0.15)
+     * [0.15] The distance away from the face of the mesh that the UI should be attached to (default: 0.15)
      */
     public distanceAwayFromFace = 0.15;
     /**
-     * The distance from the bottom of the face that the UI should be attached to (default: 0.15)
+     * [0.15] The distance from the bottom of the face that the UI should be attached to (default: 0.15)
      */
     public distanceAwayFromBottomOfFace = 0.15;
     private _faceVectors = [

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraMouseInput.ts
@@ -57,7 +57,7 @@ export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
      */
     constructor(
         /**
-         * Define if touch is enabled in the mouse input
+         * [true] Define if touch is enabled in the mouse input
          */
         public touchEnabled = true
     ) {}

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -54,7 +54,7 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
      */
     constructor(
         /**
-         * Define if mouse events can be treated as touch events
+         * [false] Define if mouse events can be treated as touch events
          */
         public allowMouse = false
     ) {

--- a/packages/dev/core/src/Culling/Octrees/octree.ts
+++ b/packages/dev/core/src/Culling/Octrees/octree.ts
@@ -35,7 +35,7 @@ export class Octree<T> {
     constructor(
         creationFunc: (entry: T, block: OctreeBlock<T>) => void,
         maxBlockCapacity?: number,
-        /** Defines the maximum depth (sub-levels) for your octree. Default value is 2, which means 8 8 8 = 512 blocks :) (This parameter takes precedence over capacity.) */
+        /** [2] Defines the maximum depth (sub-levels) for your octree. Default value is 2, which means 8 8 8 = 512 blocks :) (This parameter takes precedence over capacity.) */
         public maxDepth = 2
     ) {
         this._maxBlockCapacity = maxBlockCapacity || 64;

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -34,9 +34,9 @@ export class Ray {
         public origin: Vector3,
         /** direction */
         public direction: Vector3,
-        /** length of the ray */
+        /** [Number.MAX_VALUE] length of the ray */
         public length: number = Number.MAX_VALUE,
-        /** The epsilon value to use when calculating the ray/triangle intersection (default: Epsilon from math constants) */
+        /** [Epsilon] The epsilon value to use when calculating the ray/triangle intersection (default: Epsilon from math constants) */
         public epsilon: number = Epsilon
     ) {}
 

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -393,11 +393,11 @@ export class SkeletonViewer {
         public mesh: Nullable<AbstractMesh>,
         /** The Scene scope*/
         scene: Scene,
-        /** defines a boolean indicating if bones matrices must be forced to update before rendering (true by default)  */
+        /** [true] defines a boolean indicating if bones matrices must be forced to update before rendering (true by default)  */
         public autoUpdateBonesMatrices: boolean = true,
-        /** defines the rendering group id to use with the viewer */
+        /** [3] defines the rendering group id to use with the viewer */
         public renderingGroupId: number = 3,
-        /** is the options for the viewer */
+        /** [Object] is the options for the viewer */
         public options: Partial<ISkeletonViewerOptions> = {}
     ) {
         this._scene = scene;

--- a/packages/dev/core/src/DeviceInput/InputDevices/deviceSource.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/deviceSource.ts
@@ -38,7 +38,7 @@ export class DeviceSource<T extends DeviceType> {
         deviceInputSystem: IDeviceInputSystem,
         /** Type of device */
         public readonly deviceType: T,
-        /** "Slot" or index that device is referenced in */
+        /** [0] "Slot" or index that device is referenced in */
         public readonly deviceSlot: number = 0
     ) {
         this._deviceInputSystem = deviceInputSystem;

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -51,15 +51,15 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
      */
     constructor(
         /**
-         * Defines the red component (between 0 and 1, default is 0)
+         * [0] Defines the red component (between 0 and 1, default is 0)
          */
         public r: number = 0,
         /**
-         * Defines the green component (between 0 and 1, default is 0)
+         * [0] Defines the green component (between 0 and 1, default is 0)
          */
         public g: number = 0,
         /**
-         * Defines the blue component (between 0 and 1, default is 0)
+         * [0] Defines the blue component (between 0 and 1, default is 0)
          */
         public b: number = 0
     ) {}
@@ -1020,19 +1020,19 @@ export class Color4 implements Tensor<Tuple<number, 4>, IColor4Like>, IColor4Lik
      */
     constructor(
         /**
-         * Defines the red component (between 0 and 1, default is 0)
+         * [0] Defines the red component (between 0 and 1, default is 0)
          */
         public r: number = 0,
         /**
-         * Defines the green component (between 0 and 1, default is 0)
+         * [0] Defines the green component (between 0 and 1, default is 0)
          */
         public g: number = 0,
         /**
-         * Defines the blue component (between 0 and 1, default is 0)
+         * [0] Defines the blue component (between 0 and 1, default is 0)
          */
         public b: number = 0,
         /**
-         * Defines the alpha component (between 0 and 1, default is 1)
+         * [1] Defines the alpha component (between 0 and 1, default is 1)
          */
         public a: number = 1
     ) {}

--- a/packages/dev/core/src/Maths/math.isovector.ts
+++ b/packages/dev/core/src/Maths/math.isovector.ts
@@ -15,9 +15,9 @@ export class _IsoVector {
      * @param y defines the second coordinate, must be an integer
      */
     constructor(
-        /** defines the first coordinate */
+        /** [0] defines the first coordinate */
         public x: number = 0,
-        /** defines the second coordinate */
+        /** [0] defines the second coordinate */
         public y: number = 0
     ) {
         if (x !== Math.floor(x)) {

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -122,9 +122,9 @@ export class Vector2 implements Vector<Tuple<number, 2>, IVector2Like>, IVector2
      * @param y defines the second coordinate
      */
     constructor(
-        /** defines the first coordinate */
+        /** [0] defines the first coordinate */
         public x: number = 0,
-        /** defines the second coordinate */
+        /** [0] defines the second coordinate */
         public y: number = 0
     ) {}
 
@@ -3364,13 +3364,13 @@ export class Vector4 implements Vector<Tuple<number, 4>, IVector4Like>, IVector4
      * @param w w value of the vector
      */
     constructor(
-        /** x value of the vector */
+        /** [0] x value of the vector */
         public x: number = 0,
-        /** y value of the vector */
+        /** [0] y value of the vector */
         public y: number = 0,
-        /** z value of the vector */
+        /** [0] z value of the vector */
         public z: number = 0,
-        /** w value of the vector */
+        /** [0] w value of the vector */
         public w: number = 0
     ) {}
 

--- a/packages/dev/core/src/Maths/math.vertexFormat.ts
+++ b/packages/dev/core/src/Maths/math.vertexFormat.ts
@@ -10,9 +10,9 @@ export class PositionNormalVertex {
      * @param normal the normal of the vertex (defaut: 0,1,0)
      */
     constructor(
-        /** the position of the vertex (defaut: 0,0,0) */
+        /** [Vector3.Zero()] the position of the vertex (defaut: 0,0,0) */
         public position: Vector3 = Vector3.Zero(),
-        /** the normal of the vertex (defaut: 0,1,0) */
+        /** [Vector3.Up()] the normal of the vertex (defaut: 0,1,0) */
         public normal: Vector3 = Vector3.Up()
     ) {}
 
@@ -36,11 +36,11 @@ export class PositionNormalTextureVertex {
      * @param uv the uv of the vertex (default: 0,0)
      */
     constructor(
-        /** the position of the vertex (defaut: 0,0,0) */
+        /** [Vector3.Zero()] the position of the vertex (defaut: 0,0,0) */
         public position: Vector3 = Vector3.Zero(),
-        /** the normal of the vertex (defaut: 0,1,0) */
+        /** [Vector3.Up()] the normal of the vertex (defaut: 0,1,0) */
         public normal: Vector3 = Vector3.Up(),
-        /** the uv of the vertex (default: 0,0) */
+        /** [Vector3.Zero()] the uv of the vertex (default: 0,0) */
         public uv: Vector2 = Vector2.Zero()
     ) {}
     /**

--- a/packages/dev/core/src/Misc/observable.ts
+++ b/packages/dev/core/src/Misc/observable.ts
@@ -85,7 +85,7 @@ export class Observer<T> {
      * Creates a new observer
      * @param callback defines the callback to call when the observer is notified
      * @param mask defines the mask of the observer (used to filter notifications)
-     * @param [scope] defines the current scope used to restore the JS context
+     * @param scope defines the current scope used to restore the JS context
      */
     constructor(
         /**
@@ -97,7 +97,7 @@ export class Observer<T> {
          */
         public mask: number,
         /**
-         * [scope] Defines the current scope used to restore the JS context
+         * [null] Defines the current scope used to restore the JS context
          */
         public scope: any = null
     ) {}
@@ -169,12 +169,12 @@ export class Observable<T> {
     /**
      * Creates a new observable
      * @param onObserverAdded defines a callback to call when a new observer is added
-     * @param [notifyIfTriggered] If set to true the observable will notify when an observer was added if the observable was already triggered.
+     * @param notifyIfTriggered If set to true the observable will notify when an observer was added if the observable was already triggered.
      */
     constructor(
         onObserverAdded?: (observer: Observer<T>) => void,
         /**
-         * [notifyIfTriggered] If set to true the observable will notify when an observer was added if the observable was already triggered.
+         * [false] If set to true the observable will notify when an observer was added if the observable was already triggered.
          * This is helpful to single-state observables like the scene onReady or the dispose observable.
          */
         public notifyIfTriggered = false

--- a/packages/dev/core/src/Misc/sceneOptimizer.ts
+++ b/packages/dev/core/src/Misc/sceneOptimizer.ts
@@ -36,7 +36,7 @@ export class SceneOptimization {
      */
     constructor(
         /**
-         * Defines the priority of this optimization (0 by default which means first in the list)
+         * [0] Defines the priority of this optimization (0 by default which means first in the list)
          */
         public priority: number = 0
     ) {}
@@ -44,7 +44,7 @@ export class SceneOptimization {
 
 /**
  * Defines an optimization used to reduce the size of render target textures
- * @description More details at https://doc.babylonjs.com/features/featuresDeepDive/scene/sceneOptimizer
+ * @see https://doc.babylonjs.com/features/featuresDeepDive/scene/sceneOptimizer
  */
 export class TextureOptimization extends SceneOptimization {
     /**

--- a/packages/dev/core/src/Particles/EmitterTypes/coneParticleEmitter.ts
+++ b/packages/dev/core/src/Particles/EmitterTypes/coneParticleEmitter.ts
@@ -72,7 +72,7 @@ export class ConeParticleEmitter implements IParticleEmitterType {
     constructor(
         radius = 1,
         angle = Math.PI,
-        /** defines how much to randomize the particle direction [0-1] (default is 0) */
+        /** [0] defines how much to randomize the particle direction [0-1] (default is 0) */
         public directionRandomizer = 0
     ) {
         this.angle = angle;

--- a/packages/dev/core/src/Particles/EmitterTypes/cylinderParticleEmitter.ts
+++ b/packages/dev/core/src/Particles/EmitterTypes/cylinderParticleEmitter.ts
@@ -22,19 +22,19 @@ export class CylinderParticleEmitter implements IParticleEmitterType {
      */
     constructor(
         /**
-         * The radius of the emission cylinder.
+         * [1] The radius of the emission cylinder.
          */
         public radius = 1,
         /**
-         * The height of the emission cylinder.
+         * [1] The height of the emission cylinder.
          */
         public height = 1,
         /**
-         * The range of emission [0-1] 0 Surface only, 1 Entire Radius.
+         * [1] The range of emission [0-1] 0 Surface only, 1 Entire Radius.
          */
         public radiusRange = 1,
         /**
-         * How much to randomize the particle direction [0-1].
+         * [0] How much to randomize the particle direction [0-1].
          */
         public directionRandomizer = 0
     ) {}

--- a/packages/dev/core/src/Particles/EmitterTypes/hemisphericParticleEmitter.ts
+++ b/packages/dev/core/src/Particles/EmitterTypes/hemisphericParticleEmitter.ts
@@ -19,15 +19,15 @@ export class HemisphericParticleEmitter implements IParticleEmitterType {
      */
     constructor(
         /**
-         * The radius of the emission hemisphere.
+         * [1] The radius of the emission hemisphere.
          */
         public radius = 1,
         /**
-         * The range of emission [0-1] 0 Surface only, 1 Entire Radius.
+         * [1] The range of emission [0-1] 0 Surface only, 1 Entire Radius.
          */
         public radiusRange = 1,
         /**
-         * How much to randomize the particle direction [0-1].
+         * [0] How much to randomize the particle direction [0-1].
          */
         public directionRandomizer = 0
     ) {}

--- a/packages/dev/core/src/Particles/EmitterTypes/sphereParticleEmitter.ts
+++ b/packages/dev/core/src/Particles/EmitterTypes/sphereParticleEmitter.ts
@@ -19,15 +19,15 @@ export class SphereParticleEmitter implements IParticleEmitterType {
      */
     constructor(
         /**
-         * The radius of the emission sphere.
+         * [1] The radius of the emission sphere.
          */
         public radius = 1,
         /**
-         * The range of emission [0-1] 0 Surface only, 1 Entire Radius.
+         * [1] The range of emission [0-1] 0 Surface only, 1 Entire Radius.
          */
         public radiusRange = 1,
         /**
-         * How much to randomize the particle direction [0-1].
+         * [0] How much to randomize the particle direction [0-1].
          */
         public directionRandomizer = 0
     ) {}

--- a/packages/dev/core/src/Particles/pointsCloudSystem.ts
+++ b/packages/dev/core/src/Particles/pointsCloudSystem.ts
@@ -118,7 +118,6 @@ export class PointsCloudSystem implements IDisposable {
      * @param scene (Scene) is the scene in which the PCS is added
      * @param options defines the options of the PCS e.g.
      * * updatable (optional boolean, default true) : if the PCS must be updatable or immutable
-     * @param options.updatable
      */
     constructor(name: string, pointSize: number, scene: Scene, options?: { updatable?: boolean }) {
         this.name = name;

--- a/packages/dev/core/src/Physics/v1/physicsImpostor.ts
+++ b/packages/dev/core/src/Physics/v1/physicsImpostor.ts
@@ -443,7 +443,7 @@ export class PhysicsImpostor {
          */
         public object: IPhysicsEnabledObject,
         /**
-         * The type of the physics imposter
+         * [Object] The type of the physics imposter
          */
         public type: number,
         private _options: PhysicsImpostorParameters = { mass: 0 },

--- a/packages/dev/core/src/XR/features/WebXRBackgroundRemover.ts
+++ b/packages/dev/core/src/XR/features/WebXRBackgroundRemover.ts
@@ -60,7 +60,7 @@ export class WebXRBackgroundRemover extends WebXRAbstractFeature {
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * read-only options to be used in this module
+         * [Object] read-only options to be used in this module
          */
         public readonly options: IWebXRBackgroundRemoverOptions = {}
     ) {

--- a/packages/dev/core/src/XR/features/WebXRBackgroundRemover.ts
+++ b/packages/dev/core/src/XR/features/WebXRBackgroundRemover.ts
@@ -60,7 +60,7 @@ export class WebXRBackgroundRemover extends WebXRAbstractFeature {
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * [Object] read-only options to be used in this module
+         * [Empty Object] read-only options to be used in this module
          */
         public readonly options: IWebXRBackgroundRemoverOptions = {}
     ) {

--- a/packages/dev/core/src/XR/features/WebXRHitTest.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTest.ts
@@ -143,7 +143,7 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * [Object] options to use when constructing this feature
+         * [Empty Object] options to use when constructing this feature
          */
         public readonly options: IWebXRHitTestOptions = {}
     ) {

--- a/packages/dev/core/src/XR/features/WebXRHitTest.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTest.ts
@@ -143,7 +143,7 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * options to use when constructing this feature
+         * [Object] options to use when constructing this feature
          */
         public readonly options: IWebXRHitTestOptions = {}
     ) {

--- a/packages/dev/core/src/XR/features/WebXRHitTestLegacy.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTestLegacy.ts
@@ -87,7 +87,7 @@ export class WebXRHitTestLegacy extends WebXRAbstractFeature implements IWebXRHi
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * [Object] options to use when constructing this feature
+         * [Empty Object] options to use when constructing this feature
          */
         public readonly options: IWebXRLegacyHitTestOptions = {}
     ) {

--- a/packages/dev/core/src/XR/features/WebXRHitTestLegacy.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTestLegacy.ts
@@ -87,7 +87,7 @@ export class WebXRHitTestLegacy extends WebXRAbstractFeature implements IWebXRHi
     constructor(
         _xrSessionManager: WebXRSessionManager,
         /**
-         * options to use when constructing this feature
+         * [Object] options to use when constructing this feature
          */
         public readonly options: IWebXRLegacyHitTestOptions = {}
     ) {

--- a/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
+++ b/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
@@ -296,6 +296,7 @@ export abstract class WebXRAbstractMotionController implements IDisposable {
         public handedness: MotionControllerHandedness,
         /**
          * @internal
+         * [false]
          */
         public _doNotLoadControllerMesh: boolean = false,
         private _controllerCache?: Array<{

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2720,7 +2720,7 @@ export class Control implements IAnimatable {
         context.scale(width, height);
 
         context.beginPath();
-        context.arc(0, 0, 1, 0, 2 * Math.PI * arc);
+        context.arc(0, 0, 1, 0, 2 * Math.PI * arc, arc < 0);
 
         if (arc >= 1) {
             context.closePath();


### PR DESCRIPTION
When compiling babylon using closure compiler it complains that default parameters don't have the default value, in accordance to JSDoc specifications. as we are using tsdoc and not jsdoc, this introduces a bit of an issue if we document the constructor with default values (tsdoc doesn't have a definition for default value of a paremeter).

The solution is to add the default value to the actual documentation of the paremeter, if provided. This is needed if a constructor has a public member that is documented and has a default value. These are the ones I found, I guess there might be more and I will try adding a step to check for missing values in the future.