### PR TITLE
Fix `Epsilon` export

### DIFF
--- a/packages/dev/core/src/Maths/math.constants.ts
+++ b/packages/dev/core/src/Maths/math.constants.ts
@@ -23,5 +23,4 @@ export const PHI = (1 + Math.sqrt(5)) / 2;
  * @ignorenaming
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const Epsilon = 0.001;
-export { Epsilon };
+export const Epsilon = 0.001;


### PR DESCRIPTION
This PR condenses the exporting of `Epsilon` with its definition:

```diff
/**
 * Constant used to define the minimal number value in Babylon.js
 * @ignorenaming
 */
// eslint-disable-next-line @typescript-eslint/naming-convention
-const Epsilon = 0.001;
-export { Epsilon };
+export const Epsilon = 0.001;

```