### PR TITLE
glob update and relative dir fix in windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "mini-css-extract-plugin": "~2.6.0",
                 "nx": "^18.0.4",
                 "prettier": "^3.0.3",
-                "rimraf": "~3.0.2",
+                "rimraf": "~6.0.1",
                 "selenium-webdriver": "^4.3.1",
                 "ts-jest": "~29.1.0",
                 "ts-node": "~10.9.0",
@@ -3763,6 +3763,43 @@
             },
             "bin": {
                 "node-pre-gyp": "bin/node-pre-gyp"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "optional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "optional": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@memlab/api": {
@@ -11570,6 +11607,43 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/flat-cache/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/flat-cache/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/flatted": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -13759,6 +13833,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istanbul-lib-processinfo/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/istanbul-lib-processinfo/node_modules/p-map": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -13769,6 +13864,22 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/istanbul-lib-report": {
@@ -17981,6 +18092,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nyc/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/nyc/node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -20190,37 +20317,109 @@
             }
         },
         "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "devOptional": true,
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+            "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+            "dev": true,
             "dependencies": {
-                "glob": "^7.1.3"
+                "glob": "^11.0.0",
+                "package-json-from-dist": "^1.0.0"
             },
             "bin": {
-                "rimraf": "bin.js"
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "devOptional": true,
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+            "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+            "dev": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "engines": {
-                "node": "*"
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/jackspeak": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+            "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/rimraf/node_modules/lru-cache": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+            "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+            "dev": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -21192,6 +21391,43 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/spawn-wrap/node_modules/signal-exit": {
@@ -23489,6 +23725,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/webpack-dev-server/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/webpack-dev-server/node_modules/is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -23531,6 +23788,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "mini-css-extract-plugin": "~2.6.0",
         "nx": "^18.0.4",
         "prettier": "^3.0.3",
-        "rimraf": "~3.0.2",
+        "rimraf": "~6.0.1",
         "selenium-webdriver": "^4.3.1",
         "ts-jest": "~29.1.0",
         "ts-node": "~10.9.0",

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -35,16 +35,9 @@ function getModuleDeclaration(
         fullPath: string;
     }[]
 ) {
-    const distPosition = filename.indexOf("/dist");
+    const distPosition = filename.replace(/\\/g, "/").indexOf("/dist");
     const packageVariables = getPackageMappingByDevName(config.devPackageName);
-    let extraPackageName = filename
-        .substring(distPosition + 5)
-        .replace(".d.ts", "")
-        .replace(/\\/g, "/");
-    if (extraPackageName.includes("/dist/")) {
-        extraPackageName = "/" + extraPackageName.substring(extraPackageName.indexOf("/dist/") + 6);
-    }
-    const moduleName = getPublicPackageName(packageVariables[buildType], filename) + extraPackageName;
+    const moduleName = getPublicPackageName(packageVariables[buildType], filename) + filename.substring(distPosition + 5).replace(".d.ts", "");
     const sourceDir = path.dirname(moduleName);
     const lines = source.split("\n");
     const namedExportPathsToExcludeRegExp = config.namedExportPathsToExclude !== undefined ? new RegExp(`export {.*} from ".*${config.namedExportPathsToExclude}"`) : undefined;

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -37,7 +37,14 @@ function getModuleDeclaration(
 ) {
     const distPosition = filename.indexOf("/dist");
     const packageVariables = getPackageMappingByDevName(config.devPackageName);
-    const moduleName = getPublicPackageName(packageVariables[buildType], filename) + filename.substring(distPosition + 5).replace(".d.ts", "");
+    let extraPackageName = filename
+        .substring(distPosition + 5)
+        .replace(".d.ts", "")
+        .replace(/\\/g, "/");
+    if (extraPackageName.includes("/dist/")) {
+        extraPackageName = "/" + extraPackageName.substring(extraPackageName.indexOf("/dist/") + 6);
+    }
+    const moduleName = getPublicPackageName(packageVariables[buildType], filename) + extraPackageName;
     const sourceDir = path.dirname(moduleName);
     const lines = source.split("\n");
     const namedExportPathsToExcludeRegExp = config.namedExportPathsToExclude !== undefined ? new RegExp(`export {.*} from ".*${config.namedExportPathsToExclude}"`) : undefined;

--- a/packages/dev/gui/package.json
+++ b/packages/dev/gui/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "build": "npm run compile",
         "test": "jest -c ../../../jest.config.ts",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "npm run compile:assets",
         "compile": "npm run compile:source",
         "compile:source": "tsc -b tsconfig.build.json",

--- a/packages/dev/inspector/package.json
+++ b/packages/dev/inspector/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "npm run compile:assets",
         "compile": "npm run compile:source",
         "compile:source": "tsc -b tsconfig.build.json",

--- a/packages/dev/loaders/package.json
+++ b/packages/dev/loaders/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "build": "npm run clean && npm run compile",
         "test": "jest -c ../../../jest.config.ts",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "watch": "tsc -b tsconfig.build.json -w",
         "watch:dev": "npm run watch"

--- a/packages/dev/materials/package.json
+++ b/packages/dev/materials/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "build-tools -c build-shaders --package core",
         "compile": "tsc -b tsconfig.build.json",
         "watch:assets": "build-tools -c build-shaders --package core --watch",

--- a/packages/dev/postProcesses/package.json
+++ b/packages/dev/postProcesses/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "build-tools -c build-shaders --package core",
         "compile": "tsc -b tsconfig.build.json",
         "watch:assets": "build-tools -c build-shaders --package core --watch",

--- a/packages/dev/proceduralTextures/package.json
+++ b/packages/dev/proceduralTextures/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "build-tools -c build-shaders --package core",
         "compile": "tsc -b tsconfig.build.json",
         "watch:assets": "build-tools -c build-shaders --package procedural-textures --watch",

--- a/packages/dev/serializers/package.json
+++ b/packages/dev/serializers/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "watch": "tsc -b tsconfig.build.json -w",
         "watch:dev": "npm run watch"

--- a/packages/dev/sharedUiComponents/package.json
+++ b/packages/dev/sharedUiComponents/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "npm run compile:assets",
         "compile": "npm run compile:source",
         "compile:source": "tsc -b tsconfig.build.json",
@@ -45,4 +45,3 @@
         "webpack": "^5.73.0"
     }
 }
