### PR TITLE
Add extraInitializationsAsync to EffectWrapper Option

### DIFF
--- a/packages/dev/core/src/Materials/effectRenderer.ts
+++ b/packages/dev/core/src/Materials/effectRenderer.ts
@@ -238,6 +238,10 @@ interface EffectWrapperCreationOptions {
      * The language the shader is written in (default: GLSL)
      */
     shaderLanguage?: ShaderLanguage;
+    /**
+     * Additional async code to run before preparing the effect
+     */
+    extraInitializationsAsync?: () => Promise<void>;
 }
 
 /**
@@ -269,11 +273,11 @@ export class EffectWrapper {
      * @param creationOptions options to create the effect
      */
     constructor(creationOptions: EffectWrapperCreationOptions) {
-        let effectCreationOptions: any;
+        let shaderPath: any;
         const uniformNames = creationOptions.uniformNames || [];
 
         if (creationOptions.vertexShader) {
-            effectCreationOptions = {
+            shaderPath = {
                 fragmentSource: creationOptions.fragmentShader,
                 vertexSource: creationOptions.vertexShader,
                 spectorName: creationOptions.name || "effectWrapper",
@@ -282,7 +286,7 @@ export class EffectWrapper {
             // Default scale to use in post process vertex shader.
             uniformNames.push("scale");
 
-            effectCreationOptions = {
+            shaderPath = {
                 fragmentSource: creationOptions.fragmentShader,
                 vertex: "postprocess",
                 spectorName: creationOptions.name || "effectWrapper",
@@ -298,16 +302,16 @@ export class EffectWrapper {
         this._drawWrapper = new DrawWrapper(creationOptions.engine);
 
         if (creationOptions.useShaderStore) {
-            effectCreationOptions.fragment = effectCreationOptions.fragmentSource;
-            if (!effectCreationOptions.vertex) {
-                effectCreationOptions.vertex = effectCreationOptions.vertexSource;
+            shaderPath.fragment = shaderPath.fragmentSource;
+            if (!shaderPath.vertex) {
+                shaderPath.vertex = shaderPath.vertexSource;
             }
 
-            delete effectCreationOptions.fragmentSource;
-            delete effectCreationOptions.vertexSource;
+            delete shaderPath.fragmentSource;
+            delete shaderPath.vertexSource;
 
             this.effect = creationOptions.engine.createEffect(
-                effectCreationOptions,
+                shaderPath,
                 creationOptions.attributeNames || ["position"],
                 uniformNames,
                 creationOptions.samplerNames,
@@ -316,11 +320,12 @@ export class EffectWrapper {
                 creationOptions.onCompiled,
                 undefined,
                 undefined,
-                creationOptions.shaderLanguage
+                creationOptions.shaderLanguage,
+                creationOptions.extraInitializationsAsync
             );
         } else {
             this.effect = new Effect(
-                effectCreationOptions,
+                shaderPath,
                 creationOptions.attributeNames || ["position"],
                 uniformNames,
                 creationOptions.samplerNames,
@@ -331,7 +336,8 @@ export class EffectWrapper {
                 undefined,
                 undefined,
                 undefined,
-                creationOptions.shaderLanguage
+                creationOptions.shaderLanguage,
+                creationOptions.extraInitializationsAsync
             );
 
             this._onContextRestoredObserver = creationOptions.engine.onContextRestoredObservable.add(() => {


### PR DESCRIPTION
Add the extraInitializationsAsync option to the EffectWrapper.

This is needed to make it easier to add wgsl support to rendering logic that uses EffectWrapper.


#### Additional Context:
I'm currently trying to add wgsl support to FluidRenderer, but after looking at the source, I decided that EffectWrapper should support async shader loading first, so I created this PR.
