### PR TITLE
Rename prepass and fix local space values

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -638,9 +638,9 @@ export class Constants {
 
     /**
      * Constant used to retrieve clip-space (non-linear) depth index in the textures array in the prepass
-     * using the getIndex(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE)
+     * using the getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)
      */
-    public static readonly PREPASS_NDC_DEPTH_TEXTURE_TYPE = 10;
+    public static readonly PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE = 10;
 
     /**
      * Constant used to retrieve the velocity texture index in the textures array in the prepass

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -638,9 +638,9 @@ export class Constants {
 
     /**
      * Constant used to retrieve clip-space (non-linear) depth index in the textures array in the prepass
-     * using the getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)
+     * using the getIndex(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE)
      */
-    public static readonly PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE = 10;
+    public static readonly PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE = 10;
 
     /**
      * Constant used to retrieve the velocity texture index in the textures array in the prepass

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -637,7 +637,7 @@ export class Constants {
     public static readonly PREPASS_LOCAL_POSITION_TEXTURE_TYPE = 9;
 
     /**
-     * Constant used to retrieve clip-space (non-linear) depth index in the textures array in the prepass
+     * Constant used to retrieve screen-space (non-linear) depth index in the textures array in the prepass
      * using the getIndex(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE)
      */
     public static readonly PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE = 10;

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
@@ -126,12 +126,12 @@ export class PrePassOutputBlock extends NodeMaterialBlock {
             state.compilationString += ` fragData[PREPASS_DEPTH_INDEX] = ${vec4}(0.0, 0.0, 0.0, 0.0);\r\n`;
         }
         state.compilationString += `#endif\r\n`;
-        state.compilationString += `#ifdef PREPASS_NDC_DEPTH\r\n`;
+        state.compilationString += `#ifdef PREPASS_HYPERBOLIC_DEPTH\r\n`;
         if (viewDepthNDC.connectedPoint) {
-            state.compilationString += ` gl_FragData[PREPASS_NDC_DEPTH_INDEX] = vec4(${viewDepthNDC.associatedVariableName}, 0.0, 0.0, 1.0);\r\n`;
+            state.compilationString += ` gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] = vec4(${viewDepthNDC.associatedVariableName}, 0.0, 0.0, 1.0);\r\n`;
         } else {
             // We have to write something on the viewDepth output or it will raise a gl error
-            state.compilationString += ` gl_FragData[PREPASS_NDC_DEPTH_INDEX] = vec4(0.0, 0.0, 0.0, 0.0);\r\n`;
+            state.compilationString += ` gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] = vec4(0.0, 0.0, 0.0, 0.0);\r\n`;
         }
         state.compilationString += `#endif\r\n`;
         state.compilationString += `#ifdef PREPASS_POSITION\r\n`;

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
@@ -126,12 +126,12 @@ export class PrePassOutputBlock extends NodeMaterialBlock {
             state.compilationString += ` fragData[PREPASS_DEPTH_INDEX] = ${vec4}(0.0, 0.0, 0.0, 0.0);\r\n`;
         }
         state.compilationString += `#endif\r\n`;
-        state.compilationString += `#ifdef PREPASS_HYPERBOLIC_DEPTH\r\n`;
+        state.compilationString += `#ifdef PREPASS_SCREENSPACE_DEPTH\r\n`;
         if (viewDepthNDC.connectedPoint) {
-            state.compilationString += ` gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] = vec4(${viewDepthNDC.associatedVariableName}, 0.0, 0.0, 1.0);\r\n`;
+            state.compilationString += ` gl_FragData[PREPASS_SCREENSPACE_DEPTH_INDEX] = vec4(${viewDepthNDC.associatedVariableName}, 0.0, 0.0, 1.0);\r\n`;
         } else {
             // We have to write something on the viewDepth output or it will raise a gl error
-            state.compilationString += ` gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] = vec4(0.0, 0.0, 0.0, 0.0);\r\n`;
+            state.compilationString += ` gl_FragData[PREPASS_SCREENSPACE_DEPTH_INDEX] = vec4(0.0, 0.0, 0.0, 0.0);\r\n`;
         }
         state.compilationString += `#endif\r\n`;
         state.compilationString += `#ifdef PREPASS_POSITION\r\n`;

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
@@ -244,7 +244,7 @@ export class PrePassTextureBlock extends NodeMaterialBlock {
             effect.setTexture(this._depthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_DEPTH_TEXTURE_TYPE)]);
         }
         if (this.clipSpaceDepth.isConnected) {
-            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)]);
+            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE)]);
         }
         if (this.normal.isConnected) {
             effect.setTexture(this._normalSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_NORMAL_TEXTURE_TYPE)]);
