### PR TITLE
suppress scss deprecation warnings for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25020,12 +25020,52 @@
                 "css-loader": "^6.4.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
                 "webpack-cli": "^5.1.0",
                 "webpack-merge": "^5.8.0"
+            }
+        },
+        "packages/public/umd/babylonjs-accessibility/node_modules/sass-loader": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.1.tgz",
+            "integrity": "sha512-xACl1ToTsKnL9Ce5yYpRxrLj9QUDCnwZNhzpC7tKiFyA8zXsd3Ap+HGVnbCgkdQcm43E+i6oKAWBsvGA6ZoiMw==",
+            "dev": true,
+            "dependencies": {
+                "neo-async": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "@rspack/core": "0.x || 1.x",
+                "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "sass": "^1.3.0",
+                "sass-embedded": "*",
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rspack/core": {
+                    "optional": true
+                },
+                "node-sass": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "packages/public/umd/babylonjs-gui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20722,29 +20722,29 @@
             }
         },
         "node_modules/sass-loader": {
-            "version": "13.3.3",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.3.tgz",
-            "integrity": "sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.1.tgz",
+            "integrity": "sha512-xACl1ToTsKnL9Ce5yYpRxrLj9QUDCnwZNhzpC7tKiFyA8zXsd3Ap+HGVnbCgkdQcm43E+i6oKAWBsvGA6ZoiMw==",
             "dev": true,
             "dependencies": {
                 "neo-async": "^2.6.2"
             },
             "engines": {
-                "node": ">= 14.15.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "fibers": ">= 3.1.0",
+                "@rspack/core": "0.x || 1.x",
                 "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
                 "sass": "^1.3.0",
                 "sass-embedded": "*",
                 "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
-                "fibers": {
+                "@rspack/core": {
                     "optional": true
                 },
                 "node-sass": {
@@ -20754,6 +20754,9 @@
                     "optional": true
                 },
                 "sass-embedded": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -25028,46 +25031,6 @@
                 "webpack-merge": "^5.8.0"
             }
         },
-        "packages/public/umd/babylonjs-accessibility/node_modules/sass-loader": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.1.tgz",
-            "integrity": "sha512-xACl1ToTsKnL9Ce5yYpRxrLj9QUDCnwZNhzpC7tKiFyA8zXsd3Ap+HGVnbCgkdQcm43E+i6oKAWBsvGA6ZoiMw==",
-            "dev": true,
-            "dependencies": {
-                "neo-async": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "@rspack/core": "0.x || 1.x",
-                "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-                "sass": "^1.3.0",
-                "sass-embedded": "*",
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@rspack/core": {
-                    "optional": true
-                },
-                "node-sass": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
         "packages/public/umd/babylonjs-gui": {
             "version": "7.26.0",
             "license": "Apache-2.0",
@@ -25101,7 +25064,7 @@
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
@@ -25130,7 +25093,7 @@
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
@@ -25203,7 +25166,7 @@
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
@@ -25227,7 +25190,7 @@
                 "react": "^17.0.2",
                 "react-contextmenu": "RaananW/react-contextmenu",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
@@ -25299,7 +25262,7 @@
                 "@dev/loaders": "1.0.0",
                 "@dev/shared-ui-components": "1.0.0",
                 "@tools/viewer": "1.0.0",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "source-map-loader": "^4.0.0",
                 "ts-loader": "^9.2.6",
                 "webpack": "^5.73.0",
@@ -25412,7 +25375,7 @@
                 "@types/react-dom": "^17.0.10",
                 "copy-webpack-plugin": "^11.0.0",
                 "css-loader": "^6.4.0",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
@@ -25454,7 +25417,7 @@
                 "file-loader": "^6.2.0",
                 "html-webpack-plugin": "^5.4.0",
                 "mini-css-extract-plugin": "^2.4.3",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
@@ -25485,7 +25448,7 @@
                 "file-loader": "^6.2.0",
                 "html-webpack-plugin": "^5.4.0",
                 "mini-css-extract-plugin": "^2.4.3",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
@@ -25512,7 +25475,7 @@
                 "monaco-editor-webpack-plugin": "^4.2.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "ts-debounce": "4.0.0",
@@ -25560,7 +25523,7 @@
                 "file-loader": "^6.2.0",
                 "html-webpack-plugin": "^5.4.0",
                 "mini-css-extract-plugin": "^2.4.3",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
                 "webpack": "^5.73.0",
@@ -25700,7 +25663,7 @@
                 "@types/react-dom": "^17.0.10",
                 "copy-webpack-plugin": "^11.0.0",
                 "css-loader": "^6.4.0",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^16.0.0",
                 "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",

--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -111,9 +111,6 @@ export const getRules = (
                         loader: "sass-loader",
                         options: {
                             sourceMap: true,
-                            sassOptions: {
-                                silenceDeprecations: ["legacy-js-api"],
-                            },
                         },
                     },
                 ],

--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -133,9 +133,6 @@ export const getRules = (
                         loader: "sass-loader",
                         options: {
                             sourceMap: true,
-                            sassOptions: {
-                                silenceDeprecations: ["legacy-js-api"],
-                            },
                         },
                     },
                 ],

