### PR TITLE
WIP - IBL shadow material blending

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -650,9 +650,9 @@ export class Constants {
 
     /**
      * Constant used to retrieve the radiance texture index in the textures array in the prepass
-     * using getIndex(Constants.PREPASS_RADIANCE_TEXTURE_TYPE)
+     * using getIndex(Constants.PREPASS_DIRECTLIGHTING_TEXTURE_TYPE)
      */
-    public static readonly PREPASS_RADIANCE_TEXTURE_TYPE = 12;
+    public static readonly PREPASS_DIRECTLIGHTING_TEXTURE_TYPE = 12;
 
     /** Flag to create a readable buffer (the buffer can be the source of a copy) */
     public static readonly BUFFER_CREATIONFLAG_READ = 1;

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -648,6 +648,12 @@ export class Constants {
      */
     public static readonly PREPASS_VELOCITY_LINEAR_TEXTURE_TYPE = 11;
 
+    /**
+     * Constant used to retrieve the radiance texture index in the textures array in the prepass
+     * using getIndex(Constants.PREPASS_RADIANCE_TEXTURE_TYPE)
+     */
+    public static readonly PREPASS_RADIANCE_TEXTURE_TYPE = 12;
+
     /** Flag to create a readable buffer (the buffer can be the source of a copy) */
     public static readonly BUFFER_CREATIONFLAG_READ = 1;
     /** Flag to create a writable buffer (the buffer can be the destination of a copy) */

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -136,9 +136,9 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     /** Clip-space depth index */
     public PREPASS_NDC_DEPTH_INDEX = -1;
     /** Radiance lighting contribution */
-    public PREPASS_RADIANCE = false;
+    public PREPASS_DIRECTLIGHTING = false;
     /** Radiance lighting contribution */
-    public PREPASS_RADIANCE_INDEX = -1;
+    public PREPASS_DIRECTLIGHTING_INDEX = -1;
     /** Scene MRT count */
     public SCENE_MRT_COUNT = 0;
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -135,6 +135,10 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public PREPASS_NDC_DEPTH = false;
     /** Clip-space depth index */
     public PREPASS_NDC_DEPTH_INDEX = -1;
+    /** Radiance lighting contribution */
+    public PREPASS_RADIANCE = false;
+    /** Radiance lighting contribution */
+    public PREPASS_RADIANCE_INDEX = -1;
     /** Scene MRT count */
     public SCENE_MRT_COUNT = 0;
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -219,6 +219,8 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public PREPASS_VELOCITY_LINEAR_INDEX = -1;
     public PREPASS_REFLECTIVITY = false;
     public PREPASS_REFLECTIVITY_INDEX = -1;
+    public PREPASS_DIRECTLIGHTING = false;
+    public PREPASS_DIRECTLIGHTING_INDEX = -1;
     public SCENE_MRT_COUNT = 0;
 
     public NUM_BONE_INFLUENCERS = 0;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -868,6 +868,11 @@ export function PrepareDefinesForPrePass(scene: Scene, defines: any, canRenderTo
             define: "PREPASS_WORLD_NORMAL",
             index: "PREPASS_WORLD_NORMAL_INDEX",
         },
+        {
+            type: Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
+            define: "PREPASS_RADIANCE",
+            index: "PREPASS_RADIANCE_INDEX",
+        },
     ];
 
     if (scene.prePassRenderer && scene.prePassRenderer.enabled && canRenderToMRT) {

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -869,9 +869,9 @@ export function PrepareDefinesForPrePass(scene: Scene, defines: any, canRenderTo
             index: "PREPASS_WORLD_NORMAL_INDEX",
         },
         {
-            type: Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
-            define: "PREPASS_RADIANCE",
-            index: "PREPASS_RADIANCE_INDEX",
+            type: Constants.PREPASS_DIRECTLIGHTING_TEXTURE_TYPE,
+            define: "PREPASS_DIRECTLIGHTING",
+            index: "PREPASS_DIRECTLIGHTING_INDEX",
         },
     ];
 

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -113,7 +113,7 @@ class IblShadowsPrepassConfiguration implements PrePassEffectConfiguration {
         Constants.PREPASS_POSITION_TEXTURE_TYPE,
         Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE,
 
-        Constants.PREPASS_REFLECTIVITY_TEXTURE_TYPE,
+        Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
         // Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE,
     ];
 }
