### PR TITLE
Playground - Fixing the Monaco Editor snippet template insertion

### DIFF
--- a/packages/tools/playground/public/templates.json
+++ b/packages/tools/playground/public/templates.json
@@ -3,43 +3,37 @@
         "label": "Scene : Show the Inspector",
         "key": "Debug Layer",
         "documentation": "https://doc.babylonjs.com/toolsAndResources/inspector",
-        "insertText": "scene.debugLayer.show();",
-        "plainText": "scene.debugLayer.show();"
+        "insertText": "scene.debugLayer.show();"
     },
     {
         "label": "Scene : Setup a shadow generator",
         "key": "Shadows",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/shadows",
-        "insertText": "var shadowGenerator = new BABYLON.ShadowGenerator(${1:1024}, ${2:light});\nshadowGenerator.useExponentialShadowMap = true;",
-        "plainText": "var shadowGenerator = new BABYLON.ShadowGenerator(1024, light);\nshadowGenerator.useExponentialShadowMap = true;"
+        "insertText": "var shadowGenerator = new BABYLON.ShadowGenerator(${1:1024}, ${2:light});\nshadowGenerator.useExponentialShadowMap = true;"
     },
     {
         "label": "Scene : Setup a Skybox",
         "key": "Skybox",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/environment/skybox",
-        "insertText": "var skybox = BABYLON.MeshBuilder.CreateBox(\"skyBox\", {size:1000.0}, scene);\nvar skyboxMaterial = new BABYLON.StandardMaterial(\"skyBox\", scene);\nskyboxMaterial.backFaceCulling = false;\nskyboxMaterial.reflectionTexture = new BABYLON.CubeTexture(\"textures/skybox\", scene);\nskyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;\nskyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);\nskyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0); skybox.material = skyboxMaterial;",
-        "plainText": "var skybox = BABYLON.MeshBuilder.CreateBox(\"skyBox\", {size:1000.0}, scene);\nvar skyboxMaterial = new BABYLON.StandardMaterial(\"skyBox\", scene);\nskyboxMaterial.backFaceCulling = false;\nskyboxMaterial.reflectionTexture = new BABYLON.CubeTexture(\"textures/skybox\", scene);\nskyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;\nskyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);\nskyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0); skybox.material = skyboxMaterial;"
+        "insertText": "var skybox = BABYLON.MeshBuilder.CreateBox(\"skyBox\", {size:1000.0}, scene);\nvar skyboxMaterial = new BABYLON.StandardMaterial(\"skyBox\", scene);\nskyboxMaterial.backFaceCulling = false;\nskyboxMaterial.reflectionTexture = new BABYLON.CubeTexture(\"textures/skybox\", scene);\nskyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;\nskyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);\nskyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0); skybox.material = skyboxMaterial;"
     },
     {
         "label": "Scene : Setup a lens flare system",
         "key": "Lens Flare",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/environment/lenseFlare",
-        "insertText": "var lensFlareSystem = new BABYLON.LensFlareSystem(\"lensFlareSystem\", scene.getMeshByName(\"Cylinder_004\"), scene);\nvar flare00 = new BABYLON.LensFlare(0.1, 0, new BABYLON.Color3(1, 1, 1), \"textures/flare.png\", lensFlareSystem);\nvar flare01 = new BABYLON.LensFlare(0.075, 0.5, new BABYLON.Color3(0.8, 0.56, 0.72), \"textures/flare3.png\", lensFlareSystem);\nvar flare02 = new BABYLON.LensFlare(0.1, -0.15, new BABYLON.Color3(0.71, 0.8, 0.95), \"textures/Flare2.png\", lensFlareSystem);\nvar flare03 = new BABYLON.LensFlare(0.15, 0.25, new BABYLON.Color3(0.95, 0.89, 0.71), \"textures/flare.png\", lensFlareSystem);",
-        "plainText": "var lensFlareSystem = new BABYLON.LensFlareSystem(\"lensFlareSystem\", scene.getMeshByName(\"Cylinder_004\"), scene);\nvar flare00 = new BABYLON.LensFlare(0.1, 0, new BABYLON.Color3(1, 1, 1), \"textures/flare.png\", lensFlareSystem);\nvar flare01 = new BABYLON.LensFlare(0.075, 0.5, new BABYLON.Color3(0.8, 0.56, 0.72), \"textures/flare3.png\", lensFlareSystem);\nvar flare02 = new BABYLON.LensFlare(0.1, -0.15, new BABYLON.Color3(0.71, 0.8, 0.95), \"textures/Flare2.png\", lensFlareSystem);\nvar flare03 = new BABYLON.LensFlare(0.15, 0.25, new BABYLON.Color3(0.95, 0.89, 0.71), \"textures/flare.png\", lensFlareSystem);"
+        "insertText": "var lensFlareSystem = new BABYLON.LensFlareSystem(\"lensFlareSystem\", scene.getMeshByName(\"Cylinder_004\"), scene);\nvar flare00 = new BABYLON.LensFlare(0.1, 0, new BABYLON.Color3(1, 1, 1), \"textures/flare.png\", lensFlareSystem);\nvar flare01 = new BABYLON.LensFlare(0.075, 0.5, new BABYLON.Color3(0.8, 0.56, 0.72), \"textures/flare3.png\", lensFlareSystem);\nvar flare02 = new BABYLON.LensFlare(0.1, -0.15, new BABYLON.Color3(0.71, 0.8, 0.95), \"textures/Flare2.png\", lensFlareSystem);\nvar flare03 = new BABYLON.LensFlare(0.15, 0.25, new BABYLON.Color3(0.95, 0.89, 0.71), \"textures/flare.png\", lensFlareSystem);"
     },
     {
         "label": "Scene : Setup audio in the scene",
         "key": "Audio",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic#how-to-play-sounds-and-music",
-        "insertText": "var music = new BABYLON.Sound(\"Violons\", \"sounds/violons11.wav\", scene, null, {loop: true, autoplay: true});",
-        "plainText": "var music = new BABYLON.Sound(\"Violons\", \"sounds/violons11.wav\", scene, null, {loop: true, autoplay: true});"
+        "insertText": "var music = new BABYLON.Sound(\"Violons\", \"sounds/violons11.wav\", scene, null, {loop: true, autoplay: true});"
     },
     {
         "label": "Scene : Setup a Sprite System",
         "key": "Sprites",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/sprites/sprite_map",
-        "insertText": "// Load the spritesheet (with appropriate settings) associated with the JSON Atlas.\nlet spriteSheet = new BABYLON.Texture(\"textures/spriteMap/none_trimmed/Legends_Level_A.png\", scene,\n    false, //NoMipMaps\n    false, //InvertY usually false if exported from TexturePacker\n    BABYLON.Texture.NEAREST_NEAREST, //Sampling Mode\n    null, //Onload, you could spin up the sprite map in a function nested here\n    null, //OnError\n    null, //CustomBuffer\n    false, //DeleteBuffer\n    BABYLON.Engine.TEXTURETYPE_RGBA //ImageFormageType RGBA\n);\n// Create an assets manager to load the JSON file\nconst assetsManager = new BABYLON.AssetsManager(scene);\nconst textTask = assetsManager.addTextFileTask(\"text task\", \"textures/spriteMap/none_trimmed/Legends_Level_A.json\");\n// Create the sprite map on succeful loading\ntextTask.onSuccess = (task) => {\n    let background = new BABYLON.SpriteMap(\"background\", JSON.parse(task.text), spriteSheet, {\n            stageSize: new BABYLON.Vector2(2, 2),\n            flipU: true //Sometimes you need to flip, depending on the sprite format.\n        }, scene);\n    // Set 4 sprites one per tile.\n    for (let i = 0; i < 4; i++) {\n        background.changeTiles(0, new BABYLON.Vector2(i % 2, Math.floor(i / 2)), 9 * i + 9);\n    }\n};\n//load the assets manager\nassetsManager.load();",
-        "plainText": "// Load the spritesheet (with appropriate settings) associated with the JSON Atlas.\nlet spriteSheet = new BABYLON.Texture(\"textures/spriteMap/none_trimmed/Legends_Level_A.png\", scene,\n    false, //NoMipMaps\n    false, //InvertY usually false if exported from TexturePacker\n    BABYLON.Texture.NEAREST_NEAREST, //Sampling Mode\n    null, //Onload, you could spin up the sprite map in a function nested here\n    null, //OnError\n    null, //CustomBuffer\n    false, //DeleteBuffer\n    BABYLON.Engine.TEXTURETYPE_RGBA //ImageFormageType RGBA\n);\n// Create an assets manager to load the JSON file\nconst assetsManager = new BABYLON.AssetsManager(scene);\nconst textTask = assetsManager.addTextFileTask(\"text task\", \"textures/spriteMap/none_trimmed/Legends_Level_A.json\");\n// Create the sprite map on succeful loading\ntextTask.onSuccess = (task) => {\n    let background = new BABYLON.SpriteMap(\"background\", JSON.parse(task.text), spriteSheet, {\n            stageSize: new BABYLON.Vector2(2, 2),\n            flipU: true //Sometimes you need to flip, depending on the sprite format.\n        }, scene);\n    // Set 4 sprites one per tile.\n    for (let i = 0; i < 4; i++) {\n        background.changeTiles(0, new BABYLON.Vector2(i % 2, Math.floor(i / 2)), 9 * i + 9);\n    }\n};\n//load the assets manager\nassetsManager.load();"
+        "insertText": "// Load the spritesheet (with appropriate settings) associated with the JSON Atlas.\nlet spriteSheet = new BABYLON.Texture(\"textures/spriteMap/none_trimmed/Legends_Level_A.png\", scene,\n    false, //NoMipMaps\n    false, //InvertY usually false if exported from TexturePacker\n    BABYLON.Texture.NEAREST_NEAREST, //Sampling Mode\n    null, //Onload, you could spin up the sprite map in a function nested here\n    null, //OnError\n    null, //CustomBuffer\n    false, //DeleteBuffer\n    BABYLON.Engine.TEXTURETYPE_RGBA //ImageFormageType RGBA\n);\n// Create an assets manager to load the JSON file\nconst assetsManager = new BABYLON.AssetsManager(scene);\nconst textTask = assetsManager.addTextFileTask(\"text task\", \"textures/spriteMap/none_trimmed/Legends_Level_A.json\");\n// Create the sprite map on succeful loading\ntextTask.onSuccess = (task) => {\n    let background = new BABYLON.SpriteMap(\"background\", JSON.parse(task.text), spriteSheet, {\n            stageSize: new BABYLON.Vector2(2, 2),\n            flipU: true //Sometimes you need to flip, depending on the sprite format.\n        }, scene);\n    // Set 4 sprites one per tile.\n    for (let i = 0; i < 4; i++) {\n        background.changeTiles(0, new BABYLON.Vector2(i % 2, Math.floor(i / 2)), 9 * i + 9);\n    }\n};\n//load the assets manager\nassetsManager.load();"
     },
 
 
