### PR TITLE
Inspector pane resize doesn't stick after mouse up

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/actionTabsComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/actionTabsComponent.tsx
@@ -159,7 +159,7 @@ export class ActionTabsComponent extends React.Component<IActionTabsComponentPro
                 id="actionTabs"
                 minWidth={300}
                 maxWidth={600}
-                size={{ height: "100%" }}
+                defaultSize={{ height: "100%" }}
                 minHeight="100%"
                 enable={{ top: false, right: false, bottom: false, left: true, topRight: false, bottomRight: false, bottomLeft: false, topLeft: false }}
             >

--- a/packages/dev/inspector/src/components/embedHost/embedHostComponent.tsx
+++ b/packages/dev/inspector/src/components/embedHost/embedHostComponent.tsx
@@ -130,7 +130,7 @@ export class EmbedHostComponent extends React.Component<IEmbedHostComponentProps
                 id="embed"
                 minWidth={300}
                 maxWidth={600}
-                size={{ height: "100%" }}
+                defaultSize={{ height: "100%" }}
                 minHeight="100%"
                 enable={{ top: false, right: false, bottom: false, left: true, topRight: false, bottomRight: false, bottomLeft: false, topLeft: false }}
             >

--- a/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/sceneExplorerComponent.tsx
@@ -752,7 +752,7 @@ export class SceneExplorerComponent extends React.Component<ISceneExplorerCompon
             <ResizableCasted
                 tabIndex={-1}
                 id="sceneExplorer"
-                size={{ height: "100%" }}
+                defaultSize={{ height: "100%" }}
                 ref={this._sceneExplorerRef}
                 minWidth={300}
                 maxWidth={600}


### PR DESCRIPTION
Fixes #15548

To check - https://sandbox.babylonjs.com/?assetUrl=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DragonDispersion/glTF/DragonDispersion.gltf&snapshot=refs/pull/15549/merge