### PR TITLE
[GUI] allow any element to be focused

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -18,7 +18,6 @@ import type { Scene } from "core/scene";
 
 import { Container } from "./controls/container";
 import { Control } from "./controls/control";
-import type { IFocusableControl } from "./controls/focusableControl";
 import { Style } from "./style";
 import { Measure } from "./measure";
 import { Constants } from "core/Engines/constants";
@@ -85,7 +84,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _idealHeight = 0;
     private _useSmallestIdeal: boolean = false;
     private _renderAtIdealSize = false;
-    private _focusedControl: Nullable<IFocusableControl>;
+    private _focusedControl: Nullable<Control>;
     private _blockNextFocusCheck = false;
     private _renderScale = 1;
     private _rootElement: Nullable<HTMLElement>;
@@ -147,6 +146,12 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * Gets or sets a boolean indicating that the canvas must be reverted on Y when updating the texture
      */
     public applyYInversionOnUpdate = true;
+
+    /**
+     * A boolean indicating whether or not the elements can be navigated to using the tab key.
+     * Defaults to false.
+     */
+    public disableTabNavigation = false;
     /**
      * Gets or sets a number used to scale rendering size (2 means that the texture will be twice bigger).
      * Useful when you want more antialiasing
@@ -322,10 +327,10 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     /**
      * Gets or sets the current focused control
      */
