### PR TITLE
Move assignment before callback in PointersInput

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -192,10 +192,9 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 if (this._pointA && this._pointB === null) {
                     const offsetX = evt.clientX - this._pointA.x;
                     const offsetY = evt.clientY - this._pointA.y;
-                    this.onTouch(this._pointA, offsetX, offsetY);
-
                     this._pointA.x = evt.clientX;
                     this._pointA.y = evt.clientY;
+                    this.onTouch(this._pointA, offsetX, offsetY);
                 }
                 // Two buttons down: pinch
                 else if (this._pointA && this._pointB) {


### PR DESCRIPTION
If the onTouch callback causes any change in the state of pointers (for example, if you actively lose focus) the point `this._pointA` is set to null, and an exception will be thrown.

There is no reason I can find not to assign the x/y values before running the callback. It actually makes sense to do it before, as the point is passed as a variable.

We don't use the point at all in any of the implementations of onTouch in the framework. It can be considered a breaking change if someone created their own input implementation and implemented onTouch which uses point.x and point.y, expecting it to be a different value (the value before the current frame, or 0,0 on first frame). That's the reason I don't see that as a breaking change.