### PR TITLE
Remove check for pointer out

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2344,7 +2344,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @internal
      */
     public _onPointerOut(target: Control, pi: Nullable<PointerInfoBase>, force = false): void {
-        if (!force && (!this._isEnabled || target === this)) {
+        if (!force && !this._isEnabled) {
             return;
         }
         this._enterCount = 0;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/clicking-through-world-ui/51905?u=raananw

The problem is that (almost) every direct call for this function is calling:

`this._lastControlOver[pointerId]._onPointerOut(this._lastControlOver[pointerId], pi);`, meaning it will always return unless force is passed (which isn't being passed on standard input loop).

The call that does not use the same object to the call checks beforehnd if the target and `this` are equal, so there is no change in the default behavior. Tested with a few UI playgrounds and seems to make no difference in standard behavior.