### PR TITLE
Allow Viewer to use WebGPU

### DIFF
--- a/packages/dev/core/src/Misc/rgbdTextureTools.ts
+++ b/packages/dev/core/src/Misc/rgbdTextureTools.ts
@@ -2,7 +2,6 @@ import { Constants } from "../Engines/constants";
 import { PostProcess } from "../PostProcesses/postProcess";
 import type { Engine } from "../Engines/engine";
 
-import "../Engines/Extensions/engine.renderTarget";
 import { ApplyPostProcess } from "./textureTools";
 
 import type { Texture } from "../Materials/Textures/texture";
@@ -14,7 +13,7 @@ import { ShaderLanguage } from "core/Materials";
  * Class used to host RGBD texture specific utilities
  */
 export class RGBDTextureTools {
-    private static _ShaderImported = false;
+    private static _EngineResourcesImported = false;
 
     /**
      * Expand the RGBD Texture from RGBD to Half Float if possible.
@@ -55,12 +54,16 @@ export class RGBDTextureTools {
             const shaderLanguage = isWebGPU ? ShaderLanguage.WGSL : ShaderLanguage.GLSL;
             internalTexture.isReady = false;
 
-            if (!this._ShaderImported) {
-                this._ShaderImported = true;
+            if (!this._EngineResourcesImported) {
+                this._EngineResourcesImported = true;
                 if (isWebGPU) {
-                    await Promise.all([import("../ShadersWGSL/rgbdDecode.fragment"), import("../ShadersWGSL/rgbdEncode.fragment")]);
+                    await Promise.all([
+                        import("../ShadersWGSL/rgbdDecode.fragment"),
+                        import("../ShadersWGSL/rgbdEncode.fragment"),
+                        import("../Engines/WebGPU/Extensions/engine.renderTarget"),
+                    ]);
                 } else {
-                    await Promise.all([import("../Shaders/rgbdDecode.fragment"), import("../Shaders/rgbdEncode.fragment")]);
+                    await Promise.all([import("../Shaders/rgbdDecode.fragment"), import("../Shaders/rgbdEncode.fragment"), import("../Engines/Extensions/engine.renderTarget")]);
                 }
             }
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -7,7 +7,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Logger } from "core/Misc/logger";
-import { createViewerForCanvas } from "./viewerFactory";
+import { createViewerForCanvas, getDefaultEngine } from "./viewerFactory";
 
 // Icon SVG is pulled from https://fluentuipr.z22.web.core.windows.net/heads/master/public-docsite-v9/storybook/iframe.html?id=icons-catalog--page&viewMode=story
 const playFilledIcon = "M17.22 8.68a1.5 1.5 0 0 1 0 2.63l-10 5.5A1.5 1.5 0 0 1 5 15.5v-11A1.5 1.5 0 0 1 7.22 3.2l10 5.5Z";
@@ -209,7 +209,7 @@ export class HTML3DElement extends LitElement {
      * The engine to use for rendering.
      */
     @property({ reflect: true })
-    public engine: CanvasViewerOptions["engine"];
+    public engine: NonNullable<CanvasViewerOptions["engine"]> = getDefaultEngine();
 
     /**
      * The model URL.
@@ -273,8 +273,8 @@ export class HTML3DElement extends LitElement {
     @state()
     private _isAnimationPlaying = false;
 
-    @query("#renderCanvas")
-    private _canvas: HTMLCanvasElement;
+    @query("#canvasContainer")
+    private _canvasContainer: HTMLDivElement | undefined;
 
     /**
      * Toggles the play/pause animation state if there is a selected animation.
@@ -290,12 +290,6 @@ export class HTML3DElement extends LitElement {
     }
 
     // eslint-disable-next-line babylonjs/available
-    override firstUpdated(_changedProperties: PropertyValues): void {
-        super.firstUpdated(_changedProperties);
-        this._setupViewer();
-    }
-
-    // eslint-disable-next-line babylonjs/available
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._tearDownViewer();
@@ -305,7 +299,7 @@ export class HTML3DElement extends LitElement {
     override update(changedProperties: PropertyValues): void {
         super.update(changedProperties);
 
-        if (changedProperties.has("engine" satisfies keyof this)) {
+        if (changedProperties.get("engine" satisfies keyof this)) {
             this._tearDownViewer();
             this._setupViewer();
         } else {
@@ -331,7 +325,7 @@ export class HTML3DElement extends LitElement {
     override render() {
         return html`
             <div class="full-size">
-                <canvas id="renderCanvas" class="full-size" touch-action="none"></canvas>
+                <div id="canvasContainer" class="full-size"></div>
                 ${this.animations.length === 0
                     ? ""
                     : html`
@@ -421,64 +415,73 @@ export class HTML3DElement extends LitElement {
     }
 
     private async _setupViewer() {
-        if (this._canvas) {
-            await this._viewerLock.lockAsync(async () => {
-                if (!this._viewer) {
-                    await createViewerForCanvas(this._canvas, {
-                        engine: this.engine,
-                        onInitialized: (details) => {
-                            this._viewer = details.viewer;
+        await this._viewerLock.lockAsync(async () => {
+            // The first time the element is connected, the canvas container may not be available yet.
+            // Wait for the first update if needed.
+            if (!this._canvasContainer) {
+                await this.updateComplete;
+            }
 
-                            details.viewer.onEnvironmentChanged.add(() => {
-                                this._dispatchCustomEvent("environmentchange");
-                            });
+            if (this._canvasContainer && !this._viewer) {
+                const canvas = document.createElement("canvas");
+                canvas.className = "full-size";
+                canvas.setAttribute("touch-action", "none");
+                this._canvasContainer.appendChild(canvas);
 
-                            details.viewer.onEnvironmentError.add(() => {
-                                this._dispatchCustomEvent("environmenterror");
-                            });
+                await createViewerForCanvas(canvas, {
+                    engine: this.engine,
+                    onInitialized: (details) => {
+                        this._viewer = details.viewer;
 
-                            details.viewer.onModelChanged.add(() => {
-                                this._animations = [...(this._viewer?.animations ?? [])];
-                                this._dispatchCustomEvent("modelchange");
-                            });
+                        details.viewer.onEnvironmentChanged.add(() => {
+                            this._dispatchCustomEvent("environmentchange");
+                        });
 
-                            details.viewer.onModelError.add(() => {
-                                this._dispatchCustomEvent("modelerror");
-                            });
+                        details.viewer.onEnvironmentError.add(() => {
+                            this._dispatchCustomEvent("environmenterror");
+                        });
 
-                            details.viewer.onSelectedAnimationChanged.add(() => {
-                                this._selectedAnimation = this._viewer?.selectedAnimation ?? -1;
-                                this._dispatchCustomEvent("selectedanimationchange");
-                            });
+                        details.viewer.onModelChanged.add(() => {
+                            this._animations = [...(this._viewer?.animations ?? [])];
+                            this._dispatchCustomEvent("modelchange");
+                        });
 
-                            details.viewer.onAnimationSpeedChanged.add(() => {
-                                let speed = this._viewer?.animationSpeed ?? 1;
-                                speed = allowedAnimationSpeeds.reduce((prev, curr) => (Math.abs(curr - speed) < Math.abs(prev - speed) ? curr : prev));
-                                this.animationSpeed = speed;
-                                this._dispatchCustomEvent("animationspeedchange");
-                            });
+                        details.viewer.onModelError.add(() => {
+                            this._dispatchCustomEvent("modelerror");
+                        });
 
-                            details.viewer.onIsAnimationPlayingChanged.add(() => {
-                                this._isAnimationPlaying = this._viewer?.isAnimationPlaying ?? false;
-                                this._dispatchCustomEvent("animationplayingchange");
-                            });
+                        details.viewer.onSelectedAnimationChanged.add(() => {
+                            this._selectedAnimation = this._viewer?.selectedAnimation ?? -1;
+                            this._dispatchCustomEvent("selectedanimationchange");
+                        });
 
-                            details.viewer.onAnimationProgressChanged.add(() => {
-                                this.animationProgress = this._viewer?.animationProgress ?? 0;
-                                this._dispatchCustomEvent("animationprogresschange");
-                            });
+                        details.viewer.onAnimationSpeedChanged.add(() => {
+                            let speed = this._viewer?.animationSpeed ?? 1;
+                            speed = allowedAnimationSpeeds.reduce((prev, curr) => (Math.abs(curr - speed) < Math.abs(prev - speed) ? curr : prev));
+                            this.animationSpeed = speed;
+                            this._dispatchCustomEvent("animationspeedchange");
+                        });
 
-                            this._updateSelectedAnimation();
-                            this._updateAnimationSpeed();
-                            this._updateModel();
-                            this._updateEnv();
+                        details.viewer.onIsAnimationPlayingChanged.add(() => {
+                            this._isAnimationPlaying = this._viewer?.isAnimationPlaying ?? false;
+                            this._dispatchCustomEvent("animationplayingchange");
+                        });
 
-                            this._dispatchCustomEvent("viewerready", details);
-                        },
-                    });
-                }
-            });
-        }
+                        details.viewer.onAnimationProgressChanged.add(() => {
+                            this.animationProgress = this._viewer?.animationProgress ?? 0;
+                            this._dispatchCustomEvent("animationprogresschange");
+                        });
+
+                        this._updateSelectedAnimation();
+                        this._updateAnimationSpeed();
+                        this._updateModel();
+                        this._updateEnv();
+
+                        this._dispatchCustomEvent("viewerready", details);
+                    },
+                });
+            }
+        });
     }
 
     private async _tearDownViewer() {
@@ -486,6 +489,13 @@ export class HTML3DElement extends LitElement {
             if (this._viewer) {
                 this._viewer.dispose();
                 this._viewer = undefined;
+            }
+
+            // We want to replace the canvas for two reasons:
+            // 1. When the viewer element is reconnected to the DOM, we don't want to briefly see the last frame of the previous model.
+            // 2. If we are changing engines (e.g. WebGL to WebGPU), we need to create a new canvas for the new engine.
+            if (this._canvasContainer && this._canvasContainer.firstElementChild) {
+                this._canvasContainer.removeChild(this._canvasContainer.firstElementChild);
             }
         });
     }

--- a/packages/tools/viewer-alpha/src/viewerFactory.ts
+++ b/packages/tools/viewer-alpha/src/viewerFactory.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import type { AbstractEngine, AbstractEngineOptions, EngineOptions /*, WebGPUEngineOptions*/ } from "core/index";
+import type { AbstractEngine, AbstractEngineOptions, EngineOptions, WebGPUEngineOptions } from "core/index";
 
 import type { ViewerOptions } from "./viewer";
 import { Viewer } from "./viewer";
