### PR TITLE
Fix a couple dev dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6081,6 +6081,8 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -25044,7 +25046,17 @@
                 "@microsoft/tsdoc-config": "~0.16.1"
             },
             "devDependencies": {
-                "@types/eslint": "^9.6.1"
+                "@types/eslint": "^8.56.10"
+            }
+        },
+        "packages/tools/eslintBabylonPlugin/node_modules/@types/eslint": {
+            "version": "8.56.12",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+            "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
             }
         },
         "packages/tools/guiEditor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-            "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -142,11 +142,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-            "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+            "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
             "dependencies": {
-                "@babel/types": "^7.25.0",
+                "@babel/types": "^7.25.6",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -204,9 +204,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
-            "integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+            "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -214,7 +214,7 @@
                 "@babel/helper-optimise-call-expression": "^7.24.7",
                 "@babel/helper-replace-supers": "^7.25.0",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/traverse": "^7.25.0",
+                "@babel/traverse": "^7.25.4",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -435,12 +435,12 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-            "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+            "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
             "dependencies": {
                 "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.0"
+                "@babel/types": "^7.25.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -525,11 +525,11 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-            "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
             "dependencies": {
-                "@babel/types": "^7.25.2"
+                "@babel/types": "^7.25.6"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -701,12 +701,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
-            "integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
+            "integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -716,11 +716,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
-            "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+            "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -860,11 +860,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-            "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+            "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -905,15 +905,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
-            "integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+            "integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-remap-async-to-generator": "^7.25.0",
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/traverse": "^7.25.0"
+                "@babel/traverse": "^7.25.4"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -970,13 +970,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-            "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+            "integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-class-features-plugin": "^7.25.4",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1003,16 +1003,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
-            "integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+            "integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.24.8",
+                "@babel/helper-compilation-targets": "^7.25.2",
                 "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-replace-supers": "^7.25.0",
-                "@babel/traverse": "^7.25.0",
+                "@babel/traverse": "^7.25.4",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -1465,13 +1465,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
-            "integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+            "integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-class-features-plugin": "^7.25.4",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1767,13 +1767,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
-            "integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+            "integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.2",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1783,12 +1783,12 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.25.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
-            "integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+            "integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.25.2",
+                "@babel/compat-data": "^7.25.4",
                 "@babel/helper-compilation-targets": "^7.25.2",
                 "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-validator-option": "^7.24.8",
@@ -1817,13 +1817,13 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.24.7",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.0",
+                "@babel/plugin-transform-async-generator-functions": "^7.25.4",
                 "@babel/plugin-transform-async-to-generator": "^7.24.7",
                 "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
                 "@babel/plugin-transform-block-scoping": "^7.25.0",
-                "@babel/plugin-transform-class-properties": "^7.24.7",
+                "@babel/plugin-transform-class-properties": "^7.25.4",
                 "@babel/plugin-transform-class-static-block": "^7.24.7",
-                "@babel/plugin-transform-classes": "^7.25.0",
+                "@babel/plugin-transform-classes": "^7.25.4",
                 "@babel/plugin-transform-computed-properties": "^7.24.7",
                 "@babel/plugin-transform-destructuring": "^7.24.8",
                 "@babel/plugin-transform-dotall-regex": "^7.24.7",
@@ -1851,7 +1851,7 @@
                 "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
                 "@babel/plugin-transform-optional-chaining": "^7.24.8",
                 "@babel/plugin-transform-parameters": "^7.24.7",
-                "@babel/plugin-transform-private-methods": "^7.24.7",
+                "@babel/plugin-transform-private-methods": "^7.25.4",
                 "@babel/plugin-transform-private-property-in-object": "^7.24.7",
                 "@babel/plugin-transform-property-literals": "^7.24.7",
                 "@babel/plugin-transform-regenerator": "^7.24.7",
@@ -1864,10 +1864,10 @@
                 "@babel/plugin-transform-unicode-escapes": "^7.24.7",
                 "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
                 "@babel/plugin-transform-unicode-regex": "^7.24.7",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.4",
+                "babel-plugin-polyfill-corejs3": "^0.10.6",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
                 "core-js-compat": "^3.37.1",
                 "semver": "^6.3.1"
@@ -1948,9 +1948,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-            "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+            "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -1972,15 +1972,15 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-            "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+            "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.25.0",
-                "@babel/parser": "^7.25.3",
+                "@babel/generator": "^7.25.6",
+                "@babel/parser": "^7.25.6",
                 "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.2",
+                "@babel/types": "^7.25.6",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -1997,9 +1997,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-            "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.24.8",
                 "@babel/helper-validator-identifier": "^7.24.7",
@@ -3766,13 +3766,13 @@
             }
         },
         "node_modules/@memlab/api": {
-            "version": "1.0.33",
-            "resolved": "https://registry.npmjs.org/@memlab/api/-/api-1.0.33.tgz",
-            "integrity": "sha512-Au3saI1LZdTZAi8hdt+lrk9uKbuekxE2tMEEB56VN+VyjLsMv9RgwdFnzLwZGQELlu8t0JvpFMY/UETbKQ6iPQ==",
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@memlab/api/-/api-1.0.36.tgz",
+            "integrity": "sha512-QMQp5vkDbx2amSQvZFjxsOK1rv9hT6AFFeFYlkmj+pehs/2g+u4WjlvqTTReciHdUj4e7HNqTZVVrEejYivRGQ==",
             "dependencies": {
-                "@memlab/core": "^1.1.34",
-                "@memlab/e2e": "^1.0.34",
-                "@memlab/heap-analysis": "^1.0.31",
+                "@memlab/core": "^1.1.37",
+                "@memlab/e2e": "^1.0.37",
+                "@memlab/heap-analysis": "^1.0.34",
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
                 "chalk": "^4.0.0",
@@ -3830,15 +3830,15 @@
             }
         },
         "node_modules/@memlab/cli": {
-            "version": "1.0.36",
-            "resolved": "https://registry.npmjs.org/@memlab/cli/-/cli-1.0.36.tgz",
-            "integrity": "sha512-dYt/ycXUWLejY33f12cMl5Gf44oYfE5Hitr0zGDoUAILdo4CsiRNmFOSi6ofhpsIqIxZzd4lC1AcALQqmVG5JQ==",
+            "version": "1.0.39",
+            "resolved": "https://registry.npmjs.org/@memlab/cli/-/cli-1.0.39.tgz",
+            "integrity": "sha512-f4VkE+OB/JFw9hWsc0KhrEVOhU1u+8zW6T7XfDfPP6sKv1li9C2A9ABI1AQ+ScRkeiMDHXNI+D2P/10JrpSOvQ==",
             "hasInstallScript": true,
             "dependencies": {
-                "@memlab/api": "^1.0.33",
-                "@memlab/core": "^1.1.34",
-                "@memlab/e2e": "^1.0.34",
-                "@memlab/heap-analysis": "^1.0.31",
+                "@memlab/api": "^1.0.36",
+                "@memlab/core": "^1.1.37",
+                "@memlab/e2e": "^1.0.37",
+                "@memlab/heap-analysis": "^1.0.34",
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
                 "blessed": "^0.1.81",
@@ -3900,9 +3900,9 @@
             }
         },
         "node_modules/@memlab/core": {
-            "version": "1.1.34",
-            "resolved": "https://registry.npmjs.org/@memlab/core/-/core-1.1.34.tgz",
-            "integrity": "sha512-h5ltVNrdS6u9Tl6Xru+gaIz2/YRJMj3Xk2ozv+uqCpNMB5rmitTt4jz51ZYI+62vXNuRzle6oRh0JuXyq1nrTw==",
+            "version": "1.1.37",
+            "resolved": "https://registry.npmjs.org/@memlab/core/-/core-1.1.37.tgz",
+            "integrity": "sha512-oQGzDP4TzxvhT7RLv5xZh5Yd20oqp2wALzTXJKtI1TzeAiHFU/WlWuR0KVZasSfiRxPJc7lmDLnpvlEsEigZag==",
             "dependencies": {
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
@@ -3964,15 +3964,15 @@
             }
         },
         "node_modules/@memlab/e2e": {
-            "version": "1.0.34",
-            "resolved": "https://registry.npmjs.org/@memlab/e2e/-/e2e-1.0.34.tgz",
-            "integrity": "sha512-nCUb4QYNRuydGkSkIlpIhgl/80wnyvBzFZH6c4AhEZ/hwPj8ZlQLFsFmiq/uULI27gUltMtLDcJGvHIng9JYbQ==",
+            "version": "1.0.37",
+            "resolved": "https://registry.npmjs.org/@memlab/e2e/-/e2e-1.0.37.tgz",
+            "integrity": "sha512-Khr+fsOqKzCvq41wNiVEuukZq4jxqg4xSh1ScWdlpNY5jyeXw649/YdLvtP8a4ujE47tCyoB3jFm4f2zK+bSEg==",
             "dependencies": {
                 "@babel/generator": "^7.16.0",
                 "@babel/parser": "^7.16.4",
                 "@babel/template": "^7.16.0",
                 "@babel/traverse": "^7.16.3",
-                "@memlab/core": "^1.1.34",
+                "@memlab/core": "^1.1.37",
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
                 "chalk": "^4.0.0",
@@ -4030,12 +4030,12 @@
             }
         },
         "node_modules/@memlab/heap-analysis": {
-            "version": "1.0.31",
-            "resolved": "https://registry.npmjs.org/@memlab/heap-analysis/-/heap-analysis-1.0.31.tgz",
-            "integrity": "sha512-EB9md5Ce5bVLk5LPCQj8yatOKe+G1jC2Zq5GSD4R3bBjrt4JhkBYydezRVEqO88ZjYNbbEapfFF+3wwraBpQ5g==",
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/@memlab/heap-analysis/-/heap-analysis-1.0.34.tgz",
+            "integrity": "sha512-WzzxU1Ikm5dDGZOSq/AdMwmlBW7TjcNY2Zt+VCkE7aOwlMHIhVXUt+DKNCOT/v6OasukQvsMZ5WSr8glX0A7ow==",
             "dependencies": {
-                "@memlab/core": "^1.1.34",
-                "@memlab/e2e": "^1.0.34",
+                "@memlab/core": "^1.1.37",
+                "@memlab/e2e": "^1.0.37",
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
                 "chalk": "^4.0.0",
@@ -5039,12 +5039,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
-            "integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
+            "version": "1.46.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
+            "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.46.0"
+                "playwright": "1.46.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -5239,9 +5239,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.0.tgz",
-            "integrity": "sha512-WTWD8PfoSAJ+qL87lE7votj3syLavxunWhzCnx3XFxFiI/BA/r3X7MUM8dVrH8rb2r4AiO8jJsr3ZjdaftmnfA==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+            "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
             "cpu": [
                 "arm"
             ],
@@ -5252,9 +5252,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.0.tgz",
-            "integrity": "sha512-a1sR2zSK1B4eYkiZu17ZUZhmUQcKjk2/j9Me2IDjk1GHW7LB5Z35LEzj9iJch6gtUfsnvZs1ZNyDW2oZSThrkA==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+            "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
             "cpu": [
                 "arm64"
             ],
@@ -5265,9 +5265,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.0.tgz",
-            "integrity": "sha512-zOnKWLgDld/svhKO5PD9ozmL6roy5OQ5T4ThvdYZLpiOhEGY+dp2NwUmxK0Ld91LrbjrvtNAE0ERBwjqhZTRAA==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+            "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -5278,9 +5278,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.0.tgz",
-            "integrity": "sha512-7doS8br0xAkg48SKE2QNtMSFPFUlRdw9+votl27MvT46vo44ATBmdZdGysOevNELmZlfd+NEa0UYOA8f01WSrg==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+            "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
             "cpu": [
                 "x64"
             ],
@@ -5291,9 +5291,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.0.tgz",
-            "integrity": "sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+            "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
             "cpu": [
                 "arm"
             ],
@@ -5304,9 +5304,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.0.tgz",
-            "integrity": "sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+            "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
             "cpu": [
                 "arm"
             ],
@@ -5317,9 +5317,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.0.tgz",
-            "integrity": "sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+            "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
             "cpu": [
                 "arm64"
             ],
@@ -5330,9 +5330,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.0.tgz",
-            "integrity": "sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+            "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
             "cpu": [
                 "arm64"
             ],
@@ -5343,9 +5343,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.0.tgz",
-            "integrity": "sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+            "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -5356,9 +5356,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.0.tgz",
-            "integrity": "sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+            "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
             "cpu": [
                 "riscv64"
             ],
@@ -5369,9 +5369,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.0.tgz",
-            "integrity": "sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+            "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
             "cpu": [
                 "s390x"
             ],
@@ -5382,9 +5382,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.0.tgz",
-            "integrity": "sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+            "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
             "cpu": [
                 "x64"
             ],
@@ -5395,9 +5395,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.0.tgz",
-            "integrity": "sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+            "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
             "cpu": [
                 "x64"
             ],
@@ -5408,9 +5408,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.0.tgz",
-            "integrity": "sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+            "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5421,9 +5421,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.0.tgz",
-            "integrity": "sha512-G9+TEqRnAA6nbpqyUqgTiopmnfgnMkR3kMukFBDsiyy23LZvUCpiUwjTRx6ezYCjJODXrh52rBR9oXvm+Fp5wg==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+            "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
             "cpu": [
                 "ia32"
             ],
@@ -5434,9 +5434,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.0.tgz",
-            "integrity": "sha512-2jsCDZwtQvRhejHLfZ1JY6w6kEuEtfF9nzYsZxzSlNVKDX+DpsDJ+Rbjkm74nvg2rdx0gwBS+IMdvwJuq3S9pQ==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+            "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
             "cpu": [
                 "x64"
             ],
@@ -6037,16 +6037,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/clean-css": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
-            "integrity": "sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*",
-                "source-map": "^0.6.0"
-            }
-        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -6087,12 +6077,10 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-            "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -6163,17 +6151,6 @@
             "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "node_modules/@types/html-minifier": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
-            "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
-            "dev": true,
-            "dependencies": {
-                "@types/clean-css": "*",
-                "@types/relateurl": "*",
-                "@types/uglify-js": "*"
             }
         },
         "node_modules/@types/html-minifier-terser": {
@@ -6332,11 +6309,11 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
-            "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+            "version": "22.5.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.3.tgz",
+            "integrity": "sha512-njripolh85IA9SQGTAqbmnNZTdxv7X/4OYGPz8tgy5JDr8MP+uDBa921GpYEoDDnwm0Hmn5ZPeJgiiSTPoOzkQ==",
             "dependencies": {
-                "undici-types": "~6.18.2"
+                "undici-types": "~6.19.2"
             }
         },
         "node_modules/@types/node-forge": {
@@ -6407,12 +6384,6 @@
                 "@types/react": "^17"
             }
         },
