### PR TITLE
Fixed Playground loading on custom SnippetID

### DIFF
--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -38,7 +38,6 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                 this._load();
             })
             .catch((err) => {
-                //console.log("Unable to load procedural.json", err);
                 this._load();
             });
     }

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -31,7 +31,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         super(props);
         // First Fetch JSON data for procedural code
         this._procedural = [];
-        const url = "procedural.json?uncacher="+Date.now();
+        const url = "procedural.json?uncacher=" + Date.now();
         fetch(url)
             .then((response) => response.json())
             .then((data) => {

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -31,7 +31,8 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         super(props);
         // First Fetch JSON data for procedural code
         this._procedural = [];
-        fetch("procedural.json")
+        const url = "procedural.json?uncacher="+Date.now();
+        fetch(url)
             .then((response) => response.json())
             .then((data) => {
                 this._procedural = data;

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -37,16 +37,12 @@ export class MonacoManager {
     public constructor(public globalState: GlobalState) {
         // First Fetch JSON data for templates code
         this._templates = [];
+        this._load(globalState);
         fetch("templates.json")
             .then((response) => response.json())
             .then((data) => {
                 this._templates = data;
-                this._load(globalState);
             })
-            .catch((err) => {
-                //console.log("Unable to load templates.json", err);
-                this._load(globalState);
-            });
     }
 
     private _load(globalState: GlobalState) {
@@ -245,7 +241,7 @@ class Playground {
         let code = "";
 
         // Scene
-        code += "// Create a new Scene :\n";
+        code += "\n// Create a new Scene :\n";
         code += "var scene = new BABYLON.Scene(engine);\n";
 
         if (debugLayer) {

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -38,7 +38,8 @@ export class MonacoManager {
         // First Fetch JSON data for templates code
         this._templates = [];
         this._load(globalState);
-        fetch("templates.json")
+        const url = "templates.json?uncacher="+Date.now();
+        fetch(url)
             .then((response) => response.json())
             .then((data) => {
                 this._templates = data;

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -38,12 +38,12 @@ export class MonacoManager {
         // First Fetch JSON data for templates code
         this._templates = [];
         this._load(globalState);
-        const url = "templates.json?uncacher="+Date.now();
+        const url = "templates.json?uncacher=" + Date.now();
         fetch(url)
             .then((response) => response.json())
             .then((data) => {
                 this._templates = data;
-            })
+            });
     }
 
     private _load(globalState: GlobalState) {


### PR DESCRIPTION
In my last [PR adding the procedural code generator](https://github.com/BabylonJS/Babylon.js/pull/15243), I inserted the JSON fetch in the monacoEditor constructor, to make sure it was loaded first, but the `_load` function was called after the fetch, which could lead to "forever" engine loading UI in the event of [loading a custom PG](https://playground.babylonjs.com/#4U4QH9#9).

- This PR fixes the previous issue. (--> `_load` before `fetch`)
- It also fixes the [potential cache issue](https://forum.babylonjs.com/t/edit-released-what-about-a-code-generator-for-the-playground/50396/34) by adding an `uncacher` param to the JSON urls (since it's very light) :
`const url = "templates.json?uncacher="+Date.now();`
- Missing `"\n"` at beginning of generated code was added