### PR TITLE
Added getter for Animation group current frame

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -244,10 +244,6 @@ export class AnimationGroup implements IDisposable {
         }
     }
 
-    public get currentFrame(): number {
-        return this.animatables[0]?.masterFrame || 0;
-    }
-
     /**
      * Define if the animations are started
      */
@@ -866,6 +862,13 @@ export class AnimationGroup implements IDisposable {
         }
 
         return this;
+    }
+
+    /**
+     * Gets the current frame.
+     */
+    public getCurrentFrame(): number {
+        return this.animatables[0]?.masterFrame || 0;
     }
 
     /**

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -865,7 +865,7 @@ export class AnimationGroup implements IDisposable {
     }
 
     /**
-     * Gets the current frame.
+     * Helper to get the current frame. This will return 0 if the AnimationGroup is not running.
      */
     public getCurrentFrame(): number {
         return this.animatables[0]?.masterFrame || 0;

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -866,6 +866,7 @@ export class AnimationGroup implements IDisposable {
 
     /**
      * Helper to get the current frame. This will return 0 if the AnimationGroup is not running, and it might return wrong results if multiple animations are running in different frames.
+     * @returns current animation frame.
      */
     public getCurrentFrame(): number {
         return this.animatables[0]?.masterFrame || 0;

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -244,6 +244,10 @@ export class AnimationGroup implements IDisposable {
         }
     }
 
+    public get currentFrame(): number {
+        return this.animatables[0]?.masterFrame || 0;
+    }
+
     /**
      * Define if the animations are started
      */

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -865,7 +865,7 @@ export class AnimationGroup implements IDisposable {
     }
 
     /**
-     * Helper to get the current frame. This will return 0 if the AnimationGroup is not running.
+     * Helper to get the current frame. This will return 0 if the AnimationGroup is not running, and it might return wrong results if multiple animations are running in different frames.
      */
     public getCurrentFrame(): number {
         return this.animatables[0]?.masterFrame || 0;


### PR DESCRIPTION
Added a little helper function to try to get current frame AnimationGroup. This is required to simplify the workflow for users such as this one from the forum: https://forum.babylonjs.com/t/animationgroup-targetedanimation-get-current-animation-frame/52778