@@ -50,29 +44,25 @@
         "label": "Add Camera : Arc Rotate Camera w/Radians",
         "key": "Arc Rotate (Rad)",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
-        "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", ${2:0}, ${3:1}, ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);",
-        "plainText": "var camera = new BABYLON.ArcRotateCamera(\"camera\", 0, 1, 10, BABYLON.Vector3.Zero(), scene);\ncamera.attachControl(canvas, true);"
+        "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", ${2:0}, ${3:1}, ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);"
     },
     {
         "label": "Add Camera : Arc Rotate Camera w/Degrees",
         "key": "Arc Rotate (Deg)",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
-        "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", BABYLON.Tools.ToRadians(${2:0}), BABYLON.Tools.ToRadians(${3:57.3}), ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);",
-        "plainText": "var camera = new BABYLON.ArcRotateCamera(\"camera\", 0, BABYLON.Tools.ToRadians(57.3), 10, BABYLON.Vector3.Zero(), scene);\ncamera.attachControl(canvas, true);"
+        "insertText": "var camera = new BABYLON.ArcRotateCamera(\"${1:camera}\", BABYLON.Tools.ToRadians(${2:0}), BABYLON.Tools.ToRadians(${3:57.3}), ${4:10}, ${5:BABYLON.Vector3.Zero()}, scene);\ncamera.attachControl(canvas, true);"
     },
     {
         "label": "Add Camera : Free Camera",
         "key": "Free",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/cameras/camera_introduction",
-        "insertText": "var camera = new BABYLON.FreeCamera(\"${1:camera}\", ${2:new BABYLON.Vector3(8, 3, 0)}, scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);",
-        "plainText": "var camera = new BABYLON.FreeCamera(\"camera\", new BABYLON.Vector3(8, 3, 0), scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);"
+        "insertText": "var camera = new BABYLON.FreeCamera(\"${1:camera}\", ${2:new BABYLON.Vector3(8, 3, 0)}, scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);"
     },
     {
         "label": "Add Camera : WebXR Camera",
         "key": "WebXR",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/webXR/introToWebXR",
-        "insertText": "var camera = new BABYLON.FreeCamera(\"${1:camera}\", new BABYLON.Vector3(8, 3, 0), scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);\n/*scene.createDefaultXRExperienceAsync({}).then((defaultXRExperience) => {\n    // Make sure hardware is OK for XR context${2}\n})*/;",
-        "plainText": "var camera = new BABYLON.FreeCamera(\"camera\", new BABYLON.Vector3(8, 3, 0), scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);\n/*scene.createDefaultXRExperienceAsync({}).then((defaultXRExperience) => {\n    // Make sure hardware is OK for XR context\n})*/;"
+        "insertText": "var camera = new BABYLON.FreeCamera(\"${1:camera}\", new BABYLON.Vector3(8, 3, 0), scene);\ncamera.setTarget(BABYLON.Vector3.Zero());\ncamera.attachControl(canvas, true);\n/*scene.createDefaultXRExperienceAsync({}).then((defaultXRExperience) => {\n    // Make sure hardware is OK for XR context${2}\n})*/;"
     },
 
 
