### PR TITLE
Viewer alpha public package initial checkin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2092,6 +2092,10 @@
             "resolved": "packages/public/@babylonjs/viewer",
             "link": true
         },
+        "node_modules/@babylonjs/viewer-alpha": {
+            "resolved": "packages/public/@babylonjs/viewer-alpha",
+            "link": true
+        },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -5322,6 +5326,284 @@
             "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
             "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
             "peer": true
+        },
+        "node_modules/@rollup/plugin-terser": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+            "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+            "dev": true,
+            "dependencies": {
+                "serialize-javascript": "^6.0.1",
+                "smob": "^1.0.0",
+                "terser": "^5.17.4"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-typescript": {
+            "version": "11.1.6",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+            "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0||^3.0.0||^4.0.0",
+                "tslib": "*",
+                "typescript": ">=3.7.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                },
+                "tslib": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
+            "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
+            "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
+            "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
+            "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
+            "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
+            "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
+            "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
+            "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
+            "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
+            "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
+            "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
+            "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
+            "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
+            "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
+            "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
+            "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
@@ -10976,6 +11258,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -15908,6 +16196,15 @@
             "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
             "dev": true
         },
+        "node_modules/magic-string": {
+            "version": "0.30.10",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -20654,6 +20951,63 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rollup": {
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
+            "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.18.0",
+                "@rollup/rollup-android-arm64": "4.18.0",
+                "@rollup/rollup-darwin-arm64": "4.18.0",
+                "@rollup/rollup-darwin-x64": "4.18.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.18.0",
+                "@rollup/rollup-linux-arm64-musl": "4.18.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.18.0",
+                "@rollup/rollup-linux-x64-gnu": "4.18.0",
+                "@rollup/rollup-linux-x64-musl": "4.18.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.18.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.18.0",
+                "@rollup/rollup-win32-x64-msvc": "4.18.0",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-dts": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+            "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.10"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Swatinem"
+            },
+            "optionalDependencies": {
+                "@babel/code-frame": "^7.24.2"
+            },
+            "peerDependencies": {
+                "rollup": "^3.29.4 || ^4",
+                "typescript": "^4.5 || ^5.0"
+            }
+        },
         "node_modules/run-async": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -21451,6 +21805,12 @@
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
             }
+        },
+        "node_modules/smob": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
+            "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+            "dev": true
         },
         "node_modules/sockjs": {
             "version": "0.3.24",
@@ -24840,6 +25200,21 @@
             },
             "devDependencies": {
                 "@dev/build-tools": "^1.0.0"
+            }
+        },
+        "packages/public/@babylonjs/viewer-alpha": {
+            "version": "7.13.1-alpha",
+            "license": "Apache-2.0",
+            "devDependencies": {
+                "@dev/build-tools": "^1.0.0",
+                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-typescript": "^11.1.6",
+                "rollup": "^4.18.0",
+                "rollup-plugin-dts": "^6.1.1"
+            },
+            "peerDependencies": {
+                "@babylonjs/core": "^7.13.1",
+                "@babylonjs/loaders": "^7.13.1"
             }
         },
         "packages/public/@babylonjs/viewer/node_modules/deepmerge": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "build:source": "tsc -b ./tsconfig.devpackages.json",
         "build:source:lts": "npx nx run-many --target=compile --projects=@lts/core,@lts/gui,@lts/loaders,@lts/materials,@lts/post-processes,@lts/procedural-textures,@lts/serializers --parallel=1",
         "build:umd": "nx run-many --target=build --parallel --maxParallel=6 --projects=babylonjs,babylonjs-gui,babylonjs-inspector,babylonjs-loaders,babylonjs-materials,babylonjs-serializers,babylonjs-post-process,babylonjs-procedural-textures,babylonjs-node-editor,babylonjs-node-geometry-editor,babylonjs-gui-editor,babylonjs-ktx2decoder,babylonjs-viewer-assets,babylonjs-viewer,babylonjs-accessibility",
