### PR TITLE
Tensor: Add `toJSON` and `fromJSON` methods

### DIFF
--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -91,6 +91,26 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
         return hash;
     }
 
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IColor3Like {
+        return {
+            r: this.r,
+            g: this.g,
+            b: this.b,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IColor3Like>): this {
+        this.copyFrom(json);
+        return this;
+    }
+
     // Operators
 
     /**
@@ -1504,6 +1524,27 @@ export class Color4 implements Tensor<Tuple<number, 4>, IColor4Like>, IColor4Lik
         hash = (hash * 397) ^ ((this.b * 255) | 0);
         hash = (hash * 397) ^ ((this.a * 255) | 0);
         return hash;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IColor4Like {
+        return {
+            r: this.r,
+            g: this.g,
+            b: this.b,
+            a: this.a,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IColor4Like>): this {
+        this.copyFrom(json);
+        return this;
     }
 
     /**

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -20,7 +20,7 @@ const _ExtractAsInt = (value: number) => {
 /**
  * Represents a vector of any dimension
  */
-export interface Vector<N extends number[], I> extends Tensor<N, I> {
+export interface Vector<N extends number[], I, TJSON = I> extends Tensor<N, I, TJSON> {
     /**
      * @see Tensor.dimension
      */
@@ -61,7 +61,7 @@ export interface Vector<N extends number[], I> extends Tensor<N, I> {
      * Normalize the current Vector to a new vector
      * @returns the new Vector
      */
-    normalizeToNew(): Vector<N, I>;
+    normalizeToNew(): Vector<N, I, TJSON>;
 
     /**
      * Normalize the current Vector to the reference
@@ -74,14 +74,14 @@ export interface Vector<N extends number[], I> extends Tensor<N, I> {
 /**
  * Static side of Vector
  */
-export interface VectorStatic<T extends Vector<any[], _I>, _I = TensorLike<T>> extends TensorStatic<T, _I> {
+export interface VectorStatic<T extends Vector<any[], I, TJSON>, I = TensorLike<T>, TJSON = I> extends TensorStatic<T, I, TJSON> {
     /**
      * Checks if a given vector is inside a specific range
      * @param value defines the vector to test
      * @param min defines the minimum range
      * @param max defines the maximum range
      */
-    CheckExtends(value: _I, min: _I, max: _I): void;
+    CheckExtends(value: I, min: I, max: I): void;
 
     /**
      * Returns a new Vector equal to the normalized given vector
@@ -154,6 +154,25 @@ export class Vector2 implements Vector<Tuple<number, 2>, IVector2Like>, IVector2
         let hash = x;
         hash = (hash * 397) ^ y;
         return hash;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IVector2Like {
+        return {
+            x: this.x,
+            y: this.y,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IVector2Like>): this {
+        this.copyFrom(json);
+        return this;
     }
 
     // Operators
@@ -1168,7 +1187,7 @@ Object.defineProperties(Vector2.prototype, {
  * Reminder: js uses a left handed forward facing system
  * Example Playground - Overview - https://playground.babylonjs.com/#R1F8YU
  */
-export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like {
+export class Vector3 implements Vector<Tuple<number, 3>, Vector3, IVector3Like>, IVector3Like {
     private static _UpReadOnly = Vector3.Up() as DeepImmutable<Vector3>;
     private static _DownReadOnly = Vector3.Down() as DeepImmutable<Vector3>;
     private static _LeftHandedForwardReadOnly = Vector3.Forward(false) as DeepImmutable<Vector3>;
@@ -1274,6 +1293,26 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
         hash = (hash * 397) ^ y;
         hash = (hash * 397) ^ z;
         return hash;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IVector3Like {
+        return {
+            x: this._x,
+            y: this._y,
+            z: this._z,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IVector3Like>): this {
+        this.set(json.x, json.y, json.z);
+        return this;
     }
 
     // Operators
@@ -3346,7 +3385,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
         return ref;
     }
 }
-Vector3 satisfies VectorStatic<Vector3, Vector3>;
+Vector3 satisfies VectorStatic<Vector3, Vector3, IVector3Like>;
 Object.defineProperties(Vector3.prototype, {
     dimension: { value: [3] },
     rank: { value: 1 },
@@ -3417,6 +3456,27 @@ export class Vector4 implements Vector<Tuple<number, 4>, IVector4Like>, IVector4
         hash = (hash * 397) ^ z;
         hash = (hash * 397) ^ w;
         return hash;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IVector4Like {
+        return {
+            x: this.x,
+            y: this.y,
+            z: this.z,
+            w: this.w,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IVector4Like>): this {
+        this.copyFrom(json);
+        return this;
     }
 
     // Operators
@@ -4391,7 +4451,7 @@ Object.defineProperties(Vector4.prototype, {
  * @see https://en.wikipedia.org/wiki/Quaternion
  * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms
  */
-export class Quaternion implements Tensor<Tuple<number, 4>, Quaternion>, IQuaternionLike {
+export class Quaternion implements Tensor<Tuple<number, 4>, Quaternion, IQuaternionLike>, IQuaternionLike {
     /** @internal */
     public _x: number;
 
@@ -4502,6 +4562,27 @@ export class Quaternion implements Tensor<Tuple<number, 4>, Quaternion>, IQuater
         hash = (hash * 397) ^ z;
         hash = (hash * 397) ^ w;
         return hash;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): IQuaternionLike {
+        return {
+            x: this._x,
+            y: this._y,
+            z: this._z,
+            w: this._w,
+        };
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: DeepImmutable<IQuaternionLike>): this {
+        this.set(json.x, json.y, json.z, json.w);
+        return this;
     }
 
     /**
@@ -5928,11 +6009,13 @@ export class Quaternion implements Tensor<Tuple<number, 4>, Quaternion>, IQuater
         return ref.copyFromFloats((value1.x + value2.x) / 2, (value1.y + value2.y) / 2, (value1.z + value2.z) / 2, (value1.w + value2.w) / 2);
     }
 }
-Quaternion satisfies TensorStatic<Quaternion, Quaternion>;
+Quaternion satisfies TensorStatic<Quaternion, Quaternion, IQuaternionLike>;
 Object.defineProperties(Quaternion.prototype, {
     dimension: { value: [4] },
     rank: { value: 1 },
 });
+
+type _Tuple4x4 = Tuple<Tuple<number, 4>, 4>;
 
 /**
  * Class used to store matrix data (4x4)
@@ -5956,7 +6039,7 @@ Object.defineProperties(Quaternion.prototype, {
  * Example Playground - Overview Transformation - https://playground.babylonjs.com/#AV9X17#1
  * Example Playground - Overview Projection - https://playground.babylonjs.com/#AV9X17#2
  */
-export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>, Matrix>, IMatrixLike {
+export class Matrix implements Tensor<_Tuple4x4, Matrix, _Tuple4x4>, IMatrixLike {
     /**
      * @see Tensor.dimension
      */
@@ -6151,6 +6234,22 @@ export class Matrix implements Tensor<Tuple<Tuple<number, 4>, 4>, Matrix>, IMatr
      */
     public toString(): string {
         return `{${this.m[0]}, ${this.m[1]}, ${this.m[2]}, ${this.m[3]}\n${this.m[4]}, ${this.m[5]}, ${this.m[6]}, ${this.m[7]}\n${this.m[8]}, ${this.m[9]}, ${this.m[10]}, ${this.m[11]}\n${this.m[12]}, ${this.m[13]}, ${this.m[14]}, ${this.m[15]}}`;
+    }
+
+    /**
+     * @returns JSON object
+     */
+    public toJSON(): _Tuple4x4 {
+        return [this._m.slice(0, 4), this._m.slice(4, 8), this._m.slice(8, 12), this._m.slice(12, 16)] as _Tuple4x4;
+    }
+
+    /**
+     * @param json the JSON object to use
+     * @returns this
+     */
+    public fromJSON(json: _Tuple4x4): this {
+        this.copyFromFloats(...[...json[0], ...json[1], ...json[2], ...json[3]]);
+        return this;
     }
 
     /**

--- a/packages/dev/core/src/Maths/tensor.ts
+++ b/packages/dev/core/src/Maths/tensor.ts
@@ -22,7 +22,7 @@ export type TensorLike<T> = T extends Tensor<TensorValue, infer I> ? I : never;
  * Describes a mathematical tensor.
  * @see https://wikipedia.org/wiki/Tensor
  */
-export interface Tensor<V extends TensorValue, I> {
+export interface Tensor<V extends TensorValue, I, J = I> {
     /**
      * An array of the size of each dimension.
      * For example, [3] for a Vector3 and [4,4] for a Matrix
@@ -50,6 +50,18 @@ export interface Tensor<V extends TensorValue, I> {
      * @returns the instance hash code as a number
      */
     getHashCode(): number;
+
+    /**
+     * Copy the current instance as a JSON object
+     * @returns a JSON object with the instance data.
+     */
+    toJSON(): J;
+
+    /**
+     * Update the current instance from a JSON object
+     * @returns the current instance
+     */
+    fromJSON(json: J): this;
 
     /**
      * Sets the instance coordinates in the given array from the given index.
@@ -104,7 +116,7 @@ export interface Tensor<V extends TensorValue, I> {
      * @param other defines the other instance
      * @returns a new instance set with the addition of the current instance and the given one coordinates
      */
-    add(other: DeepImmutable<I>): Tensor<V, I>;
+    add(other: DeepImmutable<I>): Tensor<V, I, J>;
 
     /**
      * Sets the "result" coordinates with the addition of the current instance and the given one coordinates
@@ -133,7 +145,7 @@ export interface Tensor<V extends TensorValue, I> {
      * @param other defines the other instance
      * @returns a new instance
      */
-    subtract(other: DeepImmutable<I>): Tensor<V, I>;
+    subtract(other: DeepImmutable<I>): Tensor<V, I, J>;
 
     /**
      * Sets the "result" coordinates with the subtraction of the other's coordinates from the current coordinates.
@@ -155,7 +167,7 @@ export interface Tensor<V extends TensorValue, I> {
      * @param floats the coordinates to subtract
      * @returns the resulting instance
      */
-    subtractFromFloats(...floats: TensorNumberArray<V>): Tensor<V, I>;
+    subtractFromFloats(...floats: TensorNumberArray<V>): Tensor<V, I, J>;
 
     /**
      * Subtracts the given floats from the current instance coordinates and set the given instance "result" with this result
@@ -170,7 +182,7 @@ export interface Tensor<V extends TensorValue, I> {
      * @param other defines the other instance
      * @returns a new instance
      */
-    multiply(other: DeepImmutable<I>): Tensor<V, I>;
+    multiply(other: DeepImmutable<I>): Tensor<V, I, J>;
 
     /**
      * Sets "result" coordinates with the multiplication of the current instance and the given one coordinates
@@ -191,14 +203,14 @@ export interface Tensor<V extends TensorValue, I> {
      * Gets a new instance set with the instance coordinates multiplied by the given floats
      * @returns a new instance
      */
-    multiplyByFloats(...floats: TensorNumberArray<V>): Tensor<V, I>;
+    multiplyByFloats(...floats: TensorNumberArray<V>): Tensor<V, I, J>;
 
     /**
      * Returns a new instance set with the instance coordinates divided by the given one coordinates
      * @param other defines the other instance
      * @returns a new instance
      */
-    divide(other: DeepImmutable<I>): Tensor<V, I>;
+    divide(other: DeepImmutable<I>): Tensor<V, I, J>;
 
     /**
      * Sets the "result" coordinates with the instance coordinates divided by the given one coordinates
@@ -247,7 +259,7 @@ export interface Tensor<V extends TensorValue, I> {
      * Gets a new instance with current instance negated coordinates
      * @returns a new instance
      */
-    negate(): Tensor<V, I>;
+    negate(): Tensor<V, I, J>;
 
     /**
      * Negate this instance in place
@@ -274,7 +286,7 @@ export interface Tensor<V extends TensorValue, I> {
      * @param scale defines the scaling factor
      * @returns a new instance
      */
-    scale(scale: number): Tensor<V, I>;
+    scale(scale: number): Tensor<V, I, J>;
 
     /**
      * Scale the current instance values by a factor to a given instance
@@ -319,7 +331,7 @@ export interface Tensor<V extends TensorValue, I> {
      * eg (1.2, 2.31) returns (1, 2)
      * @returns a new instance
      */
-    floor(): Tensor<V, I>;
+    floor(): Tensor<V, I, J>;
 
     /**
      * Gets the current instance's floored values and stores them in result
@@ -333,7 +345,7 @@ export interface Tensor<V extends TensorValue, I> {
      * eg (1.2, 2.31) returns (0.2, 0.31)
      * @returns a new instance
      */
-    fract(): Tensor<V, I>;
+    fract(): Tensor<V, I, J>;
 
     /**
      * Gets the current instance's fractional values and stores them in result
@@ -346,7 +358,7 @@ export interface Tensor<V extends TensorValue, I> {
      * Gets a new instance copied from the instance
      * @returns a new instance
      */
-    clone(): Tensor<V, I>;
+    clone(): Tensor<V, I, J>;
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -354,7 +366,7 @@ export interface Tensor<V extends TensorValue, I> {
  * Static side of Tensor
  * @see Tensor
  */
-export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
+export interface TensorStatic<T extends Tensor<any[], I, _JSON>, I = TensorLike<T>, _JSON = I> {
     /**
      * Creates a new instance from the given coordinates
      */
@@ -411,7 +423,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param right defines second instance
      * @returns the dot product (float)
      */
-    Dot(left: DeepImmutable<_I>, right: DeepImmutable<_I>): number;
+    Dot(left: DeepImmutable<I>, right: DeepImmutable<I>): number;
 
     /**
      * Gets a new instance set with the minimal coordinate values from the "left" and "right" instances
@@ -419,7 +431,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param right defines 2nd instance
      * @returns a new instance
      */
-    Minimize(left: DeepImmutable<_I>, right: DeepImmutable<_I>): T;
+    Minimize(left: DeepImmutable<I>, right: DeepImmutable<I>): T;
 
     /**
      * Gets a new instance set with the maximal coordinate values from the "left" and "right" instances
@@ -427,7 +439,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param right defines 2nd instance
      * @returns a new instance
      */
-    Maximize(left: DeepImmutable<_I>, right: DeepImmutable<_I>): T;
+    Maximize(left: DeepImmutable<I>, right: DeepImmutable<I>): T;
 
     /**
      * Gets the distance between the instances "value1" and "value2"
@@ -435,7 +447,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param value2 defines second instance
      * @returns the distance between instances
      */
-    Distance(value1: DeepImmutable<_I>, value2: DeepImmutable<_I>): number;
+    Distance(value1: DeepImmutable<I>, value2: DeepImmutable<I>): number;
 
     /**
      * Returns the squared distance between the instances "value1" and "value2"
@@ -443,7 +455,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param value2 defines second instance
      * @returns the squared distance between instances
      */
-    DistanceSquared(value1: DeepImmutable<_I>, value2: DeepImmutable<_I>): number;
+    DistanceSquared(value1: DeepImmutable<I>, value2: DeepImmutable<I>): number;
 
     /**
      * Gets a new instance located at the center of the instances "value1" and "value2"
@@ -451,7 +463,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param value2 defines second instance
      * @returns a new instance
      */
-    Center(value1: DeepImmutable<_I>, value2: DeepImmutable<_I>): T;
+    Center(value1: DeepImmutable<I>, value2: DeepImmutable<I>): T;
 
     /**
      * Gets the center of the instances "value1" and "value2" and stores the result in the instance "ref"
@@ -460,7 +472,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param ref defines third instance
      * @returns ref
      */
-    CenterToRef(value1: DeepImmutable<_I>, value2: DeepImmutable<_I>, ref: T): T;
+    CenterToRef(value1: DeepImmutable<I>, value2: DeepImmutable<I>, ref: T): T;
 
     /**
      * Returns a new instance set with same the coordinates than "value" ones if the instance "value" is in the square defined by "min" and "max".
@@ -471,7 +483,7 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param max defines the upper limit
      * @returns a new instance
      */
-    Clamp(value: DeepImmutable<_I>, min: DeepImmutable<_I>, max: DeepImmutable<_I>): T;
+    Clamp(value: DeepImmutable<I>, min: DeepImmutable<I>, max: DeepImmutable<I>): T;
 
     /**
      * Returns a new instance set with same the coordinates than "value" ones if the instance "value" is in the square defined by "min" and "max".
@@ -483,6 +495,6 @@ export interface TensorStatic<T extends Tensor<any[], _I>, _I = TensorLike<T>> {
      * @param result defines the instance where to store the result
      * @returns the updated result instance
      */
-    ClampToRef(value: DeepImmutable<_I>, min: DeepImmutable<_I>, max: DeepImmutable<_I>, result: T): T;
+    ClampToRef(value: DeepImmutable<I>, min: DeepImmutable<I>, max: DeepImmutable<I>, result: T): T;
 }
 /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
This PR adds the `toJSON` and `fromJSON` utility methods to Tensor-compliant classes. The goal is to provide a simple way to store vectors, colors, matrices, and quaternions in plain text (with an obvious focus on JSON).

While using `asArray` and `fromArray` works fine, storing the data as an array has some consequences. To start with, data structure is not saved- for example, `Color3` and `Vector3` are saved the same. This makes reading the data difficult since a programmer needs a deeper knowledge of a code base to know what an array of numbers is.

This PR is not a comprehensive overhaul to serialization, it is giving programmers more options when serializing data involving Babylon's classes.