### PR TITLE
Don't enforce ContentSecurityPolicy for image loading if the disposition is "report"

### DIFF
--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -317,7 +317,7 @@ export const LoadImage = (
     };
 
     const cspHandler = (err: any) => {
-        if (err.blockedURI !== img.src) {
+        if (err.blockedURI !== img.src || err.disposition === "report") {
             return;
         }
 


### PR DESCRIPTION
Content-Security-Policy-Report-Only headers should not actually block the loading of content - the browser will just report violations as warnings in the console.  With this check, Babylon will no longer to refuse to load image content if the CSP is in report only mode but will still abort requests if the CSP is being enforced (using the regular Content-Security-Policy header).