-

--- a/packages/lts/core/package.json
+++ b/packages/lts/core/package.json
@@ -11,11 +11,10 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
-    "dependencies": {
-    },
+    "dependencies": {},
     "sideEffects": true,
     "devDependencies": {
         "@dev/core": "^1.0.0"

--- a/packages/lts/gui/package.json
+++ b/packages/lts/gui/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/lts/loaders/package.json
+++ b/packages/lts/loaders/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/lts/materials/package.json
+++ b/packages/lts/materials/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/lts/postProcesses/package.json
+++ b/packages/lts/postProcesses/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/lts/proceduralTextures/package.json
+++ b/packages/lts/proceduralTextures/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/lts/serializers/package.json
+++ b/packages/lts/serializers/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf generated && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json"
     },
     "dependencies": {

--- a/packages/public/@babylonjs/core/package.json
+++ b/packages/public/@babylonjs/core/package.json
@@ -15,7 +15,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(cmd|md|json|build.json|lts.json|tasks.json|cjs)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(cmd|md|json|build.json|lts.json|tasks.json|cjs)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c run-tasks",
         "watch": "node ./watcher.cjs"

--- a/packages/public/@babylonjs/gui/package.json
+++ b/packages/public/@babylonjs/gui/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/ktx2decoder/package.json
+++ b/packages/public/@babylonjs/ktx2decoder/package.json
@@ -14,7 +14,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json",
         "postcompile": "build-tools -c add-js-to-es6 && build-tools -c cp -f \"../../../tools/babylonServer/public/ktx2Transcoders/1\" -t ./wasm"
     },

