### PR TITLE
Path transform for cross-package declarations

### DIFF
--- a/packages/dev/buildTools/src/pathTransform.ts
+++ b/packages/dev/buildTools/src/pathTransform.ts
@@ -176,6 +176,14 @@ function transformerFactory<T extends TransformerNode>(context: ts.Transformatio
                 return ts.visitEachChild(node, pathReplacer, context);
             }
 
+            /**
+             * e.g.
+             * - declare module "core/path";
+             */
+            if (ts.isModuleDeclaration(node)) {
+                return ts.visitEachChild(node, pathReplacer, context);
+            }
+
             return ts.visitEachChild(node, visitor, context);
         }
 


### PR DESCRIPTION
ES6-only - 

Path transform was skipped when declaring a module that exists in a different package. This processes module declarations in ts files as well. It will be ignored if it is relative and will be transformed corectly if not.