### PR TITLE
Migrate `DeviceEventFactory` and `EngineFactory` static classes to functions

### DIFF
--- a/packages/dev/core/src/DeviceInput/eventFactory.ts
+++ b/packages/dev/core/src/DeviceInput/eventFactory.ts
@@ -1,3 +1,4 @@
+/* Wrapping `DeviceInputSystem` data into an event object */
 import { Constants } from "../Engines/constants";
 import type { IUIEvent } from "../Events/deviceInputEvents";
 import { EventConstants } from "../Events/deviceInputEvents";
@@ -6,245 +7,246 @@ import { DeviceType, NativePointerInput, PointerInput } from "./InputDevices/dev
 import type { IDeviceInputSystem } from "./inputInterfaces";
 
 /**
- * Class to wrap DeviceInputSystem data into an event object
+ * Create device input events based on provided type and slot
+ *
+ * @param deviceType Type of device
+ * @param deviceSlot "Slot" or index that device is referenced in
+ * @param inputIndex Id of input to be checked
+ * @param currentState Current value for given input
+ * @param deviceInputSystem Reference to DeviceInputSystem
+ * @param elementToAttachTo HTMLElement to reference as target for inputs
+ * @param pointerId PointerId to use for pointer events
+ * @returns IUIEvent object
  */
-export class DeviceEventFactory {
-    /**
-     * Create device input events based on provided type and slot
-     *
-     * @param deviceType Type of device
-     * @param deviceSlot "Slot" or index that device is referenced in
-     * @param inputIndex Id of input to be checked
-     * @param currentState Current value for given input
-     * @param deviceInputSystem Reference to DeviceInputSystem
-     * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @param pointerId PointerId to use for pointer events
-     * @returns IUIEvent object
-     */
-    public static CreateDeviceEvent(
-        deviceType: DeviceType,
-        deviceSlot: number,
-        inputIndex: number,
-        currentState: Nullable<number>,
-        deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo?: any,
-        pointerId?: number
-    ): IUIEvent {
-        switch (deviceType) {
-            case DeviceType.Keyboard:
-                return this._CreateKeyboardEvent(inputIndex, currentState, deviceInputSystem, elementToAttachTo);
-            case DeviceType.Mouse:
-                if (inputIndex === PointerInput.MouseWheelX || inputIndex === PointerInput.MouseWheelY || inputIndex === PointerInput.MouseWheelZ) {
-                    return this._CreateWheelEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
-                }
-            // eslint-disable-next-line no-fallthrough
-            case DeviceType.Touch:
-                return this._CreatePointerEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo, pointerId);
-            default:
-                // eslint-disable-next-line no-throw-literal
-                throw `Unable to generate event for device ${DeviceType[deviceType]}`;
-        }
+export function CreateDeviceEvent(
+    deviceType: DeviceType,
+    deviceSlot: number,
+    inputIndex: number,
+    currentState: Nullable<number>,
+    deviceInputSystem: IDeviceInputSystem,
+    elementToAttachTo?: any,
+    pointerId?: number
+): IUIEvent {
+    switch (deviceType) {
+        case DeviceType.Keyboard:
+            return _CreateKeyboardEvent(inputIndex, currentState, deviceInputSystem, elementToAttachTo);
+        case DeviceType.Mouse:
+            if (inputIndex === PointerInput.MouseWheelX || inputIndex === PointerInput.MouseWheelY || inputIndex === PointerInput.MouseWheelZ) {
+                return _CreateWheelEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
+            }
+        // eslint-disable-next-line no-fallthrough
+        case DeviceType.Touch:
+            return _CreatePointerEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo, pointerId);
+        default:
+            // eslint-disable-next-line no-throw-literal
+            throw `Unable to generate event for device ${DeviceType[deviceType]}`;
     }
+}
 
