### PR TITLE
Fix es6 build on windows

### DIFF
--- a/packages/dev/buildTools/src/addJSToCompiledFiles.ts
+++ b/packages/dev/buildTools/src/addJSToCompiledFiles.ts
@@ -31,7 +31,7 @@ export function addJsExtensionsToCompiledFiles(files: string[], forceMJS: boolea
         while ((match = dynamicRegex.exec(processed)) !== null) {
             if (!fs.existsSync(path.resolve(path.dirname(file), match[1]))) {
                 console.log(file, path.resolve(path.dirname(file), match[1]));
-                throw new Error(`File ${match[1]} does not exist. Are you importing from an index/directory?`);
+                throw new Error(`File ${match[1]} does not exist. Are you dynamically importing from an index/directory?`);
             }
         }
         fs.writeFileSync(file, processed);

--- a/packages/dev/buildTools/src/copyAssets.ts
+++ b/packages/dev/buildTools/src/copyAssets.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { glob } from "glob";
+import { globSync } from "glob";
 import * as path from "path";
 import { copyFile, checkArgs } from "./utils.js";
 import * as chokidar from "chokidar";
@@ -77,15 +77,10 @@ export const processAssets = (options: { extensions: string[] } = { extensions: 
             });
         console.log("watching for asset changes...");
     } else {
-        glob(globDirectory).then(
-            (files) => {
-                files.forEach((file) => {
-                    processFile(file, processOptions);
-                });
-            },
-            (err) => {
-                console.log(err);
-            }
-        );
+        globSync(globDirectory, {
+            windowsPathsNoEscape: true,
+        }).forEach((file) => {
+            processFile(file.replace(/\\/g, "/"), processOptions);
+        });
     }
 };

--- a/packages/dev/buildTools/src/prepareEs6Build.ts
+++ b/packages/dev/buildTools/src/prepareEs6Build.ts
@@ -9,14 +9,15 @@ export const prepareES6Build = async () => {
     const constFile = checkArgs(["--constFile", "-cf"], false, true);
     try {
         if (constFile) {
-            const constantsContent = fs.readFileSync(path.resolve(baseDir, constFile as string), "utf8").replace("export class Constants", "const Constants = ");
+            const constFilePath = path.resolve(baseDir, constFile as string);
+            const constantsContent = fs.readFileSync(constFilePath, "utf8").replace("export class Constants", "const Constants = ");
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const Constants = eval(constantsContent + "\nConstants;");
             const allSourceFiles = globSync(path.resolve(baseDir, "**", "*.js"), {
                 windowsPathsNoEscape: true,
             });
             allSourceFiles.forEach((file) => {
-                if (file.endsWith(constFile as string)) {
+                if (path.resolve(file) === constFilePath) {
                     return;
                 }
                 const fileContent = fs.readFileSync(file, "utf8");


### PR DESCRIPTION
There were two issues due to directory structure on windows.

Whoever thought that backslash is better than slash when defining a directory should never be consulted.