@@ -83,36 +73,31 @@
         "label": "Add Light : Hemispheric light",
         "key": "Hemispheric",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-hemispheric-light",
-        "insertText": "var light = new BABYLON.HemisphericLight(\"${1:hemiLight}\", new BABYLON.Vector3(${2:0}, ${3:1}, ${4:0}), scene);",
-        "plainText": "var light = new BABYLON.HemisphericLight(\"hemiLight\", new BABYLON.Vector3(0,1,0), scene);"
+        "insertText": "var light = new BABYLON.HemisphericLight(\"${1:hemiLight}\", new BABYLON.Vector3(${2:0}, ${3:1}, ${4:0}), scene);"
     },
     {
         "label": "Add Light : Directional light",
         "key": "Directionnal",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-directional-light",
-        "insertText": "var light = new BABYLON.DirectionalLight(\"${1:dirLight}\", new BABYLON.Vector3(${2:-1},${3:-2},${4:-1}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});",
-        "plainText": "var light = new BABYLON.DirectionalLight(\"dirLight\", new BABYLON.Vector3(-1,-2,-1), scene);\nlight.position = new BABYLON.Vector3(4,8,4);"
+        "insertText": "var light = new BABYLON.DirectionalLight(\"${1:dirLight}\", new BABYLON.Vector3(${2:-1},${3:-2},${4:-1}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});"
     },
     {
         "label": "Add Light : Point light",
         "key": "Point",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-point-light",
-        "insertText": "var light = new BABYLON.PointLight(\"${1:pointLight}\", new BABYLON.Vector3(${2:2},${3:4},${4:2}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});",
-        "plainText": "var light = new BABYLON.PointLight(\"pointLight\", new BABYLON.Vector3(2,4,2), scene);\nlight.position = new BABYLON.Vector3(4,8,4);"
+        "insertText": "var light = new BABYLON.PointLight(\"${1:pointLight}\", new BABYLON.Vector3(${2:2},${3:4},${4:2}), scene);\nlight.position = new BABYLON.Vector3(${5:4},${6:8},${7:4});"
     },
     {
         "label": "Add Light : Spot light",
         "key": "Spot",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-spot-light",
-        "insertText": "var light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);",
-        "plainText": "var light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);"
+        "insertText": "var light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);"
     },
     {
         "label": "Add Light : Spot lights (3 colors)",
         "key": "3 Spots",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction#the-spot-light",
-        "insertText": "//red spot\nvar light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight.diffuse = new BABYLON.Color3(1, 0, 0);\n\n//green spot\nvar light1 = new BABYLON.SpotLight(\"spotLight1\", new BABYLON.Vector3(0, 4, 1 - Math.sin(Math.PI / 6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight1.diffuse = new BABYLON.Color3(0, 1, 0);\n\n//blue spot\nvar light2 = new BABYLON.SpotLight(\"spotLight2\", new BABYLON.Vector3(Math.cos(Math.PI/6), 4, -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight2.diffuse = new BABYLON.Color3(0, 0, 1);",
-        "plainText": "//red spot\nvar light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight.diffuse = new BABYLON.Color3(1, 0, 0);\n\n//green spot\nvar light1 = new BABYLON.SpotLight(\"spotLight1\", new BABYLON.Vector3(0, 4, 1 - Math.sin(Math.PI / 6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight1.diffuse = new BABYLON.Color3(0, 1, 0);\n\n//blue spot\nvar light2 = new BABYLON.SpotLight(\"spotLight2\", new BABYLON.Vector3(Math.cos(Math.PI/6), 4, -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight2.diffuse = new BABYLON.Color3(0, 0, 1);"
+        "insertText": "//red spot\nvar light = new BABYLON.SpotLight(\"spotLight\", new BABYLON.Vector3(-Math.cos(Math.PI/6), 4 , -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight.diffuse = new BABYLON.Color3(1, 0, 0);\n\n//green spot\nvar light1 = new BABYLON.SpotLight(\"spotLight1\", new BABYLON.Vector3(0, 4, 1 - Math.sin(Math.PI / 6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight1.diffuse = new BABYLON.Color3(0, 1, 0);\n\n//blue spot\nvar light2 = new BABYLON.SpotLight(\"spotLight2\", new BABYLON.Vector3(Math.cos(Math.PI/6), 4, -Math.sin(Math.PI/6)), new BABYLON.Vector3(0, -1, 0), Math.PI / 4, 1.5, scene);\nlight2.diffuse = new BABYLON.Color3(0, 0, 1);"
     },
 
 
