### PR TITLE
Don't overwrite null root node with undefined default

### DIFF
--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -198,20 +198,32 @@ abstract class GLTFLoaderOptions {
     // eslint-disable-next-line babylonjs/available
     protected copyFrom(options?: Partial<Readonly<GLTFLoaderOptions>>) {
         if (options) {
-            const copyOption = (option: string) => {
-                const typedKey = option as keyof GLTFLoaderOptions;
-                (this as Record<keyof GLTFLoaderOptions, unknown>)[typedKey] = options[typedKey] ?? this[typedKey];
-            };
-
-            // Copy concrete properties
-            for (const option in this) {
-                copyOption(option);
-            }
-
-            // Copy abstract properties
-            for (const option of ["onParsed", "onMeshLoaded", "onSkinLoaded", "onTextureLoaded", "onMaterialLoaded", "onCameraLoaded"] satisfies (keyof GLTFLoaderOptions)[]) {
-                copyOption(option);
-            }
+            this.onParsed = options.onParsed;
+            this.coordinateSystemMode = options.coordinateSystemMode ?? this.coordinateSystemMode;
+            this.animationStartMode = options.animationStartMode ?? this.animationStartMode;
+            this.loadNodeAnimations = options.loadNodeAnimations ?? this.loadNodeAnimations;
+            this.loadSkins = options.loadSkins ?? this.loadSkins;
+            this.loadMorphTargets = options.loadMorphTargets ?? this.loadMorphTargets;
+            this.compileMaterials = options.compileMaterials ?? this.compileMaterials;
+            this.useClipPlane = options.useClipPlane ?? this.useClipPlane;
+            this.compileShadowGenerators = options.compileShadowGenerators ?? this.compileShadowGenerators;
+            this.transparencyAsCoverage = options.transparencyAsCoverage ?? this.transparencyAsCoverage;
+            this.useRangeRequests = options.useRangeRequests ?? this.useRangeRequests;
+            this.createInstances = options.createInstances ?? this.createInstances;
+            this.alwaysComputeBoundingBox = options.alwaysComputeBoundingBox ?? this.alwaysComputeBoundingBox;
+            this.loadAllMaterials = options.loadAllMaterials ?? this.loadAllMaterials;
+            this.loadOnlyMaterials = options.loadOnlyMaterials ?? this.loadOnlyMaterials;
+            this.skipMaterials = options.skipMaterials ?? this.skipMaterials;
+            this.useSRGBBuffers = options.useSRGBBuffers ?? this.useSRGBBuffers;
+            this.targetFps = options.targetFps ?? this.targetFps;
+            this.alwaysComputeSkeletonRootNode = options.alwaysComputeSkeletonRootNode ?? this.alwaysComputeSkeletonRootNode;
+            this.preprocessUrlAsync = options.preprocessUrlAsync ?? this.preprocessUrlAsync;
+            this.customRootNode = options.customRootNode;
+            this.onMeshLoaded = options.onMeshLoaded;
+            this.onSkinLoaded = options.onSkinLoaded;
+            this.onTextureLoaded = options.onTextureLoaded;
+            this.onMaterialLoaded = options.onMaterialLoaded;
+            this.onCameraLoaded = options.onCameraLoaded;
         }
     }
 

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -1265,6 +1265,7 @@ describe("Babylon Scene Loader", function () {
                     useClipPlane: !gltfFileLoader.useClipPlane,
                     useRangeRequests: !gltfFileLoader.useRangeRequests,
                     useSRGBBuffers: !gltfFileLoader.useSRGBBuffers,
+                    customRootNode: null,
                 } satisfies GLTFOptions;
 
                 const loaderPromise = new Promise<GLTFFileLoader>((resolve) => {


### PR DESCRIPTION
Addresses forum issue: https://forum.babylonjs.com/t/customrootnode-null-does-not-work/52971

Effectively the previous code did something like:
```ts
const finalOption = passedInOption ?? defaultOption;
```

This logic is incorrect when `null` is a valid value for `passedInOption` and `defaultOption` is `undefined`. This is the case for `customRootNode`.

I started to fix this in the current code, but in doing so realized that in a later revision of the original loader options PR, I also introduced a different issue. Specifically, the generic option copying logic is trying to iterate over the keys of the base class only, but since it uses `key in this`, it picks up all the properties of the derived `GLTFFileLoader` class and copies everything, which I don't think technically hurts anything but definitely not the intention. In an earlier iteration of that original PR, there was an instance of `GLTFLoaderOptions` used for default values, and I used to iterate over the keys in that object, which was correct. At some point, I ended up removing the default options instance, and since later I made `GLTFLoaderOptions` abstract to deal with callbacks in a backward compatible way, it's no longer even possible to instantiate the base class. I tried a bunch of different things to keep the generic copy logic while fixing these problems, but it just kept getting more and more complicated, so I just switched to to explicitly copy each property. If we add new options in the future, we'll just need to be careful to add a line to copy them.