### PR TITLE
Fix shaders not exported and add script to detect

### DIFF
--- a/packages/dev/core/src/Layers/index.ts
+++ b/packages/dev/core/src/Layers/index.ts
@@ -18,3 +18,9 @@ export * from "../Shaders/glowBlurPostProcess.fragment";
 export * from "../ShadersWGSL/glowMapMerge.fragment";
 export * from "../ShadersWGSL/glowMapMerge.vertex";
 export * from "../ShadersWGSL/glowBlurPostProcess.fragment";
+
+// Layers shaders
+export * from "../Shaders/layer.fragment";
+export * from "../Shaders/layer.vertex";
+export * from "../ShadersWGSL/layer.fragment";
+export * from "../ShadersWGSL/layer.vertex";

--- a/packages/dev/core/src/Layers/layer.ts
+++ b/packages/dev/core/src/Layers/layer.ts
@@ -16,8 +16,6 @@ import type { RenderTargetTexture } from "../Materials/Textures/renderTargetText
 import type { DataBuffer } from "../Buffers/dataBuffer";
 import { DrawWrapper } from "../Materials/drawWrapper";
 
-import "../Shaders/layer.fragment";
-import "../Shaders/layer.vertex";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**

--- a/packages/dev/core/src/Meshes/index.ts
+++ b/packages/dev/core/src/Meshes/index.ts
@@ -38,3 +38,5 @@ export * from "./GaussianSplatting/gaussianSplattingMesh";
 // LineMesh
 export * from "../Shaders/color.fragment";
 export * from "../Shaders/color.vertex";
+export * from "../ShadersWGSL/color.fragment";
+export * from "../ShadersWGSL/color.vertex";

--- a/packages/dev/core/src/PostProcesses/index.ts
+++ b/packages/dev/core/src/PostProcesses/index.ts
@@ -47,3 +47,4 @@ export * from "../ShadersWGSL/passCube.fragment";
 
 // vrDFistortionCorrection postprocess
 export * from "../Shaders/vrDistortionCorrection.fragment";
+export * from "../ShadersWGSL/vrDistortionCorrection.fragment";

--- a/packages/public/umd/babylonjs/package.json
+++ b/packages/public/umd/babylonjs/package.json
@@ -8,6 +8,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run build:dev && npm run build:prod && npm run build:declaration",
+        "postbuild": "node ./scripts/checkNoChunks.js",
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",

--- a/packages/public/umd/babylonjs/scripts/checkNoChunks.js
+++ b/packages/public/umd/babylonjs/scripts/checkNoChunks.js
@@ -1,0 +1,21 @@
+// get a list of files in the current directory
+const fs = require("fs");
+const path = require("path");
+
+const directoryPath = path.join(".");
+const files = fs.readdirSync(directoryPath);
+
+// check there are no files that start with number or dev_core
+let hasError = false;
+files.some((file) => {
+    if (file.startsWith("dev_core") || !isNaN(file.charAt(0))) {
+        // eslint-disable-next-line no-console
+        console.error(`#error Chunks were introduced to UMD in this build.`);
+        hasError = true;
+    }
+    return hasError;
+});
+
+if (hasError) {
+    process.exit(1);
+}


### PR DESCRIPTION
CC @deltakosh

Build will now fail if UMD has chunks generated. This will remind PR submitters to make sure to export async-imports to UMD.