### PR TITLE
IBL Shadows - Only create the post effects for IBL shadows once

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -644,8 +644,8 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
         this._listenForCameraChanges();
         this.scene.getEngine().onResizeObservable.add(this._handleResize.bind(this));
 
-        // Only turn on the pipeline if the importance sampling RT's are ready
-        this._importanceSamplingRenderer.onReadyObservable.add(() => {
+        // Only turn on the pipeline when the importance sampling RT's are ready
+        this._importanceSamplingRenderer.onReadyObservable.addOnce(() => {
             this._createEffectPasses(cameras);
             const checkVoxelRendererReady = () => {
                 if (this._voxelRenderer.isReady()) {


### PR DESCRIPTION
When a new IBL was set, an observer was being fired which caused new post effects to be created for the pipeline. This was causing problems. The post effects should only need to be created once.