### PR TITLE
[GUI] Fit texture scale to slate dimensions

### DIFF
--- a/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
+++ b/packages/dev/gui/src/3D/controls/contentDisplay3D.ts
@@ -9,8 +9,8 @@ import { Texture } from "core/Materials/Textures/texture";
  */
 export class ContentDisplay3D extends Control3D {
     private _content: Control;
-    private _facadeTexture: Nullable<AdvancedDynamicTexture>;
-    protected _contentResolution = 512;
+    protected _facadeTexture: Nullable<AdvancedDynamicTexture>;
+    protected _contentResolution: number | { width: number; height: number } = 512;
     protected _contentScaleRatio = 2;
     protected _contentScaleRatioY?: number;
 
@@ -29,14 +29,9 @@ export class ContentDisplay3D extends Control3D {
         }
 
         if (!this._facadeTexture) {
-            this._facadeTexture = new AdvancedDynamicTexture(
-                "Facade",
-                this._contentResolution,
-                this._contentResolution,
-                this._host.utilityLayer.utilityLayerScene,
-                true,
-                Texture.TRILINEAR_SAMPLINGMODE
-            );
+            const width = typeof this._contentResolution === "number" ? this._contentResolution : this._contentResolution.width;
+            const height = typeof this._contentResolution === "number" ? this._contentResolution : this._contentResolution.height;
+            this._facadeTexture = new AdvancedDynamicTexture("Facade", width, height, this._host.utilityLayer.utilityLayerScene, true, Texture.TRILINEAR_SAMPLINGMODE);
             this._setFacadeTextureScaling();
             this._facadeTexture.premulAlpha = true;
         } else {
@@ -50,6 +45,9 @@ export class ContentDisplay3D extends Control3D {
 
     protected _setFacadeTextureScaling() {
         if (this._facadeTexture) {
+            if (typeof this._contentResolution !== "number") {
+                this._contentScaleRatioY = (this._contentResolution.height / this._contentResolution.width) * this._contentScaleRatio;
+            }
             this._facadeTexture.rootContainer.scaleX = this._contentScaleRatio;
             this._facadeTexture.rootContainer.scaleY = this._contentScaleRatioY ?? this._contentScaleRatio;
         }
@@ -58,12 +56,16 @@ export class ContentDisplay3D extends Control3D {
     /**
      * Gets or sets the texture resolution used to render content (512 by default)
      */
-    public get contentResolution(): number {
+    public get contentResolution(): number | { width: number; height: number } {
         return this._contentResolution;
     }
 
-    public set contentResolution(value: number) {
-        if (this._contentResolution === value) {
+    public set contentResolution(value: number | { width: number; height: number }) {
+        const incomingWidth = typeof value === "number" ? value : value.width;
+        const incomingHeight = typeof value === "number" ? value : value.height;
+        const currentWidth = typeof this._contentResolution === "number" ? this._contentResolution : this._contentResolution.width;
+        const currentHeight = typeof this._contentResolution === "number" ? this._contentResolution : this._contentResolution.height;
+        if (incomingWidth === currentWidth && incomingHeight === currentHeight) {
             return;
         }
 

--- a/packages/dev/gui/src/3D/controls/control3D.ts
+++ b/packages/dev/gui/src/3D/controls/control3D.ts
@@ -29,39 +29,46 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
     /** @internal */
     public _isScaledByManager = false;
 
+    private _position?: Vector3;
+    private _scaling?: Vector3;
+
     /** Gets or sets the control position in world space */
     public get position(): Vector3 {
         if (!this._node) {
-            return Vector3.Zero();
+            this._position = this._position || Vector3.Zero();
+            return this._position;
         }
 
         return this._node.position;
     }
 
     public set position(value: Vector3) {
+        this._position = value;
         if (!this._node) {
             return;
         }
 
-        this._node.position = value;
+        this._node.position = this._position;
     }
 
     /** Gets or sets the control scaling in world space */
     public get scaling(): Vector3 {
         if (!this._node) {
-            return new Vector3(1, 1, 1);
+            this._scaling = this.scaling || new Vector3(1, 1, 1);
+            return this._scaling;
         }
 
         return this._node.scaling;
     }
 
     public set scaling(value: Vector3) {
+        this._scaling = value;
         if (!this._node) {
             return;
         }
 
         this._isScaledByManager = false;
-        this._node.scaling = value;
+        this._node.scaling = this._scaling;
     }
 
     /** Callback used to start pointer enter animation */
@@ -267,6 +274,12 @@ export class Control3D implements IDisposable, IBehaviorAware<Control3D> {
 
             if (!this.node) {
                 return;
+            }
+            if (this._position) {
+                this.node.position = this._position;
+            }
+            if (this._scaling) {
+                this.node.scaling = this._scaling;
             }
             this._injectGUI3DReservedDataStore(this.node).control = this; // Store the control on the reservedDataStore field in order to get it when picking
 

--- a/packages/dev/gui/src/3D/controls/holographicSlate.ts
+++ b/packages/dev/gui/src/3D/controls/holographicSlate.ts
@@ -72,6 +72,11 @@ export class HolographicSlate extends ContentDisplay3D {
     private _contentDragBehavior: PointerDragBehavior;
 
     private _defaultBehavior: DefaultBehavior;
+
+    /**
+     * If true, the content will be scaled to fit the dimensions of the slate
+     */
+    public fitContentToDimensions = false;
     /**
      * Regroups all mesh behaviors for the slate
      */
@@ -259,7 +264,7 @@ export class HolographicSlate extends ContentDisplay3D {
         if (this._contentPlate?.material && (this._contentPlate.material as FluentMaterial).albedoTexture) {
             const tex = (this._contentPlate.material as FluentMaterial).albedoTexture as Texture;
             tex.uScale = this._contentScaleRatio;
-            tex.vScale = (this._contentScaleRatio / this._contentViewport.width) * this._contentViewport.height;
+            tex.vScale = this.fitContentToDimensions ? this._contentScaleRatio : (this._contentScaleRatio / this._contentViewport.width) * this._contentViewport.height;
             tex.uOffset = this._contentViewport.x;
             tex.vOffset = this._contentViewport.y;
         }
@@ -267,7 +272,7 @@ export class HolographicSlate extends ContentDisplay3D {
 
     private _resetContentPositionAndZoom() {
         this._contentViewport.x = 0;
-        this._contentViewport.y = 1 - this._contentViewport.height / this._contentViewport.width;
+        this._contentViewport.y = 0; // 1 - this._contentViewport.height / this._contentViewport.width;
         this._contentScaleRatio = 1;
     }
 
@@ -398,6 +403,9 @@ export class HolographicSlate extends ContentDisplay3D {
 
         const offset = new Vector3();
         this._contentDragBehavior.onDragObservable.add((event) => {
+            if (this.fitContentToDimensions) {
+                return;
+            }
             offset.copyFrom(event.dragPlanePoint);
             offset.subtractInPlace(origin);
             projectedOffset.copyFromFloats(Vector3.Dot(offset, rightWorld), Vector3.Dot(offset, upWorld));

--- a/packages/dev/gui/src/3D/controls/holographicSlate.ts
+++ b/packages/dev/gui/src/3D/controls/holographicSlate.ts
@@ -474,7 +474,10 @@ export class HolographicSlate extends ContentDisplay3D {
             this.origin.setAll(0);
             this._gizmo.updateBoundingBox();
             const pivot = this.node.getAbsolutePivotPoint();
-            this.node.position.copyFrom(camera.position).subtractInPlace(backward).subtractInPlace(pivot);
+            // only if position was not yet set!
+            if (this.node.position.equalsToFloats(0, 0, 0)) {
+                this.node.position.copyFrom(camera.position).subtractInPlace(backward).subtractInPlace(pivot);
+            }
             this.node.rotationQuaternion = Quaternion.FromLookDirectionLH(backward, new Vector3(0, 1, 0));
 
             if (resetAspect) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/image-doesnt-rescale-to-fit-the-new-dimensions-of-my-holographicslate/52938?u=raananw

Setting `fitContentToDimensions` to true will make everything work as expected