### PR TITLE
Fixed Viewer Source Code Links (documentation changes only)

### DIFF
--- a/packages/public/babylonjs-viewer-assets/readme.md
+++ b/packages/public/babylonjs-viewer-assets/readme.md
@@ -6,7 +6,7 @@ This package is only needed when installing the viewer's npm package and it is i
 
 For basic and advanced viewer usage instructions please read the doc at https://doc.babylonjs.com/features/featuresDeepDive/babylonViewer/viewerExamples
 
-The source code can be found at https://github.com/BabylonJS/Babylon.js/tree/master/Viewer
+The source code can be found at https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/viewer
 
 ## Overriding the package
 

--- a/packages/public/umd/babylonjs-viewer/readme.md
+++ b/packages/public/umd/babylonjs-viewer/readme.md
@@ -6,7 +6,7 @@ The viewer automatically interacts with the DOM, searching for HTML elements nam
 
 for basic and advanced usage instructions please read the doc at https://doc.babylonjs.com/features/featuresDeepDive/babylonViewer/viewerExamples
 
-The source code can be found at https://github.com/BabylonJS/Babylon.js/tree/master/Viewer
+The source code can be found at https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/viewer
 
 ## Basic usage
 


### PR DESCRIPTION
Fixed up the link to the viewer source code in two readme.md files.