### PR TITLE
Extract SceneLoader state and functions from static class to module

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -1074,11 +1074,10 @@ function append(
  * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
  * @param scene is the instance of BABYLON.Scene to append to
  * @param options an object that configures aspects of how the scene is loaded
- * @returns The given scene
  */
-export function appendSceneAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<Scene> {
+export async function appendSceneAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<void> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return appendSceneAsyncCore(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    await appendSceneAsyncCore(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
 function appendSceneAsyncCore(
@@ -1333,13 +1332,12 @@ function importAnimations(
  * Import animations from a file into a scene
  * @experimental
  * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
- * @param scene is the instance of BABYLON.Scene to append to (default: last created scene)
+ * @param scene is the instance of BABYLON.Scene to append to
  * @param options an object that configures aspects of how the scene is loaded
- * @returns The loaded asset container
  */
-export function importAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<Scene> {
+export async function importAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<void> {
     const { rootUrl = "", overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return importAnimationsAsyncCore(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
+    await importAnimationsAsyncCore(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
 }
 
 function importAnimationsAsyncCore(

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -22,7 +22,7 @@ import { RuntimeError, ErrorCodes } from "../Misc/error";
 import type { ISpriteManager } from "../Sprites/spriteManager";
 import { RandomGUID } from "../Misc/guid";
 import { Engine } from "../Engines/engine";
-import { AbstractEngine } from "../Engines/abstractEngine";
+import type { AbstractEngine } from "../Engines/abstractEngine";
 
 /**
  * Type used for the success callback of ImportMesh
@@ -478,6 +478,917 @@ function isFile(value: unknown): value is File {
     return !!(value as File).name;
 }
 
+const _onPluginActivatedObservable = new Observable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>();
+const _registeredPlugins: { [extension: string]: IRegisteredPlugin } = {};
+let _showingLoadingScreen = false;
+
+function _getDefaultPlugin(): IRegisteredPlugin {
+    return _registeredPlugins[".babylon"];
+}
+
+function _getPluginForExtension(extension: string): IRegisteredPlugin {
+    const registeredPlugin = _registeredPlugins[extension];
+    if (registeredPlugin) {
+        return registeredPlugin;
+    }
+    Logger.Warn(
+        "Unable to find a plugin to load " +
+            extension +
+            " files. Trying to use .babylon default plugin. To load from a specific filetype (eg. gltf) see: https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes"
+    );
+    return _getDefaultPlugin();
+}
+
+function _isPluginForExtensionAvailable(extension: string): boolean {
+    return !!_registeredPlugins[extension];
+}
+
+function _getPluginForDirectLoad(data: string): IRegisteredPlugin {
+    for (const extension in _registeredPlugins) {
+        const plugin = _registeredPlugins[extension].plugin;
+
+        if (plugin.canDirectLoad && plugin.canDirectLoad(data)) {
+            return _registeredPlugins[extension];
+        }
+    }
+
+    return _getDefaultPlugin();
+}
+
+function _getPluginForFilename(sceneFilename: string): IRegisteredPlugin {
+    const queryStringPosition = sceneFilename.indexOf("?");
+
+    if (queryStringPosition !== -1) {
+        sceneFilename = sceneFilename.substring(0, queryStringPosition);
+    }
+
+    const dotPosition = sceneFilename.lastIndexOf(".");
+
+    const extension = sceneFilename.substring(dotPosition, sceneFilename.length).toLowerCase();
+    return _getPluginForExtension(extension);
+}
+
+function _getDirectLoad(sceneFilename: string): Nullable<string> {
+    if (sceneFilename.substr(0, 5) === "data:") {
+        return sceneFilename.substr(5);
+    }
+
+    return null;
+}
+
+function _formatErrorMessage(fileInfo: IFileInfo, message?: string, exception?: any): string {
+    const fromLoad = fileInfo.rawData ? "binary data" : fileInfo.url;
+    let errorMessage = "Unable to load from " + fromLoad;
+
+    if (message) {
+        errorMessage += `: ${message}`;
+    } else if (exception) {
+        errorMessage += `: ${exception}`;
+    }
+
+    return errorMessage;
+}
+
+function _loadData(
+    fileInfo: IFileInfo,
+    scene: Scene,
+    onSuccess: (plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync, data: unknown, responseURL?: string) => void,
+    onProgress: ((event: ISceneLoaderProgressEvent) => void) | undefined,
+    onError: (message?: string, exception?: any) => void,
+    onDispose: () => void,
+    pluginExtension: Nullable<string>,
+    name: string,
+    pluginOptions: PluginOptions
+): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
+    const directLoad = _getDirectLoad(fileInfo.url);
+
+    if (fileInfo.rawData && !pluginExtension) {
+        // eslint-disable-next-line no-throw-literal
+        throw "When using ArrayBufferView to load data the file extension must be provided.";
+    }
+
+    const registeredPlugin = pluginExtension ? _getPluginForExtension(pluginExtension) : directLoad ? _getPluginForDirectLoad(fileInfo.url) : _getPluginForFilename(fileInfo.url);
+
+    if (pluginOptions?.[registeredPlugin.plugin.name]?.enabled === false) {
+        throw new Error(`The '${registeredPlugin.plugin.name}' plugin is disabled via the loader options passed to the loading operation.`);
+    }
+
+    if (fileInfo.rawData && !registeredPlugin.isBinary) {
+        // eslint-disable-next-line no-throw-literal
+        throw "Loading from ArrayBufferView can not be used with plugins that don't support binary loading.";
+    }
+
+    // For plugin factories, the plugin is instantiated on each SceneLoader operation. This makes options handling
+    // much simpler as we can just pass the options to the factory, rather than passing options through to every possible
+    // plugin call. Given this, options are only supported for plugins that provide a factory function.
+    const plugin: IRegisteredPlugin["plugin"] = registeredPlugin.plugin.createPlugin?.(pluginOptions ?? {}) ?? registeredPlugin.plugin;
+    if (!plugin) {
+        // eslint-disable-next-line no-throw-literal
+        throw `The loader plugin corresponding to the '${pluginExtension}' file type has not been found. If using es6, please import the plugin you wish to use before.`;
+    }
+
+    _onPluginActivatedObservable.notifyObservers(plugin);
+
+    // Check if we have a direct load url. If the plugin is registered to handle
+    // it or it's not a base64 data url, then pass it through the direct load path.
+    if (directLoad && ((plugin.canDirectLoad && plugin.canDirectLoad(fileInfo.url)) || !IsBase64DataUrl(fileInfo.url))) {
+        if (plugin.directLoad) {
+            const result = plugin.directLoad(scene, directLoad);
+            if (result instanceof Promise) {
+                result
+                    .then((data: unknown) => {
+                        onSuccess(plugin, data);
+                    })
+                    .catch((error: any) => {
+                        onError("Error in directLoad of _loadData: " + error, error);
+                    });
+            } else {
+                onSuccess(plugin, result);
+            }
+        } else {
+            onSuccess(plugin, directLoad);
+        }
+        return plugin;
+    }
+
+    const useArrayBuffer = registeredPlugin.isBinary;
+
+    const dataCallback = (data: unknown, responseURL?: string) => {
+        if (scene.isDisposed) {
+            onError("Scene has been disposed");
+            return;
+        }
+
+        onSuccess(plugin, data, responseURL);
+    };
+
+    let request: Nullable<IFileRequest> = null;
+    let pluginDisposed = false;
+    plugin.onDisposeObservable?.add(() => {
+        pluginDisposed = true;
+
+        if (request) {
+            request.abort();
+            request = null;
+        }
+
+        onDispose();
+    });
+
+    const manifestChecked = () => {
+        if (pluginDisposed) {
+            return;
+        }
+
+        const errorCallback = (request?: WebRequest, exception?: LoadFileError) => {
+            onError(request?.statusText, exception);
+        };
+
+        if (!plugin.loadFile && fileInfo.rawData) {
+            // eslint-disable-next-line no-throw-literal
+            throw "Plugin does not support loading ArrayBufferView.";
+        }
+
+        request = plugin.loadFile
+            ? plugin.loadFile(scene, fileInfo.rawData || fileInfo.file || fileInfo.url, fileInfo.rootUrl, dataCallback, onProgress, useArrayBuffer, errorCallback, name)
+            : scene._loadFile(fileInfo.file || fileInfo.url, dataCallback, onProgress, true, useArrayBuffer, errorCallback);
+    };
+
+    const engine = scene.getEngine();
+    let canUseOfflineSupport = engine.enableOfflineSupport;
+    if (canUseOfflineSupport) {
+        // Also check for exceptions
+        let exceptionFound = false;
+        for (const regex of scene.disableOfflineSupportExceptionRules) {
+            if (regex.test(fileInfo.url)) {
+                exceptionFound = true;
+                break;
+            }
+        }
+
+        canUseOfflineSupport = !exceptionFound;
+    }
+
+    if (canUseOfflineSupport && Engine.OfflineProviderFactory) {
+        // Checking if a manifest file has been set for this scene and if offline mode has been requested
+        scene.offlineProvider = Engine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
+    } else {
+        manifestChecked();
+    }
+
+    return plugin;
+}
+
+function _getFileInfo(rootUrl: string, sceneSource: SceneSource): Nullable<IFileInfo> {
+    let url: string;
+    let name: string;
+    let file: Nullable<File> = null;
+    let rawData: Nullable<ArrayBufferView> = null;
+
+    if (!sceneSource) {
+        url = rootUrl;
+        name = Tools.GetFilename(rootUrl);
+        rootUrl = Tools.GetFolderPath(rootUrl);
+    } else if (isFile(sceneSource)) {
+        url = `file:${sceneSource.name}`;
+        name = sceneSource.name;
+        file = sceneSource;
+    } else if (ArrayBuffer.isView(sceneSource)) {
+        url = "";
+        name = RandomGUID();
+        rawData = sceneSource;
+    } else if (sceneSource.startsWith("data:")) {
+        url = sceneSource;
+        name = "";
+    } else if (rootUrl) {
+        const filename = sceneSource;
+        if (filename.substr(0, 1) === "/") {
+            Tools.Error("Wrong sceneFilename parameter");
+            return null;
+        }
+
+        url = rootUrl + filename;
+        name = filename;
+    } else {
+        url = sceneSource;
+        name = Tools.GetFilename(sceneSource);
+        rootUrl = Tools.GetFolderPath(sceneSource);
+    }
+
+    return {
+        url: url,
+        rootUrl: rootUrl,
+        name: name,
+        file: file,
+        rawData,
+    };
+}
+
+/**
+ * Adds a new plugin to the list of registered plugins
+ * @param plugin defines the plugin to add
+ */
+export function registerSceneLoaderPlugin(plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync): void {
+    if (typeof plugin.extensions === "string") {
+        const extension = plugin.extensions;
+        _registeredPlugins[extension.toLowerCase()] = {
+            plugin: plugin,
+            isBinary: false,
+        };
+    } else {
+        const extensions = plugin.extensions;
+        Object.keys(extensions).forEach((extension) => {
+            _registeredPlugins[extension.toLowerCase()] = {
+                plugin: plugin,
+                isBinary: extensions[extension].isBinary,
+            };
+        });
+    }
+}
+
+function _importMesh(
+    meshNames: string | readonly string[] | null | undefined,
+    rootUrl: string,
+    sceneFilename: SceneSource = "",
+    scene: Nullable<Scene> = EngineStore.LastCreatedScene,
+    onSuccess: Nullable<SceneLoaderSuccessCallback> = null,
+    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
+    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
+    pluginExtension: Nullable<string> = null,
+    name = "",
+    pluginOptions: PluginOptions = {}
+): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
+    if (!scene) {
+        Logger.Error("No scene available to import mesh to");
+        return null;
+    }
+
+    const fileInfo = _getFileInfo(rootUrl, sceneFilename);
+    if (!fileInfo) {
+        return null;
+    }
+
+    const loadingToken = {};
+    scene.addPendingData(loadingToken);
+
+    const disposeHandler = () => {
+        scene.removePendingData(loadingToken);
+    };
+
+    const errorHandler = (message?: string, exception?: any) => {
+        const errorMessage = _formatErrorMessage(fileInfo, message, exception);
+
+        if (onError) {
+            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
+        } else {
+            Logger.Error(errorMessage);
+            // should the exception be thrown?
+        }
+
+        disposeHandler();
+    };
+
+    const progressHandler = onProgress
+        ? (event: ISceneLoaderProgressEvent) => {
+              try {
+                  onProgress(event);
+              } catch (e) {
+                  errorHandler("Error in onProgress callback: " + e, e);
+              }
+          }
+        : undefined;
+
+    const successHandler: SceneLoaderSuccessCallback = (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
+        scene.importedMeshesFiles.push(fileInfo.url);
+
+        if (onSuccess) {
+            try {
+                onSuccess(meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers);
+            } catch (e) {
+                errorHandler("Error in onSuccess callback: " + e, e);
+            }
+        }
+
+        scene.removePendingData(loadingToken);
+    };
+
+    return _loadData(
+        fileInfo,
+        scene,
+        (plugin, data, responseURL) => {
+            if (plugin.rewriteRootURL) {
+                fileInfo.rootUrl = plugin.rewriteRootURL(fileInfo.rootUrl, responseURL);
+            }
+
+            if ((plugin as ISceneLoaderPlugin).importMesh) {
+                const syncedPlugin = <ISceneLoaderPlugin>plugin;
+                const meshes: AbstractMesh[] = [];
+                const particleSystems: IParticleSystem[] = [];
+                const skeletons: Skeleton[] = [];
+
+                if (!syncedPlugin.importMesh(meshNames, scene, data, fileInfo.rootUrl, meshes, particleSystems, skeletons, errorHandler)) {
+                    return;
+                }
+
+                scene.loadingPluginName = plugin.name;
+                successHandler(meshes, particleSystems, skeletons, [], [], [], [], []);
+            } else {
+                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
+                asyncedPlugin
+                    .importMeshAsync(meshNames, scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
+                    .then((result) => {
+                        scene.loadingPluginName = plugin.name;
+                        successHandler(
+                            result.meshes,
+                            result.particleSystems,
+                            result.skeletons,
+                            result.animationGroups,
+                            result.transformNodes,
+                            result.geometries,
+                            result.lights,
+                            result.spriteManagers
+                        );
+                    })
+                    .catch((error) => {
+                        errorHandler(error.message, error);
+                    });
+            }
+        },
+        progressHandler,
+        errorHandler,
+        disposeHandler,
+        pluginExtension,
+        name,
+        pluginOptions
+    );
+}
+
+/**
+ * Import meshes into a scene
+ * @experimental
+ * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
+ * @param scene the instance of BABYLON.Scene to append to
+ * @param options an object that configures aspects of how the scene is loaded
+ * @returns The loaded list of imported meshes, particle systems, skeletons, and animation groups
+ */
+export function importMeshAsync(source: SceneSource, scene: Scene, options?: ImportMeshOptions): Promise<ISceneLoaderAsyncResult> {
+    const { meshNames, rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
+    return _importMeshAsync(meshNames, rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+}
+
+function _importMeshAsync(
+    meshNames: string | readonly string[] | null | undefined,
+    rootUrl: string,
+    sceneFilename?: SceneSource,
+    scene?: Nullable<Scene>,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
+    name?: string,
+    pluginOptions?: PluginOptions
+): Promise<ISceneLoaderAsyncResult> {
+    return new Promise((resolve, reject) => {
+        _importMesh(
+            meshNames,
+            rootUrl,
+            sceneFilename,
+            scene,
+            (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
+                resolve({
+                    meshes: meshes,
+                    particleSystems: particleSystems,
+                    skeletons: skeletons,
+                    animationGroups: animationGroups,
+                    transformNodes: transformNodes,
+                    geometries: geometries,
+                    lights: lights,
+                    spriteManagers: spriteManagers,
+                });
+            },
+            onProgress,
+            (scene, message, exception) => {
+                reject(exception || new Error(message));
+            },
+            pluginExtension,
+            name,
+            pluginOptions
+        );
+    });
+}
+
+function _load(
+    rootUrl: string,
+    sceneFilename: SceneSource = "",
+    engine: Nullable<AbstractEngine> = EngineStore.LastCreatedEngine,
+    onSuccess: Nullable<(scene: Scene) => void> = null,
+    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
+    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
+    pluginExtension: Nullable<string> = null,
+    name = "",
+    pluginOptions: PluginOptions = {}
+): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
+    if (!engine) {
+        Tools.Error("No engine available");
+        return null;
+    }
+
+    return _append(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
+}
+
+/**
+ * Load a scene
+ * @experimental
+ * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
+ * @param engine is the instance of BABYLON.Engine to use to create the scene
+ * @param options an object that configures aspects of how the scene is loaded
+ * @returns The loaded scene
+ */
+export function loadAsync(source: SceneSource, engine: AbstractEngine, options?: LoadOptions): Promise<Scene> {
+    const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
+    return _loadAsync(rootUrl, source, engine, onProgress, pluginExtension, name, pluginOptions);
+}
+
+function _loadAsync(
+    rootUrl: string,
+    sceneFilename?: SceneSource,
+    engine?: Nullable<AbstractEngine>,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
+    name?: string,
+    pluginOptions?: PluginOptions
+): Promise<Scene> {
+    return new Promise((resolve, reject) => {
+        _load(
+            rootUrl,
+            sceneFilename,
+            engine,
+            (scene) => {
+                resolve(scene);
+            },
+            onProgress,
+            (scene, message, exception) => {
+                reject(exception || new Error(message));
+            },
+            pluginExtension,
+            name,
+            pluginOptions
+        );
+    });
+}
+
+function _append(
+    rootUrl: string,
+    sceneFilename: SceneSource = "",
+    scene: Nullable<Scene> = EngineStore.LastCreatedScene,
+    onSuccess: Nullable<(scene: Scene) => void> = null,
+    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
+    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
+    pluginExtension: Nullable<string> = null,
+    name = "",
+    pluginOptions: PluginOptions = {}
+): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
+    if (!scene) {
+        Logger.Error("No scene available to append to");
+        return null;
+    }
+
+    const fileInfo = _getFileInfo(rootUrl, sceneFilename);
+    if (!fileInfo) {
+        return null;
+    }
+
+    const loadingToken = {};
+    scene.addPendingData(loadingToken);
+
+    const disposeHandler = () => {
+        scene.removePendingData(loadingToken);
+    };
+
+    if (SceneLoaderFlags.ShowLoadingScreen && !_showingLoadingScreen) {
+        _showingLoadingScreen = true;
+        scene.getEngine().displayLoadingUI();
+        scene.executeWhenReady(() => {
+            scene.getEngine().hideLoadingUI();
+            _showingLoadingScreen = false;
+        });
+    }
+
+    const errorHandler = (message?: string, exception?: any) => {
+        const errorMessage = _formatErrorMessage(fileInfo, message, exception);
+
+        if (onError) {
+            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
+        } else {
+            Logger.Error(errorMessage);
+            // should the exception be thrown?
+        }
+
+        disposeHandler();
+    };
+
+    const progressHandler = onProgress
+        ? (event: ISceneLoaderProgressEvent) => {
+              try {
+                  onProgress(event);
+              } catch (e) {
+                  errorHandler("Error in onProgress callback", e);
+              }
+          }
+        : undefined;
+
+    const successHandler = () => {
+        if (onSuccess) {
+            try {
+                onSuccess(scene);
+            } catch (e) {
+                errorHandler("Error in onSuccess callback", e);
+            }
+        }
+
+        scene.removePendingData(loadingToken);
+    };
+
+    return _loadData(
+        fileInfo,
+        scene,
+        (plugin, data) => {
+            if ((plugin as ISceneLoaderPlugin).load) {
+                const syncedPlugin = <ISceneLoaderPlugin>plugin;
+                if (!syncedPlugin.load(scene, data, fileInfo.rootUrl, errorHandler)) {
+                    return;
+                }
+
+                scene.loadingPluginName = plugin.name;
+                successHandler();
+            } else {
+                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
+                asyncedPlugin
+                    .loadAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
+                    .then(() => {
+                        scene.loadingPluginName = plugin.name;
+                        successHandler();
+                    })
+                    .catch((error) => {
+                        errorHandler(error.message, error);
+                    });
+            }
+        },
+        progressHandler,
+        errorHandler,
+        disposeHandler,
+        pluginExtension,
+        name,
+        pluginOptions
+    );
+}
+
+/**
+ * Append a scene
+ * @experimental
+ * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
+ * @param scene is the instance of BABYLON.Scene to append to
+ * @param options an object that configures aspects of how the scene is loaded
+ * @returns The given scene
+ */
+export function appendAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<Scene> {
+    const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
+    return _appendAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+}
+
+function _appendAsync(
+    rootUrl: string,
+    sceneFilename?: SceneSource,
+    scene?: Nullable<Scene>,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
+    name?: string,
+    pluginOptions?: PluginOptions
+): Promise<Scene> {
+    return new Promise((resolve, reject) => {
+        _append(
+            rootUrl,
+            sceneFilename,
+            scene,
+            (scene) => {
+                resolve(scene);
+            },
+            onProgress,
+            (scene, message, exception) => {
+                reject(exception || new Error(message));
+            },
+            pluginExtension,
+            name,
+            pluginOptions
+        );
+    });
+}
+
+function _loadAssetContainer(
+    rootUrl: string,
+    sceneFilename: SceneSource = "",
+    scene: Nullable<Scene> = EngineStore.LastCreatedScene,
+    onSuccess: Nullable<(assets: AssetContainer) => void> = null,
+    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
+    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
+    pluginExtension: Nullable<string> = null,
+    name = "",
+    pluginOptions: PluginOptions = {}
+): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
+    if (!scene) {
+        Logger.Error("No scene available to load asset container to");
+        return null;
+    }
+
+    const fileInfo = _getFileInfo(rootUrl, sceneFilename);
+    if (!fileInfo) {
+        return null;
+    }
+
+    const loadingToken = {};
+    scene.addPendingData(loadingToken);
+
+    const disposeHandler = () => {
+        scene.removePendingData(loadingToken);
+    };
+
+    const errorHandler = (message?: string, exception?: any) => {
+        const errorMessage = _formatErrorMessage(fileInfo, message, exception);
+
+        if (onError) {
+            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
+        } else {
+            Logger.Error(errorMessage);
+            // should the exception be thrown?
+        }
+
+        disposeHandler();
+    };
+
+    const progressHandler = onProgress
+        ? (event: ISceneLoaderProgressEvent) => {
+              try {
+                  onProgress(event);
+              } catch (e) {
+                  errorHandler("Error in onProgress callback", e);
+              }
+          }
+        : undefined;
+
+    const successHandler = (assets: AssetContainer) => {
+        if (onSuccess) {
+            try {
+                onSuccess(assets);
+            } catch (e) {
+                errorHandler("Error in onSuccess callback", e);
+            }
+        }
+
+        scene.removePendingData(loadingToken);
+    };
+
+    return _loadData(
+        fileInfo,
+        scene,
+        (plugin, data) => {
+            if ((plugin as ISceneLoaderPlugin).loadAssetContainer) {
+                const syncedPlugin = <ISceneLoaderPlugin>plugin;
+                const assetContainer = syncedPlugin.loadAssetContainer(scene, data, fileInfo.rootUrl, errorHandler);
+                if (!assetContainer) {
+                    return;
+                }
+                assetContainer.populateRootNodes();
+                scene.loadingPluginName = plugin.name;
+                successHandler(assetContainer);
+            } else if ((plugin as ISceneLoaderPluginAsync).loadAssetContainerAsync) {
+                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
+                asyncedPlugin
+                    .loadAssetContainerAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
+                    .then((assetContainer) => {
+                        assetContainer.populateRootNodes();
+                        scene.loadingPluginName = plugin.name;
+                        successHandler(assetContainer);
+                    })
+                    .catch((error) => {
+                        errorHandler(error.message, error);
+                    });
+            } else {
+                errorHandler("LoadAssetContainer is not supported by this plugin. Plugin did not provide a loadAssetContainer or loadAssetContainerAsync method.");
+            }
+        },
+        progressHandler,
+        errorHandler,
+        disposeHandler,
+        pluginExtension,
+        name,
+        pluginOptions
+    );
+}
+
+/**
+ * Load a scene into an asset container
+ * @experimental
+ * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
+ * @param scene is the instance of Scene to append to
+ * @param options an object that configures aspects of how the scene is loaded
+ * @returns The loaded asset container
+ */
+export function loadAssetContainerAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<AssetContainer> {
+    const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
+    return _loadAssetContainerAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+}
+
+function _loadAssetContainerAsync(
+    rootUrl: string,
+    sceneFilename?: SceneSource,
+    scene?: Nullable<Scene>,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
+    name?: string,
+    pluginOptions?: PluginOptions
+): Promise<AssetContainer> {
+    return new Promise((resolve, reject) => {
+        _loadAssetContainer(
+            rootUrl,
+            sceneFilename,
+            scene,
+            (assets) => {
+                resolve(assets);
+            },
+            onProgress,
+            (scene, message, exception) => {
+                reject(exception || new Error(message));
+            },
+            pluginExtension,
+            name,
+            pluginOptions
+        );
+    });
+}
+
+function _importAnimations(
+    rootUrl: string,
+    sceneFilename: SceneSource = "",
+    scene: Nullable<Scene> = EngineStore.LastCreatedScene,
+    overwriteAnimations = true,
+    animationGroupLoadingMode = SceneLoaderAnimationGroupLoadingMode.Clean,
+    targetConverter: Nullable<(target: any) => any> = null,
+    onSuccess: Nullable<(scene: Scene) => void> = null,
+    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
+    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
+    pluginExtension: Nullable<string> = null,
+    name = "",
+    pluginOptions: PluginOptions = {}
+): void {
+    if (!scene) {
+        Logger.Error("No scene available to load animations to");
+        return;
+    }
+
+    if (overwriteAnimations) {
+        // Reset, stop and dispose all animations before loading new ones
+        for (const animatable of scene.animatables) {
+            animatable.reset();
+        }
+        scene.stopAllAnimations();
+        scene.animationGroups.slice().forEach((animationGroup) => {
+            animationGroup.dispose();
+        });
+        const nodes = scene.getNodes();
+        nodes.forEach((node) => {
+            if (node.animations) {
+                node.animations = [];
+            }
+        });
+    } else {
+        switch (animationGroupLoadingMode) {
+            case SceneLoaderAnimationGroupLoadingMode.Clean:
+                scene.animationGroups.slice().forEach((animationGroup) => {
+                    animationGroup.dispose();
+                });
+                break;
+            case SceneLoaderAnimationGroupLoadingMode.Stop:
+                scene.animationGroups.forEach((animationGroup) => {
+                    animationGroup.stop();
+                });
+                break;
+            case SceneLoaderAnimationGroupLoadingMode.Sync:
+                scene.animationGroups.forEach((animationGroup) => {
+                    animationGroup.reset();
+                    animationGroup.restart();
+                });
+                break;
+            case SceneLoaderAnimationGroupLoadingMode.NoSync:
+                // nothing to do
+                break;
+            default:
+                Logger.Error("Unknown animation group loading mode value '" + animationGroupLoadingMode + "'");
+                return;
+        }
+    }
+
+    const startingIndexForNewAnimatables = scene.animatables.length;
+
+    const onAssetContainerLoaded = (container: AssetContainer) => {
+        container.mergeAnimationsTo(scene, scene.animatables.slice(startingIndexForNewAnimatables), targetConverter);
+
+        container.dispose();
+
+        scene.onAnimationFileImportedObservable.notifyObservers(scene);
+
+        if (onSuccess) {
+            onSuccess(scene);
+        }
+    };
+
+    _loadAssetContainer(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
+}
+
+/**
+ * Import animations from a file into a scene
+ * @experimental
+ * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
+ * @param scene is the instance of BABYLON.Scene to append to (default: last created scene)
+ * @param options an object that configures aspects of how the scene is loaded
+ * @returns The loaded asset container
+ */
+export function importAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<Scene> {
+    const { rootUrl = "", overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions } = options ?? {};
+    return _importAnimationsAsync(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
+}
+
+function _importAnimationsAsync(
+    rootUrl: string,
+    sceneFilename?: SceneSource,
+    scene?: Nullable<Scene>,
+    overwriteAnimations?: boolean,
+    animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode,
+    targetConverter?: Nullable<(target: any) => any>,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
+    name?: string,
+    pluginOptions?: PluginOptions
+): Promise<Scene> {
+    return new Promise((resolve, reject) => {
+        _importAnimations(
+            rootUrl,
+            sceneFilename,
+            scene,
+            overwriteAnimations,
+            animationGroupLoadingMode,
+            targetConverter,
+            (scene) => {
+                resolve(scene);
+            },
+            onProgress,
+            (scene, message, exception) => {
+                reject(exception || new Error(message));
+            },
+            pluginExtension,
+            name,
+            pluginOptions
+        );
+    });
+}
+
 /**
  * Class used to load scene from various file formats using registered plugins
  * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes
@@ -555,256 +1466,14 @@ export class SceneLoader {
     /**
      * Event raised when a plugin is used to load a scene
      */
-    public static OnPluginActivatedObservable = new Observable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>();
-
-    private static _RegisteredPlugins: { [extension: string]: IRegisteredPlugin } = {};
-
-    private static _ShowingLoadingScreen = false;
+    public static readonly OnPluginActivatedObservable = _onPluginActivatedObservable;
 
     /**
      * Gets the default plugin (used to load Babylon files)
      * @returns the .babylon plugin
      */
     public static GetDefaultPlugin(): IRegisteredPlugin {
-        return SceneLoader._RegisteredPlugins[".babylon"];
-    }
-
-    private static _GetPluginForExtension(extension: string): IRegisteredPlugin {
-        const registeredPlugin = SceneLoader._RegisteredPlugins[extension];
-        if (registeredPlugin) {
-            return registeredPlugin;
-        }
-        Logger.Warn(
-            "Unable to find a plugin to load " +
-                extension +
-                " files. Trying to use .babylon default plugin. To load from a specific filetype (eg. gltf) see: https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes"
-        );
-        return SceneLoader.GetDefaultPlugin();
-    }
-
-    private static _GetPluginForDirectLoad(data: string): IRegisteredPlugin {
-        for (const extension in SceneLoader._RegisteredPlugins) {
-            const plugin = SceneLoader._RegisteredPlugins[extension].plugin;
-
-            if (plugin.canDirectLoad && plugin.canDirectLoad(data)) {
-                return SceneLoader._RegisteredPlugins[extension];
-            }
-        }
-
-        return SceneLoader.GetDefaultPlugin();
-    }
-
-    private static _GetPluginForFilename(sceneFilename: string): IRegisteredPlugin {
-        const queryStringPosition = sceneFilename.indexOf("?");
-
-        if (queryStringPosition !== -1) {
-            sceneFilename = sceneFilename.substring(0, queryStringPosition);
-        }
-
-        const dotPosition = sceneFilename.lastIndexOf(".");
-
-        const extension = sceneFilename.substring(dotPosition, sceneFilename.length).toLowerCase();
-        return SceneLoader._GetPluginForExtension(extension);
-    }
-
-    private static _GetDirectLoad(sceneFilename: string): Nullable<string> {
-        if (sceneFilename.substr(0, 5) === "data:") {
-            return sceneFilename.substr(5);
-        }
-
-        return null;
-    }
-
-    private static _FormatErrorMessage(fileInfo: IFileInfo, message?: string, exception?: any): string {
-        const fromLoad = fileInfo.rawData ? "binary data" : fileInfo.url;
-        let errorMessage = "Unable to load from " + fromLoad;
-
-        if (message) {
-            errorMessage += `: ${message}`;
-        } else if (exception) {
-            errorMessage += `: ${exception}`;
-        }
-
-        return errorMessage;
-    }
-
-    private static _LoadData(
-        fileInfo: IFileInfo,
-        scene: Scene,
-        onSuccess: (plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync, data: unknown, responseURL?: string) => void,
-        onProgress: ((event: ISceneLoaderProgressEvent) => void) | undefined,
-        onError: (message?: string, exception?: any) => void,
-        onDispose: () => void,
-        pluginExtension: Nullable<string>,
-        name: string,
-        pluginOptions: PluginOptions
-    ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        const directLoad = SceneLoader._GetDirectLoad(fileInfo.url);
-
-        if (fileInfo.rawData && !pluginExtension) {
-            // eslint-disable-next-line no-throw-literal
-            throw "When using ArrayBufferView to load data the file extension must be provided.";
-        }
-
-        const registeredPlugin = pluginExtension
-            ? SceneLoader._GetPluginForExtension(pluginExtension)
-            : directLoad
-              ? SceneLoader._GetPluginForDirectLoad(fileInfo.url)
-              : SceneLoader._GetPluginForFilename(fileInfo.url);
-
-        if (pluginOptions?.[registeredPlugin.plugin.name]?.enabled === false) {
-            throw new Error(`The '${registeredPlugin.plugin.name}' plugin is disabled via the loader options passed to the loading operation.`);
-        }
-
-        if (fileInfo.rawData && !registeredPlugin.isBinary) {
-            // eslint-disable-next-line no-throw-literal
-            throw "Loading from ArrayBufferView can not be used with plugins that don't support binary loading.";
-        }
-
-        // For plugin factories, the plugin is instantiated on each SceneLoader operation. This makes options handling
-        // much simpler as we can just pass the options to the factory, rather than passing options through to every possible
-        // plugin call. Given this, options are only supported for plugins that provide a factory function.
-        const plugin: IRegisteredPlugin["plugin"] = registeredPlugin.plugin.createPlugin?.(pluginOptions ?? {}) ?? registeredPlugin.plugin;
-        if (!plugin) {
-            // eslint-disable-next-line no-throw-literal
-            throw `The loader plugin corresponding to the '${pluginExtension}' file type has not been found. If using es6, please import the plugin you wish to use before.`;
-        }
-
-        SceneLoader.OnPluginActivatedObservable.notifyObservers(plugin);
-
-        // Check if we have a direct load url. If the plugin is registered to handle
-        // it or it's not a base64 data url, then pass it through the direct load path.
-        if (directLoad && ((plugin.canDirectLoad && plugin.canDirectLoad(fileInfo.url)) || !IsBase64DataUrl(fileInfo.url))) {
-            if (plugin.directLoad) {
-                const result = plugin.directLoad(scene, directLoad);
-                if (result instanceof Promise) {
-                    result
-                        .then((data: unknown) => {
-                            onSuccess(plugin, data);
-                        })
-                        .catch((error: any) => {
-                            onError("Error in directLoad of _loadData: " + error, error);
-                        });
-                } else {
-                    onSuccess(plugin, result);
-                }
-            } else {
-                onSuccess(plugin, directLoad);
-            }
-            return plugin;
-        }
-
-        const useArrayBuffer = registeredPlugin.isBinary;
-
-        const dataCallback = (data: unknown, responseURL?: string) => {
-            if (scene.isDisposed) {
-                onError("Scene has been disposed");
-                return;
-            }
-
-            onSuccess(plugin, data, responseURL);
-        };
-
-        let request: Nullable<IFileRequest> = null;
-        let pluginDisposed = false;
-        plugin.onDisposeObservable?.add(() => {
-            pluginDisposed = true;
-
-            if (request) {
-                request.abort();
-                request = null;
-            }
-
-            onDispose();
-        });
-
-        const manifestChecked = () => {
-            if (pluginDisposed) {
-                return;
-            }
-
-            const errorCallback = (request?: WebRequest, exception?: LoadFileError) => {
-                onError(request?.statusText, exception);
-            };
-
-            if (!plugin.loadFile && fileInfo.rawData) {
-                // eslint-disable-next-line no-throw-literal
-                throw "Plugin does not support loading ArrayBufferView.";
-            }
-
-            request = plugin.loadFile
-                ? plugin.loadFile(scene, fileInfo.rawData || fileInfo.file || fileInfo.url, fileInfo.rootUrl, dataCallback, onProgress, useArrayBuffer, errorCallback, name)
-                : scene._loadFile(fileInfo.file || fileInfo.url, dataCallback, onProgress, true, useArrayBuffer, errorCallback);
-        };
-
-        const engine = scene.getEngine();
-        let canUseOfflineSupport = engine.enableOfflineSupport;
-        if (canUseOfflineSupport) {
-            // Also check for exceptions
-            let exceptionFound = false;
-            for (const regex of scene.disableOfflineSupportExceptionRules) {
-                if (regex.test(fileInfo.url)) {
-                    exceptionFound = true;
-                    break;
-                }
-            }
-
-            canUseOfflineSupport = !exceptionFound;
-        }
-
-        if (canUseOfflineSupport && Engine.OfflineProviderFactory) {
-            // Checking if a manifest file has been set for this scene and if offline mode has been requested
-            scene.offlineProvider = Engine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
-        } else {
-            manifestChecked();
-        }
-
-        return plugin;
-    }
-
-    private static _GetFileInfo(rootUrl: string, sceneSource: SceneSource): Nullable<IFileInfo> {
-        let url: string;
-        let name: string;
-        let file: Nullable<File> = null;
-        let rawData: Nullable<ArrayBufferView> = null;
-
-        if (!sceneSource) {
-            url = rootUrl;
-            name = Tools.GetFilename(rootUrl);
-            rootUrl = Tools.GetFolderPath(rootUrl);
-        } else if (isFile(sceneSource)) {
-            url = `file:${sceneSource.name}`;
-            name = sceneSource.name;
-            file = sceneSource;
-        } else if (ArrayBuffer.isView(sceneSource)) {
-            url = "";
-            name = RandomGUID();
-            rawData = sceneSource;
-        } else if (sceneSource.startsWith("data:")) {
-            url = sceneSource;
-            name = "";
-        } else if (rootUrl) {
-            const filename = sceneSource;
-            if (filename.substr(0, 1) === "/") {
-                Tools.Error("Wrong sceneFilename parameter");
-                return null;
-            }
-
-            url = rootUrl + filename;
-            name = filename;
-        } else {
-            url = sceneSource;
-            name = Tools.GetFilename(sceneSource);
-            rootUrl = Tools.GetFolderPath(sceneSource);
-        }
-
-        return {
-            url: url,
-            rootUrl: rootUrl,
-            name: name,
-            file: file,
-            rawData,
-        };
+        return _getDefaultPlugin();
     }
 
     // Public functions
@@ -815,7 +1484,7 @@ export class SceneLoader {
      * @returns a plugin or null if none works
      */
     public static GetPluginForExtension(extension: string): ISceneLoaderPlugin | ISceneLoaderPluginAsync | ISceneLoaderPluginFactory {
-        return SceneLoader._GetPluginForExtension(extension).plugin;
+        return _getPluginForExtension(extension).plugin;
     }
 
     /**
@@ -824,7 +1493,7 @@ export class SceneLoader {
      * @returns true if the extension is supported
      */
     public static IsPluginForExtensionAvailable(extension: string): boolean {
-        return !!SceneLoader._RegisteredPlugins[extension];
+        return _isPluginForExtensionAvailable(extension);
     }
 
     /**
@@ -832,21 +1501,7 @@ export class SceneLoader {
      * @param plugin defines the plugin to add
      */
     public static RegisterPlugin(plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync): void {
-        if (typeof plugin.extensions === "string") {
-            const extension = plugin.extensions;
-            SceneLoader._RegisteredPlugins[extension.toLowerCase()] = {
-                plugin: plugin,
-                isBinary: false,
-            };
-        } else {
-            const extensions = plugin.extensions;
-            Object.keys(extensions).forEach((extension) => {
-                SceneLoader._RegisteredPlugins[extension.toLowerCase()] = {
-                    plugin: plugin,
-                    isBinary: extensions[extension].isBinary,
-                };
-            });
-        }
+        registerSceneLoaderPlugin(plugin);
     }
 
     /**
@@ -873,135 +1528,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        return SceneLoader._ImportMesh(meshNames, rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        return _importMesh(meshNames, rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
     }
-
-    private static _ImportMesh(
-        meshNames: string | readonly string[] | null | undefined,
-        rootUrl: string,
-        sceneFilename: SceneSource = "",
-        scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-        onSuccess: Nullable<SceneLoaderSuccessCallback> = null,
-        onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-        onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-        pluginExtension: Nullable<string> = null,
-        name = "",
-        pluginOptions: PluginOptions = {}
-    ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        if (!scene) {
-            Logger.Error("No scene available to import mesh to");
-            return null;
-        }
-
-        const fileInfo = SceneLoader._GetFileInfo(rootUrl, sceneFilename);
-        if (!fileInfo) {
-            return null;
-        }
-
-        const loadingToken = {};
-        scene.addPendingData(loadingToken);
-
-        const disposeHandler = () => {
-            scene.removePendingData(loadingToken);
-        };
-
-        const errorHandler = (message?: string, exception?: any) => {
-            const errorMessage = SceneLoader._FormatErrorMessage(fileInfo, message, exception);
-
-            if (onError) {
-                onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-            } else {
-                Logger.Error(errorMessage);
-                // should the exception be thrown?
-            }
-
-            disposeHandler();
-        };
-
-        const progressHandler = onProgress
-            ? (event: ISceneLoaderProgressEvent) => {
-                  try {
-                      onProgress(event);
-                  } catch (e) {
-                      errorHandler("Error in onProgress callback: " + e, e);
-                  }
-              }
-            : undefined;
-
-        const successHandler: SceneLoaderSuccessCallback = (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
-            scene.importedMeshesFiles.push(fileInfo.url);
-
-            if (onSuccess) {
-                try {
-                    onSuccess(meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers);
-                } catch (e) {
-                    errorHandler("Error in onSuccess callback: " + e, e);
-                }
-            }
-
-            scene.removePendingData(loadingToken);
-        };
-
-        return SceneLoader._LoadData(
-            fileInfo,
-            scene,
-            (plugin, data, responseURL) => {
-                if (plugin.rewriteRootURL) {
-                    fileInfo.rootUrl = plugin.rewriteRootURL(fileInfo.rootUrl, responseURL);
-                }
-
-                if ((plugin as ISceneLoaderPlugin).importMesh) {
-                    const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                    const meshes: AbstractMesh[] = [];
-                    const particleSystems: IParticleSystem[] = [];
-                    const skeletons: Skeleton[] = [];
-
-                    if (!syncedPlugin.importMesh(meshNames, scene, data, fileInfo.rootUrl, meshes, particleSystems, skeletons, errorHandler)) {
-                        return;
-                    }
-
-                    scene.loadingPluginName = plugin.name;
-                    successHandler(meshes, particleSystems, skeletons, [], [], [], [], []);
-                } else {
-                    const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                    asyncedPlugin
-                        .importMeshAsync(meshNames, scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                        .then((result) => {
-                            scene.loadingPluginName = plugin.name;
-                            successHandler(
-                                result.meshes,
-                                result.particleSystems,
-                                result.skeletons,
-                                result.animationGroups,
-                                result.transformNodes,
-                                result.geometries,
-                                result.lights,
-                                result.spriteManagers
-                            );
-                        })
-                        .catch((error) => {
-                            errorHandler(error.message, error);
-                        });
-                }
-            },
-            progressHandler,
-            errorHandler,
-            disposeHandler,
-            pluginExtension,
-            name,
-            pluginOptions
-        );
-    }
-
-    /**
-     * Import meshes into a scene
-     * @experimental
-     * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
-     * @param scene the instance of BABYLON.Scene to append to
-     * @param options an object that configures aspects of how the scene is loaded
-     * @returns The loaded list of imported meshes, particle systems, skeletons, and animation groups
-     */
-    public static ImportMeshAsync(source: SceneSource, scene: Scene, options?: ImportMeshOptions): Promise<ISceneLoaderAsyncResult>;
 
     /**
      * Import meshes into a scene
@@ -1022,75 +1550,8 @@ export class SceneLoader {
         onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
         pluginExtension?: Nullable<string>,
         name?: string
-    ): Promise<ISceneLoaderAsyncResult>;
-
-    public static ImportMeshAsync(
-        ...args:
-            | [
-                  meshNames: string | readonly string[] | null | undefined,
-                  rootUrl: string,
-                  sceneFilename?: SceneSource,
-                  scene?: Nullable<Scene>,
-                  onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-                  pluginExtension?: Nullable<string>,
-                  name?: string,
-              ]
-            | [source: SceneSource, scene: Scene, options?: ImportMeshOptions]
     ): Promise<ISceneLoaderAsyncResult> {
-        let meshNames: string | readonly string[] | null | undefined;
-        let rootUrl: string;
-        let sceneFilename: SceneSource | undefined;
-        let scene: Nullable<Scene> | undefined;
-        let onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined;
-        let pluginExtension: Nullable<string> | undefined;
-        let name: string | undefined;
-        let pluginOptions: PluginOptions;
-
-        // This is a user-defined type guard: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-        // This is the most type safe way to distinguish between the two possible argument arrays.
-        const isOptionsArgs = (maybeOptionsArgs: typeof args): maybeOptionsArgs is [SceneSource, Scene, ImportMeshOptions?] => {
-            // If the second argument is an object, then it must be the options overload.
-            return typeof maybeOptionsArgs[1] === "object";
-        };
-
-        if (isOptionsArgs(args)) {
-            // Source is mapped to sceneFileName
-            sceneFilename = args[0];
-            scene = args[1];
-            // Options determine the rest of the arguments
-            ({ meshNames, rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = args[2] ?? {});
-        } else {
-            // For the legacy signature, we just directly map each argument
-            [meshNames, rootUrl, sceneFilename, scene, onProgress, pluginExtension, name] = args;
-        }
-
-        return new Promise((resolve, reject) => {
-            SceneLoader._ImportMesh(
-                meshNames,
-                rootUrl,
-                sceneFilename,
-                scene,
-                (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
-                    resolve({
-                        meshes: meshes,
-                        particleSystems: particleSystems,
-                        skeletons: skeletons,
-                        animationGroups: animationGroups,
-                        transformNodes: transformNodes,
-                        geometries: geometries,
-                        lights: lights,
-                        spriteManagers: spriteManagers,
-                    });
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-            );
-        });
+        return _importMeshAsync(meshNames, rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1115,37 +1576,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        return SceneLoader._Load(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name);
+        return _load(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name);
     }
-
-    private static _Load(
-        rootUrl: string,
-        sceneFilename: SceneSource = "",
-        engine: Nullable<AbstractEngine> = EngineStore.LastCreatedEngine,
-        onSuccess: Nullable<(scene: Scene) => void> = null,
-        onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-        onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-        pluginExtension: Nullable<string> = null,
-        name = "",
-        pluginOptions: PluginOptions = {}
-    ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        if (!engine) {
-            Tools.Error("No engine available");
-            return null;
-        }
-
-        return SceneLoader._Append(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
-    }
-
-    /**
-     * Load a scene
-     * @experimental
-     * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
-     * @param engine is the instance of BABYLON.Engine to use to create the scene
-     * @param options an object that configures aspects of how the scene is loaded
-     * @returns The loaded scene
-     */
-    public static LoadAsync(source: SceneSource, engine: AbstractEngine, options?: LoadOptions): Promise<Scene>;
 
     /**
      * Load a scene
@@ -1164,63 +1596,8 @@ export class SceneLoader {
         onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
         pluginExtension?: Nullable<string>,
         name?: string
-    ): Promise<Scene>;
-
-    public static LoadAsync(
-        ...args:
-            | [
-                  rootUrl: string,
-                  sceneFilename?: SceneSource,
-                  engine?: Nullable<AbstractEngine>,
-                  onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-                  pluginExtension?: Nullable<string>,
-                  name?: string,
-              ]
-            | [source: SceneSource, engine: AbstractEngine, options?: LoadOptions]
     ): Promise<Scene> {
-        let rootUrl: string;
-        let sceneFilename: SceneSource | undefined;
-        let engine: Nullable<AbstractEngine> | undefined;
-        let onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined;
-        let pluginExtension: Nullable<string> | undefined;
-        let name: string | undefined;
-        let pluginOptions: PluginOptions;
-
-        // This is a user-defined type guard: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-        // This is the most type safe way to distinguish between the two possible argument arrays.
-        const isOptionsArgs = (maybeOptionsArgs: typeof args): maybeOptionsArgs is [SceneSource, AbstractEngine, LoadOptions?] => {
-            // If the second argument is an engine, then it must be the options overload.
-            return maybeOptionsArgs[1] instanceof AbstractEngine;
-        };
-
-        if (isOptionsArgs(args)) {
-            // Source is mapped to sceneFileName
-            sceneFilename = args[0];
-            engine = args[1];
-            // Options determine the rest of the arguments
-            ({ rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = args[2] ?? {});
-        } else {
-            // For the legacy signature, we just directly map each argument
-            [rootUrl, sceneFilename, engine, onProgress, pluginExtension, name] = args;
-        }
-
-        return new Promise((resolve, reject) => {
-            SceneLoader._Load(
-                rootUrl,
-                sceneFilename,
-                engine,
-                (scene) => {
-                    resolve(scene);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-            );
-        });
+        return _loadAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1245,124 +1622,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        return SceneLoader._Append(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        return _append(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
     }
-
-    private static _Append(
-        rootUrl: string,
-        sceneFilename: SceneSource = "",
-        scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-        onSuccess: Nullable<(scene: Scene) => void> = null,
-        onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-        onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-        pluginExtension: Nullable<string> = null,
-        name = "",
-        pluginOptions: PluginOptions = {}
-    ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        if (!scene) {
-            Logger.Error("No scene available to append to");
-            return null;
-        }
-
-        const fileInfo = SceneLoader._GetFileInfo(rootUrl, sceneFilename);
-        if (!fileInfo) {
-            return null;
-        }
-
-        const loadingToken = {};
-        scene.addPendingData(loadingToken);
-
-        const disposeHandler = () => {
-            scene.removePendingData(loadingToken);
-        };
-
-        if (SceneLoader.ShowLoadingScreen && !this._ShowingLoadingScreen) {
-            this._ShowingLoadingScreen = true;
-            scene.getEngine().displayLoadingUI();
-            scene.executeWhenReady(() => {
-                scene.getEngine().hideLoadingUI();
-                this._ShowingLoadingScreen = false;
-            });
-        }
-
-        const errorHandler = (message?: string, exception?: any) => {
-            const errorMessage = SceneLoader._FormatErrorMessage(fileInfo, message, exception);
-
-            if (onError) {
-                onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-            } else {
-                Logger.Error(errorMessage);
-                // should the exception be thrown?
-            }
-
-            disposeHandler();
-        };
-
-        const progressHandler = onProgress
-            ? (event: ISceneLoaderProgressEvent) => {
-                  try {
-                      onProgress(event);
-                  } catch (e) {
-                      errorHandler("Error in onProgress callback", e);
-                  }
-              }
-            : undefined;
-
-        const successHandler = () => {
-            if (onSuccess) {
-                try {
-                    onSuccess(scene);
-                } catch (e) {
-                    errorHandler("Error in onSuccess callback", e);
-                }
-            }
-
-            scene.removePendingData(loadingToken);
-        };
-
-        return SceneLoader._LoadData(
-            fileInfo,
-            scene,
-            (plugin, data) => {
-                if ((plugin as ISceneLoaderPlugin).load) {
-                    const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                    if (!syncedPlugin.load(scene, data, fileInfo.rootUrl, errorHandler)) {
-                        return;
-                    }
-
-                    scene.loadingPluginName = plugin.name;
-                    successHandler();
-                } else {
-                    const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                    asyncedPlugin
-                        .loadAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                        .then(() => {
-                            scene.loadingPluginName = plugin.name;
-                            successHandler();
-                        })
-                        .catch((error) => {
-                            errorHandler(error.message, error);
-                        });
-                }
-            },
-            progressHandler,
-            errorHandler,
-            disposeHandler,
-            pluginExtension,
-            name,
-            pluginOptions
-        );
-    }
-
-    /**
-     * Append a scene
-     * @experimental
-     * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
-     * @param scene is the instance of BABYLON.Scene to append to
-     * @param options an object that configures aspects of how the scene is loaded
-     * @returns The given scene
-     */
-    public static AppendAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<Scene>;
 
     /**
      * Append a scene
@@ -1381,63 +1642,8 @@ export class SceneLoader {
         onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
         pluginExtension?: Nullable<string>,
         name?: string
-    ): Promise<Scene>;
-
-    public static AppendAsync(
-        ...args:
-            | [
-                  rootUrl: string,
-                  sceneFilename?: SceneSource,
-                  scene?: Nullable<Scene>,
-                  onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-                  pluginExtension?: Nullable<string>,
-                  name?: string,
-              ]
-            | [source: SceneSource, scene: Scene, options?: AppendOptions]
     ): Promise<Scene> {
-        let rootUrl: string;
-        let sceneFilename: SceneSource | undefined;
-        let scene: Nullable<Scene> | undefined;
-        let onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined;
-        let pluginExtension: Nullable<string> | undefined;
-        let name: string | undefined;
-        let pluginOptions: PluginOptions;
-
-        // This is a user-defined type guard: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-        // This is the most type safe way to distinguish between the two possible argument arrays.
-        const isOptionsArgs = (maybeOptionsArgs: typeof args): maybeOptionsArgs is [SceneSource, Scene, AppendOptions?] => {
-            // If the second argument is a Scene, then it must be the options overload.
-            return maybeOptionsArgs[1] instanceof Scene;
-        };
-
-        if (isOptionsArgs(args)) {
-            // Source is mapped to sceneFileName
-            sceneFilename = args[0];
-            scene = args[1];
-            // Options determine the rest of the arguments
-            ({ rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = args[2] ?? {});
-        } else {
-            // For the legacy signature, we just directly map each argument
-            [rootUrl, sceneFilename, scene, onProgress, pluginExtension, name] = args;
-        }
-
-        return new Promise((resolve, reject) => {
-            SceneLoader._Append(
-                rootUrl,
-                sceneFilename,
-                scene,
-                (scene) => {
-                    resolve(scene);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-            );
-        });
+        return _appendAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1462,119 +1668,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        return SceneLoader._LoadAssetContainer(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        return _loadAssetContainer(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
     }
-
-    private static _LoadAssetContainer(
-        rootUrl: string,
-        sceneFilename: SceneSource = "",
-        scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-        onSuccess: Nullable<(assets: AssetContainer) => void> = null,
-        onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-        onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-        pluginExtension: Nullable<string> = null,
-        name = "",
-        pluginOptions: PluginOptions = {}
-    ): Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync> {
-        if (!scene) {
-            Logger.Error("No scene available to load asset container to");
-            return null;
-        }
-
-        const fileInfo = SceneLoader._GetFileInfo(rootUrl, sceneFilename);
-        if (!fileInfo) {
-            return null;
-        }
-
-        const loadingToken = {};
-        scene.addPendingData(loadingToken);
-
-        const disposeHandler = () => {
-            scene.removePendingData(loadingToken);
-        };
-
-        const errorHandler = (message?: string, exception?: any) => {
-            const errorMessage = SceneLoader._FormatErrorMessage(fileInfo, message, exception);
-
-            if (onError) {
-                onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-            } else {
-                Logger.Error(errorMessage);
-                // should the exception be thrown?
-            }
-
-            disposeHandler();
-        };
-
-        const progressHandler = onProgress
-            ? (event: ISceneLoaderProgressEvent) => {
-                  try {
-                      onProgress(event);
-                  } catch (e) {
-                      errorHandler("Error in onProgress callback", e);
-                  }
-              }
-            : undefined;
-
-        const successHandler = (assets: AssetContainer) => {
-            if (onSuccess) {
-                try {
-                    onSuccess(assets);
-                } catch (e) {
-                    errorHandler("Error in onSuccess callback", e);
-                }
-            }
-
-            scene.removePendingData(loadingToken);
-        };
-
-        return SceneLoader._LoadData(
-            fileInfo,
-            scene,
-            (plugin, data) => {
-                if ((plugin as ISceneLoaderPlugin).loadAssetContainer) {
-                    const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                    const assetContainer = syncedPlugin.loadAssetContainer(scene, data, fileInfo.rootUrl, errorHandler);
-                    if (!assetContainer) {
-                        return;
-                    }
-                    assetContainer.populateRootNodes();
-                    scene.loadingPluginName = plugin.name;
-                    successHandler(assetContainer);
-                } else if ((plugin as ISceneLoaderPluginAsync).loadAssetContainerAsync) {
-                    const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                    asyncedPlugin
-                        .loadAssetContainerAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                        .then((assetContainer) => {
-                            assetContainer.populateRootNodes();
-                            scene.loadingPluginName = plugin.name;
-                            successHandler(assetContainer);
-                        })
-                        .catch((error) => {
-                            errorHandler(error.message, error);
-                        });
-                } else {
-                    errorHandler("LoadAssetContainer is not supported by this plugin. Plugin did not provide a loadAssetContainer or loadAssetContainerAsync method.");
-                }
-            },
-            progressHandler,
-            errorHandler,
-            disposeHandler,
-            pluginExtension,
-            name,
-            pluginOptions
-        );
-    }
-
-    /**
-     * Load a scene into an asset container
-     * @experimental
-     * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
-     * @param scene is the instance of Scene to append to
-     * @param options an object that configures aspects of how the scene is loaded
-     * @returns The loaded asset container
-     */
-    public static LoadAssetContainerAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<AssetContainer>;
 
     /**
      * Load a scene into an asset container
@@ -1593,65 +1688,8 @@ export class SceneLoader {
         onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
         pluginExtension?: Nullable<string>,
         name?: string
-    ): Promise<AssetContainer>;
-
-    // This is the single implementation that handles both the legacy many-parameters overload and the
-    // new source + config overload. Using a parameters array union is the most type safe way to handle this.
-    public static LoadAssetContainerAsync(
-        ...args:
-            | [
-                  rootUrl: string,
-                  sceneFilename?: SceneSource,
-                  scene?: Nullable<Scene>,
-                  onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-                  pluginExtension?: Nullable<string>,
-                  name?: string,
-              ]
-            | [source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions]
     ): Promise<AssetContainer> {
-        let rootUrl: string;
-        let sceneFilename: SceneSource | undefined;
-        let scene: Nullable<Scene> | undefined;
-        let onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined;
-        let pluginExtension: Nullable<string> | undefined;
-        let name: string | undefined;
-        let pluginOptions: PluginOptions;
-
-        // This is a user-defined type guard: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-        // This is the most type safe way to distinguish between the two possible argument arrays.
-        const isOptionsArgs = (maybeOptionsArgs: typeof args): maybeOptionsArgs is [SceneSource, Scene, LoadAssetContainerOptions?] => {
-            // If the second argument is a Scene, then it must be the options overload.
-            return maybeOptionsArgs[1] instanceof Scene;
-        };
-
-        if (isOptionsArgs(args)) {
-            // Source is mapped to sceneFileName
-            sceneFilename = args[0];
-            scene = args[1];
-            // Options determine the rest of the arguments
-            ({ rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = args[2] ?? {});
-        } else {
-            // For the legacy signature, we just directly map each argument
-            [rootUrl, sceneFilename, scene, onProgress, pluginExtension, name] = args;
-        }
-
-        return new Promise((resolve, reject) => {
-            SceneLoader._LoadAssetContainer(
-                rootUrl,
-                sceneFilename,
-                scene,
-                (assetContainer) => {
-                    resolve(assetContainer);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-            );
-        });
+        return _loadAssetContainerAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1681,108 +1719,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): void {
-        SceneLoader._ImportAnimations(
-            rootUrl,
-            sceneFilename,
-            scene,
-            overwriteAnimations,
-            animationGroupLoadingMode,
-            targetConverter,
-            onSuccess,
-            onProgress,
-            onError,
-            pluginExtension,
-            name
-        );
+        _importAnimations(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onSuccess, onProgress, onError, pluginExtension, name);
     }
-
-    private static _ImportAnimations(
-        rootUrl: string,
-        sceneFilename: SceneSource = "",
-        scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-        overwriteAnimations = true,
-        animationGroupLoadingMode = SceneLoaderAnimationGroupLoadingMode.Clean,
-        targetConverter: Nullable<(target: any) => any> = null,
-        onSuccess: Nullable<(scene: Scene) => void> = null,
-        onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-        onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-        pluginExtension: Nullable<string> = null,
-        name = "",
-        pluginOptions: PluginOptions = {}
-    ): void {
-        if (!scene) {
-            Logger.Error("No scene available to load animations to");
-            return;
-        }
-
-        if (overwriteAnimations) {
-            // Reset, stop and dispose all animations before loading new ones
-            for (const animatable of scene.animatables) {
-                animatable.reset();
-            }
-            scene.stopAllAnimations();
-            scene.animationGroups.slice().forEach((animationGroup) => {
-                animationGroup.dispose();
-            });
-            const nodes = scene.getNodes();
-            nodes.forEach((node) => {
-                if (node.animations) {
-                    node.animations = [];
-                }
-            });
-        } else {
-            switch (animationGroupLoadingMode) {
-                case SceneLoaderAnimationGroupLoadingMode.Clean:
-                    scene.animationGroups.slice().forEach((animationGroup) => {
-                        animationGroup.dispose();
-                    });
-                    break;
-                case SceneLoaderAnimationGroupLoadingMode.Stop:
-                    scene.animationGroups.forEach((animationGroup) => {
-                        animationGroup.stop();
-                    });
-                    break;
-                case SceneLoaderAnimationGroupLoadingMode.Sync:
-                    scene.animationGroups.forEach((animationGroup) => {
-                        animationGroup.reset();
-                        animationGroup.restart();
-                    });
-                    break;
-                case SceneLoaderAnimationGroupLoadingMode.NoSync:
-                    // nothing to do
-                    break;
-                default:
-                    Logger.Error("Unknown animation group loading mode value '" + animationGroupLoadingMode + "'");
-                    return;
-            }
-        }
-
-        const startingIndexForNewAnimatables = scene.animatables.length;
-
-        const onAssetContainerLoaded = (container: AssetContainer) => {
-            container.mergeAnimationsTo(scene, scene.animatables.slice(startingIndexForNewAnimatables), targetConverter);
-
-            container.dispose();
-
-            scene.onAnimationFileImportedObservable.notifyObservers(scene);
-
-            if (onSuccess) {
-                onSuccess(scene);
-            }
-        };
-
-        this._LoadAssetContainer(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
-    }
-
-    /**
-     * Import animations from a file into a scene
-     * @experimental
-     * @param source a string that defines the name of the scene file, or starts with "data:" following by the stringified version of the scene, or a File object, or an ArrayBufferView
-     * @param scene is the instance of BABYLON.Scene to append to (default: last created scene)
-     * @param options an object that configures aspects of how the scene is loaded
-     * @returns The loaded asset container
-     */
-    public static ImportAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<Scene>;
 
     /**
      * Import animations from a file into a scene
@@ -1806,78 +1744,14 @@ export class SceneLoader {
         overwriteAnimations?: boolean,
         animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode,
         targetConverter?: Nullable<(target: any) => any>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onSuccess?: Nullable<(scene: Scene) => void>,
         onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>,
         pluginExtension?: Nullable<string>,
         name?: string
-    ): Promise<Scene>;
-
-    public static ImportAnimationsAsync(
-        ...args:
-            | [
-                  rootUrl: string,
-                  sceneFilename?: SceneSource,
-                  scene?: Nullable<Scene>,
-                  overwriteAnimations?: boolean,
-                  animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode,
-                  targetConverter?: Nullable<(target: any) => any>,
-                  onSuccess?: Nullable<(scene: Scene) => void>,
-                  onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-                  onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>,
-                  pluginExtension?: Nullable<string>,
-                  name?: string,
-              ]
-            | [source: SceneSource, scene: Scene, options?: ImportAnimationsOptions]
     ): Promise<Scene> {
-        let rootUrl: string;
-        let sceneFilename: SceneSource | undefined;
-        let scene: Nullable<Scene> | undefined;
-        let overwriteAnimations: boolean | undefined;
-        let animationGroupLoadingMode: SceneLoaderAnimationGroupLoadingMode | undefined;
-        let targetConverter: Nullable<(target: any) => any> | undefined;
-        let onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined;
-        let pluginExtension: Nullable<string> | undefined;
-        let name: string | undefined;
-        let pluginOptions: PluginOptions;
-
-        // This is a user-defined type guard: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-        // This is the most type safe way to distinguish between the two possible argument arrays.
-        const isOptionsArgs = (maybeOptionsArgs: typeof args): maybeOptionsArgs is [SceneSource, Scene, ImportAnimationsOptions?] => {
-            // If the second argument is a Scene, then it must be the options overload.
-            return maybeOptionsArgs[1] instanceof Scene;
-        };
-
-        if (isOptionsArgs(args)) {
-            // Source is mapped to sceneFileName
-            sceneFilename = args[0];
-            scene = args[1];
-            // Options determine the rest of the arguments
-            ({ rootUrl = "", overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions } = args[2] ?? {});
-        } else {
-            // For the legacy signature, we just directly map each argument
-            [rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, , onProgress, , pluginExtension, name] = args;
-        }
-
-        return new Promise((resolve, reject) => {
-            SceneLoader._ImportAnimations(
-                rootUrl,
-                sceneFilename,
-                scene,
-                overwriteAnimations,
-                animationGroupLoadingMode,
-                targetConverter,
-                (_scene: Scene) => {
-                    resolve(_scene);
-                },
-                onProgress,
-                (_scene: Scene, message: string, exception: any) => {
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-            );
-        });
+        return _importAnimationsAsync(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
     }
 }

--- a/packages/dev/loaders/src/OBJ/objFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.ts
@@ -3,7 +3,7 @@ import { Vector2 } from "core/Maths/math.vector";
 import { Tools } from "core/Misc/tools";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderPlugin, ISceneLoaderAsyncResult } from "core/Loading/sceneLoader";
-import { SceneLoader } from "core/Loading/sceneLoader";
+import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 import type { WebRequest } from "core/Misc/webRequest";
@@ -362,7 +362,5 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
     }
 }
 
-if (SceneLoader) {
-    //Add this loader into the register plugin
-    SceneLoader.RegisterPlugin(new OBJFileLoader());
-}
+//Add this loader into the register plugin
+registerSceneLoaderPlugin(new OBJFileLoader());

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -6,7 +6,7 @@ import type {
     ISceneLoaderPluginExtensions,
     ISceneLoaderProgressEvent,
 } from "core/Loading/sceneLoader";
-import { SceneLoader } from "core/Loading/sceneLoader";
+import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 import type { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
@@ -125,7 +125,5 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
     }
 }
 
-if (SceneLoader) {
-    //Add this loader into the register plugin
-    SceneLoader.RegisterPlugin(new SPLATFileLoader());
-}
+//Add this loader into the register plugin
+registerSceneLoaderPlugin(new SPLATFileLoader());

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -5,7 +5,7 @@ import { VertexBuffer } from "core/Buffers/buffer";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { Mesh } from "core/Meshes/mesh";
 import type { ISceneLoaderPlugin, ISceneLoaderPluginExtensions } from "core/Loading/sceneLoader";
-import { SceneLoader } from "core/Loading/sceneLoader";
+import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 
@@ -287,6 +287,4 @@ export class STLFileLoader implements ISceneLoaderPlugin {
     }
 }
 
-if (SceneLoader) {
-    SceneLoader.RegisterPlugin(new STLFileLoader());
-}
+registerSceneLoaderPlugin(new STLFileLoader());

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -16,7 +16,7 @@ import type {
     ISceneLoaderPluginExtensions,
     ISceneLoaderAsyncResult,
 } from "core/Loading/sceneLoader";
-import { SceneLoader } from "core/Loading/sceneLoader";
+import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import type { SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene, IDisposable } from "core/scene";
@@ -1303,6 +1303,4 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     private _endPerformanceCounterDisabled(counterName: string): void {}
 }
 
-if (SceneLoader) {
-    SceneLoader.RegisterPlugin(new GLTFFileLoader());
-}
+registerSceneLoaderPlugin(new GLTFFileLoader());

--- a/packages/public/@babylonjs/viewer-alpha/readme.md
+++ b/packages/public/@babylonjs/viewer-alpha/readme.md
@@ -31,9 +31,24 @@ To use the higher level `HTML3DElement` you can import the `@babylonjs/viewer` m
 <html lang="en">
   <body>
     <script type="module">
-      import '@babylonjs/viewer-alpha';
+      import '@babylonjs/viewer';
     </script>
     <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
   </body>
 </html>
 ```
+
+## CDN/Direct usage
+
+If you want to use the viewer directly in a browser without any build tools, you can use the self-contained ESM bundle (which includes all dependencies) through a CDN such as [UNPKG](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/) like this:
+
+```html
+<html lang="en">
+  <body>
+    <script type="module" src="https://unpkg.com/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
+    <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
+  </body>
+</html>
+```
+
+See the [codesandbox.io](https://codesandbox.io/p/sandbox/babylon-viewer-ws82xr) example for a live demo.

--- a/packages/tools/viewer-alpha/generateCoverageReports.mjs
+++ b/packages/tools/viewer-alpha/generateCoverageReports.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import open from "open";
 import chalk from "chalk";
-import { generateFlameChart } from "../../../scripts/folderSizeFlameChart.js";
+import { generateFlameChart } from "../../../scripts/folderSizeFlameChart.mjs";
 
 const [scriptPath, analyzeDirectory, coverageDirectory, originalDirectory, rawDirectory] = process.argv.slice(1);
 

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -14,8 +14,8 @@
         "compile": "tsc -b tsconfig.build.json",
         "bundle:analyze": "rimraf dist/analyze && rollup -c rollup.config.analyze.mjs",
         "bundle:coverage": "rimraf dist/coverage && rollup -c rollup.config.coverage.mjs",
-        "analyze": "npm run bundle:analyze && node ../../../scripts/folderSizeFlameChart dist/analyze \"**/*.js\" dist/analyze/flameChart",
-        "import-chains": "node -e \"require('../../../scripts/queryRollupStats.js').queryRollupStats(process.argv[1], 'dist/analyze/stats.json')\"",
+        "analyze": "npm run bundle:analyze && node ../../../scripts/folderSizeFlameChart.mjs dist/analyze \"**/*.js\" dist/analyze/flameChart",
+        "import-chains": "node -e \"require('../../../scripts/queryRollupStats.js').queryRollupStats(process.argv[1], process.argv[2], 'dist/analyze/stats.json')\"",
         "instrument": "npm run bundle:coverage && nyc --exclude-node-modules=false instrument dist/coverage/original dist/coverage/instrumented",
         "report-coverage": "node generateCoverageReports.mjs dist/analyze dist/coverage dist/coverage/original dist/coverage/raw",
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -118,13 +118,11 @@ export class Viewer implements IDisposable {
      * Loads a 3D model from the specified URL.
      * @remarks
      * If a model is already loaded, it will be unloaded before loading the new model.
-     * @param source A URL or File object that points to the model to load.
+     * @param source A url or File or ArrayBufferView that points to the model to load.
      * @param abortSignal An optional signal that can be used to abort the loading process.
      */
-    public async loadModelAsync(source: URL | File, abortSignal?: AbortSignal): Promise<void> {
+    public async loadModelAsync(source: string | File | ArrayBufferView, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
-
-        const finalSource = source instanceof URL ? source.href : source;
 
         this._loadModelAbortController?.abort("New model is being loaded before previous model finished loading.");
         const abortController = (this._loadModelAbortController = new AbortController());
@@ -132,21 +130,21 @@ export class Viewer implements IDisposable {
         await this._loadModelLock.lockAsync(async () => {
             this._throwIfDisposedOrAborted(abortSignal, abortController.signal);
             this._details.model?.dispose();
-            this._details.model = await loadAssetContainerAsync(finalSource, this._details.scene);
+            this._details.model = await loadAssetContainerAsync(source, this._details.scene);
             this._details.model.addAllToScene();
             this._reframeCamera();
         });
     }
 
     /**
-     * Loads an environment texture from the specified URL and sets up a corresponding skybox.
+     * Loads an environment texture from the specified url and sets up a corresponding skybox.
      * @remarks
-     * If no URL is provided, a default hemispheric light will be created.
+     * If no url is provided, a default hemispheric light will be created.
      * If an environment is already loaded, it will be unloaded before loading the new environment.
-     * @param url The URL of the environment texture to load.
+     * @param url The url of the environment texture to load.
      * @param abortSignal An optional signal that can be used to abort the loading process.
      */
-    public async loadEnvironmentAsync(url: Nullable<URL | undefined>, abortSignal?: AbortSignal): Promise<void> {
+    public async loadEnvironmentAsync(url: Nullable<string | undefined>, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
         this._loadEnvironmentAbortController?.abort("New environment is being loaded before previous environment finished loading.");
@@ -161,7 +159,7 @@ export class Viewer implements IDisposable {
                     this._details.scene.autoClear = true;
                     resolve(light);
                 } else {
-                    const cubeTexture = CubeTexture.CreateFromPrefilteredData(url.href, this._details.scene);
+                    const cubeTexture = CubeTexture.CreateFromPrefilteredData(url, this._details.scene);
                     this._details.scene.environmentTexture = cubeTexture;
                     const skybox = createSkybox(this._details.scene, cubeTexture, (this._camera.maxZ - this._camera.minZ) / 2, 0.3);
                     this._details.scene.autoClear = false;

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -3,7 +3,7 @@ import type { AbstractEngine, AssetContainer, FramingBehavior, IDisposable, Mesh
 
 import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
 import { HemisphericLight } from "core/Lights/hemisphericLight";
-import { SceneLoader } from "core/Loading/sceneLoader";
+import { loadAssetContainerAsync } from "core/Loading/sceneLoader";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { CubeTexture } from "core/Materials/Textures/cubeTexture";
 import { Texture } from "core/Materials/Textures/texture";
@@ -132,7 +132,7 @@ export class Viewer implements IDisposable {
         await this._loadModelLock.lockAsync(async () => {
             this._throwIfDisposedOrAborted(abortSignal, abortController.signal);
             this._details.model?.dispose();
-            this._details.model = await SceneLoader.LoadAssetContainerAsync(finalSource, this._details.scene);
+            this._details.model = await loadAssetContainerAsync(finalSource, this._details.scene);
             this._details.model.addAllToScene();
             this._reframeCamera();
         });

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -87,10 +87,10 @@ export class HTML3DElement extends HTMLElement {
     public attributeChangedCallback(name: (typeof HTML3DElement.observedAttributes)[number], oldValue: string, newValue: string) {
         switch (name) {
             case "src":
-                this._viewer.loadModelAsync(new URL(newValue)).catch(Logger.Log);
+                this._viewer.loadModelAsync(newValue).catch(Logger.Log);
                 break;
             case "env":
-                this._viewer.loadEnvironmentAsync(new URL(newValue)).catch(Logger.Log);
+                this._viewer.loadEnvironmentAsync(newValue).catch(Logger.Log);
                 break;
         }
     }

--- a/scripts/folderSizeFlameChart.mjs
+++ b/scripts/folderSizeFlameChart.mjs
@@ -7,14 +7,14 @@
 // node folderSizeFlameChart.js [pattern=**/*] [outputFile=FoldersSizes]
 // Example: node folderSizeFlameChart.js . "**/*.ts,!**/*.d.ts,!**/test/**"
 
-const child_process = require("child_process");
-const fs = require("fs");
-const path = require("path");
-const os = require("os");
-const https = require("https");
-const glob = require("glob");
-const chalk = require("chalk");
-const open = require("open");
+import child_process from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import https from "https";
+import { glob } from "glob";
+import chalk from "chalk";
+import open from "open";
 
 async function downloadFlameGraphScript() {
     // This is the temp path where the flamegraph.pl script will be downloaded
@@ -56,7 +56,7 @@ async function downloadFlameGraphScript() {
  * @param {function} coerceSize A function to coerce the size of a file. If not provided, the actual size is used.
  * @returns {Promise<void>} A promise that resolves when the flame chart has been generated.
  */
-async function generateFlameChart(folder, pattern, outputFile, chartSubtitle, coerceSize) {
+export async function generateFlameChart(folder, pattern, outputFile, chartSubtitle, coerceSize) {
     const flameGraphScriptPath = await downloadFlameGraphScript();
 
     // Resolve to an absolute path
@@ -103,7 +103,7 @@ async function generateFlameChart(folder, pattern, outputFile, chartSubtitle, co
     child_process.execSync(flameGraphCommand);
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
     const [scriptPath, folder = ".", pattern = "**", outputFile = "FoldersSizes"] = process.argv.slice(1);
 
     console.log(chalk.bold(`${path.basename(scriptPath)} ${folder} ${pattern} ${outputFile}`));
@@ -113,7 +113,3 @@ if (require.main === module) {
         open(`${outputFile}.svg`);
     });
 }
-
-module.exports = {
-    generateFlameChart,
-};


### PR DESCRIPTION
In a recent [PR](https://github.com/BabylonJS/Babylon.js/pull/15344), I added overloads of the various `SceneLoader` static functions that take an options param to make it easier to configure behavior of the loaders. In this PR, I am moving the new functions out of the static class and into module level functions. I'm doing this for two reasons:

1. Conceptually we want to move away from static classes to improve tree shaking.
2. Concretely in the alpha viewer I see 75% (7.5kb minified) of the SceneLoader code not being executed.

If we make this change now, then we don't have to deal with back compat later, and I can remove some of the code I previously had to add to distinguish between overloads (since the "legacy" functions are part of the static class, and the new ones are totally separate module level functions).

This change requires moving pretty much all the state and core functionality out of the SceneLoader static class and then having the static class functions just call the module level functions. This cuts the viewer package size down by about 5kb.

I also tacked on a handful of small viewer related fixes.