### PR TITLE
Viewer improvements and glTF callback options

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "esbenp.prettier-vscode",
         "webhint.vscode-webhint",
         "IronGeek.vscode-env",
-        "firsttris.vscode-jest-runner"
+        "firsttris.vscode-jest-runner",
+        "ms-playwright.playwright"
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -106,6 +106,26 @@
             }
         },
         {
+            "label": "Launch visualization test runner (Dev)",
+            "dependsOn": ["CDN Serve and watch (Dev)"],
+            "type": "shell",
+            "command": "npm",
+            "runOptions": {
+                "instanceLimit": 1
+            },
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "HEADLESS": "false"
+                }
+            },
+            "args": ["run", "test:visualization:ui"],
+            "presentation": {
+                "group": "test"
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "Run Dev host (Dev)",
             "dependsOn": ["Build (Dev)"],
             "type": "shell",

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -194,16 +194,35 @@ type DefaultExtensionOptions<BaseExtensionOptions> = {
     enabled?: boolean;
 } & BaseExtensionOptions;
 
-class GLTFLoaderOptions {
+abstract class GLTFLoaderOptions {
     // eslint-disable-next-line babylonjs/available
-    public constructor(options?: Partial<Readonly<GLTFLoaderOptions>>) {
+    protected copyFrom(options?: Partial<Readonly<GLTFLoaderOptions>>) {
         if (options) {
-            for (const key in this) {
-                const typedKey = key as keyof GLTFLoaderOptions;
+            const copyOption = (option: string) => {
+                const typedKey = option as keyof GLTFLoaderOptions;
                 (this as Record<keyof GLTFLoaderOptions, unknown>)[typedKey] = options[typedKey] ?? this[typedKey];
+            };
+
+            // Copy concrete properties
+            for (const option in this) {
+                copyOption(option);
+            }
+
+            // Copy abstract properties
+            for (const option of ["onParsed", "onMeshLoaded", "onSkinLoaded", "onTextureLoaded", "onMaterialLoaded", "onCameraLoaded"] satisfies (keyof GLTFLoaderOptions)[]) {
+                copyOption(option);
             }
         }
     }
+
+    // --------------
+    // Common options
+    // --------------
+
+    /**
+     * Raised when the asset has been parsed
+     */
+    public abstract onParsed: (loaderData: IGLTFLoaderData) => void;
 
     // ----------
     // V2 options
@@ -319,6 +338,33 @@ class GLTFLoaderOptions {
     public customRootNode?: Nullable<TransformNode>;
 
     /**
+     * Callback raised when the loader creates a mesh after parsing the glTF properties of the mesh.
+     * Note that the callback is called as soon as the mesh object is created, meaning some data may not have been setup yet for this mesh (vertex data, morph targets, material, ...)
+     */
+    public abstract onMeshLoaded: (mesh: AbstractMesh) => void;
+
+    /**
+     * Callback raised when the loader creates a skin after parsing the glTF properties of the skin node.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/glTF/glTFSkinning#ignoring-the-transform-of-the-skinned-mesh
+     */
+    public abstract onSkinLoaded: (node: TransformNode, skinnedNode: TransformNode) => void;
+
+    /**
+     * Callback raised when the loader creates a texture after parsing the glTF properties of the texture.
+     */
+    public abstract onTextureLoaded: (texture: BaseTexture) => void;
+
+    /**
+     * Callback raised when the loader creates a material after parsing the glTF properties of the material.
+     */
+    public abstract onMaterialLoaded: (material: Material) => void;
+
+    /**
+     * Callback raised when the loader creates a camera after parsing the glTF properties of the camera.
+     */
+    public abstract onCameraLoaded: (camera: Camera) => void;
+
+    /**
      * Defines options for glTF extensions.
      */
     public extensionOptions: {
@@ -341,9 +387,18 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     /** @internal */
     public static _CreateGLTF2Loader: (parent: GLTFFileLoader) => IGLTFLoader;
 
-    // --------------
-    // Common options
-    // --------------
+    /**
+     * Creates a new glTF file loader.
+     * @param options The options for the loader
+     */
+    public constructor(options?: Partial<Readonly<GLTFLoaderOptions>>) {
+        super();
+        this.copyFrom(options);
+    }
+
+    // --------------------
+    // Begin Common options
+    // --------------------
 
     /**
      * Raised when the asset has been parsed
@@ -362,9 +417,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
         this._onParsedObserver = this.onParsedObservable.add(callback);
     }
 
-    // ----------
-    // V1 options
-    // ----------
+    // ------------------
+    // End Common options
+    // ------------------
+
+    // ----------------
+    // Begin V1 options
+    // ----------------
 
     /**
      * Set this property to false to disable incremental loading which delays the loader from calling the success callback until after loading the meshes and shaders.
@@ -380,6 +439,10 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
      * @internal
      */
     public static HomogeneousCoordinates = false;
+
+    // --------------
+    // End V1 options
+    // --------------
 
     /**
      * Observable raised when the loader creates a mesh after parsing the glTF properties of the mesh.
@@ -401,12 +464,25 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     }
 
     /**
-     * Callback raised when the loader creates a skin after parsing the glTF properties of the skin node.
+     * Observable raised when the loader creates a skin after parsing the glTF properties of the skin node.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/glTF/glTFSkinning#ignoring-the-transform-of-the-skinned-mesh
      * @param node - the transform node that corresponds to the original glTF skin node used for animations
      * @param skinnedNode - the transform node that is the skinned mesh itself or the parent of the skinned meshes
      */
     public readonly onSkinLoadedObservable = new Observable<{ node: TransformNode; skinnedNode: TransformNode }>();
+
+    private _onSkinLoadedObserver: Nullable<Observer<{ node: TransformNode; skinnedNode: TransformNode }>>;
+
+    /**
+     * Callback raised when the loader creates a skin after parsing the glTF properties of the skin node.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/glTF/glTFSkinning#ignoring-the-transform-of-the-skinned-mesh
+     */
+    public set onSkinLoaded(callback: (node: TransformNode, skinnedNode: TransformNode) => void) {
+        if (this._onSkinLoadedObserver) {
+            this.onSkinLoadedObservable.remove(this._onSkinLoadedObserver);
+        }
+        this._onSkinLoadedObserver = this.onSkinLoadedObservable.add((data) => callback(data.node, data.skinnedNode));
+    }
 
     /**
      * Observable raised when the loader creates a texture after parsing the glTF properties of the texture.

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -12,7 +12,10 @@ export class HTML3DElement extends HTMLElement {
     // eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/naming-convention
     public static readonly observedAttributes = Object.freeze(["src", "env"] as const);
 
-    private readonly _viewer: Viewer;
+    /**
+     * Gets the underlying Viewer object.
+     */
+    public readonly viewer: Viewer;
 
     /**
      * Creates an instance of HTML3DElement.
@@ -48,7 +51,7 @@ export class HTML3DElement extends HTMLElement {
         `;
 
         const canvas = shadowRoot.querySelector("#renderCanvas") as HTMLCanvasElement;
-        this._viewer = createViewerForCanvas(canvas);
+        this.viewer = createViewerForCanvas(canvas);
     }
 
     /**
@@ -87,10 +90,10 @@ export class HTML3DElement extends HTMLElement {
     public attributeChangedCallback(name: (typeof HTML3DElement.observedAttributes)[number], oldValue: string, newValue: string) {
         switch (name) {
             case "src":
-                this._viewer.loadModelAsync(newValue).catch(Logger.Log);
+                this.viewer.loadModelAsync(newValue).catch(Logger.Log);
                 break;
             case "env":
-                this._viewer.loadEnvironmentAsync(newValue).catch(Logger.Log);
+                this.viewer.loadEnvironmentAsync(newValue).catch(Logger.Log);
                 break;
         }
     }

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -17,23 +17,33 @@
         </style>
     </head>
 
-    <body>
+    <body ondragover="event.preventDefault()" ondrop="onDrop(event)">
         <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env"> </babylon-viewer>
         <script type="module" src="/packages/tools/viewer-alpha/src/index.ts"></script>
         <script>
+            const viewerElement = document.querySelector("babylon-viewer");
+
             (async () => {
                 // The module referenced in the script tag above is loaded asynchronously, so we need to wait for it to load and for the custom element to be defined.
                 // Alternatively, we could just await import("/packages/tools/viewer-alpha/src/index.ts") here instead.
                 await customElements.whenDefined("babylon-viewer");
                 // "BabylonViewer" is defined as the "library" in webpack.config.js and can be used to access the Viewer as needed.
-                const viewer = document.querySelector("babylon-viewer");
                 await new Promise((resolve) => setTimeout(resolve, 2000));
-                viewer.src = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
+                viewerElement.src = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
                 // error case
-                //viewer.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb';
+                //viewerElement.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb';
                 await new Promise((resolve) => setTimeout(resolve, 2000));
-                viewer.src = "https://playground.babylonjs.com/scenes/BoomBox.glb";
+                viewerElement.src = "https://playground.babylonjs.com/scenes/BoomBox.glb";
             })();
+
+            async function onDrop(event) {
+                const file = event.dataTransfer.files[0];
+                if (file) {
+                    event.preventDefault();
+                    await customElements.whenDefined("babylon-viewer");
+                    await viewerElement.viewer.loadModelAsync(file);
+                }
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
A few small changes packed into this one PR. I can break it up if anyone strongly prefers.

- Add callbacks (e.g. `onParsed`, `onMeshLoaded`, etc.) as glTF loader options #15429 
- Update Viewer's skybox scale when a new model is loaded
- Publicly expose the underlying `Viewer` object from the `HTML3DElement` (`babylon-viewer`) (I don't want to have layers and layers of abstraction, the `HTML3DElement` is just there to make it as easy as possible to integrate the `Viewer` into a web page, but we should still expose the underlying `Viewer` for JS code)
- Add drag & drop to the Viewer test app to make it easy to test local files
- Add a VSCode task to launch the visual tests within the Playwright standalone UI
- Add the Playwright VSCode extension as a recommended extension