### PR TITLE
Filter out instance attributes in _convertToUnIndexedMesh

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3185,7 +3185,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     }
 
     private _convertToUnIndexedMesh(flattenNormals: boolean = false): Mesh {
-        const kinds = this.getVerticesDataKinds();
+        const kinds = this.getVerticesDataKinds().filter((kind) => !this.getVertexBuffer(kind)?.getIsInstanced());
         const indices = this.getIndices()!;
         const data: { [kind: string]: FloatArray } = {};
 


### PR DESCRIPTION
Forum issue: https://forum.babylonjs.com/t/for-compressed-textures-meshdebugpluginmaterial-cannot-be-used/52827

`_convertToUnIndexedMesh` should only process normal per vertex attribute data. Without filtering, it can end up including things like instance matrices (not per vertex data). In this case, this also leads to things blowing up because `getVerticesData` assumes that all attribute data is per vertex. Possibly this should also be fixed so it is possible to call `getVerticesData` on an attribute that is not per vertex, but won't affect this particular issue.