--- a/packages/public/@babylonjs/loaders/package.json
+++ b/packages/public/@babylonjs/loaders/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/materials/package.json
+++ b/packages/public/@babylonjs/materials/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/post-processes/package.json
+++ b/packages/public/@babylonjs/post-processes/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/procedural-textures/package.json
+++ b/packages/public/@babylonjs/procedural-textures/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/serializers/package.json
+++ b/packages/public/@babylonjs/serializers/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json|lts.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json|lts.json)\" -g",
         "compile": "tsc -b tsconfig.build.json && tsc -b tsconfig.lts.json",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/@babylonjs/shared-ui-components/package.json
+++ b/packages/public/@babylonjs/shared-ui-components/package.json
@@ -15,7 +15,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json)\" -g",
         "compile": "tsc -b tsconfig.build.json --verbose",
         "precompile": "build-tools -c process-assets --path-prefix ../../../dev/sharedUiComponents/ --output-dir ./",
         "postcompile": "build-tools -c add-js-to-es6"

--- a/packages/public/@babylonjs/test-tools/package.json
+++ b/packages/public/@babylonjs/test-tools/package.json
@@ -12,7 +12,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json --verbose"
     },
     "devDependencies": {
@@ -49,4 +49,3 @@
         "url": "https://github.com/BabylonJS/Babylon.js/issues"
     }
 }
-

--- a/packages/public/@babylonjs/viewer-alpha/package.json
+++ b/packages/public/@babylonjs/viewer-alpha/package.json
@@ -20,7 +20,7 @@
         "start": "npm run serve -- --open test/apps/web/index.html",
         "serve": "vite",
         "build": "npm run clean && npm run bundle",
-        "clean": "rimraf lib && rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf lib && rimraf dist && rimraf *.tsbuildinfo -g",
         "bundle": "npm run bundle:lib && npm run bundle:dist:esm",
         "bundle:lib": "rollup -c rollup.config.lib.mjs",
         "bundle:dist:esm": "rollup -c rollup.config.dist.esm.mjs",

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo && rimraf \"./**/*.!(md|json|build.json)\"",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g && rimraf \"./**/*.!(md|json|build.json)\" -g",
         "compile": "tsc -b tsconfig.build.json --verbose",
         "postcompile": "build-tools -c add-js-to-es6"
     },

--- a/packages/public/umd/babylonjs-accessibility/package.json
+++ b/packages/public/umd/babylonjs-accessibility/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0",

--- a/packages/public/umd/babylonjs-gui-editor/package.json
+++ b/packages/public/umd/babylonjs-gui-editor/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0",

--- a/packages/public/umd/babylonjs-gui/package.json
+++ b/packages/public/umd/babylonjs-gui/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylon.gui.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-inspector/package.json
+++ b/packages/public/umd/babylonjs-inspector/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0",

--- a/packages/public/umd/babylonjs-ktx2decoder/package.json
+++ b/packages/public/umd/babylonjs-ktx2decoder/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0"

--- a/packages/public/umd/babylonjs-loaders/package.json
+++ b/packages/public/umd/babylonjs-loaders/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylonjs.loaders.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-materials/package.json
+++ b/packages/public/umd/babylonjs-materials/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylonjs.materials.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-node-editor/package.json
+++ b/packages/public/umd/babylonjs-node-editor/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0"

--- a/packages/public/umd/babylonjs-node-geometry-editor/package.json
+++ b/packages/public/umd/babylonjs-node-geometry-editor/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs": "^7.24.0"

--- a/packages/public/umd/babylonjs-post-process/package.json
+++ b/packages/public/umd/babylonjs-post-process/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylonjs.postProcess.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-procedural-textures/package.json
+++ b/packages/public/umd/babylonjs-procedural-textures/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylonjs.proceduralTextures.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-serializers/package.json
+++ b/packages/public/umd/babylonjs-serializers/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "test:escheck": "es-check es6 ./babylonjs.serializers.js"
     },
     "dependencies": {

--- a/packages/public/umd/babylonjs-viewer/package.json
+++ b/packages/public/umd/babylonjs-viewer/package.json
@@ -11,7 +11,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*"
+        "clean": "rimraf dist && rimraf babylon*.* -g"
     },
     "dependencies": {
         "babylonjs-gltf2interface": "^7.24.0"

--- a/packages/public/umd/babylonjs/package.json
+++ b/packages/public/umd/babylonjs/package.json
@@ -12,7 +12,7 @@
         "build:dev": "webpack --env development",
         "build:prod": "webpack --env production",
         "build:declaration": "build-tools -c pud --config ./config.json",
-        "clean": "rimraf dist && rimraf babylon*.*",
+        "clean": "rimraf dist && rimraf babylon*.* -g",
         "postinstall": "node ./scripts/postinstall.js",
         "test:escheck": "es-check es6 ./babylon.max.js"
     },

