### PR TITLE
Fix WebGPU ACES tonemapping shader compilation error

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/imageProcessingFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/imageProcessingFunctions.fx
@@ -60,7 +60,7 @@
 		output = ACESOutputMat * output;
 
 		// Clamp to [0, 1]
-		output = saturate(output);
+		output = saturateVec3(output);
 
 		return output;
 	}


### PR DESCRIPTION
You can check out the problem in this demo:
https://www.babylonjs.com/Demos/WebGPU/forestWebGPU.html