### PR TITLE
fix UMD declaration if interface is in the default namespace

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -308,6 +308,8 @@ function getPackageDeclaration(
     const packageMapping = getPackageMappingByDevName(devPackageName);
     const defaultModuleName = getPublicPackageName(packageMapping.namespace);
     const thisFileModuleName = getPublicPackageName(packageMapping.namespace, sourceFilePath);
+    const linesToDefaultNamespace: string[] = [];
+    let addToDefaultModule = false;
     while (i < lines.length) {
         let line = lines[i];
 
@@ -334,6 +336,13 @@ function getPackageDeclaration(
 
         const match = line.match(/(\s*)declare module "(.*)" \{/);
         if (match) {
+            // try to match namespace
+            const fileToCheck = path.resolve(path.dirname(sourceFilePath), match[2] + ".d.ts");
+            const moduleName = getPublicPackageName(packageMapping.namespace, fileToCheck);
+            if (moduleName !== thisFileModuleName && moduleName === defaultModuleName) {
+                addToDefaultModule = true;
+            }
+
             lastWhitespace = match[1];
             removeNext = true;
             excludeLine = true;
@@ -342,6 +351,7 @@ function getPackageDeclaration(
         if (removeNext && line.indexOf(`${lastWhitespace}}`) === 0) {
             removeNext = false;
             excludeLine = true;
+            addToDefaultModule = false;
         }
 
         if (/namespace (.*) \{/.test(line)) {
@@ -353,13 +363,18 @@ function getPackageDeclaration(
         if (excludeLine) {
             lines[i] = "";
         } else {
-            if (line.indexOf("declare ") !== -1) {
-                lines[i] = line.replace("declare ", "");
+            if (addToDefaultModule) {
+                linesToDefaultNamespace.push(line);
+                lines[i] = "";
             } else {
-                lines[i] = line;
+                if (line.indexOf("declare ") !== -1) {
+                    lines[i] = line.replace("declare ", "");
+                } else {
+                    lines[i] = line;
+                }
+                //Add tab
+                lines[i] = "    " + lines[i];
             }
-            //Add tab
-            lines[i] = "    " + lines[i];
         }
         i++;
     }
@@ -418,6 +433,7 @@ declare module ${thisFileModuleName} {
     ${processedSource}
 }
 declare module ${defaultModuleName} {
+${linesToDefaultNamespace.join("\n")}
 `;
     }
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -18,7 +18,7 @@ declare module "../../glTFFileLoader" {
         /**
          * Defines options for the MSFT_lod extension.
          */
-        [NAME]?: Partial<{
+        ["MSFT_lod"]?: Partial<{
             /**
              * Maximum number of LODs to load, starting from the lowest LOD.
              */


### PR DESCRIPTION
See MSFT_lod as example - the declare module is updating an interface on the BABYLON namespace, but the file itself exists in a different (UMD) namespace.

This change allows making this kind of declaration - if the interface is defined in the global namespace, it will be added to the global namespace (BABYLON in UMD).

Note that when this is done, we can't have variable references inside the interface declaration (hence the change in the extension). This is because the declaration moves to a different namespace where the variable is not defined.