### PR TITLE
Migrate `ArrayTools` from a static class to functions

### DIFF
--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -1,6 +1,6 @@
 import type { Skeleton } from "./skeleton";
 import { Vector3, Quaternion, Matrix, TmpVectors } from "../Maths/math.vector";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import type { Nullable } from "../types";
 import type { TransformNode } from "../Meshes/transformNode";
 import { Node } from "../node";
@@ -14,9 +14,9 @@ import type { AnimationPropertiesOverride } from "../Animations/animationPropert
  * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons
  */
 export class Bone extends Node {
-    private static _TmpVecs: Vector3[] = ArrayTools.BuildArray(2, Vector3.Zero);
+    private static _TmpVecs: Vector3[] = BuildArray(2, Vector3.Zero);
     private static _TmpQuat = Quaternion.Identity();
-    private static _TmpMats: Matrix[] = ArrayTools.BuildArray(5, Matrix.Identity);
+    private static _TmpMats: Matrix[] = BuildArray(5, Matrix.Identity);
 
     /**
      * Gets the list of child bones

--- a/packages/dev/core/src/Bones/boneLookController.ts
+++ b/packages/dev/core/src/Bones/boneLookController.ts
@@ -1,5 +1,5 @@
 import type { Nullable } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import { Vector3, Quaternion, Matrix } from "../Maths/math.vector";
 import type { TransformNode } from "../Meshes/transformNode";
 import type { Bone } from "./bone";
@@ -10,9 +10,9 @@ import { Space, Axis } from "../Maths/math.axis";
  * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons#bonelookcontroller
  */
 export class BoneLookController {
-    private static _TmpVecs: Vector3[] = ArrayTools.BuildArray(10, Vector3.Zero);
+    private static _TmpVecs: Vector3[] = BuildArray(10, Vector3.Zero);
     private static _TmpQuat = Quaternion.Identity();
-    private static _TmpMats: Matrix[] = ArrayTools.BuildArray(5, Matrix.Identity);
+    private static _TmpMats: Matrix[] = BuildArray(5, Matrix.Identity);
 
     /**
      * The target Vector3 that the bone will look at

--- a/packages/dev/core/src/Culling/boundingBox.ts
+++ b/packages/dev/core/src/Culling/boundingBox.ts
@@ -1,5 +1,5 @@
 import type { DeepImmutable, Nullable } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { BoundingSphere } from "../Culling/boundingSphere";
 
@@ -16,7 +16,7 @@ export class BoundingBox implements ICullable {
     /**
      * Gets the 8 vectors representing the bounding box in local space
      */
-    public readonly vectors: Vector3[] = ArrayTools.BuildArray(8, Vector3.Zero);
+    public readonly vectors: Vector3[] = BuildArray(8, Vector3.Zero);
     /**
      * Gets the center of the bounding box in local space
      */
@@ -36,11 +36,11 @@ export class BoundingBox implements ICullable {
     /**
      * Gets the OBB (object bounding box) directions
      */
-    public readonly directions: Vector3[] = ArrayTools.BuildArray(3, Vector3.Zero);
+    public readonly directions: Vector3[] = BuildArray(3, Vector3.Zero);
     /**
      * Gets the 8 vectors representing the bounding box in world space
      */
-    public readonly vectorsWorld: Vector3[] = ArrayTools.BuildArray(8, Vector3.Zero);
+    public readonly vectorsWorld: Vector3[] = BuildArray(8, Vector3.Zero);
     /**
      * Gets the minimum vector in world space
      */
@@ -59,7 +59,7 @@ export class BoundingBox implements ICullable {
     public readonly maximum: Vector3 = Vector3.Zero();
 
     private _worldMatrix: DeepImmutable<Matrix>;
-    private static readonly _TmpVector3 = ArrayTools.BuildArray(3, Vector3.Zero);
+    private static readonly _TmpVector3 = BuildArray(3, Vector3.Zero);
 
     /**
      * @internal

--- a/packages/dev/core/src/Culling/boundingInfo.ts
+++ b/packages/dev/core/src/Culling/boundingInfo.ts
@@ -1,5 +1,5 @@
 import type { DeepImmutable } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import type { Matrix } from "../Maths/math.vector";
 import { TmpVectors } from "../Maths/math.vector";
 import { Vector3 } from "../Maths/math.vector";
@@ -65,7 +65,7 @@ export class BoundingInfo implements ICullable {
 
     private _isLocked = false;
 
-    private static readonly _TmpVector3 = ArrayTools.BuildArray(2, Vector3.Zero);
+    private static readonly _TmpVector3 = BuildArray(2, Vector3.Zero);
 
     /**
      * Constructs bounding info

--- a/packages/dev/core/src/Culling/boundingSphere.ts
+++ b/packages/dev/core/src/Culling/boundingSphere.ts
@@ -1,5 +1,5 @@
 import type { DeepImmutable } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { Plane } from "../Maths/math.plane";
 
@@ -33,7 +33,7 @@ export class BoundingSphere {
     public readonly maximum = Vector3.Zero();
 
     private _worldMatrix: DeepImmutable<Matrix>;
-    private static readonly _TmpVector3 = ArrayTools.BuildArray(3, Vector3.Zero);
+    private static readonly _TmpVector3 = BuildArray(3, Vector3.Zero);
 
     /**
      * Creates a new bounding sphere

--- a/packages/dev/core/src/Culling/ray.ts
+++ b/packages/dev/core/src/Culling/ray.ts
@@ -1,5 +1,5 @@
 import type { DeepImmutable, Nullable, float } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import { Matrix, Vector3, TmpVectors } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { PickingInfo } from "../Collisions/pickingInfo";
@@ -18,7 +18,7 @@ import { Epsilon } from "core/Maths/math.constants";
  * Class representing a ray with position and direction
  */
 export class Ray {
-    private static readonly _TmpVector3 = ArrayTools.BuildArray(6, Vector3.Zero);
+    private static readonly _TmpVector3 = BuildArray(6, Vector3.Zero);
     private static _RayDistant = Ray.Zero();
     private _tmpRay: Ray;
 

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -1,4 +1,4 @@
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildArray } from "../Misc/arrayTools";
 import { RegisterClass } from "../Misc/typeStore";
 import type { DeepImmutable, FloatArray, Tuple } from "../types";
 import { Epsilon, ToGammaSpace, ToLinearSpace } from "./math.constants";
@@ -1859,8 +1859,8 @@ Object.defineProperties(Color4.prototype, {
  * @internal
  */
 export class TmpColors {
-    public static Color3: Color3[] = ArrayTools.BuildArray(3, Color3.Black);
-    public static Color4: Color4[] = ArrayTools.BuildArray(3, () => new Color4(0, 0, 0, 0));
+    public static Color3: Color3[] = BuildArray(3, Color3.Black);
+    public static Color4: Color4[] = BuildArray(3, () => new Color4(0, 0, 0, 0));
 }
 
 RegisterClass("BABYLON.Color3", Color3);

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -2,7 +2,7 @@
 import { Epsilon } from "./math.constants";
 import type { Viewport } from "./math.viewport";
 import type { DeepImmutable, Nullable, FloatArray, float, Tuple } from "../types";
-import { ArrayTools } from "../Misc/arrayTools";
+import { BuildTuple } from "../Misc/arrayTools";
 import { RegisterClass } from "../Misc/typeStore";
 import type { Plane } from "./math.plane";
 import { PerformanceConfigurator } from "../Engines/performanceConfigurator";
@@ -8871,13 +8871,13 @@ Object.defineProperties(Matrix.prototype, {
  */
 class MathTmp {
     // Temporary Vector3s
-    public static Vector3 = ArrayTools.BuildTuple(11, Vector3.Zero);
+    public static Vector3 = BuildTuple(11, Vector3.Zero);
 
     // Temporary Matricies
-    public static Matrix = ArrayTools.BuildTuple(2, Matrix.Identity);
+    public static Matrix = BuildTuple(2, Matrix.Identity);
 
     // Temporary Quaternions
-    public static Quaternion = ArrayTools.BuildTuple(3, Quaternion.Zero);
+    public static Quaternion = BuildTuple(3, Quaternion.Zero);
 }
 
 /**
@@ -8885,19 +8885,19 @@ class MathTmp {
  */
 export class TmpVectors {
     /** 3 temp Vector2 at once should be enough */
-    public static Vector2 = ArrayTools.BuildTuple(3, Vector2.Zero);
+    public static Vector2 = BuildTuple(3, Vector2.Zero);
 
     /** 13 temp Vector3 at once should be enough */
-    public static Vector3 = ArrayTools.BuildTuple(13, Vector3.Zero);
+    public static Vector3 = BuildTuple(13, Vector3.Zero);
 
     /** 3 temp Vector4 at once should be enough */
-    public static Vector4 = ArrayTools.BuildTuple(3, Vector4.Zero);
+    public static Vector4 = BuildTuple(3, Vector4.Zero);
 
     /** 3 temp Quaternion at once should be enough */
-    public static Quaternion = ArrayTools.BuildTuple(3, Quaternion.Zero);
+    public static Quaternion = BuildTuple(3, Quaternion.Zero);
 
     /** 8 temp Matrices at once should be enough */
-    public static Matrix = ArrayTools.BuildTuple(8, Matrix.Identity);
+    public static Matrix = BuildTuple(8, Matrix.Identity);
 }
 
 RegisterClass("BABYLON.Vector2", Vector2);

--- a/packages/dev/core/src/Misc/arrayTools.ts
+++ b/packages/dev/core/src/Misc/arrayTools.ts
@@ -27,11 +27,6 @@ export function BuildTuple<T, N extends number>(size: N, itemBuilder: () => T): 
 }
 
 /**
- * Object containing a set of static utilities functions for arrays.
- */
-export const ArrayTools = { BuildArray, BuildTuple };
-
-/**
  * Defines the callback type used when an observed array function is triggered.
  * @internal
  */

--- a/packages/dev/core/src/Misc/arrayTools.ts
+++ b/packages/dev/core/src/Misc/arrayTools.ts
@@ -3,33 +3,33 @@
 import type { Nullable, Tuple } from "../types";
 
 /**
- * Class containing a set of static utilities functions for arrays.
+ * Returns an array of the given size filled with elements built from the given constructor and the parameters.
+ * @param size the number of element to construct and put in the array.
+ * @param itemBuilder a callback responsible for creating new instance of item. Called once per array entry.
+ * @returns a new array filled with new objects.
  */
-export class ArrayTools {
-    /**
-     * Returns an array of the given size filled with elements built from the given constructor and the parameters.
-     * @param size the number of element to construct and put in the array.
-     * @param itemBuilder a callback responsible for creating new instance of item. Called once per array entry.
-     * @returns a new array filled with new objects.
-     */
-    public static BuildArray<T>(size: number, itemBuilder: () => T): Array<T> {
-        const a: T[] = [];
-        for (let i = 0; i < size; ++i) {
-            a.push(itemBuilder());
-        }
-        return a;
+export function BuildArray<T>(size: number, itemBuilder: () => T): Array<T> {
+    const a: T[] = [];
+    for (let i = 0; i < size; ++i) {
+        a.push(itemBuilder());
     }
-
-    /**
-     * Returns a tuple of the given size filled with elements built from the given constructor and the parameters.
-     * @param size he number of element to construct and put in the tuple.
-     * @param itemBuilder a callback responsible for creating new instance of item. Called once per tuple entry.
-     * @returns a new tuple filled with new objects.
-     */
-    public static BuildTuple<T, N extends number>(size: N, itemBuilder: () => T): Tuple<T, N> {
-        return ArrayTools.BuildArray(size, itemBuilder) as any;
-    }
+    return a;
 }
+
+/**
+ * Returns a tuple of the given size filled with elements built from the given constructor and the parameters.
+ * @param size he number of element to construct and put in the tuple.
+ * @param itemBuilder a callback responsible for creating new instance of item. Called once per tuple entry.
+ * @returns a new tuple filled with new objects.
+ */
+export function BuildTuple<T, N extends number>(size: N, itemBuilder: () => T): Tuple<T, N> {
+    return BuildArray(size, itemBuilder) as any;
+}
+
+/**
+ * Object containing a set of static utilities functions for arrays.
+ */
+export const ArrayTools = { BuildArray, BuildTuple };
 
 /**
  * Defines the callback type used when an observed array function is triggered.

--- a/packages/dev/core/src/Physics/v1/physicsImpostor.ts
+++ b/packages/dev/core/src/Physics/v1/physicsImpostor.ts
@@ -1,6 +1,6 @@
 import type { Nullable, IndicesArray } from "../../types";
 import { Logger } from "../../Misc/logger";
-import { ArrayTools } from "../../Misc/arrayTools";
+import { BuildArray } from "../../Misc/arrayTools";
 import type { Matrix } from "../../Maths/math.vector";
 import { Vector3, Quaternion } from "../../Maths/math.vector";
 import type { TransformNode } from "../../Meshes/transformNode";
@@ -242,7 +242,7 @@ export class PhysicsImpostor {
 
     private _isDisposed = false;
 
-    private static _TmpVecs: Vector3[] = ArrayTools.BuildArray(3, Vector3.Zero);
+    private static _TmpVecs: Vector3[] = BuildArray(3, Vector3.Zero);
     private static _TmpQuat: Quaternion = Quaternion.Identity();
 
     /**

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -31,7 +31,7 @@ import { Mesh } from "../../../Meshes/mesh";
 import { InstancedMesh } from "../../../Meshes/instancedMesh";
 import type { Scene } from "../../../scene";
 import { VertexBuffer } from "../../../Buffers/buffer";
-import { ArrayTools } from "../../../Misc/arrayTools";
+import { BuildArray } from "../../../Misc/arrayTools";
 import { Observable } from "../../../Misc/observable";
 import type { Nullable, FloatArray } from "../../../types";
 import type { IPhysicsPointProximityQuery } from "../../physicsPointProximityQuery";
@@ -291,7 +291,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      */
     private _queryCollector;
     private _fixedTimeStep: number = 1 / 60;
-    private _tmpVec3 = ArrayTools.BuildArray(3, Vector3.Zero);
+    private _tmpVec3 = BuildArray(3, Vector3.Zero);
     private _bodies = new Map<bigint, { body: PhysicsBody; index: number }>();
     private _shapes = new Map<bigint, PhysicsShape>();
     private _bodyBuffer: number;


### PR DESCRIPTION
This PR migrates `ArrayTools` from a class with static methods and properties into a set of export functions.

- Backward compatible
- Backward-compatible exports marked as deprecated 
- PascalCase is followed for exported functions' names