### PR TITLE
Add options to refreshBoundingBox to improve performance

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -645,22 +645,6 @@ export class VertexBuffer {
     }
 
     /**
-     * Copies current buffer's data into the given float array.
-     * @param totalVertices number of vertices in the buffer to take into account
-     * @param data the destination float array
-     * @returns true if the data exist or false otherwise
-     */
-    public copyFloatData(totalVertices: number, data: Float32Array): boolean {
-        const input = this.getData();
-        if (!input) {
-            return false;
-        }
-
-        VertexBuffer.CopyFloatData(input, this._size, this.type, this.byteOffset, this.byteStride, this.normalized, totalVertices, data);
-        return true;
-    }
-
-    /**
      * Gets underlying native buffer
      * @returns underlying native buffer
      */
@@ -1067,58 +1051,5 @@ export class VertexBuffer {
         }
 
         return data;
-    }
-
-    /**
-     * Copies the given data array to the given float array.
-     * @param input the input data array
-     * @param size the number of components
-     * @param type the component type
-     * @param byteOffset the byte offset of the data
-     * @param byteStride the byte stride of the data
-     * @param normalized whether the data is normalized
-     * @param totalVertices number of vertices in the buffer to take into account
-     * @param output the output float array
-     */
-    public static CopyFloatData(
-        input: DataArray,
-        size: number,
-        type: number,
-        byteOffset: number,
-        byteStride: number,
-        normalized: boolean,
-        totalVertices: number,
-        output: Float32Array
-    ): void {
-        const tightlyPackedByteStride = size * VertexBuffer.GetTypeByteLength(type);
-        const count = totalVertices * size;
-
-        if (output.length !== count) {
-            throw new Error("Output length is not valid");
-        }
-
-        if (type !== VertexBuffer.FLOAT || byteStride !== tightlyPackedByteStride) {
-            VertexBuffer.ForEach(input, byteOffset, byteStride, size, type, count, normalized, (value, index) => (output[index] = value));
-            return;
-        }
-
-        if (input instanceof Array) {
-            const offset = byteOffset / 4;
-            output.set(input, offset);
-        } else if (input instanceof ArrayBuffer) {
-            const floatData = new Float32Array(input, byteOffset, count);
-            output.set(floatData);
-        } else {
-            let offset = input.byteOffset + byteOffset;
-
-            // Protect against bad data
-            const remainder = offset % 4;
-            if (remainder) {
-                offset = Math.max(0, offset - remainder);
-            }
-
-            const floatData = new Float32Array(input.buffer, offset, count);
-            output.set(floatData);
-        }
     }
 }

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -645,6 +645,22 @@ export class VertexBuffer {
     }
 
     /**
+     * Copies current buffer's data into the given float array.
+     * @param totalVertices number of vertices in the buffer to take into account
+     * @param data the destination float array
+     * @returns true if the data exist or false otherwise
+     */
+    public copyFloatData(totalVertices: number, data: Float32Array): boolean {
+        const input = this.getData();
+        if (!input) {
+            return false;
+        }
+
+        VertexBuffer.CopyFloatData(input, this._size, this.type, this.byteOffset, this.byteStride, this.normalized, totalVertices, data);
+        return true;
+    }
+
+    /**
      * Gets underlying native buffer
      * @returns underlying native buffer
      */
@@ -1051,5 +1067,58 @@ export class VertexBuffer {
         }
 
         return data;
