### PR TITLE
Wrong loadMipmaps flag in ddsTextureLoader

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -106,7 +106,7 @@ export class _DDSTextureLoader implements IInternalTextureLoader {
     ): void {
         const info = DDSTools.GetDDSInfo(data);
 
-        const loadMipmap = (info.isRGB || info.isLuminance || info.mipmapCount > 1) && texture.generateMipMaps && info.width >> (info.mipmapCount - 1) === 1;
+        const loadMipmap = (info.isRGB || info.isLuminance || info.mipmapCount > 1) && texture.generateMipMaps && Math.max(info.width, info.height) >> (info.mipmapCount - 1) === 1;
         callback(info.width, info.height, loadMipmap, info.isFourCC, () => {
             DDSTools.UploadDDSLevels(texture.getEngine(), texture, data, info, loadMipmap, 1);
         });


### PR DESCRIPTION
https://forum.babylonjs.com/t/wrong-loadmipmaps-flag-in-ddstextureloader/51942

As @RaananW mentioned on forum, there still'll be discussion about presence of `loadMipmaps` parameter at the first place, but here's my temp fix until it is done.