-        "node_modules/@types/relateurl": {
-            "version": "0.2.33",
-            "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
-            "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
-            "dev": true
-        },
         "node_modules/@types/resolve": {
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -6431,9 +6402,9 @@
             "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
         },
         "node_modules/@types/selenium-webdriver": {
-            "version": "4.1.25",
-            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.25.tgz",
-            "integrity": "sha512-Jnlg7h7WDq4k8N2p/zp1ax6qizvU9Pn37I/HR/KX8k5TIU1wfUAuBy8CA6x8drAqa9PY3kYykmmyNHU4tX91LQ==",
+            "version": "4.1.26",
+            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.26.tgz",
+            "integrity": "sha512-PUgqsyNffal0eAU0bzGlh37MJo558aporAPZoKqBeB/pF7zhKl1S3zqza0GpwFqgoigNxWhEIJzru75eeYco/w==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -6506,15 +6477,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
-        },
-        "node_modules/@types/uglify-js": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-            "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-            "dev": true,
-            "dependencies": {
-                "source-map": "^0.6.1"
-            }
         },
         "node_modules/@types/ws": {
             "version": "8.5.12",
@@ -7451,9 +7413,9 @@
             }
         },
         "node_modules/async": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true
         },
         "node_modules/asynckit": {
@@ -7476,9 +7438,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -7746,9 +7708,9 @@
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
-            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.3.tgz",
+            "integrity": "sha512-7RYKL+vZVCyAsMLi5SPu7QGauGGT8avnP/HO571ndEuV4MYdGXvLhtW67FuLPeEI8EiIY7zbbRR9x7x7HU0kgw==",
             "optional": true,
             "dependencies": {
                 "bare-events": "^2.0.0",
@@ -7757,9 +7719,9 @@
             }
         },
         "node_modules/bare-os": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
