### PR TITLE
buffer: copy unaligned data in GetFloatData

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -1039,6 +1039,7 @@ export class VertexBuffer {
                 const remainder = offset % 4;
 
                 if (remainder) {
+                    Logger.Warn("GetFloatData: copied misaligned data.");
                     // If not aligned, copy the data to aligned buffer
                     return new Float32Array(data.buffer.slice(offset, offset + count * 4));
                 }

--- a/packages/dev/core/src/Buffers/buffer.ts
+++ b/packages/dev/core/src/Buffers/buffer.ts
@@ -1025,7 +1025,7 @@ export class VertexBuffer {
             } else if (data instanceof ArrayBuffer) {
                 return new Float32Array(data, byteOffset, count);
             } else {
-                let offset = data.byteOffset + byteOffset;
+                const offset = data.byteOffset + byteOffset;
                 if (forceCopy) {
                     const result = new Float32Array(count);
                     const source = new Float32Array(data.buffer, offset, count);
@@ -1039,7 +1039,8 @@ export class VertexBuffer {
                 const remainder = offset % 4;
 
                 if (remainder) {
-                    offset = Math.max(0, offset - remainder);
+                    // If not aligned, copy the data to aligned buffer
+                    return new Float32Array(data.buffer.slice(offset, offset + count * 4));
                 }
 
                 return new Float32Array(data.buffer, offset, count);

--- a/packages/dev/core/src/Buffers/bufferUtils.ts
+++ b/packages/dev/core/src/Buffers/bufferUtils.ts
@@ -1,5 +1,6 @@
 import type { DataArray } from "../types";
 import { VertexBuffer } from "./buffer";
+import { Logger } from "../Misc/logger";
 
 /**
  * Copies the given data array to the given float array.
@@ -41,12 +42,15 @@ export function CopyFloatData(
         const floatData = new Float32Array(input, byteOffset, count);
         output.set(floatData);
     } else {
-        let offset = input.byteOffset + byteOffset;
+        const offset = input.byteOffset + byteOffset;
 
         // Protect against bad data
         const remainder = offset % 4;
         if (remainder) {
-            offset = Math.max(0, offset - remainder);
+            Logger.Warn("CopyFloatData: copied misaligned data.");
+            // If not aligned, copy the data to aligned buffer
+            output.set(new Float32Array(input.buffer.slice(offset, offset + count * 4)));
+            return;
         }
 
         const floatData = new Float32Array(input.buffer, offset, count);


### PR DESCRIPTION
In `VertexBuffer.GetFloatData`, if data is not aligned to 4 bytes, the current impl is to align the offset to make code work, but this would make data returned here differ from data passed to gpu, so algos depending on result of it could be wrong. This commit changes this behavior to copying the buffer on unaligned buffers or offsets.

Related playground: <https://playground.babylonjs.com/#5T7E1W#8>
Forum thread: <https://forum.babylonjs.com/t/picked-point-at-wrong-position/51698>
Related commit: https://github.com/BabylonJS/Babylon.js/commit/9c2df86f54d7660b859eabcdb3b096c1f83800d4