### PR TITLE
Couple small loader/gltf options fixes

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -423,7 +423,7 @@ interface SceneLoaderOptions {
         // NOTE: This type is doing two things:
         // 1. Adding an implicit 'enabled' property to the options for each plugin.
         // 2. Creating a mapped type of all the options of all the plugins to make it just look like a consolidated plain object in intellisense for the user.
-        [Plugin in keyof SceneLoaderPluginOptions]: {
+        [Plugin in keyof SceneLoaderPluginOptions]?: {
             [Option in keyof DefaultPluginOptions<SceneLoaderPluginOptions[Plugin]>]: DefaultPluginOptions<SceneLoaderPluginOptions[Plugin]>[Option];
         };
     };

--- a/packages/dev/loaders/src/OBJ/objFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.ts
@@ -22,7 +22,7 @@ declare module "core/Loading/sceneLoader" {
         /**
          * Defines options for the obj loader.
          */
-        [PLUGIN_OBJ]?: {};
+        [PLUGIN_OBJ]: {};
     }
 }
 

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -20,7 +20,7 @@ declare module "core/Loading/sceneLoader" {
         /**
          * Defines options for the splat loader.
          */
-        [PLUGIN_SPLAT]?: {};
+        [PLUGIN_SPLAT]: {};
     }
 }
 

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -17,7 +17,7 @@ declare module "core/Loading/sceneLoader" {
         /**
          * Defines options for the stl loader.
          */
-        [PLUGIN_STL]?: {};
+        [PLUGIN_STL]: {};
     }
 }
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_lights_image_based.ts
@@ -12,6 +12,17 @@ import { GLTFLoader, ArrayItem } from "../glTFLoader";
 
 const NAME = "EXT_lights_image_based";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the EXT_lights_image_based extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["EXT_lights_image_based"]: {};
