### PR TITLE
Add missing export of new gltf extension registry

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-internal-modules */
 export * from "./glTFLoader";
 export * from "./glTFLoaderExtension";
+export * from "./glTFLoaderExtensionRegistry";
 export * from "./glTFLoaderInterfaces";
 export * from "./Extensions/index";


### PR DESCRIPTION
Missed adding this to the index file in my previous change since all of our extension registrations are within the loaders code. I only caught this when testing in the Playground.