-            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
+            "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
             "optional": true
         },
         "node_modules/bare-path": {
@@ -7772,11 +7734,12 @@
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
-            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.1.tgz",
+            "integrity": "sha512-YTB47kHwBW9zSG8LD77MIBAAQXjU2WjAkMHeeb7hUplVs6+IoM5I7uEVQNPMB7lj9r8I76UMdoMkGnCodHOLqg==",
             "optional": true,
             "dependencies": {
+                "b4a": "^1.6.6",
                 "streamx": "^2.18.0"
             }
         },
@@ -8256,9 +8219,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001651",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-            "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+            "version": "1.0.30001655",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
+            "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8388,9 +8351,9 @@
             }
         },
         "node_modules/cjs-module-lexer": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-            "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.0.tgz",
+            "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g=="
         },
         "node_modules/classnames": {
             "version": "2.5.1",
@@ -9091,9 +9054,9 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.38.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
-            "integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
+            "version": "3.38.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+            "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.23.3"
@@ -9991,9 +9954,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.7",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.7.tgz",
-            "integrity": "sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw=="
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q=="
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -10353,9 +10316,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "engines": {
                 "node": ">=6"
             }
@@ -10495,9 +10458,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
-            "integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.9.0.tgz",
+            "integrity": "sha512-McVbYmwA3NEKwRQY5g4aWMdcZE5xZxV8i8l7CqJSrameuGSQJtSWaL/LxTEzSKKaCcOhlpDR8XEfYXWPrdo/ZQ==",
             "dev": true,
             "dependencies": {
                 "debug": "^3.2.7"
@@ -11037,9 +11000,9 @@
             }
         },
         "node_modules/expect-puppeteer": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.0.0.tgz",
