### PR TITLE
Remove usage of deprecated substr

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -145,14 +145,14 @@ function getModuleDeclaration(
                     if (processedLines[i] === "}") {
                         // +1 to enroll the last }
                         // +2 to enroll the trailing ;
-                        processedLines = processedLines.substr(0, constStart) + processedLines.substr(i + 2);
+                        processedLines = processedLines.substring(0, constStart) + processedLines.substring(i + 2);
                         break;
                     }
                 }
             }
         }
     }
-    // replaces classes definitions with namespace definitions
+    // replaces classes definitions with namespace definsubstring(0
     classesMappingArray.forEach((classMapping: { alias: string; realClassName: string; devPackageName?: DevPackageName; externalName?: string; fullPath: string }) => {
         const { alias, devPackageName, externalName } = classMapping;
         // TODO - make a list of dependencies that are accepted by each package

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -152,7 +152,7 @@ function getModuleDeclaration(
             }
         }
     }
-    // replaces classes definitions with namespace definsubstring(0
+    // replaces classes definitions with namespace definitions
     classesMappingArray.forEach((classMapping: { alias: string; realClassName: string; devPackageName?: DevPackageName; externalName?: string; fullPath: string }) => {
         const { alias, devPackageName, externalName } = classMapping;
         // TODO - make a list of dependencies that are accepted by each package

--- a/packages/dev/core/src/Compute/computeEffect.ts
+++ b/packages/dev/core/src/Compute/computeEffect.ts
@@ -327,14 +327,14 @@ export class ComputeEffect {
         }
 
         // Direct source ?
-        if (shader.substr(0, 7) === "source:") {
-            callback(shader.substr(7));
+        if (shader.substring(0, 7) === "source:") {
+            callback(shader.substring(7));
             return;
         }
 
         // Base64 encoded ?
-        if (shader.substr(0, 7) === "base64:") {
-            const shaderBinary = window.atob(shader.substr(7));
+        if (shader.substring(0, 7) === "base64:") {
+            const shaderBinary = window.atob(shader.substring(7));
             callback(shaderBinary);
             return;
         }

--- a/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/shaderDefineExpression.ts
@@ -115,7 +115,7 @@ export class ShaderDefineExpression {
 
         while (idx < infix.length) {
             const c = infix.charAt(idx),
-                token = idx < infix.length - 1 ? infix.substr(idx, 2) : "";
+                token = idx < infix.length - 1 ? infix.substring(idx, 2 + idx) : "";
 
             if (c === "(") {
                 operand = "";

--- a/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuShaderProcessorsGLSL.ts
@@ -35,7 +35,7 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
             if (isNaN(length)) {
                 length = +preProcessors[lengthInString.trim()];
             }
-            name = name.substr(0, startArray);
+            name = name.substring(0, startArray);
         }
         return [name, type, length];
     }
@@ -189,7 +189,7 @@ export class WebGPUShaderProcessorGLSL extends WebGPUShaderProcessor {
                 const componentType = uniformType.charAt(0) === "u" ? "u" : uniformType.charAt(0) === "i" ? "i" : "";
 
                 if (componentType) {
-                    uniformType = uniformType.substr(1);
+                    uniformType = uniformType.substring(1);
                 }
 
                 const sampleType = isComparisonSampler

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -1796,8 +1796,8 @@ export class NativeEngine extends Engine {
         useSRGBBuffer = false
     ): InternalTexture {
         url = url || "";
-        const fromData = url.substr(0, 5) === "data:";
-        //const fromBlob = url.substr(0, 5) === "blob:";
+        const fromData = url.substring(0, 5) === "data:";
+        //const fromBlob = url.substring(0, 5) === "blob:";
         const isBase64 = fromData && url.indexOf(";base64,") !== -1;
 
         const texture = fallback ? fallback : new InternalTexture(this, InternalTextureSource.Url);

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -525,8 +525,8 @@ function getPluginForFilename(sceneFilename: string): IRegisteredPlugin | undefi
 }
 
 function getDirectLoad(sceneFilename: string): Nullable<string> {
-    if (sceneFilename.substr(0, 5) === "data:") {
-        return sceneFilename.substr(5);
+    if (sceneFilename.substring(0, 5) === "data:") {
+        return sceneFilename.substring(5);
     }
 
     return null;
@@ -722,7 +722,7 @@ function getFileInfo(rootUrl: string, sceneSource: SceneSource): Nullable<IFileI
         name = "";
     } else if (rootUrl) {
         const filename = sceneSource;
-        if (filename.substr(0, 1) === "/") {
+        if (filename.substring(0, 1) === "/") {
             Tools.Error("Wrong sceneFilename parameter");
             return null;
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
@@ -118,7 +118,7 @@ export class ColorMergerBlock extends NodeMaterialBlock {
 
     private _buildSwizzle(len: number) {
         const swizzle = this.rSwizzle + this.gSwizzle + this.bSwizzle + this.aSwizzle;
-        return "." + swizzle.substr(0, len);
+        return "." + swizzle.substring(0, len);
     }
 
     protected override _buildBlock(state: NodeMaterialBuildState) {

--- a/packages/dev/core/src/Materials/Node/Blocks/vectorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/vectorMergerBlock.ts
@@ -176,7 +176,7 @@ export class VectorMergerBlock extends NodeMaterialBlock {
     private _buildSwizzle(len: number) {
         const swizzle = this.xSwizzle + this.ySwizzle + this.zSwizzle + this.wSwizzle;
 
-        return "." + swizzle.substr(0, len);
+        return "." + swizzle.substring(0, len);
     }
 
     protected override _buildBlock(state: NodeMaterialBuildState) {

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -889,7 +889,7 @@ export class Texture extends BaseTexture {
         }
 
         if (Texture.SerializeBuffers || Texture.ForceSerializeBuffers) {
-            if (typeof this._buffer === "string" && (this._buffer as string).substr(0, 5) === "data:") {
+            if (typeof this._buffer === "string" && (this._buffer as string).substring(0, 5) === "data:") {
                 serializationObject.base64String = this._buffer;
                 serializationObject.name = serializationObject.name.replace("data:", "");
             } else if (this.url && this.url.startsWith("data:") && this._buffer instanceof Uint8Array) {
@@ -1188,7 +1188,7 @@ export class Texture extends BaseTexture {
         creationFlags?: number,
         forcedExtension?: string
     ): Texture {
-        if (name.substr(0, 5) !== "data:") {
+        if (name.substring(0, 5) !== "data:") {
             name = "data:" + name;
         }
 

--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -214,14 +214,14 @@ function _loadShader(shader: any, key: string, optionalKey: string, callback: (d
     }
 
     // Direct source ?
-    if (shader.substr(0, 7) === "source:") {
-        callback(shader.substr(7));
+    if (shader.substring(0, 7) === "source:") {
+        callback(shader.substring(7));
         return;
     }
 
     // Base64 encoded ?
-    if (shader.substr(0, 7) === "base64:") {
-        const shaderBinary = window.atob(shader.substr(7));
+    if (shader.substring(0, 7) === "base64:") {
+        const shaderBinary = window.atob(shader.substring(7));
         callback(shaderBinary);
         return;
     }

--- a/packages/dev/core/src/Misc/PerformanceViewer/performanceViewerCollector.ts
+++ b/packages/dev/core/src/Misc/PerformanceViewer/performanceViewerCollector.ts
@@ -237,7 +237,8 @@ export class PerformanceViewerCollector {
         let hex = "#";
         for (let i = 0; i < NumberOfBitsInHexcode; i += 8) {
             const octet = (hash >> i) & 0xff;
-            hex += (HexPadding + octet.toString(16)).substr(-2);
+            const toStr = HexPadding + octet.toString(16);
+            hex += toStr.substring(toStr.length - 2);
         }
 
         return hex;

--- a/packages/dev/core/src/Misc/reflector.ts
+++ b/packages/dev/core/src/Misc/reflector.ts
@@ -27,12 +27,12 @@ export class Reflector {
         this._webSocket.onmessage = (event) => {
             const message: string = event.data;
             if (message.startsWith(Reflector._SERVER_PREFIX)) {
-                const serverMessage = message.substr(Reflector._SERVER_PREFIX.length);
-                Logger.Log(`[Reflector] Received server message: ${serverMessage.substr(0, 64)}`);
+                const serverMessage = message.substring(Reflector._SERVER_PREFIX.length);
+                Logger.Log(`[Reflector] Received server message: ${serverMessage.substring(0, 64)}`);
                 this._handleServerMessage(serverMessage);
                 return;
             } else {
-                Logger.Log(`[Reflector] Received client message: ${message.substr(0, 64)}`);
+                Logger.Log(`[Reflector] Received client message: ${message.substring(0, 64)}`);
                 this._handleClientMessage();
             }
         };

--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -540,7 +540,7 @@ export class InputText extends Control {
                     }
                     //delete single character
                     if (this._cursorOffset === 0) {
-                        this.text = this._textWrapper.substr(0, this._textWrapper.length - 1);
+                        this.text = this._textWrapper.substring(0, this._textWrapper.length - 1);
                     } else {
                         const deletePosition = this._textWrapper.length - this._cursorOffset;
                         if (deletePosition > 0) {

--- a/packages/dev/gui/src/2D/controls/inputTextArea.ts
+++ b/packages/dev/gui/src/2D/controls/inputTextArea.ts
@@ -358,7 +358,7 @@ export class InputTextArea extends InputText {
                         relativeIndex = this._cursorInfo.relativeEndIndex;
                     }
 
-                    const currentText = currentLine.text.substr(0, relativeIndex);
+                    const currentText = currentLine.text.substring(0, relativeIndex);
                     const currentWidth = this._contextForBreakLines.measureText(currentText).width;
 
                     let upperWidth = 0;
@@ -372,7 +372,7 @@ export class InputTextArea extends InputText {
                         tmpIndex++;
                         upperLineRelativeIndex++;
                         previousWidth = Math.abs(currentWidth - upperWidth);
-                        upperWidth = this._contextForBreakLines.measureText(upperLine.text.substr(0, upperLineRelativeIndex)).width;
+                        upperWidth = this._contextForBreakLines.measureText(upperLine.text.substring(0, upperLineRelativeIndex)).width;
                     }
 
                     // Find closest move
@@ -430,7 +430,7 @@ export class InputTextArea extends InputText {
                         relativeIndex = this._cursorInfo.relativeEndIndex;
                     }
 
-                    const currentText = currentLine.text.substr(0, relativeIndex);
+                    const currentText = currentLine.text.substring(0, relativeIndex);
                     const currentWidth = this._contextForBreakLines.measureText(currentText).width;
 
                     let underWidth = 0;
@@ -443,7 +443,7 @@ export class InputTextArea extends InputText {
                         tmpIndex++;
                         underLineRelativeIndex++;
                         previousWidth = Math.abs(currentWidth - underWidth);
-                        underWidth = this._contextForBreakLines.measureText(underLine.text.substr(0, underLineRelativeIndex)).width;
+                        underWidth = this._contextForBreakLines.measureText(underLine.text.substring(0, underLineRelativeIndex)).width;
                     }
 
                     // Find closest move
@@ -865,7 +865,8 @@ export class InputTextArea extends InputText {
         if (this._isFocused) {
             // Render cursor
             if (!this._blinkIsEven || this._isTextHighlightOn) {
-                let cursorLeft = this._scrollLeft + context.measureText(this._lines[this._cursorInfo.currentLineIndex].text.substr(0, this._cursorInfo.relativeStartIndex)).width;
+                let cursorLeft =
+                    this._scrollLeft + context.measureText(this._lines[this._cursorInfo.currentLineIndex].text.substring(0, this._cursorInfo.relativeStartIndex)).width;
 
                 if (cursorLeft < this._clipTextLeft) {
                     this._scrollLeft += this._clipTextLeft - cursorLeft;
@@ -929,7 +930,7 @@ export class InputTextArea extends InputText {
                     const begin = i === startLineIndex ? this._cursorInfo.relativeStartIndex : 0;
                     const end = i === endLineIndex ? this._cursorInfo.relativeEndIndex : line.text.length;
 
-                    const leftOffsetWidth = context.measureText(line.text.substr(0, begin)).width;
+                    const leftOffsetWidth = context.measureText(line.text.substring(0, begin)).width;
                     const selectedText = line.text.substring(begin, end);
                     const hightlightWidth = context.measureText(selectedText).width;
 
@@ -1079,7 +1080,7 @@ export class InputTextArea extends InputText {
                 while (currentSize < relativeXPosition && this._lines[this._cursorInfo.currentLineIndex].text.length > relativeIndex) {
                     relativeIndex++;
                     previousDist = Math.abs(relativeXPosition - currentSize);
-                    currentSize = this._contextForBreakLines.measureText(this._lines[this._cursorInfo.currentLineIndex].text.substr(0, relativeIndex)).width;
+                    currentSize = this._contextForBreakLines.measureText(this._lines[this._cursorInfo.currentLineIndex].text.substring(0, relativeIndex)).width;
                 }
 
                 // Find closest move

--- a/packages/dev/gui/src/2D/controls/textWrapper.ts
+++ b/packages/dev/gui/src/2D/controls/textWrapper.ts
@@ -51,7 +51,7 @@ export class TextWrapper {
             return temp.join("");
         }
 
-        return this._text.substr(from, length);
+        return this._text.substring(from, length ? length + from : undefined);
     }
 
     public substring(from: number, to?: number): string {

--- a/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
@@ -212,7 +212,7 @@ export class MTLFileLoader {
             }
 
             if (lastDelimiter > -1) {
-                url += value.substr(lastDelimiter + 1);
+                url += value.substring(lastDelimiter + 1);
             } else {
                 url += value;
             }

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -2494,7 +2494,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         if (IsBase64DataUrl(uri)) {
             const data = new Uint8Array(DecodeBase64UrlToBinary(uri));
-            this.log(`${context}: Decoded ${uri.substr(0, 64)}... (${data.length} bytes)`);
+            this.log(`${context}: Decoded ${uri.substring(0, 64)}... (${data.length} bytes)`);
             return Promise.resolve(data);
         }
 

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -1358,7 +1358,7 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     }
 
     private _logEnabled(message: string): void {
-        const spaces = GLTFFileLoader._logSpaces.substr(0, this._logIndentLevel * 2);
+        const spaces = GLTFFileLoader._logSpaces.substring(0, this._logIndentLevel * 2);
         Logger.Log(`${spaces}${message}`);
     }
 

--- a/packages/dev/sharedUiComponents/src/lines/hexLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/hexLineComponent.tsx
@@ -78,8 +78,8 @@ export class HexLineComponent extends React.Component<IHexLineComponentProps, { 
     }
 
     updateValue(valueString: string, raisePropertyChanged: boolean) {
-        if (valueString.substr(0, 2) != "0x") {
-            if (valueString.substr(0, 1) != "0") {
+        if (valueString.substring(0, 2) != "0x") {
+            if (valueString.substring(0, 1) != "0") {
                 valueString = "0x" + valueString;
             } else {
                 valueString = "0x" + valueString.substr(1);

--- a/packages/tools/guiEditor/src/diagram/workbench.tsx
+++ b/packages/tools/guiEditor/src/diagram/workbench.tsx
@@ -761,10 +761,10 @@ export class WorkbenchComponent extends React.Component<IWorkbenchComponentProps
 
         if (guiControl.typeName === "Line") {
             const line = guiControl as Line;
-            const x1 = (line.x1 as string).substr(0, (line.x1 as string).length - 2); //removing the 'px'
-            const x2 = (line.x2 as string).substr(0, (line.x2 as string).length - 2);
-            const y1 = (line.y1 as string).substr(0, (line.y1 as string).length - 2);
-            const y2 = (line.y2 as string).substr(0, (line.y2 as string).length - 2);
+            const x1 = (line.x1 as string).substring(0, (line.x1 as string).length - 2); //removing the 'px'
+            const x2 = (line.x2 as string).substring(0, (line.x2 as string).length - 2);
+            const y1 = (line.y1 as string).substring(0, (line.y1 as string).length - 2);
+            const y2 = (line.y2 as string).substring(0, (line.y2 as string).length - 2);
             line.x1 = (Number(x1) + newX).toFixed(2);
             line.x2 = (Number(x2) + newX).toFixed(2);
             line.y1 = (Number(y1) + newY).toFixed(2);

--- a/packages/tools/nodeEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
+++ b/packages/tools/nodeEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
@@ -24,7 +24,7 @@ export class DraggableLineWithButtonComponent extends React.Component<IDraggable
                     event.dataTransfer.setData("babylonjs-material-node", this.props.data);
                 }}
             >
-                {this.props.data.substr(0, this.props.data.length - (this.props.lenSuffixToRemove ?? 6))}
+                {this.props.data.substring(0, this.props.data.length - (this.props.lenSuffixToRemove ?? 6))}
                 <div
                     className="icon"
                     onClick={() => {

--- a/packages/tools/nodeGeometryEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/sharedComponents/draggableLineWithButtonComponent.tsx
@@ -24,7 +24,7 @@ export class DraggableLineWithButtonComponent extends React.Component<IDraggable
                     event.dataTransfer.setData("babylonjs-geometry-node", this.props.data);
                 }}
             >
-                {this.props.data.substr(0, this.props.data.length - (this.props.lenSuffixToRemove ?? 6))}
+                {this.props.data.substring(0, this.props.data.length - (this.props.lenSuffixToRemove ?? 6))}
                 <div
                     className="icon"
                     onClick={() => {

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -294,7 +294,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     code += "\r\n" + "window.scene = " + createSceneFunction + "();";
                 } else {
                     const startCar = code.search("var " + createSceneFunction);
-                    code = code.substr(0, startCar) + code.substr(startCar + 4);
+                    code = code.substring(0, startCar) + code.substr(startCar + 4);
                     code += "\n" + "window.scene = " + createSceneFunction + "();";
                 }
 

--- a/packages/tools/playground/src/tools/downloadManager.ts
+++ b/packages/tools/playground/src/tools/downloadManager.ts
@@ -92,7 +92,6 @@ export class DownloadManager {
         }
 
         const name = textures[index].name.replace("textures/", "");
-        // var name = url.substr(url.lastIndexOf("/") + 1);
 
         if (url != null) {
             return this._addContentToZipAsync(folder, name, url, null, true).then(() => {
@@ -113,7 +112,7 @@ export class DownloadManager {
         }
         const url = importedFiles[index];
 
-        const name = url.substr(url.lastIndexOf("/") + 1);
+        const name = url.substring(url.lastIndexOf("/") + 1);
 
         return this._addContentToZipAsync(folder, name, url, null, true).then(() => {
             return this._addImportedFilesToZipAsync(zip, index + 1, importedFiles, folder);

--- a/packages/tools/playground/src/tools/loadManager.ts
+++ b/packages/tools/playground/src/tools/loadManager.ts
@@ -42,7 +42,7 @@ export class LoadManager {
 
     private _cleanHash() {
         const substr = location.hash[1] === "#" ? 2 : 1;
-        const splits = decodeURIComponent(location.hash.substr(substr)).split("#");
+        const splits = decodeURIComponent(location.hash.substring(substr)).split("#");
 
         if (splits.length > 2) {
             splits.splice(2, splits.length - 2);

--- a/packages/tools/playground/src/tools/utilities.ts
+++ b/packages/tools/playground/src/tools/utilities.ts
@@ -26,7 +26,7 @@ export class Utilities {
     public static ParseQuery() {
         const queryString = location.search;
         const query: any = {};
-        const pairs = (queryString[0] === "?" ? queryString.substr(1) : queryString).split("&");
+        const pairs = (queryString[0] === "?" ? queryString.substring(1) : queryString).split("&");
         for (let i = 0; i < pairs.length; i++) {
             const pair = pairs[i].split("=");
             query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || "");

--- a/packages/tools/sandbox/src/components/reflectorZone.tsx
+++ b/packages/tools/sandbox/src/components/reflectorZone.tsx
@@ -32,7 +32,7 @@ class Reflector {
                 this._handleServerMessage(serverMessage);
                 return;
             } else {
-                Logger.Log(`[Reflector] Received client message: ${message.substr(0, 64)}`);
+                Logger.Log(`[Reflector] Received client message: ${message.substring(0, 64)}`);
                 this._handleClientMessage(message);
             }
         };

--- a/packages/tools/viewer/src/viewer/viewer.ts
+++ b/packages/tools/viewer/src/viewer/viewer.ts
@@ -192,7 +192,7 @@ export abstract class AbstractViewer {
         if (containerElement.id) {
             this.baseId = containerElement.id;
         } else {
-            this.baseId = containerElement.id = "bjs" + Math.random().toString(32).substr(2, 8);
+            this.baseId = containerElement.id = "bjs" + Math.random().toString(32).substring(2, 10);
         }
 
         this._registeredOnBeforeRenderFunctions = [];


### PR DESCRIPTION
substr has been deprecated for a while now (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) , removing all usage of substr from the framework.

`substr(0, n)` is the same as `substring(0, n)`, `substr(n)` is the same as `substring(n)`. The only difference is the second variable (or if the first is negative). Adjusted.