@@ -8,8 +8,17 @@ import { Viewer } from "./viewer";
  * Options for creating a Viewer instance that is bound to an HTML canvas.
  */
 export type CanvasViewerOptions = ViewerOptions &
-    (({ engine?: undefined } & AbstractEngineOptions) | ({ engine: "WebGL" } & EngineOptions)) /*| ({ engine: "WebGPU" } & WebGPUEngineOptions)*/;
+    (({ engine?: undefined } & AbstractEngineOptions) | ({ engine: "WebGL" } & EngineOptions) | ({ engine: "WebGPU" } & WebGPUEngineOptions));
 const defaultCanvasViewerOptions: CanvasViewerOptions = {};
+
+/**
+ * Chooses a default engine for the current browser environment.
+ * @returns The default engine to use.
+ */
+export function getDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
+    // TODO: When WebGPU is fully production ready, we may want to prefer it if it is supported by the browser.
+    return "WebGL";
+}
 
 /**
  * Creates a Viewer instance that is bound to an HTML canvas.
@@ -31,22 +40,29 @@ export async function createViewerForCanvas(canvas: HTMLCanvasElement, options?:
 
     // Create an engine instance.
     let engine: AbstractEngine;
-    switch (finalOptions.engine) {
-        case undefined:
+    switch (finalOptions.engine ?? getDefaultEngine()) {
         case "WebGL": {
             // eslint-disable-next-line @typescript-eslint/naming-convention, no-case-declarations
             const { Engine } = await import("core/Engines/engine");
             engine = new Engine(canvas, undefined, options);
             break;
         }
-        // case "WebGPU": {
-        //     // eslint-disable-next-line @typescript-eslint/naming-convention
-        //     const { WebGPUEngine } = await import("core/Engines/webgpuEngine");
-        //     const webGPUEngine = new WebGPUEngine(canvas, options);
-        //     await webGPUEngine.initAsync();
-        //     engine = webGPUEngine;
-        //     break;
-        // }
+        case "WebGPU": {
+            const [webgpuModule] = await Promise.all([
+                import("core/Engines/webgpuEngine"),
+                import("core/Engines/WebGPU/Extensions/engine.alpha"),
+                import("core/Engines/WebGPU/Extensions/engine.rawTexture"),
+                import("core/Engines/WebGPU/Extensions/engine.cubeTexture"),
+                import("core/Engines/WebGPU/Extensions/engine.renderTarget"),
+                import("core/Engines/WebGPU/Extensions/engine.renderTargetCube"),
+            ]);
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            const { WebGPUEngine } = webgpuModule;
+            const webGPUEngine = new WebGPUEngine(canvas, options);
+            await webGPUEngine.initAsync();
+            engine = webGPUEngine;
+            break;
+        }
     }
 
     // Override the onInitialized callback to add in some specific behavior.

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -15,9 +15,15 @@
                 overflow: hidden;
             }
 
-            button {
+            .toggle-dom-button {
                 position: absolute;
                 top: 10px;
+                right: 10px;
+            }
+
+            .toggle-engine-button {
+                position: absolute;
+                top: 40px;
                 right: 10px;
             }
 
@@ -51,12 +57,22 @@
                 <button onclick="viewerElement.viewer.toggleAnimation()">Toggle Animation</button>
             </div> -->
         </babylon-viewer>
-        <button onclick="onToggle()">Toggle</button>
+        <button class="toggle-dom-button" onclick="onToggleDOM()">Toggle DOM</button>
+        <button class="toggle-engine-button" onclick="onToggleEngine()">Toggle Engine</button>
         <script type="module" src="/packages/tools/viewer-alpha/src/index.ts"></script>
         <script>
             const viewerElement = document.querySelector("babylon-viewer");
+            let viewerDetail;
+            viewerElement.addEventListener(
+                "viewerready",
+                (event) => {
+                    viewerDetail = event.detail;
+                    console.log(`Viewer ready.`, viewerDetail);
+                },
+                { once: true }
+            );
             viewerElement.addEventListener("modelchange", (event) => {
-                console.log("Model loaded");
+                console.log(`Model changed.`, viewerDetail);
             });
             let isViewerConnected = true;
 
@@ -64,7 +80,6 @@
                 // The module referenced in the script tag above is loaded asynchronously, so we need to wait for it to load and for the custom element to be defined.
                 // Alternatively, we could just await import("/packages/tools/viewer-alpha/src/index.ts") here instead.
                 await customElements.whenDefined("babylon-viewer");
-                // "BabylonViewer" is defined as the "library" in webpack.config.js and can be used to access the Viewer as needed.
                 await new Promise((resolve) => setTimeout(resolve, 2000));
                 //viewerElement.src = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
                 // error case
@@ -78,13 +93,17 @@
                 if (file) {
                     event.preventDefault();
                     await customElements.whenDefined("babylon-viewer");
-                    await viewerElement.viewer.loadModelAsync(file);
+                    await viewerDetail.viewer.loadModelAsync(file);
                 }
             }
 
-            function onToggle() {
+            function onToggleDOM() {
                 isViewerConnected ? document.body.removeChild(viewerElement) : document.body.appendChild(viewerElement);
                 isViewerConnected = !isViewerConnected;
+            }
+
+            function onToggleEngine() {
+                viewerElement.engine = viewerElement.engine === "WebGL" ? "WebGPU" : "WebGL";
             }
         </script>
     </body>


### PR DESCRIPTION
This change makes it possible to select either WebGL or WebGPU for the Viewer. The associated engine is dynamically imported. The default is currently WebGL.

```html
<babylon-viewer engine="WebGPU" src="..." />
```

This change includes:
- Adding back WebGPU as an option for the `engine` property/attribute.
- Recreate the Canvas when the engine changes (the same canvas instance is not reusable between webgl and webgpu).
- Import a bunch of modules that are needed for WebGPU to work. Ideally these should be automatically (dynamically) imported in the right places in @babylonjs/core. I'm not sure if all these are always needed, or just the missing things that happen to be needed for the model I'm testing with.
- Added a button to the test app to toggle between WebGL and WebGPU.

While I don't expect it to be a common scenario, the first time I switch engines, nothing renders. I haven't debugged this yet.