-            "integrity": "sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.1.0.tgz",
+            "integrity": "sha512-d+RS+LWxlEq4RxWb2ifkXYg6/IS3VaZogAye0o2TZaf2qCFT8LN5yVLKfcYI54RQDBn/wMDRFySP+QMMFq+ZIg==",
             "engines": {
                 "node": ">=16"
             }
@@ -11618,9 +11581,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.15.8",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
+            "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
             "funding": [
                 {
                     "type": "individual",
@@ -12742,27 +12705,6 @@
             "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
             "dev": true
         },
-        "node_modules/html-minifier": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-            "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
-            "dev": true,
-            "dependencies": {
-                "camel-case": "^3.0.0",
-                "clean-css": "^4.2.1",
-                "commander": "^2.19.0",
-                "he": "^1.2.0",
-                "param-case": "^2.1.1",
-                "relateurl": "^0.2.7",
-                "uglify-js": "^3.5.1"
-            },
-            "bin": {
-                "html-minifier": "cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/html-minifier-terser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -12791,58 +12733,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/html-minifier/node_modules/camel-case": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-            "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
-            "dev": true,
-            "dependencies": {
-                "no-case": "^2.2.0",
-                "upper-case": "^1.1.1"
-            }
-        },
-        "node_modules/html-minifier/node_modules/clean-css": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-            "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-            "dev": true,
-            "dependencies": {
-                "source-map": "~0.6.0"
-            },
-            "engines": {
-                "node": ">= 4.0"
-            }
-        },
-        "node_modules/html-minifier/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
-        },
-        "node_modules/html-minifier/node_modules/lower-case": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-            "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
-            "dev": true
-        },
-        "node_modules/html-minifier/node_modules/no-case": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-            "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-            "dev": true,
-            "dependencies": {
-                "lower-case": "^1.1.1"
-            }
-        },
-        "node_modules/html-minifier/node_modules/param-case": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-            "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
-            "dev": true,
-            "dependencies": {
-                "no-case": "^2.2.0"
             }
         },
         "node_modules/html-webpack-plugin": {
@@ -13418,9 +13308,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-            "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -14255,15 +14145,15 @@
             }
         },
         "node_modules/jest-dev-server": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.0.0.tgz",
