### PR TITLE
Make inspector glTF loader/extension overrides optional

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
@@ -22,8 +22,21 @@ interface IGLTFComponentProps {
     lockObject: LockObject;
 }
 
-export class GLTFComponent extends React.Component<IGLTFComponentProps> {
+interface IGLTFComponentState {
+    showGLTFLoaderOptions: boolean;
+    showGLTFExtensionOptions: boolean;
+}
+
+export class GLTFComponent extends React.Component<IGLTFComponentProps, IGLTFComponentState> {
     private _onValidationResultsUpdatedObserver: Nullable<Observer<Nullable<IGLTFValidationResults>>> = null;
+
+    constructor(props: IGLTFComponentProps) {
+        super(props);
+        this.state = {
+            showGLTFLoaderOptions: this.props.globalState.glTFLoaderOverrideConfig,
+            showGLTFExtensionOptions: this.props.globalState.glTFLoaderOverrideExtensionsConfig,
+        };
+    }
 
     openValidationDetails() {
         const validationResults = this.props.globalState.validationResults;
@@ -115,173 +128,203 @@ export class GLTFComponent extends React.Component<IGLTFComponentProps> {
         return (
             <div>
                 <LineContainerComponent title="GLTF LOADER" closed={true} selection={this.props.globalState}>
-                    <CheckBoxLineComponent label="Always compute bounding box" target={loaderState} propertyName="alwaysComputeBoundingBox" />
-                    <CheckBoxLineComponent label="Always compute skeleton root node" target={loaderState} propertyName="alwaysComputeSkeletonRootNode" />
-                    <OptionsLine label="Animation start mode" options={animationStartMode} target={loaderState} propertyName="animationStartMode" />
-                    <CheckBoxLineComponent label="Capture performance counters" target={loaderState} propertyName="capturePerformanceCounters" />
-                    <CheckBoxLineComponent label="Compile materials" target={loaderState} propertyName="compileMaterials" />
-                    <CheckBoxLineComponent label="Compile shadow generators" target={loaderState} propertyName="compileShadowGenerators" />
-                    <OptionsLine label="Coordinate system" options={coordinateSystemMode} target={loaderState} propertyName="coordinateSystemMode" />
-                    <CheckBoxLineComponent label="Create instances" target={loaderState} propertyName="createInstances" />
-                    <CheckBoxLineComponent label="Enable logging" target={loaderState} propertyName="loggingEnabled" />
-                    <CheckBoxLineComponent label="Load all materials" target={loaderState} propertyName="loadAllMaterials" />
-                    <FloatLineComponent lockObject={this.props.lockObject} label="Target FPS" target={loaderState} propertyName="targetFps" isInteger={true} />
-                    <CheckBoxLineComponent label="Transparency as coverage" target={loaderState} propertyName="transparencyAsCoverage" />
-                    <CheckBoxLineComponent label="Use clip plane" target={loaderState} propertyName="useClipPlane" />
-                    <CheckBoxLineComponent label="Use sRGB buffers" target={loaderState} propertyName="useSRGBBuffers" />
-                    <CheckBoxLineComponent label="Validate" target={loaderState} propertyName="validate" />
-                    <MessageLineComponent text="You need to reload your file to see these changes" />
+                    <CheckBoxLineComponent
+                        label="Override glTF loader options"
+                        target={this.props.globalState}
+                        propertyName="glTFLoaderOverrideConfig"
+                        onValueChanged={() => this.setState({ showGLTFLoaderOptions: this.props.globalState.glTFLoaderOverrideConfig })}
+                    />
+                    <MessageLineComponent
+                        text={this.props.globalState.glTFLoaderOverrideConfig ? "Modify glTF loader overrides below" : "Toggle on glTF loader overrides to see and change options"}
+                    />
+                    {this.state.showGLTFLoaderOptions && (
+                        <>
+                            <CheckBoxLineComponent label="Always compute bounding box" target={loaderState} propertyName="alwaysComputeBoundingBox" />
+                            <CheckBoxLineComponent label="Always compute skeleton root node" target={loaderState} propertyName="alwaysComputeSkeletonRootNode" />
+                            <OptionsLine label="Animation start mode" options={animationStartMode} target={loaderState} propertyName="animationStartMode" />
+                            <CheckBoxLineComponent label="Capture performance counters" target={loaderState} propertyName="capturePerformanceCounters" />
+                            <CheckBoxLineComponent label="Compile materials" target={loaderState} propertyName="compileMaterials" />
+                            <CheckBoxLineComponent label="Compile shadow generators" target={loaderState} propertyName="compileShadowGenerators" />
+                            <OptionsLine label="Coordinate system" options={coordinateSystemMode} target={loaderState} propertyName="coordinateSystemMode" />
+                            <CheckBoxLineComponent label="Create instances" target={loaderState} propertyName="createInstances" />
+                            <CheckBoxLineComponent label="Enable logging" target={loaderState} propertyName="loggingEnabled" />
+                            <CheckBoxLineComponent label="Load all materials" target={loaderState} propertyName="loadAllMaterials" />
+                            <FloatLineComponent lockObject={this.props.lockObject} label="Target FPS" target={loaderState} propertyName="targetFps" isInteger={true} />
+                            <CheckBoxLineComponent label="Transparency as coverage" target={loaderState} propertyName="transparencyAsCoverage" />
+                            <CheckBoxLineComponent label="Use clip plane" target={loaderState} propertyName="useClipPlane" />
+                            <CheckBoxLineComponent label="Use sRGB buffers" target={loaderState} propertyName="useSRGBBuffers" />
+                            <CheckBoxLineComponent label="Validate" target={loaderState} propertyName="validate" />
+                            <MessageLineComponent text="You need to reload your file to see these changes" />
+                        </>
+                    )}
                 </LineContainerComponent>
                 <LineContainerComponent title="GLTF EXTENSIONS" closed={true} selection={this.props.globalState}>
                     <CheckBoxLineComponent
-                        label="EXT_lights_image_based"
-                        isSelected={() => extensionStates["EXT_lights_image_based"].enabled}
-                        onSelect={(value) => (extensionStates["EXT_lights_image_based"].enabled = value)}
+                        label="Override glTF extension options"
+                        target={this.props.globalState}
+                        propertyName="glTFLoaderOverrideExtensionsConfig"
+                        onValueChanged={() => this.setState({ showGLTFExtensionOptions: this.props.globalState.glTFLoaderOverrideExtensionsConfig })}
                     />
-                    <CheckBoxLineComponent
-                        label="EXT_mesh_gpu_instancing"
-                        isSelected={() => extensionStates["EXT_mesh_gpu_instancing"].enabled}
-                        onSelect={(value) => (extensionStates["EXT_mesh_gpu_instancing"].enabled = value)}
+                    <MessageLineComponent
+                        text={
+                            this.props.globalState.glTFLoaderOverrideExtensionsConfig
+                                ? "Modify glTF extension overrides below"
+                                : "Toggle on glTF extension overrides to see and change options"
+                        }
                     />
-                    <CheckBoxLineComponent
-                        label="EXT_texture_webp"
-                        isSelected={() => extensionStates["EXT_texture_webp"].enabled}
-                        onSelect={(value) => (extensionStates["EXT_texture_webp"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="EXT_texture_avif"
-                        isSelected={() => extensionStates["EXT_texture_avif"].enabled}
-                        onSelect={(value) => (extensionStates["EXT_texture_avif"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_draco_mesh_compression"
-                        isSelected={() => extensionStates["KHR_draco_mesh_compression"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_draco_mesh_compression"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_pbrSpecularGloss..."
-                        isSelected={() => extensionStates["KHR_materials_pbrSpecularGlossiness"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_pbrSpecularGlossiness"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_clearcoat"
-                        isSelected={() => extensionStates["KHR_materials_clearcoat"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_clearcoat"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_iridescence"
-                        isSelected={() => extensionStates["KHR_materials_iridescence"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_iridescence"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_anisotropy"
-                        isSelected={() => extensionStates["KHR_materials_anisotropy"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_anisotropy"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_emissive_strength"
-                        isSelected={() => extensionStates["KHR_materials_emissive_strength"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_emissive_strength"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_ior"
-                        isSelected={() => extensionStates["KHR_materials_ior"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_ior"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_sheen"
-                        isSelected={() => extensionStates["KHR_materials_sheen"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_sheen"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_specular"
-                        isSelected={() => extensionStates["KHR_materials_specular"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_specular"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_unlit"
-                        isSelected={() => extensionStates["KHR_materials_unlit"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_unlit"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_variants"
-                        isSelected={() => extensionStates["KHR_materials_variants"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_variants"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_transmission"
-                        isSelected={() => extensionStates["KHR_materials_transmission"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_transmission"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_diffuse_transmission"
-                        isSelected={() => extensionStates["KHR_materials_diffuse_transmission"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_diffuse_transmission"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_volume"
-                        isSelected={() => extensionStates["KHR_materials_volume"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_volume"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_materials_dispersion"
-                        isSelected={() => extensionStates["KHR_materials_dispersion"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_materials_dispersion"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_mesh_quantization"
-                        isSelected={() => extensionStates["KHR_mesh_quantization"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_mesh_quantization"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_lights_punctual"
-                        isSelected={() => extensionStates["KHR_lights_punctual"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_lights_punctual"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_texture_basisu"
-                        isSelected={() => extensionStates["KHR_texture_basisu"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_texture_basisu"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_texture_transform"
-                        isSelected={() => extensionStates["KHR_texture_transform"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_texture_transform"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="KHR_xmp_json_ld"
-                        isSelected={() => extensionStates["KHR_xmp_json_ld"].enabled}
-                        onSelect={(value) => (extensionStates["KHR_xmp_json_ld"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="MSFT_lod"
-                        isSelected={() => extensionStates["MSFT_lod"].enabled}
-                        onSelect={(value) => (extensionStates["MSFT_lod"].enabled = value)}
-                    />
-                    <FloatLineComponent
-                        lockObject={this.props.lockObject}
-                        label="Maximum LODs"
-                        target={extensionStates["MSFT_lod"]}
-                        propertyName="maxLODsToLoad"
-                        additionalClass="gltf-extension-property"
-                        isInteger={true}
-                    />
-                    <CheckBoxLineComponent
-                        label="MSFT_minecraftMesh"
-                        isSelected={() => extensionStates["MSFT_minecraftMesh"].enabled}
-                        onSelect={(value) => (extensionStates["MSFT_minecraftMesh"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="MSFT_sRGBFactors"
-                        isSelected={() => extensionStates["MSFT_sRGBFactors"].enabled}
-                        onSelect={(value) => (extensionStates["MSFT_sRGBFactors"].enabled = value)}
-                    />
-                    <CheckBoxLineComponent
-                        label="MSFT_audio_emitter"
-                        isSelected={() => extensionStates["MSFT_audio_emitter"].enabled}
-                        onSelect={(value) => (extensionStates["MSFT_audio_emitter"].enabled = value)}
-                    />
-                    <MessageLineComponent text="You need to reload your file to see these changes" />
+                    {this.state.showGLTFExtensionOptions && (
+                        <>
+                            <CheckBoxLineComponent
+                                label="EXT_lights_image_based"
+                                isSelected={() => extensionStates["EXT_lights_image_based"].enabled}
+                                onSelect={(value) => (extensionStates["EXT_lights_image_based"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="EXT_mesh_gpu_instancing"
+                                isSelected={() => extensionStates["EXT_mesh_gpu_instancing"].enabled}
+                                onSelect={(value) => (extensionStates["EXT_mesh_gpu_instancing"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="EXT_texture_webp"
+                                isSelected={() => extensionStates["EXT_texture_webp"].enabled}
+                                onSelect={(value) => (extensionStates["EXT_texture_webp"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="EXT_texture_avif"
+                                isSelected={() => extensionStates["EXT_texture_avif"].enabled}
+                                onSelect={(value) => (extensionStates["EXT_texture_avif"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_draco_mesh_compression"
+                                isSelected={() => extensionStates["KHR_draco_mesh_compression"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_draco_mesh_compression"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_pbrSpecularGloss..."
+                                isSelected={() => extensionStates["KHR_materials_pbrSpecularGlossiness"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_pbrSpecularGlossiness"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_clearcoat"
+                                isSelected={() => extensionStates["KHR_materials_clearcoat"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_clearcoat"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_iridescence"
+                                isSelected={() => extensionStates["KHR_materials_iridescence"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_iridescence"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_anisotropy"
+                                isSelected={() => extensionStates["KHR_materials_anisotropy"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_anisotropy"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_emissive_strength"
+                                isSelected={() => extensionStates["KHR_materials_emissive_strength"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_emissive_strength"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_ior"
+                                isSelected={() => extensionStates["KHR_materials_ior"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_ior"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_sheen"
+                                isSelected={() => extensionStates["KHR_materials_sheen"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_sheen"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_specular"
+                                isSelected={() => extensionStates["KHR_materials_specular"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_specular"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_unlit"
+                                isSelected={() => extensionStates["KHR_materials_unlit"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_unlit"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_variants"
+                                isSelected={() => extensionStates["KHR_materials_variants"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_variants"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_transmission"
+                                isSelected={() => extensionStates["KHR_materials_transmission"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_transmission"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_diffuse_transmission"
+                                isSelected={() => extensionStates["KHR_materials_diffuse_transmission"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_diffuse_transmission"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_volume"
+                                isSelected={() => extensionStates["KHR_materials_volume"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_volume"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_materials_dispersion"
+                                isSelected={() => extensionStates["KHR_materials_dispersion"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_materials_dispersion"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_mesh_quantization"
+                                isSelected={() => extensionStates["KHR_mesh_quantization"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_mesh_quantization"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_lights_punctual"
+                                isSelected={() => extensionStates["KHR_lights_punctual"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_lights_punctual"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_texture_basisu"
+                                isSelected={() => extensionStates["KHR_texture_basisu"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_texture_basisu"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_texture_transform"
+                                isSelected={() => extensionStates["KHR_texture_transform"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_texture_transform"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="KHR_xmp_json_ld"
+                                isSelected={() => extensionStates["KHR_xmp_json_ld"].enabled}
+                                onSelect={(value) => (extensionStates["KHR_xmp_json_ld"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="MSFT_lod"
+                                isSelected={() => extensionStates["MSFT_lod"].enabled}
+                                onSelect={(value) => (extensionStates["MSFT_lod"].enabled = value)}
+                            />
+                            <FloatLineComponent
+                                lockObject={this.props.lockObject}
+                                label="Maximum LODs"
+                                target={extensionStates["MSFT_lod"]}
+                                propertyName="maxLODsToLoad"
+                                additionalClass="gltf-extension-property"
+                                isInteger={true}
+                            />
+                            <CheckBoxLineComponent
+                                label="MSFT_minecraftMesh"
+                                isSelected={() => extensionStates["MSFT_minecraftMesh"].enabled}
+                                onSelect={(value) => (extensionStates["MSFT_minecraftMesh"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="MSFT_sRGBFactors"
+                                isSelected={() => extensionStates["MSFT_sRGBFactors"].enabled}
+                                onSelect={(value) => (extensionStates["MSFT_sRGBFactors"].enabled = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="MSFT_audio_emitter"
+                                isSelected={() => extensionStates["MSFT_audio_emitter"].enabled}
+                                onSelect={(value) => (extensionStates["MSFT_audio_emitter"].enabled = value)}
+                            />
+                            <MessageLineComponent text="You need to reload your file to see these changes" />
+                        </>
+                    )}
                 </LineContainerComponent>
                 {this.props.globalState.validationResults && this.renderValidation()}
             </div>

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -33,6 +33,7 @@ export class GlobalState {
 
     public onExtensionLoadedObservable: Observable<IGLTFLoaderExtension>;
 
+    public glTFLoaderOverrideExtensionsConfig = false;
     public glTFLoaderExtensionDefaults: { [name: string]: { [key: string]: any } } = {
         MSFT_lod: { enabled: true, maxLODsToLoad: 10 },
         MSFT_minecraftMesh: { enabled: true },
@@ -64,6 +65,7 @@ export class GlobalState {
         EXT_texture_avif: { enabled: true },
     };
 
+    public glTFLoaderOverrideConfig = false;
     public glTFLoaderDefaults: { [key: string]: any } = {
         alwaysComputeBoundingBox: false,
         alwaysComputeSkeletonRootNode: false,
@@ -131,18 +133,23 @@ export class GlobalState {
 
     public prepareGLTFPlugin(loader: GLTFFileLoader) {
         this.glTFLoaderExtensions = {};
-        const loaderState = this.glTFLoaderDefaults;
-        if (loaderState !== undefined) {
-            for (const key in loaderState) {
-                (loader as any)[key] = loaderState[key];
+
+        if (this.glTFLoaderOverrideConfig) {
+            const loaderState = this.glTFLoaderDefaults;
+            if (loaderState !== undefined) {
+                for (const key in loaderState) {
+                    (loader as any)[key] = loaderState[key];
+                }
             }
         }
 
         loader.onExtensionLoadedObservable.add((extension: import("loaders/glTF/index").IGLTFLoaderExtension) => {
-            const extensionState = this.glTFLoaderExtensionDefaults[extension.name];
-            if (extensionState !== undefined) {
-                for (const key in extensionState) {
-                    (extension as any)[key] = extensionState[key];
+            if (this.glTFLoaderOverrideExtensionsConfig) {
+                const extensionState = this.glTFLoaderExtensionDefaults[extension.name];
+                if (extensionState !== undefined) {
+                    for (const key in extensionState) {
+                        (extension as any)[key] = extensionState[key];
+                    }
                 }
             }
 


### PR DESCRIPTION
Creating draft PR to test this since I still can't get the Playground to build correctly locally (🆘 @RaananW). EDIT: Realized even though the TS is not working and `BABYLON` shows up as `any` even in JS, the JS still does work so I can at least test it that way.

Currently, Inspector always overrides glTF loader and extension options once it has been initialized. This is usually not the behavior you want, especially now with the new loader functions that take a config. In this case, all config values are just always overridden by inspector. We do still have use cases for setting loader and extension options in Inspector though, particularly in Sandbox (cc @sebavan). This change makes glTF loader and extension overrides through inspector optional, and off by default. It looks like this now by default:

![image](https://github.com/user-attachments/assets/a860ed3a-773a-45ed-b345-bb594b505604)

When these override toggles are enabled, it looks like this:

![image](https://github.com/user-attachments/assets/1e6e2218-d582-4ff2-80cc-709d8d2d70df)
...
![image](https://github.com/user-attachments/assets/825e53d1-8e09-48ed-b963-21704811a133)
...