### PR TITLE
Make `Vector3` compatible with `Vector3LikeInternal`

### DIFF
--- a/packages/dev/core/src/Maths/math.like.ts
+++ b/packages/dev/core/src/Maths/math.like.ts
@@ -34,6 +34,16 @@ export interface IVector3Like extends IVector2Like {
 /**
  * @internal
  */
+export interface Vector3LikeInternal {
+    _x: number;
+    _y: number;
+    _z: number;
+    _isDirty?: boolean;
+}
+
+/**
+ * @internal
+ */
 export interface IVector4Like extends IVector3Like {
     w: float;
 }

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -9,7 +9,7 @@ import { PerformanceConfigurator } from "../Engines/performanceConfigurator";
 import { EngineStore } from "../Engines/engineStore";
 import type { TransformNode } from "../Meshes/transformNode";
 import type { Dimension, Tensor, TensorLike, TensorStatic } from "./tensor";
-import type { IVector2Like, IVector3Like, IVector4Like, IQuaternionLike, IMatrixLike, IPlaneLike } from "./math.like";
+import type { IVector2Like, IVector3Like, IVector4Like, IQuaternionLike, IMatrixLike, IPlaneLike, Vector3LikeInternal } from "./math.like";
 import { Clamp, Lerp, NormalizeRadians, RandomRange, WithinEpsilon } from "./math.scalar.functions";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -1168,7 +1168,7 @@ Object.defineProperties(Vector2.prototype, {
  * Reminder: js uses a left handed forward facing system
  * Example Playground - Overview - https://playground.babylonjs.com/#R1F8YU
  */
-export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like {
+export class Vector3 implements Vector<Tuple<number, 3>, Vector3LikeInternal>, IVector3Like {
     private static _UpReadOnly = Vector3.Up() as DeepImmutable<Vector3>;
     private static _DownReadOnly = Vector3.Down() as DeepImmutable<Vector3>;
     private static _LeftHandedForwardReadOnly = Vector3.Forward(false) as DeepImmutable<Vector3>;
@@ -1358,7 +1358,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the resulting Vector3
      */
-    public add(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public add(otherVector: DeepImmutable<Vector3LikeInternal>): Vector3 {
         return new Vector3(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
     }
 
@@ -1369,8 +1369,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public addToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
-        return result.copyFromFloats(this._x + otherVector._x, this._y + otherVector._y, this._z + otherVector._z);
+    public addToRef<T extends Vector3LikeInternal>(otherVector: DeepImmutable<Vector3LikeInternal>, result: T): T {
+        result._x = this._x + otherVector._x;
+        result._y = this._y + otherVector._y;
+        result._z = this._z + otherVector._z;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1379,7 +1383,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public subtractInPlace(otherVector: DeepImmutable<Vector3>): this {
+    public subtractInPlace(otherVector: DeepImmutable<Vector3LikeInternal>): this {
         this._x -= otherVector._x;
         this._y -= otherVector._y;
         this._z -= otherVector._z;
@@ -1393,7 +1397,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the resulting Vector3
      */
-    public subtract(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public subtract(otherVector: DeepImmutable<Vector3LikeInternal>): Vector3 {
         return new Vector3(this._x - otherVector._x, this._y - otherVector._y, this._z - otherVector._z);
     }
 
@@ -1404,7 +1408,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public subtractToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
+    public subtractToRef<T extends Vector3LikeInternal>(otherVector: DeepImmutable<Vector3LikeInternal>, result: T): T {
         return this.subtractFromFloatsToRef(otherVector._x, otherVector._y, otherVector._z, result);
     }
 
@@ -1429,8 +1433,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public subtractFromFloatsToRef<T extends Vector3>(x: number, y: number, z: number, result: T): T {
-        return result.copyFromFloats(this._x - x, this._y - y, this._z - z);
+    public subtractFromFloatsToRef<T extends Vector3LikeInternal>(x: number, y: number, z: number, result: T): T {
+        result._x = this._x - x;
+        result._y = this._y - y;
+        result._z = this._z - z;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1461,8 +1469,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public negateToRef<T extends Vector3 = Vector3>(result: T): T {
-        return result.copyFromFloats(this._x * -1, this._y * -1, this._z * -1);
+    public negateToRef<T extends Vector3LikeInternal>(result: T): T {
+        result._x = this._x * -1;
+        result._y = this._y * -1;
+        result._z = this._z * -1;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1496,8 +1508,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public scaleToRef<T extends Vector3>(scale: number, result: T): T {
-        return result.copyFromFloats(this._x * scale, this._y * scale, this._z * scale);
+    public scaleToRef<T extends Vector3LikeInternal>(scale: number, result: T): T {
+        result._x = this._x * scale;
+        result._y = this._y * scale;
+        result._z = this._z * scale;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1592,8 +1608,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns result input
      */
-    public scaleAndAddToRef<T extends Vector3>(scale: number, result: T): T {
-        return result.addInPlaceFromFloats(this._x * scale, this._y * scale, this._z * scale);
+    public scaleAndAddToRef<T extends Vector3LikeInternal>(scale: number, result: T): T {
+        result._x += this._x * scale;
+        result._y += this._y * scale;
+        result._z += this._z * scale;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1681,7 +1701,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public multiplyInPlace(otherVector: DeepImmutable<Vector3>): this {
+    public multiplyInPlace(otherVector: DeepImmutable<Vector3LikeInternal>): this {
         this._x *= otherVector._x;
         this._y *= otherVector._y;
         this._z *= otherVector._z;
@@ -1695,7 +1715,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the new Vector3
      */
-    public multiply(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public multiply(otherVector: DeepImmutable<Vector3LikeInternal>): Vector3 {
         return this.multiplyByFloats(otherVector._x, otherVector._y, otherVector._z);
     }
 
@@ -1706,8 +1726,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public multiplyToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
-        return result.copyFromFloats(this._x * otherVector._x, this._y * otherVector._y, this._z * otherVector._z);
+    public multiplyToRef<T extends Vector3LikeInternal>(otherVector: DeepImmutable<Vector3LikeInternal>, result: T): T {
+        result._x = this._x * otherVector._x;
+        result._y = this._y * otherVector._y;
+        result._z = this._z * otherVector._z;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1728,7 +1752,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the new Vector3
      */
-    public divide(otherVector: DeepImmutable<Vector3>): Vector3 {
+    public divide(otherVector: DeepImmutable<Vector3LikeInternal>): Vector3 {
         return new Vector3(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
     }
 
@@ -1739,8 +1763,12 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result defines the Vector3 object where to store the result
      * @returns the result
      */
-    public divideToRef<T extends Vector3>(otherVector: DeepImmutable<Vector3>, result: T): T {
-        return result.copyFromFloats(this._x / otherVector._x, this._y / otherVector._y, this._z / otherVector._z);
+    public divideToRef<T extends Vector3LikeInternal>(otherVector: DeepImmutable<Vector3LikeInternal>, result: T): T {
+        result._x = this._x / otherVector._x;
+        result._y = this._y / otherVector._y;
+        result._z = this._z / otherVector._z;
+        result._isDirty = true;
+        return result;
     }
 
     /**
@@ -1749,7 +1777,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param otherVector defines the second operand
      * @returns the current updated Vector3
      */
-    public divideInPlace(otherVector: DeepImmutable<Vector3>): this {
+    public divideInPlace(otherVector: DeepImmutable<Vector3LikeInternal>): this {
         this._x = this._x / otherVector._x;
         this._y = this._y / otherVector._y;
         this._z = this._z / otherVector._z;
@@ -1763,7 +1791,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param other defines the second operand
      * @returns the current updated Vector3
      */
-    public minimizeInPlace(other: DeepImmutable<Vector3>): this {
+    public minimizeInPlace(other: DeepImmutable<Vector3LikeInternal>): this {
         return this.minimizeInPlaceFromFloats(other._x, other._y, other._z);
     }
 
@@ -1773,7 +1801,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param other defines the second operand
      * @returns the current updated Vector3
      */
-    public maximizeInPlace(other: DeepImmutable<Vector3>): this {
+    public maximizeInPlace(other: DeepImmutable<Vector3LikeInternal>): this {
         return this.maximizeInPlaceFromFloats(other._x, other._y, other._z);
     }
 
@@ -1867,7 +1895,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result the vector to store the result in
      * @returns the result vector
      */
-    public floorToRef<T extends Vector3>(result: T): T {
+    public floorToRef<T extends Vector3LikeInternal>(result: T): T {
         result._x = Math.floor(this._x);
         result._y = Math.floor(this._y);
         result._z = Math.floor(this._z);
@@ -1889,7 +1917,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
      * @param result the vector to store the result in
      * @returns the result vector
      */
-    public fractToRef<T extends Vector3>(result: T): T {
+    public fractToRef<T extends Vector3LikeInternal>(result: T): T {
         result._x = this.x - Math.floor(this._x);
         result._y = this.y - Math.floor(this._y);
         result._z = this.z - Math.floor(this._z);
@@ -2027,16 +2055,20 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
     /**
      * Normalize the current Vector3 to the reference
      * Example Playground https://playground.babylonjs.com/#R1F8YU#125
-     * @param reference define the Vector3 to update
+     * @param result define the Vector3 to update
      * @returns the updated Vector3
      */
-    public normalizeToRef<T extends Vector3>(reference: T): T {
+    public normalizeToRef<T extends Vector3LikeInternal>(result: T): T {
         const len = this.length();
         if (len === 0 || len === 1.0) {
-            return reference.copyFrom(this);
+            result._x = this._x;
+            result._y = this._y;
+            result._z = this._z;
+            result._isDirty = true;
+            return result;
         }
 
-        return this.scaleToRef(1.0 / len, reference);
+        return this.scaleToRef(1.0 / len, result);
     }
 
     /**
@@ -3346,7 +3378,7 @@ export class Vector3 implements Vector<Tuple<number, 3>, Vector3>, IVector3Like 
         return ref;
     }
 }
-Vector3 satisfies VectorStatic<Vector3, Vector3>;
+Vector3 satisfies VectorStatic<Vector3, Vector3LikeInternal>;
 Object.defineProperties(Vector3.prototype, {
     dimension: { value: [3] },
     rank: { value: 1 },


### PR DESCRIPTION
This PR makes `Vector3` work with `Vector3LikeInternal`, a new interface. The idea is that this is now valid:
```ts
const vec3 = new Vector3();

vec3.addInPlace({ _x: 1, _y: 2, _z: 3 });

const half = vec3.divide({ _x: 2, _y: 2, _z: 2 });
```

The necessary inlining of some `copyFrom` and `copyFromFloats` calls should speed up performance as well.

This was discussed in a [form post](https://forum.babylonjs.com/t/52593/26?u=vortex).