-    /**
-     * Creates pointer event
-     *
-     * @param deviceType Type of device
-     * @param deviceSlot "Slot" or index that device is referenced in
-     * @param inputIndex Id of input to be checked
-     * @param currentState Current value for given input
-     * @param deviceInputSystem Reference to DeviceInputSystem
-     * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @param pointerId PointerId to use for pointer events
-     * @returns IUIEvent object (Pointer)
-     */
-    private static _CreatePointerEvent(
-        deviceType: DeviceType,
-        deviceSlot: number,
-        inputIndex: number,
-        currentState: Nullable<number>,
-        deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo?: any,
-        pointerId?: number
-    ): any {
-        const evt = this._CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
+/**
+ * @deprecated use CreateDeviceEvent
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const CreateDeviceEvent = { CreateDeviceEvent };
 
-        if (deviceType === DeviceType.Mouse) {
-            evt.deviceType = DeviceType.Mouse;
-            evt.pointerId = 1;
-            evt.pointerType = "mouse";
-        } else {
-            evt.deviceType = DeviceType.Touch;
-            evt.pointerId = pointerId ?? deviceSlot;
-            evt.pointerType = "touch";
-        }
+/**
+ * Creates pointer event
+ *
+ * @param deviceType Type of device
+ * @param deviceSlot "Slot" or index that device is referenced in
+ * @param inputIndex Id of input to be checked
+ * @param currentState Current value for given input
+ * @param deviceInputSystem Reference to DeviceInputSystem
+ * @param elementToAttachTo HTMLElement to reference as target for inputs
+ * @param pointerId PointerId to use for pointer events
+ * @returns IUIEvent object (Pointer)
+ */
+function _CreatePointerEvent(
+    deviceType: DeviceType,
+    deviceSlot: number,
+    inputIndex: number,
+    currentState: Nullable<number>,
+    deviceInputSystem: IDeviceInputSystem,
+    elementToAttachTo?: any,
+    pointerId?: number
+): any {
+    const evt = _CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
 
-        let buttons = 0;
-
-        // Populate buttons property with current state of all mouse buttons
-        // Uses values found on: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.LeftClick);
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.RightClick) * 2;
-        buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MiddleClick) * 4;
-        evt.buttons = buttons;
-
-        if (inputIndex === PointerInput.Move) {
-            evt.type = "pointermove";
-        } else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {
-            evt.type = currentState === 1 ? "pointerdown" : "pointerup";
-            evt.button = inputIndex - 2;
-        }
-
-        return evt;
-    }
-
-    /**
-     * Create Mouse Wheel Event
-     * @param deviceType Type of device
-     * @param deviceSlot "Slot" or index that device is referenced in
-     * @param inputIndex Id of input to be checked
-     * @param currentState Current value for given input
-     * @param deviceInputSystem Reference to DeviceInputSystem
-     * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IUIEvent object (Wheel)
-     */
-    private static _CreateWheelEvent(
-        deviceType: DeviceType,
-        deviceSlot: number,
-        inputIndex: number,
-        currentState: Nullable<number>,
-        deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo: any
-    ): any {
-        const evt = this._CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
-
-        // While WheelEvents don't generally have a pointerId, we used to add one in the InputManager
-        // This line has been added to make the InputManager more platform-agnostic
-        // Similar code exists in the WebDeviceInputSystem to handle browser created events
+    if (deviceType === DeviceType.Mouse) {
+        evt.deviceType = DeviceType.Mouse;
         evt.pointerId = 1;
-        evt.type = "wheel";
-        evt.deltaMode = EventConstants.DOM_DELTA_PIXEL;
-        evt.deltaX = 0;
-        evt.deltaY = 0;
-        evt.deltaZ = 0;
-
-        switch (inputIndex) {
-            case PointerInput.MouseWheelX:
-                evt.deltaX = currentState;
-                break;
-            case PointerInput.MouseWheelY:
-                evt.deltaY = currentState;
-                break;
-            case PointerInput.MouseWheelZ:
-                evt.deltaZ = currentState;
-                break;
-        }
-
-        return evt;
+        evt.pointerType = "mouse";
+    } else {
+        evt.deviceType = DeviceType.Touch;
+        evt.pointerId = pointerId ?? deviceSlot;
+        evt.pointerType = "touch";
     }
 
-    /**
-     * Create Mouse Event
-     * @param deviceType Type of device
-     * @param deviceSlot "Slot" or index that device is referenced in
-     * @param inputIndex Id of input to be checked
-     * @param currentState Current value for given input
-     * @param deviceInputSystem Reference to DeviceInputSystem
-     * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IUIEvent object (Mouse)
-     */
-    private static _CreateMouseEvent(
-        deviceType: DeviceType,
-        deviceSlot: number,
-        inputIndex: number,
-        currentState: Nullable<number>,
-        deviceInputSystem: IDeviceInputSystem,
-        elementToAttachTo?: any
-    ): any {
-        const evt = this._CreateEvent(elementToAttachTo);
-        const pointerX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Horizontal);
-        const pointerY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Vertical);
+    let buttons = 0;
 