@@ -123,29 +108,25 @@
         "label": "Build a ground plane",
         "key": "Ground",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
-        "insertText": "var ground = BABYLON.MeshBuilder.CreateGround(\"${1:ground}\", {width: ${2:6}, height: ${3:6}}, scene);",
-        "plainText": "var ground = BABYLON.MeshBuilder.CreateGround(\"ground\", {width: 6, height: 6}, scene);"
+        "insertText": "var ground = BABYLON.MeshBuilder.CreateGround(\"${1:ground}\", {width: ${2:6}, height: ${3:6}}, scene);"
     },
     {
         "label": "Build a sphere",
         "key": "Sphere",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
-        "insertText": "var sphere = BABYLON.MeshBuilder.CreateSphere(\"${1:sphere}\", {diameter: ${2:2}}, scene);\nsphere.position.y = 1;",
-        "plainText": "var sphere = BABYLON.MeshBuilder.CreateSphere(\"sphere\", {diameter: 2}, scene);\nsphere.position.y = 1;"
+        "insertText": "var sphere = BABYLON.MeshBuilder.CreateSphere(\"${1:sphere}\", {diameter: ${2:2}}, scene);\nsphere.position.y = 1;"
     },
     {
         "label": "Build a box",
         "key": "Box",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
-        "insertText": "var box = BABYLON.MeshBuilder.CreateBox(\"${1:box}\", {size: ${2:2}}, scene);\nbox.position.y = 1;",
-        "plainText": "var box = BABYLON.MeshBuilder.CreateBox(\"box\", {size: 2}, scene);\nbox.position.y = 1;"
+        "insertText": "var box = BABYLON.MeshBuilder.CreateBox(\"${1:box}\", {size: ${2:2}}, scene);\nbox.position.y = 1;"
     },
     {
         "label": "Build a cylinder",
         "key": "Cylinder",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/set",
-        "insertText": "var cylinder = BABYLON.MeshBuilder.CreateCylinder(\"${1:cylinder}\", {height: ${2:2}, diameter: ${3:1}}, scene);\ncylinder.position.y = 1;",
-        "plainText": "var cylinder = BABYLON.MeshBuilder.CreateCylinder(\"cylinder\", {height: 2, diameter: 1}, scene);\ncylinder.position.y = 1;"
+        "insertText": "var cylinder = BABYLON.MeshBuilder.CreateCylinder(\"${1:cylinder}\", {height: ${2:2}, diameter: ${3:1}}, scene);\ncylinder.position.y = 1;"
     },
 
 
