### PR TITLE
Declarations - const enum to enums

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -168,7 +168,8 @@ function getModuleDeclaration(
             return;
         }
     });
-    processedLines = processedLines.replace(/export declare /g, "export ");
+    processedLines = processedLines.replace(/export declare /g, "export ").replace(/export const enum/g, "export enum");
+
     return `declare module "${moduleName}" {
 ${processedLines}
 }
@@ -398,6 +399,8 @@ function getPackageDeclaration(
             }
         }
     );
+
+    processedSource = processedSource.replace(/export const enum/g, "export enum");
 
     processedSource = processedSource.replace(
         / global {([^}]*)}/gm,


### PR DESCRIPTION
When preserving const enums (to be available in js) the exported code is identical to a standard export ofr an enum. However, typescript still fails compilation when trying to iterate over it though it will work correctly when used directly in js.

This reverts const enums to enums in our UMD declarations, which will allow any playground using enum iteration in typescript to work. 