@@ -256,7 +256,7 @@ export class PrePassTextureBlock extends NodeMaterialBlock {
             effect.setTexture(this._localPositionSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE)]);
         }
         if (this.clipSpaceDepth.isConnected) {
-            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)]);
+            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE)]);
         }
     }
 }

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
@@ -244,7 +244,7 @@ export class PrePassTextureBlock extends NodeMaterialBlock {
             effect.setTexture(this._depthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_DEPTH_TEXTURE_TYPE)]);
         }
         if (this.clipSpaceDepth.isConnected) {
-            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE)]);
+            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)]);
         }
         if (this.normal.isConnected) {
             effect.setTexture(this._normalSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_NORMAL_TEXTURE_TYPE)]);
@@ -256,7 +256,7 @@ export class PrePassTextureBlock extends NodeMaterialBlock {
             effect.setTexture(this._localPositionSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE)]);
         }
         if (this.clipSpaceDepth.isConnected) {
-            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE)]);
+            effect.setTexture(this._clipSpaceDepthSamplerName, sceneRT.textures[prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)]);
         }
     }
 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -132,9 +132,9 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     /** Prepass depth index */
     public PREPASS_DEPTH_INDEX = -1;
     /** Clip-space depth */
-    public PREPASS_HYPERBOLIC_DEPTH = false;
+    public PREPASS_SCREENSPACE_DEPTH = false;
     /** Clip-space depth index */
-    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
+    public PREPASS_SCREENSPACE_DEPTH_INDEX = -1;
     /** Scene MRT count */
     public SCENE_MRT_COUNT = 0;
 
