### PR TITLE
Playground code generator : from Destructive to Additive - Inserting Code Snippets at cursor position"

### DIFF
--- a/packages/tools/playground/public/procedural.json
+++ b/packages/tools/playground/public/procedural.json
@@ -1,93 +1,65 @@
 [
     {
-        "label": "Run",
-        "tooltip": "Run the code generator with these params",
-        "onClick": "onGenerate"
-    },
-    {
-        "label": "Run Auto",
-        "tooltip": "Automatic run of the code generator on param change",
-        "storeKey": "generateAuto",
-        "defaultValue": true,
-        "onCheck": "empty",
+        "label": "Scene",
+        "tooltip": "Scene tools",
+        "defaultValue": "Debug Layer",
+        "subItems": ["Debug Layer", "Shadows", "Skybox", "Audio", "Lens Flare", "Sprites"],
+        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
-        "label": "Debug Layer",
-        "tooltip": "Open debug layer",
-        "storeKey": "debugLayer",
-        "defaultValue": false,
-        "onCheck": "onUpdateGenerator",
-        "keepExpanded": true
-    },
-    {
-        "label": "Camera",
+        "label": "Cameras",
         "tooltip": "Select a camera type",
-        "storeKey": "useCamera",
         "defaultValue": "Arc Rotate (Rad)",
         "subItems": ["Arc Rotate (Rad)", "Arc Rotate (Deg)", "Free", "WebXR"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
-        "label": "Light",
+        "label": "Lights",
         "tooltip": "Select a light type",
-        "storeKey": "useLight",
         "defaultValue": "Hemispheric",
         "subItems": ["Hemispheric", "Directionnal", "Point", "Spot", "3 Spots"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
-        "label": "Shadows",
-        "tooltip": "Enable shadows",
-        "storeKey": "useShadows",
-        "defaultValue": false,
-        "onCheck": "onUpdateGenerator",
-        "keepExpanded": true
-    },
-    {
         "label": "Mesh Builder",
         "tooltip": "Build meshes using BABYLON.MeshBuilder",
-        "storeKeys": ["useGround", "useSphere", "useBox", "useCylinder"],
-        "defaultValues": [true, true, false, false],
+        "defaultValue": "Ground",
         "subItems": ["Ground", "Sphere", "Box", "Cylinder"],
-        "onCheck": "onUpdateGenerator",
+        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Animations",
         "tooltip": "Import animated characters",
-        "storeKey": "useAnimation",
-        "defaultValue": "None",
-        "subItems": ["None", "Dude", "Dummy", "Samba Girl"],
+        "defaultValue": "Dude",
+        "subItems": ["Dude", "Dummy", "Samba Girl"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Particles",
         "tooltip": "Add a simple particle system to the scene",
-        "storeKey": "useParticles",
-        "defaultValue": "None",
-        "subItems": ["None", "Simple", "Color Gradient", "Complex"],
+        "defaultValue": "Simple",
+        "subItems": ["Simple", "Color Gradient", "Complex"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Load Snippet",
         "tooltip": "Load asset from Snippet Server",
-        "storeKey": "useSnippet",
-        "defaultValue": "None",
-        "subItems": ["None", "Particles", "Node Material", "GUI", "GUI on Mesh"],
+        "defaultValue": "Particles",
+        "subItems": ["Particles", "Node Material", "GUI", "GUI on Mesh"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Import / Export",
         "tooltip": "Import or Export assets",
-        "storeKey": "useImport",
-        "defaultValue": "None",
-        "subItems": ["None", "Import Mesh", "Export GLB", "Export GLTF"],
+        "defaultValue": "Import Mesh",
+        "subItems": ["Import Mesh", "Export GLB", "Export GLTF"],
         "onClick": "onUpdateGenerator",
         "keepExpanded": true
     }

--- a/packages/tools/playground/public/procedural.json
+++ b/packages/tools/playground/public/procedural.json
@@ -2,65 +2,49 @@
     {
         "label": "Scene",
         "tooltip": "Scene tools",
-        "defaultValue": "Debug Layer",
         "subItems": ["Debug Layer", "Shadows", "Skybox", "Audio", "Lens Flare", "Sprites"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Cameras",
         "tooltip": "Select a camera type",
-        "defaultValue": "Arc Rotate (Rad)",
         "subItems": ["Arc Rotate (Rad)", "Arc Rotate (Deg)", "Free", "WebXR"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Lights",
         "tooltip": "Select a light type",
-        "defaultValue": "Hemispheric",
         "subItems": ["Hemispheric", "Directionnal", "Point", "Spot", "3 Spots"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Mesh Builder",
         "tooltip": "Build meshes using BABYLON.MeshBuilder",
-        "defaultValue": "Ground",
         "subItems": ["Ground", "Sphere", "Box", "Cylinder"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Animations",
         "tooltip": "Import animated characters",
-        "defaultValue": "Dude",
         "subItems": ["Dude", "Dummy", "Samba Girl"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Particles",
         "tooltip": "Add a simple particle system to the scene",
-        "defaultValue": "Simple",
         "subItems": ["Simple", "Color Gradient", "Complex"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Load Snippet",
         "tooltip": "Load asset from Snippet Server",
-        "defaultValue": "Particles",
         "subItems": ["Particles", "Node Material", "GUI", "GUI on Mesh"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     },
     {
         "label": "Import / Export",
         "tooltip": "Import or Export assets",
-        "defaultValue": "Import Mesh",
         "subItems": ["Import Mesh", "Export GLB", "Export GLTF"],
-        "onClick": "onUpdateGenerator",
         "keepExpanded": true
     }
 ]

--- a/packages/tools/playground/public/templates.json
+++ b/packages/tools/playground/public/templates.json
@@ -1,29 +1,69 @@
 [
     {
-        "label": "Show the Inspector",
-        "key": "debugLayer",
+        "label": "Scene : Show the Inspector",
+        "key": "Debug Layer",
         "documentation": "https://doc.babylonjs.com/toolsAndResources/inspector",
         "insertText": "scene.debugLayer.show();",
         "plainText": "scene.debugLayer.show();"
     },
     {
+        "label": "Scene : Setup a shadow generator",
+        "key": "Shadows",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/shadows",
+        "insertText": "var shadowGenerator = new BABYLON.ShadowGenerator(${1:1024}, ${2:light});\nshadowGenerator.useExponentialShadowMap = true;",
+        "plainText": "var shadowGenerator = new BABYLON.ShadowGenerator(1024, light);\nshadowGenerator.useExponentialShadowMap = true;"
+    },
+    {
+        "label": "Scene : Setup a Skybox",
+        "key": "Skybox",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/environment/skybox",
+        "insertText": "var skybox = BABYLON.MeshBuilder.CreateBox(\"skyBox\", {size:1000.0}, scene);\nvar skyboxMaterial = new BABYLON.StandardMaterial(\"skyBox\", scene);\nskyboxMaterial.backFaceCulling = false;\nskyboxMaterial.reflectionTexture = new BABYLON.CubeTexture(\"textures/skybox\", scene);\nskyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;\nskyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);\nskyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0); skybox.material = skyboxMaterial;",
+        "plainText": "var skybox = BABYLON.MeshBuilder.CreateBox(\"skyBox\", {size:1000.0}, scene);\nvar skyboxMaterial = new BABYLON.StandardMaterial(\"skyBox\", scene);\nskyboxMaterial.backFaceCulling = false;\nskyboxMaterial.reflectionTexture = new BABYLON.CubeTexture(\"textures/skybox\", scene);\nskyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;\nskyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);\nskyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0); skybox.material = skyboxMaterial;"
+    },
+    {
+        "label": "Scene : Setup a lens flare system",
+        "key": "Lens Flare",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/environment/lenseFlare",
+        "insertText": "var lensFlareSystem = new BABYLON.LensFlareSystem(\"lensFlareSystem\", scene.getMeshByName(\"Cylinder_004\"), scene);\nvar flare00 = new BABYLON.LensFlare(0.1, 0, new BABYLON.Color3(1, 1, 1), \"textures/flare.png\", lensFlareSystem);\nvar flare01 = new BABYLON.LensFlare(0.075, 0.5, new BABYLON.Color3(0.8, 0.56, 0.72), \"textures/flare3.png\", lensFlareSystem);\nvar flare02 = new BABYLON.LensFlare(0.1, -0.15, new BABYLON.Color3(0.71, 0.8, 0.95), \"textures/Flare2.png\", lensFlareSystem);\nvar flare03 = new BABYLON.LensFlare(0.15, 0.25, new BABYLON.Color3(0.95, 0.89, 0.71), \"textures/flare.png\", lensFlareSystem);",
+        "plainText": "var lensFlareSystem = new BABYLON.LensFlareSystem(\"lensFlareSystem\", scene.getMeshByName(\"Cylinder_004\"), scene);\nvar flare00 = new BABYLON.LensFlare(0.1, 0, new BABYLON.Color3(1, 1, 1), \"textures/flare.png\", lensFlareSystem);\nvar flare01 = new BABYLON.LensFlare(0.075, 0.5, new BABYLON.Color3(0.8, 0.56, 0.72), \"textures/flare3.png\", lensFlareSystem);\nvar flare02 = new BABYLON.LensFlare(0.1, -0.15, new BABYLON.Color3(0.71, 0.8, 0.95), \"textures/Flare2.png\", lensFlareSystem);\nvar flare03 = new BABYLON.LensFlare(0.15, 0.25, new BABYLON.Color3(0.95, 0.89, 0.71), \"textures/flare.png\", lensFlareSystem);"
+    },
+    {
+        "label": "Scene : Setup audio in the scene",
+        "key": "Audio",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic#how-to-play-sounds-and-music",
+        "insertText": "var music = new BABYLON.Sound(\"Violons\", \"sounds/violons11.wav\", scene, null, {loop: true, autoplay: true});",
+        "plainText": "var music = new BABYLON.Sound(\"Violons\", \"sounds/violons11.wav\", scene, null, {loop: true, autoplay: true});"
+    },
+    {
+        "label": "Scene : Setup a Sprite System",
+        "key": "Sprites",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/sprites/sprite_map",
+        "insertText": "// Load the spritesheet (with appropriate settings) associated with the JSON Atlas.\nlet spriteSheet = new BABYLON.Texture(\"textures/spriteMap/none_trimmed/Legends_Level_A.png\", scene,\n    false, //NoMipMaps\n    false, //InvertY usually false if exported from TexturePacker\n    BABYLON.Texture.NEAREST_NEAREST, //Sampling Mode\n    null, //Onload, you could spin up the sprite map in a function nested here\n    null, //OnError\n    null, //CustomBuffer\n    false, //DeleteBuffer\n    BABYLON.Engine.TEXTURETYPE_RGBA //ImageFormageType RGBA\n);\n// Create an assets manager to load the JSON file\nconst assetsManager = new BABYLON.AssetsManager(scene);\nconst textTask = assetsManager.addTextFileTask(\"text task\", \"textures/spriteMap/none_trimmed/Legends_Level_A.json\");\n// Create the sprite map on succeful loading\ntextTask.onSuccess = (task) => {\n    let background = new BABYLON.SpriteMap(\"background\", JSON.parse(task.text), spriteSheet, {\n            stageSize: new BABYLON.Vector2(2, 2),\n            flipU: true //Sometimes you need to flip, depending on the sprite format.\n        }, scene);\n    // Set 4 sprites one per tile.\n    for (let i = 0; i < 4; i++) {\n        background.changeTiles(0, new BABYLON.Vector2(i % 2, Math.floor(i / 2)), 9 * i + 9);\n    }\n};\n//load the assets manager\nassetsManager.load();",
+        "plainText": "// Load the spritesheet (with appropriate settings) associated with the JSON Atlas.\nlet spriteSheet = new BABYLON.Texture(\"textures/spriteMap/none_trimmed/Legends_Level_A.png\", scene,\n    false, //NoMipMaps\n    false, //InvertY usually false if exported from TexturePacker\n    BABYLON.Texture.NEAREST_NEAREST, //Sampling Mode\n    null, //Onload, you could spin up the sprite map in a function nested here\n    null, //OnError\n    null, //CustomBuffer\n    false, //DeleteBuffer\n    BABYLON.Engine.TEXTURETYPE_RGBA //ImageFormageType RGBA\n);\n// Create an assets manager to load the JSON file\nconst assetsManager = new BABYLON.AssetsManager(scene);\nconst textTask = assetsManager.addTextFileTask(\"text task\", \"textures/spriteMap/none_trimmed/Legends_Level_A.json\");\n// Create the sprite map on succeful loading\ntextTask.onSuccess = (task) => {\n    let background = new BABYLON.SpriteMap(\"background\", JSON.parse(task.text), spriteSheet, {\n            stageSize: new BABYLON.Vector2(2, 2),\n            flipU: true //Sometimes you need to flip, depending on the sprite format.\n        }, scene);\n    // Set 4 sprites one per tile.\n    for (let i = 0; i < 4; i++) {\n        background.changeTiles(0, new BABYLON.Vector2(i % 2, Math.floor(i / 2)), 9 * i + 9);\n    }\n};\n//load the assets manager\nassetsManager.load();"
+    },
+
+
+
+
+
+    {
         "label": "Add Camera : Arc Rotate Camera w/Radians",
         "key": "Arc Rotate (Rad)",
-        "documentation": "https://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
         "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", ${2:0}, ${3:1}, ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);",
         "plainText": "var camera = new BABYLON.ArcRotateCamera(\"camera\", 0, 1, 10, BABYLON.Vector3.Zero(), scene);\ncamera.attachControl(canvas, true);"
     },
     {
         "label": "Add Camera : Arc Rotate Camera w/Degrees",
         "key": "Arc Rotate (Deg)",
-        "documentation": "https://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
         "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", BABYLON.Tools.ToRadians(${2:0}), BABYLON.Tools.ToRadians(${3:57.3}), ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);",
         "plainText": "var camera = new BABYLON.ArcRotateCamera(\"camera\", 0, BABYLON.Tools.ToRadians(57.3), 10, BABYLON.Vector3.Zero(), scene);\ncamera.attachControl(canvas, true);"
     },
     {
         "label": "Add Camera : Free Camera",
         "key": "Free",
-        "documentation": "https://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
         "insertText": "var camera = new BABYLON.FreeCamera(\"${1:camera}\", ${2:new BABYLON.Vector3(8, 3, 0)}, scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);",
         "plainText": "var camera = new BABYLON.FreeCamera(\"camera\", new BABYLON.Vector3(8, 3, 0), scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);"
     },
@@ -42,35 +82,35 @@
     {
         "label": "Add Light : Hemispheric light",
         "key": "Hemispheric",
-        "documentation": "https://doc.babylonjs.com/babylon101/lights#the-hemispheric-light",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-hemispheric-light",
         "insertText": "var light = new BABYLON.HemisphericLight(\"${1:hemiLight}\", new BABYLON.Vector3(${2:0}, ${3:1}, ${4:0}), scene);",
         "plainText": "var light = new BABYLON.HemisphericLight(\"hemiLight\", new BABYLON.Vector3(0,1,0), scene);"
     },
     {
         "label": "Add Light : Directional light",
         "key": "Directionnal",
-        "documentation": "https://doc.babylonjs.com/babylon101/lights#the-directional-light",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-directional-light",
         "insertText": "var light = new BABYLON.DirectionalLight(\"${1:dirLight}\", new BABYLON.Vector3(${2:-1},${3:-2},${4:-1}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});",
         "plainText": "var light = new BABYLON.DirectionalLight(\"dirLight\", new BABYLON.Vector3(-1,-2,-1), scene);\nlight.position = new BABYLON.Vector3(4,8,4);"
     },
     {
         "label": "Add Light : Point light",
         "key": "Point",
-        "documentation": "https://doc.babylonjs.com/babylon101/lights#the-point-light",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-point-light",
         "insertText": "var light = new BABYLON.PointLight(\"${1:pointLight}\", new BABYLON.Vector3(${2:2},${3:4},${4:2}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});",
         "plainText": "var light = new BABYLON.PointLight(\"pointLight\", new BABYLON.Vector3(2,4,2), scene);\nlight.position = new BABYLON.Vector3(4,8,4);"
     },
     {
         "label": "Add Light : Spot light",
         "key": "Spot",
-        "documentation": "https://doc.babylonjs.com/babylon101/lights#the-spot-light",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-spot-light",
         "insertText": "var light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);",
         "plainText": "var light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);"
     },
     {
         "label": "Add Light : Spot lights (3 colors)",
         "key": "3 Spots",
-        "documentation": "https://doc.babylonjs.com/babylon101/lights#the-spot-light",
+        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-spot-light",
         "insertText": "//red spot\nvar light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight.diffuse = new BABYLON.Color3(1, 0, 0);\n\n//green spot\nvar light1 = new BABYLON.SpotLight(\"spotLight1\", new BABYLON.Vector3(0, 4, 1 - Math.sin(Math.PI / 6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight1.diffuse = new BABYLON.Color3(0, 1, 0);\n\n//blue spot\nvar light2 = new BABYLON.SpotLight(\"spotLight2\", new BABYLON.Vector3(Math.cos(Math.PI/6), 4, -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight2.diffuse = new BABYLON.Color3(0, 0, 1);",
         "plainText": "//red spot\nvar light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight.diffuse = new BABYLON.Color3(1, 0, 0);\n\n//green spot\nvar light1 = new BABYLON.SpotLight(\"spotLight1\", new BABYLON.Vector3(0, 4, 1 - Math.sin(Math.PI / 6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight1.diffuse = new BABYLON.Color3(0, 1, 0);\n\n//blue spot\nvar light2 = new BABYLON.SpotLight(\"spotLight2\", new BABYLON.Vector3(Math.cos(Math.PI/6), 4, -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight2.diffuse = new BABYLON.Color3(0, 0, 1);"
     },
@@ -80,41 +120,29 @@
 
 
     {
-        "label": "Setup a shadow generator",
-        "key": "useShadows",
-        "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/shadows",
-        "insertText": "var shadowGenerator = new BABYLON.ShadowGenerator(${1:1024}, ${2:light});\nshadowGenerator.useExponentialShadowMap = true;",
-        "plainText": "var shadowGenerator = new BABYLON.ShadowGenerator(1024, light);\nshadowGenerator.useExponentialShadowMap = true;"
-    },
-
-
-
-
-
-    {
         "label": "Build a ground plane",
-        "key": "useGround",
+        "key": "Ground",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
         "insertText": "var ground = BABYLON.MeshBuilder.CreateGround(\"${1:ground}\", {width: ${2:6}, height: ${3:6}}, scene);",
         "plainText": "var ground = BABYLON.MeshBuilder.CreateGround(\"ground\", {width: 6, height: 6}, scene);"
     },
     {
         "label": "Build a sphere",
-        "key": "useSphere",
+        "key": "Sphere",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
         "insertText": "var sphere = BABYLON.MeshBuilder.CreateSphere(\"${1:sphere}\", {diameter: ${2:2}}, scene);\nsphere.position.y = 1;",
         "plainText": "var sphere = BABYLON.MeshBuilder.CreateSphere(\"sphere\", {diameter: 2}, scene);\nsphere.position.y = 1;"
     },
     {
         "label": "Build a box",
-        "key": "useBox",
+        "key": "Box",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
         "insertText": "var box = BABYLON.MeshBuilder.CreateBox(\"${1:box}\", {size: ${2:2}}, scene);\nbox.position.y = 1;",
         "plainText": "var box = BABYLON.MeshBuilder.CreateBox(\"box\", {size: 2}, scene);\nbox.position.y = 1;"
     },
     {
         "label": "Build a cylinder",
-        "key": "useCylinder",
+        "key": "Cylinder",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
         "insertText": "var cylinder = BABYLON.MeshBuilder.CreateCylinder(\"${1:cylinder}\", {height: ${2:2}, diameter: ${3:1}}, scene);\ncylinder.position.y = 1;",
         "plainText": "var cylinder = BABYLON.MeshBuilder.CreateCylinder(\"cylinder\", {height: 2, diameter: 1}, scene);\ncylinder.position.y = 1;"

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -19,11 +19,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
     private _procedural: {
         label: string;
         tooltip: string;
-        storeKey?: string;
-        defaultValue?: boolean | string;
         subItems?: string[];
-        onClick?: string;
-        onCheck?: string;
         keepExpanded?: boolean;
     }[];
 
@@ -67,8 +63,8 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         this.props.globalState.onNewRequiredObservable.notifyObservers();
     }
 
-    onInsertSnippet() {
-        this.props.globalState.onInsertSnippetRequiredObservable.notifyObservers();
+    onInsertSnippet(snippetKey: string) {
+        this.props.globalState.onInsertSnippetRequiredObservable.notifyObservers(snippetKey);
     }
 
     onClear() {
@@ -194,9 +190,9 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         let proceduralOptions: any[] = [];
         proceduralOptions = this._procedural.map((item) => ({
             ...item,
-            storeKey: "snippetKey",
-            onClick: () => {
-                this.onInsertSnippet();
+            onClick: () => {},
+            onInsert: (snippetKey: string) => {
+                this.onInsertSnippet(snippetKey);
             },
         }));
 

--- a/packages/tools/playground/src/components/commandBarComponent.tsx
+++ b/packages/tools/playground/src/components/commandBarComponent.tsx
@@ -67,12 +67,8 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         this.props.globalState.onNewRequiredObservable.notifyObservers();
     }
 
-    onUpdateGenerator() {
-        this.props.globalState.onUpdateGeneratorRequiredObservable.notifyObservers();
-    }
-
-    onGenerate() {
-        this.props.globalState.onGenerateRequiredObservable.notifyObservers();
+    onInsertSnippet() {
+        this.props.globalState.onInsertSnippetRequiredObservable.notifyObservers();
     }
 
     onClear() {
@@ -198,30 +194,10 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
         let proceduralOptions: any[] = [];
         proceduralOptions = this._procedural.map((item) => ({
             ...item,
-            onClick:
-                typeof item.onClick === "string"
-                    ? {
-                          empty: () => {},
-                          onGenerate: () => {
-                              this.onGenerate();
-                          },
-                          onUpdateGenerator: () => {
-                              this.onUpdateGenerator();
-                          },
-                      }[item.onClick]
-                    : undefined,
-            onCheck:
-                typeof item.onCheck === "string"
-                    ? {
-                          empty: () => {},
-                          onGenerate: () => {
-                              this.onGenerate();
-                          },
-                          onUpdateGenerator: () => {
-                              this.onUpdateGenerator();
-                          },
-                      }[item.onCheck]
-                    : undefined,
+            storeKey: "snippetKey",
+            onClick: () => {
+                this.onInsertSnippet();
+            },
         }));
 
         // Engine Version Options

--- a/packages/tools/playground/src/components/commandDropdownComponent.tsx
+++ b/packages/tools/playground/src/components/commandDropdownComponent.tsx
@@ -16,6 +16,7 @@ interface ICommandDropdownComponentProps {
         tooltip?: string;
         onClick?: () => void;
         onCheck?: (value: boolean) => void;
+        onInsert?: (value: string) => void;
         storeKey?: string;
         isActive?: boolean;
         defaultValue?: boolean | string;
@@ -94,7 +95,6 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                             if (m.validate && !m.validate()) {
                                                 return;
                                             }
-
                                             if (!m.onClick) {
                                                 const newValue = !Utilities.ReadBoolFromStore(m.storeKey!, (m.defaultValue as boolean) || false);
                                                 Utilities.StoreBoolToStore(m.storeKey!, newValue);
@@ -153,6 +153,9 @@ export class CommandDropdownComponent extends React.Component<ICommandDropdownCo
                                                                 }
                                                                 if (m.storeKey) {
                                                                     Utilities.StoreStringToStore(m.storeKey, s, this.props.useSessionStorage);
+                                                                }
+                                                                if (m.onInsert) {
+                                                                    m.onInsert(s);
                                                                 }
                                                                 m.onClick!();
                                                                 this.setState({ isExpanded: m.keepExpanded || false });

--- a/packages/tools/playground/src/globalState.ts
+++ b/packages/tools/playground/src/globalState.ts
@@ -44,8 +44,7 @@ export class GlobalState {
     public onRunExecutedObservable = new Observable<void>();
     public onSavedObservable = new Observable<void>();
     public onNewRequiredObservable = new Observable<void>();
-    public onUpdateGeneratorRequiredObservable = new Observable<void>();
-    public onGenerateRequiredObservable = new Observable<void>();
+    public onInsertSnippetRequiredObservable = new Observable<void>();
     public onClearRequiredObservable = new Observable<void>();
     public onSaveRequiredObservable = new Observable<void>();
     public onLoadRequiredObservable = new Observable<string>();

--- a/packages/tools/playground/src/globalState.ts
+++ b/packages/tools/playground/src/globalState.ts
@@ -44,7 +44,7 @@ export class GlobalState {
     public onRunExecutedObservable = new Observable<void>();
     public onSavedObservable = new Observable<void>();
     public onNewRequiredObservable = new Observable<void>();
-    public onInsertSnippetRequiredObservable = new Observable<void>();
+    public onInsertSnippetRequiredObservable = new Observable<string>();
     public onClearRequiredObservable = new Observable<void>();
     public onSaveRequiredObservable = new Observable<void>();
     public onLoadRequiredObservable = new Observable<string>();

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -62,8 +62,8 @@ export class MonacoManager {
             }
         });
 
-        globalState.onInsertSnippetRequiredObservable.add(() => {
-            this._insertSnippet();
+        globalState.onInsertSnippetRequiredObservable.add((snippetKey: string) => {
+            this._insertSnippet(snippetKey);
         });
 
         globalState.onClearRequiredObservable.add(() => {
@@ -231,12 +231,9 @@ class Playground {
         }
     }
 
-    private _insertSnippet() {
-        const snippetKey = Utilities.ReadStringFromStore("snippetKey", "");
-        if (snippetKey.length) {
-            const snippet = this._getCode(snippetKey);
-            this._insertCodeAtCursor(snippet);
-        }
+    private _insertSnippet(snippetKey: string) {
+        const snippet = this._getCode(snippetKey);
+        this._insertCodeAtCursor(snippet);
     }
 
     private _resetEditor(resetMetadata?: boolean) {

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -62,18 +62,8 @@ export class MonacoManager {
             }
         });
 
-        globalState.onUpdateGeneratorRequiredObservable.add(() => {
-            if (Utilities.ReadBoolFromStore("generateAuto", true)) {
-                this._setGeneratedContent();
-                this._resetEditor(true);
-            }
-        });
-
-        globalState.onGenerateRequiredObservable.add(() => {
-            if (Utilities.CheckSafeMode("Are you sure you want to create a new playground?")) {
-                this._setGeneratedContent();
-                this._resetEditor(true);
-            }
+        globalState.onInsertSnippetRequiredObservable.add(() => {
+            this._insertSnippet();
         });
 
         globalState.onClearRequiredObservable.add(() => {
@@ -220,126 +210,33 @@ class Playground {
         return code + "\n";
     }
 
-    private _setGeneratedContent() {
-        this._createEditor();
-        this.globalState.currentSnippetToken = "";
-
-        // Retreive user params
-        const debugLayer = Utilities.ReadBoolFromStore("debugLayer", false);
-        const useCamera = Utilities.ReadStringFromStore("useCamera", "Arc Rotate (Rad)");
-        const useLight = Utilities.ReadStringFromStore("useLight", "Hemispheric");
-        const useShadows = Utilities.ReadBoolFromStore("useShadows", false);
-        const useGround = Utilities.ReadBoolFromStore("useGround", true);
-        const useSphere = Utilities.ReadBoolFromStore("useSphere", true);
-        const useBox = Utilities.ReadBoolFromStore("useBox", false);
-        const useCylinder = Utilities.ReadBoolFromStore("useCylinder", false);
-        const useAnimation = Utilities.ReadStringFromStore("useAnimation", "None");
-        const useParticles = Utilities.ReadStringFromStore("useParticles", "None");
-        const useSnippet = Utilities.ReadStringFromStore("useSnippet", "None");
-        const useImport = Utilities.ReadStringFromStore("useImport", "None");
-
-        // Build code
-        let code = "";
-
-        // Scene
-        code += "\n// Create a new Scene :\n";
-        code += "var scene = new BABYLON.Scene(engine);\n";
-
-        if (debugLayer) {
-            code += "\n// Show the inspector :\n";
-            code += this._getCode("debugLayer");
-        }
-
-        // Camera
-        code += "\n// Create a camera and attach it to canvas :\n";
-        code += this._getCode(useCamera);
-
-        // Light
-        code += "\n// Create light :\n";
-        code += this._getCode(useLight);
-
-        // Shadows
-        if (useShadows) {
-            code += "\n// Create a shadow generator :\n";
-            if (useLight == "Hemispheric") {
-                code += "// Shadows cannot be generated with Hemispheric light !\n";
-            } else {
-                code += this._getCode("useShadows");
+    private _insertCodeAtCursor(code: string) {
+        if (this._editor) {
+            // Get the current position of the cursor
+            const position = this._editor?.getPosition();
+            if (position) {
+                // Fix indent regarding current position
+                if (position.column && position.column > 1) {
+                    code = this._indentCode(code, position.column - 1).slice(position.column - 1);
+                }
+                // Insert code
+                this._editor?.executeEdits("", [
+                    {
+                        range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+                        text: code,
+                        forceMoveMarkers: true,
+                    },
+                ]);
             }
         }
+    }
 
-        // Meshes
-        if (useGround || useSphere || useBox || useCylinder) {
-            code += "\n// Add geometry\n";
+    private _insertSnippet() {
+        const snippetKey = Utilities.ReadStringFromStore("snippetKey", "");
+        if (snippetKey.length) {
+            const snippet = this._getCode(snippetKey);
+            this._insertCodeAtCursor(snippet);
         }
-        if (useGround) {
-            code += this._getCode("useGround");
-            if (this._templates.length && useShadows && useLight != "Hemispheric") {
-                code += "ground.receiveShadows = true;\n";
-            }
-        }
-        if (useSphere) {
-            code += this._getCode("useSphere");
-            if (this._templates.length && useShadows && useLight != "Hemispheric") {
-                code += "shadowGenerator.addShadowCaster(sphere);\n";
-            }
-        }
-        if (useBox) {
-            code += this._getCode("useBox");
-            if (this._templates.length && useShadows && useLight != "Hemispheric") {
-                code += "shadowGenerator.addShadowCaster(box);\n";
-            }
-        }
-        if (useCylinder) {
-            code += this._getCode("useCylinder");
-            if (this._templates.length && useShadows && useLight != "Hemispheric") {
-                code += "shadowGenerator.addShadowCaster(cylinder);\n";
-            }
-        }
-
-        // Animations
-        if (useAnimation != "None") {
-            code += "\n// Import animated character :\n";
-            code += this._getCode(useAnimation);
-            if (this._templates.length && useShadows && useLight != "Hemispheric") {
-                code = code.slice(0, code.length - 4) + "    shadowGenerator.addShadowCaster(hero);\n});\n";
-            }
-        }
-
-        // Particles
-        if (useParticles != "None") {
-            code += "\n// Create particle system :\n";
-            code += this._getCode(useParticles);
-        }
-
-        // Snippets
-        if (useSnippet != "None") {
-            code += "\n// Load snippet from server :\n";
-            code += this._getCode(useSnippet);
-        }
-
-        // Import / Export
-        if (useImport != "None") {
-            code += "\n// Import or Export meshes :\n";
-            code += this._getCode(useImport);
-        }
-
-        code += "\n// Return\nreturn scene;";
-
-        // Encapsulate function (Javascript)
-        let all_code = "";
-        if (this.globalState.language === "JS") {
-            all_code = "var createScene = function () {" + this._indentCode(code, 4) + "\n};";
-
-            // Encapsulate function (Typescript)
-        } else {
-            all_code += "class Playground {\n";
-            all_code += "    public static CreateScene(engine: BABYLON.Engine, canvas: HTMLCanvasElement): BABYLON.Scene {" + this._indentCode(code, 8) + "\n";
-            all_code += "    }\n";
-            all_code += "}";
-        }
-        // Edit
-        this._editor?.setValue(all_code);
     }
 
     private _resetEditor(resetMetadata?: boolean) {

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -213,14 +213,14 @@ class Playground {
     private _insertCodeAtCursor(code: string) {
         if (this._editor) {
             // Get the current position of the cursor
-            const position = this._editor?.getPosition();
+            const position = this._editor.getPosition();
             if (position) {
                 // Fix indent regarding current position
                 if (position.column && position.column > 1) {
                     code = this._indentCode(code, position.column - 1).slice(position.column - 1);
                 }
                 // Insert code
-                this._editor?.executeEdits("", [
+                this._editor.executeEdits("", [
                     {
                         range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
                         text: code,


### PR DESCRIPTION
Following discussions on the [Code Generator Topic](https://forum.babylonjs.com/t/edit-released-what-about-a-code-generator-for-the-playground/50396/45), the drop down menu is now only additive and no longer destructive.

- Checkboxes replaced by buttons
- Removed onUpdateGenerator && onGenerate
- Added onInsertSnippet
- Fixing indentation based on cursor position
- Fixed some old dead urls in snippet docs links (`/babylon101/`)
- Added new snippets : Skybox, Lens Flares, Audio, Sprites