+    }
+
+    /**
+     * Copies the given data array to the given float array.
+     * @param input the input data array
+     * @param size the number of components
+     * @param type the component type
+     * @param byteOffset the byte offset of the data
+     * @param byteStride the byte stride of the data
+     * @param normalized whether the data is normalized
+     * @param totalVertices number of vertices in the buffer to take into account
+     * @param output the output float array
+     */
+    public static CopyFloatData(
+        input: DataArray,
+        size: number,
+        type: number,
+        byteOffset: number,
+        byteStride: number,
+        normalized: boolean,
+        totalVertices: number,
+        output: Float32Array
+    ): void {
+        const tightlyPackedByteStride = size * VertexBuffer.GetTypeByteLength(type);
+        const count = totalVertices * size;
+
+        if (output.length !== count) {
+            throw new Error("Output length is not valid");
+        }
+
+        if (type !== VertexBuffer.FLOAT || byteStride !== tightlyPackedByteStride) {
+            VertexBuffer.ForEach(input, byteOffset, byteStride, size, type, count, normalized, (value, index) => (output[index] = value));
+            return;
+        }
+
+        if (input instanceof Array) {
+            const offset = byteOffset / 4;
+            output.set(input, offset);
+        } else if (input instanceof ArrayBuffer) {
+            const floatData = new Float32Array(input, byteOffset, count);
+            output.set(floatData);
+        } else {
+            let offset = input.byteOffset + byteOffset;
+
+            // Protect against bad data
+            const remainder = offset % 4;
+            if (remainder) {
+                offset = Math.max(0, offset - remainder);
+            }
+
+            const floatData = new Float32Array(input.buffer, offset, count);
+            output.set(floatData);
+        }
     }
 }

--- a/packages/dev/core/src/Buffers/bufferUtils.ts
+++ b/packages/dev/core/src/Buffers/bufferUtils.ts
@@ -1,0 +1,55 @@
+import type { DataArray } from "../types";
+import { VertexBuffer } from "./buffer";
+
+/**
+ * Copies the given data array to the given float array.
+ * @param input the input data array
+ * @param size the number of components
+ * @param type the component type
+ * @param byteOffset the byte offset of the data
+ * @param byteStride the byte stride of the data
+ * @param normalized whether the data is normalized
+ * @param totalVertices number of vertices in the buffer to take into account
+ * @param output the output float array
+ */
+export function CopyFloatData(
+    input: DataArray,
+    size: number,
+    type: number,
+    byteOffset: number,
+    byteStride: number,
+    normalized: boolean,
+    totalVertices: number,
+    output: Float32Array
+): void {
+    const tightlyPackedByteStride = size * VertexBuffer.GetTypeByteLength(type);
+    const count = totalVertices * size;
+
+    if (output.length !== count) {
+        throw new Error("Output length is not valid");
+    }
+
+    if (type !== VertexBuffer.FLOAT || byteStride !== tightlyPackedByteStride) {
+        VertexBuffer.ForEach(input, byteOffset, byteStride, size, type, count, normalized, (value, index) => (output[index] = value));
+        return;
+    }
+
+    if (input instanceof Array) {
+        const offset = byteOffset / 4;
+        output.set(input, offset);
+    } else if (input instanceof ArrayBuffer) {
+        const floatData = new Float32Array(input, byteOffset, count);
+        output.set(floatData);
+    } else {
+        let offset = input.byteOffset + byteOffset;
+
+        // Protect against bad data
+        const remainder = offset % 4;
+        if (remainder) {
+            offset = Math.max(0, offset - remainder);
+        }
+
+        const floatData = new Float32Array(input.buffer, offset, count);
+        output.set(floatData);
+    }
+}

--- a/packages/dev/core/src/Buffers/index.ts
+++ b/packages/dev/core/src/Buffers/index.ts
@@ -1,4 +1,5 @@
 export * from "./buffer";
+export * from "./bufferUtils";
 export * from "./dataBuffer";
 export * from "./storageBuffer";
 import "./buffer.align";

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -6226,9 +6226,22 @@ export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>, Matrix>, IMatr
     public addToSelf(other: DeepImmutable<Matrix>): this {
         const m = this._m;
         const otherM = other.m;
-        for (let index = 0; index < 16; index++) {
-            m[index] += otherM[index];
-        }
+        m[0] += otherM[0];
+        m[1] += otherM[1];
+        m[2] += otherM[2];
+        m[3] += otherM[3];
+        m[4] += otherM[4];
+        m[5] += otherM[5];
+        m[6] += otherM[6];
+        m[7] += otherM[7];
+        m[8] += otherM[8];
+        m[9] += otherM[9];
+        m[10] += otherM[10];
+        m[11] += otherM[11];
+        m[12] += otherM[12];
+        m[13] += otherM[13];
+        m[14] += otherM[14];
+        m[15] += otherM[15];
         this.markAsUpdated();
         return this;
     }
