### PR TITLE
Native Texture Loaders

### DIFF
--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -1810,7 +1810,12 @@ export class NativeEngine extends Engine {
         const lastDot = url.lastIndexOf(".");
         const extension = forcedExtension ? forcedExtension : lastDot > -1 ? url.substring(lastDot).toLowerCase() : "";
 
-        const loaderPromise = _GetCompatibleTextureLoader(extension);
+        // some formats are already supported by bimg, no need to try to load them with JS
+        // leaving TextureLoader extension check for future use
+        let loaderPromise = null;
+        if (extension.endsWith(".basis") || extension.endsWith(".ktx") || extension.endsWith(".ktx2") || mimeType === "image/ktx" || mimeType === "image/ktx2") {
+            loaderPromise = _GetCompatibleTextureLoader(extension);
+        }
 
         if (scene) {
             scene.addPendingData(texture);


### PR DESCRIPTION
Use native (bimg) texture loaders for tga, exr, hdr, dds