-            "integrity": "sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.0.tgz",
+            "integrity": "sha512-zB5phqImkP1w6ANhRPrpr4oW84SDRRAhQhCEJ+NGGET4yapNf0Fu8ymS7inNPNQ8zQYgm8IfqyUGgEforPt8pg==",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "cwd": "^0.10.0",
                 "find-process": "^1.4.7",
                 "prompts": "^2.4.2",
-                "spawnd": "^10.0.0",
+                "spawnd": "^10.1.0",
                 "tree-kill": "^1.2.2",
                 "wait-on": "^7.2.0"
             },
@@ -14529,14 +14419,14 @@
             }
         },
         "node_modules/jest-environment-puppeteer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.0.1.tgz",
-            "integrity": "sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.0.tgz",
+            "integrity": "sha512-bP1L64wGPQJMVKcH3XIw1X0R+s8VQ5yYqi/5aRFlqwXerUoop+FFlKBeGWfCxpGwo1ICpVymhP0bfV1S0yzfWA==",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "cosmiconfig": "^8.3.6",
                 "deepmerge": "^4.3.1",
-                "jest-dev-server": "^10.0.0",
+                "jest-dev-server": "^10.1.0",
                 "jest-environment-node": "^29.7.0"
             },
             "engines": {
@@ -14818,12 +14708,12 @@
             }
         },
         "node_modules/jest-puppeteer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.0.1.tgz",
-            "integrity": "sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.1.0.tgz",
+            "integrity": "sha512-jQY3GfOq5eTi4YEHFqueQtRmOvEmkfqDJPpoU9Y16Gyo73b9xtSd3tlQz9o4pEfDQdmOeTt0FjQSVn2Ydl50ig==",
             "dependencies": {
-                "expect-puppeteer": "^10.0.0",
-                "jest-environment-puppeteer": "^10.0.1"
+                "expect-puppeteer": "^10.1.0",
+                "jest-environment-puppeteer": "^10.1.0"
             },
             "engines": {
                 "node": ">=16"
@@ -15496,9 +15386,9 @@
             "dev": true
         },
         "node_modules/launch-editor": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.1.tgz",
-            "integrity": "sha512-elBx2l/tp9z99X5H/qev8uyDywVh0VXAwEbjk8kJhnc5grOFkGh7aW6q55me9xnYbss261XtnUrysZ+XvGbhQA==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.2.tgz",
+            "integrity": "sha512-eF5slEUZXmi6WvFzI3dYcv+hA24/iKnROf24HztcURJpSz9RBmBgz5cNCVOeguouf1llrwy6Yctl4C4HM+xI8g==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
@@ -16387,16 +16277,23 @@
             }
         },
         "node_modules/memlab": {
-            "version": "1.1.51",
-            "resolved": "https://registry.npmjs.org/memlab/-/memlab-1.1.51.tgz",
-            "integrity": "sha512-m+rTGJ0xDxTPJCwybsR+sctHbIUzZhq/EKvPTGF5zr6NxmFFA/GZs/otBP5RTictaCQ9xh/YYoMUDae7gBbcQA==",
+            "version": "1.1.54",
+            "resolved": "https://registry.npmjs.org/memlab/-/memlab-1.1.54.tgz",
+            "integrity": "sha512-4tYXcoh9a/jYAecs7BsEeWGdevdWQxwVik7fDSKS9vhFh+RlHJhTXjMRJYecsViKnEZLPBfWX/TxIEHhZsSjkg==",
             "hasInstallScript": true,
+            "workspaces": [
+                "./packages/core",
+                "./packages/e2e",
+                "./packages/heap-analysis",
+                "./packages/api",
+                "./packages/cli"
+            ],
             "dependencies": {
-                "@memlab/api": "^1.0.33",
-                "@memlab/cli": "^1.0.36",
-                "@memlab/core": "^1.1.34",
-                "@memlab/e2e": "^1.0.34",
-                "@memlab/heap-analysis": "^1.0.31",
+                "@memlab/api": "^1.0.36",
+                "@memlab/cli": "^1.0.39",
+                "@memlab/core": "^1.1.37",
+                "@memlab/e2e": "^1.0.37",
+                "@memlab/heap-analysis": "^1.0.34",
                 "ansi": "^0.3.1",
                 "babar": "^0.2.0",
                 "chalk": "^4.0.0",
@@ -16800,38 +16697,49 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/minify-html-literals": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
-            "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+        "node_modules/minify-literals": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/minify-literals/-/minify-literals-1.0.10.tgz",
+            "integrity": "sha512-3gzrwHTd7kRTqsoGhGw4iySDy7JGgc3RozKZ7IT9vcXPyno5egKkpFqud+F1ECSPxi/ls2JwQCUYZr5SeUci0Q==",
             "dev": true,
             "dependencies": {
-                "@types/html-minifier": "^3.5.3",
-                "clean-css": "^4.2.1",
-                "html-minifier": "^4.0.0",
-                "magic-string": "^0.25.0",
+                "clean-css": "^5.3.3",
+                "html-minifier-terser": "^7.2.0",
+                "magic-string": "^0.30.7",
                 "parse-literals": "^1.2.1"
-            }
-        },
-        "node_modules/minify-html-literals/node_modules/clean-css": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-            "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-            "dev": true,
-            "dependencies": {
-                "source-map": "~0.6.0"
             },
             "engines": {
-                "node": ">= 4.0"
+                "node": ">=20.0.0"
             }
         },
