### PR TITLE
Make `CleanUrl` effective in fileTools.ts

### DIFF
--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -210,7 +210,7 @@ export const LoadImage = (
         usingObjectURL = true;
     } else {
         url = FileToolsOptions.CleanUrl(input);
-        url = FileToolsOptions.PreprocessUrl(input);
+        url = FileToolsOptions.PreprocessUrl(url);
     }
 
     const onErrorHandler = (exception: any) => {


### PR DESCRIPTION
Hi looks like there was a bug in `fileTools.ts`, where the cleaned URL is not passed to `PreprocessUrl`.