-        // Handle offsets/deltas based on existence of HTMLElement
-        if (elementToAttachTo) {
-            evt.movementX = 0;
-            evt.movementY = 0;
-            evt.offsetX = evt.movementX - elementToAttachTo.getBoundingClientRect().x;
-            evt.offsetY = evt.movementY - elementToAttachTo.getBoundingClientRect().y;
-        } else {
-            evt.movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaHorizontal); // DeltaHorizontal
-            evt.movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaVertical); // DeltaVertical
-            evt.offsetX = 0;
-            evt.offsetY = 0;
-        }
-        this._CheckNonCharacterKeys(evt, deviceInputSystem);
+    // Populate buttons property with current state of all mouse buttons
+    // Uses values found on: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+    buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.LeftClick);
+    buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.RightClick) * 2;
+    buttons += deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.MiddleClick) * 4;
+    evt.buttons = buttons;
 
-        evt.clientX = pointerX;
-        evt.clientY = pointerY;
-        evt.x = pointerX;
-        evt.y = pointerY;
-
-        evt.deviceType = deviceType;
-        evt.deviceSlot = deviceSlot;
-        evt.inputIndex = inputIndex;
-
-        return evt;
+    if (inputIndex === PointerInput.Move) {
+        evt.type = "pointermove";
+    } else if (inputIndex >= PointerInput.LeftClick && inputIndex <= PointerInput.RightClick) {
+        evt.type = currentState === 1 ? "pointerdown" : "pointerup";
+        evt.button = inputIndex - 2;
     }
 
-    /**
-     * Create Keyboard Event
-     * @param inputIndex Id of input to be checked
-     * @param currentState Current value for given input
-     * @param deviceInputSystem Reference to DeviceInputSystem
-     * @param elementToAttachTo HTMLElement to reference as target for inputs
-     * @returns IEvent object (Keyboard)
-     */
-    private static _CreateKeyboardEvent(inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): any {
-        const evt = this._CreateEvent(elementToAttachTo);
-        this._CheckNonCharacterKeys(evt, deviceInputSystem);
-        evt.deviceType = DeviceType.Keyboard;
-        evt.deviceSlot = 0;
-        evt.inputIndex = inputIndex;
+    return evt;
+}
 
-        evt.type = currentState === 1 ? "keydown" : "keyup";
-        evt.key = String.fromCharCode(inputIndex);
-        evt.keyCode = inputIndex;
+/**
+ * Create Mouse Wheel Event
+ * @param deviceType Type of device
+ * @param deviceSlot "Slot" or index that device is referenced in
+ * @param inputIndex Id of input to be checked
+ * @param currentState Current value for given input
+ * @param deviceInputSystem Reference to DeviceInputSystem
+ * @param elementToAttachTo HTMLElement to reference as target for inputs
+ * @returns IUIEvent object (Wheel)
+ */
+function _CreateWheelEvent(
+    deviceType: DeviceType,
+    deviceSlot: number,
+    inputIndex: number,
+    currentState: Nullable<number>,
+    deviceInputSystem: IDeviceInputSystem,
+    elementToAttachTo: any
+): any {
+    const evt = _CreateMouseEvent(deviceType, deviceSlot, inputIndex, currentState, deviceInputSystem, elementToAttachTo);
 
-        return evt;
+    // While WheelEvents don't generally have a pointerId, we used to add one in the InputManager
+    // This line has been added to make the InputManager more platform-agnostic
+    // Similar code exists in the WebDeviceInputSystem to handle browser created events
+    evt.pointerId = 1;
+    evt.type = "wheel";
+    evt.deltaMode = EventConstants.DOM_DELTA_PIXEL;
+    evt.deltaX = 0;
+    evt.deltaY = 0;
+    evt.deltaZ = 0;
+
+    switch (inputIndex) {
+        case PointerInput.MouseWheelX:
+            evt.deltaX = currentState;
+            break;
+        case PointerInput.MouseWheelY:
+            evt.deltaY = currentState;
+            break;
+        case PointerInput.MouseWheelZ:
+            evt.deltaZ = currentState;
+            break;
     }
 
-    /**
-     * Add parameters for non-character keys (Ctrl, Alt, Meta, Shift)
-     * @param evt Event object to add parameters to
-     * @param deviceInputSystem DeviceInputSystem to pull values from
-     */
-    private static _CheckNonCharacterKeys(evt: any, deviceInputSystem: IDeviceInputSystem): void {
-        const isKeyboardActive = deviceInputSystem.isDeviceAvailable(DeviceType.Keyboard);
-        const altKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_ALT_KEY) === 1;
-        const ctrlKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_CTRL_KEY) === 1;
-        const metaKey =
-            isKeyboardActive &&
-            (deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY1) === 1 ||
-                deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY2) === 1 ||
-                deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY3) === 1);
-        const shiftKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_SHIFT_KEY) === 1;
+    return evt;
+}
 