@@ -7245,9 +7258,22 @@ export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>, Matrix>, IMatr
      * @returns result input
      */
     public static FromFloat32ArrayToRefScaled<T extends Matrix>(array: DeepImmutable<Float32Array | Array<number>>, offset: number, scale: number, result: T): T {
-        for (let index = 0; index < 16; index++) {
-            result._m[index] = array[index + offset] * scale;
-        }
+        result._m[0] = array[0 + offset] * scale;
+        result._m[1] = array[1 + offset] * scale;
+        result._m[2] = array[2 + offset] * scale;
+        result._m[3] = array[3 + offset] * scale;
+        result._m[4] = array[4 + offset] * scale;
+        result._m[5] = array[5 + offset] * scale;
+        result._m[6] = array[6 + offset] * scale;
+        result._m[7] = array[7 + offset] * scale;
+        result._m[8] = array[8 + offset] * scale;
+        result._m[9] = array[9 + offset] * scale;
+        result._m[10] = array[10 + offset] * scale;
+        result._m[11] = array[11 + offset] * scale;
+        result._m[12] = array[12 + offset] * scale;
+        result._m[13] = array[13 + offset] * scale;
+        result._m[14] = array[14 + offset] * scale;
+        result._m[15] = array[15 + offset] * scale;
         result.markAsUpdated();
         return result;
     }

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -46,7 +46,6 @@ import type { IEdgesRendererOptions } from "../Rendering/edgesRenderer";
 import type { MorphTarget } from "../Morph/morphTarget";
 import { nativeOverride } from "../Misc/decorators";
 
