### PR TITLE
fix screenshot tools custom texture

### DIFF
--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -338,6 +338,7 @@ export function CreateScreenshotUsingRenderTarget(
  * @param enableStencilBuffer Whether the stencil buffer should be enabled or not (default: false)
  * @param useLayerMask if the camera's layer mask should be used to filter what should be rendered (default: true)
  * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+ * @param customizeTexture An optional callback that can be used to modify the render target texture before taking the screenshot. This can be used, for instance, to enable camera post-processes before taking the screenshot.
  * @returns screenshot as a string of base64-encoded characters. This string can be assigned
  * to the src parameter of an <img> to display it
  */
@@ -352,7 +353,8 @@ export function CreateScreenshotUsingRenderTargetAsync(
     renderSprites = false,
     enableStencilBuffer = false,
     useLayerMask = true,
-    quality?: number
+    quality?: number,
+    customizeTexture?: (texture: RenderTargetTexture) => void
 ): Promise<string> {
     return new Promise((resolve, reject) => {
         CreateScreenshotUsingRenderTarget(
@@ -373,7 +375,8 @@ export function CreateScreenshotUsingRenderTargetAsync(
             renderSprites,
             enableStencilBuffer,
             useLayerMask,
-            quality
+            quality,
+            customizeTexture
         );
     });
 }

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -28,6 +28,7 @@ import type { Camera } from "../Cameras/camera";
 import type { IColor4Like } from "../Maths/math.like";
 import { IsExponentOfTwo, Mix } from "./tools.functions";
 import type { AbstractEngine } from "../Engines/abstractEngine";
+import type { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 
 declare function importScripts(...urls: string[]): void;
 
@@ -1071,6 +1072,7 @@ export class Tools {
      * @param enableStencilBuffer Whether the stencil buffer should be enabled or not (default: false)
      * @param useLayerMask if the camera's layer mask should be used to filter what should be rendered (default: true)
      * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+     * @param customizeTexture An optional callback that can be used to modify the render target texture before taking the screenshot. This can be used, for instance, to enable camera post-processes before taking the screenshot.
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static CreateScreenshotUsingRenderTarget(
@@ -1085,7 +1087,8 @@ export class Tools {
         renderSprites = false,
         enableStencilBuffer = false,
         useLayerMask = true,
-        quality?: number
+        quality?: number,
+        customizeTexture?: (texture: RenderTargetTexture) => void
     ): void {
         throw _WarnImport("ScreenshotTools");
     }
@@ -1106,11 +1109,12 @@ export class Tools {
      * @param samples Texture samples (default: 1)
      * @param antialiasing Whether antialiasing should be turned on or not (default: false)
      * @param fileName A name for for the downloaded file.
-     * @returns screenshot as a string of base64-encoded characters. This string can be assigned
      * @param renderSprites Whether the sprites should be rendered or not (default: false)
      * @param enableStencilBuffer Whether the stencil buffer should be enabled or not (default: false)
      * @param useLayerMask if the camera's layer mask should be used to filter what should be rendered (default: true)
      * @param quality The quality of the image if lossy mimeType is used (e.g. image/jpeg, image/webp). See {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob | HTMLCanvasElement.toBlob()}'s `quality` parameter.
+     * @param customizeTexture An optional callback that can be used to modify the render target texture before taking the screenshot. This can be used, for instance, to enable camera post-processes before taking the screenshot.
+     * @returns screenshot as a string of base64-encoded characters. This string can be assigned
      * to the src parameter of an <img> to display it
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1125,7 +1129,8 @@ export class Tools {
         renderSprites = false,
         enableStencilBuffer = false,
         useLayerMask = true,
-        quality?: number
+        quality?: number,
+        customizeTexture?: (texture: RenderTargetTexture) => void
     ): Promise<string> {
         throw _WarnImport("ScreenshotTools");
     }


### PR DESCRIPTION
https://forum.babylonjs.com/t/wrong-function-signature-type-for-create-screenshot-using-rendertarget/53233