-        evt.altKey = altKey;
-        evt.ctrlKey = ctrlKey;
-        evt.metaKey = metaKey;
-        evt.shiftKey = shiftKey;
+/**
+ * Create Mouse Event
+ * @param deviceType Type of device
+ * @param deviceSlot "Slot" or index that device is referenced in
+ * @param inputIndex Id of input to be checked
+ * @param currentState Current value for given input
+ * @param deviceInputSystem Reference to DeviceInputSystem
+ * @param elementToAttachTo HTMLElement to reference as target for inputs
+ * @returns IUIEvent object (Mouse)
+ */
+function _CreateMouseEvent(
+    deviceType: DeviceType,
+    deviceSlot: number,
+    inputIndex: number,
+    currentState: Nullable<number>,
+    deviceInputSystem: IDeviceInputSystem,
+    elementToAttachTo?: any
+): any {
+    const evt = _CreateEvent(elementToAttachTo);
+    const pointerX = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Horizontal);
+    const pointerY = deviceInputSystem.pollInput(deviceType, deviceSlot, PointerInput.Vertical);
+
+    // Handle offsets/deltas based on existence of HTMLElement
+    if (elementToAttachTo) {
+        evt.movementX = 0;
+        evt.movementY = 0;
+        evt.offsetX = evt.movementX - elementToAttachTo.getBoundingClientRect().x;
+        evt.offsetY = evt.movementY - elementToAttachTo.getBoundingClientRect().y;
+    } else {
+        evt.movementX = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaHorizontal); // DeltaHorizontal
+        evt.movementY = deviceInputSystem.pollInput(deviceType, deviceSlot, NativePointerInput.DeltaVertical); // DeltaVertical
+        evt.offsetX = 0;
+        evt.offsetY = 0;
     }
+    _CheckNonCharacterKeys(evt, deviceInputSystem);
 