+    }
+}
+
 declare module "babylonjs-gltf2interface" {
     /** @internal */
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_mesh_gpu_instancing.ts
@@ -12,6 +12,17 @@ import "core/Meshes/thinInstanceMesh";
 
 const NAME = "EXT_mesh_gpu_instancing";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the EXT_mesh_gpu_instancing extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["EXT_mesh_gpu_instancing"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md)
  * [Playground Sample](https://playground.babylonjs.com/#QFIGLW#9)

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_meshopt_compression.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_meshopt_compression.ts
@@ -7,6 +7,17 @@ import { MeshoptCompression } from "core/Meshes/Compression/meshoptCompression";
 
 const NAME = "EXT_meshopt_compression";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the EXT_meshopt_compression extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["EXT_meshopt_compression"]: {};
+    }
+}
+
 interface IBufferViewMeshopt extends IBufferView {
     _meshOptData?: Promise<ArrayBufferView>;
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_avif.ts
@@ -7,6 +7,17 @@ import type { IEXTTextureAVIF } from "babylonjs-gltf2interface";
 
 const NAME = "EXT_texture_avif";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the EXT_texture_avif extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["EXT_texture_avif"]: {};
+    }
+}
+
 /**
  * [glTF PR](https://github.com/KhronosGroup/glTF/pull/2235)
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_avif/README.md)

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_webp.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_texture_webp.ts
@@ -7,6 +7,17 @@ import type { IEXTTextureWebP } from "babylonjs-gltf2interface";
 
 const NAME = "EXT_texture_webp";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the EXT_texture_webp extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["EXT_texture_webp"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/ExtrasAsMetadata.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/ExtrasAsMetadata.ts
@@ -10,6 +10,17 @@ import type { Material } from "core/Materials/material";
 
 const NAME = "ExtrasAsMetadata";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the ExtrasAsMetadata extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["ExtrasAsMetadata"]: {};
+    }
+}
+
 interface ObjectWithMetadata {
     metadata: any;
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_animation_pointer.ts
@@ -13,6 +13,17 @@ import type { AnimationPropertyInfo } from "../glTFLoaderAnimation";
 
 const NAME = "KHR_animation_pointer";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_animation_pointer extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_animation_pointer"]: {};
+    }
+}
+
 /**
  * Class to convert an animation pointer path to a smart object that
  * gets data from the animation buffer and creates animations.

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -12,6 +12,17 @@ import { GLTFLoader, ArrayItem } from "../glTFLoader";
 
 const NAME = "KHR_draco_mesh_compression";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_draco_mesh_compression extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_draco_mesh_compression"]: {};
+    }
+}
+
 interface IBufferViewDraco extends IBufferView {
     _dracoBabylonGeometry?: Promise<Geometry>;
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
@@ -9,6 +9,17 @@ import { InteractivityPathToObjectConverter } from "./interactivityPathToObjectC
 
 const NAME = "KHR_interactivity";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_interactivity extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_interactivity"]: {};
+    }
+}
+
 /**
  * Loader extension for KHR_interactivity
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -16,6 +16,17 @@ import { GLTFLoader, ArrayItem } from "../glTFLoader";
 
 const NAME = "KHR_lights_punctual";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_lights_punctual extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_lights_punctual"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_anisotropy.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsAnisotropy } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_anisotropy";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_anisotropy extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_anisotropy"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsClearcoat } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_clearcoat";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_clearcoat extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_clearcoat"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md)
  * [Playground Sample](https://www.babylonjs-playground.com/frame.html#7F7PN6#8)

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_diffuse_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_diffuse_transmission.ts
@@ -10,6 +10,17 @@ import { Color3 } from "core/Maths/math.color";
 
 const NAME = "KHR_materials_diffuse_transmission";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_diffuse_transmission extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_diffuse_transmission"]: {};
+    }
+}
+
 /**
  * [Proposed Specification](https://github.com/KhronosGroup/glTF/pull/1825)
  * !!! Experimental Extension Subject to Changes !!!

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_dispersion.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_dispersion.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsDispersion } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_dispersion";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_dispersion extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_dispersion"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/87bd64a7f5e23c84b6aef2e6082069583ed0ddb4/extensions/2.0/Khronos/KHR_materials_dispersion/README.md)
  * @experimental

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsEmissiveStrength } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_emissive_strength";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_emissive_strength extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_emissive_strength"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_ior.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_ior.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsIor } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_ior";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_ior extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_ior"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_ior/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_iridescence.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_iridescence.ts
@@ -9,6 +9,17 @@ import type { IKHRMaterialsIridescence } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_iridescence";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_iridescence extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_iridescence"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_iridescence/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -10,6 +10,17 @@ import type { IKHRMaterialsPbrSpecularGlossiness } from "babylonjs-gltf2interfac
 
 const NAME = "KHR_materials_pbrSpecularGlossiness";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_pbrSpecularGlossiness extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_pbrSpecularGlossiness"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_sheen.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_sheen.ts
@@ -10,6 +10,17 @@ import type { IKHRMaterialsSheen } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_sheen";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_sheen extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_sheen"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_sheen/README.md)
  * [Playground Sample](https://www.babylonjs-playground.com/frame.html#BNIZX6#4)

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -10,6 +10,17 @@ import type { IKHRMaterialsSpecular } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_specular";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_specular extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_specular"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_specular/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -317,6 +317,17 @@ class TransmissionHelper {
 
 const NAME = "KHR_materials_transmission";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_transmission extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_transmission"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_transmission/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_unlit.ts
@@ -9,6 +9,17 @@ import { GLTFLoader } from "../glTFLoader";
 
 const NAME = "KHR_materials_unlit";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_unlit extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_unlit"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_unlit/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
@@ -12,6 +12,17 @@ import type { TransformNode } from "core/Meshes/transformNode";
 
 const NAME = "KHR_materials_variants";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_variants extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_variants"]: {};
+    }
+}
+
 interface IVariantsMap {
     [key: string]: Array<{ mesh: AbstractMesh; material: Nullable<Material> }>;
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_volume.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_volume.ts
@@ -10,6 +10,17 @@ import type { IKHRMaterialsVolume } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_materials_volume";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_materials_volume extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_materials_volume"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md)
  * @since 5.0.0

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_mesh_quantization.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_mesh_quantization.ts
@@ -3,6 +3,17 @@ import { GLTFLoader } from "../glTFLoader";
 
 const NAME = "KHR_mesh_quantization";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_mesh_quantization extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_mesh_quantization"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_mesh_quantization/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_texture_basisu.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_texture_basisu.ts
@@ -7,6 +7,17 @@ import type { IKHRTextureBasisU } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_texture_basisu";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_texture_basisu extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_texture_basisu"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_basisu/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_texture_transform.ts
@@ -9,6 +9,17 @@ import type { IKHRTextureTransform } from "babylonjs-gltf2interface";
 
 const NAME = "KHR_texture_transform";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_texture_transform extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_texture_transform"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_transform/README.md)
  */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_xmp_json_ld.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_xmp_json_ld.ts
@@ -4,6 +4,17 @@ import type { IKHRXmpJsonLd_Gltf, IKHRXmpJsonLd_Node } from "babylonjs-gltf2inte
 
 const NAME = "KHR_xmp_json_ld";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_xmp_json_ld extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_xmp_json_ld"]: {};
