### PR TITLE
exclude VLS text from webgl1

### DIFF
--- a/packages/tools/tests/test/performance/config.json
+++ b/packages/tools/tests/test/performance/config.json
@@ -10,14 +10,9 @@
             "playgroundId": "#WIR77Z"
         },
         {
-            "title": "Particle subemitters",
-            "playgroundId": "#1LK70I#21"
-        },
-        {
             "title": "Performance playground",
             "playgroundId": "#6HWS9M#60",
             "renderCount": 300
         }
     ]
 }
-

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1685,7 +1685,8 @@
             "title": "Baked Vertex Animation with Volumetric Light Scattering Post Process",
             "renderCount": 20,
             "playgroundId": "#1LF9GK#3",
-            "referenceImage": "bakedVertexAnimationVLS.png"
+            "referenceImage": "bakedVertexAnimationVLS.png",
+            "excludedEngines": ["webgl1"]
         },
         {
             "title": "Bones and morphs computation order",


### PR DESCRIPTION
It seems to fail on webgl1 using firefox (but is working correctly on chrome)