### PR TITLE
changes to image adding when using Image in GUI

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -583,10 +583,12 @@ export class Image extends Control {
         this._domImage = engine.createCanvasImage();
         // need to add to enforce rendering
         const imgElement = this._domImage as HTMLImageElement;
-        if (imgElement.style) {
+        let addedToDom = false;
+        if (imgElement.style && this._source?.endsWith(".svg")) {
             imgElement.style.visibility = "hidden";
             imgElement.style.position = "absolute";
             engine.getRenderingCanvas()?.parentNode?.appendChild(imgElement);
+            addedToDom = true;
         }
 
         if (value) {
@@ -602,10 +604,12 @@ export class Image extends Control {
                         waitingCallback();
                     }
                     cachedData.waitingForLoadCallback.length = 0;
+                    addedToDom && imgElement.remove();
                     return;
                 }
             }
             this._onImageLoaded();
+            addedToDom && imgElement.remove();
         };
         if (value) {
             Tools.SetCorsBehavior(value, this._domImage);


### PR DESCRIPTION
This changes the behavior that was added to support svg files:

1. Only SVGs are added to the DOM (files that end with .svg)
2. The SVGs are removed from thee DOM right after they are no longer needed.

PG for testing: #XCPP9Y#21986