### PR TITLE
IBL Shadow Support for .env IBL's

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsImportanceSamplingRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsImportanceSamplingRenderer.ts
@@ -17,7 +17,7 @@ import { Vector4 } from "../../Maths/math.vector";
 import { RawTexture } from "../../Materials/Textures/rawTexture";
 import type { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { Observable } from "../../Misc/observable";
-import { HDRCubeTexture } from "../../Materials/Textures/hdrCubeTexture";
+import type { CubeTexture } from "../../Materials/Textures/cubeTexture";
 
 /**
  * Build cdf maps for IBL importance sampling during IBL shadow computation.
@@ -51,17 +51,17 @@ export class _IblShadowsImportanceSamplingRenderer {
         }
         this._disposeTextures();
         this._iblSource = source;
-        if (source instanceof Texture) {
+        if (source.isCube) {
             if (source.isReadyOrNotBlocking()) {
                 this._recreateAssetsFromNewIbl(source);
             } else {
-                source.onLoadObservable.addOnce(this._recreateAssetsFromNewIbl.bind(this, source));
+                (source as CubeTexture).onLoadObservable.addOnce(this._recreateAssetsFromNewIbl.bind(this, source));
             }
-        } else if (source instanceof HDRCubeTexture) {
+        } else {
             if (source.isReadyOrNotBlocking()) {
                 this._recreateAssetsFromNewIbl(source);
             } else {
-                source.onLoadObservable.addOnce(this._recreateAssetsFromNewIbl.bind(this, source));
+                (source as Texture).onLoadObservable.addOnce(this._recreateAssetsFromNewIbl.bind(this, source));
             }
         }
     }

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
@@ -175,7 +175,7 @@ export class _IblShadowsVoxelTracingPass {
     }
 
     /** The default rotation of the environment map will align the shadows with the default lighting orientation */
-    private _envRotation: number = -Math.PI / 2.0;
+    private _envRotation: number = 0.0;
     private _downscale: number = 1.0;
 
     /**
@@ -273,7 +273,8 @@ export class _IblShadowsVoxelTracingPass {
         this._frameId++;
 
         const downscaleSquared = this._downscale * this._downscale;
-        const rotation = this._scene.useRightHandedSystem ? this._envRotation : (this._envRotation + Math.PI) % (2.0 * Math.PI);
+        let rotation = this._scene.useRightHandedSystem ? -this._envRotation - 0.5 * Math.PI : -this._envRotation - Math.PI;
+        rotation = rotation % (2.0 * Math.PI);
         effect.setVector4("shadowParameters", new Vector4(this._sampleDirections, this._frameId / downscaleSquared, this._downscale, rotation));
         const offset = new Vector2(0.0, 0.0);
         const voxelGrid = this._renderPipeline!.getVoxelGridTexture();


### PR DESCRIPTION
This fixes support for IBL's stored as CubeTexture rather than HDRCubeTexture.
I also fixed inconsistency with IBL rotation so that the same rotation value can be used for the skybox and for the IBL shadows pipeline and it works for both right and left-handed systems.