### PR TITLE
Move playground qr code position

### DIFF
--- a/packages/tools/playground/src/scss/qrCode.scss
+++ b/packages/tools/playground/src/scss/qrCode.scss
@@ -1,15 +1,12 @@
 .qr-code {
     position: absolute;
-    grid-column: 1 / 3;
-    grid-row: 1 / 3;
+    padding: 10px;
+    margin: 0;
     bottom: 0px;
-    right: calc(50% - 150px);
-    width: 300px;
-    height: 300px;
+    width: 256px;
+    height: 256px;
     z-index: 100;
     display: grid;
-    align-content: center;
-    justify-content: center;
     user-select: none;
     cursor: pointer;
 }


### PR DESCRIPTION
Move to bottom left to be less obstructive.