### PR TITLE
Initial size analysis tooling for alpha viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26695,8 +26695,6 @@
                 "@rollup/plugin-terser": "^0.4.4",
                 "@rollup/plugin-typescript": "^11.1.6",
                 "chalk": "^5.3.0",
-                "source-map-loader": "^4.0.0",
-                "ts-loader": "^9.2.6",
                 "vite": "^5.3.3"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "eslint-plugin-prettier": "~5.0.0",
                 "eslint-plugin-tsdoc": "~0.2.14",
                 "fs-extra": "^10.0.1",
+                "glob": "^11.0.0",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.5.0",
                 "jest-junit": "~13.2.0",
@@ -3165,6 +3166,26 @@
                 }
             }
         },
+        "node_modules/@jest/reporters/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -5695,6 +5716,132 @@
             "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
             "peer": true
         },
+        "node_modules/@rollup/plugin-alias": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+            "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+            "dev": true,
+            "dependencies": {
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-alias/node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "26.0.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.1.tgz",
+            "integrity": "sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "glob": "^10.4.1",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "dev": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+            "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-builtin-module": "^3.2.1",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/plugin-terser": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
@@ -7336,6 +7483,12 @@
             "dependencies": {
                 "@types/react": "^17"
             }
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+            "dev": true
         },
         "node_modules/@types/retry": {
             "version": "0.12.0",
@@ -9544,6 +9697,12 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true
         },
         "node_modules/compare-func": {
             "version": "2.0.0",
@@ -12839,20 +12998,23 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+            "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+            "dev": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "engines": {
-                "node": "*"
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -12875,6 +13037,73 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/glob/node_modules/jackspeak": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+            "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/glob/node_modules/lru-cache": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+            "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+            "dev": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/global-modules": {
             "version": "0.2.3",
@@ -14052,6 +14281,12 @@
             "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
             "dev": true
         },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true
+        },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -14126,6 +14361,15 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
+        },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -14629,6 +14873,26 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/jest-config/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/jest-config/node_modules/jest-environment-node": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -15018,6 +15282,27 @@
                 }
             }
         },
+        "node_modules/jest-image-snapshot/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "optional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/jest-image-snapshot/node_modules/rimraf": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15319,6 +15604,26 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runtime/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/jest-snapshot": {
@@ -19115,6 +19420,12 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+            "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+            "dev": true
+        },
         "node_modules/pacote": {
             "version": "17.0.7",
             "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.7.tgz",
@@ -21357,6 +21668,27 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "devOptional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/rollup": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
@@ -22990,6 +23322,27 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/temp-fs/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/temp-fs/node_modules/rimraf": {
             "version": "2.5.4",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
@@ -23160,6 +23513,26 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/text-decoder": {
@@ -26311,9 +26684,16 @@
         "packages/tools/viewer-alpha": {
             "name": "@tools/viewer-alpha",
             "version": "1.0.0",
-            "devDependencies": {
+            "dependencies": {
                 "@dev/core": "1.0.0",
-                "@dev/loaders": "1.0.0",
+                "@dev/loaders": "1.0.0"
+            },
+            "devDependencies": {
+                "@rollup/plugin-alias": "^5.1.0",
+                "@rollup/plugin-commonjs": "^26.0.1",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-typescript": "^11.1.6",
                 "chalk": "^5.3.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "eslint-plugin-prettier": "~5.0.0",
                 "eslint-plugin-tsdoc": "~0.2.14",
                 "fs-extra": "^10.0.1",
-                "glob": "^11.0.0",
+                "glob": "^10.4.5",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.5.0",
                 "jest-junit": "~13.2.0",
@@ -5773,50 +5773,6 @@
                 }
             }
         },
-        "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@rollup/plugin-node-resolve": {
             "version": "15.2.3",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
@@ -6182,15 +6138,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@sigstore/sign/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/@sigstore/sign/node_modules/cacache": {
             "version": "17.1.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
@@ -6212,28 +6159,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@sigstore/sign/node_modules/lru-cache": {
@@ -6278,21 +6203,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@sigstore/sign/node_modules/minipass-collect": {
@@ -9158,37 +9068,6 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
-        "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/cacache/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/cacache/node_modules/lru-cache": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
@@ -9196,21 +9075,6 @@
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
-            }
-        },
-        "node_modules/cacache/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/cacache/node_modules/ssri": {
@@ -12998,23 +12862,20 @@
             }
         },
         "node_modules/glob": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-            "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^4.0.1",