--- a/packages/tools/accessibility/package.json
+++ b/packages/tools/accessibility/package.json
@@ -12,7 +12,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "precompile": "npm run compile:assets",
         "compile": "npm run compile:source",
         "compile:source": "tsc -b tsconfig.build.json",

--- a/packages/tools/guiEditor/package.json
+++ b/packages/tools/guiEditor/package.json
@@ -18,7 +18,7 @@
         "serve:prod": "webpack serve --env mode=production",
         "serve:https": "webpack serve --env mode=development --server-type https --host ::",
         "serve:dev": "webpack serve --env mode=development --env watch=all",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo"
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g"
     },
     "dependencies": {
         "react": "^17.0.2",

--- a/packages/tools/nodeEditor/package.json
+++ b/packages/tools/nodeEditor/package.json
@@ -18,7 +18,7 @@
         "serve:prod": "webpack serve --env mode=production",
         "serve:https": "webpack serve --env mode=development --server-type https --host ::",
         "serve:dev": "webpack serve --env mode=development --env watch=all",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo"
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g"
     },
     "dependencies": {
         "react": "^17.0.2",

--- a/packages/tools/nodeGeometryEditor/package.json
+++ b/packages/tools/nodeGeometryEditor/package.json
@@ -18,7 +18,7 @@
         "serve:prod": "webpack serve --env mode=production",
         "serve:https": "webpack serve --env mode=development --server-type https --host ::",
         "serve:dev": "webpack serve --env mode=development --env watch=all",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo"
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g"
     },
     "dependencies": {
         "react": "^17.0.2",

--- a/packages/tools/testTools/package.json
+++ b/packages/tools/testTools/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "watch": "tsc -b tsconfig.build.json --watch",
         "postcompile": "node scripts/copyDeclaration.js"

--- a/packages/tools/testsMemoryLeaks/package.json
+++ b/packages/tools/testsMemoryLeaks/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "npm run clean && npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "watch": "tsc -b tsconfig.build.json --watch",
         "test": "npm run compile && node ./dist/index.js"

--- a/packages/tools/viewer-alpha/package.json
+++ b/packages/tools/viewer-alpha/package.json
@@ -10,7 +10,7 @@
         "start:coverage": "npm run bundle:analyze && npm run instrument && npm run serve -- --open packages/tools/viewer-alpha/test/apps/web/coverage.html",
         "serve": "cross-env COVERAGE_DIR=dist/coverage/raw vite",
         "build": "npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "bundle:analyze": "rimraf dist/analyze && rollup -c rollup.config.analyze.mjs",
         "bundle:coverage": "rimraf dist/coverage && rollup -c rollup.config.coverage.mjs",

--- a/packages/tools/viewer/package.json
+++ b/packages/tools/viewer/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "serve": "webpack serve",
         "build": "npm run compile",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo",
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g",
         "compile": "tsc -b tsconfig.build.json",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/packages/tools/vsm/package.json
+++ b/packages/tools/vsm/package.json
@@ -19,7 +19,7 @@
         "serve:prod": "webpack serve --env mode=production",
         "serve:https": "webpack serve --env mode=development --server-type https --host ::",
         "serve:dev": "webpack serve --env mode=development --env watch=all",
-        "clean": "rimraf dist && rimraf *.tsbuildinfo"
+        "clean": "rimraf dist && rimraf *.tsbuildinfo -g"
     },
     "dependencies": {
         "react": "^17.0.2",


### PR DESCRIPTION
Under windows, declaration was using complete directories which could have caused an issue when using the declaration in the local playground, depending on the directory used.

This adjusts the directory to be relative, making the declaration define the modules correctly.

I also updated rimraf to a new version, to make sure we don't use an old unsupported glob version