-    /**
-     * Create base event object
-     * @param elementToAttachTo Value to use as event target
-     * @returns
-     */
-    private static _CreateEvent(elementToAttachTo: any): any {
-        const evt: { [k: string]: any } = {};
-        evt.preventDefault = () => {};
-        evt.target = elementToAttachTo;
+    evt.clientX = pointerX;
+    evt.clientY = pointerY;
+    evt.x = pointerX;
+    evt.y = pointerY;
 
-        return evt;
-    }
+    evt.deviceType = deviceType;
+    evt.deviceSlot = deviceSlot;
+    evt.inputIndex = inputIndex;
+
+    return evt;
+}
+
+/**
+ * Create Keyboard Event
+ * @param inputIndex Id of input to be checked
+ * @param currentState Current value for given input
+ * @param deviceInputSystem Reference to DeviceInputSystem
+ * @param elementToAttachTo HTMLElement to reference as target for inputs
+ * @returns IEvent object (Keyboard)
+ */
+function _CreateKeyboardEvent(inputIndex: number, currentState: Nullable<number>, deviceInputSystem: IDeviceInputSystem, elementToAttachTo?: any): any {
+    const evt = _CreateEvent(elementToAttachTo);
+    _CheckNonCharacterKeys(evt, deviceInputSystem);
+    evt.deviceType = DeviceType.Keyboard;
+    evt.deviceSlot = 0;
+    evt.inputIndex = inputIndex;
+
+    evt.type = currentState === 1 ? "keydown" : "keyup";
+    evt.key = String.fromCharCode(inputIndex);
+    evt.keyCode = inputIndex;
+
+    return evt;
+}
+
+/**
+ * Add parameters for non-character keys (Ctrl, Alt, Meta, Shift)
+ * @param evt Event object to add parameters to
+ * @param deviceInputSystem DeviceInputSystem to pull values from
+ */
+function _CheckNonCharacterKeys(evt: any, deviceInputSystem: IDeviceInputSystem): void {
+    const isKeyboardActive = deviceInputSystem.isDeviceAvailable(DeviceType.Keyboard);
+    const altKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_ALT_KEY) === 1;
+    const ctrlKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_CTRL_KEY) === 1;
+    const metaKey =
+        isKeyboardActive &&
+        (deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY1) === 1 ||
+            deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY2) === 1 ||
+            deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_META_KEY3) === 1);
+    const shiftKey = isKeyboardActive && deviceInputSystem.pollInput(DeviceType.Keyboard, 0, Constants.INPUT_SHIFT_KEY) === 1;
+
+    evt.altKey = altKey;
+    evt.ctrlKey = ctrlKey;
+    evt.metaKey = metaKey;
+    evt.shiftKey = shiftKey;
+}
+
+/**
+ * Create base event object
+ * @param elementToAttachTo Value to use as event target
+ * @returns
+ */
+function _CreateEvent(elementToAttachTo: any): any {
+    const evt: { [k: string]: any } = {};
+    evt.preventDefault = () => {};
+    evt.target = elementToAttachTo;
+
+    return evt;
 }

--- a/packages/dev/core/src/DeviceInput/nativeDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/nativeDeviceInputSystem.ts
@@ -1,6 +1,6 @@
 import type { INative } from "../Engines/Native/nativeInterfaces";
 import type { IUIEvent } from "../Events/deviceInputEvents";
-import { DeviceEventFactory } from "./eventFactory";
+import { CreateDeviceEvent } from "./eventFactory";
 import { DeviceType } from "./InputDevices/deviceEnums";
 import type { IDeviceInputSystem } from "./inputInterfaces";
 
@@ -17,7 +17,7 @@ export class NativeDeviceInputSystem implements IDeviceInputSystem {
     ) {
         this._nativeInput = _native.DeviceInputSystem
             ? new _native.DeviceInputSystem(onDeviceConnected, onDeviceDisconnected, (deviceType, deviceSlot, inputIndex, currentState) => {
-                  const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
+                  const evt = CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this);
 
                   onInputChanged(deviceType, deviceSlot, evt);
               })

--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -4,7 +4,7 @@ import { IsNavigatorAvailable } from "../Misc/domManagement";
 import type { Observer } from "../Misc/observable";
 import { Tools } from "../Misc/tools";
 import type { Nullable } from "../types";
-import { DeviceEventFactory } from "./eventFactory";
+import { CreateDeviceEvent } from "./eventFactory";
 import { DeviceType, PointerInput } from "./InputDevices/deviceEnums";
 import type { IDeviceInputSystem } from "./inputInterfaces";
 
@@ -376,7 +376,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 if (this._usingMacOS && evt.key === "Meta" && this._metaKeys.length > 0) {
                     for (const keyCode of this._metaKeys) {
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, keyCode, 0, this, this._elementToAttachTo);
+                        const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Keyboard, 0, keyCode, 0, this, this._elementToAttachTo);
                         kbKey[keyCode] = 0;
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
@@ -395,7 +395,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (kbKey[i] !== 0) {
                         kbKey[i] = 0;
 
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Keyboard, 0, i, 0, this, this._elementToAttachTo);
+                        const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Keyboard, 0, i, 0, this, this._elementToAttachTo);
 
                         this._onInputChanged(DeviceType.Keyboard, 0, deviceEvent);
                     }
