### PR TITLE
Disable audio extensions in alpha viewer

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -136,6 +136,28 @@ export class Viewer implements IDisposable {
         this._loadModelAbortController?.abort("New model is being loaded before previous model finished loading.");
         const abortController = (this._loadModelAbortController = new AbortController());
 
+        // TODO: Disable audio for now, later figure out how to re-introduce it through dynamic imports.
+        options = {
+            ...options,
+            pluginOptions: {
+                ...options?.pluginOptions,
+                gltf: {
+                    ...options?.pluginOptions?.gltf,
+                    extensionOptions: {
+                        ...options?.pluginOptions?.gltf?.extensionOptions,
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        KHR_audio: {
+                            enabled: false,
+                        },
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        MSFT_audio_emitter: {
+                            enabled: false,
+                        },
+                    },
+                },
+            },
+        };
+
         await this._loadModelLock.lockAsync(async () => {
             this._throwIfDisposedOrAborted(abortSignal, abortController.signal);
             this._details.model?.dispose();


### PR DESCRIPTION
We don't currently include the audio engine, so just disabling audio extensions that try to use the audio engine. Currently the viewer allows the full options to be passed in, but I will probably change this when doing the animation controls work, and then this code should be a bit simpler.

Later, we can look into pulling in audio via a dynamic import, but we should do this work for loaders and glTF extensions first.