@@ -156,22 +137,19 @@
         "label": "Import a Mesh",
         "key": "Import Mesh",
         "documentation": "https://doc.babylonjs.com/toolsAndResources/thePlayground/externalPGAssets",
-        "insertText": "BABYLON.SceneLoader.ImportMesh(\"${1:meshName}\", \"${2:url/to/parent/directory}\", \"${3:fileName.fileExtension}\", scene, function(newMeshes){\n\n});",
-        "plainText": "BABYLON.SceneLoader.ImportMesh(\"meshName\", \"url/to/parent/directory\", \"fileName.fileExtension\", scene, function(newMeshes){\n\n});"
+        "insertText": "BABYLON.SceneLoader.ImportMesh(\"${1:meshName}\", \"${2:url/to/parent/directory}\", \"${3:fileName.fileExtension}\", scene, function(newMeshes){\n\n});"
     },
     {
         "label": "Export scene to GLB",
         "key": "Export GLB",
         "documentation": "https://doc.babylonjs.com/extensions/gltfexporter#exporting-a-scene-to-gltf",
-        "insertText": "BABYLON.GLTF2Export.GLBAsync(scene, \"${1:fileName}\").then((glb) => {\n     glb.downloadFiles();\n});",
-        "plainText": "BABYLON.GLTF2Export.GLBAsync(scene, \"fileName\").then((glb) => {\n     //glb.downloadFiles();\n});"
+        "insertText": "BABYLON.GLTF2Export.GLBAsync(scene, \"${1:fileName}\").then((glb) => {\n     glb.downloadFiles();\n});"
     },
     {
         "label": "Export scene to GLTF",
         "key": "Export GLTF",
         "documentation": "https://doc.babylonjs.com/extensions/gltfexporter#exporting-a-scene-to-gltf",
-        "insertText": "BABYLON.GLTF2Export.GLTFAsync(scene, \"${1:fileName}\").then((gltf) => {\n     gltf.downloadFiles();\n});",
-        "plainText": "BABYLON.GLTF2Export.GLTFAsync(scene, \"fileName\").then((gltf) => {\n     //gltf.downloadFiles();\n});"
+        "insertText": "BABYLON.GLTF2Export.GLTFAsync(scene, \"${1:fileName}\").then((gltf) => {\n     gltf.downloadFiles();\n});"
     },
 
 