-/** @internal */
 function applyMorph(data: FloatArray, kind: string, morphTargetManager: MorphTargetManager): void {
     let getTargetData: Nullable<(target: MorphTarget) => Nullable<FloatArray>> = null;
     switch (kind) {
@@ -82,7 +81,6 @@ function applyMorph(data: FloatArray, kind: string, morphTargetManager: MorphTar
     }
 }
 
-/** @internal */
 function applySkeleton(
     data: FloatArray,
     kind: string,
@@ -1638,10 +1636,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
         this._updateBoundingInfo();
     }
 
-    /**
-     * This function is only here so we can apply the nativeOverride decorator.
-     * @internal
-     */
+    // This function is only here so we can apply the nativeOverride decorator.
     @nativeOverride.filter(
         (...[data, matricesIndicesData, matricesWeightsData, matricesIndicesExtraData, matricesWeightsExtraData]: Parameters<typeof AbstractMesh._ApplySkeleton>) =>
             !Array.isArray(data) &&

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -910,9 +910,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     }
 
     /** @internal */
-    public get _positions(): Nullable<Vector3[]> {
-        return this._internalAbstractMeshDataInfo._positions;
-    }
+    public abstract get _positions(): Nullable<Vector3[]>;
 
     // Loading properties
     /** @internal */

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -458,6 +458,21 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     /**
+     * Copies the requested vertex data kind into the given vertex data map. Float data is constructed if the map doesn't have the data.
+     * @param kind defines the data kind (Position, normal, etc...)
+     * @param vertexData defines the map that stores the resulting data
+     */
+    public copyVerticesData(kind: string, vertexData: { [kind: string]: Float32Array }): void {
+        const vertexBuffer = this.getVertexBuffer(kind);
+        if (!vertexBuffer) {
+            return;
+        }
+
+        vertexData[kind] ||= new Float32Array(this._totalVertices * vertexBuffer.getSize());
+        vertexBuffer.copyFloatData(this._totalVertices, vertexData[kind]);
+    }
+
+    /**
      * Returns a boolean defining if the vertex data for the requested `kind` is updatable
      * @param kind defines the data kind (Position, normal, etc...)
      * @returns true if the vertex buffer with the specified kind is updatable

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -24,6 +24,7 @@ import type { Mesh } from "../Meshes/mesh";
 import type { Buffer } from "../Buffers/buffer";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { ThinEngine } from "../Engines/thinEngine";
+import { CopyFloatData } from "../Buffers/bufferUtils";
 
 /**
  * Class used to store geometry data (vertex buffers + index buffer)
@@ -469,7 +470,19 @@ export class Geometry implements IGetSetVerticesData {
         }
 
         vertexData[kind] ||= new Float32Array(this._totalVertices * vertexBuffer.getSize());
-        vertexBuffer.copyFloatData(this._totalVertices, vertexData[kind]);
+        const data = vertexBuffer.getData();
+        if (data) {
+            CopyFloatData(
+                data,
+                vertexBuffer.getSize(),
+                vertexBuffer.type,
+                vertexBuffer.byteOffset,
+                vertexBuffer.byteStride,
+                vertexBuffer.normalized,
+                this._totalVertices,
+                vertexData[kind]
+            );
+        }
     }
 
     /**

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -4,6 +4,7 @@ import { Matrix, TmpVectors } from "../Maths/math.vector";
 import { Logger } from "../Misc/logger";
 import type { Camera } from "../Cameras/camera";
 import type { Node } from "../node";
+import type { IMeshDataOptions } from "../Meshes/abstractMesh";
 import { AbstractMesh } from "../Meshes/abstractMesh";
 import { Mesh } from "../Meshes/mesh";
 import type { Material } from "../Materials/material";
@@ -227,6 +228,10 @@ export class InstancedMesh extends AbstractMesh {
         return this._sourceMesh.getVerticesData(kind, copyWhenShared, forceCopy);
     }
 
+    public override copyVerticesData(kind: string, vertexData: { [kind: string]: Float32Array }): void {
+        this._sourceMesh.copyVerticesData(kind, vertexData);
+    }
+
     /**
      * Sets the vertex data of the mesh geometry for the requested `kind`.
      * If the mesh has no geometry, a new Geometry object is set to the mesh and then passed this vertex data.
@@ -349,20 +354,8 @@ export class InstancedMesh extends AbstractMesh {
         return this._sourceMesh._positions;
     }
 
-    /**
-     * This method recomputes and sets a new BoundingInfo to the mesh unless it is locked.
-     * This means the mesh underlying bounding box and sphere are recomputed.
-     * @param applySkeleton defines whether to apply the skeleton before computing the bounding info
-     * @param applyMorph  defines whether to apply the morph target before computing the bounding info
-     * @returns the current mesh
-     */
-    public override refreshBoundingInfo(applySkeleton: boolean = false, applyMorph: boolean = false): InstancedMesh {
-        if (this.hasBoundingInfo && this.getBoundingInfo().isLocked) {
-            return this;
-        }
-
-        const bias = this._sourceMesh.geometry ? this._sourceMesh.geometry.boundingBias : null;
-        this._refreshBoundingInfo(this._sourceMesh._getPositionData(applySkeleton, applyMorph), bias);
+    public override refreshBoundingInfo(applySkeletonOrOptions: boolean | IMeshDataOptions = false, applyMorph: boolean = false): InstancedMesh {
+        this._sourceMesh.refreshBoundingInfo(applySkeletonOrOptions, applyMorph);
         return this;
     }
 

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -355,7 +355,22 @@ export class InstancedMesh extends AbstractMesh {
     }
 
     public override refreshBoundingInfo(applySkeletonOrOptions: boolean | IMeshDataOptions = false, applyMorph: boolean = false): InstancedMesh {
-        this._sourceMesh.refreshBoundingInfo(applySkeletonOrOptions, applyMorph);
+        if (this.hasBoundingInfo && this.getBoundingInfo().isLocked) {
+            return this;
+        }
+
+        let options: IMeshDataOptions;
+        if (typeof applySkeletonOrOptions === "object") {
+            options = applySkeletonOrOptions;
+        } else {
+            options = {
+                applySkeleton: applySkeletonOrOptions,
+                applyMorph: applyMorph,
+            };
+        }
+
+        const bias = this._sourceMesh.geometry ? this._sourceMesh.geometry.boundingBias : null;
+        this._refreshBoundingInfo(this._getData(options, null, VertexBuffer.PositionKind), bias);
         return this;
     }
 

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1483,7 +1483,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         const bias = this.geometry ? this.geometry.boundingBias : null;
-        this._refreshBoundingInfo(this._getPositionData(options), bias);
+        this._refreshBoundingInfo(this._getData(options, null, VertexBuffer.PositionKind), bias);
         return this;
     }
 
@@ -2899,14 +2899,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /** @internal */
     public override get _positions(): Nullable<Vector3[]> {
-        if (this._internalAbstractMeshDataInfo._positions) {
-            return this._internalAbstractMeshDataInfo._positions;
-        }
-
-        if (this._geometry) {
-            return this._geometry._positions;
-        }
-        return null;
+        return this._internalAbstractMeshDataInfo._positions || (this._geometry && this._geometry._positions) || null;
     }
 
     /** @internal */

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -21,6 +21,7 @@ import type { IGetSetVerticesData } from "./mesh.vertexData";
 import { VertexData } from "./mesh.vertexData";
 
 import { Geometry } from "./geometry";
+import type { IMeshDataOptions } from "./abstractMesh";
 import { AbstractMesh } from "./abstractMesh";
 import { SubMesh } from "./subMesh";
 import type { BoundingSphere } from "../Culling/boundingSphere";
@@ -1118,6 +1119,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         return data;
     }
 
