### PR TITLE
Fix glob sync load

### DIFF
--- a/packages/dev/buildTools/src/addJSToCompiledFiles.ts
+++ b/packages/dev/buildTools/src/addJSToCompiledFiles.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as fs from "fs";
-import * as glob from "glob";
+import { globSync } from "glob";
 import * as path from "path";
 import { checkArgs } from "./utils.js";
 
@@ -47,6 +47,6 @@ export const addJsExtensionsToCompiledFilesCommand = () => {
     }
     if (typeof pathForFiles === "string") {
         console.log(`Adding .js extensions to files in ${pathForFiles}`);
-        addJsExtensionsToCompiledFiles(glob.sync(pathForFiles), forceMJS);
+        addJsExtensionsToCompiledFiles(globSync(pathForFiles), forceMJS);
     }
 };

--- a/packages/dev/buildTools/src/declarationsEs6.ts
+++ b/packages/dev/buildTools/src/declarationsEs6.ts
@@ -1,7 +1,7 @@
 import { checkArgs } from "./utils.js";
 import * as fs from "fs";
 import * as path from "path";
-import * as glob from "glob";
+import { globSync } from "glob";
 
 export const declarationsEs6 = () => {
     const root = checkArgs(["--root", "-r"]) as string;
@@ -11,8 +11,9 @@ export const declarationsEs6 = () => {
     console.log(`Declarations ES6: root: ${root}`, appendToFile ? `append to file: ${appendToFile}` : "");
 
     const fileContent = fs.readFileSync(path.join(".", appendToFile), "utf8");
-    const mixins = glob
-        .sync(path.join(root, "**/*.d.ts"))
+    const mixins = globSync(path.join(root, "**/*.d.ts"), {
+        windowsPathsNoEscape: true,
+    })
         .map((file) => {
             return fs.readFileSync(file, "utf8");
         })
@@ -29,7 +30,9 @@ ${mixins}
     if (constEnumToEnum) {
         // iterate over all files in the current directory and change const enum to enum
         // This can be done since we are exporting the enums to js as well
-        const files = glob.sync(path.join("./**/*.d.ts"));
+        const files = globSync(path.join("./**/*.d.ts"), {
+            windowsPathsNoEscape: true,
+        });
 
         files.forEach((file) => {
             let content = fs.readFileSync(file, "utf8");

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import * as glob from "glob";
+import { globSync } from "glob";
 import * as fs from "fs";
 import * as path from "path";
 import * as chokidar from "chokidar";
@@ -530,9 +530,21 @@ export function generateDeclaration() {
 
         const debounced = debounce(() => {
             const { output, namespaceDeclaration, looseDeclarationsString } = generateCombinedDeclaration(
-                directoriesToWatch.map((dir) => glob.sync(dir)).flat(),
+                directoriesToWatch
+                    .map((dir) =>
+                        globSync(dir, {
+                            windowsPathsNoEscape: true,
+                        })
+                    )
+                    .flat(),
                 config,
-                looseDeclarations.map((dir) => glob.sync(dir)).flat(),
+                looseDeclarations
+                    .map((dir) =>
+                        globSync(dir, {
+                            windowsPathsNoEscape: true,
+                        })
+                    )
+                    .flat(),
                 config.buildType
             );
             const filename = `${outputDir}/${config.filename || "index.d.ts"}`;

--- a/packages/dev/buildTools/src/ltsTransformer.ts
+++ b/packages/dev/buildTools/src/ltsTransformer.ts
@@ -2,7 +2,7 @@
 import * as path from "path";
 import * as ts from "typescript";
 import * as fs from "fs";
-import * as glob from "glob";
+import { globSync } from "glob";
 import * as chokidar from "chokidar";
 
 import { removeDir, checkDirectorySync, checkArgs, copyFile } from "./utils.js";
@@ -200,9 +200,9 @@ export const transformLtsCommand = () => {
     const sourceBaseDir = `./../../dev/${baseDir}/src`;
 
     // all LTS source files
-    const sourceFiles = glob.sync("./src/**/*.ts");
+    const sourceFiles = globSync("./src/**/*.ts");
     // all original sources
-    const baseSources = glob.sync(`${sourceBaseDir}/**/*.ts`);
+    const baseSources = globSync(`${sourceBaseDir}/**/*.ts`);
     const sourceToGenerated = (filePath: any, silent?: boolean) => {
         // check if not in base sources
         const relative = path.relative(sourceBaseDir, filePath);

--- a/packages/dev/buildTools/src/prepareEs6Build.ts
+++ b/packages/dev/buildTools/src/prepareEs6Build.ts
@@ -12,7 +12,9 @@ export const prepareES6Build = async () => {
             const constantsContent = fs.readFileSync(path.resolve(baseDir, constFile as string), "utf8").replace("export class Constants", "const Constants = ");
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const Constants = eval(constantsContent + "\nConstants;");
-            const allSourceFiles = globSync(path.resolve(baseDir, "**", "*.js"));
+            const allSourceFiles = globSync(path.resolve(baseDir, "**", "*.js"), {
+                windowsPathsNoEscape: true,
+            });
             allSourceFiles.forEach((file) => {
                 if (file.endsWith(constFile as string)) {
                     return;

--- a/packages/dev/buildTools/src/prepareEs6Build.ts
+++ b/packages/dev/buildTools/src/prepareEs6Build.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as path from "path";
-import * as glob from "glob";
+import { globSync } from "glob";
 import * as fs from "fs-extra";
 import { checkArgs } from "./utils.js";
 
@@ -12,7 +12,7 @@ export const prepareES6Build = async () => {
             const constantsContent = fs.readFileSync(path.resolve(baseDir, constFile as string), "utf8").replace("export class Constants", "const Constants = ");
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const Constants = eval(constantsContent + "\nConstants;");
-            const allSourceFiles = glob.sync(path.resolve(baseDir, "**", "*.js"));
+            const allSourceFiles = globSync(path.resolve(baseDir, "**", "*.js"));
             allSourceFiles.forEach((file) => {
                 if (file.endsWith(constFile as string)) {
                     return;

--- a/packages/dev/buildTools/src/prepareSnapshot.ts
+++ b/packages/dev/buildTools/src/prepareSnapshot.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as glob from "glob";
+import { globSync } from "glob";
 import * as path from "path";
 import type { UMDPackageName } from "./packageMapping.js";
 import { umdPackageMapping } from "./packageMapping.js";
@@ -11,7 +11,7 @@ export const prepareSnapshot = () => {
     Object.keys(umdPackageMapping).forEach((packageName) => {
         const metadata = umdPackageMapping[packageName as UMDPackageName];
         const corePath = path.join(baseDirectory, "packages", "public", "umd", packageName);
-        const coreUmd = glob.sync(`${corePath}/*+(.js|.d.ts|.map)`);
+        const coreUmd = globSync(`${corePath}/*+(.js|.d.ts|.map)`);
         for (const file of coreUmd) {
             copyFile(file, path.join(snapshotDirectory, metadata.baseDir, path.basename(file)), true);
         }
@@ -20,7 +20,7 @@ export const prepareSnapshot = () => {
     // copy gltf2interface
     {
         const baseLocation = path.join(baseDirectory, "packages", "public");
-        const staticFiles = glob.sync(`${baseLocation}/glTF2Interface/*.*`);
+        const staticFiles = globSync(`${baseLocation}/glTF2Interface/*.*`);
         for (const file of staticFiles) {
             // ignore package.json files
             if (path.basename(file) === "package.json") {
@@ -34,7 +34,7 @@ export const prepareSnapshot = () => {
     // make sure the .d.ts files are also available, clone the .module.d.ts files
     {
         const baseLocation = path.join(baseDirectory, ".snapshot");
-        const staticFiles = glob.sync(`${baseLocation}/**/*.module.d.ts`);
+        const staticFiles = globSync(`${baseLocation}/**/*.module.d.ts`);
         for (const file of staticFiles) {
             // check if the file already exists. if it isn't, copy it
             if (!fs.existsSync(file.replace(".module", ""))) {
@@ -45,7 +45,7 @@ export const prepareSnapshot = () => {
 
     // copy all static files
     const baseLocation = path.join(baseDirectory, "packages", "tools", "babylonServer", "public");
-    const staticFiles = glob.sync(`${baseLocation}/**/*.*`);
+    const staticFiles = globSync(`${baseLocation}/**/*.*`);
     for (const file of staticFiles) {
         // ignore package.json files
         if (path.basename(file) === "package.json") {
@@ -56,7 +56,7 @@ export const prepareSnapshot = () => {
     }
     // copy dist from babylon server
     const baseLocationDist = path.join(baseDirectory, "packages", "tools", "babylonServer", "dist");
-    const staticFilesDist = glob.sync(`${baseLocationDist}/**/*.js`);
+    const staticFilesDist = globSync(`${baseLocationDist}/**/*.js`);
     for (const file of staticFilesDist) {
         const relative = path.relative(baseLocationDist, file);
         copyFile(file, path.join(snapshotDirectory, relative), true);

--- a/packages/dev/buildTools/src/utils.ts
+++ b/packages/dev/buildTools/src/utils.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as dotenv from "dotenv";
 import * as crypto from "crypto";
-import { glob } from "glob";
+import { globSync } from "glob";
 
 export function populateEnvironment() {
     dotenv.config({ path: path.resolve(findRootDirectory(), "./.env") });
@@ -110,7 +110,11 @@ export function copyFolder(from: string, to: string, silent?: boolean) {
     try {
         isDirectory = fs.lstatSync(from).isDirectory();
     } catch (e) {}
-    const files = isDirectory ? fs.readdirSync(from) : glob.sync(from);
+    const files = isDirectory
+        ? fs.readdirSync(from)
+        : globSync(from, {
+              windowsPathsNoEscape: true,
+          });
     const baseDir = isDirectory ? from : "";
     for (const file of files) {
         const basename = isDirectory ? file : path.basename(file);

--- a/packages/tools/tests/scripts/generateFileSizes.js
+++ b/packages/tools/tests/scripts/generateFileSizes.js
@@ -3,7 +3,7 @@ const glob = require("glob");
 const path = require("path");
 
 const sizes = {};
-glob.sync("./dist/**/*.js").forEach((file) => {
+glob.globSync("./dist/**/*.js").forEach((file) => {
     const stats = statSync(file);
     console.log(`${file} - ${stats.size}`);
     const filename = path.basename(file);

--- a/scripts/typedoc-generator.js
+++ b/scripts/typedoc-generator.js
@@ -81,7 +81,7 @@ async function main() {
     const packages = process.argv.includes("--packages") ? process.argv[process.argv.indexOf("--packages") + 1].split(",") : ["core", "loaders", "materials", "gui", "serializers"];
     const full = process.argv.includes("--full");
     const filesChanged = (await runCommand(process.env.GIT_CHANGES_COMMAND || "git diff --name-only master")).split("\n");
-    const files = glob.sync(`packages/dev/@(${packages.join("|")})/src/index.ts`).filter((f) => /*!f.endsWith("index.ts") && */ !f.endsWith(".d.ts"));
+    const files = glob.globSync(`packages/dev/@(${packages.join("|")})/src/index.ts`).filter((f) => /*!f.endsWith("index.ts") && */ !f.endsWith(".d.ts"));
     console.log(files);
     const dirList = files.filter((file) => {
         return file.endsWith(".ts");

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const exec = require("child_process").exec;
 const path = require("path");
 const fs = require("fs");
@@ -49,7 +50,7 @@ const updateEngineVersion = async (version) => {
 
 const updateSinceTag = (version) => {
     // get all typescript files in the dev folder
-    const files = glob.sync(path.join(baseDirectory, "packages", "dev", "**", "*.ts"));
+    const files = glob.globSync(path.join(baseDirectory, "packages", "dev", "**", "*.ts"));
     files.forEach((file) => {
         try {
             // check if file contains @since\n
@@ -76,7 +77,7 @@ const updateSinceTag = (version) => {
 
 const updatePeerDependencies = async (version) => {
     // get all package.json files in the dev folder
-    const files = glob.sync(path.join(baseDirectory, "packages", "public", "**", "package.json"));
+    const files = glob.globSync(path.join(baseDirectory, "packages", "public", "**", "package.json"));
     files.forEach((file) => {
         try {
             // check if file contains @since\n


### PR DESCRIPTION
new glob version doesn't support windows paths, unless a specific flag is provided. path.resolve provides a windows path, so whenever we use path.resolve we have to pass the flag to `globSync`.

This will fix declaration generation on local windows.