+    }
+}
+
 /**
  * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_xmp_json_ld/README.md)
  * @since 5.0.0

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
@@ -15,6 +15,17 @@ import { IMSFTAudioEmitter_AnimationEventAction } from "babylonjs-gltf2interface
 
 const NAME = "MSFT_audio_emitter";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the MSFT_audio_emitter extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["MSFT_audio_emitter"]: {};
+    }
+}
+
 interface ILoaderClip extends IMSFTAudioEmitter_Clip, IArrayItem {
     _objectURL?: Promise<string>;
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -18,7 +18,7 @@ declare module "../../glTFFileLoader" {
         /**
          * Defines options for the MSFT_lod extension.
          */
-        ["MSFT_lod"]?: Partial<{
+        ["MSFT_lod"]: Partial<{
             /**
              * Maximum number of LODs to load, starting from the lowest LOD.
              */

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_lod.ts
@@ -18,6 +18,7 @@ declare module "../../glTFFileLoader" {
         /**
          * Defines options for the MSFT_lod extension.
          */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
         ["MSFT_lod"]: Partial<{
             /**
              * Maximum number of LODs to load, starting from the lowest LOD.

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
@@ -8,6 +8,17 @@ import { GLTFLoader } from "../glTFLoader";
 
 const NAME = "MSFT_minecraftMesh";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the MSFT_minecraftMesh extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["MSFT_minecraftMesh"]: {};
+    }
+}
+
 /** @internal */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class MSFT_minecraftMesh implements IGLTFLoaderExtension {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_sRGBFactors.ts
@@ -8,6 +8,17 @@ import { GLTFLoader } from "../glTFLoader";
 
 const NAME = "MSFT_sRGBFactors";
 
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the MSFT_sRGBFactors extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["MSFT_sRGBFactors"]: {};
+    }
+}
+
 /** @internal */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class MSFT_sRGBFactors implements IGLTFLoaderExtension {

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -45,7 +45,7 @@ declare module "core/Loading/sceneLoader" {
         /**
          * Defines options for the glTF loader.
          */
-        [PLUGIN_GLTF]?: Partial<GLTFLoaderOptions>;
+        [PLUGIN_GLTF]: Partial<GLTFLoaderOptions>;
     }
 }
 
@@ -222,7 +222,7 @@ abstract class GLTFLoaderOptions {
     /**
      * Raised when the asset has been parsed
      */
-    public abstract onParsed: (loaderData: IGLTFLoaderData) => void;
+    public abstract onParsed?: (loaderData: IGLTFLoaderData) => void;
 
     // ----------
     // V2 options
@@ -341,28 +341,28 @@ abstract class GLTFLoaderOptions {
      * Callback raised when the loader creates a mesh after parsing the glTF properties of the mesh.
      * Note that the callback is called as soon as the mesh object is created, meaning some data may not have been setup yet for this mesh (vertex data, morph targets, material, ...)
      */
-    public abstract onMeshLoaded: (mesh: AbstractMesh) => void;
+    public abstract onMeshLoaded?: (mesh: AbstractMesh) => void;
 
     /**
      * Callback raised when the loader creates a skin after parsing the glTF properties of the skin node.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/glTF/glTFSkinning#ignoring-the-transform-of-the-skinned-mesh
      */
-    public abstract onSkinLoaded: (node: TransformNode, skinnedNode: TransformNode) => void;
+    public abstract onSkinLoaded?: (node: TransformNode, skinnedNode: TransformNode) => void;
 
     /**
      * Callback raised when the loader creates a texture after parsing the glTF properties of the texture.
      */
-    public abstract onTextureLoaded: (texture: BaseTexture) => void;
+    public abstract onTextureLoaded?: (texture: BaseTexture) => void;
 
     /**
      * Callback raised when the loader creates a material after parsing the glTF properties of the material.
      */
-    public abstract onMaterialLoaded: (material: Material) => void;
+    public abstract onMaterialLoaded?: (material: Material) => void;
 
     /**
      * Callback raised when the loader creates a camera after parsing the glTF properties of the camera.
      */
-    public abstract onCameraLoaded: (camera: Camera) => void;
+    public abstract onCameraLoaded?: (camera: Camera) => void;
 
     /**
      * Defines options for glTF extensions.
@@ -371,7 +371,7 @@ abstract class GLTFLoaderOptions {
         // NOTE: This type is doing two things:
         // 1. Adding an implicit 'enabled' property to the options for each extension.
         // 2. Creating a mapped type of all the options of all the extensions to make it just look like a consolidated plain object in intellisense for the user.
-        [Extension in keyof GLTFLoaderExtensionOptions]: {
+        [Extension in keyof GLTFLoaderExtensionOptions]?: {
             [Option in keyof DefaultExtensionOptions<GLTFLoaderExtensionOptions[Extension]>]: DefaultExtensionOptions<GLTFLoaderExtensionOptions[Extension]>[Option];
         };
     } = {};
@@ -410,11 +410,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     /**
      * Raised when the asset has been parsed
      */
-    public set onParsed(callback: (loaderData: IGLTFLoaderData) => void) {
+    public set onParsed(callback: ((loaderData: IGLTFLoaderData) => void) | undefined) {
         if (this._onParsedObserver) {
             this.onParsedObservable.remove(this._onParsedObserver);
         }
-        this._onParsedObserver = this.onParsedObservable.add(callback);
+        if (callback) {
+            this._onParsedObserver = this.onParsedObservable.add(callback);
+        }
     }
 
     // ------------------
@@ -456,11 +458,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
      * Callback raised when the loader creates a mesh after parsing the glTF properties of the mesh.
      * Note that the callback is called as soon as the mesh object is created, meaning some data may not have been setup yet for this mesh (vertex data, morph targets, material, ...)
      */
-    public set onMeshLoaded(callback: (mesh: AbstractMesh) => void) {
+    public set onMeshLoaded(callback: ((mesh: AbstractMesh) => void) | undefined) {
         if (this._onMeshLoadedObserver) {
             this.onMeshLoadedObservable.remove(this._onMeshLoadedObserver);
         }
-        this._onMeshLoadedObserver = this.onMeshLoadedObservable.add(callback);
+        if (callback) {
+            this._onMeshLoadedObserver = this.onMeshLoadedObservable.add(callback);
+        }
     }
 
     /**
@@ -477,11 +481,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
      * Callback raised when the loader creates a skin after parsing the glTF properties of the skin node.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/glTF/glTFSkinning#ignoring-the-transform-of-the-skinned-mesh
      */
-    public set onSkinLoaded(callback: (node: TransformNode, skinnedNode: TransformNode) => void) {
+    public set onSkinLoaded(callback: ((node: TransformNode, skinnedNode: TransformNode) => void) | undefined) {
         if (this._onSkinLoadedObserver) {
             this.onSkinLoadedObservable.remove(this._onSkinLoadedObserver);
         }
-        this._onSkinLoadedObserver = this.onSkinLoadedObservable.add((data) => callback(data.node, data.skinnedNode));
+        if (callback) {
+            this._onSkinLoadedObserver = this.onSkinLoadedObservable.add((data) => callback(data.node, data.skinnedNode));
+        }
     }
 
     /**
@@ -494,11 +500,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     /**
      * Callback raised when the loader creates a texture after parsing the glTF properties of the texture.
      */
-    public set onTextureLoaded(callback: (texture: BaseTexture) => void) {
+    public set onTextureLoaded(callback: ((texture: BaseTexture) => void) | undefined) {
         if (this._onTextureLoadedObserver) {
             this.onTextureLoadedObservable.remove(this._onTextureLoadedObserver);
         }
-        this._onTextureLoadedObserver = this.onTextureLoadedObservable.add(callback);
+        if (callback) {
+            this._onTextureLoadedObserver = this.onTextureLoadedObservable.add(callback);
+        }
     }
 
     /**
@@ -511,11 +519,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     /**
      * Callback raised when the loader creates a material after parsing the glTF properties of the material.
      */
-    public set onMaterialLoaded(callback: (material: Material) => void) {
+    public set onMaterialLoaded(callback: ((material: Material) => void) | undefined) {
         if (this._onMaterialLoadedObserver) {
             this.onMaterialLoadedObservable.remove(this._onMaterialLoadedObserver);
         }
-        this._onMaterialLoadedObserver = this.onMaterialLoadedObservable.add(callback);
+        if (callback) {
+            this._onMaterialLoadedObserver = this.onMaterialLoadedObservable.add(callback);
+        }
     }
 
     /**
@@ -528,11 +538,13 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     /**
      * Callback raised when the loader creates a camera after parsing the glTF properties of the camera.
      */
-    public set onCameraLoaded(callback: (camera: Camera) => void) {
+    public set onCameraLoaded(callback: ((camera: Camera) => void) | undefined) {
         if (this._onCameraLoadedObserver) {
             this.onCameraLoadedObservable.remove(this._onCameraLoadedObserver);
         }
-        this._onCameraLoadedObserver = this.onCameraLoadedObservable.add(callback);
+        if (callback) {
+            this._onCameraLoadedObserver = this.onCameraLoadedObservable.add(callback);
+        }
     }
 
     /**


### PR DESCRIPTION
1. Force loader/extension options to be optional - prevent a loader plugin or glTF extension from accidentally adding a required option set
2. Allow callback options to be undefined, and only add callback to observable if it is defined
3. Augment extensionOptions for all glTF extensions so they at least show up in intellisense for enabling/disabling them