### PR TITLE
Add viewerready event and other fixes

### DIFF
--- a/packages/dev/core/src/Audio/weightedsound.ts
+++ b/packages/dev/core/src/Audio/weightedsound.ts
@@ -153,6 +153,7 @@ export class WeightedSound {
      * @param startOffset Position the clip head at a specific time in seconds.
      */
     public play(startOffset?: number) {
+        this._currentIndex = 0;
         if (!this.isPaused) {
             this.stop();
             const randomValue = Math.random();
@@ -165,7 +166,7 @@ export class WeightedSound {
                 }
             }
         }
-        const sound = this._sounds[this._currentIndex!];
+        const sound = this._sounds[this._currentIndex];
         if (sound.isReady()) {
             sound.play(0, this.isPaused ? undefined : startOffset);
         } else {

--- a/packages/dev/core/src/Audio/weightedsound.ts
+++ b/packages/dev/core/src/Audio/weightedsound.ts
@@ -132,9 +132,11 @@ export class WeightedSound {
      * Suspend playback
      */
     public pause() {
-        this.isPaused = true;
-        if (this._currentIndex !== undefined) {
-            this._sounds[this._currentIndex].pause();
+        if (this.isPlaying) {
+            this.isPaused = true;
+            if (this._currentIndex !== undefined) {
+                this._sounds[this._currentIndex].pause();
+            }
         }
     }
 
@@ -153,7 +155,6 @@ export class WeightedSound {
      * @param startOffset Position the clip head at a specific time in seconds.
      */
     public play(startOffset?: number) {
-        this._currentIndex = 0;
         if (!this.isPaused) {
             this.stop();
             const randomValue = Math.random();
@@ -166,7 +167,7 @@ export class WeightedSound {
                 }
             }
         }
-        const sound = this._sounds[this._currentIndex];
+        const sound = this._sounds[this._currentIndex ?? 0];
         if (sound.isReady()) {
             sound.play(0, this.isPaused ? undefined : startOffset);
         } else {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_audio_emitter.ts
@@ -14,6 +14,8 @@ import type { IMSFTAudioEmitter_Clip, IMSFTAudioEmitter_Emitter, IMSFTAudioEmitt
 import { IMSFTAudioEmitter_AnimationEventAction } from "babylonjs-gltf2interface";
 import { registerGLTFExtension, unregisterGLTFExtension } from "../glTFLoaderExtensionRegistry";
 
+import "core/Audio/audioSceneComponent";
+
 const NAME = "MSFT_audio_emitter";
 
 declare module "../../glTFFileLoader" {

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -208,20 +208,28 @@ export class HTML3DElement extends LitElement {
     /**
      * The engine to use for rendering.
      */
-    @property()
+    @property({ reflect: true })
     public engine: CanvasViewerOptions["engine"];
 
     /**
      * The model URL.
      */
-    @property()
-    public src = "";
+    @property({ reflect: true })
+    public src: string | undefined;
+
+    /**
+     * Forces the model to be loaded with the specified extension.
+     * @remarks
+     * If this property is not set, the extension will be inferred from the model URL when possible.
+     */
+    @property({ reflect: true })
+    public extension: string | undefined;
 
     /**
      * The environment URL.
      */
-    @property()
-    public env = "";
+    @property({ reflect: true })
+    public env: string | undefined;
 
     /**
      * The list of animation names for the currently loaded model.
@@ -247,7 +255,7 @@ export class HTML3DElement extends LitElement {
     /**
      * The speed scale at which animations are played.
      */
-    @property({ attribute: "animation-speed" })
+    @property({ attribute: "animation-speed", reflect: true })
     public animationSpeed = 1;
 
     /**
@@ -497,7 +505,7 @@ export class HTML3DElement extends LitElement {
     private async _updateModel() {
         try {
             if (this.src) {
-                await this._viewer?.loadModelAsync(this.src);
+                await this._viewer?.loadModelAsync(this.src, { pluginExtension: this.extension });
             } else {
                 await this._viewer?.resetModelAsync();
             }

--- a/packages/tools/viewer-alpha/src/viewerFactory.ts
+++ b/packages/tools/viewer-alpha/src/viewerFactory.ts
@@ -4,7 +4,7 @@ import type { EngineOptions } from "core/Engines";
 import type { ViewerOptions } from "./viewer";
 import { Viewer } from "./viewer";
 
-type CanvasViewerOptions = ViewerOptions & ({ engine: "WebGL" } & EngineOptions);
+type CanvasViewerOptions = ViewerOptions & ({ engine?: "WebGL" } & EngineOptions);
 const defaultCanvasViewerOptions: CanvasViewerOptions = {
     engine: "WebGL",
 };

--- a/packages/tools/viewer-alpha/src/viewerFactory.ts
+++ b/packages/tools/viewer-alpha/src/viewerFactory.ts
@@ -1,13 +1,15 @@
-import { Engine } from "core/Engines/engine";
-import type { EngineOptions } from "core/Engines";
+// eslint-disable-next-line import/no-internal-modules
+import type { AbstractEngine, AbstractEngineOptions, EngineOptions /*, WebGPUEngineOptions*/ } from "core/index";
 
 import type { ViewerOptions } from "./viewer";
 import { Viewer } from "./viewer";
 
-type CanvasViewerOptions = ViewerOptions & ({ engine?: "WebGL" } & EngineOptions);
-const defaultCanvasViewerOptions: CanvasViewerOptions = {
-    engine: "WebGL",
-};
+/**
+ * Options for creating a Viewer instance that is bound to an HTML canvas.
+ */
+export type CanvasViewerOptions = ViewerOptions &
+    (({ engine?: undefined } & AbstractEngineOptions) | ({ engine: "WebGL" } & EngineOptions)) /*| ({ engine: "WebGPU" } & WebGPUEngineOptions)*/;
+const defaultCanvasViewerOptions: CanvasViewerOptions = {};
 
 /**
  * Creates a Viewer instance that is bound to an HTML canvas.
@@ -17,7 +19,7 @@ const defaultCanvasViewerOptions: CanvasViewerOptions = {
  * @param options The options to use when creating the Viewer and binding it to the specified canvas.
  * @returns A Viewer instance that is bound to the specified canvas.
  */
-export function createViewerForCanvas(canvas: HTMLCanvasElement, options?: CanvasViewerOptions): Viewer {
+export async function createViewerForCanvas(canvas: HTMLCanvasElement, options?: CanvasViewerOptions): Promise<Viewer> {
     const finalOptions = { ...defaultCanvasViewerOptions, ...options };
     const disposeActions: (() => void)[] = [];
 
@@ -28,8 +30,24 @@ export function createViewerForCanvas(canvas: HTMLCanvasElement, options?: Canva
     disposeActions.push(() => resizeObserver.disconnect());
 
     // Create an engine instance.
-    // TODO: Create a WebGL or WebGPUEngine based on the engine option.
-    const engine = new Engine(canvas, undefined, options);
+    let engine: AbstractEngine;
+    switch (finalOptions.engine) {
+        case undefined:
+        case "WebGL": {
+            // eslint-disable-next-line @typescript-eslint/naming-convention, no-case-declarations
+            const { Engine } = await import("core/Engines/engine");
+            engine = new Engine(canvas, undefined, options);
+            break;
+        }
+        // case "WebGPU": {
+        //     // eslint-disable-next-line @typescript-eslint/naming-convention
+        //     const { WebGPUEngine } = await import("core/Engines/webgpuEngine");
+        //     const webGPUEngine = new WebGPUEngine(canvas, options);
+        //     await webGPUEngine.initAsync();
+        //     engine = webGPUEngine;
+        //     break;
+        // }
+    }
 
     // Override the onInitialized callback to add in some specific behavior.
     const onInitialized = finalOptions.onInitialized;
@@ -55,10 +73,6 @@ export function createViewerForCanvas(canvas: HTMLCanvasElement, options?: Canva
 
     // Override the Viewer's dispose method to add in additional cleanup.
     viewer.dispose = () => disposeActions.forEach((dispose) => dispose());
-
-    // TODO: Creating an engine instance will be async if we use a dynamic import for choosing either Engine or WebGPUEngine,
-    //       or even when just creating a WebGPUEngine since we have to call initAsync. To keep the UI integration layer
-    //       simple (e.g. not have to deal with asynchronous creation of the Viewer), should we also be able to pass Promise<AbstractEngine> to the Viewer constructor?
 
     return viewer;
 }


### PR DESCRIPTION
This PR has a number of fixes related to the new viewer, mostly in response to usages of the new viewer in different contexts.

1. The viewer html element previously exposed the underlying viewer object as a property. However, the underlying viewer is created asynchronously depending on various factors (whether or not the element is in the DOM, asynchrony of the Lit update/render sequence, and now also additional asynchrony for Babylon engine instantiation). This makes it quite hard to use, so I've replaced the property with an event (`viewerready`) that fires every time a viewer instantiation has completed.
1. Added events for environment change and error.
1. Made viewer API more consistent for loading/resetting the environment/model.
1. Enabled Lit property "reflection" (e.g. changing the property will "reflect" back to the attribute, which allows for CSS styling based on attribute values).
1. Added an "engine" attribute/property that can be undefined (we make the best choice of engine for you based on implementation details) or "WebGL" or "WebGPU", and updated aspects of the code to be async to account for the fact that WebGPUEngine creation is asynchronous (requires a call to `initAsync`). However, I am leaving out "WebGPU" for now because there are a number of problems due to missing dependencies that come from side effects. Some of these looked easy to fix (e.g. they are already in an async context), and some of them not so easy. @deltakosh not sure if this is the expected state of things for WebGPUEngine.
1. Changed MSFT_audio_emitter to import `audioSceneComponent` (it can't work without this). @bghgary 
1. Fixed a bug in weightedsound where if pause was called when not playing, then play will try to index into the sounds array with an undefined index value. @docEdub 