### PR TITLE
move isPaused to restart

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -731,8 +731,6 @@ export class AnimationGroup implements IDisposable {
             this.start(loop, this._speedRatio);
         }
 
-        this._isPaused = false;
-
         return this;
     }
 
@@ -773,6 +771,8 @@ export class AnimationGroup implements IDisposable {
         this.syncWithMask();
 
         this.onAnimationGroupPlayObservable.notifyObservers(this);
+
+        this._isPaused = false;
 
         return this;
     }


### PR DESCRIPTION
Fixes #15416

The reason for removing is from "play" is that it is already being set in both start and restart. Better yet, under certain conditions it will not be set in `start` and it is therefore better not to set it in `play`, as `start` is not 100% guaranteed to start it