### PR TITLE
Some fixes for Tab control

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -419,10 +419,13 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             // check if tab is pressed
             if (!this.disableTabNavigation && info.type === KeyboardEventTypes.KEYDOWN && info.event.code === "Tab") {
                 const forward = !info.event.shiftKey;
-                if ((forward && this._focusProperties.index === this._focusProperties.total - 1) || (!forward && this._focusProperties.index === 0)) {
+                if (
+                    (forward && this._focusProperties.index === this._focusProperties.total - 1) ||
+                    (!forward && this._focusProperties.index === 0 && this._focusProperties.total > 0)
+                ) {
                     this.focusedControl = null;
                     this._focusProperties.index = 0;
-                    this._focusProperties.total = 0;
+                    this._focusProperties.total = -1;
                     return;
                 }
                 this._focusNextElement(forward);
@@ -1002,7 +1005,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._attachToOnBlur(scene);
     }
 
-    private _focusProperties: { index: number; total: number } = { index: 0, total: 0 };
+    private _focusProperties: { index: number; total: number } = { index: 0, total: -1 };
 
     private _focusNextElement(forward: boolean = true): void {
         // generate the order of tab-able controls
@@ -1023,19 +1026,20 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         });
         this._focusProperties.total = sortedTabbableControls.length;
         // if no control is focused, focus the first one
+        let nextIndex = -1;
         if (!this._focusedControl) {
-            sortedTabbableControls[0].focus();
+            nextIndex = forward ? 0 : sortedTabbableControls.length - 1;
         } else {
             const currentIndex = sortedTabbableControls.indexOf(this._focusedControl);
-            let nextIndex = currentIndex + (forward ? 1 : -1);
+            nextIndex = currentIndex + (forward ? 1 : -1);
             if (nextIndex < 0) {
                 nextIndex = sortedTabbableControls.length - 1;
             } else if (nextIndex >= sortedTabbableControls.length) {
                 nextIndex = 0;
             }
-            sortedTabbableControls[nextIndex].focus();
-            this._focusProperties.index = nextIndex;
         }
+        sortedTabbableControls[nextIndex].focus();
+        this._focusProperties.index = nextIndex;
     }
 
     /**

--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -418,7 +418,14 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._preKeyboardObserver = scene.onPreKeyboardObservable.add((info) => {
             // check if tab is pressed
             if (!this.disableTabNavigation && info.type === KeyboardEventTypes.KEYDOWN && info.event.code === "Tab") {
-                this._focusNextElement(!info.event.shiftKey);
+                const forward = !info.event.shiftKey;
+                if ((forward && this._focusProperties.index === this._focusProperties.total - 1) || (!forward && this._focusProperties.index === 0)) {
+                    this.focusedControl = null;
+                    this._focusProperties.index = 0;
+                    this._focusProperties.total = 0;
+                    return;
+                }
+                this._focusNextElement(forward);
                 info.event.preventDefault();
                 return;
             }
@@ -995,6 +1002,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         this._attachToOnBlur(scene);
     }
 
+    private _focusProperties: { index: number; total: number } = { index: 0, total: 0 };
+
     private _focusNextElement(forward: boolean = true): void {
         // generate the order of tab-able controls
         const sortedTabbableControls: Control[] = [];
@@ -1012,6 +1021,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
             // if tabIndex is 0, put it in the end of the list, otherwise sort by tabIndex
             return a.tabIndex === 0 ? 1 : b.tabIndex === 0 ? -1 : a.tabIndex - b.tabIndex;
         });
+        this._focusProperties.total = sortedTabbableControls.length;
         // if no control is focused, focus the first one
         if (!this._focusedControl) {
             sortedTabbableControls[0].focus();
@@ -1024,6 +1034,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 nextIndex = 0;
             }
             sortedTabbableControls[nextIndex].focus();
+            this._focusProperties.index = nextIndex;
         }
     }
 

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2368,6 +2368,10 @@ export class Control implements IAnimatable, IFocusableControl {
         // Event redundancy is checked inside the function.
         this._onPointerEnter(this, pi);
 
+        if (this.tabIndex !== -1) {
+            this.host.focusedControl = this;
+        }
+
         if (this._downCount !== 0) {
             return false;
         }


### PR DESCRIPTION
The current behavior locks Tab control within the ADT and doesn't let it escape.

These changes make the elements of the GUI merge with the browser's elements. Tab and Shift-Tab will work correctly, and will let the focus escape the ADT if at the end of the list.

Test with #BCU1XR#7421