@@ -715,7 +715,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             const prePassRenderer = this.scene.prePassRenderer;
             if (prePassRenderer) {
                 // const irradianceIndex = prePassRenderer.getIndex(Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE);
-                const reflectivityIndex = prePassRenderer.getIndex(Constants.PREPASS_REFLECTIVITY_TEXTURE_TYPE);
+                const reflectivityIndex = prePassRenderer.getIndex(Constants.PREPASS_RADIANCE_TEXTURE_TYPE);
                 // if (irradianceIndex >= 0) effect.setTexture("irradianceSampler", prePassRenderer.getRenderTarget().textures[irradianceIndex]);
                 if (reflectivityIndex >= 0) effect.setTexture("reflectivitySampler", prePassRenderer.getRenderTarget().textures[reflectivityIndex]);
             }

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -112,6 +112,9 @@ class IblShadowsPrepassConfiguration implements PrePassEffectConfiguration {
         // Local positions used for shadow accumulation pass
         Constants.PREPASS_POSITION_TEXTURE_TYPE,
         Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE,
+
+        Constants.PREPASS_REFLECTIVITY_TEXTURE_TYPE,
+        // Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE,
     ];
 }
 
@@ -688,7 +691,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             width: this.scene.getEngine().getRenderWidth(),
             height: this.scene.getEngine().getRenderHeight(),
             uniforms: ["shadowOpacity"],
-            samplers: ["sceneTexture"],
+            samplers: ["sceneTexture", "irradianceSampler", "reflectivitySampler"],
             samplingMode: Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
             engine: this.scene.getEngine(),
             textureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
@@ -708,6 +711,13 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
                 this._accumulationPass?.isReady()
             ) {
                 this.update();
+            }
+            const prePassRenderer = this.scene.prePassRenderer;
+            if (prePassRenderer) {
+                // const irradianceIndex = prePassRenderer.getIndex(Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE);
+                const reflectivityIndex = prePassRenderer.getIndex(Constants.PREPASS_REFLECTIVITY_TEXTURE_TYPE);
+                // if (irradianceIndex >= 0) effect.setTexture("irradianceSampler", prePassRenderer.getRenderTarget().textures[irradianceIndex]);
+                if (reflectivityIndex >= 0) effect.setTexture("reflectivitySampler", prePassRenderer.getRenderTarget().textures[reflectivityIndex]);
             }
         });
         this._shadowCompositePP._prePassEffectConfiguration = this._prePassEffectConfiguration;

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -113,7 +113,7 @@ class IblShadowsPrepassConfiguration implements PrePassEffectConfiguration {
         Constants.PREPASS_POSITION_TEXTURE_TYPE,
         Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE,
 
-        Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
+        Constants.PREPASS_DIRECTLIGHTING_TEXTURE_TYPE,
         // Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE,
     ];
 }
@@ -715,7 +715,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             const prePassRenderer = this.scene.prePassRenderer;
             if (prePassRenderer) {
                 // const irradianceIndex = prePassRenderer.getIndex(Constants.PREPASS_IRRADIANCE_TEXTURE_TYPE);
-                const reflectivityIndex = prePassRenderer.getIndex(Constants.PREPASS_RADIANCE_TEXTURE_TYPE);
+                const reflectivityIndex = prePassRenderer.getIndex(Constants.PREPASS_DIRECTLIGHTING_TEXTURE_TYPE);
                 // if (irradianceIndex >= 0) effect.setTexture("irradianceSampler", prePassRenderer.getRenderTarget().textures[irradianceIndex]);
                 if (reflectivityIndex >= 0) effect.setTexture("reflectivitySampler", prePassRenderer.getRenderTarget().textures[reflectivityIndex]);
             }

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -194,6 +194,12 @@ export class PrePassRenderer {
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_VelocityLinear",
         },
