### PR TITLE
Rewrite morph target gltf export

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -107,7 +107,7 @@ export class _GLTFUtilities {
         return { min, max };
     }
 
-    public static _NormalizeTangentFromRef(tangent: Vector4) {
+    public static _NormalizeTangentFromRef(tangent: Vector4 | Vector3) {
         const length = Math.sqrt(tangent.x * tangent.x + tangent.y * tangent.y + tangent.z * tangent.z);
         if (length > 0) {
             tangent.x /= length;


### PR DESCRIPTION
`glTFExporter` had logic to export morph targets, but it did not work correctly with submeshes (see this forum thread: https://forum.babylonjs.com/t/gltfexporter-not-working-with-morph-targets/51337). There were a couple significant problems with the code that basically required a rewrite of this logic:
1. It was writing separate segments of data to the buffer (and separate buffer views) for each submesh. This is always wrong for indexed geometry, and is broken if there are multiple submeshes.
2. The logic for determining the range of vertex data to write per submesh was just wrong, and could only work for indexed geometry with one submesh.

For 2, I couldn't even tell what the logic was trying to do:
```ts
for (let k = meshPrimitive.verticesStart; k < meshPrimitive.verticesCount; ++k) {
  index = meshPrimitive.indexStart + k * stride;
    const vertexData = Vector3.FromArray(meshAttributeArray, index);
```
`verticesStart` is only meaningful for non-indexed geometry, so combining `indexStart` and `verticesStart` in any way doesn't make sense. I think this code only worked because it was only ever tested in cases where both `indexStart` and `verticesStart` were zero.

Overall, the approach now is to write all the morph target vertex data for the entire mesh and create an associated buffer view for each attribute (where morph data is present), then create one accessor per submesh per morph target that potentially has an offset into the buffer view (for submeshes beyond the first).

This does not fix the pre-existing issues with non-indexed geometry in general, but that should be handled in a separate PR. This approach does not prevent us from making non-indexed geometry work, there are just additional changes needed that can be done in isolation from these changes.