### PR TITLE
Dynamically imported loader plugins

### DIFF
--- a/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
@@ -2,6 +2,7 @@ import type { Nullable } from "core/types";
 import { Color3 } from "core/Maths/math.color";
 import { Texture } from "core/Materials/Textures/texture";
 import { StandardMaterial } from "core/Materials/standardMaterial";
+import { ObjLoadingFlags } from "./objLoadingFlags";
 
 import type { Scene } from "core/scene";
 import type { AssetContainer } from "core/assetContainer";
@@ -12,7 +13,13 @@ export class MTLFileLoader {
     /**
      * Invert Y-Axis of referenced textures on load
      */
-    public static INVERT_TEXTURE_Y = true;
+    public static get INVERT_TEXTURE_Y() {
+        return ObjLoadingFlags.INVERT_TEXTURE_Y;
+    }
+
+    public static set INVERT_TEXTURE_Y(value: boolean) {
+        ObjLoadingFlags.INVERT_TEXTURE_Y = value;
+    }
 
     /**
      * All material loaded from the mtl will be set here

--- a/packages/dev/loaders/src/OBJ/objFileLoader.impl.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.impl.ts
@@ -1,0 +1,218 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { AbstractMesh, ISceneLoaderAsyncResult, Mesh, Nullable, Scene, WebRequest } from "core/index";
+import type { OBJLoadingOptions } from "./objLoadingOptions";
+
+import { AssetContainer } from "core/assetContainer";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Tools } from "core/Misc/tools";
+import { MTLFileLoader } from "./mtlFileLoader";
+import { SolidParser } from "./solidParser";
+
+/**
+ * @internal
+ * Calls synchronously the MTL file attached to this obj.
+ * Load function or importMesh function don't enable to load 2 files in the same time asynchronously.
+ * Without this function materials are not displayed in the first frame (but displayed after).
+ * In consequence it is impossible to get material information in your HTML file
+ *
+ * @param url The URL of the MTL file
+ * @param rootUrl defines where to load data from
+ * @param onSuccess Callback function to be called when the MTL file is loaded
+ * @param onFailure
+ */
+function loadMTL(url: string, rootUrl: string, onSuccess: (response: string | ArrayBuffer, responseUrl?: string) => any, onFailure: (pathOfFile: string, exception?: any) => void) {
+    //The complete path to the mtl file
+    const pathOfFile = rootUrl + url;
+
+    // Loads through the babylon tools to allow fileInput search.
+    Tools.LoadFile(pathOfFile, onSuccess, undefined, undefined, false, (request?: WebRequest | undefined, exception?: any) => {
+        onFailure(pathOfFile, exception);
+    });
+}
+
+/**
+ * @internal
+ * Read the OBJ file and create an Array of meshes.
+ * Each mesh contains all information given by the OBJ and the MTL file.
+ * i.e. vertices positions and indices, optional normals values, optional UV values, optional material
+ * @param meshesNames defines a string or array of strings of the mesh names that should be loaded from the file
+ * @param scene defines the scene where are displayed the data
+ * @param assetContainer defines the asset container to store the material in (can be null)
+ * @param loadingOptions options for loading and parsing OBJ/MTL files.
+ * @param data defines the content of the obj file
+ * @param rootUrl defines the path to the folder
+ * @returns the list of loaded meshes
+ */
+export function parseSolid(
+    meshesNames: any,
+    scene: Scene,
+    assetContainer: Nullable<AssetContainer>,
+    loadingOptions: OBJLoadingOptions,
+    data: string,
+    rootUrl: string
+): Promise<Array<AbstractMesh>> {
+    let fileToLoad: string = ""; //The name of the mtlFile to load
+    const materialsFromMTLFile: MTLFileLoader = new MTLFileLoader();
+    const materialToUse: string[] = [];
+    const babylonMeshesArray: Array<Mesh> = []; //The mesh for babylon
+
+    // Sanitize data
+    data = data.replace(/#.*$/gm, "").trim();
+
+    // Main function
+    const solidParser = new SolidParser(materialToUse, babylonMeshesArray, loadingOptions);
+
+    solidParser.parse(meshesNames, data, scene, assetContainer, (fileName: string) => {
+        fileToLoad = fileName;
+    });
+
+    // load the materials
+    const mtlPromises: Array<Promise<void>> = [];
+    // Check if we have a file to load
+    if (fileToLoad !== "" && !loadingOptions.skipMaterials) {
+        //Load the file synchronously
+        mtlPromises.push(
+            new Promise((resolve, reject) => {
+                loadMTL(
+                    fileToLoad,
+                    rootUrl,
+                    (dataLoaded) => {
+                        try {
+                            //Create materials thanks MTLLoader function
+                            materialsFromMTLFile.parseMTL(scene, dataLoaded, rootUrl, assetContainer);
+                            //Look at each material loaded in the mtl file
+                            for (let n = 0; n < materialsFromMTLFile.materials.length; n++) {
+                                //Three variables to get all meshes with the same material
+                                let startIndex = 0;
+                                const _indices = [];
+                                let _index;
+
+                                //The material from MTL file is used in the meshes loaded
+                                //Push the indice in an array
+                                //Check if the material is not used for another mesh
+                                while ((_index = materialToUse.indexOf(materialsFromMTLFile.materials[n].name, startIndex)) > -1) {
+                                    _indices.push(_index);
+                                    startIndex = _index + 1;
+                                }
+                                //If the material is not used dispose it
+                                if (_index === -1 && _indices.length === 0) {
+                                    //If the material is not needed, remove it
+                                    materialsFromMTLFile.materials[n].dispose();
+                                } else {
+                                    for (let o = 0; o < _indices.length; o++) {
+                                        //Apply the material to the Mesh for each mesh with the material
+                                        const mesh = babylonMeshesArray[_indices[o]];
+                                        const material = materialsFromMTLFile.materials[n];
+                                        mesh.material = material;
+
+                                        if (!mesh.getTotalIndices()) {
+                                            // No indices, we need to turn on point cloud
+                                            material.pointsCloud = true;
+                                        }
+                                    }
+                                }
+                            }
+                            resolve();
+                        } catch (e) {
+                            Tools.Warn(`Error processing MTL file: '${fileToLoad}'`);
+                            if (loadingOptions.materialLoadingFailsSilently) {
+                                resolve();
+                            } else {
+                                reject(e);
+                            }
+                        }
+                    },
+                    (pathOfFile: string, exception?: any) => {
+                        Tools.Warn(`Error downloading MTL file: '${fileToLoad}'`);
+                        if (loadingOptions.materialLoadingFailsSilently) {
+                            resolve();
+                        } else {
+                            reject(exception);
+                        }
+                    }
+                );
+            })
+        );
+    }
+    //Return an array with all Mesh
+    return Promise.all(mtlPromises).then(() => {
+        const isLine = (mesh: AbstractMesh) => Boolean(mesh._internalMetadata?.["_isLine"] ?? false);
+
+        // Iterate over the mesh, determine if it is a line mesh, clone or modify the material to line rendering.
+        babylonMeshesArray.forEach((mesh) => {
+            if (isLine(mesh)) {
+                let mat = mesh.material ?? new StandardMaterial(mesh.name + "_line", scene);
+                // If another mesh is using this material and it is not a line then we need to clone it.
+                const needClone = mat.getBindedMeshes().filter((e) => !isLine(e)).length > 0;
+                if (needClone) {
+                    mat = mat.clone(mat.name + "_line") ?? mat;
+                }
+                mat.wireframe = true;
+                mesh.material = mat;
+                if (mesh._internalMetadata) {
+                    mesh._internalMetadata["_isLine"] = undefined;
+                }
+            }
+        });
+
+        return babylonMeshesArray;
+    });
+}
+
+/**
+ * @internal
+ */
+export async function importMeshAsync(
+    meshesNames: any,
+    scene: Scene,
+    assetContainer: Nullable<AssetContainer>,
+    loadingOptions: OBJLoadingOptions,
+    data: any,
+    rootUrl: string
+): Promise<ISceneLoaderAsyncResult> {
+    //get the meshes from OBJ file
+    const meshes = await parseSolid(meshesNames, scene, assetContainer, loadingOptions, data, rootUrl);
+    return {
+        meshes,
+        particleSystems: [],
+        skeletons: [],
+        animationGroups: [],
+        transformNodes: [],
+        geometries: [],
+        lights: [],
+        spriteManagers: [],
+    };
+}
+
+/**
+ * @internal
+ */
+export async function loadAssetContainerAsync(scene: Scene, loadingOptions: OBJLoadingOptions, data: string, rootUrl: string): Promise<AssetContainer> {
+    const container = new AssetContainer();
+
+    return importMeshAsync(null, scene, container, loadingOptions, data, rootUrl)
+        .then((result) => {
+            result.meshes.forEach((mesh) => container.meshes.push(mesh));
+            result.meshes.forEach((mesh) => {
+                const material = mesh.material;
+                if (material) {
+                    // Materials
+                    if (container.materials.indexOf(material) == -1) {
+                        container.materials.push(material);
+
+                        // Textures
+                        const textures = material.getActiveTextures();
+                        textures.forEach((t) => {
+                            if (container.textures.indexOf(t) == -1) {
+                                container.textures.push(t);
+                            }
+                        });
+                    }
+                }
+            });
+            return container;
+        })
+        .catch((ex) => {
+            throw ex;
+        });
+}

--- a/packages/dev/loaders/src/OBJ/objLoadingFlags.ts
+++ b/packages/dev/loaders/src/OBJ/objLoadingFlags.ts
@@ -1,0 +1,9 @@
+/**
+ * Holds flag state used by the obj file loading related classes.
+ */
+export class ObjLoadingFlags {
+    /**
+     * Invert Y-Axis of referenced textures on load
+     */
+    public static INVERT_TEXTURE_Y = true;
+}


### PR DESCRIPTION
This is my current proposal for how to handle dynamic importing for scene loader plugins. Originally my thought was that we could rely on the existing `ISceneLoaderPluginFactory` and just allow it to return a plugin instance (like it does today) or a promise that resolves to a plugin instance. Unfortunately after starting down this route I realized that this is not possible without introducing a back compat breaking change. Specifically, all the old scene loader functions (the callback ones) synchronously return the plugin instance. I also considered the possibility of only allowing async plugin factories to work with the new async functions, and if you used the old ones you would get a runtime error. But then once again to maintain back compat, we still need to register synchronous factories for the existing plugins. At that point, the only option would be to say that if you are using the newer async loader APIs and async factories, you need to import a different file (maybe `objFileLoader.dynamic` or something like that). We could still go this route, but it seemed like it got maybe overly complicated, so right now I'm thinking just making the dynamic import an implementation detail of the already async plugin functions is a better balance of simple and minimizing size.

With this change, when I import `objFileLoader` in the alpha viewer, it adds 1.5k of minified code statically to the main chunk, and 57k to a dynamic chunk that is only downloaded when you try to load an obj file. If people are onboard with this approach, then I would do this for the other loader plugins as well. For gltf, I *think* we can do better for extensions, something more like just having the existing factories be able to return a promise, but I haven't looked deeply yet so it is possible that we'll hit the same kind of back compat issues.