### PR TITLE
[XR] Change default behavior for anchors

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -21,6 +21,12 @@ export interface IWebXRAnchorSystemOptions {
      * If not defined, anchors will be removed from the array when the feature is detached or the session ended.
      */
     doNotRemoveAnchorsOnSessionEnded?: boolean;
+
+    /**
+     * Not setting this flag will clear the anchors array when the session is initialized.
+     * Note that the native anchors will not be removed. The onl thing cleared would be the anchors array of the feature itself.
+     */
+    doNotClearAnchorsOnSessionInit?: boolean;
 }
 
 /**
@@ -140,6 +146,17 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
     ) {
         super(_xrSessionManager);
         this.xrNativeFeatureName = "anchors";
+        // because of a browser issue in chrome, forcing the `doNotRemoveAnchorsOnSessionEnded` to true
+        // will cause the anchors to not be removed from the feature!
+        this._options.doNotRemoveAnchorsOnSessionEnded = true;
+
+        if (!this._options.doNotClearAnchorsOnSessionInit) {
+            this._xrSessionManager.onXRSessionInit.add(() => {
+                this._trackedAnchors.length = 0;
+                this._futureAnchors.length = 0;
+                this._lastFrameDetected.clear();
+            });
+        }
     }
 
     private _tmpVector = new Vector3();

--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -24,7 +24,8 @@ export interface IWebXRAnchorSystemOptions {
 
     /**
      * Not setting this flag will clear the anchors array when the session is initialized.
-     * Note that the native anchors will not be removed. The onl thing cleared would be the anchors array of the feature itself.
+     * Note that the native anchors will not be removed. The only thing cleared would be the anchors array of the feature itself.
+
      */
     doNotClearAnchorsOnSessionInit?: boolean;
 }

--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -334,7 +334,7 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
                     const newAnchor: Partial<IWebXRAnchor> = {
                         id: anchorIdProvider++,
                         xrAnchor: xrAnchor,
-                        remove: () => {},
+                        remove: () => xrAnchor.delete(),
                     };
                     const anchor = this._updateAnchorWithXRFrame(xrAnchor, newAnchor, frame);
                     this._trackedAnchors.push(anchor);

--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -144,11 +144,11 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         _xrSessionManager: WebXRSessionManager,
         private _options: IWebXRAnchorSystemOptions = {}
     ) {
-        super(_xrSessionManager);
-        this.xrNativeFeatureName = "anchors";
         // because of a browser issue in chrome, forcing the `doNotRemoveAnchorsOnSessionEnded` to true
         // will cause the anchors to not be removed from the feature!
-        this._options.doNotRemoveAnchorsOnSessionEnded = true;
+        _options.doNotRemoveAnchorsOnSessionEnded = true;
+        super(_xrSessionManager);
+        this.xrNativeFeatureName = "anchors";
 
         if (!this._options.doNotClearAnchorsOnSessionInit) {
             this._xrSessionManager.onXRSessionInit.add(() => {
@@ -334,7 +334,7 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
                     const newAnchor: Partial<IWebXRAnchor> = {
                         id: anchorIdProvider++,
                         xrAnchor: xrAnchor,
-                        remove: () => xrAnchor.delete(),
+                        remove: () => {},
                     };
                     const anchor = this._updateAnchorWithXRFrame(xrAnchor, newAnchor, frame);
                     this._trackedAnchors.push(anchor);


### PR DESCRIPTION
It seems like chrome has an issue with removing created anchors after a session has ended. I am still investigating the source of the issue, but until then - setting the flag to true to not remove the anchors on session end allows the scene to continue correctly.

Also added a new flag to reset the list of anchors on session init (without using the webxr "delete" function)