### PR TITLE
Move to const enum where possible

### DIFF
--- a/packages/dev/core/src/Animations/animationGroupMask.ts
+++ b/packages/dev/core/src/Animations/animationGroupMask.ts
@@ -1,7 +1,7 @@
 /**
  * Enum used to define the mode for an animation group mask
  */
-export enum AnimationGroupMaskMode {
+export const enum AnimationGroupMaskMode {
     /**
      * The mask defines the animatable target names that should be included
      */

--- a/packages/dev/core/src/Animations/animationKey.ts
+++ b/packages/dev/core/src/Animations/animationKey.ts
@@ -37,7 +37,7 @@ export interface IAnimationKey {
 /**
  * Enum for the animation key frame interpolation type
  */
-export enum AnimationKeyInterpolation {
+export const enum AnimationKeyInterpolation {
     /**
      * Use tangents to interpolate between start and end values.
      */

--- a/packages/dev/core/src/Behaviors/Meshes/handConstraintBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/handConstraintBehavior.ts
@@ -16,7 +16,7 @@ import { Tools } from "core/Misc/tools";
 /**
  * Zones around the hand
  */
-export enum HandConstraintZone {
+export const enum HandConstraintZone {
     /**
      * Above finger tips
      */
@@ -38,7 +38,7 @@ export enum HandConstraintZone {
 /**
  * Orientations for the hand zones and for the attached node
  */
-export enum HandConstraintOrientation {
+export const enum HandConstraintOrientation {
     /**
      * Orientation is towards the camera
      */
@@ -52,7 +52,7 @@ export enum HandConstraintOrientation {
 /**
  * Orientations for the hand zones and for the attached node
  */
-export enum HandConstraintVisibility {
+export const enum HandConstraintVisibility {
     /**
      * Constraint is always visible
      */

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -193,7 +193,7 @@ Object.defineProperty(Scene.prototype, "debugLayer", {
 /**
  * Enum of inspector action tab
  */
-export enum DebugLayerTab {
+export const enum DebugLayerTab {
     /**
      * Properties tag (default)
      */

--- a/packages/dev/core/src/Decorators/nodeDecorator.ts
+++ b/packages/dev/core/src/Decorators/nodeDecorator.ts
@@ -4,7 +4,7 @@ import type { Scene } from "../scene";
 /**
  * Enum defining the type of properties that can be edited in the property pages in the node editor
  */
-export enum PropertyTypeForEdition {
+export const enum PropertyTypeForEdition {
     /** property is a boolean */
     Boolean,
     /** property is a float */

--- a/packages/dev/core/src/DeviceInput/InputDevices/deviceEnums.ts
+++ b/packages/dev/core/src/DeviceInput/InputDevices/deviceEnums.ts
@@ -50,7 +50,7 @@ export enum PointerInput {
 }
 
 /** @internal */
-export enum NativePointerInput {
+export const enum NativePointerInput {
     /** Horizontal Axis */
     Horizontal = PointerInput.Horizontal,
     /** Vertical Axis */
@@ -80,7 +80,7 @@ export enum NativePointerInput {
 /**
  * Enum for Dual Shock Gamepad
  */
-export enum DualShockInput {
+export const enum DualShockInput {
     /** Cross */
     Cross = 0,
     /** Circle */
@@ -130,7 +130,7 @@ export enum DualShockInput {
 /**
  * Enum for Dual Sense Gamepad
  */
-export enum DualSenseInput {
+export const enum DualSenseInput {
     /** Cross */
     Cross = 0,
     /** Circle */
@@ -180,7 +180,7 @@ export enum DualSenseInput {
 /**
  * Enum for Xbox Gamepad
  */
-export enum XboxInput {
+export const enum XboxInput {
     /** A */
     A = 0,
     /** B */
@@ -228,7 +228,7 @@ export enum XboxInput {
 /**
  * Enum for Switch (Pro/JoyCon L+R) Gamepad
  */
-export enum SwitchInput {
+export const enum SwitchInput {
     /** B */
     B = 0,
     /** A */

--- a/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.computeShader.ts
@@ -47,7 +47,7 @@ export interface ComputeCompilationMessages {
 }
 
 /** @internal */
-export enum ComputeBindingType {
+export const enum ComputeBindingType {
     Texture = 0,
     StorageTexture = 1,
     UniformBuffer = 2,

--- a/packages/dev/core/src/Engines/WebGPU/webgpuConstants.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuConstants.ts
@@ -1,12 +1,12 @@
 /** @internal */
 // eslint-disable-next-line import/export
-export enum PowerPreference {
+export const enum PowerPreference {
     LowPower = "low-power",
     HighPerformance = "high-performance",
 }
 
 /** @internal */
-export enum FeatureName {
+export const enum FeatureName {
     DepthClipControl = "depth-clip-control",
     Depth32FloatStencil8 = "depth32float-stencil8",
     TextureCompressionBC = "texture-compression-bc",
@@ -21,7 +21,7 @@ export enum FeatureName {
 }
 
 /** @internal */
-export enum BufferMapState {
+export const enum BufferMapState {
     Unmapped = "unmapped",
     Pending = "pending",
     Mapped = "mapped",
@@ -42,20 +42,20 @@ export enum BufferUsage {
 }
 
 /** @internal */
-export enum MapMode {
+export const enum MapMode {
     Read = 1,
     Write = 2,
 }
 
 /** @internal */
-export enum TextureDimension {
+export const enum TextureDimension {
     E1d = "1d",
     E2d = "2d",
     E3d = "3d",
 }
 
 /** @internal */
-export enum TextureUsage {
+export const enum TextureUsage {
     CopySrc = 1,
     CopyDst = 2,
     TextureBinding = 4,
@@ -64,7 +64,7 @@ export enum TextureUsage {
 }
 
 /** @internal */
-export enum TextureViewDimension {
+export const enum TextureViewDimension {
     E1d = "1d",
     E2d = "2d",
     E2dArray = "2d-array",
@@ -74,7 +74,7 @@ export enum TextureViewDimension {
 }
 
 /** @internal */
-export enum TextureAspect {
+export const enum TextureAspect {
     All = "all",
     StencilOnly = "stencil-only",
     DepthOnly = "depth-only",
@@ -84,7 +84,7 @@ export enum TextureAspect {
  * Comments taken from https://github.com/gfx-rs/wgpu/blob/master/wgpu-types/src/lib.rs
  * @internal
  */
-export enum TextureFormat {
+export const enum TextureFormat {
     // 8-bit formats
     R8Unorm = "r8unorm", // Red channel only. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
     R8Snorm = "r8snorm", // Red channel only. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader.
@@ -206,26 +206,26 @@ export enum TextureFormat {
 }
 
 /** @internal */
-export enum AddressMode {
+export const enum AddressMode {
     ClampToEdge = "clamp-to-edge",
     Repeat = "repeat",
     MirrorRepeat = "mirror-repeat",
 }
 
 /** @internal */
-export enum FilterMode {
+export const enum FilterMode {
     Nearest = "nearest",
     Linear = "linear",
 }
 
 /** @internal */
-export enum MipmapFilterMode {
+export const enum MipmapFilterMode {
     Nearest = "nearest",
     Linear = "linear",
 }
 
 /** @internal */
-export enum CompareFunction {
+export const enum CompareFunction {
     Never = "never",
     Less = "less",
     Equal = "equal",
@@ -237,28 +237,28 @@ export enum CompareFunction {
 }
 
 /** @internal */
-export enum ShaderStage {
+export const enum ShaderStage {
     Vertex = 1,
     Fragment = 2,
     Compute = 4,
 }
 
 /** @internal */
-export enum BufferBindingType {
+export const enum BufferBindingType {
     Uniform = "uniform",
     Storage = "storage",
     ReadOnlyStorage = "read-only-storage",
 }
 
 /** @internal */
-export enum SamplerBindingType {
+export const enum SamplerBindingType {
     Filtering = "filtering",
     NonFiltering = "non-filtering",
     Comparison = "comparison",
 }
 
 /** @internal */
-export enum TextureSampleType {
+export const enum TextureSampleType {
     Float = "float",
     UnfilterableFloat = "unfilterable-float",
     Depth = "depth",
@@ -267,32 +267,32 @@ export enum TextureSampleType {
 }
 
 /** @internal */
-export enum StorageTextureAccess {
+export const enum StorageTextureAccess {
     WriteOnly = "write-only",
     ReadOnly = "read-only",
     ReadWrite = "read-write",
 }
 
 /** @internal */
-export enum CompilationMessageType {
+export const enum CompilationMessageType {
     Error = "error",
     Warning = "warning",
     Info = "info",
 }
 
 /** @internal */
-export enum PipelineErrorReason {
+export const enum PipelineErrorReason {
     Validation = "validation",
     Internal = "internal",
 }
 
 /** @internal */
-export enum AutoLayoutMode {
+export const enum AutoLayoutMode {
     Auto = "auto",
 }
 
 /** @internal */
-export enum PrimitiveTopology {
+export const enum PrimitiveTopology {
     PointList = "point-list",
     LineList = "line-list",
     LineStrip = "line-strip",
@@ -301,20 +301,20 @@ export enum PrimitiveTopology {
 }
 
 /** @internal */
-export enum FrontFace {
+export const enum FrontFace {
     CCW = "ccw",
     CW = "cw",
 }
 
 /** @internal */
-export enum CullMode {
+export const enum CullMode {
     None = "none",
     Front = "front",
     Back = "back",
 }
 
 /** @internal */
-export enum ColorWrite {
+export const enum ColorWrite {
     Red = 1,
     Green = 2,
     Blue = 4,
@@ -323,7 +323,7 @@ export enum ColorWrite {
 }
 
 /** @internal */
-export enum BlendFactor {
+export const enum BlendFactor {
     Zero = "zero",
     One = "one",
     Src = "src",
@@ -340,7 +340,7 @@ export enum BlendFactor {
 }
 
 /** @internal */
-export enum BlendOperation {
+export const enum BlendOperation {
     Add = "add",
     Subtract = "subtract",
     ReverseSubtract = "reverse-subtract",
@@ -349,7 +349,7 @@ export enum BlendOperation {
 }
 
 /** @internal */
-export enum StencilOperation {
+export const enum StencilOperation {
     Keep = "keep",
     Zero = "zero",
     Replace = "replace",
@@ -361,13 +361,13 @@ export enum StencilOperation {
 }
 
 /** @internal */
-export enum IndexFormat {
+export const enum IndexFormat {
     Uint16 = "uint16",
     Uint32 = "uint32",
 }
 
 /** @internal */
-export enum VertexFormat {
+export const enum VertexFormat {
     Uint8x2 = "uint8x2",
     Uint8x4 = "uint8x4",
     Sint8x2 = "sint8x2",
@@ -402,55 +402,55 @@ export enum VertexFormat {
 }
 
 /** @internal */
-export enum VertexStepMode {
+export const enum VertexStepMode {
     Vertex = "vertex",
     Instance = "instance",
 }
 
 /** @internal */
-export enum ComputePassTimestampLocation {
+export const enum ComputePassTimestampLocation {
     Beginning = "beginning",
     End = "end",
 }
 
 /** @internal */
-export enum RenderPassTimestampLocation {
+export const enum RenderPassTimestampLocation {
     Beginning = "beginning",
     End = "end",
 }
 
 /** @internal */
-export enum LoadOp {
+export const enum LoadOp {
     Load = "load",
     Clear = "clear",
 }
 
 /** @internal */
-export enum StoreOp {
+export const enum StoreOp {
     Store = "store",
     Discard = "discard",
 }
 
 /** @internal */
-export enum QueryType {
+export const enum QueryType {
     Occlusion = "occlusion",
     Timestamp = "timestamp",
 }
 
 /** @internal */
-export enum CanvasAlphaMode {
+export const enum CanvasAlphaMode {
     Opaque = "opaque",
     Premultiplied = "premultiplied",
 }
 
 /** @internal */
-export enum DeviceLostReason {
+export const enum DeviceLostReason {
     Unknown = "unknown",
     Destroyed = "destroyed",
 }
 
 /** @internal */
-export enum ErrorFilter {
+export const enum ErrorFilter {
     Validation = "validation",
     OutOfMemory = "out-of-memory",
     Internal = "internal",

--- a/packages/dev/core/src/Events/deviceInputEvents.ts
+++ b/packages/dev/core/src/Events/deviceInputEvents.ts
@@ -3,7 +3,7 @@ import type { PointerInput } from "../DeviceInput/InputDevices/deviceEnums";
 /**
  * Event Types
  */
-export enum DeviceInputEventType {
+export const enum DeviceInputEventType {
     // Pointers
     /** PointerMove */
     PointerMove,

--- a/packages/dev/core/src/FlowGraph/flowGraph.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraph.ts
@@ -14,7 +14,7 @@ import { _isADescendantOf } from "./utils";
 import type { IPathToObjectConverter } from "../ObjectModel/objectModelInterfaces";
 import { defaultValueParseFunction } from "./serialization";
 
-export enum FlowGraphState {
+export const enum FlowGraphState {
     /**
      * The graph is stopped
      */

--- a/packages/dev/core/src/FlowGraph/flowGraphConnection.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphConnection.ts
@@ -6,7 +6,7 @@ import type { FlowGraphBlock } from "./flowGraphBlock";
  * @experimental
  * The type of a connection point - inpput or output.
  */
-export enum FlowGraphConnectionType {
+export const enum FlowGraphConnectionType {
     Input,
     Output,
 }

--- a/packages/dev/core/src/Gamepads/dualShockGamepad.ts
+++ b/packages/dev/core/src/Gamepads/dualShockGamepad.ts
@@ -4,7 +4,7 @@ import { Gamepad } from "./gamepad";
 /**
  * Defines supported buttons for DualShock compatible gamepads
  */
-export enum DualShockButton {
+export const enum DualShockButton {
     /** Cross */
     Cross = 0,
     /** Circle */
@@ -28,7 +28,7 @@ export enum DualShockButton {
 }
 
 /** Defines values for DualShock DPad  */
-export enum DualShockDpad {
+export const enum DualShockDpad {
     /** Up */
     Up = 12,
     /** Down */

--- a/packages/dev/core/src/Gamepads/xboxGamepad.ts
+++ b/packages/dev/core/src/Gamepads/xboxGamepad.ts
@@ -3,7 +3,7 @@ import { Gamepad } from "../Gamepads/gamepad";
 /**
  * Defines supported buttons for XBox360 compatible gamepads
  */
-export enum Xbox360Button {
+export const enum Xbox360Button {
     /** A */
     A = 0,
     /** B */
@@ -27,7 +27,7 @@ export enum Xbox360Button {
 }
 
 /** Defines values for XBox360 DPad  */
-export enum Xbox360Dpad {
+export const enum Xbox360Dpad {
     /** Up */
     Up = 12,
     /** Down */

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -41,7 +41,7 @@ export interface GizmoAxisCache {
 /**
  * Anchor options where the Gizmo can be positioned in relation to its anchored node
  */
-export enum GizmoAnchorPoint {
+export const enum GizmoAnchorPoint {
     /** The origin of the attached node */
     Origin,
     /** The pivot point of the attached node*/
@@ -51,7 +51,7 @@ export enum GizmoAnchorPoint {
 /**
  * Coordinates mode: Local or World. Defines how axis is aligned: either on world axis or transform local axis
  */
-export enum GizmoCoordinatesMode {
+export const enum GizmoCoordinatesMode {
     World,
     Local,
 }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -296,7 +296,7 @@ export interface ISceneLoaderPluginAsync extends ISceneLoaderPluginBase {
 /**
  * Mode that determines how to handle old animation groups before loading new ones.
  */
-export enum SceneLoaderAnimationGroupLoadingMode {
+export const enum SceneLoaderAnimationGroupLoadingMode {
     /**
      * Reset all old animations to initial state then dispose them.
      */

--- a/packages/dev/core/src/Materials/GreasedLine/greasedLineMaterialInterfaces.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLineMaterialInterfaces.ts
@@ -115,7 +115,7 @@ export interface IGreasedLineMaterial {
  * Material types for GreasedLine
  * {@link https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line#materialtype}
  */
-export enum GreasedLineMeshMaterialType {
+export const enum GreasedLineMeshMaterialType {
     /**
      * StandardMaterial
      */
@@ -134,7 +134,7 @@ export enum GreasedLineMeshMaterialType {
  * Color blending mode of the @see GreasedLineMaterial and the base material
  * {@link https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line#colormode}
  */
-export enum GreasedLineMeshColorMode {
+export const enum GreasedLineMeshColorMode {
     /**
      * Color blending mode SET
      */
@@ -154,7 +154,7 @@ export enum GreasedLineMeshColorMode {
  * {@link https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line#colordistributiontype}
  *
  */
-export enum GreasedLineMeshColorDistributionType {
+export const enum GreasedLineMeshColorDistributionType {
     /**
      * Colors distributed between segments of the line
      */

--- a/packages/dev/core/src/Materials/Node/Blocks/meshAttributeExistsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/meshAttributeExistsBlock.ts
@@ -9,7 +9,7 @@ import { MorphTargetsBlock } from "./Vertex/morphTargetsBlock";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../Decorators/nodeDecorator";
 import type { Scene } from "core/scene";
 
-export enum MeshAttributeExistsBlockTypes {
+export const enum MeshAttributeExistsBlockTypes {
     None,
     Normal,
     Tangent,

--- a/packages/dev/core/src/Materials/Node/Blocks/waveBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/waveBlock.ts
@@ -9,7 +9,7 @@ import type { Scene } from "../../../scene";
 /**
  * Operations supported by the Wave block
  */
-export enum WaveBlockKind {
+export const enum WaveBlockKind {
     /** SawTooth */
     SawTooth,
     /** Square */

--- a/packages/dev/core/src/Materials/Node/Enums/nodeMaterialBlockConnectionPointMode.ts
+++ b/packages/dev/core/src/Materials/Node/Enums/nodeMaterialBlockConnectionPointMode.ts
@@ -1,7 +1,7 @@
 /**
  * Enum defining the mode of a NodeMaterialBlockConnectionPoint
  */
-export enum NodeMaterialBlockConnectionPointMode {
+export const enum NodeMaterialBlockConnectionPointMode {
     /** Value is an uniform */
     Uniform,
     /** Value is a mesh attribute */

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -9,7 +9,7 @@ import type { NodeMaterialBlock } from "./nodeMaterialBlock";
 /**
  * Enum used to define the compatibility state between two connection points
  */
-export enum NodeMaterialConnectionPointCompatibilityStates {
+export const enum NodeMaterialConnectionPointCompatibilityStates {
     /** Points are compatibles */
     Compatible,
     /** Points are incompatible because of their types */
@@ -23,7 +23,7 @@ export enum NodeMaterialConnectionPointCompatibilityStates {
 /**
  * Defines the direction of a connection point
  */
-export enum NodeMaterialConnectionPointDirection {
+export const enum NodeMaterialConnectionPointDirection {
     /** Input */
     Input,
     /** Output */

--- a/packages/dev/core/src/Materials/Textures/internalTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/internalTexture.ts
@@ -11,7 +11,7 @@ import type { SphericalPolynomial } from "../../Maths/sphericalPolynomial";
 /**
  * Defines the source of the internal texture
  */
-export enum InternalTextureSource {
+export const enum InternalTextureSource {
     /**
      * The source of the texture data is unknown
      */

--- a/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
+++ b/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
@@ -17,7 +17,7 @@ export enum TranscodeTarget {
     RG8,
 }
 
-export enum EngineFormat {
+export const enum EngineFormat {
     COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8e8c,
     COMPRESSED_RGBA_ASTC_4X4_KHR = 0x93b0,
     COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83f0,

--- a/packages/dev/core/src/Materials/materialPluginEvent.ts
+++ b/packages/dev/core/src/Materials/materialPluginEvent.ts
@@ -94,7 +94,7 @@ export type MaterialPluginHardBindForSubMesh = {
 /**
  * @internal
  */
-export enum MaterialPluginEvent {
+export const enum MaterialPluginEvent {
     Created = 0x0001,
     Disposed = 0x0002,
     GetDefineNames = 0x0004,

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -173,7 +173,7 @@ const defaultMaterialColors = [
 /**
  * Supported visualizations of MeshDebugPluginMaterial
  */
-export enum MeshDebugMode {
+export const enum MeshDebugMode {
     /**
      * Material without any mesh debug visualization
      */

--- a/packages/dev/core/src/Materials/shaderLanguage.ts
+++ b/packages/dev/core/src/Materials/shaderLanguage.ts
@@ -1,7 +1,7 @@
 /**
  * Language of the shader code
  */
-export enum ShaderLanguage {
+export const enum ShaderLanguage {
     /** language is GLSL (used by WebGL) */
     GLSL,
     /** language is WGSL (used by WebGPU) */

--- a/packages/dev/core/src/Maths/math.axis.ts
+++ b/packages/dev/core/src/Maths/math.axis.ts
@@ -1,7 +1,7 @@
 import { Vector3 } from "./math.vector";
 
 /** Defines supported spaces */
-export enum Space {
+export const enum Space {
     /** Local (object) space */
     LOCAL = 0,
     /** World space */
@@ -23,7 +23,7 @@ export class Axis {
 /**
  * Defines cartesian components.
  */
-export enum Coordinate {
+export const enum Coordinate {
     /** X axis */
     X,
     /** Y axis */

--- a/packages/dev/core/src/Maths/math.path.ts
+++ b/packages/dev/core/src/Maths/math.path.ts
@@ -7,7 +7,7 @@ import { Epsilon } from "./math.constants";
 /**
  * Defines potential orientation for back face culling
  */
-export enum Orientation {
+export const enum Orientation {
     /**
      * Clockwise
      */

--- a/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
@@ -19,7 +19,7 @@ import { GreasedLineMaterialDefaults } from "../../Materials/GreasedLine/greased
  * How are the colors distributed along the color table
  * {@link https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line#colors-and-colordistribution}
  */
-export enum GreasedLineMeshColorDistribution {
+export const enum GreasedLineMeshColorDistribution {
     /**
      * Do no modify the color table
      */
@@ -50,7 +50,7 @@ export enum GreasedLineMeshColorDistribution {
  * How are the widths distributed along the width table
  * {@link https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line#widths-and-widthdistribution}
  */
-export enum GreasedLineMeshWidthDistribution {
+export const enum GreasedLineMeshWidthDistribution {
     /**
      * Do no modify the width table
      */

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -14,7 +14,7 @@ import type { FloatArray, IndicesArray } from "../../types";
  * In POINTS_MODE_POINTS every array of points will become the center (backbone) of the ribbon. The ribbon will be expanded by `width / 2` to `+direction` and `-direction` as well.
  * In POINTS_MODE_PATHS every array of points specifies an edge. These will be used to build one ribbon.
  */
-export enum GreasedLineRibbonPointsMode {
+export const enum GreasedLineRibbonPointsMode {
     POINTS_MODE_POINTS = 0,
     POINTS_MODE_PATHS = 1,
 }
@@ -24,7 +24,7 @@ export enum GreasedLineRibbonPointsMode {
  * FACES_MODE_SINGLE_SIDED_NO_BACKFACE_CULLING single sided without back face culling. Sets backFaceCulling = false on the material so it affects all line ribbons added to the line ribbon instance.
  * FACES_MODE_DOUBLE_SIDED extra back faces are created. This doubles the amount of faces of the mesh.
  */
-export enum GreasedLineRibbonFacesMode {
+export const enum GreasedLineRibbonFacesMode {
     FACES_MODE_SINGLE_SIDED = 0,
     FACES_MODE_SINGLE_SIDED_NO_BACKFACE_CULLING = 1,
     FACES_MODE_DOUBLE_SIDED = 2,
@@ -38,7 +38,7 @@ export enum GreasedLineRibbonFacesMode {
  * AUTO_DIRECTIONS_FACE_TO in this mode the direction (slope) will be calculated for each line segment according to the direction vector between each point of the line segments and a direction (face-to) vector specified in direction. The resulting line will face to the direction of this face-to vector.
  * AUTO_DIRECTIONS_NONE you have to set the direction (slope) manually. Recommended.
  */
-export enum GreasedLineRibbonAutoDirectionMode {
+export const enum GreasedLineRibbonAutoDirectionMode {
     AUTO_DIRECTIONS_FROM_FIRST_SEGMENT = 0,
     AUTO_DIRECTIONS_FROM_ALL_SEGMENTS = 1,
     AUTO_DIRECTIONS_ENHANCED = 2,

--- a/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
@@ -8,7 +8,7 @@ import type { NodeGeometryBuildState } from "./nodeGeometryBuildState";
 /**
  * Enum used to define the compatibility state between two connection points
  */
-export enum NodeGeometryConnectionPointCompatibilityStates {
+export const enum NodeGeometryConnectionPointCompatibilityStates {
     /** Points are compatibles */
     Compatible,
     /** Points are incompatible because of their types */
@@ -20,7 +20,7 @@ export enum NodeGeometryConnectionPointCompatibilityStates {
 /**
  * Defines the direction of a connection point
  */
-export enum NodeGeometryConnectionPointDirection {
+export const enum NodeGeometryConnectionPointDirection {
     /** Input */
     Input,
     /** Output */

--- a/packages/dev/core/src/Meshes/meshSimplification.ts
+++ b/packages/dev/core/src/Meshes/meshSimplification.ts
@@ -197,7 +197,7 @@ export class SimplificationQueue {
  * At the moment only Quadratic Error Decimation is implemented
  * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/simplifyingMeshes
  */
-export enum SimplificationType {
+export const enum SimplificationType {
     /** Quadratic error decimation */
     QUADRATIC,
 }

--- a/packages/dev/core/src/Misc/assetsManager.ts
+++ b/packages/dev/core/src/Misc/assetsManager.ts
@@ -21,7 +21,7 @@ import type { Nullable } from "../types";
 /**
  * Defines the list of states available for a task inside a AssetsManager
  */
-export enum AssetTaskState {
+export const enum AssetTaskState {
     /**
      * Initialization
      */

--- a/packages/dev/core/src/Misc/copyTextureToTexture.ts
+++ b/packages/dev/core/src/Misc/copyTextureToTexture.ts
@@ -10,7 +10,7 @@ import "../Shaders/copyTextureToTexture.fragment";
 /**
  * Conversion modes available when copying a texture into another one
  */
-export enum ConversionMode {
+export const enum ConversionMode {
     None = 0,
     ToLinearSpace = 1,
     ToGammaSpace = 2,

--- a/packages/dev/core/src/Misc/iInspectable.ts
+++ b/packages/dev/core/src/Misc/iInspectable.ts
@@ -1,7 +1,7 @@
 /**
  * Enum that determines the text-wrapping mode to use.
  */
-export enum InspectableType {
+export const enum InspectableType {
     /**
      * Checkbox for booleans
      */

--- a/packages/dev/core/src/Misc/timer.ts
+++ b/packages/dev/core/src/Misc/timer.ts
@@ -73,7 +73,7 @@ export interface ITimerData<T> {
 /**
  * The current state of the timer
  */
-export enum TimerState {
+export const enum TimerState {
     /**
      * Timer initialized, not yet started
      */

--- a/packages/dev/core/src/Misc/virtualJoystick.ts
+++ b/packages/dev/core/src/Misc/virtualJoystick.ts
@@ -9,7 +9,7 @@ import { StringDictionary } from "./stringDictionary";
 /**
  * Defines the potential axis of a Joystick
  */
-export enum JoystickAxis {
+export const enum JoystickAxis {
     /** X axis */
     X,
     /** Y axis */

--- a/packages/dev/core/src/Particles/pointsCloudSystem.ts
+++ b/packages/dev/core/src/Particles/pointsCloudSystem.ts
@@ -16,7 +16,7 @@ import { Scalar } from "../Maths/math.scalar";
 import type { Material } from "../Materials/material";
 
 /** Defines the 4 color options */
-export enum PointColor {
+export const enum PointColor {
     /** color value */
     Color = 2,
     /** uv value */

--- a/packages/dev/core/src/Particles/subEmitter.ts
+++ b/packages/dev/core/src/Particles/subEmitter.ts
@@ -10,7 +10,7 @@ import type { ParticleSystem } from "../Particles/particleSystem";
 /**
  * Type of sub emitter
  */
-export enum SubEmitterType {
+export const enum SubEmitterType {
     /**
      * Attached to the particle over it's lifetime
      */

--- a/packages/dev/core/src/Physics/physicsHelper.ts
+++ b/packages/dev/core/src/Physics/physicsHelper.ts
@@ -1142,7 +1142,7 @@ export class PhysicsVortexEventOptions {
  * The strength of the force in correspondence to the distance of the affected object
  * @see https://doc.babylonjs.com/features/featuresDeepDive/physics/usingPhysicsEngine#further-functionality-of-the-impostor-class
  */
-export enum PhysicsRadialImpulseFalloff {
+export const enum PhysicsRadialImpulseFalloff {
     /** Defines that impulse is constant in strength across it's whole radius */
     Constant,
     /** Defines that impulse gets weaker if it's further from the origin */
@@ -1153,7 +1153,7 @@ export enum PhysicsRadialImpulseFalloff {
  * The strength of the force in correspondence to the distance of the affected object
  * @see https://doc.babylonjs.com/features/featuresDeepDive/physics/usingPhysicsEngine#further-functionality-of-the-impostor-class
  */
-export enum PhysicsUpdraftMode {
+export const enum PhysicsUpdraftMode {
     /** Defines that the upstream forces will pull towards the top center of the cylinder */
     Center,
     /** Defines that once a impostor is inside the cylinder, it will shoot out perpendicular from the ground of the cylinder */

--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -12,7 +12,7 @@ import type { Observable } from "../../Misc/observable";
 import type { GroundMesh } from "../../Meshes/groundMesh";
 
 /** How a specific axis can be constrained */
-export enum PhysicsConstraintAxisLimitMode {
+export const enum PhysicsConstraintAxisLimitMode {
     /*
      * The axis is not restricted at all
      */
@@ -28,7 +28,7 @@ export enum PhysicsConstraintAxisLimitMode {
 }
 
 /** The constraint specific axis to use when setting Friction, `ConstraintAxisLimitMode`, max force, ... */
-export enum PhysicsConstraintAxis {
+export const enum PhysicsConstraintAxis {
     /*
      * Translation along the primary axis of the constraint (i.e. the
      * direction specified by PhysicsConstraintParameters.axisA/axisB)
@@ -68,7 +68,7 @@ export enum PhysicsConstraintAxis {
 }
 
 /** Type of Constraint */
-export enum PhysicsConstraintType {
+export const enum PhysicsConstraintType {
     /**
      * A ball and socket constraint will attempt to line up the pivot
      * positions in each body, and have no restrictions on rotation
@@ -109,7 +109,7 @@ export enum PhysicsConstraintType {
 }
 
 /** Type of Shape */
-export enum PhysicsShapeType {
+export const enum PhysicsShapeType {
     SPHERE,
     CAPSULE,
     CYLINDER,
@@ -121,13 +121,13 @@ export enum PhysicsShapeType {
 }
 
 /** Optional motor which attempts to move a body at a specific velocity, or at a specific position */
-export enum PhysicsConstraintMotorType {
+export const enum PhysicsConstraintMotorType {
     NONE,
     VELOCITY,
     POSITION,
 }
 
-export enum PhysicsEventType {
+export const enum PhysicsEventType {
     COLLISION_STARTED = "COLLISION_STARTED",
     COLLISION_CONTINUED = "COLLISION_CONTINUED",
     COLLISION_FINISHED = "COLLISION_FINISHED",
@@ -345,7 +345,7 @@ export interface PhysicsMassProperties {
 /**
  * Indicates how the body will behave.
  */
-export enum PhysicsMotionType {
+export const enum PhysicsMotionType {
     STATIC,
     ANIMATED,
     DYNAMIC,
@@ -354,7 +354,7 @@ export enum PhysicsMotionType {
 /**
  * Controls the body sleep mode.
  */
-export enum PhysicsActivationControl {
+export const enum PhysicsActivationControl {
     SIMULATION_CONTROLLED,
     ALWAYS_ACTIVE,
     ALWAYS_INACTIVE,

--- a/packages/dev/core/src/Physics/v2/physicsMaterial.ts
+++ b/packages/dev/core/src/Physics/v2/physicsMaterial.ts
@@ -5,7 +5,7 @@
  * is used will be selected based on their order in this enum - i.e.
  * a value later in this list will be preferentially used.
  */
-export enum PhysicsMaterialCombineMode {
+export const enum PhysicsMaterialCombineMode {
     /**
      * The final value will be the geometric mean of the two values:
      * sqrt( valueA *  valueB )

--- a/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldEffect.ts
@@ -14,7 +14,7 @@ import { Constants } from "../Engines/constants";
 /**
  * Specifies the level of max blur that should be applied when using the depth of field effect
  */
-export enum DepthOfFieldEffectBlurLevel {
+export const enum DepthOfFieldEffectBlurLevel {
     /**
      * Subtle blur
      */

--- a/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
@@ -9,7 +9,7 @@ import type { Nullable } from "../types";
 import type { Engine } from "../Engines/engine";
 
 /** Defines operator used for tonemapping */
-export enum TonemappingOperator {
+export const enum TonemappingOperator {
     /** Hable */
     Hable = 0,
     /** Reinhard */

--- a/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderingTargetRenderer.ts
+++ b/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderingTargetRenderer.ts
@@ -18,7 +18,7 @@ import type { WebGPUEngine } from "core/Engines/webgpuEngine";
 /**
  * Textures that can be displayed as a debugging tool
  */
-export enum FluidRenderingDebug {
+export const enum FluidRenderingDebug {
     DepthTexture,
     DepthBlurredTexture,
     ThicknessTexture,

--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -126,7 +126,7 @@ export interface IWebXRHandTrackingOptions {
 /**
  * Parts of the hands divided to writs and finger names
  */
-export enum HandPart {
+export const enum HandPart {
     /**
      * HandPart - Wrist
      */
@@ -157,7 +157,7 @@ export enum HandPart {
  * Joints of the hand as defined by the WebXR specification.
  * https://immersive-web.github.io/webxr-hand-input/#skeleton-joints-section
  */
-export enum WebXRHandJoint {
+export const enum WebXRHandJoint {
     /** Wrist */
     WRIST = "wrist",
 

--- a/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
+++ b/packages/dev/core/src/XR/features/WebXRNearInteraction.ts
@@ -73,7 +73,7 @@ enum ControllerOrbAnimationState {
 /**
  * Where should the near interaction mesh be attached to when using a motion controller for near interaction
  */
-export enum WebXRNearControllerMode {
+export const enum WebXRNearControllerMode {
     /**
      * Motion controllers will not support near interaction
      */

--- a/packages/dev/core/src/XR/webXRTypes.ts
+++ b/packages/dev/core/src/XR/webXRTypes.ts
@@ -4,7 +4,7 @@ import type { IDisposable } from "../scene";
 /**
  * States of the webXR experience
  */
-export enum WebXRState {
+export const enum WebXRState {
     /**
      * Transitioning to being in XR mode
      */
@@ -26,7 +26,7 @@ export enum WebXRState {
 /**
  * The state of the XR camera's tracking
  */
-export enum WebXRTrackingState {
+export const enum WebXRTrackingState {
     /**
      * No transformation received, device is not being tracked
      */

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -129,7 +129,7 @@ export interface SceneOptions {
 /**
  * Define how the scene should favor performance over ease of use
  */
-export enum ScenePerformancePriority {
+export const enum ScenePerformancePriority {
     /** Default mode. No change. Performance will be treated as less important than backward compatibility */
     BackwardCompatible,
     /** Some performance options will be turned on trying to strike a balance between perf and ease of use */

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -11,7 +11,7 @@ import { EngineStore } from "core/Engines/engineStore";
 /**
  * Enum that determines the text-wrapping mode to use.
  */
-export enum TextWrapping {
+export const enum TextWrapping {
     /**
      * Clip the text when it's larger than Control.width; this is the default mode.
      */

--- a/packages/dev/gui/src/3D/gizmos/gizmoHandle.ts
+++ b/packages/dev/gui/src/3D/gizmos/gizmoHandle.ts
@@ -11,7 +11,7 @@ import type { Observer } from "core/Misc/observable";
 /**
  * State of the handle regarding user interaction
  */
-export enum HandleState {
+export const enum HandleState {
     /**
      * Handle is idle
      */

--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -66,7 +66,13 @@ export class MSCTranscoder extends Transcoder {
                         script.setAttribute("src", Transcoder.GetWasmUrl(MSCTranscoder.JSModuleURL));
 
                         script.onload = () => {
-                            MSC_TRANSCODER({ wasmBinary }).then((basisModule: any) => {
+                            // defensive
+                            if (typeof MSC_TRANSCODER === "undefined") {
+                                reject("MSC_TRANSCODER script loaded but MSC_TRANSCODER is not defined.");
+                                return;
+                            }
+
+                            (MSC_TRANSCODER as any)({ wasmBinary }).then((basisModule: any) => {
                                 basisModule.initTranscoders();
                                 this._mscBasisModule = basisModule;
                                 resolve();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -18,6 +18,7 @@
         "strictFunctionTypes": true,
         "skipLibCheck": true,
         "removeComments": false,
+        "preserveConstEnums": true,
         "jsx": "react-jsx",
         "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "es2020.bigint", "es2017"],
         "paths": {


### PR DESCRIPTION
This change has no direct influence on any of our users, but will improve performance slightly.

Since we are exporting the const-enums (a change in this PR), js developers can still use it, and they will still be included in the types. We are maintainin back-compat. The only difference is that modules using the const enums in this repository will get the value injected directly, thus avoiding one object lookup.

The only way this could be considered breaking change is for people who are creating a framework that embeds babylon and exporing it - in this case, they will need to preserve const enums as well, otherwise their js (and only js) consumers won't find them. The compiled application will still work correctly.

CC @ryantrem who suggested using const enums (for a slightly different use-case). This step will allow us to start using const enums more often in more performance-heavy sections of the framework.

note (probably slightly repeating myself) - the string lookup that typescript enums do is still present and has not been changed. It improves perf only for compiled js files that are a part of the framework.