### PR TITLE
Fix detailmap, depthprepass, morphtarget, decal, refreaction on webgpu

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
@@ -1,4 +1,4 @@
 #ifdef DEPTHPREPASS
-	gl_FragColor =  vec4f(0., 0., 0., 1.0);
+	fragmentOutputs.color =  vec4f(0., 0., 0., 1.0);
 	return;
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
@@ -1,4 +1,4 @@
 #ifdef DEPTHPREPASS
 	fragmentOutputs.color =  vec4f(0., 0., 0., 1.0);
-	return;
+	return fragmentOutputs;
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -33,7 +33,7 @@
 		#endif
 
 		#ifdef MORPHTARGETS_TANGENT
-		    tangentUpdated.xyz = tangentUpdated.xyz + (vertexInputs.tangent{X} - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[{X}];
+		    tangentUpdated = vec4f(tangentUpdated.xyz + (vertexInputs.tangent{X} - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[{X}], tangentUpdated.a);
 		#endif
 
 		#ifdef MORPHTARGETS_UV

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/oitFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/oitFragment.fx
@@ -6,7 +6,7 @@
     var fragDepth: f32 = fragmentInputs.position.z;   // 0 - 1
 
 #ifdef ORDER_INDEPENDENT_TRANSPARENCY_16BITS
-    uvar halfFloat: i32 = packHalf2x16( vec2f(fragDepth));
+    var halfFloat: i32 = packHalf2x16( vec2f(fragDepth));
     var full: vec2f = unpackHalf2x16(halfFloat);
     fragDepth = full.x;
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockAlbedoOpacity.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockAlbedoOpacity.fx
@@ -53,7 +53,7 @@ fn albedoOpacityBlock(
     #endif
 
     #ifdef DETAIL
-        var detailAlbedo: f32 = 2.0 * mix(0.5, detailColor.r, vDetailInfos.y);
+        var detailAlbedo: f32 = 2.0 * mix(0.5, detailColor.r, fragmentInputs.vDetailInfos.y);
         surfaceAlbedo = surfaceAlbedo.rgb * detailAlbedo * detailAlbedo; // should be pow(detailAlbedo, 2.2) but detailAlbedo² is close enough and cheaper to compute
     #endif
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockAlbedoOpacity.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockAlbedoOpacity.fx
@@ -53,7 +53,7 @@ fn albedoOpacityBlock(
     #endif
 
     #ifdef DETAIL
-        var detailAlbedo: f32 = 2.0 * mix(0.5, detailColor.r, fragmentInputs.vDetailInfos.y);
+        var detailAlbedo: f32 = 2.0 * mix(0.5, detailColor.r, vDetailInfos.y);
         surfaceAlbedo = surfaceAlbedo.rgb * detailAlbedo * detailAlbedo; // should be pow(detailAlbedo, 2.2) but detailAlbedo² is close enough and cheaper to compute
     #endif
 

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -148,7 +148,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 #endif
 
 #ifdef DETAIL
-    baseColor = vec4f(baseColor.rgb * 2.0 * mix(0.5, detailColor.r, fragmentInputs.vDetailInfos.y), baseColor.a);
+    baseColor = vec4f(baseColor.rgb * 2.0 * mix(0.5, detailColor.r, uniforms.vDetailInfos.y), baseColor.a);
 #endif
 
 #if defined(DECAL) && defined(DECAL_AFTER_DETAIL)

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -221,7 +221,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 			refractionColor = refractionLookup;
 		}
 	#else
-		var vRefractionUVW: vec3f =  vec3f(uniforms.refractionMatrix * (scene.view *  vec4f(fragmentInputs.vPositionW + refractionVector * uniforms.vRefractionInfos.z, 1.0)));
+		var vRefractionUVW: vec3f =  (uniforms.refractionMatrix * (scene.view *  vec4f(fragmentInputs.vPositionW + refractionVector * uniforms.vRefractionInfos.z, 1.0))).xyz;
 
 		var refractionCoords: vec2f = vRefractionUVW.xy / vRefractionUVW.z;
 

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -148,7 +148,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 #endif
 
 #ifdef DETAIL
-    baseColor = vec4f(baseColor.rgb * 2.0 * mix(0.5, detailColor.r, vDetailInfos.y), baseColor.a);
+    baseColor = vec4f(baseColor.rgb * 2.0 * mix(0.5, detailColor.r, fragmentInputs.vDetailInfos.y), baseColor.a);
 #endif
 
 #if defined(DECAL) && defined(DECAL_AFTER_DETAIL)

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -137,7 +137,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 #endif
 
 #if defined(DECAL) && !defined(DECAL_AFTER_DETAIL)
-	var decalColor: vec4f = textureSample(decalSampler, decalSamplerSampler, vDecalUV + uvOffset);
+	var decalColor: vec4f = textureSample(decalSampler, decalSamplerSampler, fragmentInputs.vDecalUV + uvOffset);
 	#include<decalFragment>(surfaceAlbedo, baseColor, GAMMADECAL, _GAMMADECAL_NOTUSED_)
 #endif
 
@@ -152,7 +152,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 #endif
 
 #if defined(DECAL) && defined(DECAL_AFTER_DETAIL)
-	var decalColor: vec4f = textureSample(decalSampler, decalSamplerSampler, vDecalUV + uvOffset);
+	var decalColor: vec4f = textureSample(decalSampler, decalSamplerSampler, fragmentInputs.vDecalUV + uvOffset);
 	#include<decalFragment>(surfaceAlbedo, baseColor, GAMMADECAL, _GAMMADECAL_NOTUSED_)
 #endif
 
@@ -221,7 +221,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 			refractionColor = refractionLookup;
 		}
 	#else
-		var vRefractionUVW: vec3f =  vec3f(refractionMatrix * (view *  vec4f(fragmentInputs.vPositionW + refractionVector * uniforms.vRefractionInfos.z, 1.0)));
+		var vRefractionUVW: vec3f =  vec3f(uniforms.refractionMatrix * (scene.view *  vec4f(fragmentInputs.vPositionW + refractionVector * uniforms.vRefractionInfos.z, 1.0)));
 
 		var refractionCoords: vec2f = vRefractionUVW.xy / vRefractionUVW.z;
 


### PR DESCRIPTION
I did a quick look at the standard material and all the shaders it includes.

detailmap: #F8FDYT#1
depthprepass: #7A66KI
morphtarget: tangent morph target is required for test
decal: just no clue for make test :>
refraction: #22KZUW#15

+ oit doesn't support half float blending in WebGPU engine so it wont be problem. but i modified