-    public get focusedControl(): Nullable<IFocusableControl> {
+    public get focusedControl(): Nullable<Control> {
         return this._focusedControl;
     }
-    public set focusedControl(control: Nullable<IFocusableControl>) {
+    public set focusedControl(control: Nullable<Control>) {
         if (this._focusedControl == control) {
             return;
         }
@@ -411,6 +416,12 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             }
         });
         this._preKeyboardObserver = scene.onPreKeyboardObservable.add((info) => {
+            // check if tab is pressed
+            if (!this.disableTabNavigation && info.type === KeyboardEventTypes.KEYDOWN && info.event.code === "Tab") {
+                this._focusNextElement(!info.event.shiftKey);
+                info.event.preventDefault();
+                return;
+            }
             if (!this._focusedControl) {
                 return;
             }
@@ -984,6 +995,38 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._attachToOnBlur(scene);
     }
 
+    private _focusNextElement(forward: boolean = true): void {
+        // generate the order of tab-able controls
+        const sortedTabbableControls: Control[] = [];
+        this.executeOnAllControls((control) => {
+            if (control.isFocusInvisible || !control.isVisible || control.tabIndex < 0) {
+                return;
+            }
+            sortedTabbableControls.push(control);
+        });
+        // if no control is tab-able, return
+        if (sortedTabbableControls.length === 0) {
+            return;
+        }
+        sortedTabbableControls.sort((a, b) => {
+            // if tabIndex is 0, put it in the end of the list, otherwise sort by tabIndex
+            return a.tabIndex === 0 ? 1 : b.tabIndex === 0 ? -1 : a.tabIndex - b.tabIndex;
+        });
+        // if no control is focused, focus the first one
+        if (!this._focusedControl) {
+            sortedTabbableControls[0].focus();
+        } else {
+            const currentIndex = sortedTabbableControls.indexOf(this._focusedControl);
+            let nextIndex = currentIndex + (forward ? 1 : -1);
+            if (nextIndex < 0) {
+                nextIndex = sortedTabbableControls.length - 1;
+            } else if (nextIndex >= sortedTabbableControls.length) {
+                nextIndex = 0;
+            }
+            sortedTabbableControls[nextIndex].focus();
+        }
+    }
+
     /**
      * @internal
      */
@@ -1189,7 +1232,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * Move the focus to a specific control
      * @param control defines the control which will receive the focus
      */
-    public moveFocusToControl(control: IFocusableControl): void {
+    public moveFocusToControl(control: Control): void {
         this.focusedControl = control;
         this._lastPickedControl = <any>control;
         this._blockNextFocusCheck = true;

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -23,17 +23,18 @@ import { SerializationHelper } from "core/Misc/decorators.serialization";
 import type { ICanvasGradient, ICanvasRenderingContext } from "core/Engines/ICanvas";
 import { EngineStore } from "core/Engines/engineStore";
 import type { IAccessibilityTag } from "core/IAccessibilityTag";
-import type { IPointerEvent } from "core/Events/deviceInputEvents";
+import type { IKeyboardEvent, IPointerEvent } from "core/Events/deviceInputEvents";
 import type { IAnimatable } from "core/Animations/animatable.interface";
 import type { Animation } from "core/Animations/animation";
 import type { BaseGradient } from "./gradient/BaseGradient";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
+import type { IFocusableControl } from "./focusableControl";
 
 /**
  * Root class used for all 2D controls
  * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#controls
  */
-export class Control implements IAnimatable {
+export class Control implements IAnimatable, IFocusableControl {
     /**
      * Gets or sets a boolean indicating if alpha must be an inherited value (false by default)
      */
@@ -364,6 +365,11 @@ export class Control implements IAnimatable {
      * An event triggered when a control is clicked on
      */
     public onPointerClickObservable = new Observable<Vector2WithInfo>();
+
+    /**
+     * An event triggered when a control receives an ENTER key down event
+     */
+    public onEnterPressedObservable = new Observable<Control>();
 
     /**
      * An event triggered when pointer enters the control
@@ -1303,6 +1309,96 @@ export class Control implements IAnimatable {
      * Array of animations
      */
     animations: Nullable<Animation[]> = null;
+
+    // Focus functionality
+
+    protected _focusedColor: Nullable<string> = null;
+    /**
+     * Border color when control is focused
+     * When not defined the ADT color will be used. If no ADT color is defined, focused state won't have any border
+     */
+    public get focusedColor(): Nullable<string> {
+        return this._focusedColor;
+    }
+    public set focusedColor(value: Nullable<string>) {
+        this._focusedColor = value;
+    }
+    /**
+     * The tab index of this control. -1 indicates this control is not part of the tab navigation.
+     * A positive value indicates the order of the control in the tab navigation.
+     * A value of 0 indicated the control will be focused after all controls with a positive index.
+     * More than one control can have the same tab index and the navigation would then go through all controls with the same value in an order defined by the layout or the hierarchy.
+     * The value can be changed at any time.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+     */
+    public tabIndex: number = -1;
+    protected _isFocused = false;
+    protected _unfocusedColor: Nullable<string> = null;
+
+    /** Observable raised when the control gets the focus */
+    public onFocusObservable = new Observable<Control>();
+    /** Observable raised when the control loses the focus */
+    public onBlurObservable = new Observable<Control>();
+    /** Observable raised when a key event was processed */
+    public onKeyboardEventProcessedObservable = new Observable<IKeyboardEvent>();
+
+    /** @internal */
+    public onBlur(): void {
+        if (this._isFocused) {
+            this._isFocused = false;
+            if (this.focusedColor && this._unfocusedColor != null) {
+                // Set color back to saved unfocused color
+                this.color = this._unfocusedColor;
+            }
+            this.onBlurObservable.notifyObservers(this);
+        }
+    }
+
+    /** @internal */
+    public onFocus(): void {
+        this._isFocused = true;
+
+        if (this.focusedColor) {
+            // Save the unfocused color
+            this._unfocusedColor = this.color;
+            this.color = this.focusedColor;
+        }
+        this.onFocusObservable.notifyObservers(this);
+    }
+
+    /**
+     * Function called to get the list of controls that should not steal the focus from this control
+     * @returns an array of controls
+     */
+    public keepsFocusWith(): Nullable<Control[]> {
+        return null;
+    }
+
+    /**
+     * Function to focus a button programmatically
+     */
+    public focus() {
+        this._host.moveFocusToControl(this);
+    }
+
+    /**
+     * Function to unfocus a button programmatically
+     */
+    public blur() {
+        this._host.focusedControl = null;
+    }
+
+    /**
+     * Handles the keyboard event
+     * @param evt Defines the KeyboardEvent
+     */
+    public processKeyboard(evt: IKeyboardEvent): void {
+        // if enter, trigger the new observable
+        if (evt.key === "Enter") {
+            this.onEnterPressedObservable.notifyObservers(this);
+        }
+        this.onKeyboardEventProcessedObservable.notifyObservers(evt, -1, this);
+    }
 
     // Functions
 
@@ -2601,6 +2697,11 @@ export class Control implements IAnimatable {
         this.onPointerUpObservable.clear();
         this.onPointerClickObservable.clear();
         this.onWheelObservable.clear();
+
+        // focus
+        this.onBlurObservable.clear();
+        this.onFocusObservable.clear();
+        this.onKeyboardEventProcessedObservable.clear();
 
         if (this._styleObserver && this._style) {
             this._style.onChangedObservable.remove(this._styleObserver);

--- a/packages/dev/gui/src/2D/controls/focusableButton.ts
+++ b/packages/dev/gui/src/2D/controls/focusableButton.ts
@@ -1,4 +1,3 @@
-import type { Nullable } from "core/types";
 import type { Vector2 } from "core/Maths/math.vector";
 
 import { Button } from "./button";
@@ -6,84 +5,16 @@ import type { Control } from "./control";
 import { RegisterClass } from "core/Misc/typeStore";
 import type { PointerInfoBase } from "core/Events/pointerEvents";
 import type { IFocusableControl } from "./focusableControl";
-import { Observable } from "core/Misc/observable";
-import type { IKeyboardEvent } from "core/Events/deviceInputEvents";
 
 /**
  * Class used to create a focusable button that can easily handle keyboard events
  * @since 5.0.0
  */
 export class FocusableButton extends Button implements IFocusableControl {
-    /** Highlight color when button is focused */
-    public focusedColor: Nullable<string> = null;
-    private _isFocused = false;
-    private _unfocusedColor: Nullable<string> = null;
-
-    /** Observable raised when the control gets the focus */
-    public onFocusObservable = new Observable<Button>();
-    /** Observable raised when the control loses the focus */
-    public onBlurObservable = new Observable<Button>();
-    /** Observable raised when a key event was processed */
-    public onKeyboardEventProcessedObservable = new Observable<IKeyboardEvent>();
-
     constructor(public override name?: string) {
         super(name);
 
         this._unfocusedColor = this.color;
-    }
-
-    /** @internal */
-    public onBlur(): void {
-        if (this._isFocused) {
-            this._isFocused = false;
-            if (this.focusedColor && this._unfocusedColor != null) {
-                // Set color back to saved unfocused color
-                this.color = this._unfocusedColor;
-            }
-            this.onBlurObservable.notifyObservers(this);
-        }
-    }
-
-    /** @internal */
-    public onFocus(): void {
-        this._isFocused = true;
-
-        if (this.focusedColor) {
-            // Save the unfocused color
-            this._unfocusedColor = this.color;
-            this.color = this.focusedColor;
-        }
-        this.onFocusObservable.notifyObservers(this);
-    }
-
-    /**
-     * Function called to get the list of controls that should not steal the focus from this control
-     * @returns an array of controls
-     */
-    public keepsFocusWith(): Nullable<Control[]> {
-        return null;
-    }
-
-    /**
-     * Function to focus a button programmatically
-     */
-    public focus() {
-        this._host.moveFocusToControl(this);
-    }
-
-    /**
-     * Function to unfocus a button programmatically
-     */
-    public blur() {
-        this._host.focusedControl = null;
-    }
-
-    /**
-     * Handles the keyboard event
-     * @param evt Defines the KeyboardEvent
-     */
-    public processKeyboard(evt: IKeyboardEvent): void {
-        this.onKeyboardEventProcessedObservable.notifyObservers(evt, -1, this);
     }
 
     /**
@@ -96,15 +27,6 @@ export class FocusableButton extends Button implements IFocusableControl {
         }
 
         return super._onPointerDown(target, coordinates, pointerId, buttonIndex, pi);
-    }
-
-    /** @internal */
-    public override dispose() {
-        super.dispose();
-
-        this.onBlurObservable.clear();
-        this.onFocusObservable.clear();
-        this.onKeyboardEventProcessedObservable.clear();
     }
 }
 RegisterClass("BABYLON.GUI.FocusableButton", FocusableButton);

--- a/packages/dev/gui/src/2D/controls/focusableControl.ts
+++ b/packages/dev/gui/src/2D/controls/focusableControl.ts
@@ -32,4 +32,15 @@ export interface IFocusableControl {
      * Function to unfocus the control programmatically
      */
     blur(): void;
+
+    /**
+     * Gets or sets the tabIndex of the control
+     */
+    tabIndex?: number;
+
+    /**
+     * Gets or sets the color used to draw the focus border
+     * Defaults to "white"
+     */
+    focusBorderColor?: string;
 }

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -8,7 +8,6 @@ import type { PointerInfo, PointerInfoBase } from "core/Events/pointerEvents";
 import { PointerEventTypes } from "core/Events/pointerEvents";
 
 import { Control } from "./control";
-import type { IFocusableControl } from "./focusableControl";
 import { ValueAndUnit } from "../valueAndUnit";
 import type { VirtualKeyboard } from "./virtualKeyboard";
 import { RegisterClass } from "core/Misc/typeStore";
@@ -20,18 +19,16 @@ import type { ICanvasRenderingContext } from "core/Engines/ICanvas";
 /**
  * Class used to create input text control
  */
-export class InputText extends Control implements IFocusableControl {
+export class InputText extends Control {
     protected _textWrapper: TextWrapper;
     protected _placeholderText = "";
     protected _background = "#222222";
     protected _focusedBackground = "#000000";
-    protected _focusedColor = "white";
     protected _placeholderColor = "gray";
     protected _thickness = 1;
     protected _margin = new ValueAndUnit(10, ValueAndUnit.UNITMODE_PIXEL);
     protected _autoStretchWidth = true;
     protected _maxWidth = new ValueAndUnit(1, ValueAndUnit.UNITMODE_PERCENTAGE, false);
-    protected _isFocused = false;
     /** the type of device that most recently focused the input: "mouse", "touch" or "pen" */
     protected _focusedBy: string;
     protected _blinkTimeout: number;
@@ -101,10 +98,6 @@ export class InputText extends Control implements IFocusableControl {
     public onTextChangedObservable = new Observable<InputText>();
     /** Observable raised just before an entered character is to be added */
     public onBeforeKeyAddObservable = new Observable<InputText>();
-    /** Observable raised when the control gets the focus */
-    public onFocusObservable = new Observable<InputText>();
-    /** Observable raised when the control loses the focus */
-    public onBlurObservable = new Observable<InputText>();
     /** Observable raised when the text is highlighted */
     public onTextHighlightObservable = new Observable<InputText>();
     /** Observable raised when copy event is triggered */
@@ -113,8 +106,6 @@ export class InputText extends Control implements IFocusableControl {
     public onTextCutObservable = new Observable<InputText>();
     /** Observable raised when paste event is triggered */
     public onTextPasteObservable = new Observable<InputText>();
-    /** Observable raised when a key event was processed */
-    public onKeyboardEventProcessedObservable = new Observable<IKeyboardEvent>();
 
     /** Gets or sets the maximum width allowed by the control */
     @serialize()
@@ -246,12 +237,7 @@ export class InputText extends Control implements IFocusableControl {
     }
 
     /** Gets or sets the background color when focused */
-    @serialize()
-    public get focusedColor(): string {
-        return this._focusedColor;
-    }
-
-    public set focusedColor(value: string) {
+    public override set focusedColor(value: string) {
         if (this._focusedColor === value) {
             return;
         }
@@ -408,10 +394,11 @@ export class InputText extends Control implements IFocusableControl {
 
         this.text = text;
         this.isPointerBlocker = true;
+        this._focusedColor = "white";
     }
 
     /** @internal */
-    public onBlur(): void {
+    public override onBlur(): void {
         this._isFocused = false;
         this._scrollLeft = null;
         this._cursorOffset = 0;
@@ -431,7 +418,7 @@ export class InputText extends Control implements IFocusableControl {
     }
 
     /** @internal */
-    public onFocus(): void {
+    public override onFocus(): void {
         if (!this._isEnabled) {
             return;
         }
@@ -441,7 +428,7 @@ export class InputText extends Control implements IFocusableControl {
         this._cursorOffset = 0;
         this._markAsDirty();
 
-        this.onFocusObservable.notifyObservers(this);
+        this.onFocusObservable.notifyObservers(this as Control);
 
         if (this._focusedBy === "touch" && !this.disableMobilePrompt) {
             const value = prompt(this.promptMessage);
@@ -493,20 +480,6 @@ export class InputText extends Control implements IFocusableControl {
         }
     }
 
-    /**
-     * Function to focus an inputText programmatically
-     */
-    public focus() {
-        this._host.moveFocusToControl(this);
-    }
-
-    /**
-     * Function to unfocus an inputText programmatically
-     */
-    public blur() {
-        this._host.focusedControl = null;
-    }
-
     protected override _getTypeName(): string {
         return "InputText";
     }
@@ -515,7 +488,7 @@ export class InputText extends Control implements IFocusableControl {
      * Function called to get the list of controls that should not steal the focus from this control
      * @returns an array of controls
      */
-    public keepsFocusWith(): Nullable<Control[]> {
+    public override keepsFocusWith(): Nullable<Control[]> {
         if (!this._connectedVirtualKeyboard) {
             return null;
         }
@@ -843,11 +816,11 @@ export class InputText extends Control implements IFocusableControl {
      * Handles the keyboard event
      * @param evt Defines the KeyboardEvent
      */
-    public processKeyboard(evt: IKeyboardEvent): void {
+    public override processKeyboard(evt: IKeyboardEvent): void {
         // process pressed key
         this.processKey(evt.keyCode, evt.key, evt);
 
-        this.onKeyboardEventProcessedObservable.notifyObservers(evt);
+        super.processKeyboard(evt);
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
+++ b/packages/dev/gui/src/2D/controls/virtualKeyboard.ts
@@ -10,6 +10,7 @@ import type { InputText } from "./inputText";
 import { RegisterClass } from "core/Misc/typeStore";
 import type { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import { InputTextArea } from "./inputTextArea";
+import type { Control } from "./control";
 
 /**
  * Class used to store key control properties
@@ -35,8 +36,8 @@ export class KeyPropertySet {
 
 type ConnectedInputText = {
     input: InputText;
-    onFocusObserver: Nullable<Observer<InputText>>;
-    onBlurObserver: Nullable<Observer<InputText>>;
+    onFocusObserver: Nullable<Observer<Control>>;
+    onBlurObserver: Nullable<Observer<Control>>;
 };
 
 /**
@@ -239,13 +240,13 @@ export class VirtualKeyboard extends StackPanel {
         input._connectedVirtualKeyboard = this;
 
         // Events hooking
-        const onFocusObserver: Nullable<Observer<InputText>> = input.onFocusObservable.add(() => {
+        const onFocusObserver: Nullable<Observer<Control>> = input.onFocusObservable.add(() => {
             this._currentlyConnectedInputText = input;
             input._connectedVirtualKeyboard = this;
             this.isVisible = true;
         });
 
-        const onBlurObserver: Nullable<Observer<InputText>> = input.onBlurObservable.add(() => {
+        const onBlurObserver: Nullable<Observer<Control>> = input.onBlurObservable.add(() => {
             input._connectedVirtualKeyboard = null;
             this._currentlyConnectedInputText = null;
             this.isVisible = false;


### PR DESCRIPTION
This PR adds a few parameters to control (the base class of all GUI elements):

1. tabIndex - works similar to tabIndex in HTML. Defaults to -1, meaning - not focusable
2. focusedColor - the (border) color of the element if it is focussed using tab
3. onEnterPressedObservable - works similat to onPointerClicked - what happens when enter is pressed on a focused element.

Any control has onBlur and onFocus callbacks, and observables to catch these events.

The ADT has a flag that can turn off the entire behavior (`disableTabNavigation`). It is on per default, but since tabIndex is -1 per default, it shouldn't change anything.

There is a slight typing change, but it shouldn't be a breaking change, as we moved from an interface to a class that holds the entire interface (and actually implements it).
The only real breaking change is the onFocusObservable in virtual keyboard, which is not often used.

Test with this playground - #KKA6L4#16