### PR TITLE
Set correct peerDependencies versions based on recent changes

### DIFF
--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -30,8 +30,8 @@
         "lit": "^3.2.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^7.23.0",
-        "@babylonjs/loaders": "^7.23.0"
+        "@babylonjs/core": "^7.23.1",
+        "@babylonjs/loaders": "^7.23.1"
     },
     "devDependencies": {
         "@dev/build-tools": "^1.0.0",


### PR DESCRIPTION
I was not able to set the correct peerDependencies versions with the previous PR. I had to publish a patch version first. So correcting this now.