### PR TITLE
Scene meshes ordering list

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2467,8 +2467,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         const index = this.meshes.indexOf(toRemove);
         if (index !== -1) {
             // Remove from the scene if mesh found
-            this.meshes[index] = this.meshes[this.meshes.length - 1];
-            this.meshes.pop();
+            this.meshes.splice(index, index);
 
             if (!toRemove.parent) {
                 toRemove._removeFromSceneRootNodes();

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2467,7 +2467,7 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
         const index = this.meshes.indexOf(toRemove);
         if (index !== -1) {
             // Remove from the scene if mesh found
-            this.meshes.splice(index, index);
+            this.meshes.splice(index, 1);
 
             if (!toRemove.parent) {
                 toRemove._removeFromSceneRootNodes();


### PR DESCRIPTION
Follow up https://forum.babylonjs.com/t/instanced-meshes-are-rendered-twice/52871

When removing a mesh, its slot in the scene.meshes list is replaced with latest mesh in that list.
If the removed meshes entry is replaced with an instanceMesh, then that mesh is rendered 2 times. Each time all with its instances.
Simple solution: preserve order. idk if there is a noticeable performance impact here @RaananW 
Another possible solution @deltakosh ?