### PR TITLE
Remove Engine dependency from WebGPU

### DIFF
--- a/packages/dev/core/src/Audio/analyser.ts
+++ b/packages/dev/core/src/Audio/analyser.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { Nullable } from "../types";
 import type { Scene } from "../scene";
-import { Engine } from "../Engines/engine";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import { Tools } from "../Misc/tools";
 import { EngineStore } from "../Engines/engineStore";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Class used to work with sound analyzer using fast fourier transform (FFT)
@@ -57,11 +57,11 @@ export class Analyser {
             return;
         }
         this._scene = scene;
-        if (!Engine.audioEngine) {
+        if (!AbstractEngine.audioEngine) {
             Tools.Warn("No audio engine initialized, failed to create an audio analyser");
             return;
         }
-        this._audioEngine = Engine.audioEngine;
+        this._audioEngine = AbstractEngine.audioEngine;
         if (this._audioEngine.canUseWebAudio && this._audioEngine.audioContext) {
             this._webAudioAnalyser = this._audioEngine.audioContext.createAnalyser();
             this._webAudioAnalyser.minDecibels = -140;

--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -1,6 +1,5 @@
 import { Sound } from "./sound";
 import { SoundTrack } from "./soundTrack";
-import { Engine } from "../Engines/engine";
 import type { Nullable } from "../types";
 import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { ISceneSerializableComponent } from "../sceneComponent";
@@ -12,6 +11,7 @@ import type { AssetContainer } from "../assetContainer";
 import "./audioEngine";
 import { PrecisionDate } from "../Misc/precisionDate";
 import { EngineStore } from "../Engines/engineStore";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 // Adds the parser to the scene parsers.
 AbstractScene.AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
@@ -22,7 +22,7 @@ AbstractScene.AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, sc
     if (parsedData.sounds !== undefined && parsedData.sounds !== null) {
         for (let index = 0, cache = parsedData.sounds.length; index < cache; index++) {
             const parsedSound = parsedData.sounds[index];
-            if (Engine.audioEngine?.canUseWebAudio) {
+            if (AbstractEngine.audioEngine?.canUseWebAudio) {
                 if (!parsedSound.url) {
                     parsedSound.url = parsedSound.name;
                 }
@@ -434,8 +434,8 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
         const scene = this.scene;
         this._audioEnabled = false;
 
-        if (Engine.audioEngine && Engine.audioEngine.audioContext) {
-            Engine.audioEngine.audioContext.suspend();
+        if (AbstractEngine.audioEngine && AbstractEngine.audioEngine.audioContext) {
+            AbstractEngine.audioEngine.audioContext.suspend();
         }
 
         let i: number;
@@ -458,8 +458,8 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
         const scene = this.scene;
         this._audioEnabled = true;
 
-        if (Engine.audioEngine && Engine.audioEngine.audioContext) {
-            Engine.audioEngine.audioContext.resume();
+        if (AbstractEngine.audioEngine && AbstractEngine.audioEngine.audioContext) {
+            AbstractEngine.audioEngine.audioContext.resume();
         }
 
         let i: number;
@@ -529,7 +529,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
             return;
         }
 
-        const audioEngine = Engine.audioEngine;
+        const audioEngine = AbstractEngine.audioEngine;
 
         if (!audioEngine) {
             return;

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -3,7 +3,6 @@ import { Observable } from "../Misc/observable";
 import { Vector3 } from "../Maths/math.vector";
 import type { Nullable } from "../types";
 import type { Scene } from "../scene";
-import { Engine } from "../Engines/engine";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { TransformNode } from "../Meshes/transformNode";
 import { Logger } from "../Misc/logger";
@@ -13,6 +12,7 @@ import { EngineStore } from "../Engines/engineStore";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import type { Observer } from "../Misc/observable";
 import { RegisterClass } from "../Misc/typeStore";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Defines a sound that can be played in the application.
@@ -107,10 +107,10 @@ export class Sound {
             return this._htmlAudioElement.currentTime;
         }
 
-        if (Engine.audioEngine?.audioContext && (this.isPlaying || this.isPaused)) {
+        if (AbstractEngine.audioEngine?.audioContext && (this.isPlaying || this.isPaused)) {
             // The `_currentTime` member is only updated when the sound is paused. Add the time since the last start
             // to get the actual current time.
-            const timeSinceLastStart = this.isPaused ? 0 : Engine.audioEngine.audioContext.currentTime - this._startTime;
+            const timeSinceLastStart = this.isPaused ? 0 : AbstractEngine.audioEngine.audioContext.currentTime - this._startTime;
             return this._currentTime + timeSinceLastStart;
         }
 
@@ -238,8 +238,8 @@ export class Sound {
             this._offset = options.offset;
         }
 
-        if (Engine.audioEngine?.canUseWebAudio && Engine.audioEngine.audioContext) {
-            this._soundGain = Engine.audioEngine.audioContext.createGain();
+        if (AbstractEngine.audioEngine?.canUseWebAudio && AbstractEngine.audioEngine.audioContext) {
+            this._soundGain = AbstractEngine.audioEngine.audioContext.createGain();
             this._soundGain!.gain.value = this._volume;
             this._inputAudioNode = this._soundGain;
             this._outputAudioNode = this._soundGain;
@@ -274,7 +274,7 @@ export class Sound {
                         case "MediaElement":
                             this._streaming = true;
                             this._isReadyToPlay = true;
-                            this._streamingSource = Engine.audioEngine.audioContext.createMediaElementSource(urlOrArrayBuffer);
+                            this._streamingSource = AbstractEngine.audioEngine.audioContext.createMediaElementSource(urlOrArrayBuffer);
 
                             if (this.autoplay) {
                                 this.play(0, this._offset, this._length);
@@ -287,7 +287,7 @@ export class Sound {
                         case "MediaStream":
                             this._streaming = true;
                             this._isReadyToPlay = true;
-                            this._streamingSource = Engine.audioEngine.audioContext.createMediaStreamSource(urlOrArrayBuffer);
+                            this._streamingSource = AbstractEngine.audioEngine.audioContext.createMediaStreamSource(urlOrArrayBuffer);
 
                             if (this.autoplay) {
                                 this.play(0, this._offset, this._length);
@@ -318,8 +318,8 @@ export class Sound {
                                 const url = urls[i];
                                 codecSupportedFound =
                                     (options && options.skipCodecCheck) ||
-                                    (url.indexOf(".mp3", url.length - 4) !== -1 && Engine.audioEngine.isMP3supported) ||
-                                    (url.indexOf(".ogg", url.length - 4) !== -1 && Engine.audioEngine.isOGGsupported) ||
+                                    (url.indexOf(".mp3", url.length - 4) !== -1 && AbstractEngine.audioEngine.isMP3supported) ||
+                                    (url.indexOf(".ogg", url.length - 4) !== -1 && AbstractEngine.audioEngine.isOGGsupported) ||
                                     url.indexOf(".wav", url.length - 4) !== -1 ||
                                     url.indexOf(".m4a", url.length - 4) !== -1 ||
                                     url.indexOf(".mp4", url.length - 4) !== -1 ||
@@ -395,9 +395,9 @@ export class Sound {
         } else {
             // Adding an empty sound to avoid breaking audio calls for non Web Audio browsers
             this._scene.mainSoundTrack.addSound(this);
-            if (Engine.audioEngine && !Engine.audioEngine.WarnedWebAudioUnsupported) {
+            if (AbstractEngine.audioEngine && !AbstractEngine.audioEngine.WarnedWebAudioUnsupported) {
                 Logger.Error("Web Audio is not supported by your browser.");
-                Engine.audioEngine.WarnedWebAudioUnsupported = true;
+                AbstractEngine.audioEngine.WarnedWebAudioUnsupported = true;
             }
             // Simulating a ready to play event to avoid breaking code for non web audio browsers
             if (this._readyToPlayCallback) {
@@ -414,7 +414,7 @@ export class Sound {
      * Release the sound and its associated resources
      */
     public dispose() {
-        if (Engine.audioEngine?.canUseWebAudio) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio) {
             if (this.isPlaying) {
                 this.stop();
             }
@@ -474,7 +474,7 @@ export class Sound {
     }
 
     private _audioBufferLoaded(buffer: AudioBuffer) {
-        if (!Engine.audioEngine?.audioContext) {
+        if (!AbstractEngine.audioEngine?.audioContext) {
             return;
         }
         this._audioBuffer = buffer;
@@ -488,10 +488,10 @@ export class Sound {
     }
 
     private _soundLoaded(audioData: ArrayBuffer) {
-        if (!Engine.audioEngine?.audioContext) {
+        if (!AbstractEngine.audioEngine?.audioContext) {
             return;
         }
-        Engine.audioEngine.audioContext.decodeAudioData(
+        AbstractEngine.audioEngine.audioContext.decodeAudioData(
             audioData,
             (buffer) => {
                 this._audioBufferLoaded(buffer);
@@ -507,7 +507,7 @@ export class Sound {
      * @param audioBuffer The audioBuffer containing the data
      */
     public setAudioBuffer(audioBuffer: AudioBuffer): void {
-        if (Engine.audioEngine?.canUseWebAudio) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio) {
             this._audioBuffer = audioBuffer;
             this._isReadyToPlay = true;
         }
@@ -556,11 +556,11 @@ export class Sound {
     }
 
     private _createSpatialParameters() {
-        if (Engine.audioEngine?.canUseWebAudio && Engine.audioEngine.audioContext) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && AbstractEngine.audioEngine.audioContext) {
             if (this._scene.headphone) {
                 this._panningModel = "HRTF";
             }
-            this._soundPanner = this._soundPanner ?? Engine.audioEngine.audioContext.createPanner();
+            this._soundPanner = this._soundPanner ?? AbstractEngine.audioEngine.audioContext.createPanner();
             if (this._soundPanner && this._outputAudioNode) {
                 this._updateSpatialParameters();
                 this._soundPanner.connect(this._outputAudioNode);
@@ -624,7 +624,7 @@ export class Sound {
     }
 
     private _switchPanningModel() {
-        if (Engine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
             this._soundPanner.panningModel = this._panningModel as any;
         }
     }
@@ -634,7 +634,7 @@ export class Sound {
      * @param soundTrackAudioNode the sound track audio node to connect to
      */
     public connectToSoundTrackAudioNode(soundTrackAudioNode: AudioNode): void {
-        if (Engine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
             if (this._isOutputConnected) {
                 this._outputAudioNode.disconnect();
             }
@@ -683,7 +683,7 @@ export class Sound {
             }
 
             this._coneInnerAngle = value;
-            if (Engine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
+            if (AbstractEngine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
                 this._soundPanner.coneInnerAngle = this._coneInnerAngle;
             }
         }
@@ -707,7 +707,7 @@ export class Sound {
             }
 
             this._coneOuterAngle = value;
-            if (Engine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
+            if (AbstractEngine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner) {
                 this._soundPanner.coneOuterAngle = this._coneOuterAngle;
             }
         }
@@ -723,7 +723,14 @@ export class Sound {
         }
         this._position.copyFrom(newPosition);
 
-        if (Engine.audioEngine?.canUseWebAudio && this._spatialSound && this._soundPanner && !isNaN(this._position.x) && !isNaN(this._position.y) && !isNaN(this._position.z)) {
+        if (
+            AbstractEngine.audioEngine?.canUseWebAudio &&
+            this._spatialSound &&
+            this._soundPanner &&
+            !isNaN(this._position.x) &&
+            !isNaN(this._position.y) &&
+            !isNaN(this._position.z)
+        ) {
             this._soundPanner.positionX.value = this._position.x;
             this._soundPanner.positionY.value = this._position.y;
             this._soundPanner.positionZ.value = this._position.z;
@@ -737,7 +744,7 @@ export class Sound {
     public setLocalDirectionToMesh(newLocalDirection: Vector3): void {
         this._localDirection = newLocalDirection;
 
-        if (Engine.audioEngine?.canUseWebAudio && this._connectedTransformNode && this.isPlaying) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._connectedTransformNode && this.isPlaying) {
             this._updateDirection();
         }
     }
@@ -757,7 +764,7 @@ export class Sound {
 
     /** @internal */
     public updateDistanceFromListener() {
-        if (Engine.audioEngine?.canUseWebAudio && this._connectedTransformNode && this.useCustomAttenuation && this._soundGain && this._scene.activeCamera) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._connectedTransformNode && this.useCustomAttenuation && this._soundGain && this._scene.activeCamera) {
             const distance = this._scene.audioListenerPositionProvider
                 ? this._connectedTransformNode.position.subtract(this._scene.audioListenerPositionProvider()).length()
                 : this._connectedTransformNode.getDistanceToCamera(this._scene.activeCamera);
@@ -781,11 +788,11 @@ export class Sound {
      * @param length (optional) Sound duration (in seconds)
      */
     public play(time?: number, offset?: number, length?: number): void {
-        if (this._isReadyToPlay && this._scene.audioEnabled && Engine.audioEngine?.audioContext) {
+        if (this._isReadyToPlay && this._scene.audioEnabled && AbstractEngine.audioEngine?.audioContext) {
             try {
                 this._clearTimeoutsAndObservers();
 
-                let startTime = time ? Engine.audioEngine?.audioContext.currentTime + time : Engine.audioEngine?.audioContext.currentTime;
+                let startTime = time ? AbstractEngine.audioEngine?.audioContext.currentTime + time : AbstractEngine.audioEngine?.audioContext.currentTime;
                 if (!this._soundSource || !this._streamingSource) {
                     if (this._spatialSound && this._soundPanner) {
                         if (!isNaN(this._position.x) && !isNaN(this._position.y) && !isNaN(this._position.z)) {
@@ -807,7 +814,7 @@ export class Sound {
                 }
                 if (this._streaming) {
                     if (!this._streamingSource) {
-                        this._streamingSource = Engine.audioEngine.audioContext.createMediaElementSource(this._htmlAudioElement);
+                        this._streamingSource = AbstractEngine.audioEngine.audioContext.createMediaElementSource(this._htmlAudioElement);
                         this._htmlAudioElement.onended = () => {
                             this._onended();
                         };
@@ -823,7 +830,7 @@ export class Sound {
                         // the audio engine to be unlocked by a user gesture before trying to play
                         // an HTML Audio element
                         const tryToPlay = () => {
-                            if (Engine.audioEngine?.unlocked) {
+                            if (AbstractEngine.audioEngine?.unlocked) {
                                 const playPromise = this._htmlAudioElement.play();
 
                                 // In browsers that don’t yet support this functionality,
@@ -832,9 +839,9 @@ export class Sound {
                                     playPromise.catch(() => {
                                         // Automatic playback failed.
                                         // Waiting for the audio engine to be unlocked by user click on unmute
-                                        Engine.audioEngine?.lock();
+                                        AbstractEngine.audioEngine?.lock();
                                         if (this.loop || this.autoplay) {
-                                            this._audioUnlockedObserver = Engine.audioEngine?.onAudioUnlockedObservable.addOnce(() => {
+                                            this._audioUnlockedObserver = AbstractEngine.audioEngine?.onAudioUnlockedObservable.addOnce(() => {
                                                 tryToPlay();
                                             });
                                         }
@@ -842,7 +849,7 @@ export class Sound {
                                 }
                             } else {
                                 if (this.loop || this.autoplay) {
-                                    this._audioUnlockedObserver = Engine.audioEngine?.onAudioUnlockedObservable.addOnce(() => {
+                                    this._audioUnlockedObserver = AbstractEngine.audioEngine?.onAudioUnlockedObservable.addOnce(() => {
                                         tryToPlay();
                                     });
                                 }
@@ -852,7 +859,7 @@ export class Sound {
                     }
                 } else {
                     const tryToPlay = () => {
-                        if (Engine.audioEngine?.audioContext) {
+                        if (AbstractEngine.audioEngine?.audioContext) {
                             length = length || this._length;
 
                             if (offset !== undefined) {
@@ -865,7 +872,7 @@ export class Sound {
                                     oldSource.disconnect();
                                 };
                             }
-                            this._soundSource = Engine.audioEngine?.audioContext.createBufferSource();
+                            this._soundSource = AbstractEngine.audioEngine?.audioContext.createBufferSource();
                             if (this._soundSource && this._inputAudioNode) {
                                 this._soundSource.buffer = this._audioBuffer;
                                 this._soundSource.connect(this._inputAudioNode);
@@ -880,22 +887,22 @@ export class Sound {
                                 this._soundSource.onended = () => {
                                     this._onended();
                                 };
-                                startTime = time ? Engine.audioEngine?.audioContext!.currentTime + time : Engine.audioEngine.audioContext!.currentTime;
+                                startTime = time ? AbstractEngine.audioEngine?.audioContext!.currentTime + time : AbstractEngine.audioEngine.audioContext!.currentTime;
                                 const actualOffset = ((this.isPaused ? this.currentTime : 0) + (this._offset ?? 0)) % this._soundSource!.buffer!.duration;
                                 this._soundSource!.start(startTime, actualOffset, this.loop ? undefined : length);
                             }
                         }
                     };
 
-                    if (Engine.audioEngine?.audioContext.state === "suspended") {
+                    if (AbstractEngine.audioEngine?.audioContext.state === "suspended") {
                         // Wait a bit for FF as context seems late to be ready.
                         this._tryToPlayTimeout = setTimeout(() => {
-                            if (Engine.audioEngine?.audioContext!.state === "suspended") {
+                            if (AbstractEngine.audioEngine?.audioContext!.state === "suspended") {
                                 // Automatic playback failed.
                                 // Waiting for the audio engine to be unlocked by user click on unmute
-                                Engine.audioEngine.lock();
+                                AbstractEngine.audioEngine.lock();
                                 if (this.loop || this.autoplay) {
-                                    this._audioUnlockedObserver = Engine.audioEngine.onAudioUnlockedObservable.addOnce(() => {
+                                    this._audioUnlockedObserver = AbstractEngine.audioEngine.onAudioUnlockedObservable.addOnce(() => {
                                         tryToPlay();
                                     });
                                 }
@@ -944,8 +951,8 @@ export class Sound {
                     this._streamingSource.disconnect();
                 }
                 this.isPlaying = false;
-            } else if (Engine.audioEngine?.audioContext && this._soundSource) {
-                const stopTime = time ? Engine.audioEngine.audioContext.currentTime + time : undefined;
+            } else if (AbstractEngine.audioEngine?.audioContext && this._soundSource) {
+                const stopTime = time ? AbstractEngine.audioEngine.audioContext.currentTime + time : undefined;
                 this._soundSource.onended = () => {
                     this.isPlaying = false;
                     this.isPaused = false;
@@ -981,12 +988,12 @@ export class Sound {
                 }
                 this.isPlaying = false;
                 this.isPaused = true;
-            } else if (Engine.audioEngine?.audioContext && this._soundSource) {
+            } else if (AbstractEngine.audioEngine?.audioContext && this._soundSource) {
                 this._soundSource.onended = () => void 0;
                 this._soundSource.stop();
                 this.isPlaying = false;
                 this.isPaused = true;
-                this._currentTime += Engine.audioEngine.audioContext.currentTime - this._startTime;
+                this._currentTime += AbstractEngine.audioEngine.audioContext.currentTime - this._startTime;
             }
         }
     }
@@ -997,11 +1004,11 @@ export class Sound {
      * @param time Define time for gradual change to new volume
      */
     public setVolume(newVolume: number, time?: number): void {
-        if (Engine.audioEngine?.canUseWebAudio && this._soundGain) {
-            if (time && Engine.audioEngine.audioContext) {
-                this._soundGain.gain.cancelScheduledValues(Engine.audioEngine.audioContext.currentTime);
-                this._soundGain.gain.setValueAtTime(this._soundGain.gain.value, Engine.audioEngine.audioContext.currentTime);
-                this._soundGain.gain.linearRampToValueAtTime(newVolume, Engine.audioEngine.audioContext.currentTime + time);
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._soundGain) {
+            if (time && AbstractEngine.audioEngine.audioContext) {
+                this._soundGain.gain.cancelScheduledValues(AbstractEngine.audioEngine.audioContext.currentTime);
+                this._soundGain.gain.setValueAtTime(this._soundGain.gain.value, AbstractEngine.audioEngine.audioContext.currentTime);
+                this._soundGain.gain.linearRampToValueAtTime(newVolume, AbstractEngine.audioEngine.audioContext.currentTime + time);
             } else {
                 this._soundGain.gain.value = newVolume;
             }
@@ -1084,7 +1091,7 @@ export class Sound {
             const boundingInfo = mesh.getBoundingInfo();
             this.setPosition(boundingInfo.boundingSphere.centerWorld);
         }
-        if (Engine.audioEngine?.canUseWebAudio && this._isDirectional && this.isPlaying) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._isDirectional && this.isPlaying) {
             this._updateDirection();
         }
     }
@@ -1302,7 +1309,7 @@ export class Sound {
             this._tryToPlayTimeout = null;
         }
         if (this._audioUnlockedObserver) {
-            Engine.audioEngine?.onAudioUnlockedObservable.remove(this._audioUnlockedObserver);
+            AbstractEngine.audioEngine?.onAudioUnlockedObservable.remove(this._audioUnlockedObserver);
             this._audioUnlockedObserver = null;
         }
     }

--- a/packages/dev/core/src/Audio/soundTrack.ts
+++ b/packages/dev/core/src/Audio/soundTrack.ts
@@ -2,8 +2,8 @@ import type { Sound } from "./sound";
 import type { Analyser } from "./analyser";
 import type { Nullable } from "../types";
 import type { Scene } from "../scene";
-import { Engine } from "../Engines/engine";
 import { EngineStore } from "../Engines/engineStore";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Options allowed during the creation of a sound track.
@@ -62,9 +62,9 @@ export class SoundTrack {
     }
 
     private _initializeSoundTrackAudioGraph() {
-        if (Engine.audioEngine?.canUseWebAudio && Engine.audioEngine.audioContext) {
-            this._outputAudioNode = Engine.audioEngine.audioContext.createGain();
-            this._outputAudioNode.connect(Engine.audioEngine.masterGain);
+        if (AbstractEngine.audioEngine?.canUseWebAudio && AbstractEngine.audioEngine.audioContext) {
+            this._outputAudioNode = AbstractEngine.audioEngine.audioContext.createGain();
+            this._outputAudioNode.connect(AbstractEngine.audioEngine.masterGain);
 
             if (this._options) {
                 if (this._options.volume) {
@@ -80,7 +80,7 @@ export class SoundTrack {
      * Release the sound track and its associated resources
      */
     public dispose(): void {
-        if (Engine.audioEngine && Engine.audioEngine.canUseWebAudio) {
+        if (AbstractEngine.audioEngine && AbstractEngine.audioEngine.canUseWebAudio) {
             if (this._connectedAnalyser) {
                 this._connectedAnalyser.stopDebugCanvas();
             }
@@ -103,7 +103,7 @@ export class SoundTrack {
         if (!this._isInitialized) {
             this._initializeSoundTrackAudioGraph();
         }
-        if (Engine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
             sound.connectToSoundTrackAudioNode(this._outputAudioNode);
         }
         if (sound.soundTrackId !== undefined) {
@@ -135,7 +135,7 @@ export class SoundTrack {
      * @param newVolume Define the new volume of the sound track
      */
     public setVolume(newVolume: number): void {
-        if (Engine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
             this._outputAudioNode.gain.value = newVolume;
         }
     }
@@ -146,7 +146,7 @@ export class SoundTrack {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic#creating-a-spatial-3d-sound
      */
     public switchPanningModelToHRTF(): void {
-        if (Engine.audioEngine?.canUseWebAudio) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio) {
             for (let i = 0; i < this.soundCollection.length; i++) {
                 this.soundCollection[i].switchPanningModelToHRTF();
             }
@@ -159,7 +159,7 @@ export class SoundTrack {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic#creating-a-spatial-3d-sound
      */
     public switchPanningModelToEqualPower(): void {
-        if (Engine.audioEngine?.canUseWebAudio) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio) {
             for (let i = 0; i < this.soundCollection.length; i++) {
                 this.soundCollection[i].switchPanningModelToEqualPower();
             }
@@ -177,9 +177,9 @@ export class SoundTrack {
             this._connectedAnalyser.stopDebugCanvas();
         }
         this._connectedAnalyser = analyser;
-        if (Engine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
+        if (AbstractEngine.audioEngine?.canUseWebAudio && this._outputAudioNode) {
             this._outputAudioNode.disconnect();
-            this._connectedAnalyser.connectAudioNodes(this._outputAudioNode, Engine.audioEngine.masterGain);
+            this._connectedAnalyser.connectAudioNodes(this._outputAudioNode, AbstractEngine.audioEngine.masterGain);
         }
     }
 }

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -3,7 +3,6 @@ import type { Nullable } from "../types";
 import type { Scene } from "../scene";
 import type { Quaternion } from "../Maths/math.vector";
 import { Vector3 } from "../Maths/math.vector";
-import { Engine } from "../Engines/engine";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { TargetCamera } from "./targetCamera";
 import { FlyCameraInputsManager } from "./flyCameraInputsManager";
@@ -13,6 +12,7 @@ import { Tools } from "../Misc/tools";
 import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * This is a flying camera, designed for 3D movement and rotation in all directions,
@@ -361,7 +361,7 @@ export class FlyCamera extends TargetCamera {
 
             this._newPosition.subtractToRef(this._oldPosition, this._diffPosition);
 
-            if (this._diffPosition.length() > Engine.CollisionsEpsilon) {
+            if (this._diffPosition.length() > AbstractEngine.CollisionsEpsilon) {
                 this.position.addInPlace(this._diffPosition);
                 if (this.onCollide && collidedMesh) {
                     this.onCollide(collidedMesh);

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -3,7 +3,6 @@ import { serializeAsVector3, serialize } from "../Misc/decorators";
 import { Vector3, Vector2 } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Scene } from "../scene";
-import { Engine } from "../Engines/engine";
 import { TargetCamera } from "./targetCamera";
 import { FreeCameraInputsManager } from "./freeCameraInputsManager";
 import type { FreeCameraMouseInput } from "../Cameras/Inputs/freeCameraMouseInput";
@@ -12,6 +11,7 @@ import { Tools } from "../Misc/tools";
 import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * This represents a free type of camera. It can be useful in First Person Shooter game for instance.
@@ -385,7 +385,7 @@ export class FreeCamera extends TargetCamera {
 
         this._newPosition.subtractToRef(this._oldPosition, this._diffPosition);
 
-        if (this._diffPosition.length() > Engine.CollisionsEpsilon) {
+        if (this._diffPosition.length() > AbstractEngine.CollisionsEpsilon) {
             this.position.addToRef(this._diffPosition, this._deferredPositionUpdate);
             if (!this._deferOnly) {
                 this.position.copyFrom(this._deferredPositionUpdate);

--- a/packages/dev/core/src/Collisions/collisionCoordinator.ts
+++ b/packages/dev/core/src/Collisions/collisionCoordinator.ts
@@ -1,9 +1,9 @@
 import type { Nullable } from "../types";
 import { Scene } from "../scene";
 import { Vector3 } from "../Maths/math.vector";
-import { Engine } from "../Engines/engine";
 import { Collider } from "./collider";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /** @internal */
 export interface ICollisionCoordinator {
@@ -67,7 +67,7 @@ export class DefaultCollisionCoordinator implements ICollisionCoordinator {
         finalPosition: Vector3,
         excludedMesh: Nullable<AbstractMesh> = null
     ): void {
-        const closeDistance = Engine.CollisionsEpsilon * 10.0;
+        const closeDistance = AbstractEngine.CollisionsEpsilon * 10.0;
 
         if (collider._retry >= maximumRetry) {
             finalPosition.copyFrom(position);

--- a/packages/dev/core/src/Debug/debugLayer.ts
+++ b/packages/dev/core/src/Debug/debugLayer.ts
@@ -1,10 +1,10 @@
 import { Tools } from "../Misc/tools";
 import { Observable } from "../Misc/observable";
 import { Scene } from "../scene";
-import { Engine } from "../Engines/engine";
 import { EngineStore } from "../Engines/engineStore";
 import type { IInspectable } from "../Misc/iInspectable";
 import type { Camera } from "../Cameras/camera";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 // declare INSPECTOR namespace for compilation issue
 declare let INSPECTOR: any;
@@ -227,7 +227,7 @@ export class DebugLayer {
      * By default it uses the babylonjs CDN.
      * @ignoreNaming
      */
-    public static InspectorURL = `${Tools._DefaultCdnUrl}/v${Engine.Version}/inspector/babylon.inspector.bundle.js`;
+    public static InspectorURL = `${Tools._DefaultCdnUrl}/v${AbstractEngine.Version}/inspector/babylon.inspector.bundle.js`;
 
     /**
      * The default configuration of the inspector

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -51,7 +51,6 @@ import { IsDocumentAvailable, IsNavigatorAvailable, IsWindowObjectExist } from "
 import { Constants } from "./constants";
 import { Observable } from "../Misc/observable";
 import { EngineFunctionContext, _loadFile } from "./abstractEngine.functions";
-import { CeilingPOT, FloorPOT, GetExponentOfTwo, NearestPOT } from "core/Misc/tools.functions";
 import type { Material } from "core/Materials/material";
 
 /**
@@ -2679,36 +2678,6 @@ export abstract class AbstractEngine {
      * Gets or sets the epsilon value used by collision engine
      */
     public static CollisionsEpsilon = 0.001;
-
-    /**
-     * Find the next highest power of two.
-     * @param x Number to start search from.
-     * @returns Next highest power of two.
-     */
-    public static CeilingPOT: (x: number) => number = CeilingPOT;
-
-    /**
-     * Find the next lowest power of two.
-     * @param x Number to start search from.
-     * @returns Next lowest power of two.
-     */
-    public static FloorPOT: (x: number) => number = FloorPOT;
-
-    /**
-     * Find the nearest power of two.
-     * @param x Number to start search from.
-     * @returns Next nearest power of two.
-     */
-    public static NearestPOT: (x: number) => number = NearestPOT;
-
-    /**
-     * Get the closest exponent of two
-     * @param value defines the value to approximate
-     * @param max defines the maximum value to return
-     * @param mode defines how to define the closest value
-     * @returns closest exponent of two of the given value
-     */
-    public static GetExponentOfTwo: (value: number, max: number, mode: number) => number = GetExponentOfTwo;
 
     /**
      * Queue a new function into the requested animation frame pool (ie. this function will be executed by the browser (or the javascript engine) for the next frame)

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -51,6 +51,8 @@ import { IsDocumentAvailable, IsNavigatorAvailable, IsWindowObjectExist } from "
 import { Constants } from "./constants";
 import { Observable } from "../Misc/observable";
 import { EngineFunctionContext, _loadFile } from "./abstractEngine.functions";
+import { CeilingPOT, FloorPOT, GetExponentOfTwo, NearestPOT } from "core/Misc/tools.functions";
+import type { Material } from "core/Materials/material";
 
 /**
  * Defines the interface used by objects working like Scene
@@ -2655,4 +2657,64 @@ export abstract class AbstractEngine {
      * By default, this will create a Database object if the workload has been embedded.
      */
     public static OfflineProviderFactory: (urlToScene: string, callbackManifestChecked: (checked: boolean) => any, disableManifestCheck: boolean) => IOfflineProvider;
+
+    /**
+     * Will flag all materials in all scenes in all engines as dirty to trigger new shader compilation
+     * @param flag defines which part of the materials must be marked as dirty
+     * @param predicate defines a predicate used to filter which materials should be affected
+     */
+    public static MarkAllMaterialsAsDirty(flag: number, predicate?: (mat: Material) => boolean): void {
+        for (let engineIndex = 0; engineIndex < EngineStore.Instances.length; engineIndex++) {
+            const engine = EngineStore.Instances[engineIndex];
+
+            for (let sceneIndex = 0; sceneIndex < engine.scenes.length; sceneIndex++) {
+                engine.scenes[sceneIndex].markAllMaterialsAsDirty(flag, predicate);
+            }
+        }
+    }
+
+    // Updatable statics so stick with vars here
+
+    /**
+     * Gets or sets the epsilon value used by collision engine
+     */
+    public static CollisionsEpsilon = 0.001;
+
+    /**
+     * Find the next highest power of two.
+     * @param x Number to start search from.
+     * @returns Next highest power of two.
+     */
+    public static CeilingPOT: (x: number) => number = CeilingPOT;
+
+    /**
+     * Find the next lowest power of two.
+     * @param x Number to start search from.
+     * @returns Next lowest power of two.
+     */
+    public static FloorPOT: (x: number) => number = FloorPOT;
+
+    /**
+     * Find the nearest power of two.
+     * @param x Number to start search from.
+     * @returns Next nearest power of two.
+     */
+    public static NearestPOT: (x: number) => number = NearestPOT;
+
+    /**
+     * Get the closest exponent of two
+     * @param value defines the value to approximate
+     * @param max defines the maximum value to return
+     * @param mode defines how to define the closest value
+     * @returns closest exponent of two of the given value
+     */
+    public static GetExponentOfTwo: (value: number, max: number, mode: number) => number = GetExponentOfTwo;
+
+    /**
+     * Queue a new function into the requested animation frame pool (ie. this function will be executed by the browser (or the javascript engine) for the next frame)
+     * @param func - the function to be called
+     * @param requester - the object that will request the next frame. Falls back to window.
+     * @returns frame number
+     */
+    public static QueueNewFrame: (func: () => void, requester?: any) => number = QueueNewFrame;
 }

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -287,21 +287,6 @@ export class Engine extends ThinEngine {
 
     /** @internal */
 
-    /**
-     * Will flag all materials in all scenes in all engines as dirty to trigger new shader compilation
-     * @param flag defines which part of the materials must be marked as dirty
-     * @param predicate defines a predicate used to filter which materials should be affected
-     */
-    public static MarkAllMaterialsAsDirty(flag: number, predicate?: (mat: Material) => boolean): void {
-        for (let engineIndex = 0; engineIndex < Engine.Instances.length; engineIndex++) {
-            const engine = Engine.Instances[engineIndex];
-
-            for (let sceneIndex = 0; sceneIndex < engine.scenes.length; sceneIndex++) {
-                engine.scenes[sceneIndex].markAllMaterialsAsDirty(flag, predicate);
-            }
-        }
-    }
-
     // eslint-disable-next-line jsdoc/require-returns-check
     /**
      * Method called to create the default loading screen.

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -27,7 +27,6 @@ import "./AbstractEngine/abstractEngine.states";
 import "./AbstractEngine/abstractEngine.renderPass";
 import "./AbstractEngine/abstractEngine.texture";
 
-import type { Material } from "../Materials/material";
 import type { PostProcess } from "../PostProcesses/postProcess";
 import { AbstractEngine } from "./abstractEngine";
 import {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -42,8 +42,8 @@ import { IsWindowObjectExist } from "../Misc/domManagement";
 import { WebGLShaderProcessor } from "./WebGL/webGLShaderProcessors";
 import { WebGL2ShaderProcessor } from "./WebGL/webGL2ShaderProcessors";
 import { WebGLDataBuffer } from "../Meshes/WebGL/webGLDataBuffer";
-import { CeilingPOT, FloorPOT, GetExponentOfTwo, NearestPOT } from "../Misc/tools.functions";
-import { AbstractEngine, QueueNewFrame } from "./abstractEngine";
+import { GetExponentOfTwo } from "../Misc/tools.functions";
+import { AbstractEngine } from "./abstractEngine";
 import { Constants } from "./constants";
 import { WebGLHardwareTexture } from "./WebGL/webGLHardwareTexture";
 import { ShaderLanguage } from "../Materials/shaderLanguage";
@@ -147,13 +147,6 @@ export class ThinEngine extends AbstractEngine {
     public get version(): number {
         return this._webGLVersion;
     }
-
-    // Updatable statics so stick with vars here
-
-    /**
-     * Gets or sets the epsilon value used by collision engine
-     */
-    public static CollisionsEpsilon = 0.001;
 
     /**
      * Gets or sets the relative url used to load shaders if using the engine in non-minified mode
@@ -4384,44 +4377,6 @@ export class ThinEngine extends AbstractEngine {
 
         return this._HasMajorPerformanceCaveat;
     }
-
-    /**
-     * Find the next highest power of two.
-     * @param x Number to start search from.
-     * @returns Next highest power of two.
-     */
-    public static CeilingPOT: (x: number) => number = CeilingPOT;
-
-    /**
-     * Find the next lowest power of two.
-     * @param x Number to start search from.
-     * @returns Next lowest power of two.
-     */
-    public static FloorPOT: (x: number) => number = FloorPOT;
-
-    /**
-     * Find the nearest power of two.
-     * @param x Number to start search from.
-     * @returns Next nearest power of two.
-     */
-    public static NearestPOT: (x: number) => number = NearestPOT;
-
-    /**
-     * Get the closest exponent of two
-     * @param value defines the value to approximate
-     * @param max defines the maximum value to return
-     * @param mode defines how to define the closest value
-     * @returns closest exponent of two of the given value
-     */
-    public static GetExponentOfTwo: (value: number, max: number, mode: number) => number = GetExponentOfTwo;
-
-    /**
-     * Queue a new function into the requested animation frame pool (ie. this function will be executed by the browser (or the javascript engine) for the next frame)
-     * @param func - the function to be called
-     * @param requester - the object that will request the next frame. Falls back to window.
-     * @returns frame number
-     */
-    public static QueueNewFrame: (func: () => void, requester?: any) => number = QueueNewFrame;
 }
 
 interface TexImageParameters {

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -2,7 +2,6 @@
 import { Logger } from "../Misc/logger";
 import type { Nullable, DataArray, IndicesArray, Immutable, FloatArray } from "../types";
 import { Color4 } from "../Maths/math";
-import { Engine } from "../Engines/engine";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
 import type { IEffectCreationOptions, IShaderPath } from "../Materials/effect";
 import { Effect } from "../Materials/effect";
@@ -621,7 +620,7 @@ export class WebGPUEngine extends AbstractEngine {
         options.deviceDescriptor = options.deviceDescriptor || {};
         options.enableGPUDebugMarkers = options.enableGPUDebugMarkers ?? false;
 
-        Logger.Log(`Babylon.js v${Engine.Version} - ${this.description} engine`);
+        Logger.Log(`Babylon.js v${AbstractEngine.Version} - ${this.description} engine`);
         if (!navigator.gpu) {
             Logger.Error("WebGPU is not supported by your browser.");
             return;

--- a/packages/dev/core/src/Gamepads/gamepadManager.ts
+++ b/packages/dev/core/src/Gamepads/gamepadManager.ts
@@ -4,9 +4,9 @@ import type { Nullable } from "../types";
 import type { Scene } from "../scene";
 import { Xbox360Pad } from "./xboxGamepad";
 import { Gamepad, GenericPad } from "./gamepad";
-import { Engine } from "../Engines/engine";
 import { DualShockPad } from "./dualShockGamepad";
 import { Tools } from "../Misc/tools";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 /**
  * Manager for handling gamepads
  */
@@ -222,7 +222,7 @@ export class GamepadManager {
         }
 
         if (this._isMonitoring) {
-            Engine.QueueNewFrame(() => {
+            AbstractEngine.QueueNewFrame(() => {
                 this._checkGamepadsStatus();
             });
         }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -21,8 +21,7 @@ import type { Light } from "../Lights/light";
 import { RuntimeError, ErrorCodes } from "../Misc/error";
 import type { ISpriteManager } from "../Sprites/spriteManager";
 import { RandomGUID } from "../Misc/guid";
-import { Engine } from "../Engines/engine";
-import type { AbstractEngine } from "../Engines/abstractEngine";
+import { AbstractEngine } from "../Engines/abstractEngine";
 
 /**
  * Type used for the success callback of ImportMesh
@@ -669,9 +668,9 @@ function loadData(
         canUseOfflineSupport = !exceptionFound;
     }
 
-    if (canUseOfflineSupport && Engine.OfflineProviderFactory) {
+    if (canUseOfflineSupport && AbstractEngine.OfflineProviderFactory) {
         // Checking if a manifest file has been set for this scene and if offline mode has been requested
-        scene.offlineProvider = Engine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
+        scene.offlineProvider = AbstractEngine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
     } else {
         manifestChecked();
     }

--- a/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -1,12 +1,12 @@
 import type { Nullable } from "../../../types";
 import { SphericalPolynomial } from "../../../Maths/sphericalPolynomial";
-import { Engine } from "../../../Engines/engine";
 import type { InternalTexture } from "../../../Materials/Textures/internalTexture";
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
 import type { DDSInfo } from "../../../Misc/dds";
 import { DDSTools } from "../../../Misc/dds";
 
 import "../../../Engines/Extensions/engine.cubeTexture";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Implementation of the DDS Texture Loader.
@@ -114,4 +114,4 @@ export class _DDSTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _DDSTextureLoader());
+AbstractEngine._TextureLoaders.push(new _DDSTextureLoader());

--- a/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ddsTextureLoader.ts
@@ -7,6 +7,7 @@ import { DDSTools } from "../../../Misc/dds";
 
 import "../../../Engines/Extensions/engine.cubeTexture";
 import { AbstractEngine } from "core/Engines/abstractEngine";
+import type { Engine } from "core/Engines/engine";
 
 /**
  * Implementation of the DDS Texture Loader.

--- a/packages/dev/core/src/Materials/Textures/Loaders/envTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/envTextureLoader.ts
@@ -1,8 +1,8 @@
 import { GetEnvInfo, UploadEnvLevelsAsync, UploadEnvSpherical } from "../../../Misc/environmentTextureTools";
 import type { Nullable } from "../../../types";
-import { Engine } from "../../../Engines/engine";
 import type { InternalTexture } from "../../../Materials/Textures/internalTexture";
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Implementation of the ENV Texture Loader.
@@ -81,4 +81,4 @@ export class _ENVTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _ENVTextureLoader());
+AbstractEngine._TextureLoaders.push(new _ENVTextureLoader());

--- a/packages/dev/core/src/Materials/Textures/Loaders/hdrTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/hdrTextureLoader.ts
@@ -1,8 +1,8 @@
 import { RGBE_ReadHeader, RGBE_ReadPixels } from "../../../Misc/HighDynamicRange/hdr";
-import { Engine } from "../../../Engines/engine";
 import type { InternalTexture } from "../../../Materials/Textures/internalTexture";
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
 import { Constants } from "../../../Engines/constants";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Implementation of the HDR Texture Loader.
@@ -67,4 +67,4 @@ export class _HDRTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _HDRTextureLoader());
+AbstractEngine._TextureLoaders.push(new _HDRTextureLoader());

--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -1,13 +1,13 @@
 import { KhronosTextureContainer } from "../../../Misc/khronosTextureContainer";
 import { KhronosTextureContainer2 } from "../../../Misc/khronosTextureContainer2";
 import type { Nullable } from "../../../types";
-import { Engine } from "../../../Engines/engine";
 import type { InternalTexture } from "../../../Materials/Textures/internalTexture";
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
 import { Logger } from "../../../Misc/logger";
 import { Constants } from "../../../Engines/constants";
 
 import "../../../Engines/Extensions/engine.cubeTexture";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 function mapSRGBToLinear(format: number): Nullable<number> {
     switch (format) {
@@ -146,4 +146,4 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _KTXTextureLoader());
+AbstractEngine._TextureLoaders.push(new _KTXTextureLoader());

--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -8,6 +8,7 @@ import { Constants } from "../../../Engines/constants";
 
 import "../../../Engines/Extensions/engine.cubeTexture";
 import { AbstractEngine } from "core/Engines/abstractEngine";
+import type { Engine } from "core/Engines/engine";
 
 function mapSRGBToLinear(format: number): Nullable<number> {
     switch (format) {

--- a/packages/dev/core/src/Materials/Textures/Loaders/tgaTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/tgaTextureLoader.ts
@@ -1,7 +1,7 @@
 import { GetTGAHeader, UploadContent } from "../../../Misc/tga";
-import { Engine } from "../../../Engines/engine";
 import type { InternalTexture } from "../../../Materials/Textures/internalTexture";
 import type { IInternalTextureLoader } from "../../../Materials/Textures/internalTextureLoader";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Implementation of the TGA Texture Loader.
@@ -52,4 +52,4 @@ export class _TGATextureLoader implements IInternalTextureLoader {
 }
 
 // Register the loader.
-Engine._TextureLoaders.push(new _TGATextureLoader());
+AbstractEngine._TextureLoaders.push(new _TGATextureLoader());

--- a/packages/dev/core/src/Materials/Textures/Packer/packer.ts
+++ b/packages/dev/core/src/Materials/Textures/Packer/packer.ts
@@ -1,4 +1,3 @@
-import { Engine } from "../../../Engines/engine";
 import type { AbstractMesh } from "../../../Meshes/abstractMesh";
 import { VertexBuffer } from "../../../Buffers/buffer";
 import type { Scene } from "../../../scene";
@@ -11,6 +10,7 @@ import { Color3, Color4 } from "../../../Maths/math.color";
 import { TexturePackerFrame } from "./frame";
 import { Logger } from "../../../Misc/logger";
 import { Tools } from "../../../Misc/tools";
+import { Constants } from "core/Engines/constants";
 
 /**
  * Defines the basic options interface of a TexturePacker
@@ -243,7 +243,7 @@ export class TexturePacker {
                 this.scene,
                 true, //Generate Mips
                 Texture.TRILINEAR_SAMPLINGMODE,
-                Engine.TEXTUREFORMAT_RGBA
+                Constants.TEXTUREFORMAT_RGBA
             );
 
             const dtx = dt.getContext();

--- a/packages/dev/core/src/Materials/fresnelParameters.ts
+++ b/packages/dev/core/src/Materials/fresnelParameters.ts
@@ -1,9 +1,9 @@
 import { DeepCopier } from "../Misc/deepCopier";
 import type { DeepImmutable } from "../types";
 import { Color3 } from "../Maths/math.color";
-import { Engine } from "../Engines/engine";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { Constants } from "../Engines/constants";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Options to be used when creating a FresnelParameters.
@@ -83,7 +83,7 @@ export class FresnelParameters {
         }
 
         this._isEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_FresnelDirtyFlag | Constants.MATERIAL_MiscDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_FresnelDirtyFlag | Constants.MATERIAL_MiscDirtyFlag);
     }
 
     /**

--- a/packages/dev/core/src/Materials/materialFlags.ts
+++ b/packages/dev/core/src/Materials/materialFlags.ts
@@ -1,4 +1,4 @@
-import { Engine } from "../Engines/engine";
+import { AbstractEngine } from "../Engines/abstractEngine";
 import { Constants } from "../Engines/constants";
 
 /**
@@ -19,7 +19,7 @@ export class MaterialFlags {
         }
 
         this._DiffuseTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _DetailTextureEnabled = true;
@@ -35,7 +35,7 @@ export class MaterialFlags {
         }
 
         this._DetailTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _DecalMapEnabled = true;
@@ -51,7 +51,7 @@ export class MaterialFlags {
         }
 
         this._DecalMapEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _AmbientTextureEnabled = true;
@@ -67,7 +67,7 @@ export class MaterialFlags {
         }
 
         this._AmbientTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _OpacityTextureEnabled = true;
@@ -83,7 +83,7 @@ export class MaterialFlags {
         }
 
         this._OpacityTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _ReflectionTextureEnabled = true;
@@ -99,7 +99,7 @@ export class MaterialFlags {
         }
 
         this._ReflectionTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _EmissiveTextureEnabled = true;
@@ -115,7 +115,7 @@ export class MaterialFlags {
         }
 
         this._EmissiveTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _SpecularTextureEnabled = true;
@@ -131,7 +131,7 @@ export class MaterialFlags {
         }
 
         this._SpecularTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _BumpTextureEnabled = true;
@@ -147,7 +147,7 @@ export class MaterialFlags {
         }
 
         this._BumpTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _LightmapTextureEnabled = true;
@@ -163,7 +163,7 @@ export class MaterialFlags {
         }
 
         this._LightmapTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _RefractionTextureEnabled = true;
@@ -179,7 +179,7 @@ export class MaterialFlags {
         }
 
         this._RefractionTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _ColorGradingTextureEnabled = true;
@@ -195,7 +195,7 @@ export class MaterialFlags {
         }
 
         this._ColorGradingTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _FresnelEnabled = true;
@@ -211,7 +211,7 @@ export class MaterialFlags {
         }
 
         this._FresnelEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_FresnelDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_FresnelDirtyFlag);
     }
 
     private static _ClearCoatTextureEnabled = true;
@@ -227,7 +227,7 @@ export class MaterialFlags {
         }
 
         this._ClearCoatTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _ClearCoatBumpTextureEnabled = true;
@@ -243,7 +243,7 @@ export class MaterialFlags {
         }
 
         this._ClearCoatBumpTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _ClearCoatTintTextureEnabled = true;
@@ -259,7 +259,7 @@ export class MaterialFlags {
         }
 
         this._ClearCoatTintTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _SheenTextureEnabled = true;
@@ -275,7 +275,7 @@ export class MaterialFlags {
         }
 
         this._SheenTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _AnisotropicTextureEnabled = true;
@@ -291,7 +291,7 @@ export class MaterialFlags {
         }
 
         this._AnisotropicTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _ThicknessTextureEnabled = true;
@@ -307,7 +307,7 @@ export class MaterialFlags {
         }
 
         this._ThicknessTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _RefractionIntensityTextureEnabled = true;
@@ -323,7 +323,7 @@ export class MaterialFlags {
         }
 
         this._RefractionIntensityTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _TranslucencyIntensityTextureEnabled = true;
@@ -339,7 +339,7 @@ export class MaterialFlags {
         }
 
         this._TranslucencyIntensityTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _TranslucencyColorTextureEnabled = true;
@@ -355,7 +355,7 @@ export class MaterialFlags {
         }
 
         this._TranslucencyColorTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 
     private static _IridescenceTextureEnabled = true;
@@ -371,6 +371,6 @@ export class MaterialFlags {
         }
 
         this._IridescenceTextureEnabled = value;
-        Engine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        AbstractEngine.MarkAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }
 }

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -18,7 +18,7 @@ import type { TeleportOutBlock } from "./Blocks/Teleport/teleportOutBlock";
 import type { TeleportInBlock } from "./Blocks/Teleport/teleportInBlock";
 import { Tools } from "../../Misc/tools";
 import type { Color4 } from "../../Maths/math.color";
-import { Engine } from "../../Engines/engine";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 // declare NODEGEOMETRYEDITOR namespace for compilation issue
 declare let NODEGEOMETRYEDITOR: any;
@@ -50,7 +50,7 @@ export class NodeGeometry {
     private _buildExecutionTime: number = 0;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `${Tools._DefaultCdnUrl}/v${Engine.Version}/nodeGeometryEditor/babylon.nodeGeometryEditor.js`;
+    public static EditorURL = `${Tools._DefaultCdnUrl}/v${AbstractEngine.Version}/nodeGeometryEditor/babylon.nodeGeometryEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -5,7 +5,6 @@ import type { Scene, IDisposable } from "../scene";
 import { ScenePerformancePriority } from "../scene";
 import type { Vector2 } from "../Maths/math.vector";
 import { Quaternion, Matrix, Vector3, TmpVectors } from "../Maths/math.vector";
-import { Engine } from "../Engines/engine";
 import type { Node } from "../node";
 import { VertexBuffer } from "../Buffers/buffer";
 import type { IGetSetVerticesData } from "../Meshes/mesh.vertexData";
@@ -45,6 +44,7 @@ import type { RenderingGroup } from "../Rendering/renderingGroup";
 import type { IEdgesRendererOptions } from "../Rendering/edgesRenderer";
 import type { MorphTarget } from "../Morph/morphTarget";
 import { nativeOverride } from "../Misc/decorators";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 function applyMorph(data: FloatArray, kind: string, morphTargetManager: MorphTargetManager): void {
     let getTargetData: Nullable<(target: MorphTarget) => Nullable<FloatArray>> = null;
@@ -1934,7 +1934,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             this._internalAbstractMeshDataInfo._meshCollisionData._diffPositionForCollisions
         );
 
-        if (this._internalAbstractMeshDataInfo._meshCollisionData._diffPositionForCollisions.length() > Engine.CollisionsEpsilon) {
+        if (this._internalAbstractMeshDataInfo._meshCollisionData._diffPositionForCollisions.length() > AbstractEngine.CollisionsEpsilon) {
             this.position.addInPlace(this._internalAbstractMeshDataInfo._meshCollisionData._diffPositionForCollisions);
         }
 

--- a/packages/dev/core/src/Offline/database.ts
+++ b/packages/dev/core/src/Offline/database.ts
@@ -2,12 +2,12 @@ import type { Nullable } from "../types";
 import { Tools } from "../Misc/tools";
 import { Logger } from "../Misc/logger";
 import { GetTGAHeader } from "../Misc/tga";
-import { Engine } from "../Engines/engine";
 import type { IOfflineProvider } from "./IOfflineProvider";
 import { WebRequest } from "../Misc/webRequest";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 // Sets the default offline provider to Babylon.js
-Engine.OfflineProviderFactory = (urlToScene: string, callbackManifestChecked: (checked: boolean) => any, disableManifestCheck = false) => {
+AbstractEngine.OfflineProviderFactory = (urlToScene: string, callbackManifestChecked: (checked: boolean) => any, disableManifestCheck = false) => {
     return new Database(urlToScene, callbackManifestChecked, disableManifestCheck);
 };
 

--- a/packages/dev/core/src/Sprites/spriteMap.ts
+++ b/packages/dev/core/src/Sprites/spriteMap.ts
@@ -1,4 +1,3 @@
-import { Engine } from "../Engines/engine";
 import type { IDisposable, Scene } from "../scene";
 import type { Nullable } from "../types";
 import { Vector2, Vector3 } from "../Maths/math.vector";
@@ -13,6 +12,7 @@ import { Effect } from "../Materials/effect";
 import { CreatePlane } from "../Meshes/Builders/planeBuilder";
 import "../Shaders/spriteMap.fragment";
 import "../Shaders/spriteMap.vertex";
+import { Constants } from "core/Engines/constants";
 
 /**
  * Defines the basic options interface of a SpriteMap
@@ -385,7 +385,7 @@ export class SpriteMap implements ISpriteMap {
 
         const floatArray = new Float32Array(data);
 
-        const t = RawTexture.CreateRGBATexture(floatArray, this.spriteCount, 4, this._scene, false, false, Texture.NEAREST_NEAREST, Engine.TEXTURETYPE_FLOAT);
+        const t = RawTexture.CreateRGBATexture(floatArray, this.spriteCount, 4, this._scene, false, false, Texture.NEAREST_NEAREST, Constants.TEXTURETYPE_FLOAT);
 
         return t;
     }
@@ -417,7 +417,7 @@ export class SpriteMap implements ISpriteMap {
         }
 
         const floatArray = new Float32Array(data);
-        const t = RawTexture.CreateRGBATexture(floatArray, _tx, _ty, this._scene, false, false, Texture.NEAREST_NEAREST, Engine.TEXTURETYPE_FLOAT);
+        const t = RawTexture.CreateRGBATexture(floatArray, _tx, _ty, this._scene, false, false, Texture.NEAREST_NEAREST, Constants.TEXTURETYPE_FLOAT);
 
         return t;
     }
@@ -487,7 +487,7 @@ export class SpriteMap implements ISpriteMap {
             false,
             false,
             Texture.NEAREST_NEAREST,
-            Engine.TEXTURETYPE_FLOAT
+            Constants.TEXTURETYPE_FLOAT
         );
 
         return t;

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
@@ -4,13 +4,13 @@ import type { WebXRSessionManager } from "../webXRSessionManager";
 import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import { Tools } from "../../Misc/tools";
 import { Texture } from "../../Materials/Textures/texture";
-import { Engine } from "../../Engines/engine";
 import { Observable } from "../../Misc/observable";
 import type { Nullable } from "../../types";
 import { Constants } from "../../Engines/constants";
 import { WebGLHardwareTexture } from "../../Engines/WebGL/webGLHardwareTexture";
 import { InternalTexture, InternalTextureSource } from "../../Materials/Textures/internalTexture";
 import type { ThinEngine } from "../../Engines/thinEngine";
+import type { Engine } from "core/Engines/engine";
 
 export type WebXRDepthUsage = "cpu" | "gpu";
 export type WebXRDepthDataFormat = "ushort" | "float";
@@ -263,7 +263,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 false,
                 true,
                 Texture.NEAREST_SAMPLINGMODE,
-                Engine.TEXTURETYPE_FLOAT
+                Constants.TEXTURETYPE_FLOAT
             );
         }
 
@@ -306,7 +306,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 false,
                 true,
                 Texture.NEAREST_SAMPLINGMODE,
-                dataFormat === "ushort" ? Engine.TEXTURETYPE_UNSIGNED_BYTE : Engine.TEXTURETYPE_FLOAT
+                dataFormat === "ushort" ? Constants.TEXTURETYPE_UNSIGNED_BYTE : Constants.TEXTURETYPE_FLOAT
             );
         }
 

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -10,8 +10,8 @@ import { WebXRFeatureName, WebXRFeaturesManager } from "./webXRFeaturesManager";
 import { Logger } from "../Misc/logger";
 import { UniversalCamera } from "../Cameras/universalCamera";
 import { Quaternion, Vector3 } from "../Maths/math.vector";
-import { Engine } from "../Engines/engine";
 import type { ThinEngine } from "../Engines/thinEngine";
+import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
  * Options for setting up XR spectator camera.
@@ -183,7 +183,7 @@ export class WebXRExperienceHelper implements IDisposable {
             }
 
             // Vision Pro suspends the audio context when entering XR, so we resume it here if needed.
-            Engine.audioEngine?._resumeAudioContextOnStateChange();
+            AbstractEngine.audioEngine?._resumeAudioContextOnStateChange();
 
             this.sessionManager.onXRSessionEnded.addOnce(() => {
                 // when using the back button and not the exit button (default on mobile), the session is ending but the EXITING state was not set

--- a/packages/dev/core/test/unit/Audio/audioEngine.test.ts
+++ b/packages/dev/core/test/unit/Audio/audioEngine.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { AudioEngine } from "core/Audio";
-import { Engine, NullEngine } from "core/Engines";
+import { AbstractEngine, NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { Sound } from "core/Audio/sound";
 
@@ -26,7 +26,7 @@ describe("AudioEngine", () => {
         mock = new MockedAudioObjects;
         engine = new NullEngine;
         scene = new Scene(engine);
-        audioEngine = Engine.audioEngine = new AudioEngine(null, new AudioContext, null);
+        audioEngine = AbstractEngine.audioEngine = new AudioEngine(null, new AudioContext, null);
     });
 
     afterEach(() => {

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { AudioEngine, Sound } from "core/Audio";
-import { Engine, NullEngine } from "core/Engines";
+import { AbstractEngine, NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 
 import { AudioTestHelper } from "./helpers/audioTestHelper";
@@ -34,7 +34,7 @@ describe("Sound", () => {
         mock = new MockedAudioObjects;
         engine = new NullEngine;
         scene = new Scene(engine);
-        audioEngine = Engine.audioEngine = new AudioEngine(null, new AudioContext, null);
+        audioEngine = AbstractEngine.audioEngine = new AudioEngine(null, new AudioContext, null);
     });
 
     afterEach(() => {
@@ -205,7 +205,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given .mp3 when supported", () => {
-        (Engine.audioEngine as any).isMP3supported = true;
+        (AbstractEngine.audioEngine as any).isMP3supported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -216,7 +216,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given .ogg when supported", () => {
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -227,7 +227,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given .wav", () => {
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -238,7 +238,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given .m4a", () => {
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -249,7 +249,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given .mp4", () => {
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -260,7 +260,7 @@ describe("Sound", () => {
     });
 
     it("constructor loads given blob", () => {
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -271,8 +271,8 @@ describe("Sound", () => {
     });
 
     it("constructor skips given .ogg when not supported", () => {
-        (Engine.audioEngine as any).isMP3supported = true;
-        (Engine.audioEngine as any).isOGGsupported = false;
+        (AbstractEngine.audioEngine as any).isMP3supported = true;
+        (AbstractEngine.audioEngine as any).isOGGsupported = false;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -283,8 +283,8 @@ describe("Sound", () => {
     });
 
     it("constructor skips given .mp3 when not supported", () => {
-        (Engine.audioEngine as any).isMP3supported = false;
-        (Engine.audioEngine as any).isOGGsupported = true;
+        (AbstractEngine.audioEngine as any).isMP3supported = false;
+        (AbstractEngine.audioEngine as any).isOGGsupported = true;
         const sceneLoadFileMock = jest.fn().mockName("scene._loadFile");
         scene!._loadFile = sceneLoadFileMock;
 
@@ -529,7 +529,7 @@ describe("Sound", () => {
 
         AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
         sound.stop();
-        Engine.audioEngine!.unlock();
+        AbstractEngine.audioEngine!.unlock();
 
         return AudioTestHelper.WhenAudioContextResumes(() => {
             expect(AudioTestHelper.SoundWasStarted()).toBe(false);
@@ -543,7 +543,7 @@ describe("Sound", () => {
         sound.play();
         AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
         sound.stop();
-        Engine.audioEngine!.unlock();
+        AbstractEngine.audioEngine!.unlock();
 
         return AudioTestHelper.WhenAudioContextResumes(() => {
             expect(AudioTestHelper.SoundWasStarted()).toBe(false);


### PR DESCRIPTION
Change the references to static members of the Engine to AbstractEngine to ensure that effective treeshaking is performed on the WebGPU Engine.

Depending on how strict you are, there may be Breaking Changes.
Check out `abstractEngine.ts` and `thinEngine.ts`.