### PR TITLE
Viewer alpha inline dynamic imports

### DIFF
--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
@@ -12,6 +12,7 @@ const commonConfig = {
         sourcemap: true,
         format: "es",
         exports: "named",
+        inlineDynamicImports: true,
     },
     plugins: [
         typescript({ tsconfig: "tsconfig.build.dist.json" }),
@@ -31,7 +32,7 @@ const maxConfig = {
     output: {
         ...commonConfig.output,
         file: "dist/babylon-viewer.esm.js",
-    }
+    },
 };
 
 const minConfig = {
@@ -40,10 +41,7 @@ const minConfig = {
         ...commonConfig.output,
         file: "dist/babylon-viewer.esm.min.js",
     },
-    plugins: [
-        ...commonConfig.plugins,
-        terser(),
-    ]
+    plugins: [...commonConfig.plugins, terser()],
 };
 
 export default [maxConfig, minConfig];


### PR DESCRIPTION
To unblock the build, I am just explicitly configuring inline dynamic imports. This just embeds dynamic imports directly in the single file bundle, and retains the asynchrony so it behaves the same.

In a later PR, I will take a bit more time and update the rollup config to actually respect the dynamic imports and test it all out.

NOTE: For some reason this file was not correctly formatted. I guess my format on save must have stopped working in a previous VSCode session. So there are a few small formatting changes included as well.