### PR TITLE
make sure radius is always positive or 0

### DIFF
--- a/packages/dev/gui/src/2D/controls/sliders/slider.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/slider.ts
@@ -146,6 +146,7 @@ export class Slider extends BaseSlider {
         } else {
             radius = (this._effectiveThumbThickness - this._effectiveBarOffset) / 2;
         }
+        radius = Math.max(0, radius);
 
         if (this.shadowBlur || this.shadowOffsetX || this.shadowOffsetY) {
             context.shadowColor = this.shadowColor;


### PR DESCRIPTION
Fixes https://forum.babylonjs.com/t/the-gui-editor-loses-all-color-when-the-slider-width-is-adjusted/52797?u=raananw