### PR TITLE
Fix ReferenceError: Property 'name' doesn't exist at _copySource

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -682,7 +682,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         // Pivot
         this.setPivotMatrix(source.getPivotMatrix(), this._postMultiplyPivotMatrix);
 
-        this.id = name + "." + source.id;
+        this.id = this.name + "." + source.id;
 
         // Material
         this.material = source.material;
@@ -694,7 +694,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 const child = directDescendants[index];
 
                 if ((<any>child).clone) {
-                    (<any>child).clone(name + "." + child.name, this);
+                    (<any>child).clone(this.name + "." + child.name, this);
                 }
             }
         }


### PR DESCRIPTION
When cloning a Mesh with the current version 7.17 I get a ReferenceError in the _copySource method of the Mesh object. The error was caused by accessing "name" without this. Prefixed "name" with this in _copySource.