-        "build:es6": "nx run-many --target=build --parallel --maxParallel=6 --projects=@babylonjs/core,@babylonjs/gui,@babylonjs/loaders,@babylonjs/materials,@babylonjs/serializers,@babylonjs/post-processes,@babylonjs/procedural-textures,@babylonjs/node-editor,@babylonjs/node-geometry-editor,@babylonjs/inspector,@babylonjs/gui-editor,@babylonjs/viewer,@babylonjs/shared-ui-components,@babylonjs/accessibility,@babylonjs/ktx2decoder",
+        "build:es6": "nx run-many --target=build --parallel --maxParallel=6 --projects=@babylonjs/core,@babylonjs/gui,@babylonjs/loaders,@babylonjs/materials,@babylonjs/serializers,@babylonjs/post-processes,@babylonjs/procedural-textures,@babylonjs/node-editor,@babylonjs/node-geometry-editor,@babylonjs/inspector,@babylonjs/gui-editor,@babylonjs/viewer,@babylonjs/viewer-alpha,@babylonjs/shared-ui-components,@babylonjs/accessibility,@babylonjs/ktx2decoder",
         "watch:shaders": "build-tools -c build-shaders --global --watch",
         "watch:assets": "build-tools -c pa --global --watch",
         "watch:source:dev": "tsc -b ./tsconfig.devpackages.json -w",

--- a/packages/public/@babylonjs/viewer-alpha/license.md
+++ b/packages/public/@babylonjs/viewer-alpha/license.md
@@ -1,0 +1,71 @@
+# Apache License 2.0 (Apache)
+
+Apache License
+Version 2.0, January 2004
+<http://www.apache.org/licenses/>
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+## Definitions
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+## Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+## Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+## Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+1. You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+2. You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+3. You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+4. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+## Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+## Trademarks
+
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+## Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+## Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+## Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.

--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -1,0 +1,52 @@
+{
+    "name": "@babylonjs/viewer-alpha",
+    "version": "7.13.1",
+    "private": true,
+    "type": "module",
+    "main": "lib/index.js",
+    "module": "lib/index.js",
+    "esnext": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "files": [
+        "lib/**/*.js",
+        "lib/**/*.d.ts",
+        "lib/**/*.map",
+        "readme.md",
+        "license.md"
+    ],
+    "scripts": {
+        "build": "npm run clean && npm run bundle",
+        "clean": "rimraf lib && rimraf src && rimraf *.tsbuildinfo",
+        "bundle": "rollup -c",
+        "pack": "npm run build && npm pack",
+        "prepublish": "prepublish.cjs"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^7.13.1",
+        "@babylonjs/loaders": "^7.13.1"
+    },
+    "devDependencies": {
+        "@dev/build-tools": "^1.0.0",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "rollup": "^4.18.0",
+        "rollup-plugin-dts": "^6.1.1"
+    },
+    "keywords": [
+        "3D",
+        "javascript",
+        "html5",
+        "webgl",
+        "babylon.js"
+    ],
+    "license": "Apache-2.0",
+    "sideEffects": false,
+    "homepage": "https://www.babylonjs.com",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/BabylonJS/Babylon.js.git"
+    },
+    "bugs": {
+        "url": "https://github.com/BabylonJS/Babylon.js/issues"
+    }
+}

--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@babylonjs/viewer-alpha",
-    "version": "7.13.1",
+    "version": "1.0.0",
     "private": true,
     "type": "module",
     "main": "lib/index.js",
@@ -18,12 +18,11 @@
         "build": "npm run clean && npm run bundle",
         "clean": "rimraf lib && rimraf src && rimraf *.tsbuildinfo",
         "bundle": "rollup -c",