+    public override copyVerticesData(kind: string, vertexData: { [kind: string]: Float32Array }): void {
+        if (this._geometry) {
+            this._geometry.copyVerticesData(kind, vertexData);
+        }
+    }
+
     /**
      * Returns the mesh VertexBuffer object from the requested `kind`
      * @param kind defines which buffer to read from (positions, indices, normals, etc). Possible `kind` values :
@@ -1456,17 +1463,27 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
      * This method recomputes and sets a new BoundingInfo to the mesh unless it is locked.
      * This means the mesh underlying bounding box and sphere are recomputed.
-     * @param applySkeleton defines whether to apply the skeleton before computing the bounding info
-     * @param applyMorph  defines whether to apply the morph target before computing the bounding info
+     * @param applySkeletonOrOptions defines whether to apply the skeleton before computing the bounding info or a set of options
+     * @param applyMorph defines whether to apply the morph target before computing the bounding info
      * @returns the current mesh
      */
-    public override refreshBoundingInfo(applySkeleton: boolean = false, applyMorph: boolean = false): Mesh {
+    public override refreshBoundingInfo(applySkeletonOrOptions: boolean | IMeshDataOptions = false, applyMorph: boolean = false): Mesh {
         if (this.hasBoundingInfo && this.getBoundingInfo().isLocked) {
             return this;
         }
 
+        let options: IMeshDataOptions;
+        if (typeof applySkeletonOrOptions === "object") {
+            options = applySkeletonOrOptions;
+        } else {
+            options = {
+                applySkeleton: applySkeletonOrOptions,
+                applyMorph: applyMorph,
+            };
+        }
+
         const bias = this.geometry ? this.geometry.boundingBias : null;
-        this._refreshBoundingInfo(this._getPositionData(applySkeleton, applyMorph), bias);
+        this._refreshBoundingInfo(this._getPositionData(options), bias);
         return this;
     }
 


### PR DESCRIPTION
Before:
``` js
refreshBoundingInfo(applySkeleton: boolean, applyMorph: boolean)
```

After:
``` js
export interface IMeshDataOptions {
    applySkeleton?: boolean;
    applyMorph?: boolean;
    updatePositionsArray?: boolean;
    cache?: IMeshDataCache;
}

refreshBoundingInfo(options: IMeshDataOptions)
```

The `updatePositionsArray` flag will allow users to disable computing this array which isn't used in all situations.
The `cache` object will cache the allocations, reduce `slice` calls, etc.

On my machine:
[Before](https://playground.babylonjs.com/#B8B8Z2#5): 2.81s
[After](http://localhost:1338/#B8B8Z2#61): 1.67s