### PR TITLE
Make isVisible optionally inheritable

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -231,6 +231,12 @@ class _InternalAbstractMeshDataInfo {
      * We use that as a clue to force the material to sideOrientation = null
      */
     public _sideOrientationHint = false;
+
+    /**
+     * @internal
+     * if this is set to true, the mesh will be visible only if its parent(s) are also visible
+     */
+    public _inheritedVisibility = false;
 }
 
 /**
@@ -539,7 +545,13 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     /**
      * If set to true, a mesh will only be visible only if its parent(s) are also visible (default is false)
      */
-    public inheritedVisibility = false;
+    public get inheritedVisibility(): boolean {
+        return this._internalAbstractMeshDataInfo._inheritedVisibility;
+    }
+
+    public set inheritedVisibility(value: boolean) {
+        this._internalAbstractMeshDataInfo._inheritedVisibility = value;
+    }
 
     private _isVisible = true;
     /**

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -537,9 +537,34 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public alphaIndex = Number.MAX_VALUE;
 
     /**
+     * If set to true, a mesh will only be visible only if its parent(s) are also visible (default is false)
+     */
+    public inheritedVisibility = false;
+
+    private _isVisible = true;
+    /**
      * Gets or sets a boolean indicating if the mesh is visible (renderable). Default is true
      */
-    public isVisible = true;
+    public get isVisible(): boolean {
+        if (!this._isVisible || !this.inheritedVisibility || !this._parentNode) {
+            return this._isVisible;
+        }
+        if (this._isVisible) {
+            let parent: Nullable<Node> = this._parentNode;
+            while (parent) {
+                const parentVisible = (parent as AbstractMesh).isVisible;
+                if (typeof parentVisible !== "undefined") {
+                    return this._isVisible && parentVisible;
+                }
+                parent = parent.parent;
+            }
+        }
+        return this._isVisible;
+    }
+
+    public set isVisible(value: boolean) {
+        this._isVisible = value;
+    }
 
     /**
      * Gets or sets a boolean indicating if the mesh can be picked (by scene.pick for instance or through actions). Default is true

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -236,7 +236,7 @@ class _InternalAbstractMeshDataInfo {
      * @internal
      * if this is set to true, the mesh will be visible only if its parent(s) are also visible
      */
-    public _inheritedVisibility = false;
+    public _inheritVisibility = false;
 }
 
 /**
@@ -545,12 +545,12 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     /**
      * If set to true, a mesh will only be visible only if its parent(s) are also visible (default is false)
      */
-    public get inheritedVisibility(): boolean {
-        return this._internalAbstractMeshDataInfo._inheritedVisibility;
+    public get inheritVisibility(): boolean {
+        return this._internalAbstractMeshDataInfo._inheritVisibility;
     }
 
-    public set inheritedVisibility(value: boolean) {
-        this._internalAbstractMeshDataInfo._inheritedVisibility = value;
+    public set inheritVisibility(value: boolean) {
+        this._internalAbstractMeshDataInfo._inheritVisibility = value;
     }
 
     private _isVisible = true;
@@ -558,7 +558,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
      * Gets or sets a boolean indicating if the mesh is visible (renderable). Default is true
      */
     public get isVisible(): boolean {
-        if (!this._isVisible || !this.inheritedVisibility || !this._parentNode) {
+        if (!this._isVisible || !this.inheritVisibility || !this._parentNode) {
             return this._isVisible;
         }
         if (this._isVisible) {
@@ -566,7 +566,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             while (parent) {
                 const parentVisible = (parent as AbstractMesh).isVisible;
                 if (typeof parentVisible !== "undefined") {
-                    return this._isVisible && parentVisible;
+                    return parentVisible;
                 }
                 parent = parent.parent;
             }


### PR DESCRIPTION
KHR Visibility, a new glTF extension, sets visibility as inherited value from a node's parent(s). Meaning, a node is only visible if it is set to be visible and all of its parents are visible. This is not what we are doing in Babylon. 

This PR adds a flag that should only be turned on when using the KHR visibility extension for each mesh of the loaded glTF. Enabling the flag will allow checking  mesh's visibility, based on its parents visibility as well.

This PR is a suggestion only, but it will be needed to support the latest extension. I understand there is a slight perf hit for the default behavior. I did my best to make sure we return early for the current behavior, without iteration the parents.

Test PG - #ABDDD6#118 (emulating enabling KHR interactivity).