-        "node_modules/minify-html-literals/node_modules/magic-string": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+        "node_modules/minify-literals/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/minify-literals/node_modules/html-minifier-terser": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+            "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
             "dev": true,
             "dependencies": {
-                "sourcemap-codec": "^1.4.8"
+                "camel-case": "^4.1.2",
+                "clean-css": "~5.3.2",
+                "commander": "^10.0.0",
+                "entities": "^4.4.0",
+                "param-case": "^3.0.4",
+                "relateurl": "^0.2.7",
+                "terser": "^5.15.1"
+            },
+            "bin": {
+                "html-minifier-terser": "cli.js"
+            },
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/minimalistic-assert": {
@@ -17346,9 +17254,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
-            "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+            "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
             "optional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
@@ -18874,9 +18782,9 @@
             "integrity": "sha512-5yHVB9OHqKd9fr/OIsn8ss0NgThQ9buaqrEuwr9Or5YjPp6h+WTDKWZI+xZLaBGZCtODTnFtlSHNmhFsq67THg=="
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -18990,12 +18898,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
-            "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
+            "version": "1.46.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+            "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.46.0"
+                "playwright-core": "1.46.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -19008,9 +18916,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
-            "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
+            "version": "1.46.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+            "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
@@ -19051,9 +18959,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.41",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+            "version": "8.4.45",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
+            "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
             "dev": true,
             "funding": [
                 {
@@ -19678,7 +19586,6 @@
             "version": "3.14.1",
             "resolved": "git+ssh://git@github.com/RaananW/react-contextmenu.git#5b414bd92952d8d871b076f14a864bd36d8295f4",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "classnames": "^2.2.5"
             },
@@ -20318,18 +20225,37 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+            "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
             "dev": true,
-            "peer": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.21.2",
+                "@rollup/rollup-android-arm64": "4.21.2",
+                "@rollup/rollup-darwin-arm64": "4.21.2",
+                "@rollup/rollup-darwin-x64": "4.21.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.21.2",
+                "@rollup/rollup-linux-arm64-musl": "4.21.2",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.21.2",
+                "@rollup/rollup-linux-x64-gnu": "4.21.2",
+                "@rollup/rollup-linux-x64-musl": "4.21.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.21.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.21.2",
+                "@rollup/rollup-win32-x64-msvc": "4.21.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -20355,17 +20281,17 @@
                 "typescript": "^4.5 || ^5.0"
             }
         },
-        "node_modules/rollup-plugin-minify-html-literals": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.6.tgz",
-            "integrity": "sha512-JRq2fjlCTiw0zu+1Sy3ClHGCxA79dWGr4HLHWSQgd060StVW9fBVksuj8Xw/suPkNSGClJf/4xNQ1MF6JeXPaw==",
+        "node_modules/rollup-plugin-minify-template-literals": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-minify-template-literals/-/rollup-plugin-minify-template-literals-1.1.7.tgz",
+            "integrity": "sha512-PT3xboFF649fuzIP8woyjVL5lJgEJaGzXt4y+OTvFyWcI1TzL/M9GlHec4W+Nvp0Sl35o6w91C1DENMPDl54jg==",
             "dev": true,
             "dependencies": {
-                "minify-html-literals": "^1.3.5",
-                "rollup-pluginutils": "^2.8.2"
+                "@rollup/pluginutils": "^5.1.0",
+                "minify-literals": "^1.0.0"
             },
-            "peerDependencies": {
-                "rollup": "^0.65.2 || ^1.0.0 || ^2.0.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/rollup-plugin-visualizer": {
@@ -20455,21 +20381,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/rollup-pluginutils": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-            "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-            "dev": true,
-            "dependencies": {
-                "estree-walker": "^0.6.1"
-            }
-        },
-        "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-            "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-            "dev": true
         },
         "node_modules/run-applescript": {
             "version": "7.0.0",
@@ -20577,9 +20488,9 @@
             }
         },
         "node_modules/safe-stable-stringify": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -20592,9 +20503,9 @@
             "devOptional": true
         },
         "node_modules/sass": {
-            "version": "1.77.8",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-            "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.78.0.tgz",
+            "integrity": "sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -20692,15 +20603,15 @@
             "dev": true
         },
         "node_modules/selenium-webdriver": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.23.0.tgz",