@@ -182,22 +160,19 @@
         "label": "Import animated character : Dude",
         "key": "Dude",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/animation/animatedCharacter",
-        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"scenes/Dude/\", \"dude.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.03);\n    scene.beginAnimation(skeletons[0], 0, 100, true, 1.0);\n    hero.position.x = 2;\n});",
-        "plainText": "BABYLON.SceneLoader.ImportMesh(\"\", \"scenes/Dude/\", \"dude.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.03);\n    scene.beginAnimation(skeletons[0], 0, 100, true, 1.0);\n    hero.position.x = 2;\n});"
+        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"scenes/Dude/\", \"dude.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.03);\n    scene.beginAnimation(skeletons[0], 0, 100, true, 1.0);\n    hero.position.x = 2;\n});"
     },
     {
         "label": "Import animated character : Dummy",
         "key": "Dummy",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/animation/animatedCharacter",
-        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"./scenes/\", \"dummy3.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    var skeleton = skeletons[0];\n    var walkRange = skeleton.getAnimationRange(\"YBot_Walk\");\n    scene.beginAnimation(skeleton, walkRange.from, walkRange.to, true);\n    hero.position.x = 2;\n});",
-        "plainText": "BABYLON.SceneLoader.ImportMesh(\"\", \"./scenes/\", \"dummy3.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    var skeleton = skeletons[0];\n    var walkRange = skeleton.getAnimationRange(\"YBot_Walk\");\n    scene.beginAnimation(skeleton, walkRange.from, walkRange.to, true);\n    hero.position.x = 2;\n});"
+        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"./scenes/\", \"dummy3.babylon\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    var skeleton = skeletons[0];\n    var walkRange = skeleton.getAnimationRange(\"YBot_Walk\");\n    scene.beginAnimation(skeleton, walkRange.from, walkRange.to, true);\n    hero.position.x = 2;\n});"
     },
     {
         "label": "Import animated character : Samba Girl",
         "key": "Samba Girl",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/animation/animatedCharacter",
-        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"https://assets.babylonjs.com/meshes/\", \"HVGirl.glb\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.08);\n    const sambaAnim = scene.getAnimationGroupByName(\"Samba\");\n    sambaAnim.start(true, 1.0, sambaAnim.from, sambaAnim.to, false);\n    hero.position.x = 2;\n});",
-        "plainText": "BABYLON.SceneLoader.ImportMesh(\"\", \"https://assets.babylonjs.com/meshes/\", \"HVGirl.glb\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.08);\n    const sambaAnim = scene.getAnimationGroupByName(\"Samba\");\n    sambaAnim.start(true, 1.0, sambaAnim.from, sambaAnim.to, false);\n    hero.position.x = 2;\n});"
+        "insertText": "BABYLON.SceneLoader.ImportMesh(\"\", \"https://assets.babylonjs.com/meshes/\", \"HVGirl.glb\", scene, function (newMeshes, particleSystems, skeletons) {\n    var hero = newMeshes[0];\n    hero.scaling.scaleInPlace(0.08);\n    const sambaAnim = scene.getAnimationGroupByName(\"Samba\");\n    sambaAnim.start(true, 1.0, sambaAnim.from, sambaAnim.to, false);\n    hero.position.x = 2;\n});"
     },
 
 
@@ -209,22 +184,19 @@
         "label": "Create a particle system (simple)",
         "key": "Simple",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro",