-        "pack": "npm run build && npm pack",
-        "prepublish": "prepublish.cjs"
+        "pack": "npm run build && npm pack"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^7.13.1",
-        "@babylonjs/loaders": "^7.13.1"
+        "@babylonjs/core": "^7.13.2",
+        "@babylonjs/loaders": "^7.0.0"
     },
     "devDependencies": {
         "@dev/build-tools": "^1.0.0",

--- a/packages/public/@babylonjs/viewer-alpha/prepublish.cjs
+++ b/packages/public/@babylonjs/viewer-alpha/prepublish.cjs
@@ -1,0 +1,25 @@
+// The alpha version of the viewer package must have a unique package name within the context of the mono repo / npm workspace
+// as long as the legacy version is still being maintained and published. Therefore, the alpha package has a unique name, but this
+// is not the actual name we want to publish it under. This script copies the name and version from the legacy package.json to the
+// alpha package.json, appends "-alpha" to the version, and removes the private flag, scripts, and devDependencies from the alpha,
+// and finally deletes the legacy package.json. This script should be run after the alpha package has been built and before it is
+// published. This script is not necessary when the legacy package is deprecated and the alpha package is published under the same
+// name as the legacy package.
+
+const fs = require("fs");
+const path = require("path");
+
+const legacyPackageJsonPath = path.resolve(__dirname, "../viewer/package.json");
+const alphaPackageJsonPath = path.resolve(__dirname, "package.json");
+
+const legacyPackageJsonContent = require(legacyPackageJsonPath);
+const alphaPackageJsonContent = require(alphaPackageJsonPath);
+
+alphaPackageJsonContent.name = legacyPackageJsonContent.name;
+alphaPackageJsonContent.version = `${legacyPackageJsonContent.version}-alpha`;
+delete alphaPackageJsonContent.private;
+delete alphaPackageJsonContent.scripts;
+delete alphaPackageJsonContent.devDependencies;
+
+fs.unlinkSync(legacyPackageJsonPath);
+fs.writeFileSync(alphaPackageJsonPath, JSON.stringify(alphaPackageJsonContent, null, 4));

--- a/packages/public/@babylonjs/viewer-alpha/readme.md
+++ b/packages/public/@babylonjs/viewer-alpha/readme.md
@@ -1,0 +1,39 @@
+# BabylonJS Viewer
+
+This project is the alpha version of a new a 3d model viewer using babylonjs.
+
+`Viewer` is a lower level JavaScript class that implements the bulk of the features, and can be used in any babylonjs context (in the browser using pure HTML, in the browser using React, or even in Babylon Native).
+
+`HTML3DElement` is a custom HTML element that wraps the `Viewer` class and provides a declarative way to use it specifically in HTML via the custom element `<babylon-viewer>`.
+
+## ES6/NPM usage
+
+Install the package using npm:
+
+```bash
+npm install @babylonjs/viewer@preview --save
+```
+
+If you want to use the lower level `Viewer` directly in JavaScript code, you can import it and use it like this:
+
+```bash
+import { Engine } from '@babylonjs/core';
+import { Viewer } from '@babylonjs/viewer';
+
+const engine = new Engine(canvas);
+const viewer = new Viewer(engine);
+viewer.loadModelAsync("https://playground.babylonjs.com/scenes/BoomBox.glb");
+```
+
+To use the higher level `HTML3DElement` you can import the `@babylonjs/viewer` module and then reference the `<babylon-viewer>` element in your HTML like this:
+
+```html
+<html lang="en">
+  <body>
+    <script type="module">
+      import '@babylonjs/viewer-alpha';
+    </script>
+    <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
+  </body>
+</html>
+```

--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.mjs
@@ -2,8 +2,12 @@ import typescript from "@rollup/plugin-typescript";
 //import terser from "@rollup/plugin-terser";
 import { dts } from "rollup-plugin-dts";
 
-const jsConfig = {
+const commonConfig = {
     input: "../../../tools/viewer-alpha/src/index.ts",
+};
+
+const jsConfig = {
+    ...commonConfig,
     output: {
         dir: "lib",
         sourcemap: true,
@@ -14,7 +18,7 @@ const jsConfig = {
 };
 
 const dtsConfig = {
-    input: "../../../tools/viewer-alpha/src/index.ts",
+    ...commonConfig,
     output: {
         file: "lib/index.d.ts",
         format: "es",

--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.mjs
@@ -1,0 +1,25 @@
+import typescript from "@rollup/plugin-typescript";
+//import terser from "@rollup/plugin-terser";
+import { dts } from "rollup-plugin-dts";
+
+const jsConfig = {
+    input: "../../../tools/viewer-alpha/src/index.ts",
+    output: {
+        dir: "lib",
+        sourcemap: true,
+        format: "es",
+        exports: "named",
+    },
+    plugins: [typescript({ tsconfig: "tsconfig.build.json" })],
+};
+
+const dtsConfig = {
+    input: "../../../tools/viewer-alpha/src/index.ts",
+    output: {
+        file: "lib/index.d.ts",
+        format: "es",
+    },
+    plugins: [dts({ tsconfig: "tsconfig.build.json" })],
+};
+
+export default [jsConfig, dtsConfig];

--- a/packages/public/@babylonjs/viewer-alpha/tsconfig.build.json
+++ b/packages/public/@babylonjs/viewer-alpha/tsconfig.build.json
@@ -1,0 +1,29 @@
+{
+    "extends": "../../../../tsconfig.build.json",
+
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "../../../",
+        "declaration": false,
+        "target": "ES2020",
+        "importHelpers": true,
+        "plugins": [
+            {
+                "transform": "@dev/build-tools/dist/pathTransform.js",
+                "after": true,
+                "buildType": "es6",
+                "basePackage": "@babylonjs/viewer-alpha",
+                "appendJS": true
+            },
+            {
+                "transform": "@dev/build-tools/dist/pathTransform.js",
+                "afterDeclarations": true,
+                "buildType": "es6",
+                "basePackage": "@babylonjs/viewer-alpha",
+                "appendJS": true
+            }
+        ]
+    },
+
+    "include": ["../../../tools/viewer-alpha/src/**/*"]
+}

--- a/packages/public/@babylonjs/viewer-alpha/tsconfig.json
+++ b/packages/public/@babylonjs/viewer-alpha/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../../tsconfig.json",
+
+    "compilerOptions": {},
+
+    "include": ["../../../tools/viewer-alpha/src/**/*"]
+}

--- a/packages/tools/viewer-alpha/src/viewerFactory.ts
+++ b/packages/tools/viewer-alpha/src/viewerFactory.ts
@@ -1,4 +1,5 @@
-import { Engine, type EngineOptions } from "core/Engines";
+import { Engine } from "core/Engines/engine";
+import type { EngineOptions } from "core/Engines";
 
 import type { ViewerOptions } from "./viewer";
 import { Viewer } from "./viewer";


### PR DESCRIPTION
This PR introduces the public package build for the alpha viewer that was previously introduced in this PR: https://github.com/BabylonJS/Babylon.js/pull/15241

The overall strategy is summarized in the comment at the top of the `prepublish.cjs` script:
```js
// The alpha version of the viewer package must have a unique package name within the context of the mono repo / npm workspace
// as long as the legacy version is still being maintained and published. Therefore, the alpha package has a unique name, but this
// is not the actual name we want to publish it under. This script copies the name and version from the legacy package.json to the
// alpha package.json, appends "-alpha" to the version, and removes the private flag, scripts, and devDependencies from the alpha,
// and finally deletes the legacy package.json. This script should be run after the alpha package has been built and before it is
// published. This script is not necessary when the legacy package is deprecated and the alpha package is published under the same
// name as the legacy package.
```

Given this, the high level aspects of this new folder are:
- Includes a rollup based build that bundles everything into a single file but still uses esm (webpack is good at creating umd bundle files, but not esm bundle files).
  - Bundling to esm allows us to not "ship our directory structure," which gives us the freedom to update the directory structure or file names in the viewer source without creating back compat issues.
  - It also bundles the d.ts files into a single d.ts
  - Later when we introduce dynamic imports, it won't be one bundle file but rather a handful. Technically people could import the dynamic import bundles, but it's unlikely someone would do so since rollup basically gives them random names.
- Includes a prepublish.cjs script that modifies the package.json and deletes the legacy viewer package.json so the new alpha viewer can be published with the same name (with the `-alpha` version suffix).

Separately, @RaananW (or me with @RaananW's help) will modify the CI build to run this prepublish step and then specifically publish the new alpha viewer package. That will come in a different PR.

I also had to make a few changes to the actual viewer source code to get this all working (tested a local build of the package in a vanilla-ts Vite project).