-            "integrity": "sha512-DdvtInpnMt95Td8VApvmAw7oSydBD9twIRXqoMyRoGMvL1dAnMFxdrwnW6L0d/pF/uoNTjbVUarwGZ9wIGNStA==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.24.0.tgz",
+            "integrity": "sha512-qrqoHhHPZuKLiz5VAQUxrn3ILs7/cYqn2/x96r35g5JjkLUjOS1lX+F+tEJKhRMlQ/MGJ+N1016JF5g2xZUFzw==",
             "dev": true,
             "dependencies": {
                 "@bazel/runfiles": "^5.8.1",
                 "jszip": "^3.10.1",
                 "tmp": "^0.2.3",
-                "ws": "^8.17.1"
+                "ws": "^8.18.0"
             },
             "engines": {
                 "node": ">= 14.21.0"
@@ -21245,13 +21156,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/sourcemap-codec": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-            "dev": true
-        },
         "node_modules/spawn-command": {
             "version": "0.0.2-1",
             "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
@@ -21295,9 +21199,9 @@
             "dev": true
         },
         "node_modules/spawnd": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.0.0.tgz",
-            "integrity": "sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.0.tgz",
+            "integrity": "sha512-QeRBuEIUVPHQ908BoyeiLw+MyB78vztbzH+C+Gfd4OfFTLE1PBPqhyN8smkct4esF+uyDr+TZ9mCwZPcQ1krhA==",
             "dependencies": {
                 "signal-exit": "^4.1.0",
                 "tree-kill": "^1.2.2"
@@ -21333,9 +21237,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.18",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-            "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
+            "version": "3.0.20",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+            "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
             "dev": true
         },
         "node_modules/spdy": {
@@ -21465,9 +21369,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-            "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
+            "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
             "dependencies": {
                 "fast-fifo": "^1.3.2",
                 "queue-tick": "^1.0.1",
@@ -22583,9 +22487,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -22810,10 +22714,10 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.19.2",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
-            "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
-            "devOptional": true,
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
             },
@@ -22845,9 +22749,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
-            "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -22974,12 +22878,6 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
-        },
-        "node_modules/upper-case": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-            "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==",
-            "dev": true
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -23188,13 +23086,13 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
-            "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
+            "integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.41",
+                "postcss": "^8.4.43",
                 "rollup": "^4.20.0"
             },
             "bin": {
@@ -23244,41 +23142,6 @@
                 "terser": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite/node_modules/rollup": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.0.tgz",
-            "integrity": "sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "1.0.5"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.0",
-                "@rollup/rollup-android-arm64": "4.21.0",
-                "@rollup/rollup-darwin-arm64": "4.21.0",
-                "@rollup/rollup-darwin-x64": "4.21.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.0",
-                "@rollup/rollup-linux-arm64-musl": "4.21.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-musl": "4.21.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.0",
-                "@rollup/rollup-win32-x64-msvc": "4.21.0",
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/vscode-oniguruma": {
@@ -24347,9 +24210,9 @@
             }
         },
         "packages/dev/buildTools/node_modules/@types/node": {
-            "version": "16.18.105",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
-            "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA==",
+            "version": "16.18.107",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.107.tgz",
+            "integrity": "sha512-VSha8UIBpCpETub8FZ1nXkODXm+k+YRwpuVQsF3zOuD6QyPQeuIdPRm6IBVa2E5en58CUFJfaw6GmYHP2q/vkQ==",
             "dev": true
         },
         "packages/dev/core": {
@@ -24775,7 +24638,7 @@
                 "chalk": "^5.3.0",
                 "rollup": "^4.18.0",
                 "rollup-plugin-dts": "^6.1.1",
-                "rollup-plugin-minify-html-literals": "^1.2.6",
+                "rollup-plugin-minify-template-literals": "^1.1.7",
                 "vite": "^5.4.2"
             },
             "peerDependencies": {
@@ -24793,41 +24656,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/public/@babylonjs/viewer-alpha/node_modules/rollup": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.0.tgz",
-            "integrity": "sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "1.0.5"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.0",
-                "@rollup/rollup-android-arm64": "4.21.0",
-                "@rollup/rollup-darwin-arm64": "4.21.0",
-                "@rollup/rollup-darwin-x64": "4.21.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.0",
-                "@rollup/rollup-linux-arm64-musl": "4.21.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-musl": "4.21.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.0",
-                "@rollup/rollup-win32-x64-msvc": "4.21.0",
-                "fsevents": "~2.3.2"
             }
         },
         "packages/public/@babylonjs/viewer/node_modules/deepmerge": {
@@ -25215,7 +25043,9 @@
                 "@microsoft/tsdoc": "~0.14.1",
                 "@microsoft/tsdoc-config": "~0.16.1"
             },
