### PR TITLE
OutlineRenderer to WebGPU

### DIFF
--- a/packages/dev/core/src/Rendering/index.ts
+++ b/packages/dev/core/src/Rendering/index.ts
@@ -41,3 +41,9 @@ export * from "../Shaders/line.fragment";
 export * from "../Shaders/line.vertex";
 export * from "../ShadersWGSL/line.fragment";
 export * from "../ShadersWGSL/line.vertex";
+
+// Outline Renderer
+export * from "../Shaders/outline.fragment";
+export * from "../Shaders/outline.vertex";
+export * from "../ShadersWGSL/outline.fragment";
+export * from "../ShadersWGSL/outline.vertex";

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -9,10 +9,11 @@ import type { ISceneComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import { DrawWrapper } from "../Materials/drawWrapper";
 
-import "../Shaders/outline.fragment";
-import "../Shaders/outline.vertex";
 import { addClipPlaneUniforms, bindClipPlane, prepareStringDefinesForClipPlanes } from "core/Materials/clipPlaneMaterialHelper";
-import { BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { EffectFallbacks } from "core/Materials/effectFallbacks";
+import type { IEffectCreationOptions } from "core/Materials/effect";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 declare module "../scene" {
     export interface Scene {
@@ -121,6 +122,16 @@ export class OutlineRenderer implements ISceneComponent {
     private _savedDepthWrite: boolean;
     private _passIdForDrawWrapper: number[];
 
+    /** Shader language used by the Outline renderer. */
+    protected _shaderLanguage = ShaderLanguage.GLSL;
+
+    /**
+     * Gets the shader language used in the Outline renderer.
+     */
+    public get shaderLanguage(): ShaderLanguage {
+        return this._shaderLanguage;
+    }
+
     /**
      * Instantiates a new outline renderer. (There could be only one per scene).
      * @param scene Defines the scene it belongs to
@@ -132,6 +143,11 @@ export class OutlineRenderer implements ISceneComponent {
         this._passIdForDrawWrapper = [];
         for (let i = 0; i < 4; ++i) {
             this._passIdForDrawWrapper[i] = this._engine.createRenderPassId(`Outline Renderer (${i})`);
+        }
+
+        const engine = this._engine;
+        if (engine.isWebGPU) {
+            this._shaderLanguage = ShaderLanguage.WGSL;
         }
     }
 
@@ -207,9 +223,7 @@ export class OutlineRenderer implements ISceneComponent {
         effect.setMatrix("world", effectiveMesh.getWorldMatrix());
 
         // Bones
-        if (renderingMesh.useBones && renderingMesh.computeBonesUsingShaders && renderingMesh.skeleton) {
-            effect.setMatrices("mBones", renderingMesh.skeleton.getTransformMatrices(renderingMesh));
-        }
+        BindBonesParameters(effectiveMesh, effect);
 
         if (renderingMesh.morphTargetManager && renderingMesh.morphTargetManager.isUsingTextureForTargets) {
             renderingMesh.morphTargetManager._bind(effect);
@@ -220,6 +234,12 @@ export class OutlineRenderer implements ISceneComponent {
 
         if (!hardwareInstancedRendering) {
             renderingMesh._bind(subMesh, effect, material.fillMode);
+        }
+
+        // Baked vertex animations
+        const bvaManager = subMesh.getMesh().bakedVertexAnimationManager;
+        if (hardwareInstancedRendering && bvaManager && bvaManager.isEnabled) {
+            bvaManager.bind(effect, true);
         }
 
         // Alpha test
@@ -288,15 +308,25 @@ export class OutlineRenderer implements ISceneComponent {
         prepareStringDefinesForClipPlanes(material, scene, defines);
 
         // Bones
-        if (mesh.useBones && mesh.computeBonesUsingShaders) {
+        const fallbacks = new EffectFallbacks();
+        if (mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
             attribs.push(VertexBuffer.MatricesIndicesKind);
             attribs.push(VertexBuffer.MatricesWeightsKind);
             if (mesh.numBoneInfluencers > 4) {
                 attribs.push(VertexBuffer.MatricesIndicesExtraKind);
                 attribs.push(VertexBuffer.MatricesWeightsExtraKind);
             }
+            const skeleton = mesh.skeleton;
             defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
-            defines.push("#define BonesPerMesh " + (mesh.skeleton ? mesh.skeleton.bones.length + 1 : 0));
+            if (mesh.numBoneInfluencers > 0) {
+                fallbacks.addCPUSkinningFallback(0, mesh);
+            }
+
+            if (skeleton.isUsingTextureForMatrices) {
+                defines.push("#define BONETEXTURE");
+            } else {
+                defines.push("#define BonesPerMesh " + (skeleton.bones.length + 1));
+            }
         } else {
             defines.push("#define NUM_BONE_INFLUENCERS 0");
         }
@@ -327,6 +357,13 @@ export class OutlineRenderer implements ISceneComponent {
             }
         }
 
+        // Baked vertex animations
+        const bvaManager = mesh.bakedVertexAnimationManager;
+        if (useInstances && bvaManager && bvaManager.isEnabled) {
+            defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
+            attribs.push("bakedVertexAnimationSettingsInstanced");
+        }
+
         // Get correct effect
         const drawWrapper = subMesh._getDrawWrapper(renderPassId, true)!;
         const cachedDefines = drawWrapper.defines;
@@ -342,16 +379,43 @@ export class OutlineRenderer implements ISceneComponent {
                 "color",
                 "logarithmicDepthConstant",
                 "morphTargetInfluences",
+                "boneTextureWidth",
                 "morphTargetCount",
                 "morphTargetTextureInfo",
                 "morphTargetTextureIndices",
+                "bakedVertexAnimationSettings",
+                "bakedVertexAnimationTextureSizeInverted",
+                "bakedVertexAnimationTime",
+                "bakedVertexAnimationTexture",
             ];
+            const samplers = ["diffuseSampler", "boneSampler", "morphTargets", "bakedVertexAnimationTexture"];
+
             addClipPlaneUniforms(uniforms);
 
             drawWrapper.setEffect(
-                this.scene.getEngine().createEffect("outline", attribs, uniforms, ["diffuseSampler", "morphTargets"], join, undefined, undefined, undefined, {
-                    maxSimultaneousMorphTargets: numMorphInfluencers,
-                }),
+                this.scene.getEngine().createEffect(
+                    "outline",
+                    <IEffectCreationOptions>{
+                        attributes: attribs,
+                        uniformsNames: uniforms,
+                        uniformBuffersNames: [],
+                        samplers: samplers,
+                        defines: join,
+                        fallbacks: fallbacks,
+                        onCompiled: null,
+                        onError: null,
+                        indexParameters: { maxSimultaneousMorphTargets: numMorphInfluencers },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: async () => {
+                            if (this._shaderLanguage === ShaderLanguage.WGSL) {
+                                await Promise.all([import("../ShadersWGSL/outline.fragment"), import("../ShadersWGSL/outline.vertex")]);
+                            } else {
+                                await Promise.all([import("../Shaders/outline.fragment"), import("../Shaders/outline.vertex")]);
+                            }
+                        },
+                    },
+                    this.scene.getEngine()
+                ),
                 join
             );
         }

--- a/packages/dev/core/src/ShadersWGSL/outline.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/outline.fragment.fx
@@ -1,0 +1,30 @@
+﻿uniform color: vec4f;
+
+#ifdef ALPHATEST
+varying vUV: vec2;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+#endif
+#include<clipPlaneFragmentDeclaration>
+#include<logDepthDeclaration>
+
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+#ifdef ALPHATEST
+    if (textureSample(diffuseSampler, diffuseSamplerSampler, fragmentInputs.vUV).a < 0.4) {
+        discard;
+    }
+#endif
+#include<logDepthFragment>
+    fragmentOutputs.color = uniforms.color;
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/core/src/ShadersWGSL/outline.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/outline.vertex.fx
@@ -1,0 +1,65 @@
+﻿// Attribute
+attribute position: vec3f;
+attribute normal: vec3f;
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+#include<morphTargetsVertexGlobalDeclaration>
+#include<morphTargetsVertexDeclaration>[0..maxSimultaneousMorphTargets]
+
+#include<clipPlaneVertexDeclaration>
+
+// Uniform
+uniform offset: f32;
+
+#include<instancesDeclaration>
+
+uniform viewProjection: mat4x4f;
+
+#ifdef ALPHATEST
+varying vUV: vec2f;
+uniform diffuseMatrix: mat4x4f; 
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#endif
+#include<logDepthDeclaration>
+
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input: VertexInputs) -> FragmentInputs {
+    var positionUpdated: vec3f = vertexInputs.position;
+    var normalUpdated: vec3f = vertexInputs.normal;
+#ifdef UV1
+    var uvUpdated: vec2f = vertexInputs.uv;
+#endif
+    #include<morphTargetsVertexGlobal>
+    #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]
+
+	var offsetPosition: vec3f = positionUpdated + (normalUpdated * uniforms.offset);
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+    var worldPos: vec4f = finalWorld * vec4f(offsetPosition, 1.0);
+
+    vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+#ifdef ALPHATEST
+#ifdef UV1
+    vertexOutputs.vUV = (uniforms.diffuseMatrix * vec4f(uvUpdated, 1.0, 0.0)).xy;
+#endif
+#ifdef UV2
+    vertexOutputs.vUV = (uniforms.diffuseMatrix * vec4f(vertexInputs.uv2, 1.0, 0.0)).xy;
+#endif
+#endif
+#include<clipPlaneVertex>
+#include<logDepthVertex>
+}


### PR DESCRIPTION
Add a WGSL implementation to the Outline Renderer.

Also adds support for skeletons using textures and VAT.