### PR TITLE
fix VAT with non instanced mesh

### DIFF
--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1336,9 +1336,9 @@ export class ShadowGenerator implements IShadowGenerator {
                 }
 
                 // Baked vertex animations
-                const bvaManager = (<Mesh>subMesh.getMesh()).bakedVertexAnimationManager;
-                if (hardwareInstancedRendering && bvaManager && bvaManager.isEnabled) {
-                    bvaManager.bind(effect, true);
+                const bvaManager = subMesh.getMesh().bakedVertexAnimationManager;
+                if (bvaManager && bvaManager.isEnabled) {
+                    bvaManager.bind(effect, hardwareInstancedRendering);
                 }
 
                 // Clip planes
@@ -1657,10 +1657,12 @@ export class ShadowGenerator implements IShadowGenerator {
             }
 
             // Baked vertex animations
-            const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
-            if (useInstances && bvaManager && bvaManager.isEnabled) {
+            const bvaManager = mesh.bakedVertexAnimationManager;
+            if (bvaManager && bvaManager.isEnabled) {
                 defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
-                attribs.push("bakedVertexAnimationSettingsInstanced");
+                if (useInstances) {
+                    attribs.push("bakedVertexAnimationSettingsInstanced");
+                }
             }
 
             // Get correct effect

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -238,8 +238,8 @@ export class OutlineRenderer implements ISceneComponent {
 
         // Baked vertex animations
         const bvaManager = subMesh.getMesh().bakedVertexAnimationManager;
-        if (hardwareInstancedRendering && bvaManager && bvaManager.isEnabled) {
-            bvaManager.bind(effect, true);
+        if (bvaManager && bvaManager.isEnabled) {
+            bvaManager.bind(effect, hardwareInstancedRendering);
         }
 
         // Alpha test
@@ -359,9 +359,11 @@ export class OutlineRenderer implements ISceneComponent {
 
         // Baked vertex animations
         const bvaManager = mesh.bakedVertexAnimationManager;
-        if (useInstances && bvaManager && bvaManager.isEnabled) {
+        if (bvaManager && bvaManager.isEnabled) {
             defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
-            attribs.push("bakedVertexAnimationSettingsInstanced");
+            if (useInstances) {
+                attribs.push("bakedVertexAnimationSettingsInstanced");
+            }
         }
 
         // Get correct effect


### PR DESCRIPTION
The implementation of VAT supports both meshes that use instancing and those that don't,

but the binding code was only working for meshes that only instanced. fixed this.

*I recently added VAT support to the Outline Renderer, but when I did so, I copied the code from the shadowGenerator, which has the problem.*