### PR TITLE
Migrate `DumpTools` from a class to functions

### DIFF
--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -22,7 +22,7 @@ import "../../Engines/Extensions/engine.renderTargetCube";
 import "../../Engines/Extensions/engine.renderTargetTexture";
 
 import { _ObserveArray } from "../../Misc/arrayTools";
-import { DumpTools } from "../../Misc/dumpTools";
+import { DumpFramebuffer } from "../../Misc/dumpTools";
 
 import type { Material } from "../material";
 import { FloorPOT, NearestPOT } from "../../Misc/tools.functions";
@@ -1304,7 +1304,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
             // Dump ?
             if (dumpForDebug) {
-                DumpTools.DumpFramebuffer(this.getRenderWidth(), this.getRenderHeight(), engine);
+                DumpFramebuffer(this.getRenderWidth(), this.getRenderHeight(), engine);
             }
         } else {
             // Clear

--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -19,197 +19,207 @@ type DumpToolsEngine = {
     wrapper: EffectWrapper;
 };
 
-/**
- * Class containing a set of static utilities functions to dump data from a canvas
- */
-export class DumpTools {
-    private static _DumpToolsEngine: Nullable<DumpToolsEngine>;
+let _dumpToolsEngine: Nullable<DumpToolsEngine>;
 
-    private static _CreateDumpRenderer(): DumpToolsEngine {
-        if (!DumpTools._DumpToolsEngine) {
-            let canvas: HTMLCanvasElement | OffscreenCanvas;
-            let engine: Nullable<ThinEngine> = null;
-            const options = {
-                preserveDrawingBuffer: true,
-                depth: false,
-                stencil: false,
-                alpha: true,
-                premultipliedAlpha: false,
-                antialias: false,
-                failIfMajorPerformanceCaveat: false,
-            };
-            try {
-                canvas = new OffscreenCanvas(100, 100); // will be resized later
-                engine = new ThinEngine(canvas, false, options);
-            } catch (e) {
-                // The browser either does not support OffscreenCanvas or WebGL context in OffscreenCanvas, fallback on a regular canvas
-                canvas = document.createElement("canvas");
-                engine = new ThinEngine(canvas, false, options);
-            }
-            // remove this engine from the list of instances to avoid using it for other purposes
-            EngineStore.Instances.pop();
-            // However, make sure to dispose it when no other engines are left
-            EngineStore.OnEnginesDisposedObservable.add((e) => {
-                // guaranteed to run when no other instances are left
-                // only dispose if it's not the current engine
-                if (engine && e !== engine && !engine.isDisposed && EngineStore.Instances.length === 0) {
-                    // Dump the engine and the associated resources
-                    DumpTools.Dispose();
-                }
-            });
-            engine.getCaps().parallelShaderCompile = undefined;
-            const renderer = new EffectRenderer(engine);
-            const wrapper = new EffectWrapper({
-                engine,
-                name: passPixelShader.name,
-                fragmentShader: passPixelShader.shader,
-                samplerNames: ["textureSampler"],
-            });
-            DumpTools._DumpToolsEngine = {
-                canvas,
-                engine,
-                renderer,
-                wrapper,
-            };
+function _CreateDumpRenderer(): DumpToolsEngine {
+    if (!_dumpToolsEngine) {
+        let canvas: HTMLCanvasElement | OffscreenCanvas;
+        let engine: Nullable<ThinEngine> = null;
+        const options = {
+            preserveDrawingBuffer: true,
+            depth: false,
+            stencil: false,
+            alpha: true,
+            premultipliedAlpha: false,
+            antialias: false,
+            failIfMajorPerformanceCaveat: false,
+        };
+        try {
+            canvas = new OffscreenCanvas(100, 100); // will be resized later
+            engine = new ThinEngine(canvas, false, options);
+        } catch (e) {
+            // The browser either does not support OffscreenCanvas or WebGL context in OffscreenCanvas, fallback on a regular canvas
+            canvas = document.createElement("canvas");
+            engine = new ThinEngine(canvas, false, options);
         }
-        return DumpTools._DumpToolsEngine;
-    }
-
-    /**
-     * Dumps the current bound framebuffer
-     * @param width defines the rendering width
-     * @param height defines the rendering height
-     * @param engine defines the hosting engine
-     * @param successCallback defines the callback triggered once the data are available
-     * @param mimeType defines the mime type of the result
-     * @param fileName defines the filename to download. If present, the result will automatically be downloaded
-     * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
-     * @returns a void promise
-     */
-    public static async DumpFramebuffer(
-        width: number,
-        height: number,
-        engine: AbstractEngine,
-        successCallback?: (data: string) => void,
-        mimeType = "image/png",
-        fileName?: string,
-        quality?: number
-    ) {
-        // Read the contents of the framebuffer
-        const bufferView = await engine.readPixels(0, 0, width, height);
-
-        const data = new Uint8Array(bufferView.buffer);
-
-        DumpTools.DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
-    }
-
-    /**
-     * Dumps an array buffer
-     * @param width defines the rendering width
-     * @param height defines the rendering height
-     * @param data the data array
-     * @param mimeType defines the mime type of the result
-     * @param fileName defines the filename to download. If present, the result will automatically be downloaded
-     * @param invertY true to invert the picture in the Y dimension
-     * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
-     * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
-     * @returns a promise that resolve to the final data
-     */
-    public static DumpDataAsync(
-        width: number,
-        height: number,
-        data: ArrayBufferView,
-        mimeType = "image/png",
-        fileName?: string,
-        invertY = false,
-        toArrayBuffer = false,
-        quality?: number
-    ): Promise<string | ArrayBuffer> {
-        return new Promise((resolve) => {
-            DumpTools.DumpData(width, height, data, (result) => resolve(result), mimeType, fileName, invertY, toArrayBuffer, quality);
+        // remove this engine from the list of instances to avoid using it for other purposes
+        EngineStore.Instances.pop();
+        // However, make sure to dispose it when no other engines are left
+        EngineStore.OnEnginesDisposedObservable.add((e) => {
+            // guaranteed to run when no other instances are left
+            // only dispose if it's not the current engine
+            if (engine && e !== engine && !engine.isDisposed && EngineStore.Instances.length === 0) {
+                // Dump the engine and the associated resources
+                Dispose();
+            }
         });
+        engine.getCaps().parallelShaderCompile = undefined;
+        const renderer = new EffectRenderer(engine);
+        const wrapper = new EffectWrapper({
+            engine,
+            name: passPixelShader.name,
+            fragmentShader: passPixelShader.shader,
+            samplerNames: ["textureSampler"],
+        });
+        _dumpToolsEngine = {
+            canvas,
+            engine,
+            renderer,
+            wrapper,
+        };
     }
-
-    /**
-     * Dumps an array buffer
-     * @param width defines the rendering width
-     * @param height defines the rendering height
-     * @param data the data array
-     * @param successCallback defines the callback triggered once the data are available
-     * @param mimeType defines the mime type of the result
-     * @param fileName defines the filename to download. If present, the result will automatically be downloaded
-     * @param invertY true to invert the picture in the Y dimension
-     * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
-     * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
-     */
-    public static DumpData(
-        width: number,
-        height: number,
-        data: ArrayBufferView,
-        successCallback?: (data: string | ArrayBuffer) => void,
-        mimeType = "image/png",
-        fileName?: string,
-        invertY = false,
-        toArrayBuffer = false,
-        quality?: number
-    ) {
-        const renderer = DumpTools._CreateDumpRenderer();
-        renderer.engine.setSize(width, height, true);
-
-        // Convert if data are float32
-        if (data instanceof Float32Array) {
-            const data2 = new Uint8Array(data.length);
-            let n = data.length;
-            while (n--) {
-                const v = data[n];
-                data2[n] = Math.round(Scalar.Clamp(v) * 255);
-            }
-            data = data2;
-        }
-
-        // Create the image
-        const texture = renderer.engine.createRawTexture(data, width, height, Constants.TEXTUREFORMAT_RGBA, false, !invertY, Constants.TEXTURE_NEAREST_NEAREST);
-
-        renderer.renderer.setViewport();
-        renderer.renderer.applyEffectWrapper(renderer.wrapper);
-        renderer.wrapper.effect._bindTexture("textureSampler", texture);
-        renderer.renderer.draw();
-
-        if (toArrayBuffer) {
-            Tools.ToBlob(
-                renderer.canvas,
-                (blob) => {
-                    const fileReader = new FileReader();
-                    fileReader.onload = (event: any) => {
-                        const arrayBuffer = event.target!.result as ArrayBuffer;
-                        if (successCallback) {
-                            successCallback(arrayBuffer);
-                        }
-                    };
-                    fileReader.readAsArrayBuffer(blob!);
-                },
-                mimeType,
-                quality
-            );
-        } else {
-            Tools.EncodeScreenshotCanvasData(renderer.canvas, successCallback, mimeType, fileName, quality);
-        }
-
-        texture.dispose();
-    }
-
-    /**
-     * Dispose the dump tools associated resources
-     */
-    public static Dispose() {
-        if (DumpTools._DumpToolsEngine) {
-            DumpTools._DumpToolsEngine.wrapper.dispose();
-            DumpTools._DumpToolsEngine.renderer.dispose();
-            DumpTools._DumpToolsEngine.engine.dispose();
-        }
-        DumpTools._DumpToolsEngine = null;
-    }
+    return _dumpToolsEngine;
 }
+
+/**
+ * Dumps the current bound framebuffer
+ * @param width defines the rendering width
+ * @param height defines the rendering height
+ * @param engine defines the hosting engine
+ * @param successCallback defines the callback triggered once the data are available
+ * @param mimeType defines the mime type of the result
+ * @param fileName defines the filename to download. If present, the result will automatically be downloaded
+ * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+ * @returns a void promise
+ */
+export async function DumpFramebuffer(
+    width: number,
+    height: number,
+    engine: AbstractEngine,
+    successCallback?: (data: string) => void,
+    mimeType = "image/png",
+    fileName?: string,
+    quality?: number
+) {
+    // Read the contents of the framebuffer
+    const bufferView = await engine.readPixels(0, 0, width, height);
+
+    const data = new Uint8Array(bufferView.buffer);
+
+    DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
+}
+
+/**
+ * Dumps an array buffer
+ * @param width defines the rendering width
+ * @param height defines the rendering height
+ * @param data the data array
+ * @param mimeType defines the mime type of the result
+ * @param fileName defines the filename to download. If present, the result will automatically be downloaded
+ * @param invertY true to invert the picture in the Y dimension
+ * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
+ * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+ * @returns a promise that resolve to the final data
+ */
+export function DumpDataAsync(
+    width: number,
+    height: number,
+    data: ArrayBufferView,
+    mimeType = "image/png",
+    fileName?: string,
+    invertY = false,
+    toArrayBuffer = false,
+    quality?: number
+): Promise<string | ArrayBuffer> {
+    return new Promise((resolve) => {
+        DumpData(width, height, data, (result) => resolve(result), mimeType, fileName, invertY, toArrayBuffer, quality);
+    });
+}
+
+/**
+ * Dumps an array buffer
+ * @param width defines the rendering width
+ * @param height defines the rendering height
+ * @param data the data array
+ * @param successCallback defines the callback triggered once the data are available
+ * @param mimeType defines the mime type of the result
+ * @param fileName defines the filename to download. If present, the result will automatically be downloaded
+ * @param invertY true to invert the picture in the Y dimension
+ * @param toArrayBuffer true to convert the data to an ArrayBuffer (encoded as `mimeType`) instead of a base64 string
+ * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+ */
+export function DumpData(
+    width: number,
+    height: number,
+    data: ArrayBufferView,
+    successCallback?: (data: string | ArrayBuffer) => void,
+    mimeType = "image/png",
+    fileName?: string,
+    invertY = false,
+    toArrayBuffer = false,
+    quality?: number
+) {
+    const renderer = _CreateDumpRenderer();
+    renderer.engine.setSize(width, height, true);
+
+    // Convert if data are float32
+    if (data instanceof Float32Array) {
+        const data2 = new Uint8Array(data.length);
+        let n = data.length;
+        while (n--) {
+            const v = data[n];
+            data2[n] = Math.round(Scalar.Clamp(v) * 255);
+        }
+        data = data2;
+    }
+
+    // Create the image
+    const texture = renderer.engine.createRawTexture(data, width, height, Constants.TEXTUREFORMAT_RGBA, false, !invertY, Constants.TEXTURE_NEAREST_NEAREST);
+
+    renderer.renderer.setViewport();
+    renderer.renderer.applyEffectWrapper(renderer.wrapper);
+    renderer.wrapper.effect._bindTexture("textureSampler", texture);
+    renderer.renderer.draw();
+
+    if (toArrayBuffer) {
+        Tools.ToBlob(
+            renderer.canvas,
+            (blob) => {
+                const fileReader = new FileReader();
+                fileReader.onload = (event: any) => {
+                    const arrayBuffer = event.target!.result as ArrayBuffer;
+                    if (successCallback) {
+                        successCallback(arrayBuffer);
+                    }
+                };
+                fileReader.readAsArrayBuffer(blob!);
+            },
+            mimeType,
+            quality
+        );
+    } else {
+        Tools.EncodeScreenshotCanvasData(renderer.canvas, successCallback, mimeType, fileName, quality);
+    }
+
+    texture.dispose();
+}
+
+/**
+ * Dispose the dump tools associated resources
+ */
+export function Dispose() {
+    if (_dumpToolsEngine) {
+        _dumpToolsEngine.wrapper.dispose();
+        _dumpToolsEngine.renderer.dispose();
+        _dumpToolsEngine.engine.dispose();
+    }
+    _dumpToolsEngine = null;
+}
+
+/**
+ * Object containing a set of static utilities functions to dump data from a canvas
+ * @deprecated use functions
+ */
+export const DumpTools = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    DumpData,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    DumpDataAsync,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    DumpFramebuffer,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Dispose,
+};
 
 /**
  * This will be executed automatically for UMD and es5.
@@ -219,9 +229,9 @@ export class DumpTools {
  */
 const initSideEffects = () => {
     // References the dependencies.
-    Tools.DumpData = DumpTools.DumpData;
-    Tools.DumpDataAsync = DumpTools.DumpDataAsync;
-    Tools.DumpFramebuffer = DumpTools.DumpFramebuffer;
+    Tools.DumpData = DumpData;
+    Tools.DumpDataAsync = DumpDataAsync;
+    Tools.DumpFramebuffer = DumpFramebuffer;
 };
 
 initSideEffects();

--- a/packages/dev/core/src/Misc/environmentTextureTools.ts
+++ b/packages/dev/core/src/Misc/environmentTextureTools.ts
@@ -20,7 +20,7 @@ import "../Materials/Textures/baseTexture.polynomial";
 
 import "../Shaders/rgbdEncode.fragment";
 import "../Shaders/rgbdDecode.fragment";
-import { DumpTools } from "../Misc/dumpTools";
+import { DumpDataAsync } from "../Misc/dumpTools";
 
 const DefaultEnvironmentTextureImageType = "image/png";
 const CurrentVersion = 2;
@@ -302,7 +302,7 @@ export async function CreateEnvTextureAsync(texture: BaseTexture, options: Creat
 
             const rgbdEncodedData = await engine._readTexturePixels(tempTexture, faceWidth, faceWidth);
 
-            const imageEncodedData = await DumpTools.DumpDataAsync(faceWidth, faceWidth, rgbdEncodedData, imageType, undefined, false, true, options.imageQuality);
+            const imageEncodedData = await DumpDataAsync(faceWidth, faceWidth, rgbdEncodedData, imageType, undefined, false, true, options.imageQuality);
 
             specularTextures[i * 6 + face] = imageEncodedData as ArrayBuffer;
 

--- a/packages/dev/core/src/Misc/equirectangularCapture.ts
+++ b/packages/dev/core/src/Misc/equirectangularCapture.ts
@@ -3,7 +3,7 @@ import { ReflectionProbe } from "../Probes/reflectionProbe";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { CustomProceduralTexture } from "../Materials/Textures/Procedurals/customProceduralTexture";
-import { DumpTools } from "./dumpTools";
+import { DumpData } from "./dumpTools";
 import type { Vector3 } from "../Maths/math.vector";
 import "../Shaders/equirectangularPanorama.fragment";
 
@@ -76,7 +76,7 @@ export async function captureEquirectangularFromScene(scene: Scene, options: Equ
                     probe.dispose();
                 }
                 if (options.filename) {
-                    DumpTools.DumpData(options.size * 2, options.size, pixelData, undefined, "image/png", options.filename);
+                    DumpData(options.size * 2, options.size, pixelData, undefined, "image/png", options.filename);
                     resolve(null);
                 } else {
                     resolve(pixelData);

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -63,7 +63,7 @@ export * from "./error";
 // eslint-disable-next-line import/export
 export * from "./observableCoroutine";
 export * from "./copyTextureToTexture";
-export * from "./dumpTools";
+export * as DumpTools from "./dumpTools";
 export * from "./greasedLineTools";
 export * from "./equirectangularCapture";
 export * from "./decorators.serialization";

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -63,7 +63,8 @@ export * from "./error";
 // eslint-disable-next-line import/export
 export * from "./observableCoroutine";
 export * from "./copyTextureToTexture";
-export * as DumpTools from "./dumpTools";
+/** @deprecated Use individual exports */
+export { DumpTools } from "./dumpTools";
 export * from "./greasedLineTools";
 export * from "./equirectangularCapture";
 export * from "./decorators.serialization";

--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -7,7 +7,7 @@ import { Constants } from "../Engines/constants";
 import { Logger } from "./logger";
 import { Tools } from "./tools";
 import type { IScreenshotSize } from "./interfaces/screenshotSize";
-import { DumpTools } from "./dumpTools";
+import { DumpData } from "./dumpTools";
 import type { Nullable } from "../types";
 import { ApplyPostProcess } from "./textureTools";
 
@@ -264,23 +264,13 @@ export function CreateScreenshotUsingRenderTarget(
             engine.onEndFrameObservable.addOnce(() => {
                 if (finalWidth === width && finalHeight === height) {
                     texture.readPixels(undefined, undefined, undefined, false)!.then((data) => {
-                        DumpTools.DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
+                        DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
                         texture.dispose();
                     });
                 } else {
                     ApplyPostProcess("pass", texture.getInternalTexture()!, scene, undefined, undefined, undefined, finalWidth, finalHeight).then((texture) => {
                         engine._readTexturePixels(texture, finalWidth, finalHeight, -1, 0, null, true, false, 0, 0).then((data) => {
-                            DumpTools.DumpData(
-                                finalWidth,
-                                finalHeight,
-                                data,
-                                successCallback as (data: string | ArrayBuffer) => void,
-                                mimeType,
-                                fileName,
-                                true,
-                                undefined,
-                                quality
-                            );
+                            DumpData(finalWidth, finalHeight, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
                             texture.dispose();
                         });
                     });


### PR DESCRIPTION
This PR migrates `DumpTools` from a class with static methods and properties into a set of export functions.

- Backward compatible
- Backward-compatible exports marked as deprecated 
- PascalCase is followed for exported functions' names

#### `initSideEffects`
Something I noticed is `initSideEffects`, which I think could be unwrapped, and the statements just placed at the top level of the `dumpTools.ts` module. In ES6/ESM, the function will still be called, so the doc comment "If esm dev wants the side effects to execute they will have to run it manually" is incorrect. Please let me know what you think about this. I haven't made the change yet, but if you want me to it should only take a few seconds.

This is for #14805.