-                "minimatch": "^10.0.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
                 "minipass": "^7.1.2",
                 "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -13047,59 +12908,16 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/glob/node_modules/jackspeak": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
-            "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
-            "dev": true,
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/glob/node_modules/lru-cache": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-            "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
-            "dev": true,
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/glob/node_modules/path-scurry": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -18122,37 +17940,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/node-gyp/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/node-gyp/node_modules/isexe": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -18160,21 +17947,6 @@
             "dev": true,
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/node-gyp/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/node-gyp/node_modules/nopt": {
@@ -18493,15 +18265,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/npm-registry-fetch/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/npm-registry-fetch/node_modules/cacache": {
             "version": "17.1.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
@@ -18526,37 +18289,6 @@
             }
         },
         "node_modules/npm-registry-fetch/node_modules/cacache/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/npm-registry-fetch/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/npm-registry-fetch/node_modules/glob/node_modules/minipass": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
@@ -18610,21 +18342,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm-registry-fetch/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm-registry-fetch/node_modules/minipass": {
@@ -19538,28 +19255,6 @@
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/pacote/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/pacote/node_modules/hosted-git-info": {
@@ -21077,37 +20772,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/read-package-json/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/read-package-json/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/read-package-json/node_modules/hosted-git-info": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -21136,21 +20800,6 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/read-package-json/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/read-package-json/node_modules/normalize-package-data": {
@@ -22280,15 +21929,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/sigstore/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/sigstore/node_modules/cacache": {
             "version": "17.1.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
@@ -22310,28 +21950,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/sigstore/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/sigstore/node_modules/lru-cache": {
@@ -22376,21 +21994,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/sigstore/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/sigstore/node_modules/minipass-collect": {
@@ -23962,15 +23565,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/tuf-js/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/tuf-js/node_modules/cacache": {
             "version": "17.1.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
@@ -23992,28 +23586,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/glob": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-            "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tuf-js/node_modules/lru-cache": {
@@ -24058,21 +23630,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/tuf-js/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tuf-js/node_modules/minipass-collect": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint-plugin-prettier": "~5.0.0",
         "eslint-plugin-tsdoc": "~0.2.14",
         "fs-extra": "^10.0.1",
+        "glob": "^11.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-junit": "~13.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "eslint-plugin-prettier": "~5.0.0",
         "eslint-plugin-tsdoc": "~0.2.14",
         "fs-extra": "^10.0.1",
-        "glob": "^11.0.0",
+        "glob": "^10.4.5",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-junit": "~13.2.0",

--- a/packages/dev/buildTools/src/copyAssets.ts
+++ b/packages/dev/buildTools/src/copyAssets.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import * as glob from "glob";
+import { glob } from "glob";
 import * as path from "path";
 import { copyFile, checkArgs } from "./utils.js";
 import * as chokidar from "chokidar";
@@ -60,14 +60,15 @@ export const processAssets = (options: { extensions: string[] } = { extensions: 
             });
         console.log("watching for asset changes...");
     } else {
-        glob(globDirectory, (err, files) => {
-            if (err) {
-                console.log(err);
-            } else {
+        glob(globDirectory).then(
+            (files) => {
                 files.forEach((file) => {
                     processFile(file, processOptions);
                 });
+            },
+            (err) => {
+                console.log(err);
             }
-        });
+        );
     }
 };

