### PR TITLE
AnimationGroup start should restart if an animatable is available

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -859,6 +859,9 @@ export class AnimationGroup implements IDisposable {
      * Dispose all associated resources
      */
     public dispose(): void {
+        if (this.isStarted) {
+            this.stop();
+        }
         this._targetedAnimations.length = 0;
         this._animatables.length = 0;
 

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -717,8 +717,8 @@ export class AnimationGroup implements IDisposable {
      * @returns the animation group
      */
     public play(loop?: boolean): AnimationGroup {
-        // only if all animatables are ready and exist
-        if (this.isStarted && this._animatables.length === this._targetedAnimations.length) {
+        // only if there are animatable available
+        if (this.isStarted && this._animatables.length) {
             if (loop !== undefined) {
                 this.loopAnimation = loop;
             }
@@ -754,7 +754,7 @@ export class AnimationGroup implements IDisposable {
     }
 
     /**
-     * Restart animations from key 0
+     * Restart animations from after pausing it
      * @returns the animation group
      */
     public restart(): AnimationGroup {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/animationgroup-documentation-issue/52001?u=raananw

PG to test with - #ZI9AK7#4084

Also addressing https://forum.babylonjs.com/t/scene-removeanimationgroup-not-working/52006?u=raananw - the dispose function will stop the animation if it is running.