@@ -628,7 +628,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointer[inputIndex] === 1) {
                         pointer[inputIndex] = 0;
 
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
+                        const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
                         this._onInputChanged(DeviceType.Mouse, 0, deviceEvent);
                     }
@@ -647,15 +647,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
 
                 this._inputs[DeviceType.Touch][deviceSlot][PointerInput.LeftClick] = 0;
 
-                const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(
-                    DeviceType.Touch,
-                    deviceSlot,
-                    PointerInput.LeftClick,
-                    0,
-                    this,
-                    this._elementToAttachTo,
-                    evt.pointerId
-                );
+                const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo, evt.pointerId);
 
                 this._onInputChanged(DeviceType.Touch, deviceSlot, deviceEvent);
 
@@ -705,7 +697,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointer[inputIndex] === 1) {
                         pointer[inputIndex] = 0;
 
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
+                        const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Mouse, 0, inputIndex, 0, this, this._elementToAttachTo);
 
                         this._onInputChanged(DeviceType.Mouse, 0, deviceEvent);
                     }
@@ -726,15 +718,7 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
                     if (pointerId !== -1 && pointer[deviceSlot]?.[PointerInput.LeftClick] === 1) {
                         pointer[deviceSlot][PointerInput.LeftClick] = 0;
 
-                        const deviceEvent: IUIEvent = DeviceEventFactory.CreateDeviceEvent(
-                            DeviceType.Touch,
-                            deviceSlot,
-                            PointerInput.LeftClick,
-                            0,
-                            this,
-                            this._elementToAttachTo,
-                            pointerId
-                        );
+                        const deviceEvent: IUIEvent = CreateDeviceEvent(DeviceType.Touch, deviceSlot, PointerInput.LeftClick, 0, this, this._elementToAttachTo, pointerId);
 
                         this._onInputChanged(DeviceType.Touch, deviceSlot, deviceEvent);
 

--- a/packages/dev/core/src/Engines/engineFactory.ts
+++ b/packages/dev/core/src/Engines/engineFactory.ts
@@ -4,23 +4,25 @@ import { NullEngine } from "./nullEngine";
 import { WebGPUEngine } from "./webgpuEngine";
 
 /**
- * Helper class to create the best engine depending on the current hardware
+ * Creates an engine based on the capabilities of the underlying hardware
+ * @param canvas Defines the canvas to use to display the result
+ * @param options Defines the options passed to the engine to create the context dependencies
+ * @returns a promise that resolves with the created engine
  */
-export class EngineFactory {
-    /**
-     * Creates an engine based on the capabilities of the underlying hardware
-     * @param canvas Defines the canvas to use to display the result
-     * @param options Defines the options passed to the engine to create the context dependencies
-     * @returns a promise that resolves with the created engine
-     */
-    public static async CreateAsync(canvas: HTMLCanvasElement, options: any): Promise<AbstractEngine> {
-        const supported = await WebGPUEngine.IsSupportedAsync;
-        if (supported) {
-            return WebGPUEngine.CreateAsync(canvas, options);
-        }
-        if (Engine.IsSupported) {
-            return new Engine(canvas, undefined, options);
-        }
-        return new NullEngine(options);
+export async function CreateEngineAsync(canvas: HTMLCanvasElement, options: any): Promise<AbstractEngine> {
+    const supported = await WebGPUEngine.IsSupportedAsync;
+    if (supported) {
+        return WebGPUEngine.CreateAsync(canvas, options);
     }
+    if (Engine.IsSupported) {
+        return new Engine(canvas, undefined, options);
+    }
+    return new NullEngine(options);
 }
+
+/**
+ * Helper to create the best engine depending on the current hardware
+ * @deprecated use `CreateEngineAsync`
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const EngineFactory = { CreateAsync: CreateEngineAsync };

--- a/packages/dev/core/test/unit/Cameras/babylon.arcRotateCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.arcRotateCameraInputs.test.ts
@@ -1,6 +1,6 @@
 import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
 import { PickingInfo } from "core/Collisions";
-import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
+import { CreateDeviceEvent } from "core/DeviceInput/eventFactory";
 import { DeviceType, PointerInput } from "core/DeviceInput/InputDevices/deviceEnums";
 import { NullEngine } from "core/Engines/nullEngine";
 import { PointerEventTypes, PointerInfo } from "core/Events";
@@ -57,18 +57,18 @@ describe("ArcRotateCameraMouseInput", () => {
         testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 0, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 0, false);
 
-        const downEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downEvt1 = CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 1, testDeviceInputSystem);
         const downPI1 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt1 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 15, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 15, false);
 
-        const moveEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt1 = CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI1 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt1 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0, false);
 
-        const upEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upEvt1 = CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 0, testDeviceInputSystem);
         const upPI1 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt1 as IMouseEvent, new PickingInfo());
 
         // Second touch events
@@ -76,18 +76,18 @@ describe("ArcRotateCameraMouseInput", () => {
         testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 127, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 127, false);
 
-        const downEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downEvt2 = CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 1, testDeviceInputSystem);
         const downPI2 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt2 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 112, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 112, false);
 
-        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt2 = CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0, false);
 
-        const upEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upEvt2 = CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 0, testDeviceInputSystem);
         const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
 
         // Third touch events
@@ -96,24 +96,24 @@ describe("ArcRotateCameraMouseInput", () => {
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
 
-        const downEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downEvt3 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
         const downPI3 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt3 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 50, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 50, false);
 
-        const moveEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt3 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI3 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt3 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
 
-        const upEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upEvt3 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
         const upPI3 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt3 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
 
-        const moveEvt4 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt4 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI4 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt4 as IMouseEvent, new PickingInfo());
 
         // Start pinch gesture

--- a/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.freeCameraInputs.test.ts
@@ -1,6 +1,6 @@
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { PickingInfo } from "core/Collisions";
-import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
+import { CreateDeviceEvent } from "core/DeviceInput/eventFactory";
 import { DeviceType, PointerInput } from "core/DeviceInput/InputDevices/deviceEnums";
 import { NullEngine } from "core/Engines/nullEngine";
 import { PointerEventTypes, PointerInfo } from "core/Events";
@@ -52,18 +52,18 @@ describe("FreeCameraMouseInput", () => {
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 0, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 0, false);
 
-        const downEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downEvt1 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
         const downPI1 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt1 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 10, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 10, false);
 
-        const moveEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt1 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI1 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt1 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
 
-        const upEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upEvt1 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
         const upPI1 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt1 as IMouseEvent, new PickingInfo());
 
         // Second touch
@@ -71,18 +71,18 @@ describe("FreeCameraMouseInput", () => {
         testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Horizontal, 20, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Vertical, 20, false);
 
-        const downEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 3, PointerInput.LeftClick, 1, testDeviceInputSystem);
+        const downEvt2 = CreateDeviceEvent(DeviceType.Touch, 3, PointerInput.LeftClick, 1, testDeviceInputSystem);
         const downPI2 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt2 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Horizontal, 0, false);
         testDeviceInputSystem.changeInput(DeviceType.Touch, 3, PointerInput.Vertical, 0, false);
 
-        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+        const moveEvt2 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
         const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2 as IMouseEvent, new PickingInfo());
 
         testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
 
-        const upEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+        const upEvt2 = CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
         const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
 
         // With the first touch, the camera should rotate
@@ -110,14 +110,14 @@ describe("FreeCameraMouseInput", () => {
             () => {}
         );
         testDeviceInputSystem.connectDevice(DeviceType.Mouse, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
-        
+
         // Create two events with different movement values
-        const moveEvt = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
+        const moveEvt = CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
         moveEvt.movementX = 10;
         moveEvt.movementY = 10;
         const movePI = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt, new PickingInfo());
 
-        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
+        const moveEvt2 = CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, testDeviceInputSystem) as IMouseEvent;
         moveEvt2.movementX = -15;
         moveEvt2.movementY = -15;
         const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2, new PickingInfo());

--- a/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
+++ b/packages/dev/core/test/unit/DeviceInput/babylon.deviceInput.test.ts
@@ -6,9 +6,9 @@ import type { Engine } from "core/Engines/engine";
 import { NullEngine } from "core/Engines/nullEngine";
 import type { IPointerEvent, IUIEvent } from "core/Events";
 import type { Nullable } from "core/types";
-import type { ITestDeviceInputSystem} from "./testDeviceInputSystem";
+import type { ITestDeviceInputSystem } from "./testDeviceInputSystem";
 import { TestDeviceInputSystem } from "./testDeviceInputSystem";
-import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
+import { CreateDeviceEvent } from "core/DeviceInput/eventFactory";
 
 jest.mock("core/DeviceInput/webDeviceInputSystem", () => {
     return {
@@ -224,45 +224,45 @@ describe("DeviceSourceManager", () => {
         expect(disposeSpy).toBeCalledTimes(1);
     });
 
-    it ("DeviceEventFactory can create proper pointer events", () => {
+    it("CreateDeviceEvent can create proper pointer events", () => {
         const deviceInputSystem = new TestDeviceInputSystem(
             engine!,
             () => {},
             () => {},
             () => {}
         );
-    
+
         // Connect device and grab DeviceSource
         deviceInputSystem.connectDevice(DeviceType.Mouse, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
-    
+
         // Click down the three main mouse buttons
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 1);
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 1);
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 1);
-    
+
         // Create a pointer event
-        const threeButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
-    
+        const threeButtonsEvent = CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
+
         // Verify that the three buttons are pressed down
         expect(threeButtonsEvent.buttons).toBe(7);
-    
+
         // Release middle button and verify that it's no longer pressed
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0);
-    
+
         // Create a pointer event
-        const twoButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0, deviceInputSystem) as IPointerEvent;
-    
+        const twoButtonsEvent = CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.MiddleClick, 0, deviceInputSystem) as IPointerEvent;
+
         // Verify that two buttons are pressed down and the middle is released
         expect(twoButtonsEvent.buttons).toBe(3);
         expect(twoButtonsEvent.button).toBe(1);
-    
+
         // Release the rest of the buttons
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.LeftClick, 0);
         deviceInputSystem.changeInput(DeviceType.Mouse, 0, PointerInput.RightClick, 0);
-    
+
         // Create a pointer event
-        const noButtonsEvent = DeviceEventFactory.CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
-    
+        const noButtonsEvent = CreateDeviceEvent(DeviceType.Mouse, 0, PointerInput.Move, 1, deviceInputSystem) as IPointerEvent;
+
         // Verify that no buttons are pressed down
         expect(noButtonsEvent.buttons).toBe(0);
     });

--- a/packages/dev/core/test/unit/DeviceInput/testDeviceInputSystem.ts
+++ b/packages/dev/core/test/unit/DeviceInput/testDeviceInputSystem.ts
@@ -1,4 +1,4 @@
-import { DeviceEventFactory } from "core/DeviceInput/eventFactory";
+import { CreateDeviceEvent } from "core/DeviceInput/eventFactory";
 import { DeviceType } from "core/DeviceInput/InputDevices/deviceEnums";
 import type { IDeviceInputSystem } from "core/DeviceInput/inputInterfaces";
 import type { Engine } from "core/Engines/engine";
@@ -82,16 +82,16 @@ export class TestDeviceInputSystem implements ITestDeviceInputSystem {
         }
 
         const device = this._inputs[deviceType][deviceSlot];
-        
-            if (device) {
-                device[inputIndex] = currentState;
-                if (createEvent) {
-                const evt = DeviceEventFactory.CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this as unknown as IDeviceInputSystem);
+
+        if (device) {
+            device[inputIndex] = currentState;
+            if (createEvent) {
+                const evt = CreateDeviceEvent(deviceType, deviceSlot, inputIndex, currentState, this as unknown as IDeviceInputSystem);
                 this._onInputChanged(deviceType, deviceSlot, evt);
-                }
-            } else {
-                throw `Unable to find device type ${DeviceType[deviceType]}:${deviceSlot}`;
             }
+        } else {
+            throw `Unable to find device type ${DeviceType[deviceType]}:${deviceSlot}`;
+        }
     }
 
     public dispose(): void {


### PR DESCRIPTION
This PR migrates the static factory classes `DeviceEventFactory` and `EngineFactory` to functions. It is backward-compatible, and the backward-compatible exports are marked as deprecated. This should improve performance slightly (because of the direct function access), though the bundle size will stay about the same. It should improve tree shaking.

This PR is more about code cleanup than runtime changes. Refer to #14805 