### PR TITLE
allow url query parameters on svg paths

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -620,7 +620,7 @@ export class Image extends Control {
      * @returns the svg
      */
     private _svgCheck(value: string): string {
-        if (window.SVGSVGElement && value.search(/.svg#/gi) !== -1 && value.indexOf("#") === value.lastIndexOf("#")) {
+        if (window.SVGSVGElement && value.search(/.svg.*#/gi) !== -1 && value.indexOf("#") === value.lastIndexOf("#")) {
             this._isSVG = true;
             const svgsrc = value.split("#")[0];
             const elemid = value.split("#")[1];

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -620,7 +620,7 @@ export class Image extends Control {
      * @returns the svg
      */
     private _svgCheck(value: string): string {
-        if (window.SVGSVGElement && value.search(/.svg.*#/gi) !== -1 && value.indexOf("#") === value.lastIndexOf("#")) {
+        if (window.SVGSVGElement && value.search(/(\.svg|\.svg?[?|#].*)$/gi) !== -1 && value.indexOf("#") === value.lastIndexOf("#")) {
             this._isSVG = true;
             const svgsrc = value.split("#")[0];
             const elemid = value.split("#")[1];


### PR DESCRIPTION
Allow svg file paths to contain url query parameters (eg: cache busters) or uri fragments (eg: svg fragment identifiers).