-        "insertText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Start the particle system\nparticleSystem.start();",
-        "plainText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Start the particle system\nparticleSystem.start();"
+        "insertText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Start the particle system\nparticleSystem.start();"
     },
     {
         "label": "Create a particle system (color gradient)",
         "key": "Color Gradient",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro",
-        "insertText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Color Gradient over lifetime\nparticleSystem.addColorGradient(0, new BABYLON.Color4(1, 0, 0, 1), new BABYLON.Color4(1, 0, 1, 1));\nparticleSystem.addColorGradient(1, new BABYLON.Color4(0, 1, 0, 1), new BABYLON.Color4(1, 1, 0, 1));\n// Start the particle system\nparticleSystem.start();",
-        "plainText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Color Gradient over lifetime\nparticleSystem.addColorGradient(0, new BABYLON.Color4(1, 0, 0, 1), new BABYLON.Color4(1, 0, 1, 1));\nparticleSystem.addColorGradient(1, new BABYLON.Color4(0, 1, 0, 1), new BABYLON.Color4(1, 1, 0, 1));\n// Start the particle system\nparticleSystem.start();"
+        "insertText": "// Create a particle system\nconst particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"textures/flare.png\");\n// Color Gradient over lifetime\nparticleSystem.addColorGradient(0, new BABYLON.Color4(1, 0, 0, 1), new BABYLON.Color4(1, 0, 1, 1));\nparticleSystem.addColorGradient(1, new BABYLON.Color4(0, 1, 0, 1), new BABYLON.Color4(1, 1, 0, 1));\n// Start the particle system\nparticleSystem.start();"
     },
     {
         "label": "Create a particle system (complex)",
         "key": "Complex",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/shape_emitters",
-        "insertText": "// Create a particle system\nvar particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"/textures/flare.png\", scene);\n// Where the particles come from\nparticleSystem.emitter = BABYLON.Vector3.Zero(); // the starting location\n// Colors of particles over time\nparticleSystem.color1 = new BABYLON.Color4(0.7, 0.8, 1.0, 1.0);\nparticleSystem.color2 = new BABYLON.Color4(0.2, 0.5, 1.0, 1.0);\nparticleSystem.colorDead = new BABYLON.Color4(0, 0, 0.2, 0.0);\n// Size of each particle (random between...)\nparticleSystem.minSize = 0.1;\nparticleSystem.maxSize = 0.5;\n// Life time of each particle (random between...)\nparticleSystem.minLifeTime = 0.3;\nparticleSystem.maxLifeTime = 1.5;\n// Emission rate\nparticleSystem.emitRate = 1000;\n// Emission space\nparticleSystem.createPointEmitter(new BABYLON.Vector3(-7, 8, 3), new BABYLON.Vector3(7, 8, -3));\n// Speed\nparticleSystem.minEmitPower = 1;\nparticleSystem.maxEmitPower = 3;\nparticleSystem.updateSpeed = 0.005;\n// Start the particle system\nparticleSystem.start();",
-        "plainText": "// Create a particle system\nvar particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"/textures/flare.png\", scene);\n// Where the particles come from\nparticleSystem.emitter = BABYLON.Vector3.Zero(); // the starting location\n// Colors of particles over time\nparticleSystem.color1 = new BABYLON.Color4(0.7, 0.8, 1.0, 1.0);\nparticleSystem.color2 = new BABYLON.Color4(0.2, 0.5, 1.0, 1.0);\nparticleSystem.colorDead = new BABYLON.Color4(0, 0, 0.2, 0.0);\n// Size of each particle (random between...)\nparticleSystem.minSize = 0.1;\nparticleSystem.maxSize = 0.5;\n// Life time of each particle (random between...)\nparticleSystem.minLifeTime = 0.3;\nparticleSystem.maxLifeTime = 1.5;\n// Emission rate\nparticleSystem.emitRate = 1000;\n// Emission space\nparticleSystem.createPointEmitter(new BABYLON.Vector3(-7, 8, 3), new BABYLON.Vector3(7, 8, -3));\n// Speed\nparticleSystem.minEmitPower = 1;\nparticleSystem.maxEmitPower = 3;\nparticleSystem.updateSpeed = 0.005;\n// Start the particle system\nparticleSystem.start();"
+        "insertText": "// Create a particle system\nvar particleSystem = new BABYLON.ParticleSystem(\"particles\", 2000, scene);\n// Texture of each particle\nparticleSystem.particleTexture = new BABYLON.Texture(\"/textures/flare.png\", scene);\n// Where the particles come from\nparticleSystem.emitter = BABYLON.Vector3.Zero(); // the starting location\n// Colors of particles over time\nparticleSystem.color1 = new BABYLON.Color4(0.7, 0.8, 1.0, 1.0);\nparticleSystem.color2 = new BABYLON.Color4(0.2, 0.5, 1.0, 1.0);\nparticleSystem.colorDead = new BABYLON.Color4(0, 0, 0.2, 0.0);\n// Size of each particle (random between...)\nparticleSystem.minSize = 0.1;\nparticleSystem.maxSize = 0.5;\n// Life time of each particle (random between...)\nparticleSystem.minLifeTime = 0.3;\nparticleSystem.maxLifeTime = 1.5;\n// Emission rate\nparticleSystem.emitRate = 1000;\n// Emission space\nparticleSystem.createPointEmitter(new BABYLON.Vector3(-7, 8, 3), new BABYLON.Vector3(7, 8, -3));\n// Speed\nparticleSystem.minEmitPower = 1;\nparticleSystem.maxEmitPower = 3;\nparticleSystem.updateSpeed = 0.005;\n// Start the particle system\nparticleSystem.start();"
     },
 
 
