### PR TITLE
New HTML Text wrapping mode

### DIFF
--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -490,7 +490,7 @@ export class TextBlock extends Control {
 
     protected _breakLines(refWidth: number, refHeight: number, context: ICanvasRenderingContext): object[] {
         this._linesTemp.length = 0;
-        const _lines = this.text.split("\n");
+        const _lines = this._textWrapping === TextWrapping.HTML ? this._parseHTMLText(refWidth, refHeight, context) : this.text.split("\n");
 
         switch (this._textWrapping) {
             case TextWrapping.WordWrap:
@@ -509,12 +509,6 @@ export class TextBlock extends Control {
                 }
                 break;
             case TextWrapping.HTML:
-                _lines.length = 0;
-                _lines.push(...this._parseHTMLText(refWidth, refHeight, context));
-                for (const _line of _lines) {
-                    this._linesTemp.push(this._parseLine(_line, context));
-                }
-                break;
             default:
                 for (const _line of _lines) {
                     this._linesTemp.push(this._parseLine(_line, context));

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -519,12 +519,19 @@ export class TextBlock extends Control {
         return this._linesTemp;
     }
 
+    private _htmlElement: HTMLElement;
+
     protected _parseHTMLText(refWidth: number, refHeight: number, context: ICanvasRenderingContext): string[] {
         const lines = [] as string[];
-        const htmlElement = document.createElement("div");
-        htmlElement.innerHTML = this.text;
+        if (!this._htmlElement) {
+            this._htmlElement = document.createElement("div");
+            document.body.appendChild(this._htmlElement);
+        }
+        const htmlElement = this._htmlElement;
+        htmlElement.textContent = this.text;
         htmlElement.style.font = context.font;
         htmlElement.style.position = "absolute";
+        htmlElement.style.visibility = "hidden";
         htmlElement.style.top = "-1000px";
         htmlElement.style.left = "-1000px";
         this.adjustWordWrappingHTMLElement?.(htmlElement);
@@ -534,8 +541,6 @@ export class TextBlock extends Control {
         if (!textContent) {
             return lines;
         }
-        document.body.appendChild(htmlElement);
-
         // get the text node
         const textNode = htmlElement.childNodes[0];
         const range = document.createRange();
@@ -548,8 +553,6 @@ export class TextBlock extends Control {
             lines[lineIndex] = (lines[lineIndex] || "") + c;
             idx++;
         }
-
-        document.body.removeChild(htmlElement);
 
         return lines;
     }
@@ -736,6 +739,7 @@ export class TextBlock extends Control {
         super.dispose();
 
         this.onTextChangedObservable.clear();
+        this._htmlElement?.remove();
     }
 }
 RegisterClass("BABYLON.GUI.TextBlock", TextBlock);

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -30,7 +30,12 @@ export const enum TextWrapping {
     /**
      * Wrap the text word-wise and clip the text when the text's height is larger than the Control.height, and shrink the last line with trailing … .
      */
-    WordWrapEllipsis,
+    WordWrapEllipsis = 3,
+
+    /**
+     * Use HTML to wrap the text. This is the only mode that supports east-asian languages.
+     */
+    HTML = 4,
 }
 
 /**
@@ -67,6 +72,13 @@ export class TextBlock extends Control {
      * Function used to split a string into words. By default, a string is split at each space character found
      */
     public wordSplittingFunction: Nullable<(line: string) => string[]>;
+
+    /**
+     * This function will be called when a new HTML element is generated to be used for word wrapping.
+     * This is only used when wrapping mode HTML is selected.
+     * Using this function you can adjust word-break, overflow-wrap, hyphens, or any other CSS properties of the HTML element, language-dependent.
+     */
+    public adjustWordWrappingHTMLElement: Nullable<(element: HTMLElement) => void>;
 
     /**
      * Return the line list (you may need to use the onLinesReadyObservable to make sure the list is ready)
@@ -480,25 +492,72 @@ export class TextBlock extends Control {
         this._linesTemp.length = 0;
         const _lines = this.text.split("\n");
 
-        if (this._textWrapping === TextWrapping.Ellipsis) {
-            for (const _line of _lines) {
-                this._linesTemp.push(this._parseLineEllipsis(_line, refWidth, context));
-            }
-        } else if (this._textWrapping === TextWrapping.WordWrap) {
-            for (const _line of _lines) {
-                this._linesTemp.push(...this._parseLineWordWrap(_line, refWidth, context));
-            }
-        } else if (this._textWrapping === TextWrapping.WordWrapEllipsis) {
-            for (const _line of _lines) {
-                this._linesTemp.push(...this._parseLineWordWrapEllipsis(_line, refWidth, refHeight!, context));
-            }
-        } else {
-            for (const _line of _lines) {
-                this._linesTemp.push(this._parseLine(_line, context));
-            }
+        switch (this._textWrapping) {
+            case TextWrapping.WordWrap:
+                for (const _line of _lines) {
+                    this._linesTemp.push(...this._parseLineWordWrap(_line, refWidth, context));
+                }
+                break;
+            case TextWrapping.Ellipsis:
+                for (const _line of _lines) {
+                    this._linesTemp.push(this._parseLineEllipsis(_line, refWidth, context));
+                }
+                break;
+            case TextWrapping.WordWrapEllipsis:
+                for (const _line of _lines) {
+                    this._linesTemp.push(...this._parseLineWordWrapEllipsis(_line, refWidth, refHeight, context));
+                }
+                break;
+            case TextWrapping.HTML:
+                _lines.length = 0;
+                _lines.push(...this._parseHTMLText(refWidth, refHeight, context));
+                for (const _line of _lines) {
+                    this._linesTemp.push(this._parseLine(_line, context));
+                }
+                break;
+            default:
+                for (const _line of _lines) {
+                    this._linesTemp.push(this._parseLine(_line, context));
+                }
+                break;
         }
 
         return this._linesTemp;
+    }
+
+    protected _parseHTMLText(refWidth: number, refHeight: number, context: ICanvasRenderingContext): string[] {
+        const lines = [] as string[];
+        const htmlElement = document.createElement("div");
+        htmlElement.innerHTML = this.text;
+        htmlElement.style.font = context.font;
+        htmlElement.style.position = "absolute";
+        htmlElement.style.top = "-1000px";
+        htmlElement.style.left = "-1000px";
+        this.adjustWordWrappingHTMLElement?.(htmlElement);
+        htmlElement.style.width = refWidth + "px";
+        htmlElement.style.height = refHeight + "px";
+        const textContent = htmlElement.textContent;
+        if (!textContent) {
+            return lines;
+        }
+        document.body.appendChild(htmlElement);
+
+        // get the text node
+        const textNode = htmlElement.childNodes[0];
+        const range = document.createRange();
+        let idx = 0;
+        for (const c of textContent) {
+            range.setStart(textNode, 0);
+            range.setEnd(textNode, idx + 1);
+            // "select" text from beginning to this position to determine the line
+            const lineIndex = range.getClientRects().length - 1;
+            lines[lineIndex] = (lines[lineIndex] || "") + c;
+            idx++;
+        }
+
+        document.body.removeChild(htmlElement);
+
+        return lines;
     }
 
     protected _parseLine(line: string = "", context: ICanvasRenderingContext): object {

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -81,6 +81,11 @@ export class TextBlock extends Control {
     public adjustWordWrappingHTMLElement: Nullable<(element: HTMLElement) => void>;
 
     /**
+     * Gets or sets a boolean indicating if the HTML element generated for word wrapping should be reused or removed after each wrapping.
+     */
+    public reuseHTMLForWordWrapping: boolean = false;
+
+    /**
      * Return the line list (you may need to use the onLinesReadyObservable to make sure the list is ready)
      */
     public get lines(): any[] {
@@ -519,7 +524,7 @@ export class TextBlock extends Control {
         return this._linesTemp;
     }
 
-    private _htmlElement: HTMLElement;
+    private _htmlElement: Nullable<HTMLElement> = null;
 
     protected _parseHTMLText(refWidth: number, refHeight: number, context: ICanvasRenderingContext): string[] {
         const lines = [] as string[];
@@ -552,6 +557,11 @@ export class TextBlock extends Control {
             const lineIndex = range.getClientRects().length - 1;
             lines[lineIndex] = (lines[lineIndex] || "") + c;
             idx++;
+        }
+
+        if (!this.reuseHTMLForWordWrapping) {
+            htmlElement.remove();
+            this._htmlElement = null;
         }
 
         return lines;
@@ -740,6 +750,7 @@ export class TextBlock extends Control {
 
         this.onTextChangedObservable.clear();
         this._htmlElement?.remove();
+        this._htmlElement = null;
     }
 }
 RegisterClass("BABYLON.GUI.TextBlock", TextBlock);


### PR DESCRIPTION
Introducing a new text wrapping mode in the GUI's text block - HTML.

The HTML wrapping mode will use a native HTML element to decide how to wrap the text. Especially useful for east-asian languages (CJK) that don't separate words with a " ", which is the method we used until now. It is possible to configure the HTML element to fit the needs of the application. Per default it is using the default wrapping configuration of an HTML element.

Playground to test with: https://playground.babylonjs.com/?snapshot=refs/pull/15266/merge#44KYLP#499