### PR TITLE
Update physicsBody.ts to not silently fail when scene is not provided

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -97,6 +97,7 @@ export class PhysicsBody {
      */
     constructor(transformNode: TransformNode, motionType: PhysicsMotionType, startsAsleep: boolean, scene: Scene) {
         if (!scene) {
+            throw new Error("No scene found for new PhysicsBody.");
             return;
         }
         const physicsEngine = scene.getPhysicsEngine() as PhysicsEngine;


### PR DESCRIPTION
It might just be a documentation fix, but if we want to address the silent fail we can also do it. Is there a situation that we want to make PhysicsBody without inputting Scene at the very start? Shapes cannot be attached without Scene.

https://github.com/BabylonJS/Documentation/pull/1156