-            "devDependencies": {}
+            "devDependencies": {
+                "@types/eslint": "^9.6.1"
+            }
         },
         "packages/tools/guiEditor": {
             "name": "@tools/gui-editor",
@@ -25438,9 +25268,9 @@
             }
         },
         "packages/tools/testTools/node_modules/@types/node": {
-            "version": "16.18.105",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
-            "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA==",
+            "version": "16.18.107",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.107.tgz",
+            "integrity": "sha512-VSha8UIBpCpETub8FZ1nXkODXm+k+YRwpuVQsF3zOuD6QyPQeuIdPRm6IBVa2E5en58CUFJfaw6GmYHP2q/vkQ==",
             "dev": true
         },
         "packages/tools/viewer": {
@@ -25480,7 +25310,7 @@
                 "nyc": "^17.0.0",
                 "open": "^10.1.0",
                 "rollup": "^4.18.0",
-                "rollup-plugin-minify-html-literals": "^1.2.6",
+                "rollup-plugin-minify-template-literals": "^1.1.7",
                 "rollup-plugin-visualizer": "^5.12.0",
                 "vite": "^5.3.3"
             }
@@ -25495,41 +25325,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/tools/viewer-alpha/node_modules/rollup": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.0.tgz",
-            "integrity": "sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "1.0.5"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.0",
-                "@rollup/rollup-android-arm64": "4.21.0",
-                "@rollup/rollup-darwin-arm64": "4.21.0",
-                "@rollup/rollup-darwin-x64": "4.21.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.0",
-                "@rollup/rollup-linux-arm64-musl": "4.21.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-gnu": "4.21.0",
-                "@rollup/rollup-linux-x64-musl": "4.21.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.0",
-                "@rollup/rollup-win32-x64-msvc": "4.21.0",
-                "fsevents": "~2.3.2"
             }
         },
         "packages/tools/viewer/node_modules/deepmerge": {

--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -43,7 +43,7 @@
         "chalk": "^5.3.0",
         "rollup": "^4.18.0",
         "rollup-plugin-dts": "^6.1.1",
-        "rollup-plugin-minify-html-literals": "^1.2.6",
+        "rollup-plugin-minify-template-literals": "^1.1.7",
         "vite": "^5.4.2"
     },
     "keywords": [

--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
@@ -3,9 +3,7 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import alias from "@rollup/plugin-alias";
 import terser from "@rollup/plugin-terser";
-import minifyHTMLModule from "rollup-plugin-minify-html-literals";
-
-const minifyHTML = minifyHTMLModule.default;
+import { minifyTemplateLiterals } from "rollup-plugin-minify-template-literals";
 
 const source = "dev";
 
@@ -46,7 +44,7 @@ const minConfig = {
         entryFileNames: "babylon-viewer.esm.min.js",
         chunkFileNames: "chunks/[name]-[hash].esm.min.js",
     },
-    plugins: [...commonConfig.plugins, terser(), minifyHTML()],
+    plugins: [...commonConfig.plugins, terser(), minifyTemplateLiterals()],
 };
 
 export default [maxConfig, minConfig];

--- a/packages/tools/eslintBabylonPlugin/package.json
+++ b/packages/tools/eslintBabylonPlugin/package.json
@@ -24,5 +24,6 @@
         "@microsoft/tsdoc-config": "~0.16.1"
     },
     "devDependencies": {
+        "@types/eslint": "^9.6.1"
     }
 }

--- a/packages/tools/eslintBabylonPlugin/package.json
+++ b/packages/tools/eslintBabylonPlugin/package.json
@@ -24,6 +24,6 @@
         "@microsoft/tsdoc-config": "~0.16.1"
     },
     "devDependencies": {
-        "@types/eslint": "^9.6.1"
+        "@types/eslint": "^8.56.10"
     }
 }

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -37,7 +37,7 @@
         "nyc": "^17.0.0",
         "open": "^10.1.0",
         "rollup": "^4.18.0",
-        "rollup-plugin-minify-html-literals": "^1.2.6",
+        "rollup-plugin-minify-template-literals": "^1.1.7",
         "rollup-plugin-visualizer": "^5.12.0",
         "vite": "^5.3.3"
     }

--- a/packages/tools/viewer-alpha/rollup.config.analyze.mjs
+++ b/packages/tools/viewer-alpha/rollup.config.analyze.mjs
@@ -1,11 +1,9 @@
 import { createConfig } from "./rollup.config.common.mjs";
 import terser from "@rollup/plugin-terser";
-import minifyHTMLModule from "rollup-plugin-minify-html-literals";
+import { minifyTemplateLiterals } from "rollup-plugin-minify-template-literals";
 import { visualizer } from "rollup-plugin-visualizer";
 
-const minifyHTML = minifyHTMLModule.default;
-
 const analyzeConfig = createConfig("dist/analyze");
-analyzeConfig.plugins = [...analyzeConfig.plugins, terser(), minifyHTML(), visualizer({ filename: "dist/analyze/stats.json", template: "raw-data" })];
+analyzeConfig.plugins = [...analyzeConfig.plugins, terser(), minifyTemplateLiterals(), visualizer({ filename: "dist/analyze/stats.json", template: "raw-data" })];
 
 export default analyzeConfig;


### PR DESCRIPTION
1. Switch from rollup-plugin-minify-html-literals (old, dependency on rollup is out of date) to rollup-plugin-minify-template-literals (newer, forked from the former, fixes this issue and a few others).
2. Add explicit dependency on @types/eslint to packages/tools/eslintBabylonPlugin/package.json (no idea why the dependency is no longer being implicitly installed, but having an explicit dependency is still correct).