### PR TITLE
Fix AnimationGroup Animatable leak and onAnimationGroupEndObservable

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -798,6 +798,11 @@ export class AnimationGroup implements IDisposable {
             const animatable = this._scene._activeAnimatables[index];
             if (animatable._runtimeAnimations.length > 0) {
                 this._scene._activeAnimatables[curIndex++] = animatable;
+            } else if (skipOnAnimationEnd) {
+                // We normally rely on the onAnimationEnd callback (assigned in the start function) to be notified when an animatable
+                // ends and should be removed from the active animatables array. However, if the animatable is stopped with the skipOnAnimationEnd
+                // flag set to true, then we need to explicitly remove it from the active animatables array.
+                this._checkAnimationGroupEnded(animatable, skipOnAnimationEnd);
             }
         }
         this._scene._activeAnimatables.length = curIndex;
@@ -892,7 +897,7 @@ export class AnimationGroup implements IDisposable {
         this.onAnimationGroupLoopObservable.clear();
     }
 
-    private _checkAnimationGroupEnded(animatable: Animatable) {
+    private _checkAnimationGroupEnded(animatable: Animatable, skipOnAnimationEnd = false) {
         // animatable should be taken out of the array
         const idx = this._animatables.indexOf(animatable);
         if (idx > -1) {
@@ -902,7 +907,9 @@ export class AnimationGroup implements IDisposable {
         // all animatables were removed? animation group ended!
         if (this._animatables.length === 0) {
             this._isStarted = false;
-            this.onAnimationGroupEndObservable.notifyObservers(this);
+            if (!skipOnAnimationEnd) {
+                this.onAnimationGroupEndObservable.notifyObservers(this);
+            }
         }
     }
 


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/onanimationgroupendobservable-can-only-trigger-once/52494/2

In a [recent change](https://github.com/BabylonJS/Babylon.js/pull/15339), the `onAnimationEnd` event can be suppressed when an animation is stopped. `AnimationGroup` uses this, but also relies on `onAnimationEnd` to know when to remove an `Animatable`. Since it no longer fires, `Animatables` are not removed and just keep accumulating in the `_animatables` array (e.g. if you keep calling `stop`/`start` on the `AnimationGroup`). Additionally, since these `Animatable`s are accumulating indefinitely, the array will never be empty again and so `onAnimationGroupEndObservable` stops firing.

See https://playground.babylonjs.com/#7V0Y1I#4118

The change here is to explicitly remove the `Animatable`(s) when the `AnimationGroup` is stopped and the `onAnimationEnd` event is suppressed (and also suppress the `AnimationGroup` from triggering `onAnimationGroupEndObservable`). The `AnimationGroup` logic is a bit complex, so I'm not 100% sure this is the right fix.