### PR TITLE
set activeView regardless of view.camera

### DIFF
--- a/packages/dev/core/src/Engines/AbstractEngine/abstractEngine.views.ts
+++ b/packages/dev/core/src/Engines/AbstractEngine/abstractEngine.views.ts
@@ -183,8 +183,6 @@ AbstractEngine.prototype._renderViewStep = function (view: EngineView): boolean 
         previewCamera = scene.activeCamera;
         previewCameras = scene.activeCameras;
 
-        this.activeView = view;
-
         if (Array.isArray(camera)) {
             scene.activeCameras = camera;
         } else {
@@ -192,6 +190,7 @@ AbstractEngine.prototype._renderViewStep = function (view: EngineView): boolean 
             scene.activeCameras = null;
         }
     }
+    this.activeView = view;
 
     if (view.customResize) {
         view.customResize(canvas);


### PR DESCRIPTION
fixes where `engine.activeView` was always null if no camera is set

addresses https://forum.babylonjs.com/t/activeview-for-multi-canvas-should-be-set-regardless-of-camera/52329