--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -111,6 +111,9 @@ export const getRules = (
                         loader: "sass-loader",
                         options: {
                             sourceMap: true,
+                            sassOptions: {
+                                silenceDeprecations: ["legacy-js-api"],
+                            },
                         },
                     },
                 ],
@@ -133,6 +136,9 @@ export const getRules = (
                         loader: "sass-loader",
                         options: {
                             sourceMap: true,
+                            sassOptions: {
+                                silenceDeprecations: ["legacy-js-api"],
+                            },
                         },
                     },
                 ],

--- a/packages/public/umd/babylonjs-accessibility/package.json
+++ b/packages/public/umd/babylonjs-accessibility/package.json
@@ -26,7 +26,7 @@
         "css-loader": "^6.4.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/public/umd/babylonjs-gui-editor/package.json
+++ b/packages/public/umd/babylonjs-gui-editor/package.json
@@ -27,7 +27,7 @@
         "react": "^17.0.2",
         "react-contextmenu": "RaananW/react-contextmenu",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/public/umd/babylonjs-inspector/package.json
+++ b/packages/public/umd/babylonjs-inspector/package.json
@@ -31,7 +31,7 @@
         "react": "^17.0.2",
         "react-contextmenu": "RaananW/react-contextmenu",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/public/umd/babylonjs-node-editor/package.json
+++ b/packages/public/umd/babylonjs-node-editor/package.json
@@ -26,7 +26,7 @@
         "react": "^17.0.2",
         "react-contextmenu": "RaananW/react-contextmenu",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/public/umd/babylonjs-node-geometry-editor/package.json
+++ b/packages/public/umd/babylonjs-node-geometry-editor/package.json
@@ -26,7 +26,7 @@
         "react": "^17.0.2",
         "react-contextmenu": "RaananW/react-contextmenu",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/public/umd/babylonjs-viewer/package.json
+++ b/packages/public/umd/babylonjs-viewer/package.json
@@ -22,7 +22,7 @@
         "@dev/loaders": "1.0.0",
         "@dev/shared-ui-components": "1.0.0",
         "@tools/viewer": "1.0.0",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "source-map-loader": "^4.0.0",
         "ts-loader": "^9.2.6",
         "webpack": "^5.73.0",

--- a/packages/tools/guiEditor/package.json
+++ b/packages/tools/guiEditor/package.json
@@ -35,7 +35,7 @@
         "@types/react-dom": "^17.0.10",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.4.0",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",

--- a/packages/tools/nodeEditor/package.json
+++ b/packages/tools/nodeEditor/package.json
@@ -38,7 +38,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.4.0",
         "mini-css-extract-plugin": "^2.4.3",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",

--- a/packages/tools/nodeGeometryEditor/package.json
+++ b/packages/tools/nodeGeometryEditor/package.json
@@ -39,7 +39,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.4.0",
         "mini-css-extract-plugin": "^2.4.3",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",

--- a/packages/tools/playground/package.json
+++ b/packages/tools/playground/package.json
@@ -27,7 +27,7 @@
         "monaco-editor-webpack-plugin": "^4.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "ts-debounce": "4.0.0",

--- a/packages/tools/sandbox/package.json
+++ b/packages/tools/sandbox/package.json
@@ -37,7 +37,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.4.0",
         "mini-css-extract-plugin": "^2.4.3",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.73.0",

--- a/packages/tools/vsm/package.json
+++ b/packages/tools/vsm/package.json
@@ -36,7 +36,7 @@
         "@types/react-dom": "^17.0.10",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.4.0",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^16.0.0",
         "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",


### PR DESCRIPTION
If you have installed the new dependency versions you might have noticed a slight increase in warning messages in your console!
This PR updates the dependencies loading our styles, which will remove this warning.

Whoever reviews this PR - please check the tools' styles before fully approving it. There shouldn't be any issue, but let's stay on the safe side.