### PR TITLE
Allow using pointer-tap event for clicking in GUI

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -152,6 +152,11 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * Defaults to false.
      */
     public disableTabNavigation = false;
+
+    /**
+     * If set to true, the POINTERTAP event type will be used for "click", instead of POINTERUP
+     */
+    public usePointerTapForClickEvent = false;
     /**
      * Gets or sets a number used to scale rendering size (2 means that the texture will be twice bigger).
      * Useful when you want more antialiasing
@@ -984,7 +989,8 @@ export class AdvancedDynamicTexture extends DynamicTexture {
                 pi.type !== PointerEventTypes.POINTERMOVE &&
                 pi.type !== PointerEventTypes.POINTERUP &&
                 pi.type !== PointerEventTypes.POINTERDOWN &&
-                pi.type !== PointerEventTypes.POINTERWHEEL
+                pi.type !== PointerEventTypes.POINTERWHEEL &&
+                pi.type !== PointerEventTypes.POINTERTAP
             ) {
                 return;
             }

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2406,7 +2406,9 @@ export class Control implements IAnimatable, IFocusableControl {
 
         let canNotifyClick: boolean = notifyClick;
         if (notifyClick && (this._enterCount > 0 || this._enterCount === -1)) {
-            canNotifyClick = this.onPointerClickObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
+            if (!this._host.usePointerTapForClickEvent) {
+                canNotifyClick = this.onPointerClickObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
+            }
         }
         const canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
 
@@ -2417,6 +2419,23 @@ export class Control implements IAnimatable, IFocusableControl {
         if (pi && this.uniqueId !== this._host.rootContainer.uniqueId) {
             this._host._capturedPointerIds.delete((pi.event as IPointerEvent).pointerId);
         }
+    }
+
+    public _onPointerPick(target: Control, coordinates: Vector2, pointerId: number, buttonIndex: number, notifyClick: boolean, pi: Nullable<PointerInfoBase>): boolean {
+        if (!this._host.usePointerTapForClickEvent) {
+            return false;
+        }
+
+        let canNotifyClick: boolean = notifyClick;
+        if (notifyClick && (this._enterCount > 0 || this._enterCount === -1)) {
+            canNotifyClick = this.onPointerClickObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
+        }
+        const canNotify: boolean = this.onPointerUpObservable.notifyObservers(new Vector2WithInfo(coordinates, buttonIndex), -1, target, this, pi);
+
+        if (canNotify && this.parent != null && !this.isPointerBlocker) {
+            this.parent._onPointerPick(target, coordinates, pointerId, buttonIndex, canNotifyClick, pi);
+        }
+        return true;
     }
 
     /**
@@ -2480,28 +2499,30 @@ export class Control implements IAnimatable, IFocusableControl {
 
             this._host._lastControlOver[pointerId] = this;
             return true;
-        }
-
-        if (type === PointerEventTypes.POINTERDOWN) {
+        } else if (type === PointerEventTypes.POINTERDOWN) {
             this._onPointerDown(this, this._dummyVector2, pointerId, buttonIndex, pi);
             this._host._registerLastControlDown(this, pointerId);
             this._host._lastPickedControl = this;
             return true;
-        }
-
-        if (type === PointerEventTypes.POINTERUP) {
+        } else if (type === PointerEventTypes.POINTERUP) {
             if (this._host._lastControlDown[pointerId]) {
                 this._host._lastControlDown[pointerId]._onPointerUp(this, this._dummyVector2, pointerId, buttonIndex, true, pi);
             }
-            delete this._host._lastControlDown[pointerId];
+            if (!this._host.usePointerTapForClickEvent) {
+                delete this._host._lastControlDown[pointerId];
+            }
             return true;
-        }
-
-        if (type === PointerEventTypes.POINTERWHEEL) {
+        } else if (type === PointerEventTypes.POINTERWHEEL) {
             if (this._host._lastControlOver[pointerId]) {
                 this._host._lastControlOver[pointerId]._onWheelScroll(deltaX, deltaY);
                 return true;
             }
+        } else if (type === PointerEventTypes.POINTERTAP) {
+            if (this._host._lastControlDown[pointerId]) {
+                this._host._lastControlDown[pointerId]._onPointerPick(this, this._dummyVector2, pointerId, buttonIndex, true, pi);
+            }
+            delete this._host._lastControlDown[pointerId];
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Test PG - #XCPP9Y#22137

This allows GUI users to use the POINTERTAP type to for click events. The difference here is that a tap will not be triggered if the pointer has moved. So a click will only be triggered if the pointer pressed down, up and no movement in between.

In the PG above, try clicking on one of the buttons and see the console. then try moving while holding the pointer and then release - a click will not be triggered. The standard behavior is to trigger a click even in this scenario.