+        {
+            purpose: Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
+            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            format: Constants.TEXTUREFORMAT_RGBA,
+            name: "prePass_Radiance",
+        },
     ];
 
     private _isDirty: boolean = true;

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -195,7 +195,7 @@ export class PrePassRenderer {
             name: "prePass_VelocityLinear",
         },
         {
-            purpose: Constants.PREPASS_RADIANCE_TEXTURE_TYPE,
+            purpose: Constants.PREPASS_DIRECTLIGHTING_TEXTURE_TYPE,
             type: Constants.TEXTURETYPE_UNSIGNED_INT,
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_Radiance",

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalDirectLightingComposition.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalDirectLightingComposition.fx
@@ -1,0 +1,29 @@
+vec3 finalDirectLightingColor = vec3(
+#ifndef UNLIT
+    #ifdef SPECULARTERM
+        finalSpecularScaled +
+    #endif
+    #ifdef CLEARCOAT
+        finalClearCoatScaled +
+    #endif
+    #ifdef SHEEN
+        finalSheenScaled +
+    #endif
+    #ifdef SS_REFRACTION
+        subSurfaceOut.finalRefraction +
+    #endif
+    #ifdef REFLECTION
+        finalRadianceScaled +
+        #if defined(SHEEN) && defined(ENVIRONMENTBRDF)
+            sheenOut.finalSheenRadianceScaled +
+        #endif
+        #ifdef CLEARCOAT
+            clearcoatOut.finalClearCoatRadianceScaled +
+        #endif
+    #endif
+#endif
+    vec3(0.0)
+);
+
+// _____________________________ Finally ___________________________________________
+finalDirectLightingColor = max(finalDirectLightingColor, 0.0);

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalIndirectLightingComposition.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalIndirectLightingComposition.fx
@@ -1,0 +1,25 @@
+vec4 finalIndirectLightingColor = vec4(
+#ifndef UNLIT
+    #ifdef REFLECTION
+        finalIrradiance +
+    #endif
+#endif
+        finalAmbient +
+        finalDiffuse,
+        alpha);
+
+// _____________________________ LightMappping _____________________________________
+#ifdef LIGHTMAP
+    #ifndef LIGHTMAPEXCLUDED
+        #ifdef USELIGHTMAPASSHADOWMAP
+            finalIndirectLightingColor.rgb *= lightmapColor.rgb;
+        #else
+            finalIndirectLightingColor.rgb += lightmapColor.rgb;
+        #endif
+    #endif
+#endif
+
+#define CUSTOM_FRAGMENT_BEFORE_FOG
+
+// _____________________________ Finally ___________________________________________
+finalIndirectLightingColor = max(finalIndirectLightingColor, 0.0);

--- a/packages/dev/core/src/Shaders/iblShadowsCombine.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowsCombine.fragment.fx
@@ -1,6 +1,8 @@
 precision highp float;
 varying vec2 vUV;
 
+#include<helperFunctions>
+
 uniform sampler2D sceneTexture;
 uniform sampler2D textureSampler;
 uniform sampler2D irradianceSampler;
@@ -8,11 +10,11 @@ uniform sampler2D reflectivitySampler;
 uniform float shadowOpacity;
 
 void main(void) {
-  vec3 color = texture(sceneTexture, vUV).rgb;
-  vec3 shadow = texture(textureSampler, vUV).rgb;
-  vec4 reflectivity = texture(reflectivitySampler, vUV);
+  vec3 color = toLinearSpace(texture(sceneTexture, vUV).rgb);
+  vec3 shadow = toLinearSpace(texture(textureSampler, vUV).rgb);
+  vec4 reflectivity = toLinearSpace(texture(reflectivitySampler, vUV));
   vec4 irradiance = texture(irradianceSampler, vUV);
   float shadowValue = mix(1.0, shadow.x, shadowOpacity);
-  shadowValue = mix(shadowValue, 1.0, reflectivity.a);
-  gl_FragColor = vec4(color.rgb * shadowValue, 1.0);
+  float specularShadowValue = mix(shadowValue, 1.0, reflectivity.a);
+  gl_FragColor = toGammaSpace(vec4(color.rgb * shadowValue + reflectivity.rgb * specularShadowValue, 1.0));
 }

--- a/packages/dev/core/src/Shaders/iblShadowsCombine.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowsCombine.fragment.fx
@@ -3,12 +3,16 @@ varying vec2 vUV;
 
 uniform sampler2D sceneTexture;
 uniform sampler2D textureSampler;
+uniform sampler2D irradianceSampler;
+uniform sampler2D reflectivitySampler;
 uniform float shadowOpacity;
 
-void main(void)
-{
+void main(void) {
   vec3 color = texture(sceneTexture, vUV).rgb;
   vec3 shadow = texture(textureSampler, vUV).rgb;
+  vec4 reflectivity = texture(reflectivitySampler, vUV);
+  vec4 irradiance = texture(irradianceSampler, vUV);
   float shadowValue = mix(1.0, shadow.x, shadowOpacity);
-  gl_FragColor = vec4(color * shadowValue, 1.0);
+  shadowValue = mix(shadowValue, 1.0, reflectivity.a);
+  gl_FragColor = vec4(color.rgb * shadowValue, 1.0);
 }

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -711,6 +711,18 @@ void main(void) {
         gl_FragData[PREPASS_ALBEDO_SQRT_INDEX] = vec4(sqAlbedo, writeGeometryInfo); // albedo, for pre and post scatter
 #endif
 
+#ifdef PREPASS_RADIANCE
+#ifndef UNLIT
+    #ifdef REFLECTION
+            gl_FragData[PREPASS_RADIANCE_INDEX] = vec4(finalRadianceScaled, microSurface) * writeGeometryInfo;
+    #else
+            gl_FragData[PREPASS_RADIANCE_INDEX] = vec4( 0.0, 0.0, 0.0, 1.0 ) * writeGeometryInfo;
+    #endif
+#else
+            gl_FragData[PREPASS_RADIANCE_INDEX] = vec4( 0.0, 0.0, 0.0, 1.0 ) * writeGeometryInfo;
+#endif
+#endif
+
 #ifdef PREPASS_REFLECTIVITY
 #ifndef UNLIT
     #ifdef REFLECTION

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -713,7 +713,13 @@ void main(void) {
 
 #ifdef PREPASS_REFLECTIVITY
 #ifndef UNLIT
+    #ifdef REFLECTION
+    // Make prepass RT that causes irradiance and radiance parts to be split.
+    // Then we shouldn't need both irradiance and radiance prepasses.
+            gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(finalRadianceScaled, microSurface) * writeGeometryInfo;
+    #else
             gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(specularEnvironmentR0, microSurface) * writeGeometryInfo;
+    #endif
 #else
             gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4( 0.0, 0.0, 0.0, 1.0 ) * writeGeometryInfo;
 #endif


### PR DESCRIPTION
I'm working on how to combine the generated shadow image with the actual material properties.
Shadows should only apply to view-independent lighting and so don't work really well for things like specular reflections.
Therefore, I want to apply them 100% to diffuse (indirect) lighting and scale their affect on specular (direct) lighting based on surface roughness. The more rough the surface, the less view-dependent the specular component becomes.

I'm struggling with the best way to do this in Babylon. Currently, I'm trying to use prepass buffers to write out this view-independent/dependent lighting and then I combine them with shadows in a post process. This is simple but has some issues:
1. I ended up hijacking fragData[0] for the indirect lighting component because, otherwise, this data is wasted and I end up using an additional buffer. Then, anything else (like UI) that was written to the fragData[0] is lost when I apply the shadows.
2. Some things, like emissive, might be technically view-independent but they shouldn't have shadows applied.

It might be better to apply the shadows in the material shader directly to handle all the material properties as needed. However, this implies rendering all the prepass buffers **before** the final material render. This means everything will be drawn an extra time. This is how I've implemented this effect before but in, WebGL, I worry about the performance implications of rendering all the geometry another time...