### PR TITLE
modify declaration's const enum to enums

### DIFF
--- a/packages/dev/buildTools/src/declarationsEs6.ts
+++ b/packages/dev/buildTools/src/declarationsEs6.ts
@@ -6,6 +6,7 @@ import * as glob from "glob";
 export const declarationsEs6 = () => {
     const root = checkArgs(["--root", "-r"]) as string;
     const appendToFile = checkArgs(["--append-to-file", "-atf"]) as string;
+    const constEnumToEnum = checkArgs(["--const-enum-to-enum", "-cete"]) as boolean;
     // eslint-disable-next-line no-console
     console.log(`Declarations ES6: root: ${root}`, appendToFile ? `append to file: ${appendToFile}` : "");
 
@@ -24,4 +25,16 @@ declare global{
 ${mixins}
 }`;
     fs.writeFileSync(path.join(".", appendToFile), newContent);
+
+    if (constEnumToEnum) {
+        // iterate over all files in the current directory and change const enum to enum
+        // This can be done since we are exporting the enums to js as well
+        const files = glob.sync(path.join("./**/*.d.ts"));
+
+        files.forEach((file) => {
+            let content = fs.readFileSync(file, "utf8");
+            content = content.replace(/const enum/g, "enum");
+            fs.writeFileSync(file, content);
+        });
+    }
 };

--- a/packages/public/@babylonjs/core/config.tasks.json
+++ b/packages/public/@babylonjs/core/config.tasks.json
@@ -2,7 +2,7 @@
     "commands": [
         {
             "command": "declarations-es6",
-            "args": ["-r", "../../../dev/core/src/LibDeclarations", "-atf", "./Engines/engine.d.ts"]
+            "args": ["-r", "../../../dev/core/src/LibDeclarations", "-atf", "./Engines/engine.d.ts", "-cete"]
         },
         {
             "command": "add-js-to-es6"


### PR DESCRIPTION
Fixes #15238

We can do that since typescript exports the const enums just as if they were enums. The step to use const enums still provides advantages to people consuming the framework, but this way typescript will treat them as regular enums on projects using babylon.