### PR TITLE
Allow overriding the default texture loaders

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
@@ -1,5 +1,16 @@
-import type { Nullable } from "core/types";
 import type { IInternalTextureLoader } from "./internalTextureLoader";
+import type { Nullable } from "../../../types";
+
+export const OverrideTextureLoader: {
+    /**
+     * Function used to get the correct texture loader for a specific extension.
+     * This function will be executed before the default loader. If it returns null, the default loader will be used.
+     * @param extension defines the file extension of the file being loaded
+     */
+    getTextureLoader: Nullable<(extension: string, mimeType?: string) => Nullable<Promise<IInternalTextureLoader>>>;
+} = {
+    getTextureLoader: null,
+};
 
 /**
  * Function used to get the correct texture loader for a specific extension.
@@ -8,6 +19,13 @@ import type { IInternalTextureLoader } from "./internalTextureLoader";
  * @returns the IInternalTextureLoader or null if it wasn't found
  */
 export function _GetCompatibleTextureLoader(extension: string, mimeType?: string): Nullable<Promise<IInternalTextureLoader>> {
+    if (OverrideTextureLoader.getTextureLoader) {
+        const loader = OverrideTextureLoader.getTextureLoader(extension, mimeType);
+        if (loader) {
+            return loader;
+        }
+    }
+
     if (extension.endsWith(".dds")) {
         return import("./ddsTextureLoader").then((module) => new module._DDSTextureLoader());
     }

--- a/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
@@ -36,7 +36,7 @@ export function _GetCompatibleTextureLoader(extension: string, mimeType?: string
     if (mimeType === "image/ktx" || mimeType === "image/ktx2") {
         extension = ".ktx";
     }
-    if (!_registeredTextureLoaders.get(extension)) {
+    if (!_registeredTextureLoaders.has(extension)) {
         if (extension.endsWith(".dds")) {
             registerTextureLoader(".dds", () => import("./ddsTextureLoader").then((module) => new module._DDSTextureLoader()));
         }

--- a/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/textureLoaderManager.ts
@@ -1,16 +1,30 @@
 import type { IInternalTextureLoader } from "./internalTextureLoader";
 import type { Nullable } from "../../../types";
+import { Logger } from "core/Misc/logger";
 
-export const OverrideTextureLoader: {
-    /**
-     * Function used to get the correct texture loader for a specific extension.
-     * This function will be executed before the default loader. If it returns null, the default loader will be used.
-     * @param extension defines the file extension of the file being loaded
-     */
-    getTextureLoader: Nullable<(extension: string, mimeType?: string) => Nullable<Promise<IInternalTextureLoader>>>;
-} = {
-    getTextureLoader: null,
-};
+const _registeredTextureLoaders = new Map<string, (mimeType?: string) => IInternalTextureLoader | Promise<IInternalTextureLoader>>();
+
+/**
+ * Registers a texture loader.
+ * If a loader for the extension exists in the registry, it will be replaced.
+ * @param extension The name of the loader extension.
+ * @param loaderFactory The factory function that creates the loader extension.
+ */
+export function registerTextureLoader(extension: string, loaderFactory: (mimeType?: string) => IInternalTextureLoader | Promise<IInternalTextureLoader>): void {
+    if (unregisterTextureLoader(extension)) {
+        Logger.Warn(`Extension with the name '${name}' already exists`);
+    }
+    _registeredTextureLoaders.set(extension, loaderFactory);
+}
+
+/**
+ * Unregisters a texture loader.
+ * @param extension The name of the loader extension.
+ * @returns A boolean indicating whether the extension has been unregistered
+ */
+export function unregisterTextureLoader(extension: string): boolean {
+    return _registeredTextureLoaders.delete(extension);
+}
 
 /**
  * Function used to get the correct texture loader for a specific extension.
@@ -19,35 +33,34 @@ export const OverrideTextureLoader: {
  * @returns the IInternalTextureLoader or null if it wasn't found
  */
 export function _GetCompatibleTextureLoader(extension: string, mimeType?: string): Nullable<Promise<IInternalTextureLoader>> {
-    if (OverrideTextureLoader.getTextureLoader) {
-        const loader = OverrideTextureLoader.getTextureLoader(extension, mimeType);
-        if (loader) {
-            return loader;
+    if (mimeType === "image/ktx" || mimeType === "image/ktx2") {
+        extension = ".ktx";
+    }
+    if (!_registeredTextureLoaders.get(extension)) {
+        if (extension.endsWith(".dds")) {
+            registerTextureLoader(".dds", () => import("./ddsTextureLoader").then((module) => new module._DDSTextureLoader()));
+        }
+        if (extension.endsWith(".basis")) {
+            registerTextureLoader(".basis", () => import("./basisTextureLoader").then((module) => new module._BasisTextureLoader()));
+        }
+        if (extension.endsWith(".env")) {
+            registerTextureLoader(".env", () => import("./envTextureLoader").then((module) => new module._ENVTextureLoader()));
+        }
+        if (extension.endsWith(".hdr")) {
+            registerTextureLoader(".hdr", () => import("./hdrTextureLoader").then((module) => new module._HDRTextureLoader()));
+        }
+        // The ".ktx2" file extension is still up for debate: https://github.com/KhronosGroup/KTX-Specification/issues/18
+        if (extension.endsWith(".ktx") || extension.endsWith(".ktx2")) {
+            registerTextureLoader(".ktx", () => import("./ktxTextureLoader").then((module) => new module._KTXTextureLoader()));
+            registerTextureLoader(".ktx2", () => import("./ktxTextureLoader").then((module) => new module._KTXTextureLoader()));
+        }
+        if (extension.endsWith(".tga")) {
+            registerTextureLoader(".tga", () => import("./tgaTextureLoader").then((module) => new module._TGATextureLoader()));
+        }
+        if (extension.endsWith(".exr")) {
+            registerTextureLoader(".exr", () => import("./exrTextureLoader").then((module) => new module._ExrTextureLoader()));
         }
     }
-
-    if (extension.endsWith(".dds")) {
-        return import("./ddsTextureLoader").then((module) => new module._DDSTextureLoader());
-    }
-    if (extension.endsWith(".basis")) {
-        return import("./basisTextureLoader").then((module) => new module._BasisTextureLoader());
-    }
-    if (extension.endsWith(".env")) {
-        return import("./envTextureLoader").then((module) => new module._ENVTextureLoader());
-    }
-    if (extension.endsWith(".hdr")) {
-        return import("./hdrTextureLoader").then((module) => new module._HDRTextureLoader());
-    }
-    // The ".ktx2" file extension is still up for debate: https://github.com/KhronosGroup/KTX-Specification/issues/18
-    if (extension.endsWith(".ktx") || extension.endsWith(".ktx2") || mimeType === "image/ktx" || mimeType === "image/ktx2") {
-        return import("./ktxTextureLoader").then((module) => new module._KTXTextureLoader());
-    }
-    if (extension.endsWith(".tga")) {
-        return import("./tgaTextureLoader").then((module) => new module._TGATextureLoader());
-    }
-    if (extension.endsWith(".exr")) {
-        return import("./exrTextureLoader").then((module) => new module._ExrTextureLoader());
-    }
-
-    return null;
+    const registered = _registeredTextureLoaders.get(extension);
+    return registered ? Promise.resolve(registered(mimeType)) : null;
 }


### PR DESCRIPTION
If an experience has developed their own texture loader there is currently no way to use them.

This allows defining a function that will either return null and then continue using the default texture loader(s) or a promise that returns the texture loader. 