### PR TITLE
Remove viewer-alpha dependency on sceneHelpers

### DIFF
--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -87,10 +87,10 @@ export class HTML3DElement extends HTMLElement {
     public attributeChangedCallback(name: (typeof HTML3DElement.observedAttributes)[number], oldValue: string, newValue: string) {
         switch (name) {
             case "src":
-                this._viewer.loadModelAsync(newValue).catch(Logger.Log);
+                this._viewer.loadModelAsync(new URL(newValue)).catch(Logger.Log);
                 break;
             case "env":
-                this._viewer.loadEnvironmentAsync(newValue).catch(Logger.Log);
+                this._viewer.loadEnvironmentAsync(new URL(newValue)).catch(Logger.Log);
                 break;
         }
     }

--- a/scripts/queryRollupStats.js
+++ b/scripts/queryRollupStats.js
@@ -28,9 +28,6 @@ function stringToColorHash(str) {
 }
 
 function queryRollupStats(filter, statsFilePath) {
-    console.log(`filter: ${filter}`);
-    console.log(`statsFilePath: ${statsFilePath}`);
-
     const { nodeMetas } = JSON.parse(fs.readFileSync(statsFilePath, "utf8"));
     const referenceStack = [];
 


### PR DESCRIPTION
`sceneHelpers` pulls in a ton of stuff, which we knew, but I was waiting to make this change until getting some of the size analysis tooling in place. Removing this dependency reduces the package size by about 560kb.

Also included in this PR are a couple other small changes:
- Switch from `string` to `URL` for model/env source. I don't think we want to support anything other than valid URLs for the viewer.
- Also accept `File` for the model. It would make sense to do this for env as well, but this isn't currently supported in Babylon, so I'll revisit it later.
- Remove a couple `console.log` statements that were added for debugging and accidentally left in with a previous PR.