--- a/packages/dev/buildTools/src/copyAssets.ts
+++ b/packages/dev/buildTools/src/copyAssets.ts
@@ -14,7 +14,7 @@ const processFile = (file: string, options: { isCore?: boolean; basePackageName?
         buildShader(file, options.basePackageName, options.isCore);
     } else {
         if (options.pathPrefix) {
-            const regex = new RegExp(`${options.pathPrefix.replace(/\//g, "\\/")}./src([/\\\\])`);
+            const regex = new RegExp(`${options.pathPrefix.replace(/\//g, "\\/")}src([/\\\\])`);
             copyFile(file, file.replace(regex, `${options.outputDir}$1`), true, true);
         } else {
             copyFile(file, file.replace(/src([/\\])/, `${options.outputDir}$1`), true, true);
@@ -28,7 +28,7 @@ export const processAssets = (options: { extensions: string[] } = { extensions: 
     const fileTypes = checkArgs(["--file-types", "-ft"], false, true);
     const extensions = fileTypes && typeof fileTypes === "string" ? fileTypes.split(",") : options.extensions;
     const pathPrefix = (checkArgs("--path-prefix", false, true) as string) || "";
-    const globDirectory = global ? `./packages/**/*/src/**/*.+(${extensions.join("|")})` : pathPrefix + `./src/**/*.+(${extensions.join("|")})`;
+    const globDirectory = global ? `./packages/**/*/src/**/*.+(${extensions.join("|")})` : pathPrefix + `src/**/*.+(${extensions.join("|")})`;
     const isCore = !!checkArgs("--isCore", true);
     const outputDir = checkArgs(["--output-dir"], false, true) as string;
     let basePackageName: DevPackageName = "core";

--- a/packages/dev/core/package.json
+++ b/packages/dev/core/package.json
@@ -25,7 +25,7 @@
         "watch:source": "tsc -b tsconfig.build.json -w",
         "watch": "build-tools -c dev-watch --packages \"core\" -wa"
     },
-    "sideEffects": false,
+    "sideEffects": true,
     "devDependencies": {
         "@dev/build-tools": "^1.0.0",
         "@types/draco3d": "^1.4.3",

--- a/packages/dev/loaders/package.json
+++ b/packages/dev/loaders/package.json
@@ -20,6 +20,6 @@
     "devDependencies": {
         "@dev/core": "^1.0.0"
     },
-    "sideEffects": false,
+    "sideEffects": true,
     "dependencies": {}
 }

--- a/packages/tools/viewer-alpha/README.md
+++ b/packages/tools/viewer-alpha/README.md
@@ -1,0 +1,20 @@
+# Viewer Alpha
+
+This package is the alpha version of the new @babylonjs/viewer package.
+
+## Layers
+
+There are currently three layers (one of them is "internal"):
+1. The pure JS layer is viewer.ts. This layer is not tied to the DOM and can be used in the browser or with Babylon Native.
+1. The canvas factory layer is in viewerFactory.ts. This layer binds the viewer to a Canvas.
+1. The Web Components custom element is in viewerElement.ts. This layer uses the canvas factory and exposes the <babylon-viewer> element.
+
+The Canvas factory could be used for other browser based UI framework integrations like React.
+
+## Tools
+
+Run `npm run start:web` to run the test app and debug the code.
+
+Run `npm run analyze` to visualize the bundled size as a flame chart. This is useful for understanding how different parts of @babylonjs/core and @babylonjs/loaders contribute to the bundle size, and how to optimize it.
+
+Run `npm run start:bundle-test` to test the bundled code in a browser. This is just here to verify that the bundled code has everything needed to actually run successfully, so we know we are not missing any code in our size analysis.

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -5,14 +5,16 @@
     "sideEffects": false,
     "description": "A viewer using BabylonJS to display 3D elements natively",
     "scripts": {
-        "start:web": "npm run serve -- --open test/apps/web/index.html",
+        "start:web": "npm run serve -- --open packages/tools/viewer-alpha/test/apps/web/index.html",
+        "start:bundle-test": "npm run bundle && npm run serve -- --open packages/tools/viewer-alpha/test/apps/web/bundle-test.html",
         "preserve": "npm run build",
         "serve": "vite",
         "build": "npm run compile",
         "clean": "rimraf dist && rimraf *.tsbuildinfo",
         "compile": "tsc -b tsconfig.build.json",
+        "bundle": "rollup -c rollup.config.analyze.bundle.mjs",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "analyze": "rollup -c rollup.config.analyze.mjs && node ../../../scripts/folderSizeFlameChart dist/analyze **/*.js"
+        "analyze": "rollup -c rollup.config.analyze.mjs && node ../../../scripts/folderSizeFlameChart dist/analyze/loose **/*.js"
     },
     "files": [
         "dist"

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -30,8 +30,6 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "chalk": "^5.3.0",
-        "source-map-loader": "^4.0.0",
-        "ts-loader": "^9.2.6",
         "vite": "^5.3.3"
     }
 }

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -14,11 +14,8 @@
         "compile": "tsc -b tsconfig.build.json",
         "bundle": "rollup -c rollup.config.analyze.mjs",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "analyze": "npm run bundle && node ../../../scripts/folderSizeFlameChart dist/analyze **/*.js"
+        "analyze": "npm run clean && npm run bundle && node ../../../scripts/folderSizeFlameChart dist/analyze **/*.js"
     },
-    "files": [
-        "dist"
-    ],
     "dependencies": {
         "@dev/core": "1.0.0",
         "@dev/loaders": "1.0.0"

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -11,14 +11,22 @@
         "build": "npm run compile",
         "clean": "rimraf dist && rimraf *.tsbuildinfo",
         "compile": "tsc -b tsconfig.build.json",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "analyze": "rollup -c rollup.config.analyze.mjs && node ../../../scripts/folderSizeFlameChart dist/analyze **/*.js"
     },
     "files": [
         "dist"
     ],
-    "devDependencies": {
+    "dependencies": {
         "@dev/core": "1.0.0",
-        "@dev/loaders": "1.0.0",
+        "@dev/loaders": "1.0.0"
+    },
+    "devDependencies": {
+        "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-commonjs": "^26.0.1",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
         "chalk": "^5.3.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -12,9 +12,9 @@
         "build": "npm run compile",
         "clean": "rimraf dist && rimraf *.tsbuildinfo",
         "compile": "tsc -b tsconfig.build.json",
-        "bundle": "rollup -c rollup.config.analyze.bundle.mjs",
+        "bundle": "rollup -c rollup.config.analyze.mjs",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "analyze": "rollup -c rollup.config.analyze.mjs && node ../../../scripts/folderSizeFlameChart dist/analyze/loose **/*.js"
+        "analyze": "npm run bundle && node ../../../scripts/folderSizeFlameChart dist/analyze **/*.js"
     },
     "files": [
         "dist"

--- a/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
@@ -1,0 +1,7 @@
+import config from "./rollup.config.analyze.mjs";
+
+config.output.file = "dist/analyze/bundle/index.js";
+delete config.output.dir;
+config.output.preserveModules = false;
+
+export default config;

--- a/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
@@ -1,5 +1,6 @@
 import config from "./rollup.config.analyze.mjs";
 
+// Output to a single bundled file to make it easy to verify total size and that everything needed to run is being included
 config.output.file = "dist/analyze/bundle/index.js";
 delete config.output.dir;
 config.output.preserveModules = false;

--- a/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.bundle.mjs
@@ -1,8 +1,0 @@
-import config from "./rollup.config.analyze.mjs";
-
-// Output to a single bundled file to make it easy to verify total size and that everything needed to run is being included
-config.output.file = "dist/analyze/bundle/index.js";
-delete config.output.dir;
-config.output.preserveModules = false;
-
-export default config;

--- a/packages/tools/viewer-alpha/rollup.config.analyze.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.mjs
@@ -1,0 +1,32 @@
+import typescript from "@rollup/plugin-typescript";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import alias from "@rollup/plugin-alias";
+import terser from "@rollup/plugin-terser";
+
+const source = "dev";
+
+export default {
+    input: "src/index.ts",
+    output: {
+        //file: "dist/analyze/index.js",
+        dir: "dist/analyze",
+        sourcemap: false,
+        format: "es",
+        exports: "named",
+        preserveModules: true,
+        preserveModulesRoot: "../../",
+    },
+    plugins: [
+        typescript({ tsconfig: "tsconfig.build.json", sourceMap: false, inlineSources: false, declaration: false, declarationMap: false, outDir: "dist/analyze" }),
+        alias({
+            entries: [
+                { find: "core", replacement: `@${source}/core/dist` },
+                { find: "loaders", replacement: `@${source}/loaders/dist` },
+            ],
+        }),
+        nodeResolve({ mainFields: ["browser", "module", "main"] }),
+        commonjs(),
+        terser(),
+    ],
+};

--- a/packages/tools/viewer-alpha/rollup.config.analyze.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.mjs
@@ -9,7 +9,7 @@ const source = "dev";
 export default {
     input: "src/index.ts",
     output: {
-        dir: "dist/analyze/loose",
+        dir: "dist/analyze",
         // No need for source maps for size analysis
         sourcemap: false,
         // Output as ES module
@@ -21,7 +21,7 @@ export default {
         preserveModulesRoot: "../../",
     },
     plugins: [
-        typescript({ tsconfig: "tsconfig.build.json", sourceMap: false, inlineSources: false, declaration: false, declarationMap: false, outDir: "dist/analyze/loose" }),
+        typescript({ tsconfig: "tsconfig.build.json", sourceMap: false, inlineSources: false, declaration: false, declarationMap: false, outDir: "dist/analyze" }),
         alias({
             entries: [
                 { find: "core", replacement: `@${source}/core/dist` },

--- a/packages/tools/viewer-alpha/rollup.config.analyze.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.mjs
@@ -10,9 +10,13 @@ export default {
     input: "src/index.ts",
     output: {
         dir: "dist/analyze/loose",
+        // No need for source maps for size analysis
         sourcemap: false,
+        // Output as ES module
         format: "es",
         exports: "named",
+        // Prevent bundling multiple files into one
+        // We want to keep them separate so we can easily see file/folder size
         preserveModules: true,
         preserveModulesRoot: "../../",
     },

--- a/packages/tools/viewer-alpha/rollup.config.analyze.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.mjs
@@ -9,8 +9,7 @@ const source = "dev";
 export default {
     input: "src/index.ts",
     output: {
-        //file: "dist/analyze/index.js",
-        dir: "dist/analyze",
+        dir: "dist/analyze/loose",
         sourcemap: false,
         format: "es",
         exports: "named",
@@ -18,7 +17,7 @@ export default {
         preserveModulesRoot: "../../",
     },
     plugins: [
-        typescript({ tsconfig: "tsconfig.build.json", sourceMap: false, inlineSources: false, declaration: false, declarationMap: false, outDir: "dist/analyze" }),
+        typescript({ tsconfig: "tsconfig.build.json", sourceMap: false, inlineSources: false, declaration: false, declarationMap: false, outDir: "dist/analyze/loose" }),
         alias({
             entries: [
                 { find: "core", replacement: `@${source}/core/dist` },

--- a/packages/tools/viewer-alpha/test/apps/web/bundle-test.html
+++ b/packages/tools/viewer-alpha/test/apps/web/bundle-test.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Viewer Bundle Test</title>
+
+        <style>
+            html,
+            body {
+                width: 100%;
+                height: 100%;
+                padding: 0;
+                margin: 0;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+
+    <body>
+        <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env"> </babylon-viewer>
+        <script type="module" src="/packages/tools/viewer-alpha/dist/analyze/bundle/index.js"></script>
+    </body>
+</html>

--- a/packages/tools/viewer-alpha/test/apps/web/bundle-test.html
+++ b/packages/tools/viewer-alpha/test/apps/web/bundle-test.html
@@ -19,6 +19,6 @@
 
     <body>
         <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env"> </babylon-viewer>
-        <script type="module" src="/packages/tools/viewer-alpha/dist/analyze/bundle/index.js"></script>
+        <script type="module" src="/packages/tools/viewer-alpha/dist/analyze/tools/viewer-alpha/src/index.js"></script>
     </body>
 </html>

--- a/packages/tools/viewer-alpha/tsconfig.build.json
+++ b/packages/tools/viewer-alpha/tsconfig.build.json
@@ -2,7 +2,7 @@
     "extends": "../../../tsconfig.build.json",
 
     "compilerOptions": {
-        "outDir": "./dist",
+        "outDir": "./dist/tsbuild",
         "rootDir": "./src"
     },
 

--- a/packages/tools/viewer-alpha/vite.config.mjs
+++ b/packages/tools/viewer-alpha/vite.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig(({ mode }) => {
 
     const port = env.VIEWER_PORT ?? 1342;
     console.log(`${chalk.bold(`Web Test App`)}: ${chalk.cyan(`http://localhost:${port}/packages/tools/viewer-alpha/test/apps/web/index.html`)}`);
+    console.log(`${chalk.bold(`Bundle Test App`)}: ${chalk.cyan(`http://localhost:${port}/packages/tools/viewer-alpha/test/apps/web/bundle-test.html`)}`);
 
     return {
         root: "../../../",

--- a/scripts/folderSizeFlameChart.js
+++ b/scripts/folderSizeFlameChart.js
@@ -1,0 +1,63 @@
+"use strict";
+
+// This script generates an interactive flame chart for file/folder sizes.
+// node folderSizeFlameChart.js [pattern=**/*] [outputFile=FoldersSizes]
+// Example: node folderSizeFlameChart.js **/*.ts,!**/*.d.ts,!**/test/**
+
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const https = require("https");
+const glob = require("glob");
+
+let [scriptPath, folder = ".", pattern = "**", outputFile = "FoldersSizes"] = process.argv.slice(1);
+
+console.log(`${path.basename(scriptPath)} ${folder} ${pattern} ${outputFile}`);
+
+folder = path.resolve(folder);
+
+const flameGraphScriptPath = path.join(os.tmpdir(), "flamegraph.pl");
+
+if (!fs.existsSync(flameGraphScriptPath)) {
+    const downloadUrl = "https://raw.githubusercontent.com/brendangregg/FlameGraph/cd9ee4c4449775a2f867acf31c84b7fe4b132ad5/flamegraph.pl";
+    console.log(`Downloading flamegraph.pl from ${downloadUrl}`);
+    https.get(downloadUrl, (response) => {
+        const file = fs.createWriteStream(flameGraphScriptPath);
+        response.pipe(file);
+        file.on("finish", () => {
+            file.close();
+            fs.chmodSync(flameGraphScriptPath, "755");
+            generateFlameGraph();
+        });
+    });
+} else {
+    generateFlameGraph();
+}
+
+function generateFlameGraph() {
+    const patterns = pattern.split(",");
+    const positivePatterns = patterns.filter((p) => !p.startsWith("!"));
+    const negativePatterns = patterns.filter((p) => p.startsWith("!")).map((p) => p.substring(1));
+    let stacks = [];
+    for (const filePath of glob.globIterateSync(positivePatterns, {
+        ignore: negativePatterns,
+        cwd: folder,
+    })) {
+        const stats = fs.statSync(path.resolve(folder, filePath));
+        if (stats.isFile()) {
+            stacks.push(`${filePath.replace(/[\/]/g, ";")} ${stats.size}`);
+        }
+    }
+
+    stacks = stacks.join("\n");
+
+    const tempFilePath = path.join(os.tmpdir(), "fileSizeStacks.txt");
+    fs.writeFileSync(tempFilePath, stacks);
+
+    const flameGraphCommand = `${flameGraphScriptPath} --title "File &amp; Folder Sizes" --subtitle "Sizes of files and folders matching glob '${pattern}' under '${folder}'" --width 1800 --height 32 --countname "bytes" --nametype Folder/File ${tempFilePath} > ${outputFile}.svg`;
+    console.log(`Running command: ${flameGraphCommand}`);
+    child_process.execSync(flameGraphCommand);
+
+    child_process.exec(`open ${outputFile}.svg`);
+}

--- a/scripts/folderSizeFlameChart.js
+++ b/scripts/folderSizeFlameChart.js
@@ -15,10 +15,13 @@ let [scriptPath, folder = ".", pattern = "**", outputFile = "FoldersSizes"] = pr
 
 console.log(`${path.basename(scriptPath)} ${folder} ${pattern} ${outputFile}`);
 
+// Resolve to an absolute path
 folder = path.resolve(folder);
 
+// This is the temp path where the flamegraph.pl script will be downloaded
 const flameGraphScriptPath = path.join(os.tmpdir(), "flamegraph.pl");
 
+// If the flamegraph.pl script does not exist, download it
 if (!fs.existsSync(flameGraphScriptPath)) {
     const downloadUrl = "https://raw.githubusercontent.com/brendangregg/FlameGraph/cd9ee4c4449775a2f867acf31c84b7fe4b132ad5/flamegraph.pl";
     console.log(`Downloading flamegraph.pl from ${downloadUrl}`);
@@ -28,36 +31,51 @@ if (!fs.existsSync(flameGraphScriptPath)) {
         file.on("finish", () => {
             file.close();
             fs.chmodSync(flameGraphScriptPath, "755");
-            generateFlameGraph();
+
+            // Now generate the flame chart
+            generateFlameChart();
         });
     });
 } else {
-    generateFlameGraph();
+    // Flamegraph.pl script already exists, generate the flame chart
+    generateFlameChart();
 }
 
-function generateFlameGraph() {
+function generateFlameChart() {
+    // patterns is a comma separated list
     const patterns = pattern.split(",");
+
+    // glob doesn't directly support the ! operator, so we need to separate positive and negative patterns
     const positivePatterns = patterns.filter((p) => !p.startsWith("!"));
     const negativePatterns = patterns.filter((p) => p.startsWith("!")).map((p) => p.substring(1));
+
+    // Iterate over all files matching the patterns to create a list of "stacks"
     let stacks = [];
     for (const filePath of glob.globIterateSync(positivePatterns, {
         ignore: negativePatterns,
         cwd: folder,
     })) {
+        // Get file stats given the absolute file path
         const stats = fs.statSync(path.resolve(folder, filePath));
+
+        // Only process files (folder info is implicit in the flame chart)
         if (stats.isFile()) {
+            // The format of each stack is "path/to/file; size"
             stacks.push(`${filePath.replace(/[\/]/g, ";")} ${stats.size}`);
         }
     }
 
-    stacks = stacks.join("\n");
-
+    // Write the stacks to a temp file
     const tempFilePath = path.join(os.tmpdir(), "fileSizeStacks.txt");
-    fs.writeFileSync(tempFilePath, stacks);
+    fs.writeFileSync(tempFilePath, stacks.join("\n"));
 
+    // Construct the flamegraph command
     const flameGraphCommand = `${flameGraphScriptPath} --title "File &amp; Folder Sizes" --subtitle "Sizes of files and folders matching glob '${pattern}' under '${folder}'" --width 1800 --height 32 --countname "bytes" --nametype Folder/File ${tempFilePath} > ${outputFile}.svg`;
     console.log(`Running command: ${flameGraphCommand}`);
+
+    // Execute the flamegraph command, waiting for it to finish
     child_process.execSync(flameGraphCommand);
 
+    // Open the svg (will generally open in the default browser, where it can be interacted with)
     child_process.exec(`open ${outputFile}.svg`);
 }

--- a/scripts/folderSizeFlameChart.js
+++ b/scripts/folderSizeFlameChart.js
@@ -1,5 +1,7 @@
 "use strict";
 
+/* eslint-disable no-console */
+
 // This script generates an interactive flame chart for file/folder sizes.
 // node folderSizeFlameChart.js [pattern=**/*] [outputFile=FoldersSizes]
 // Example: node folderSizeFlameChart.js **/*.ts,!**/*.d.ts,!**/test/**
@@ -10,10 +12,11 @@ const path = require("path");
 const os = require("os");
 const https = require("https");
 const glob = require("glob");
+const chalk = require("chalk");
 
 let [scriptPath, folder = ".", pattern = "**", outputFile = "FoldersSizes"] = process.argv.slice(1);
 
-console.log(`${path.basename(scriptPath)} ${folder} ${pattern} ${outputFile}`);
+console.log(chalk.bold(`${path.basename(scriptPath)} ${folder} ${pattern} ${outputFile}`));
 
 // Resolve to an absolute path
 folder = path.resolve(folder);
@@ -71,7 +74,7 @@ function generateFlameChart() {
 
     // Construct the flamegraph command
     const flameGraphCommand = `${flameGraphScriptPath} --title "File &amp; Folder Sizes" --subtitle "Sizes of files and folders matching glob '${pattern}' under '${folder}'" --width 1800 --height 32 --countname "bytes" --nametype Folder/File ${tempFilePath} > ${outputFile}.svg`;
-    console.log(`Running command: ${flameGraphCommand}`);
+    console.log(`${chalk.bold(chalk.italic(`Running command`))}: ${chalk.italic(flameGraphCommand)}`);
 
     // Execute the flamegraph command, waiting for it to finish
     child_process.execSync(flameGraphCommand);


### PR DESCRIPTION
This PR primarily adds an `npm run analyze` command to the viewer alpha. This tree shakes and minifies the code (including the @babylonjs/core and @babylonjs/loaders), but does not bundle it, and then it runs a script that generates a flame chart to visualize the breakdown of file/folder sizes. The flame chart is an SVG that is interactive when opened in a browser (e.g. you can drill into the flame chart or search for file/folder names), and can also just be opened as an image.

This PR also adds an `npm run start:bundle-test` that can be used to verify that all the right code is being included and that it actually executes correctly. ~The bundle-test also bundles into a single file just to simplify the test app and double check the overall size.~ I decided to get rid of this and just directly test the loose files. We will add a single file bundle to the public package later, so I don't really want to duplicate it here.

The minified bundle is about 2.3mb currently.

The flame chart looks like this:
![FoldersSizes](https://github.com/user-attachments/assets/9832e1c3-bc44-496a-900f-ff9bd06842cf)

And then drilling into materials for example looks like this:
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/e1a5990b-7e06-435c-a3b8-3bac05b3bd56">

Other notes on this PR:
- Set sideEffects to true in dev/core/package.json and dev/loaders/package.json (these were incorrectly set to false which messed up the bundling)
- Added a short README with some notes on the new viewer package
- Changed line endings in the package.json to CRLF (which unfortunately messes up the diff for this file in this PR)
- Added various Rollup plugins and a Rollup config to transpile, tree shake, minify, but not bundle (for the size analysis flame chart input)
- Added a Rollup config that does almost the same as above but bundles into a single file
- Added a test html page that consumes the single bundle (to verify the tree shaked code)
- Added a small script that gets file sizes and then uses an OSS flame chart generating perl script to create the flame chart

For the flame chart script, it just downloads the inner flame chart Perl script on demand. We could check it in, but I kind of like the node script being self contained and it makes it clear where the Perl script is coming from. Open to other perspectives on this.
