### PR TITLE
Make `CompatibilityOptions` an object, not a class

### DIFF
--- a/packages/dev/core/src/Compat/compatibilityOptions.ts
+++ b/packages/dev/core/src/Compat/compatibilityOptions.ts
@@ -1,9 +1,6 @@
+/* Options used to control default behaviors regarding compatibility support */
+
 /**
- * Options used to control default behaviors regarding compatibility support
+ * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
  */
-export class CompatibilityOptions {
-    /**
-     * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
-     */
-    public static UseOpenGLOrientationForUV = false;
-}
+export const useOpenGLOrientationForUV = false;

--- a/packages/dev/core/src/Compat/compatibilityOptions.ts
+++ b/packages/dev/core/src/Compat/compatibilityOptions.ts
@@ -1,14 +1,10 @@
-/* Options used to control default behaviors regarding compatibility support */
-
 /**
- * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
- */
-export const useOpenGLOrientationForUV = false;
-
-/**
- * @deprecated use compatibility options variables
+ * Options used to control default behaviors regarding compatibility support
  */
 export const CompatibilityOptions = {
+    /**
+     * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    UseOpenGLOrientationForUV: useOpenGLOrientationForUV,
+    UseOpenGLOrientationForUV: false,
 };

--- a/packages/dev/core/src/Compat/compatibilityOptions.ts
+++ b/packages/dev/core/src/Compat/compatibilityOptions.ts
@@ -1,10 +1,27 @@
 /**
+ * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
+ */
+export let useOpenGLOrientationForUV = false;
+
+/**
+ * Sets whether to use OpenGL convention for UVs
+ * @param value the new value
+ */
+export function setOpenGLOrientationForUV(value: boolean) {
+    useOpenGLOrientationForUV = value;
+}
+
+/**
  * Options used to control default behaviors regarding compatibility support
+ * @deprecated please use named exports
  */
 export const CompatibilityOptions = {
-    /**
-     * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
-     */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    UseOpenGLOrientationForUV: false,
+    /* eslint-disable @typescript-eslint/naming-convention */
+    get UseOpenGLOrientationForUV() {
+        return useOpenGLOrientationForUV;
+    },
+    set UseOpenGLOrientationForUV(value) {
+        useOpenGLOrientationForUV = value;
+    },
+    /* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/packages/dev/core/src/Compat/compatibilityOptions.ts
+++ b/packages/dev/core/src/Compat/compatibilityOptions.ts
@@ -4,3 +4,11 @@
  * Defines if the system should use OpenGL convention for UVs when creating geometry or loading .babylon files (false by default)
  */
 export const useOpenGLOrientationForUV = false;
+
+/**
+ * @deprecated use compatibility options variables
+ */
+export const CompatibilityOptions = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    UseOpenGLOrientationForUV: useOpenGLOrientationForUV,
+};

--- a/packages/dev/core/src/Compat/index.ts
+++ b/packages/dev/core/src/Compat/index.ts
@@ -1,1 +1,1 @@
-export * from "./compatibilityOptions";
+export { CompatibilityOptions } from "./compatibilityOptions";

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -437,7 +437,7 @@ export class Texture extends BaseTexture {
 
         this._gammaSpace = gammaSpace;
         this._noMipmap = noMipmap;
-        this._invertY = invertY === undefined ? (useOpenGLOrientationForUV ? false : true) : invertY;
+        this._invertY = invertY === undefined ? !useOpenGLOrientationForUV : invertY;
         this._initialSamplingMode = samplingMode;
         this._buffer = buffer;
         this._deleteBuffer = deleteBuffer;

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -13,7 +13,7 @@ import { InstantiationTools } from "../../Misc/instantiationTools";
 import { Plane } from "../../Maths/math.plane";
 import { EncodeArrayBufferToBase64 } from "../../Misc/stringTools";
 import { GenerateBase64StringFromTexture, GenerateBase64StringFromTextureAsync } from "../../Misc/copyTools";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 import type { InternalTexture } from "./internalTexture";
 
 import type { CubeTexture } from "../../Materials/Textures/cubeTexture";
@@ -418,7 +418,7 @@ export class Texture extends BaseTexture {
 
         if (typeof noMipmapOrOptions === "object" && noMipmapOrOptions !== null) {
             noMipmap = noMipmapOrOptions.noMipmap ?? false;
-            invertY = noMipmapOrOptions.invertY ?? !CompatibilityOptions.UseOpenGLOrientationForUV;
+            invertY = noMipmapOrOptions.invertY ?? !useOpenGLOrientationForUV;
             samplingMode = noMipmapOrOptions.samplingMode ?? Texture.TRILINEAR_SAMPLINGMODE;
             onLoad = noMipmapOrOptions.onLoad ?? null;
             onError = noMipmapOrOptions.onError ?? null;
@@ -437,7 +437,7 @@ export class Texture extends BaseTexture {
 
         this._gammaSpace = gammaSpace;
         this._noMipmap = noMipmap;
-        this._invertY = invertY === undefined ? !CompatibilityOptions.UseOpenGLOrientationForUV : invertY;
+        this._invertY = invertY === undefined ? !useOpenGLOrientationForUV : invertY;
         this._initialSamplingMode = samplingMode;
         this._buffer = buffer;
         this._deleteBuffer = deleteBuffer;

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -13,7 +13,7 @@ import { InstantiationTools } from "../../Misc/instantiationTools";
 import { Plane } from "../../Maths/math.plane";
 import { EncodeArrayBufferToBase64 } from "../../Misc/stringTools";
 import { GenerateBase64StringFromTexture, GenerateBase64StringFromTextureAsync } from "../../Misc/copyTools";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 import type { InternalTexture } from "./internalTexture";
 
 import type { CubeTexture } from "../../Materials/Textures/cubeTexture";
@@ -418,7 +418,7 @@ export class Texture extends BaseTexture {
 
         if (typeof noMipmapOrOptions === "object" && noMipmapOrOptions !== null) {
             noMipmap = noMipmapOrOptions.noMipmap ?? false;
-            invertY = noMipmapOrOptions.invertY ?? !useOpenGLOrientationForUV;
+            invertY = noMipmapOrOptions.invertY ?? !CompatibilityOptions.UseOpenGLOrientationForUV;
             samplingMode = noMipmapOrOptions.samplingMode ?? Texture.TRILINEAR_SAMPLINGMODE;
             onLoad = noMipmapOrOptions.onLoad ?? null;
             onError = noMipmapOrOptions.onError ?? null;
@@ -437,7 +437,7 @@ export class Texture extends BaseTexture {
 
         this._gammaSpace = gammaSpace;
         this._noMipmap = noMipmap;
-        this._invertY = invertY === undefined ? !useOpenGLOrientationForUV : invertY;
+        this._invertY = invertY === undefined ? !CompatibilityOptions.UseOpenGLOrientationForUV : invertY;
         this._initialSamplingMode = samplingMode;
         this._buffer = buffer;
         this._deleteBuffer = deleteBuffer;

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -13,7 +13,7 @@ import { InstantiationTools } from "../../Misc/instantiationTools";
 import { Plane } from "../../Maths/math.plane";
 import { EncodeArrayBufferToBase64 } from "../../Misc/stringTools";
 import { GenerateBase64StringFromTexture, GenerateBase64StringFromTextureAsync } from "../../Misc/copyTools";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 import type { InternalTexture } from "./internalTexture";
 
 import type { CubeTexture } from "../../Materials/Textures/cubeTexture";
@@ -418,7 +418,7 @@ export class Texture extends BaseTexture {
 
         if (typeof noMipmapOrOptions === "object" && noMipmapOrOptions !== null) {
             noMipmap = noMipmapOrOptions.noMipmap ?? false;
-            invertY = noMipmapOrOptions.invertY ?? (CompatibilityOptions.UseOpenGLOrientationForUV ? false : true);
+            invertY = noMipmapOrOptions.invertY ?? !useOpenGLOrientationForUV;
             samplingMode = noMipmapOrOptions.samplingMode ?? Texture.TRILINEAR_SAMPLINGMODE;
             onLoad = noMipmapOrOptions.onLoad ?? null;
             onError = noMipmapOrOptions.onError ?? null;
@@ -437,7 +437,7 @@ export class Texture extends BaseTexture {
 
         this._gammaSpace = gammaSpace;
         this._noMipmap = noMipmap;
-        this._invertY = invertY === undefined ? (CompatibilityOptions.UseOpenGLOrientationForUV ? false : true) : invertY;
+        this._invertY = invertY === undefined ? (useOpenGLOrientationForUV ? false : true) : invertY;
         this._initialSamplingMode = samplingMode;
         this._buffer = buffer;
         this._deleteBuffer = deleteBuffer;

--- a/packages/dev/core/src/Meshes/Builders/boxBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/boxBuilder.ts
@@ -4,7 +4,7 @@ import { Matrix, Vector4 } from "../../Maths/math.vector";
 import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 import { CreateGroundVertexData } from "./groundBuilder";
 
 /**
@@ -115,10 +115,10 @@ export function CreateBoxVertexData(options: {
 
     // Create each face in turn.
     for (let index = 0; index < nbFaces; index++) {
-        uvs.push(faceUV[index].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
-        uvs.push(faceUV[index].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
-        uvs.push(faceUV[index].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
-        uvs.push(faceUV[index].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
+        uvs.push(faceUV[index].z, useOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
+        uvs.push(faceUV[index].x, useOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
+        uvs.push(faceUV[index].x, useOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
+        uvs.push(faceUV[index].z, useOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
         if (faceColors) {
             for (let c = 0; c < 4; c++) {
                 colors.push(faceColors[index].r, faceColors[index].g, faceColors[index].b, faceColors[index].a);

--- a/packages/dev/core/src/Meshes/Builders/boxBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/boxBuilder.ts
@@ -4,7 +4,7 @@ import { Matrix, Vector4 } from "../../Maths/math.vector";
 import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 import { CreateGroundVertexData } from "./groundBuilder";
 
 /**
@@ -115,10 +115,10 @@ export function CreateBoxVertexData(options: {
 
     // Create each face in turn.
     for (let index = 0; index < nbFaces; index++) {
-        uvs.push(faceUV[index].z, useOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
-        uvs.push(faceUV[index].x, useOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
-        uvs.push(faceUV[index].x, useOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
-        uvs.push(faceUV[index].z, useOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
+        uvs.push(faceUV[index].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
+        uvs.push(faceUV[index].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].w : faceUV[index].w);
+        uvs.push(faceUV[index].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
+        uvs.push(faceUV[index].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[index].y : faceUV[index].y);
         if (faceColors) {
             for (let c = 0; c < 4; c++) {
                 colors.push(faceColors[index].r, faceColors[index].g, faceColors[index].b, faceColors[index].a);

--- a/packages/dev/core/src/Meshes/Builders/capsuleBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/capsuleBuilder.ts
@@ -3,7 +3,7 @@ import { Vector2, Vector3, Matrix } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import type { Nullable } from "../../types";
 import type { Scene } from "../../scene";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 /**
  * Scripts based off of https://github.com/maximeq/three-js-capsule-geometry/blob/master/src/CapsuleBufferGeometry.js
  * @param options the constructors options used to shape the mesh.
@@ -94,7 +94,7 @@ export function CreateCapsuleVertexData(
             normal.set(cosA * sinTheta, sinA, cosA * cosTheta);
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index
@@ -126,7 +126,7 @@ export function CreateCapsuleVertexData(
             normal.set(sinTheta, slope, cosTheta).normalize();
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index
@@ -158,7 +158,7 @@ export function CreateCapsuleVertexData(
             normal.set(cosA * sinTheta, sinA, cosA * cosTheta);
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index

--- a/packages/dev/core/src/Meshes/Builders/capsuleBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/capsuleBuilder.ts
@@ -3,7 +3,7 @@ import { Vector2, Vector3, Matrix } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import type { Nullable } from "../../types";
 import type { Scene } from "../../scene";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 /**
  * Scripts based off of https://github.com/maximeq/three-js-capsule-geometry/blob/master/src/CapsuleBufferGeometry.js
  * @param options the constructors options used to shape the mesh.
@@ -94,7 +94,7 @@ export function CreateCapsuleVertexData(
             normal.set(cosA * sinTheta, sinA, cosA * cosTheta);
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index
@@ -126,7 +126,7 @@ export function CreateCapsuleVertexData(
             normal.set(sinTheta, slope, cosTheta).normalize();
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index
@@ -158,7 +158,7 @@ export function CreateCapsuleVertexData(
             normal.set(cosA * sinTheta, sinA, cosA * cosTheta);
             normals.push(normal.x, normal.y, normal.z);
             // uv
-            uvs.push(u, useOpenGLOrientationForUV ? v / vl : 1 - v / vl);
+            uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? v / vl : 1 - v / vl);
             // save index of vertex in respective row
             indexRow.push(index);
             // increase index

--- a/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
@@ -5,7 +5,7 @@ import { VertexData } from "../mesh.vertexData";
 import { Scene } from "../../scene";
 import type { Nullable } from "../../types";
 import { Axis } from "../../Maths/math.axis";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a cylinder, cone or prism
@@ -147,7 +147,7 @@ export function CreateCylinderVertexData(options: {
                 } else {
                     v = faceUV[s].y + (faceUV[s].w - faceUV[s].y) * h;
                 }
-                uvs.push(faceUV[s].x + ((faceUV[s].z - faceUV[s].x) * j) / tessellation, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s].x + ((faceUV[s].z - faceUV[s].x) * j) / tessellation, useOpenGLOrientationForUV ? 1 - v : v);
                 if (faceColors) {
                     colors.push(faceColors[s].r, faceColors[s].g, faceColors[s].b, faceColors[s].a);
                 }
@@ -170,15 +170,15 @@ export function CreateCylinderVertexData(options: {
                 } else {
                     v = faceUV[s + 1].y + (faceUV[s + 1].w - faceUV[s + 1].y) * h;
                 }
-                uvs.push(faceUV[s + 1].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
-                uvs.push(faceUV[s + 1].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 1].x, useOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 1].z, useOpenGLOrientationForUV ? 1 - v : v);
                 if (hasRings) {
                     v = cs !== s ? faceUV[s + 2].y : faceUV[s + 2].w;
                 } else {
                     v = faceUV[s + 2].y + (faceUV[s + 2].w - faceUV[s + 2].y) * h;
                 }
-                uvs.push(faceUV[s + 2].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
-                uvs.push(faceUV[s + 2].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 2].x, useOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 2].z, useOpenGLOrientationForUV ? 1 - v : v);
                 if (faceColors) {
                     colors.push(faceColors[s + 1].r, faceColors[s + 1].g, faceColors[s + 1].b, faceColors[s + 1].a);
                     colors.push(faceColors[s + 1].r, faceColors[s + 1].g, faceColors[s + 1].b, faceColors[s + 1].a);
@@ -241,7 +241,7 @@ export function CreateCylinderVertexData(options: {
         positions.push(center.x, center.y, center.z);
         normals.push(0, isTop ? 1 : -1, 0);
         const v = u.y + (u.w - u.y) * 0.5;
-        uvs.push(u.x + (u.z - u.x) * 0.5, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+        uvs.push(u.x + (u.z - u.x) * 0.5, useOpenGLOrientationForUV ? 1 - v : v);
         if (c) {
             colors.push(c.r, c.g, c.b, c.a);
         }
@@ -256,7 +256,7 @@ export function CreateCylinderVertexData(options: {
             positions.push(circleVector.x, circleVector.y, circleVector.z);
             normals.push(0, isTop ? 1 : -1, 0);
             const v = u.y + (u.w - u.y) * textureCoordinate.y;
-            uvs.push(u.x + (u.z - u.x) * textureCoordinate.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+            uvs.push(u.x + (u.z - u.x) * textureCoordinate.x, useOpenGLOrientationForUV ? 1 - v : v);
             if (c) {
                 colors.push(c.r, c.g, c.b, c.a);
             }

--- a/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/cylinderBuilder.ts
@@ -5,7 +5,7 @@ import { VertexData } from "../mesh.vertexData";
 import { Scene } from "../../scene";
 import type { Nullable } from "../../types";
 import { Axis } from "../../Maths/math.axis";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a cylinder, cone or prism
@@ -147,7 +147,7 @@ export function CreateCylinderVertexData(options: {
                 } else {
                     v = faceUV[s].y + (faceUV[s].w - faceUV[s].y) * h;
                 }
-                uvs.push(faceUV[s].x + ((faceUV[s].z - faceUV[s].x) * j) / tessellation, useOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s].x + ((faceUV[s].z - faceUV[s].x) * j) / tessellation, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
                 if (faceColors) {
                     colors.push(faceColors[s].r, faceColors[s].g, faceColors[s].b, faceColors[s].a);
                 }
@@ -170,15 +170,15 @@ export function CreateCylinderVertexData(options: {
                 } else {
                     v = faceUV[s + 1].y + (faceUV[s + 1].w - faceUV[s + 1].y) * h;
                 }
-                uvs.push(faceUV[s + 1].x, useOpenGLOrientationForUV ? 1 - v : v);
-                uvs.push(faceUV[s + 1].z, useOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 1].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 1].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
                 if (hasRings) {
                     v = cs !== s ? faceUV[s + 2].y : faceUV[s + 2].w;
                 } else {
                     v = faceUV[s + 2].y + (faceUV[s + 2].w - faceUV[s + 2].y) * h;
                 }
-                uvs.push(faceUV[s + 2].x, useOpenGLOrientationForUV ? 1 - v : v);
-                uvs.push(faceUV[s + 2].z, useOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 2].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                uvs.push(faceUV[s + 2].z, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
                 if (faceColors) {
                     colors.push(faceColors[s + 1].r, faceColors[s + 1].g, faceColors[s + 1].b, faceColors[s + 1].a);
                     colors.push(faceColors[s + 1].r, faceColors[s + 1].g, faceColors[s + 1].b, faceColors[s + 1].a);
@@ -241,7 +241,7 @@ export function CreateCylinderVertexData(options: {
         positions.push(center.x, center.y, center.z);
         normals.push(0, isTop ? 1 : -1, 0);
         const v = u.y + (u.w - u.y) * 0.5;
-        uvs.push(u.x + (u.z - u.x) * 0.5, useOpenGLOrientationForUV ? 1 - v : v);
+        uvs.push(u.x + (u.z - u.x) * 0.5, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
         if (c) {
             colors.push(c.r, c.g, c.b, c.a);
         }
@@ -256,7 +256,7 @@ export function CreateCylinderVertexData(options: {
             positions.push(circleVector.x, circleVector.y, circleVector.z);
             normals.push(0, isTop ? 1 : -1, 0);
             const v = u.y + (u.w - u.y) * textureCoordinate.y;
-            uvs.push(u.x + (u.z - u.x) * textureCoordinate.x, useOpenGLOrientationForUV ? 1 - v : v);
+            uvs.push(u.x + (u.z - u.x) * textureCoordinate.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
             if (c) {
                 colors.push(c.r, c.g, c.b, c.a);
             }

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -6,7 +6,7 @@ import { VertexBuffer } from "../../Buffers/buffer";
 import { VertexData } from "../mesh.vertexData";
 import type { AbstractMesh } from "../abstractMesh";
 import type { Camera } from "../../Cameras/camera";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 const xpAxis = new Vector3(1, 0, 0);
 const xnAxis = new Vector3(-1, 0, 0);
@@ -131,7 +131,7 @@ export function CreateDecal(
 
         if (options.captureUVS && uvs) {
             const v = uvs[vertexId * 2 + 1];
-            result.uv = new Vector2(uvs[vertexId * 2], CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+            result.uv = new Vector2(uvs[vertexId * 2], useOpenGLOrientationForUV ? 1 - v : v);
         }
 
         return result;
@@ -479,7 +479,7 @@ export function CreateDecal(
                 if (!options.captureUVS) {
                     (<number[]>vertexData.uvs).push(0.5 + vertex.position.x / size.x);
                     const v = 0.5 + vertex.position.y / size.y;
-                    (<number[]>vertexData.uvs).push(CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+                    (<number[]>vertexData.uvs).push(useOpenGLOrientationForUV ? 1 - v : v);
                 } else {
                     vertex.uv.toArray(vertexData.uvs, currentVertexDataIndex * 2);
                 }

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -201,21 +201,21 @@ export function CreateDecal(
                 weights[3] /= sumw;
             }
 
-            const v0LocalPositionX = v0.localPositionOverride ? v0.localPositionOverride[0] : localPositions?.[v0.vertexIdx] ?? 0;
-            const v0LocalPositionY = v0.localPositionOverride ? v0.localPositionOverride[1] : localPositions?.[v0.vertexIdx + 1] ?? 0;
-            const v0LocalPositionZ = v0.localPositionOverride ? v0.localPositionOverride[2] : localPositions?.[v0.vertexIdx + 2] ?? 0;
+            const v0LocalPositionX = v0.localPositionOverride ? v0.localPositionOverride[0] : (localPositions?.[v0.vertexIdx] ?? 0);
+            const v0LocalPositionY = v0.localPositionOverride ? v0.localPositionOverride[1] : (localPositions?.[v0.vertexIdx + 1] ?? 0);
+            const v0LocalPositionZ = v0.localPositionOverride ? v0.localPositionOverride[2] : (localPositions?.[v0.vertexIdx + 2] ?? 0);
 
-            const v1LocalPositionX = v1.localPositionOverride ? v1.localPositionOverride[0] : localPositions?.[v1.vertexIdx] ?? 0;
-            const v1LocalPositionY = v1.localPositionOverride ? v1.localPositionOverride[1] : localPositions?.[v1.vertexIdx + 1] ?? 0;
-            const v1LocalPositionZ = v1.localPositionOverride ? v1.localPositionOverride[2] : localPositions?.[v1.vertexIdx + 2] ?? 0;
+            const v1LocalPositionX = v1.localPositionOverride ? v1.localPositionOverride[0] : (localPositions?.[v1.vertexIdx] ?? 0);
+            const v1LocalPositionY = v1.localPositionOverride ? v1.localPositionOverride[1] : (localPositions?.[v1.vertexIdx + 1] ?? 0);
+            const v1LocalPositionZ = v1.localPositionOverride ? v1.localPositionOverride[2] : (localPositions?.[v1.vertexIdx + 2] ?? 0);
 
-            const v0LocalNormalX = v0.localNormalOverride ? v0.localNormalOverride[0] : localNormals?.[v0.vertexIdx] ?? 0;
-            const v0LocalNormalY = v0.localNormalOverride ? v0.localNormalOverride[1] : localNormals?.[v0.vertexIdx + 1] ?? 0;
-            const v0LocalNormalZ = v0.localNormalOverride ? v0.localNormalOverride[2] : localNormals?.[v0.vertexIdx + 2] ?? 0;
+            const v0LocalNormalX = v0.localNormalOverride ? v0.localNormalOverride[0] : (localNormals?.[v0.vertexIdx] ?? 0);
+            const v0LocalNormalY = v0.localNormalOverride ? v0.localNormalOverride[1] : (localNormals?.[v0.vertexIdx + 1] ?? 0);
+            const v0LocalNormalZ = v0.localNormalOverride ? v0.localNormalOverride[2] : (localNormals?.[v0.vertexIdx + 2] ?? 0);
 
-            const v1LocalNormalX = v1.localNormalOverride ? v1.localNormalOverride[0] : localNormals?.[v1.vertexIdx] ?? 0;
-            const v1LocalNormalY = v1.localNormalOverride ? v1.localNormalOverride[1] : localNormals?.[v1.vertexIdx + 1] ?? 0;
-            const v1LocalNormalZ = v1.localNormalOverride ? v1.localNormalOverride[2] : localNormals?.[v1.vertexIdx + 2] ?? 0;
+            const v1LocalNormalX = v1.localNormalOverride ? v1.localNormalOverride[0] : (localNormals?.[v1.vertexIdx] ?? 0);
+            const v1LocalNormalY = v1.localNormalOverride ? v1.localNormalOverride[1] : (localNormals?.[v1.vertexIdx + 1] ?? 0);
+            const v1LocalNormalZ = v1.localNormalOverride ? v1.localNormalOverride[2] : (localNormals?.[v1.vertexIdx + 2] ?? 0);
 
             const interpNormalX = v0LocalNormalX + (v1LocalNormalX - v0LocalNormalX) * clipFactor;
             const interpNormalY = v0LocalNormalY + (v1LocalNormalY - v0LocalNormalY) * clipFactor;

--- a/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/decalBuilder.ts
@@ -6,7 +6,7 @@ import { VertexBuffer } from "../../Buffers/buffer";
 import { VertexData } from "../mesh.vertexData";
 import type { AbstractMesh } from "../abstractMesh";
 import type { Camera } from "../../Cameras/camera";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 const xpAxis = new Vector3(1, 0, 0);
 const xnAxis = new Vector3(-1, 0, 0);
@@ -131,7 +131,7 @@ export function CreateDecal(
 
         if (options.captureUVS && uvs) {
             const v = uvs[vertexId * 2 + 1];
-            result.uv = new Vector2(uvs[vertexId * 2], useOpenGLOrientationForUV ? 1 - v : v);
+            result.uv = new Vector2(uvs[vertexId * 2], CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
         }
 
         return result;
@@ -201,21 +201,21 @@ export function CreateDecal(
                 weights[3] /= sumw;
             }
 
-            const v0LocalPositionX = v0.localPositionOverride ? v0.localPositionOverride[0] : (localPositions?.[v0.vertexIdx] ?? 0);
-            const v0LocalPositionY = v0.localPositionOverride ? v0.localPositionOverride[1] : (localPositions?.[v0.vertexIdx + 1] ?? 0);
-            const v0LocalPositionZ = v0.localPositionOverride ? v0.localPositionOverride[2] : (localPositions?.[v0.vertexIdx + 2] ?? 0);
+            const v0LocalPositionX = v0.localPositionOverride ? v0.localPositionOverride[0] : localPositions?.[v0.vertexIdx] ?? 0;
+            const v0LocalPositionY = v0.localPositionOverride ? v0.localPositionOverride[1] : localPositions?.[v0.vertexIdx + 1] ?? 0;
+            const v0LocalPositionZ = v0.localPositionOverride ? v0.localPositionOverride[2] : localPositions?.[v0.vertexIdx + 2] ?? 0;
 
-            const v1LocalPositionX = v1.localPositionOverride ? v1.localPositionOverride[0] : (localPositions?.[v1.vertexIdx] ?? 0);
-            const v1LocalPositionY = v1.localPositionOverride ? v1.localPositionOverride[1] : (localPositions?.[v1.vertexIdx + 1] ?? 0);
-            const v1LocalPositionZ = v1.localPositionOverride ? v1.localPositionOverride[2] : (localPositions?.[v1.vertexIdx + 2] ?? 0);
+            const v1LocalPositionX = v1.localPositionOverride ? v1.localPositionOverride[0] : localPositions?.[v1.vertexIdx] ?? 0;
+            const v1LocalPositionY = v1.localPositionOverride ? v1.localPositionOverride[1] : localPositions?.[v1.vertexIdx + 1] ?? 0;
+            const v1LocalPositionZ = v1.localPositionOverride ? v1.localPositionOverride[2] : localPositions?.[v1.vertexIdx + 2] ?? 0;
 
-            const v0LocalNormalX = v0.localNormalOverride ? v0.localNormalOverride[0] : (localNormals?.[v0.vertexIdx] ?? 0);
-            const v0LocalNormalY = v0.localNormalOverride ? v0.localNormalOverride[1] : (localNormals?.[v0.vertexIdx + 1] ?? 0);
-            const v0LocalNormalZ = v0.localNormalOverride ? v0.localNormalOverride[2] : (localNormals?.[v0.vertexIdx + 2] ?? 0);
+            const v0LocalNormalX = v0.localNormalOverride ? v0.localNormalOverride[0] : localNormals?.[v0.vertexIdx] ?? 0;
+            const v0LocalNormalY = v0.localNormalOverride ? v0.localNormalOverride[1] : localNormals?.[v0.vertexIdx + 1] ?? 0;
+            const v0LocalNormalZ = v0.localNormalOverride ? v0.localNormalOverride[2] : localNormals?.[v0.vertexIdx + 2] ?? 0;
 
-            const v1LocalNormalX = v1.localNormalOverride ? v1.localNormalOverride[0] : (localNormals?.[v1.vertexIdx] ?? 0);
-            const v1LocalNormalY = v1.localNormalOverride ? v1.localNormalOverride[1] : (localNormals?.[v1.vertexIdx + 1] ?? 0);
-            const v1LocalNormalZ = v1.localNormalOverride ? v1.localNormalOverride[2] : (localNormals?.[v1.vertexIdx + 2] ?? 0);
+            const v1LocalNormalX = v1.localNormalOverride ? v1.localNormalOverride[0] : localNormals?.[v1.vertexIdx] ?? 0;
+            const v1LocalNormalY = v1.localNormalOverride ? v1.localNormalOverride[1] : localNormals?.[v1.vertexIdx + 1] ?? 0;
+            const v1LocalNormalZ = v1.localNormalOverride ? v1.localNormalOverride[2] : localNormals?.[v1.vertexIdx + 2] ?? 0;
 
             const interpNormalX = v0LocalNormalX + (v1LocalNormalX - v0LocalNormalX) * clipFactor;
             const interpNormalY = v0LocalNormalY + (v1LocalNormalY - v0LocalNormalY) * clipFactor;
@@ -479,7 +479,7 @@ export function CreateDecal(
                 if (!options.captureUVS) {
                     (<number[]>vertexData.uvs).push(0.5 + vertex.position.x / size.x);
                     const v = 0.5 + vertex.position.y / size.y;
-                    (<number[]>vertexData.uvs).push(useOpenGLOrientationForUV ? 1 - v : v);
+                    (<number[]>vertexData.uvs).push(CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
                 } else {
                     vertex.uv.toArray(vertexData.uvs, currentVertexDataIndex * 2);
                 }

--- a/packages/dev/core/src/Meshes/Builders/discBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/discBuilder.ts
@@ -3,7 +3,7 @@ import type { Scene } from "../../scene";
 import type { Vector4 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData of the Disc or regular Polygon
@@ -48,12 +48,12 @@ export function CreateDiscVertexData(options: {
         const u = (x + 1) / 2;
         const v = (1 - y) / 2;
         positions.push(radius * x, radius * y, 0);
-        uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
+        uvs.push(u, useOpenGLOrientationForUV ? 1 - v : v);
         a += step;
     }
     if (arc === 1) {
         positions.push(positions[3], positions[4], positions[5]); // close the circle
-        uvs.push(uvs[2], CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - uvs[3] : uvs[3]);
+        uvs.push(uvs[2], useOpenGLOrientationForUV ? 1 - uvs[3] : uvs[3]);
     }
 
     //indices

--- a/packages/dev/core/src/Meshes/Builders/discBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/discBuilder.ts
@@ -3,7 +3,7 @@ import type { Scene } from "../../scene";
 import type { Vector4 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData of the Disc or regular Polygon
@@ -48,12 +48,12 @@ export function CreateDiscVertexData(options: {
         const u = (x + 1) / 2;
         const v = (1 - y) / 2;
         positions.push(radius * x, radius * y, 0);
-        uvs.push(u, useOpenGLOrientationForUV ? 1 - v : v);
+        uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - v : v);
         a += step;
     }
     if (arc === 1) {
         positions.push(positions[3], positions[4], positions[5]); // close the circle
-        uvs.push(uvs[2], useOpenGLOrientationForUV ? 1 - uvs[3] : uvs[3]);
+        uvs.push(uvs[2], CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - uvs[3] : uvs[3]);
     }
 
     //indices

--- a/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
@@ -8,7 +8,7 @@ import { Logger } from "../../Misc/logger";
 import type { PolyhedronData } from "../geodesicMesh";
 import { _PrimaryIsoTriangle, GeodesicData } from "../geodesicMesh";
 import { GoldbergMesh } from "../goldbergMesh";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Defines the set of data required to create goldberg vertex data.
@@ -98,7 +98,7 @@ export function CreateGoldbergVertexData(options: GoldbergVertexDataOption, gold
             const pdata = goldbergData.vertex[verts[v]];
             positions.push(pdata[0] * sizeX, pdata[1] * sizeY, pdata[2] * sizeZ);
             const vCoord = (pdata[1] * sizeY - minY) / (maxY - minY);
-            uvs.push((pdata[0] * sizeX - minX) / (maxX - minX), useOpenGLOrientationForUV ? 1 - vCoord : vCoord);
+            uvs.push((pdata[0] * sizeX - minX) / (maxX - minX), CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - vCoord : vCoord);
         }
         for (let v = 0; v < verts.length - 2; v++) {
             indices.push(index, index + v + 2, index + v + 1);

--- a/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/goldbergBuilder.ts
@@ -8,7 +8,7 @@ import { Logger } from "../../Misc/logger";
 import type { PolyhedronData } from "../geodesicMesh";
 import { _PrimaryIsoTriangle, GeodesicData } from "../geodesicMesh";
 import { GoldbergMesh } from "../goldbergMesh";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Defines the set of data required to create goldberg vertex data.
@@ -98,7 +98,7 @@ export function CreateGoldbergVertexData(options: GoldbergVertexDataOption, gold
             const pdata = goldbergData.vertex[verts[v]];
             positions.push(pdata[0] * sizeX, pdata[1] * sizeY, pdata[2] * sizeZ);
             const vCoord = (pdata[1] * sizeY - minY) / (maxY - minY);
-            uvs.push((pdata[0] * sizeX - minX) / (maxX - minX), CompatibilityOptions.UseOpenGLOrientationForUV ? 1 - vCoord : vCoord);
+            uvs.push((pdata[0] * sizeX - minX) / (maxX - minX), useOpenGLOrientationForUV ? 1 - vCoord : vCoord);
         }
         for (let v = 0; v < verts.length - 2; v++) {
             indices.push(index, index + v + 2, index + v + 1);

--- a/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
@@ -8,7 +8,7 @@ import { Tools } from "../../Misc/tools";
 import type { Nullable } from "../../types";
 import { EngineStore } from "../../Engines/engineStore";
 import { Epsilon } from "../../Maths/math.constants";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Ground
@@ -39,7 +39,7 @@ export function CreateGroundVertexData(options: { width?: number; height?: numbe
 
             positions.push(position.x, position.y, position.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(col / subdivisionsX, CompatibilityOptions.UseOpenGLOrientationForUV ? row / subdivisionsY : 1.0 - row / subdivisionsY);
+            uvs.push(col / subdivisionsX, useOpenGLOrientationForUV ? row / subdivisionsY : 1.0 - row / subdivisionsY);
         }
     }
 

--- a/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
@@ -8,7 +8,7 @@ import { Tools } from "../../Misc/tools";
 import type { Nullable } from "../../types";
 import { EngineStore } from "../../Engines/engineStore";
 import { Epsilon } from "../../Maths/math.constants";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Ground
@@ -39,7 +39,7 @@ export function CreateGroundVertexData(options: { width?: number; height?: numbe
 
             positions.push(position.x, position.y, position.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(col / subdivisionsX, useOpenGLOrientationForUV ? row / subdivisionsY : 1.0 - row / subdivisionsY);
+            uvs.push(col / subdivisionsX, CompatibilityOptions.UseOpenGLOrientationForUV ? row / subdivisionsY : 1.0 - row / subdivisionsY);
         }
     }
 

--- a/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
@@ -4,7 +4,7 @@ import { Vector3, Vector2 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData of the IcoSphere
@@ -343,7 +343,7 @@ export function CreateIcoSphereVertexData(options: {
             const uv_interp = subdivisions === i2 ? face_vertex_uv[2] : Vector2.Lerp(uv_x0, uv_x1, i1 / (subdivisions - i2));
             positions.push(pos_interp.x * radiusX, pos_interp.y * radiusY, pos_interp.z * radiusZ);
             normals.push(vertex_normal.x, vertex_normal.y, vertex_normal.z);
-            uvs.push(uv_interp.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - uv_interp.y : uv_interp.y);
+            uvs.push(uv_interp.x, useOpenGLOrientationForUV ? 1.0 - uv_interp.y : uv_interp.y);
             // push each vertex has member of a face
             // Same vertex can belong to multiple face, it is pushed multiple time (duplicate vertex are present)
             indices.push(current_indice);

--- a/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/icoSphereBuilder.ts
@@ -4,7 +4,7 @@ import { Vector3, Vector2 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData of the IcoSphere
@@ -343,7 +343,7 @@ export function CreateIcoSphereVertexData(options: {
             const uv_interp = subdivisions === i2 ? face_vertex_uv[2] : Vector2.Lerp(uv_x0, uv_x1, i1 / (subdivisions - i2));
             positions.push(pos_interp.x * radiusX, pos_interp.y * radiusY, pos_interp.z * radiusZ);
             normals.push(vertex_normal.x, vertex_normal.y, vertex_normal.z);
-            uvs.push(uv_interp.x, useOpenGLOrientationForUV ? 1.0 - uv_interp.y : uv_interp.y);
+            uvs.push(uv_interp.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - uv_interp.y : uv_interp.y);
             // push each vertex has member of a face
             // Same vertex can belong to multiple face, it is pushed multiple time (duplicate vertex are present)
             indices.push(current_indice);

--- a/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
@@ -4,7 +4,7 @@ import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
 import type { Plane } from "../../Maths/math.plane";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Plane
@@ -33,19 +33,19 @@ export function CreatePlaneVertexData(options: { size?: number; width?: number; 
 
     positions.push(-halfWidth, -halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(0.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0.0);
+    uvs.push(0.0, useOpenGLOrientationForUV ? 1.0 : 0.0);
 
     positions.push(halfWidth, -halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(1.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0.0);
+    uvs.push(1.0, useOpenGLOrientationForUV ? 1.0 : 0.0);
 
     positions.push(halfWidth, halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(1.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 0.0 : 1.0);
+    uvs.push(1.0, useOpenGLOrientationForUV ? 0.0 : 1.0);
 
     positions.push(-halfWidth, halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(0.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 0.0 : 1.0);
+    uvs.push(0.0, useOpenGLOrientationForUV ? 0.0 : 1.0);
 
     // Indices
     indices.push(0);

--- a/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
@@ -4,7 +4,7 @@ import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
 import type { Plane } from "../../Maths/math.plane";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Plane
@@ -33,19 +33,19 @@ export function CreatePlaneVertexData(options: { size?: number; width?: number; 
 
     positions.push(-halfWidth, -halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(0.0, useOpenGLOrientationForUV ? 1.0 : 0.0);
+    uvs.push(0.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0.0);
 
     positions.push(halfWidth, -halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(1.0, useOpenGLOrientationForUV ? 1.0 : 0.0);
+    uvs.push(1.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0.0);
 
     positions.push(halfWidth, halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(1.0, useOpenGLOrientationForUV ? 0.0 : 1.0);
+    uvs.push(1.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 0.0 : 1.0);
 
     positions.push(-halfWidth, halfHeight, 0);
     normals.push(0, 0, -1.0);
-    uvs.push(0.0, useOpenGLOrientationForUV ? 0.0 : 1.0);
+    uvs.push(0.0, CompatibilityOptions.UseOpenGLOrientationForUV ? 0.0 : 1.0);
 
     // Indices
     indices.push(0);

--- a/packages/dev/core/src/Meshes/Builders/polygonBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/polygonBuilder.ts
@@ -9,7 +9,7 @@ import { PolygonMeshBuilder } from "../polygonMesh";
 import type { FloatArray, IndicesArray, Nullable } from "../../types";
 import { VertexBuffer } from "../../Buffers/buffer";
 import { EngineStore } from "../../Engines/engineStore";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 declare let earcut: any;
 
@@ -94,15 +94,15 @@ export function CreatePolygonVertexData(polygon: Mesh, sideOrientation: number, 
                 }
             }
             if (disp % 2 === 0) {
-                uvs[2 * idx + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[face].w : faceUV[face].w;
+                uvs[2 * idx + 1] = useOpenGLOrientationForUV ? 1.0 - faceUV[face].w : faceUV[face].w;
             } else {
-                uvs[2 * idx + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[face].y : faceUV[face].y;
+                uvs[2 * idx + 1] = useOpenGLOrientationForUV ? 1.0 - faceUV[face].y : faceUV[face].y;
             }
         } else {
             uvs[2 * idx] = (1 - uvs[2 * idx]) * faceUV[face].x + uvs[2 * idx] * faceUV[face].z;
             uvs[2 * idx + 1] = (1 - uvs[2 * idx + 1]) * faceUV[face].y + uvs[2 * idx + 1] * faceUV[face].w;
 
-            if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+            if (useOpenGLOrientationForUV) {
                 uvs[2 * idx + 1] = 1.0 - uvs[2 * idx + 1];
             }
         }

--- a/packages/dev/core/src/Meshes/Builders/polygonBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/polygonBuilder.ts
@@ -9,7 +9,7 @@ import { PolygonMeshBuilder } from "../polygonMesh";
 import type { FloatArray, IndicesArray, Nullable } from "../../types";
 import { VertexBuffer } from "../../Buffers/buffer";
 import { EngineStore } from "../../Engines/engineStore";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 declare let earcut: any;
 
@@ -94,15 +94,15 @@ export function CreatePolygonVertexData(polygon: Mesh, sideOrientation: number, 
                 }
             }
             if (disp % 2 === 0) {
-                uvs[2 * idx + 1] = useOpenGLOrientationForUV ? 1.0 - faceUV[face].w : faceUV[face].w;
+                uvs[2 * idx + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[face].w : faceUV[face].w;
             } else {
-                uvs[2 * idx + 1] = useOpenGLOrientationForUV ? 1.0 - faceUV[face].y : faceUV[face].y;
+                uvs[2 * idx + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - faceUV[face].y : faceUV[face].y;
             }
         } else {
             uvs[2 * idx] = (1 - uvs[2 * idx]) * faceUV[face].x + uvs[2 * idx] * faceUV[face].z;
             uvs[2 * idx + 1] = (1 - uvs[2 * idx + 1]) * faceUV[face].y + uvs[2 * idx + 1] * faceUV[face].w;
 
-            if (useOpenGLOrientationForUV) {
+            if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                 uvs[2 * idx + 1] = 1.0 - uvs[2 * idx + 1];
             }
         }

--- a/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
@@ -4,7 +4,7 @@ import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 // inspired from // http://stemkoski.github.io/Three.js/Polyhedra.html
 /**
@@ -505,7 +505,7 @@ export function CreatePolyhedronVertexData(options: {
     if (!flat) {
         for (i = 0; i < data.vertex.length; i++) {
             positions.push(data.vertex[i][0] * sizeX, data.vertex[i][1] * sizeY, data.vertex[i][2] * sizeZ);
-            uvs.push(0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0);
+            uvs.push(0, useOpenGLOrientationForUV ? 1.0 : 0);
         }
         for (f = 0; f < nbfaces; f++) {
             for (i = 0; i < data.face[f].length - 2; i++) {
@@ -528,7 +528,7 @@ export function CreatePolyhedronVertexData(options: {
                 // uvs
                 u = faceUV[f].x + (faceUV[f].z - faceUV[f].x) * (0.5 + x);
                 v = faceUV[f].y + (faceUV[f].w - faceUV[f].y) * (y - 0.5);
-                uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - v : v);
+                uvs.push(u, useOpenGLOrientationForUV ? 1.0 - v : v);
                 tmp = x * Math.cos(ang) - y * Math.sin(ang);
                 y = x * Math.sin(ang) + y * Math.cos(ang);
                 x = tmp;

--- a/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/polyhedronBuilder.ts
@@ -4,7 +4,7 @@ import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "../../types";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 // inspired from // http://stemkoski.github.io/Three.js/Polyhedra.html
 /**
@@ -505,7 +505,7 @@ export function CreatePolyhedronVertexData(options: {
     if (!flat) {
         for (i = 0; i < data.vertex.length; i++) {
             positions.push(data.vertex[i][0] * sizeX, data.vertex[i][1] * sizeY, data.vertex[i][2] * sizeZ);
-            uvs.push(0, useOpenGLOrientationForUV ? 1.0 : 0);
+            uvs.push(0, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 : 0);
         }
         for (f = 0; f < nbfaces; f++) {
             for (i = 0; i < data.face[f].length - 2; i++) {
@@ -528,7 +528,7 @@ export function CreatePolyhedronVertexData(options: {
                 // uvs
                 u = faceUV[f].x + (faceUV[f].z - faceUV[f].x) * (0.5 + x);
                 v = faceUV[f].y + (faceUV[f].w - faceUV[f].y) * (y - 0.5);
-                uvs.push(u, useOpenGLOrientationForUV ? 1.0 - v : v);
+                uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - v : v);
                 tmp = x * Math.cos(ang) - y * Math.sin(ang);
                 y = x * Math.sin(ang) + y * Math.cos(ang);
                 x = tmp;

--- a/packages/dev/core/src/Meshes/Builders/ribbonBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/ribbonBuilder.ts
@@ -6,7 +6,7 @@ import type { Color4 } from "../../Maths/math.color";
 import { Mesh, _CreationDataStorage } from "../mesh";
 import { VertexBuffer } from "../../Buffers/buffer";
 import { VertexData } from "../mesh.vertexData";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Ribbon
@@ -147,7 +147,7 @@ export function CreateRibbonVertexData(options: {
     let v: number;
     if (customUV) {
         for (p = 0; p < customUV.length; p++) {
-            uvs.push(customUV[p].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - customUV[p].y : customUV[p].y);
+            uvs.push(customUV[p].x, useOpenGLOrientationForUV ? 1.0 - customUV[p].y : customUV[p].y);
         }
     } else {
         for (p = 0; p < pathArray.length + closeArrayCorr; p++) {
@@ -157,7 +157,7 @@ export function CreateRibbonVertexData(options: {
                 if (invertUV) {
                     uvs.push(v, u);
                 } else {
-                    uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - v : v);
+                    uvs.push(u, useOpenGLOrientationForUV ? 1.0 - v : v);
                 }
             }
         }
@@ -378,7 +378,7 @@ export function CreateRibbon(
             const uvs = <FloatArray>instance.getVerticesData(VertexBuffer.UVKind);
             for (let i = 0; i < options.uvs.length; i++) {
                 uvs[i * 2] = options.uvs[i].x;
-                uvs[i * 2 + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - options.uvs[i].y : options.uvs[i].y;
+                uvs[i * 2 + 1] = useOpenGLOrientationForUV ? 1.0 - options.uvs[i].y : options.uvs[i].y;
             }
             instance.updateVerticesData(VertexBuffer.UVKind, uvs, false, false);
         }

--- a/packages/dev/core/src/Meshes/Builders/ribbonBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/ribbonBuilder.ts
@@ -6,7 +6,7 @@ import type { Color4 } from "../../Maths/math.color";
 import { Mesh, _CreationDataStorage } from "../mesh";
 import { VertexBuffer } from "../../Buffers/buffer";
 import { VertexData } from "../mesh.vertexData";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a Ribbon
@@ -147,7 +147,7 @@ export function CreateRibbonVertexData(options: {
     let v: number;
     if (customUV) {
         for (p = 0; p < customUV.length; p++) {
-            uvs.push(customUV[p].x, useOpenGLOrientationForUV ? 1.0 - customUV[p].y : customUV[p].y);
+            uvs.push(customUV[p].x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - customUV[p].y : customUV[p].y);
         }
     } else {
         for (p = 0; p < pathArray.length + closeArrayCorr; p++) {
@@ -157,7 +157,7 @@ export function CreateRibbonVertexData(options: {
                 if (invertUV) {
                     uvs.push(v, u);
                 } else {
-                    uvs.push(u, useOpenGLOrientationForUV ? 1.0 - v : v);
+                    uvs.push(u, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - v : v);
                 }
             }
         }
@@ -378,7 +378,7 @@ export function CreateRibbon(
             const uvs = <FloatArray>instance.getVerticesData(VertexBuffer.UVKind);
             for (let i = 0; i < options.uvs.length; i++) {
                 uvs[i * 2] = options.uvs[i].x;
-                uvs[i * 2 + 1] = useOpenGLOrientationForUV ? 1.0 - options.uvs[i].y : options.uvs[i].y;
+                uvs[i * 2 + 1] = CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - options.uvs[i].y : options.uvs[i].y;
             }
             instance.updateVerticesData(VertexBuffer.UVKind, uvs, false, false);
         }

--- a/packages/dev/core/src/Meshes/Builders/sphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/sphereBuilder.ts
@@ -4,7 +4,7 @@ import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
 import type { Nullable } from "../../types";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for an ellipsoid, defaults to a sphere
@@ -72,7 +72,7 @@ export function CreateSphereVertexData(options: {
 
             positions.push(vertex.x, vertex.y, vertex.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(normalizedY, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - normalizedZ : normalizedZ);
+            uvs.push(normalizedY, useOpenGLOrientationForUV ? 1.0 - normalizedZ : normalizedZ);
         }
 
         if (zRotationStep > 0) {

--- a/packages/dev/core/src/Meshes/Builders/sphereBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/sphereBuilder.ts
@@ -4,7 +4,7 @@ import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
 import type { Nullable } from "../../types";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for an ellipsoid, defaults to a sphere
@@ -72,7 +72,7 @@ export function CreateSphereVertexData(options: {
 
             positions.push(vertex.x, vertex.y, vertex.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(normalizedY, useOpenGLOrientationForUV ? 1.0 - normalizedZ : normalizedZ);
+            uvs.push(normalizedY, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - normalizedZ : normalizedZ);
         }
 
         if (zRotationStep > 0) {

--- a/packages/dev/core/src/Meshes/Builders/tiledBoxBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/tiledBoxBuilder.ts
@@ -5,7 +5,7 @@ import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import { CreateTiledPlaneVertexData } from "./tiledPlaneBuilder";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a tiled box
@@ -164,7 +164,7 @@ export function CreateTiledBoxVertexData(options: {
             newFaceUV[f][i] = faceUV[f].x + (faceUV[f].z - faceUV[f].x) * faceVertexData[f].uvs![i];
             newFaceUV[f][i + 1] = faceUV[f].y + (faceUV[f].w - faceUV[f].y) * faceVertexData[f].uvs![i + 1];
 
-            if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+            if (useOpenGLOrientationForUV) {
                 newFaceUV[f][i + 1] = 1.0 - newFaceUV[f][i + 1];
             }
         }

--- a/packages/dev/core/src/Meshes/Builders/tiledBoxBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/tiledBoxBuilder.ts
@@ -5,7 +5,7 @@ import { Color4 } from "../../Maths/math.color";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import { CreateTiledPlaneVertexData } from "./tiledPlaneBuilder";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a tiled box
@@ -164,7 +164,7 @@ export function CreateTiledBoxVertexData(options: {
             newFaceUV[f][i] = faceUV[f].x + (faceUV[f].z - faceUV[f].x) * faceVertexData[f].uvs![i];
             newFaceUV[f][i + 1] = faceUV[f].y + (faceUV[f].w - faceUV[f].y) * faceVertexData[f].uvs![i + 1];
 
-            if (useOpenGLOrientationForUV) {
+            if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                 newFaceUV[f][i + 1] = 1.0 - newFaceUV[f][i + 1];
             }
         }

--- a/packages/dev/core/src/Meshes/Builders/torusBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/torusBuilder.ts
@@ -3,7 +3,7 @@ import { Matrix, Vector3, Vector2 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a torus
@@ -59,7 +59,7 @@ export function CreateTorusVertexData(options: { diameter?: number; thickness?: 
 
             positions.push(position.x, position.y, position.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(textureCoordinate.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - textureCoordinate.y : textureCoordinate.y);
+            uvs.push(textureCoordinate.x, useOpenGLOrientationForUV ? 1.0 - textureCoordinate.y : textureCoordinate.y);
 
             // And create indices for two triangles.
             const nextI = (i + 1) % stride;

--- a/packages/dev/core/src/Meshes/Builders/torusBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/torusBuilder.ts
@@ -3,7 +3,7 @@ import { Matrix, Vector3, Vector2 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 /**
  * Creates the VertexData for a torus
@@ -59,7 +59,7 @@ export function CreateTorusVertexData(options: { diameter?: number; thickness?: 
 
             positions.push(position.x, position.y, position.z);
             normals.push(normal.x, normal.y, normal.z);
-            uvs.push(textureCoordinate.x, useOpenGLOrientationForUV ? 1.0 - textureCoordinate.y : textureCoordinate.y);
+            uvs.push(textureCoordinate.x, CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - textureCoordinate.y : textureCoordinate.y);
 
             // And create indices for two triangles.
             const nextI = (i + 1) % stride;

--- a/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
@@ -3,7 +3,7 @@ import { Vector3 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
-import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
 
 // based on http://code.google.com/p/away3d/source/browse/trunk/fp10/Away3D/src/away3d/primitives/TorusKnot.as?spec=svn2473&r=2473
 /**
@@ -95,7 +95,7 @@ export function CreateTorusKnotVertexData(options: {
             positions.push(p1.z + cx * n.z + cy * bitan.z);
 
             uvs.push(i / radialSegments);
-            uvs.push(CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - j / tubularSegments : j / tubularSegments);
+            uvs.push(useOpenGLOrientationForUV ? 1.0 - j / tubularSegments : j / tubularSegments);
         }
     }
 

--- a/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/torusKnotBuilder.ts
@@ -3,7 +3,7 @@ import { Vector3 } from "../../Maths/math.vector";
 import { Mesh } from "../mesh";
 import { VertexData } from "../mesh.vertexData";
 import type { Scene } from "../../scene";
-import { useOpenGLOrientationForUV } from "../../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../../Compat/compatibilityOptions";
 
 // based on http://code.google.com/p/away3d/source/browse/trunk/fp10/Away3D/src/away3d/primitives/TorusKnot.as?spec=svn2473&r=2473
 /**
@@ -95,7 +95,7 @@ export function CreateTorusKnotVertexData(options: {
             positions.push(p1.z + cx * n.z + cy * bitan.z);
 
             uvs.push(i / radialSegments);
-            uvs.push(useOpenGLOrientationForUV ? 1.0 - j / tubularSegments : j / tubularSegments);
+            uvs.push(CompatibilityOptions.UseOpenGLOrientationForUV ? 1.0 - j / tubularSegments : j / tubularSegments);
         }
     }
 

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -18,7 +18,7 @@ import type { DataBuffer } from "../Buffers/dataBuffer";
 import { extractMinAndMax } from "../Maths/math.functions";
 import type { AbstractScene } from "../abstractScene";
 import { EngineStore } from "../Engines/engineStore";
-import { CompatibilityOptions } from "../Compat/compatibilityOptions";
+import { useOpenGLOrientationForUV } from "../Compat/compatibilityOptions";
 
 import type { Mesh } from "../Meshes/mesh";
 import type { Buffer } from "../Buffers/buffer";
@@ -1287,7 +1287,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvsAttrDesc && binaryInfo.uvsAttrDesc.count > 0) {
                 const uvsData = new Float32Array(parsedGeometry, binaryInfo.uvsAttrDesc.offset, binaryInfo.uvsAttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvsData.length; index += 2) {
                         uvsData[index] = 1 - uvsData[index];
                     }
@@ -1297,7 +1297,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs2AttrDesc && binaryInfo.uvs2AttrDesc.count > 0) {
                 const uvs2Data = new Float32Array(parsedGeometry, binaryInfo.uvs2AttrDesc.offset, binaryInfo.uvs2AttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs2Data.length; index += 2) {
                         uvs2Data[index] = 1 - uvs2Data[index];
                     }
@@ -1307,7 +1307,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs3AttrDesc && binaryInfo.uvs3AttrDesc.count > 0) {
                 const uvs3Data = new Float32Array(parsedGeometry, binaryInfo.uvs3AttrDesc.offset, binaryInfo.uvs3AttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs3Data.length; index += 2) {
                         uvs3Data[index] = 1 - uvs3Data[index];
                     }
@@ -1317,7 +1317,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs4AttrDesc && binaryInfo.uvs4AttrDesc.count > 0) {
                 const uvs4Data = new Float32Array(parsedGeometry, binaryInfo.uvs4AttrDesc.offset, binaryInfo.uvs4AttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs4Data.length; index += 2) {
                         uvs4Data[index] = 1 - uvs4Data[index];
                     }
@@ -1327,7 +1327,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs5AttrDesc && binaryInfo.uvs5AttrDesc.count > 0) {
                 const uvs5Data = new Float32Array(parsedGeometry, binaryInfo.uvs5AttrDesc.offset, binaryInfo.uvs5AttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs5Data.length; index += 2) {
                         uvs5Data[index] = 1 - uvs5Data[index];
                     }
@@ -1337,7 +1337,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs6AttrDesc && binaryInfo.uvs6AttrDesc.count > 0) {
                 const uvs6Data = new Float32Array(parsedGeometry, binaryInfo.uvs6AttrDesc.offset, binaryInfo.uvs6AttrDesc.count);
-                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
+                if (useOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs6Data.length; index += 2) {
                         uvs6Data[index] = 1 - uvs6Data[index];
                     }

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -18,7 +18,7 @@ import type { DataBuffer } from "../Buffers/dataBuffer";
 import { extractMinAndMax } from "../Maths/math.functions";
 import type { AbstractScene } from "../abstractScene";
 import { EngineStore } from "../Engines/engineStore";
-import { useOpenGLOrientationForUV } from "../Compat/compatibilityOptions";
+import { CompatibilityOptions } from "../Compat/compatibilityOptions";
 
 import type { Mesh } from "../Meshes/mesh";
 import type { Buffer } from "../Buffers/buffer";
@@ -1287,7 +1287,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvsAttrDesc && binaryInfo.uvsAttrDesc.count > 0) {
                 const uvsData = new Float32Array(parsedGeometry, binaryInfo.uvsAttrDesc.offset, binaryInfo.uvsAttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvsData.length; index += 2) {
                         uvsData[index] = 1 - uvsData[index];
                     }
@@ -1297,7 +1297,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs2AttrDesc && binaryInfo.uvs2AttrDesc.count > 0) {
                 const uvs2Data = new Float32Array(parsedGeometry, binaryInfo.uvs2AttrDesc.offset, binaryInfo.uvs2AttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs2Data.length; index += 2) {
                         uvs2Data[index] = 1 - uvs2Data[index];
                     }
@@ -1307,7 +1307,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs3AttrDesc && binaryInfo.uvs3AttrDesc.count > 0) {
                 const uvs3Data = new Float32Array(parsedGeometry, binaryInfo.uvs3AttrDesc.offset, binaryInfo.uvs3AttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs3Data.length; index += 2) {
                         uvs3Data[index] = 1 - uvs3Data[index];
                     }
@@ -1317,7 +1317,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs4AttrDesc && binaryInfo.uvs4AttrDesc.count > 0) {
                 const uvs4Data = new Float32Array(parsedGeometry, binaryInfo.uvs4AttrDesc.offset, binaryInfo.uvs4AttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs4Data.length; index += 2) {
                         uvs4Data[index] = 1 - uvs4Data[index];
                     }
@@ -1327,7 +1327,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs5AttrDesc && binaryInfo.uvs5AttrDesc.count > 0) {
                 const uvs5Data = new Float32Array(parsedGeometry, binaryInfo.uvs5AttrDesc.offset, binaryInfo.uvs5AttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs5Data.length; index += 2) {
                         uvs5Data[index] = 1 - uvs5Data[index];
                     }
@@ -1337,7 +1337,7 @@ export class Geometry implements IGetSetVerticesData {
 
             if (binaryInfo.uvs6AttrDesc && binaryInfo.uvs6AttrDesc.count > 0) {
                 const uvs6Data = new Float32Array(parsedGeometry, binaryInfo.uvs6AttrDesc.offset, binaryInfo.uvs6AttrDesc.count);
-                if (useOpenGLOrientationForUV) {
+                if (CompatibilityOptions.UseOpenGLOrientationForUV) {
                     for (let index = 1; index < uvs6Data.length; index += 2) {
                         uvs6Data[index] = 1 - uvs6Data[index];
                     }


### PR DESCRIPTION
This PR migrates `CompatibilityOptions` from a class with static properties into a plain Javascript object. This is from https://github.com/BabylonJS/Babylon.js/issues/14805. Continued from #15376.