### PR TITLE
Fix glTF transmission refraction texture export

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_clearcoat.ts
@@ -89,7 +89,7 @@ export class KHR_materials_clearcoat implements IGLTFLoaderExtension {
         if (properties.clearcoatTexture) {
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/clearcoatTexture`, properties.clearcoatTexture, (texture) => {
-                    texture.name = `${babylonMaterial.name} (ClearCoat Intensity)`;
+                    texture.name = `${babylonMaterial.name} (ClearCoat)`;
                     babylonMaterial.clearCoat.texture = texture;
                 })
             );

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_diffuse_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_diffuse_transmission.ts
@@ -108,6 +108,7 @@ export class KHR_materials_diffuse_transmission implements IGLTFLoaderExtension 
             (extension.diffuseTransmissionTexture as ITextureInfo).nonColorData = true;
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/diffuseTransmissionTexture`, extension.diffuseTransmissionTexture).then((texture: BaseTexture) => {
+                    texture.name = `${babylonMaterial.name} (Diffuse Transmission)`;
                     pbrMaterial.subSurface.translucencyIntensityTexture = texture;
                 })
             );
@@ -122,6 +123,7 @@ export class KHR_materials_diffuse_transmission implements IGLTFLoaderExtension 
         if (extension.diffuseTransmissionColorTexture) {
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/diffuseTransmissionColorTexture`, extension.diffuseTransmissionColorTexture).then((texture: BaseTexture) => {
+                    texture.name = `${babylonMaterial.name} (Diffuse Transmission Color)`;
                     pbrMaterial.subSurface.translucencyColorTexture = texture;
                 })
             );

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_iridescence.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_iridescence.ts
@@ -85,7 +85,7 @@ export class KHR_materials_iridescence implements IGLTFLoaderExtension {
         if (properties.iridescenceTexture) {
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/iridescenceTexture`, properties.iridescenceTexture, (texture) => {
-                    texture.name = `${babylonMaterial.name} (Iridescence Intensity)`;
+                    texture.name = `${babylonMaterial.name} (Iridescence)`;
                     babylonMaterial.iridescence.texture = texture;
                 })
             );

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_specular.ts
@@ -88,7 +88,7 @@ export class KHR_materials_specular implements IGLTFLoaderExtension {
             (properties.specularTexture as ITextureInfo).nonColorData = true;
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/specularTexture`, properties.specularTexture, (texture) => {
-                    texture.name = `${babylonMaterial.name} (Specular F0 Strength)`;
+                    texture.name = `${babylonMaterial.name} (Specular)`;
                     babylonMaterial.metallicReflectanceTexture = texture;
                     babylonMaterial.useOnlyMetallicFromMetallicReflectanceTexture = true;
                 })
@@ -98,7 +98,7 @@ export class KHR_materials_specular implements IGLTFLoaderExtension {
         if (properties.specularColorTexture) {
             promises.push(
                 this._loader.loadTextureInfoAsync(`${context}/specularColorTexture`, properties.specularColorTexture, (texture) => {
-                    texture.name = `${babylonMaterial.name} (Specular F0 Color)`;
+                    texture.name = `${babylonMaterial.name} (Specular Color)`;
                     babylonMaterial.reflectanceTexture = texture;
                 })
             );

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -414,6 +414,7 @@ export class KHR_materials_transmission implements IGLTFLoaderExtension {
         if (extension.transmissionTexture) {
             (extension.transmissionTexture as ITextureInfo).nonColorData = true;
             return this._loader.loadTextureInfoAsync(`${context}/transmissionTexture`, extension.transmissionTexture, undefined).then((texture: BaseTexture) => {
+                texture.name = `${babylonMaterial.name} (Transmission)`;
                 pbrMaterial.subSurface.refractionIntensityTexture = texture;
                 pbrMaterial.subSurface.useGltfStyleTextures = true;
             });

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_volume.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_volume.ts
@@ -102,7 +102,7 @@ export class KHR_materials_volume implements IGLTFLoaderExtension {
         if (extension.thicknessTexture) {
             (extension.thicknessTexture as ITextureInfo).nonColorData = true;
             return this._loader.loadTextureInfoAsync(`${context}/thicknessTexture`, extension.thicknessTexture).then((texture: BaseTexture) => {
-                texture.name = `${babylonMaterial.name} (thickness)`;
+                texture.name = `${babylonMaterial.name} (Thickness)`;
                 babylonMaterial.subSurface.thicknessTexture = texture;
                 babylonMaterial.subSurface.useGltfStyleTextures = true;
             });

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -1,9 +1,10 @@
-import type { IMaterial, IKHRMaterialsTransmission } from "babylonjs-gltf2interface";
+import { type IMaterial, type IKHRMaterialsTransmission, ImageMimeType } from "babylonjs-gltf2interface";
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
 import { _Exporter } from "../glTFExporter";
 import type { Material } from "core/Materials/material";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";
+import { Logger } from "core/Misc/logger";
 
 const NAME = "KHR_materials_transmission";
 
@@ -79,28 +80,36 @@ export class KHR_materials_transmission implements IGLTFExporterExtensionV2 {
      * @param babylonMaterial corresponding babylon material
      * @returns true if successful
      */
-    public postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
-        return new Promise((resolve) => {
-            if (babylonMaterial instanceof PBRMaterial && this._isExtensionEnabled(babylonMaterial)) {
-                this._wasUsed = true;
+    public async postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial> {
+        if (babylonMaterial instanceof PBRMaterial && this._isExtensionEnabled(babylonMaterial)) {
+            this._wasUsed = true;
 
-                const subs = babylonMaterial.subSurface;
-                const transmissionFactor = subs.refractionIntensity === 0 ? undefined : subs.refractionIntensity;
+            const subSurface = babylonMaterial.subSurface;
+            const transmissionFactor = subSurface.refractionIntensity === 0 ? undefined : subSurface.refractionIntensity;
 
-                const transmissionTexture = this._exporter._glTFMaterialExporter._getTextureInfo(subs.refractionIntensityTexture) ?? undefined;
+            const volumeInfo: IKHRMaterialsTransmission = {
+                transmissionFactor: transmissionFactor,
+                hasTextures: () => {
+                    return this._hasTexturesExtension(babylonMaterial);
+                },
+            };
 
-                const volumeInfo: IKHRMaterialsTransmission = {
-                    transmissionFactor: transmissionFactor,
-                    transmissionTexture: transmissionTexture,
-                    hasTextures: () => {
-                        return this._hasTexturesExtension(babylonMaterial);
-                    },
-                };
-                node.extensions = node.extensions || {};
-                node.extensions[NAME] = volumeInfo;
+            if (subSurface.refractionIntensityTexture) {
+                if (subSurface.useGltfStyleTextures) {
+                    const transmissionTexture = await this._exporter._glTFMaterialExporter._exportTextureInfoAsync(subSurface.refractionIntensityTexture, ImageMimeType.PNG);
+                    if (transmissionTexture) {
+                        volumeInfo.transmissionTexture = transmissionTexture;
+                    }
+                } else {
+                    Logger.Warn(`${context}: Exporting a subsurface refraction intensity texture without \`useGltfStyleTextures\` is not supported`);
+                }
             }
-            resolve(node);
-        });
+
+            node.extensions ||= {};
+            node.extensions[NAME] = volumeInfo;
+        }
+
+        return node;
     }
 }
 

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -1,4 +1,5 @@
-import { type IMaterial, type IKHRMaterialsTransmission, ImageMimeType } from "babylonjs-gltf2interface";
+import type { IMaterial, IKHRMaterialsTransmission } from "babylonjs-gltf2interface";
+import { ImageMimeType } from "babylonjs-gltf2interface";
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
 import { _Exporter } from "../glTFExporter";
 import type { Material } from "core/Materials/material";


### PR DESCRIPTION
See https://forum.babylonjs.com/t/gltf-export-lost-transmission-texture/53315.

This change also makes the texture names more consistent when loading textures from glTF extensions.