### PR TITLE
Add cancellation and "lock many" to AsyncLock

### DIFF
--- a/packages/dev/core/src/Misc/asyncLock.ts
+++ b/packages/dev/core/src/Misc/asyncLock.ts
@@ -1,3 +1,5 @@
+import { Deferred } from "./deferred";
+
 /**
  * Provides a simple way of creating the rough equivalent of an async critical section.
  *
@@ -17,14 +19,75 @@ export class AsyncLock {
     private _currentOperation: Promise<void> = Promise.resolve();
 
     /**
-     * Executes the func when the lock is acquired (e.g. when the previous operation finishes).
+     * Executes the provided function when the lock is acquired (e.g. when the previous operation finishes).
      * @param func The function to execute.
+     * @param signal An optional signal that can be used to abort the operation.
      * @returns A promise that resolves when the func finishes executing.
      */
-    public lockAsync<T>(func: () => T | Promise<T>): Promise<T> {
-        const newOperation = this._currentOperation.then(func);
+    public lockAsync<T>(func: () => T | Promise<T>, signal?: AbortSignal): Promise<T> {
+        const wrappedFunc = signal
+            ? () => {
+                  signal.throwIfAborted();
+                  return func();
+              }
+            : func;
+
+        const newOperation = this._currentOperation.then(wrappedFunc);
         // NOTE: It would be simpler to just hold a Promise<unknown>, but this class should not prevent an object held by the returned promise from being garbage collected.
         this._currentOperation = new Promise<void>((resolve) => newOperation.then(() => resolve(), resolve));
         return newOperation;
+    }
+
+    /**
+     * Executes the provided function when all the specified locks are acquired.
+     * @param func The function to execute.
+     * @param locks The locks to acquire.
+     * @returns A promise that resolves when the func finishes executing.
+     */
+    public static LockAsync<T>(func: () => T | Promise<T>, ...locks: AsyncLock[]): Promise<T>;
+
+    /**
+     * Executes the provided function when all the specified locks are acquired.
+     * @param func The function to execute.
+     * @param signal A signal that can be used to abort the operation.
+     * @param locks The locks to acquire.
+     * @returns A promise that resolves when the func finishes executing.
+     */
+    public static LockAsync<T>(func: () => T | Promise<T>, signal: AbortSignal, ...locks: AsyncLock[]): Promise<T>;
+
+    public static async LockAsync<T>(
+        ...args: [func: () => T | Promise<T>, ...locks: AsyncLock[]] | [func: () => T | Promise<T>, signal: AbortSignal, ...locks: AsyncLock[]]
+    ): Promise<T> {
+        const [func, arg1, ...locks] = args;
+        let signal: AbortSignal | undefined;
+        if (!(arg1 instanceof AbortSignal)) {
+            signal = undefined;
+            locks.unshift(arg1);
+        } else {
+            signal = arg1;
+        }
+
+        signal?.throwIfAborted();
+
+        if (locks.length === 0) {
+            return await func();
+        }
+
+        const deferred = new Deferred<T>();
+        let acquiredLocks = 0;
+
+        locks.forEach((lock) =>
+            lock
+                .lockAsync(async () => {
+                    acquiredLocks++;
+                    if (acquiredLocks === locks.length) {
+                        deferred.resolve(await func());
+                    }
+                    return deferred.promise;
+                }, signal)
+                .catch((e) => deferred.reject(e))
+        );
+
+        return deferred.promise;
     }
 }

