### PR TITLE
Bugfix for part matching in xmlLoader

### DIFF
--- a/packages/dev/gui/src/2D/xmlLoader.ts
+++ b/packages/dev/gui/src/2D/xmlLoader.ts
@@ -87,7 +87,10 @@ export class XmlLoader {
                     }
                 } else if (node.attributes[i].value.match(/{{.*}}/)) {
                     const matches = node.attributes[i].value.match(/{{(.*)}}/);
-                    const element = (node.attributes[i].value as string).replace(/{{.*}}/, `${this._getChainElement(matches[1])}`);
+                    let element = this._getChainElement(matches[1]);
+                    if(!(node.attributes[i].value.startsWith("{{") && node.attributes[i].value.endsWith("}}")){
+                        element = (node.attributes[i].value as string).replace(/{{.*}}/, `${element}`);
+                    }
                     guiNode[node.attributes[i].name] = element;
                 } else if (!this._objectAttributes[node.attributes[i].name]) {
                     if (node.attributes[i].value == "true" || node.attributes[i].value == "false") {

--- a/packages/dev/gui/src/2D/xmlLoader.ts
+++ b/packages/dev/gui/src/2D/xmlLoader.ts
@@ -88,7 +88,7 @@ export class XmlLoader {
                 } else if (node.attributes[i].value.match(/{{.*}}/)) {
                     const matches = node.attributes[i].value.match(/{{(.*)}}/);
                     let element = this._getChainElement(matches[1]);
-                    if(!(node.attributes[i].value.startsWith("{{") && node.attributes[i].value.endsWith("}}"))){
+                    if (!(node.attributes[i].value.startsWith("{{") && node.attributes[i].value.endsWith("}}"))) {
                         element = (node.attributes[i].value as string).replace(/{{.*}}/, `${element}`);
                     }
                     guiNode[node.attributes[i].name] = element;

--- a/packages/dev/gui/src/2D/xmlLoader.ts
+++ b/packages/dev/gui/src/2D/xmlLoader.ts
@@ -88,7 +88,7 @@ export class XmlLoader {
                 } else if (node.attributes[i].value.match(/{{.*}}/)) {
                     const matches = node.attributes[i].value.match(/{{(.*)}}/);
                     let element = this._getChainElement(matches[1]);
-                    if(!(node.attributes[i].value.startsWith("{{") && node.attributes[i].value.endsWith("}}")){
+                    if(!(node.attributes[i].value.startsWith("{{") && node.attributes[i].value.endsWith("}}"))){
                         element = (node.attributes[i].value as string).replace(/{{.*}}/, `${element}`);
                     }
                     guiNode[node.attributes[i].name] = element;


### PR DESCRIPTION
A new change made to the the XML Loader in commit #15262 introduced a new bug that causes gui node attribute values to always be cast as string, producing unintended behaviour.

This is a small bugfix to restore the previous (intended) behaviour while keeping the new feature intact.