### PR TITLE
Fix alphaCutOff bug for prepasses with PBRMaterial

### DIFF
--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -626,7 +626,7 @@ void main(void) {
     #define CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR
 
 #ifdef PREPASS
-    float writeGeometryInfo = finalColor.a > 0.4 ? 1.0 : 0.0;
+    float writeGeometryInfo = finalColor.a > ALPHATESTVALUE ? 1.0 : 0.0;
 
     #ifdef PREPASS_POSITION
     gl_FragData[PREPASS_POSITION_INDEX] = vec4(vPositionW, writeGeometryInfo);


### PR DESCRIPTION
This seems like a bug that's been here since 2020?

https://github.com/BabylonJS/Babylon.js/commit/b0ea94d2da49bb433be9e1f683fb8601ec7602e3#diff-2a4a53d0e5c40a5418e4772bae04358b45cdaf0efc65291d9e8873b47b08a8a4