### PR TITLE
Viewer alpha code splitting / chunking for dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23178,14 +23178,14 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
-            "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
+            "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.40",
-                "rollup": "^4.13.0"
+                "postcss": "^8.4.41",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -24763,13 +24763,27 @@
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-terser": "^0.4.4",
                 "@rollup/plugin-typescript": "^11.1.6",
+                "chalk": "^5.3.0",
                 "rollup": "^4.18.0",
                 "rollup-plugin-dts": "^6.1.1",
-                "rollup-plugin-minify-html-literals": "^1.2.6"
+                "rollup-plugin-minify-html-literals": "^1.2.6",
+                "vite": "^5.4.2"
             },
             "peerDependencies": {
                 "@babylonjs/core": "^7.13.2",
                 "@babylonjs/loaders": "^7.0.0"
+            }
+        },
+        "packages/public/@babylonjs/viewer-alpha/node_modules/chalk": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "dev": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "packages/public/@babylonjs/viewer-alpha/node_modules/rollup": {

--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -17,6 +17,8 @@
         "license.md"
     ],
     "scripts": {
+        "start": "npm run serve -- --open test/apps/web/index.html",
+        "serve": "vite",
         "build": "npm run clean && npm run bundle",
         "clean": "rimraf lib && rimraf dist && rimraf *.tsbuildinfo",
         "bundle": "npm run bundle:lib && npm run bundle:dist:esm",
@@ -38,9 +40,11 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
+        "chalk": "^5.3.0",
         "rollup": "^4.18.0",
         "rollup-plugin-dts": "^6.1.1",
-        "rollup-plugin-minify-html-literals": "^1.2.6"
+        "rollup-plugin-minify-html-literals": "^1.2.6",
+        "vite": "^5.4.2"
     },
     "keywords": [
         "3D",

--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
@@ -12,10 +12,10 @@ const source = "dev";
 const commonConfig = {
     input: "../../../tools/viewer-alpha/src/index.ts",
     output: {
+        dir: "dist",
         sourcemap: true,
         format: "es",
         exports: "named",
-        inlineDynamicImports: true,
     },
     plugins: [
         typescript({ tsconfig: "tsconfig.build.dist.json" }),
@@ -34,7 +34,8 @@ const maxConfig = {
     ...commonConfig,
     output: {
         ...commonConfig.output,
-        file: "dist/babylon-viewer.esm.js",
+        entryFileNames: "babylon-viewer.esm.js",
+        chunkFileNames: "chunks/[name]-[hash].esm.js",
     },
 };
 
@@ -42,7 +43,8 @@ const minConfig = {
     ...commonConfig,
     output: {
         ...commonConfig.output,
-        file: "dist/babylon-viewer.esm.min.js",
+        entryFileNames: "babylon-viewer.esm.min.js",
+        chunkFileNames: "chunks/[name]-[hash].esm.min.js",
     },
     plugins: [...commonConfig.plugins, terser(), minifyHTML()],
 };

--- a/packages/public/@babylonjs/viewer-alpha/test/apps/web/index.html
+++ b/packages/public/@babylonjs/viewer-alpha/test/apps/web/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+    <style>
+        html,
+        body {
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+            overflow: hidden;
+        }
+    </style>
+    <body>
+        <script type="module" src="../../../dist/babylon-viewer.esm.js"></script>
+        <babylon-viewer src="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env">
+        </babylon-viewer>
+    </body>
+</html>

--- a/packages/public/@babylonjs/viewer-alpha/tsconfig.build.dist.json
+++ b/packages/public/@babylonjs/viewer-alpha/tsconfig.build.dist.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tools/viewer-alpha/tsconfig.build.json",
     "compilerOptions": {
-        "declaration": false,
+        "outDir": "dist",
+        "declaration": false
     }
 }

--- a/packages/public/@babylonjs/viewer-alpha/vite.config.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/vite.config.mjs
@@ -1,0 +1,20 @@
+"use strict";
+
+/* eslint-disable no-console */
+
+import { defineConfig, loadEnv } from "vite";
+import chalk from "chalk";
+
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd());
+
+    const port = env.VIEWER_PORT ?? 1343;
+    console.log(`${chalk.bold(`Web Test App`)}: ${chalk.cyan(`http://localhost:${port}/test/apps/web/index.html`)}`);
+
+    return {
+        root: ".",
+        server: {
+            port,
+        },
+    };
+});

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -304,43 +304,44 @@ export class HTML3DElement extends LitElement {
         return html`
             <div class="full-size">
                 <canvas id="renderCanvas" class="full-size" touch-action="none"></canvas>
-                ${this.animations.length > 0 &&
-                html`
-                    <slot name="tool-bar">
-                        <div part="tool-bar" class="tool-bar">
-                            <div class="progress-control">
-                                <button aria-label="${this.isAnimationPlaying ? "Pause" : "Play"}" @click="${this.toggleAnimation}">
-                                    ${!this.isAnimationPlaying
-                                        ? html`<svg viewBox="0 0 20 20">
-                                              <path d="${playFilledIcon}" fill="currentColor"></path>
-                                          </svg>`
-                                        : html`<svg viewBox="-3 -2 24 24">
-                                              <path d="${pauseFilledIcon}" fill="currentColor"></path>
-                                          </svg>`}
-                                </button>
-                                <input
-                                    aria-label="Animation Progress"
-                                    class="progress-wrapper"
-                                    type="range"
-                                    min="0"
-                                    max="1"
-                                    step="0.0001"
-                                    .value="${this.animationProgress}"
-                                    @input="${this._onProgressChanged}"
-                                    @pointerdown="${this._onProgressPointerDown}"
-                                />
-                            </div>
-                            <select aria-label="Select Animation Speed" @change="${this._onAnimationSpeedChanged}">
-                                ${allowedAnimationSpeeds.map((speed) => html`<option value="${speed}" .selected="${this.animationSpeed === speed}">${speed}x</option>`)}
-                            </select>
-                            ${this.animations.length > 1
-                                ? html`<select aria-label="Select Animation" @change="${this._onSelectedAnimationChanged}">
-                                      ${this.animations.map((name, index) => html`<option value="${index}" .selected="${this.selectedAnimation == index}">${name}</option>`)}
-                                  </select>`
-                                : ""}
-                        </div>
-                    </slot>
-                `}
+                ${this.animations.length === 0
+                    ? ""
+                    : html`
+                          <slot name="tool-bar">
+                              <div part="tool-bar" class="tool-bar">
+                                  <div class="progress-control">
+                                      <button aria-label="${this.isAnimationPlaying ? "Pause" : "Play"}" @click="${this.toggleAnimation}">
+                                          ${!this.isAnimationPlaying
+                                              ? html`<svg viewBox="0 0 20 20">
+                                                    <path d="${playFilledIcon}" fill="currentColor"></path>
+                                                </svg>`
+                                              : html`<svg viewBox="-3 -2 24 24">
+                                                    <path d="${pauseFilledIcon}" fill="currentColor"></path>
+                                                </svg>`}
+                                      </button>
+                                      <input
+                                          aria-label="Animation Progress"
+                                          class="progress-wrapper"
+                                          type="range"
+                                          min="0"
+                                          max="1"
+                                          step="0.0001"
+                                          .value="${this.animationProgress}"
+                                          @input="${this._onProgressChanged}"
+                                          @pointerdown="${this._onProgressPointerDown}"
+                                      />
+                                  </div>
+                                  <select aria-label="Select Animation Speed" @change="${this._onAnimationSpeedChanged}">
+                                      ${allowedAnimationSpeeds.map((speed) => html`<option value="${speed}" .selected="${this.animationSpeed === speed}">${speed}x</option>`)}
+                                  </select>
+                                  ${this.animations.length > 1
+                                      ? html`<select aria-label="Select Animation" @change="${this._onSelectedAnimationChanged}">
+                                            ${this.animations.map((name, index) => html`<option value="${index}" .selected="${this.selectedAnimation == index}">${name}</option>`)}
+                                        </select>`
+                                      : ""}
+                              </div>
+                          </slot>
+                      `}
             </div>
         `;
     }


### PR DESCRIPTION
This change configures rollup to allow code splitting / chunking for dynamic imports (previously we just inlined the dynamic imports). This only affects the `dist` folder of the alpha viewer, which even if it is not being used right now, it is useful for testing. The dist folder now looks like this (truncated):

![image](https://github.com/user-attachments/assets/519bf567-ce20-45cb-a04e-2446265b933e)

This chunking breaks it into 23 js files instead of 1 (per min/max). This gets the top level minified file back down to about 1.5mb as expected.

I also added a very simple test app to the public package directory to make it easy to test the built dist locally.

Lastly, I made one tiny fix to `ViewerElement.ts`, where I had used `??` to make the animation controls conditional, which meant when a model with no animation is loaded, it actually ends up inserting a "false" string into the dom. When the viewer is taking up the full space of the parent, it's not visible, so I missed it previously. I just changed it to use a ternary operator and substitute empty string when there is no animation.