@@ -236,28 +208,24 @@
         "label": "Load from Snippet : Particle System",
         "key": "Particles",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_snippets",
-        "insertText": "BABYLON.ParticleHelper.ParseFromSnippetAsync(\"${1:T54JV7}\", scene, false).then(system => {\n\n});",
-        "plainText": "BABYLON.ParticleHelper.ParseFromSnippetAsync(\"T54JV7\", scene, false).then(system => {\n\n});"
+        "insertText": "BABYLON.ParticleHelper.ParseFromSnippetAsync(\"${1:T54JV7}\", scene, false).then(system => {\n\n});"
     },
     {
         "label": "Load from Snippet : Node Material",
         "key": "Node Material",
         "documentation": "https://doc.babylonjs.com/how_to/node_material#loading-from-a-file-saved-from-the-node-material-editor",
-        "insertText": "BABYLON.NodeMaterial.ParseFromSnippetAsync(\"${1:2F999G}\", scene).then(nodeMaterial => {\n     ${2:mesh_to_apply_node_material_to}.material = nodeMaterial;\n});",
-        "plainText": "BABYLON.NodeMaterial.ParseFromSnippetAsync(\"2F999G\", scene).then(nodeMaterial => {\n     //mesh.material = nodeMaterial;\n});"
+        "insertText": "BABYLON.NodeMaterial.ParseFromSnippetAsync(\"${1:2F999G}\", scene).then(nodeMaterial => {\n     ${2:mesh_to_apply_node_material_to}.material = nodeMaterial;\n});"
     },
     {
         "label": "Load from Snippet : GUI",
         "key": "GUI",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#loading-from-snippet-server",
-        "insertText": "let advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI(\"${1:name}\", true, scene);\nlet loadedGUI = advancedTexture.parseFromSnippetAsync(\"${2:I59XFB#11}\");",
-        "plainText": "let advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI(\"name\", true, scene);\nlet loadedGUI = advancedTexture.parseFromSnippetAsync(\"I59XFB#11\");"
+        "insertText": "let advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI(\"${1:name}\", true, scene);\nlet loadedGUI = advancedTexture.parseFromSnippetAsync(\"${2:I59XFB#11}\");"
     },
     {
         "label": "Load from Snippet : GUI on Mesh",
         "key": "GUI on Mesh",
         "documentation": "https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#loading-from-snippet-server",
-        "insertText": "var groundGUI = BABYLON.MeshBuilder.CreateGround(\"groundGUI\", {width: 6, height: 6}, scene);\ngroundGUI.position.y +=1\nlet guiTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateForMesh(${1:groundGUI}, 1024, 1024);\nguiTexture.parseFromSnippetAsync(\"${2:I59XFB#11}\");",
-        "plainText": "var groundGUI = BABYLON.MeshBuilder.CreateGround(\"groundGUI\", {width: 6, height: 6}, scene);\ngroundGUI.position.y +=1\nlet guiTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateForMesh(groundGUI, 1024, 1024);\nguiTexture.parseFromSnippetAsync(\"I59XFB#11\");"
+        "insertText": "var groundGUI = BABYLON.MeshBuilder.CreateGround(\"groundGUI\", {width: 6, height: 6}, scene);\ngroundGUI.position.y +=1\nlet guiTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateForMesh(${1:groundGUI}, 1024, 1024);\nguiTexture.parseFromSnippetAsync(\"${2:I59XFB#11}\");"
     }
 ]

--- a/packages/tools/playground/src/tools/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monacoManager.ts
@@ -25,7 +25,6 @@ export class MonacoManager {
         key: string;
         documentation: string;
         insertText: string;
-        plainText: string;
         language: string;
         kind: number;
         sortText: string;
@@ -204,7 +203,9 @@ class Playground {
         let code = "";
         this._templates.forEach(function (item) {
             if (item.key === key) {
-                code = item.plainText;
+                // Remove monaco placeholders
+                const regex = /\$\{[0-9]+:([^}]+)\}|\$\{[0-9]+\}/g;
+                code = item.insertText.replace(regex, (match, p1) => p1 || "");
             }
         });
         return code + "\n";


### PR DESCRIPTION
Changes have been detailed in [this post of the BJS forum](https://forum.babylonjs.com/t/pg-snippets-issue/52210/11)
- Removed 'plainText' key from Monaco snippet JSON
- Replaced by regex rule (`insertText` --> `plainText`)