@@ -1038,7 +1038,7 @@ export class NodeMaterial extends PushMaterial {
         }
 
         if (prePassOutputBlock.viewDepthNDC.isConnected) {
-            result.push(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
+            result.push(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE);
         }
 
         if (prePassOutputBlock.viewNormal.isConnected) {
@@ -1070,8 +1070,8 @@ export class NodeMaterial extends PushMaterial {
             if (block.depth.isConnected && !result.includes(Constants.PREPASS_DEPTH_TEXTURE_TYPE)) {
                 result.push(Constants.PREPASS_DEPTH_TEXTURE_TYPE);
             }
-            if (block.clipSpaceDepth.isConnected && !result.includes(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)) {
-                result.push(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
+            if (block.clipSpaceDepth.isConnected && !result.includes(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE)) {
+                result.push(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE);
             }
             if (block.normal.isConnected && !result.includes(Constants.PREPASS_NORMAL_TEXTURE_TYPE)) {
                 result.push(Constants.PREPASS_NORMAL_TEXTURE_TYPE);

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -132,9 +132,9 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     /** Prepass depth index */
     public PREPASS_DEPTH_INDEX = -1;
     /** Clip-space depth */
-    public PREPASS_NDC_DEPTH = false;
+    public PREPASS_HYPERBOLIC_DEPTH = false;
     /** Clip-space depth index */
-    public PREPASS_NDC_DEPTH_INDEX = -1;
+    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
     /** Scene MRT count */
     public SCENE_MRT_COUNT = 0;
 
@@ -1038,7 +1038,7 @@ export class NodeMaterial extends PushMaterial {
         }
 
         if (prePassOutputBlock.viewDepthNDC.isConnected) {
-            result.push(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE);
+            result.push(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
         }
 
         if (prePassOutputBlock.viewNormal.isConnected) {
@@ -1070,8 +1070,8 @@ export class NodeMaterial extends PushMaterial {
             if (block.depth.isConnected && !result.includes(Constants.PREPASS_DEPTH_TEXTURE_TYPE)) {
                 result.push(Constants.PREPASS_DEPTH_TEXTURE_TYPE);
             }
-            if (block.clipSpaceDepth.isConnected && !result.includes(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE)) {
-                result.push(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE);
+            if (block.clipSpaceDepth.isConnected && !result.includes(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE)) {
+                result.push(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
             }
             if (block.normal.isConnected && !result.includes(Constants.PREPASS_NORMAL_TEXTURE_TYPE)) {
                 result.push(Constants.PREPASS_NORMAL_TEXTURE_TYPE);

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -202,8 +202,8 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public PREPASS_ALBEDO_SQRT_INDEX = -1;
     public PREPASS_DEPTH = false;
     public PREPASS_DEPTH_INDEX = -1;
-    public PREPASS_NDC_DEPTH = false;
-    public PREPASS_NDC_DEPTH_INDEX = -1;
+    public PREPASS_HYPERBOLIC_DEPTH = false;
+    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
     public PREPASS_NORMAL = false;
     public PREPASS_NORMAL_INDEX = -1;
     public PREPASS_NORMAL_WORLDSPACE = false;

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -202,8 +202,8 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public PREPASS_ALBEDO_SQRT_INDEX = -1;
     public PREPASS_DEPTH = false;
     public PREPASS_DEPTH_INDEX = -1;
-    public PREPASS_HYPERBOLIC_DEPTH = false;
-    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
+    public PREPASS_SCREENSPACE_DEPTH = false;
+    public PREPASS_SCREENSPACE_DEPTH_INDEX = -1;
     public PREPASS_NORMAL = false;
     public PREPASS_NORMAL_INDEX = -1;
     public PREPASS_NORMAL_WORLDSPACE = false;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -854,9 +854,9 @@ export function PrepareDefinesForPrePass(scene: Scene, defines: any, canRenderTo
             index: "PREPASS_DEPTH_INDEX",
         },
         {
-            type: Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE,
-            define: "PREPASS_NDC_DEPTH",
-            index: "PREPASS_NDC_DEPTH_INDEX",
+            type: Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
+            define: "PREPASS_HYPERBOLIC_DEPTH",
+            index: "PREPASS_HYPERBOLIC_DEPTH_INDEX",
         },
         {
             type: Constants.PREPASS_NORMAL_TEXTURE_TYPE,

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -854,9 +854,9 @@ export function PrepareDefinesForPrePass(scene: Scene, defines: any, canRenderTo
             index: "PREPASS_DEPTH_INDEX",
         },
         {
-            type: Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
-            define: "PREPASS_HYPERBOLIC_DEPTH",
-            index: "PREPASS_HYPERBOLIC_DEPTH_INDEX",
+            type: Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE,
+            define: "PREPASS_SCREENSPACE_DEPTH",
+            index: "PREPASS_SCREENSPACE_DEPTH_INDEX",
         },
         {
             type: Constants.PREPASS_NORMAL_TEXTURE_TYPE,

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -173,8 +173,8 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public PREPASS_ALBEDO_SQRT_INDEX = -1;
     public PREPASS_DEPTH = false;
     public PREPASS_DEPTH_INDEX = -1;
-    public PREPASS_NDC_DEPTH = false;
-    public PREPASS_NDC_DEPTH_INDEX = -1;
+    public PREPASS_HYPERBOLIC_DEPTH = false;
+    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
     public PREPASS_NORMAL = false;
     public PREPASS_NORMAL_INDEX = -1;
     public PREPASS_NORMAL_WORLDSPACE = false;

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -173,8 +173,8 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public PREPASS_ALBEDO_SQRT_INDEX = -1;
     public PREPASS_DEPTH = false;
     public PREPASS_DEPTH_INDEX = -1;
-    public PREPASS_HYPERBOLIC_DEPTH = false;
-    public PREPASS_HYPERBOLIC_DEPTH_INDEX = -1;
+    public PREPASS_SCREENSPACE_DEPTH = false;
+    public PREPASS_SCREENSPACE_DEPTH_INDEX = -1;
     public PREPASS_NORMAL = false;
     public PREPASS_NORMAL_INDEX = -1;
     public PREPASS_NORMAL_WORLDSPACE = false;

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
@@ -185,7 +185,7 @@ export class _IblShadowsAccumulationPass {
         localPositionCopyPP.autoClear = false;
         localPositionCopyPP.onApplyObservable.add((effect) => {
             const prePassRenderer = this._scene!.prePassRenderer;
-            const index = prePassRenderer!.getIndex(Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE);
+            const index = prePassRenderer!.getIndex(Constants.PREPASS_POSITION_TEXTURE_TYPE);
             if (index >= 0) effect.setTexture("textureSampler", prePassRenderer!.getRenderTarget().textures[index]);
         });
         this._oldLocalPositionRT.addPostProcess(localPositionCopyPP);
@@ -278,7 +278,7 @@ export class _IblShadowsAccumulationPass {
 
         const prePassRenderer = this._scene.prePassRenderer;
         if (prePassRenderer) {
-            const localPositionIndex = prePassRenderer.getIndex(Constants.PREPASS_LOCAL_POSITION_TEXTURE_TYPE);
+            const localPositionIndex = prePassRenderer.getIndex(Constants.PREPASS_POSITION_TEXTURE_TYPE);
             if (localPositionIndex >= 0) effect.setTexture("localPositionSampler", prePassRenderer.getRenderTarget().textures[localPositionIndex]);
             const velocityIndex = prePassRenderer.getIndex(Constants.PREPASS_VELOCITY_LINEAR_TEXTURE_TYPE);
             if (velocityIndex >= 0) effect.setTexture("motionSampler", prePassRenderer.getRenderTarget().textures[velocityIndex]);

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -103,7 +103,7 @@ class IblShadowsPrepassConfiguration implements PrePassEffectConfiguration {
      */
     public readonly texturesRequired: number[] = [
         Constants.PREPASS_DEPTH_TEXTURE_TYPE,
-        Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
+        Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE,
         Constants.PREPASS_WORLD_NORMAL_TEXTURE_TYPE,
         // Constants.PREPASS_NORMAL_TEXTURE_TYPE, // TODO - don't need this for IBL shadows
         Constants.PREPASS_VELOCITY_LINEAR_TEXTURE_TYPE,

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -103,7 +103,7 @@ class IblShadowsPrepassConfiguration implements PrePassEffectConfiguration {
      */
     public readonly texturesRequired: number[] = [
         Constants.PREPASS_DEPTH_TEXTURE_TYPE,
-        Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE,
+        Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
         Constants.PREPASS_WORLD_NORMAL_TEXTURE_TYPE,
         // Constants.PREPASS_NORMAL_TEXTURE_TYPE, // TODO - don't need this for IBL shadows
         Constants.PREPASS_VELOCITY_LINEAR_TEXTURE_TYPE,

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
@@ -312,7 +312,7 @@ export class _IblShadowsVoxelTracingPass {
         const prePassRenderer = this._scene.prePassRenderer;
         if (prePassRenderer) {
             const wnormalIndex = prePassRenderer.getIndex(Constants.PREPASS_WORLD_NORMAL_TEXTURE_TYPE);
-            const clipDepthIndex = prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
+            const clipDepthIndex = prePassRenderer.getIndex(Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE);
             const wPositionIndex = prePassRenderer.getIndex(Constants.PREPASS_POSITION_TEXTURE_TYPE);
             if (wnormalIndex >= 0) effect.setTexture("worldNormalSampler", prePassRenderer.getRenderTarget().textures[wnormalIndex]);
             if (clipDepthIndex >= 0) effect.setTexture("depthSampler", prePassRenderer.getRenderTarget().textures[clipDepthIndex]);

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
@@ -312,7 +312,7 @@ export class _IblShadowsVoxelTracingPass {
         const prePassRenderer = this._scene.prePassRenderer;
         if (prePassRenderer) {
             const wnormalIndex = prePassRenderer.getIndex(Constants.PREPASS_WORLD_NORMAL_TEXTURE_TYPE);
-            const clipDepthIndex = prePassRenderer.getIndex(Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE);
+            const clipDepthIndex = prePassRenderer.getIndex(Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE);
             const wPositionIndex = prePassRenderer.getIndex(Constants.PREPASS_POSITION_TEXTURE_TYPE);
             if (wnormalIndex >= 0) effect.setTexture("worldNormalSampler", prePassRenderer.getRenderTarget().textures[wnormalIndex]);
             if (clipDepthIndex >= 0) effect.setTexture("depthSampler", prePassRenderer.getRenderTarget().textures[clipDepthIndex]);

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -183,7 +183,7 @@ export class PrePassRenderer {
             name: "prePass_LocalPosition",
         },
         {
-            purpose: Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
+            purpose: Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE,
             type: Constants.TEXTURETYPE_FLOAT,
             format: Constants.TEXTUREFORMAT_R,
             name: "prePass_NdcDepth",

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -183,7 +183,7 @@ export class PrePassRenderer {
             name: "prePass_LocalPosition",
         },
         {
-            purpose: Constants.PREPASS_NDC_DEPTH_TEXTURE_TYPE,
+            purpose: Constants.PREPASS_HYPERBOLIC_DEPTH_TEXTURE_TYPE,
             type: Constants.TEXTURETYPE_FLOAT,
             format: Constants.TEXTUREFORMAT_R,
             name: "prePass_NdcDepth",

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -467,9 +467,9 @@ color.rgb = max(color.rgb, 0.);
         vec4(vViewPos.z, 0.0, 0.0, writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_HYPERBOLIC_DEPTH
-    gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
-        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_SCREENSPACE_DEPTH
+    gl_FragData[PREPASS_SCREENSPACE_DEPTH_INDEX] =
+        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo);
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -436,7 +436,7 @@ color.rgb = max(color.rgb, 0.);
 
 #ifdef PREPASS_LOCAL_POSITION
     gl_FragData[PREPASS_LOCAL_POSITION_INDEX] =
-        vec4(vPosition * 0.5 + 0.5, writeGeometryInfo);
+        vec4(vPosition, writeGeometryInfo);
 #endif
 
 #if defined(PREPASS_VELOCITY)
@@ -467,9 +467,9 @@ color.rgb = max(color.rgb, 0.);
         vec4(vViewPos.z, 0.0, 0.0, writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_NDC_DEPTH
-        gl_FragData[PREPASS_NDC_DEPTH_INDEX] = vec4(
-            gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_HYPERBOLIC_DEPTH
+    gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
+        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -688,9 +688,9 @@ void main(void) {
         vec4(vViewPos.z, 0.0, 0.0, writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_HYPERBOLIC_DEPTH
-    gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
-        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_SCREENSPACE_DEPTH
+    gl_FragData[PREPASS_SCREENSPACE_DEPTH_INDEX] =
+        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo);
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -633,8 +633,9 @@ void main(void) {
     #endif
 
     #ifdef PREPASS_LOCAL_POSITION
-    gl_FragData[PREPASS_LOCAL_POSITION_INDEX] = vec4(vPosition * 0.5 + 0.5, writeGeometryInfo);
-    #endif
+    gl_FragData[PREPASS_LOCAL_POSITION_INDEX] =
+        vec4(vPosition, writeGeometryInfo);
+#endif
 
 #if defined(PREPASS_VELOCITY)
     vec2 a = (vCurrentPosition.xy / vCurrentPosition.w) * 0.5 + 0.5;
@@ -687,9 +688,9 @@ void main(void) {
         vec4(vViewPos.z, 0.0, 0.0, writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_NDC_DEPTH
-        gl_FragData[PREPASS_NDC_DEPTH_INDEX] = vec4(
-            gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_HYPERBOLIC_DEPTH
+    gl_FragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
+        vec4(gl_FragCoord.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -432,7 +432,7 @@ color = vec4f(max(color.rgb, vec3f(0.)), color.a);
 
 #ifdef PREPASS_LOCAL_POSITION
     fragData[PREPASS_LOCAL_POSITION_INDEX] =
-        vec4f(fragmentInputs.vPosition * 0.5 + 0.5, writeGeometryInfo);
+        vec4f(fragmentInputs.vPosition, writeGeometryInfo);
 #endif
 
 #ifdef PREPASS_VELOCITY
@@ -463,9 +463,10 @@ color = vec4f(max(color.rgb, vec3f(0.)), color.a);
                                           writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_NDC_DEPTH
-        fragData[PREPASS_NDC_DEPTH_INDEX] = vec4f(
-            fragmentInputs.position.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_HYPERBOLIC_DEPTH
+    fragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
+        vec4f(fragmentInputs.position.z, 0.0, 0.0,
+              writeGeometryInfo); // Clip-space depth
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -463,10 +463,9 @@ color = vec4f(max(color.rgb, vec3f(0.)), color.a);
                                           writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_HYPERBOLIC_DEPTH
-    fragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
-        vec4f(fragmentInputs.position.z, 0.0, 0.0,
-              writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_SCREENSPACE_DEPTH
+    fragData[PREPASS_SCREENSPACE_DEPTH_INDEX] =
+        vec4f(fragmentInputs.position.z, 0.0, 0.0, writeGeometryInfo);
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
@@ -636,10 +636,11 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     #endif
 
     #ifdef PREPASS_LOCAL_POSITION
-    fragData[PREPASS_LOCAL_POSITION_INDEX] = vec4f(fragmentInputs.vPosition * 0.5 + 0.5, writeGeometryInfo);
-    #endif
+    fragData[PREPASS_LOCAL_POSITION_INDEX] =
+        vec4f(fragmentInputs.vPosition, writeGeometryInfo);
+#endif
 
-    #ifdef PREPASS_VELOCITY
+#ifdef PREPASS_VELOCITY
     var a: vec2f = (fragmentInputs.vCurrentPosition.xy / fragmentInputs.vCurrentPosition.w) * 0.5 + 0.5;
     var b: vec2f = (fragmentInputs.vPreviousPosition.xy / fragmentInputs.vPreviousPosition.w) * 0.5 + 0.5;
 
@@ -690,9 +691,10 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
                                           writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_NDC_DEPTH
-        fragData[PREPASS_NDC_DEPTH_INDEX] = vec4f(
-            fragmentInputs.position.z, 0.0, 0.0, writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_HYPERBOLIC_DEPTH
+    fragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
+        vec4f(fragmentInputs.position.z, 0.0, 0.0,
+              writeGeometryInfo); // Clip-space depth
 #endif
 
 #ifdef PREPASS_NORMAL

--- a/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
@@ -691,10 +691,9 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
                                           writeGeometryInfo); // Linear depth
 #endif
 
-#ifdef PREPASS_HYPERBOLIC_DEPTH
-    fragData[PREPASS_HYPERBOLIC_DEPTH_INDEX] =
-        vec4f(fragmentInputs.position.z, 0.0, 0.0,
-              writeGeometryInfo); // Clip-space depth
+#ifdef PREPASS_SCREENSPACE_DEPTH
+    fragData[PREPASS_SCREENSPACE_DEPTH_INDEX] =
+        vec4f(fragmentInputs.position.z, 0.0, 0.0, writeGeometryInfo);
 #endif
 
 #ifdef PREPASS_NORMAL


### PR DESCRIPTION
As suggested by @Popov72 , the local space prepass wasn't actually outputting pure, local space. And the "NDC" prepass wasn't truly NDC so I've renamed it to PREPASS_HYPERBOLIC_DEPTH to distinguish it from the linear PREPASS_DEPTH