--- a/packages/dev/core/src/Misc/asyncLock.ts
+++ b/packages/dev/core/src/Misc/asyncLock.ts
@@ -25,6 +25,8 @@ export class AsyncLock {
      * @returns A promise that resolves when the func finishes executing.
      */
     public lockAsync<T>(func: () => T | Promise<T>, signal?: AbortSignal): Promise<T> {
+        signal?.throwIfAborted();
+
         const wrappedFunc = signal
             ? () => {
                   signal.throwIfAborted();
@@ -42,31 +44,10 @@ export class AsyncLock {
      * Executes the provided function when all the specified locks are acquired.
      * @param func The function to execute.
      * @param locks The locks to acquire.
+     * @param signal An optional signal that can be used to abort the operation.
      * @returns A promise that resolves when the func finishes executing.
      */
-    public static LockAsync<T>(func: () => T | Promise<T>, ...locks: AsyncLock[]): Promise<T>;
-
-    /**
-     * Executes the provided function when all the specified locks are acquired.
-     * @param func The function to execute.
-     * @param signal A signal that can be used to abort the operation.
-     * @param locks The locks to acquire.
-     * @returns A promise that resolves when the func finishes executing.
-     */
-    public static LockAsync<T>(func: () => T | Promise<T>, signal: AbortSignal, ...locks: AsyncLock[]): Promise<T>;
-
-    public static async LockAsync<T>(
-        ...args: [func: () => T | Promise<T>, ...locks: AsyncLock[]] | [func: () => T | Promise<T>, signal: AbortSignal, ...locks: AsyncLock[]]
-    ): Promise<T> {
-        const [func, arg1, ...locks] = args;
-        let signal: AbortSignal | undefined;
-        if (!(arg1 instanceof AbortSignal)) {
-            signal = undefined;
-            locks.unshift(arg1);
-        } else {
-            signal = arg1;
-        }
-
+    public static async LockAsync<T>(func: () => T | Promise<T>, locks: AsyncLock[], signal?: AbortSignal): Promise<T> {
         signal?.throwIfAborted();
 
         if (locks.length === 0) {

--- a/packages/dev/core/test/unit/Misc/asyncLock.test.ts
+++ b/packages/dev/core/test/unit/Misc/asyncLock.test.ts
@@ -30,6 +30,22 @@ describe("AsyncLock", () => {
         expect(result).toBe(42);
     });
 
+    it("basic func throws error", async () => {
+        const asyncLock = new AsyncLock();
+
+        const expectedError = new Error("Test error");
+        let actualError: Nullable<unknown> = null;
+        try {
+            await asyncLock.lockAsync(() => {
+                throw expectedError;
+            });
+        } catch (e: unknown) {
+            actualError = e;
+        }
+
+        expect(actualError).toBe(expectedError);
+    });
+
     it("basic sequencing", async () => {
         const asyncLock = new AsyncLock();
         const operation1Started = new Deferred<void>();
@@ -143,6 +159,26 @@ describe("AsyncLock", () => {
         expect(lockAcquired).toBe(true);
 
         expect(await promise).toBe(42);
+    });
+
+    it("lock many func throws error", async () => {
+        const asyncLock1 = new AsyncLock();
+        const asyncLock2 = new AsyncLock();
+
+        asyncLock1.lockAsync(() => {});
+        asyncLock2.lockAsync(() => {});
+
+        const expectedError = new Error("Test error");
+        let actualError: Nullable<unknown> = null;
+        try {
+            await AsyncLock.LockAsync(() => {
+                throw expectedError;
+            }, [asyncLock1, asyncLock2]);
+        } catch (e: unknown) {
+            actualError = e;
+        }
+
+        expect(actualError).toBe(expectedError);
     });
 
     it("lock many basic cancellation", async () => {

--- a/packages/dev/core/test/unit/Misc/asyncLock.test.ts
+++ b/packages/dev/core/test/unit/Misc/asyncLock.test.ts
@@ -1,0 +1,207 @@
+import { AsyncLock } from "core/Misc/asyncLock";
+import { Deferred } from "core/Misc/deferred";
+import { Nullable } from "core/types";
+
+async function whenJSFrames(count: number): Promise<void> {
+    for (let i = 0; i < count - 1; i++) {
+        await undefined;
+    }
+}
+
+describe("AsyncLock", () => {
+    it("no contention - synchronous", async () => {
+        const asyncLock = new AsyncLock();
+
+        const result = await asyncLock.lockAsync(() => {
+            return 42;
+        });
+
+        expect(result).toBe(42);
+    });
+
+    it("no contention - asynchronous", async () => {
+        const asyncLock = new AsyncLock();
+
+        const result = await asyncLock.lockAsync(async () => {
+            await Promise.resolve();
+            return 42;
+        });
+
+        expect(result).toBe(42);
+    });
+
+    it("basic sequencing", async () => {
+        const asyncLock = new AsyncLock();
+        const operation1Started = new Deferred<void>();
+        const operation1Completed = new Deferred<void>();
+        let operation1LockAcquired = false;
+        let operation2LockAcquired = false;
+
+        asyncLock.lockAsync(() => {
+            operation1LockAcquired = true;
+            operation1Started.resolve();
+            return operation1Completed.promise;
+        });
+
+        asyncLock.lockAsync(() => {
+            operation2LockAcquired = true;
+        });
+
+        expect(operation1LockAcquired).toBe(false);
+        expect(operation2LockAcquired).toBe(false);
+
+        await whenJSFrames(5);
+
+        expect(operation2LockAcquired).toBe(false);
+        expect(operation1LockAcquired).toBe(true);
+
+        await whenJSFrames(5);
+
+        expect(operation2LockAcquired).toBe(false);
+
+        operation1Completed.resolve();
+        await operation1Completed.promise;
+
+        await whenJSFrames(5);
+
+        expect(operation2LockAcquired).toBe(true);
+    });
+
+    it("basic cancellation", async () => {
+        const asyncLock = new AsyncLock();
+        let operation1LockAcquired = false;
+        const abortController = new AbortController();
+
+        const promise = asyncLock.lockAsync(() => {
+            operation1LockAcquired = true;
+        }, abortController.signal);
+
+        const expectedAbortReason = "Aborting operation before it starts.";
+        abortController.abort(expectedAbortReason);
+
+        let actualAbortReason: Nullable<string> = null;
+        try {
+            await promise;
+        } catch (e: unknown) {
+            actualAbortReason = String(e);
+        }
+
+        expect(operation1LockAcquired).toBe(false);
+        expect(actualAbortReason).toBe(expectedAbortReason);
+    });
+
+    it("lock acquired after cancellation", async () => {
+        const asyncLock = new AsyncLock();
+        const abortController = new AbortController();
+
+        const operation1Promise = asyncLock.lockAsync(() => 42, abortController.signal);
+        const operation2Promise = asyncLock.lockAsync(() => 43);
+
+        const expectedAbortReason = "Aborting operation before it starts.";
+        abortController.abort(expectedAbortReason);
+
+        let actualAbortReason: Nullable<string> = null;
+        try {
+            await operation1Promise;
+        } catch (e: unknown) {
+            actualAbortReason = String(e);
+        }
+
+        expect(actualAbortReason).toBe(expectedAbortReason);
+
+        expect(await operation2Promise).toBe(43);
+    });
+
+    it("basic lock many", async () => {
+        const asyncLock1 = new AsyncLock();
+        const asyncLock2 = new AsyncLock();
+
+        const operation1Completed = new Deferred<void>();
+        const operation2Completed = new Deferred<void>();
+        let lockAcquired = false;
+
+        asyncLock1.lockAsync(() => {
+            return operation1Completed.promise;
+        });
+
+        asyncLock2.lockAsync(() => {
+            return operation2Completed.promise;
+        });
+
+        const promise = AsyncLock.LockAsync(
+            () => {
+                lockAcquired = true;
+                return 42;
+            },
+            asyncLock1,
+            asyncLock2
+        );
+
+        await whenJSFrames(5);
+        expect(lockAcquired).toBe(false);
+        operation1Completed.resolve();
+        await whenJSFrames(5);
+        expect(lockAcquired).toBe(false);
+        operation2Completed.resolve();
+        await whenJSFrames(5);
+        expect(lockAcquired).toBe(true);
+
+        expect(await promise).toBe(42);
+    });
+
+    it("lock many basic cancellation", async () => {
+        const asyncLock1 = new AsyncLock();
+        const asyncLock2 = new AsyncLock();
+        const abortController = new AbortController();
+
+        asyncLock1.lockAsync(() => {});
+        asyncLock2.lockAsync(() => {});
+
+        let lockAcquired = false;
+        const promise = AsyncLock.LockAsync(
+            () => {
+                lockAcquired = true;
+            },
+            abortController.signal,
+            asyncLock1,
+            asyncLock2
+        );
+
+        const expectedAbortReason = "Aborting operation before it starts.";
+        abortController.abort(expectedAbortReason);
+
+        expect(lockAcquired).toBe(false);
+        let actualAbortReason: Nullable<string> = null;
+        try {
+            await promise;
+        } catch (e: unknown) {
+            actualAbortReason = String(e);
+        }
+
+        expect(lockAcquired).toBe(false);
+        expect(actualAbortReason).toBe(expectedAbortReason);
+    });
+
+    it("lock many acquired after cancellation", async () => {
+        const asyncLock1 = new AsyncLock();
+        const asyncLock2 = new AsyncLock();
+        const abortController = new AbortController();
+
+        asyncLock1.lockAsync(() => {}, abortController.signal);
+        asyncLock2.lockAsync(() => {}, abortController.signal);
+
+        let lockAcquired = false;
+        AsyncLock.LockAsync(
+            () => {
+                lockAcquired = true;
+            },
+            asyncLock1,
+            asyncLock2
+        );
+
+        expect(lockAcquired).toBe(false);
+        abortController.abort();
+        await whenJSFrames(5);
+        expect(lockAcquired).toBe(true);
+    });
+});

--- a/packages/dev/core/test/unit/Misc/asyncLock.test.ts
+++ b/packages/dev/core/test/unit/Misc/asyncLock.test.ts
@@ -128,14 +128,10 @@ describe("AsyncLock", () => {
             return operation2Completed.promise;
         });
 
-        const promise = AsyncLock.LockAsync(
-            () => {
-                lockAcquired = true;
-                return 42;
-            },
-            asyncLock1,
-            asyncLock2
-        );
+        const promise = AsyncLock.LockAsync(() => {
+            lockAcquired = true;
+            return 42;
+        }, [asyncLock1, asyncLock2]);
 
         await whenJSFrames(5);
         expect(lockAcquired).toBe(false);
@@ -162,9 +158,8 @@ describe("AsyncLock", () => {
             () => {
                 lockAcquired = true;
             },
-            abortController.signal,
-            asyncLock1,
-            asyncLock2
+            [asyncLock1, asyncLock2],
+            abortController.signal
         );
 
         const expectedAbortReason = "Aborting operation before it starts.";
@@ -191,13 +186,9 @@ describe("AsyncLock", () => {
         asyncLock2.lockAsync(() => {}, abortController.signal);
 
         let lockAcquired = false;
-        AsyncLock.LockAsync(
-            () => {
-                lockAcquired = true;
-            },
-            asyncLock1,
-            asyncLock2
-        );
+        AsyncLock.LockAsync(() => {
+            lockAcquired = true;
+        }, [asyncLock1, asyncLock2]);
 
         expect(lockAcquired).toBe(false);
         abortController.abort();


### PR DESCRIPTION
I added this `AsyncLock` as part of the initial alpha viewer impl. I expect to need to better cancellation support and the ability to acquire multiple locks (especially for the dispose scenario), but as much as possible I don't want to keep upping the alpha viewer's min version of the dependency on @babylonjs/core (more of a hassle for consumers), so I wanted to proactively get this additional `AsyncLock` behavior in sooner than later. Since I don't have code using it quite yet, I added unit tests. If there is opposition to adding this code before it is being used, then I can sit on this PR, it just means I'll need to update the min ver on the @babylonjs/core dependency and anyone using the alpha viewer will have to update their @babylonjs/core dependency.